### PR TITLE
Handle deletion of projects 

### DIFF
--- a/internal/controller/project/controller_conditions.go
+++ b/internal/controller/project/controller_conditions.go
@@ -24,18 +24,38 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
-// Constants for condition types for the project controller
+const (
+	// ConditionCreated represents whether the project is created
+	ConditionCreated controller.ConditionType = "Created"
+	// ConditionFinalizing represents whether the project is being finalized
+	ConditionFinalizing controller.ConditionType = "Finalizing"
+)
 
-// ReasonProjectCreated is the reason used when a project is created/ready
-const ReasonProjectCreated controller.ConditionReason = "ProjectCreated"
+const (
+	// ReasonProjectCreated is the reason used when a project is created/ready
+	ReasonProjectCreated controller.ConditionReason = "ProjectCreated"
+
+	// ReasonProjectFinalizing is the reason used when a projects's dependents are being deleted'
+	ReasonProjectFinalizing controller.ConditionReason = "ProjectFinalizing"
+)
 
 // NewProjectCreatedCondition creates a condition to indicate the project is created/ready
 func NewProjectCreatedCondition(generation int64) metav1.Condition {
 	return controller.NewCondition(
-		controller.TypeCreated,
+		ConditionCreated,
 		metav1.ConditionTrue,
 		ReasonProjectCreated,
 		"Project is created",
+		generation,
+	)
+}
+
+func NewProjectFinalizingCondition(generation int64) metav1.Condition {
+	return controller.NewCondition(
+		ConditionFinalizing,
+		metav1.ConditionTrue,
+		ReasonProjectFinalizing,
+		"Project is finalizing",
 		generation,
 	)
 }

--- a/internal/controller/project/controller_finalize.go
+++ b/internal/controller/project/controller_finalize.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package project
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	choreov1 "github.com/openchoreo/openchoreo/api/v1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+const (
+	// ProjectCleanupFinalizer is the finalizer that is used to clean up project resources.
+	ProjectCleanupFinalizer = "core.choreo.dev/project-cleanup"
+)
+
+// ensureFinalizer ensures that the finalizer is added to the project.
+// The first return value indicates whether the finalizer was added to the project.
+func (r *Reconciler) ensureFinalizer(ctx context.Context, project *choreov1.Project) (bool, error) {
+	// If the project is being deleted, no need to add the finalizer
+	if !project.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+
+	if controllerutil.AddFinalizer(project, ProjectCleanupFinalizer) {
+		return true, r.Update(ctx, project)
+	}
+
+	return false, nil
+}
+
+// finalize cleans up the resources associated with the project.
+func (r *Reconciler) finalize(ctx context.Context, old, project *choreov1.Project) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("project", project.Name)
+
+	if !controllerutil.ContainsFinalizer(project, ProjectCleanupFinalizer) {
+		// Nothing to do if the finalizer is not present
+		return ctrl.Result{}, nil
+	}
+
+	// Mark the project condition as finalizing and return so that the project will indicate that it is being finalized.
+	// The actual finalization will be done in the next reconcile loop triggered by the status update.
+	if meta.SetStatusCondition(&project.Status.Conditions, NewProjectFinalizingCondition(project.Generation)) {
+		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, project)
+	}
+
+	// Perform cleanup logic for deployment tracks
+	artifactsDeleted, err := r.deleteComponentsAndWait(ctx, project)
+	if err != nil {
+		logger.Error(err, "Failed to delete components")
+		return ctrl.Result{}, err
+	}
+	if !artifactsDeleted {
+		logger.Info("Components are still being deleted", "name", project.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Remove the finalizer once cleanup is done
+	if controllerutil.RemoveFinalizer(project, ProjectCleanupFinalizer) {
+		if err := r.Update(ctx, project); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		}
+	}
+
+	logger.Info("Successfully finalized project")
+	return ctrl.Result{}, nil
+}
+
+// deleteComponentsAndWait cleans up any resources that are dependent on this Project
+func (r *Reconciler) deleteComponentsAndWait(ctx context.Context, project *choreov1.Project) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("project", project.Name)
+	logger.Info("Cleaning up dependent resources")
+
+	// Find all Components owned by this Project using the project label
+	componentsList := &choreov1.ComponentList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(project.Namespace),
+		client.MatchingLabels{
+			labels.LabelKeyOrganizationName: controller.GetOrganizationName(project),
+			labels.LabelKeyProjectName:      project.Name,
+		},
+	}
+
+	if err := r.List(ctx, componentsList, listOpts...); err != nil {
+		if errors.IsNotFound(err) {
+			// The Component resource may have been deleted since it triggered the reconcile
+			logger.Info("Component not found. Ignoring since it must either be deleted or no components have been created.")
+			return true, nil
+		}
+
+		// It's a real error
+		return false, fmt.Errorf("failed to list components: %w", err)
+	}
+
+	pendingDeletion := false
+	// Check if any components still exist
+	if len(componentsList.Items) > 0 {
+		// Process each Component
+		for i := range componentsList.Items {
+			component := &componentsList.Items[i]
+
+			// Check if the component is already being deleted
+			if !component.DeletionTimestamp.IsZero() {
+				// Still in the process of being deleted
+				pendingDeletion = true
+				logger.Info("Component is still being deleted", "name", component.Name)
+				continue
+			}
+
+			// If not being deleted, trigger deletion
+			logger.Info("Deleting component", "name", component.Name)
+			if err := r.Delete(ctx, component); err != nil {
+				if errors.IsNotFound(err) {
+					logger.Info("Component already deleted", "name", component.Name)
+					continue
+				}
+				return false, fmt.Errorf("failed to delete component %s: %w", component.Name, err)
+			}
+
+			// Mark as pending since we just triggered deletion
+			pendingDeletion = true
+		}
+
+		// If there are still components being deleted, go to next iteration to check again later
+		if pendingDeletion {
+			return false, nil
+		}
+	}
+
+	logger.Info("All components are deleted")
+	return true, nil
+}

--- a/internal/controller/project/controller_finalize.go
+++ b/internal/controller/project/controller_finalize.go
@@ -114,13 +114,13 @@ func (r *Reconciler) deleteChildAndLinkedResources(ctx context.Context, project 
 	// At this point all control plane resource from components downwards should be deleted
 	// Also all dataplane resources from deployments in the project should be deleted
 	// Now we can delete the dataplane namespaces
-	dataplaneDeleted, err := r.deleteDataplaneResourcesAndWait(ctx, project)
+	externalResourcesDeleted, err := r.deleteExternalResourcesAndWait(ctx, project)
 	if err != nil {
-		logger.Error(err, "Failed to delete dataplane resources")
+		logger.Error(err, "Failed to delete external resources")
 		return false, err
 	}
-	if !dataplaneDeleted {
-		logger.Info("Dataplane resources are still being deleted", "name", project.Name)
+	if !externalResourcesDeleted {
+		logger.Info("External resources are still being deleted", "name", project.Name)
 		return false, nil
 	}
 
@@ -192,8 +192,8 @@ func (r *Reconciler) deleteComponentsAndWait(ctx context.Context, project *chore
 	return true, nil
 }
 
-// deleteDataplaneResourcesAndWait cleans up any resources that are dependent on this Project
-func (r *Reconciler) deleteDataplaneResourcesAndWait(ctx context.Context, project *choreov1.Project) (bool, error) {
+// deleteExternalResourcesAndWait cleans up any resources that are dependent on this Project
+func (r *Reconciler) deleteExternalResourcesAndWait(ctx context.Context, project *choreov1.Project) (bool, error) {
 	logger := log.FromContext(ctx).WithValues("project", project.Name)
 
 	// Create the project context for external resource deletions

--- a/internal/controller/project/controller_test.go
+++ b/internal/controller/project/controller_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Project Controller", func() {
 						},
 					},
 					Spec: apiv1.ProjectSpec{
-						DeploymentPipelineRef: "test-pipeline",
+						DeploymentPipelineRef: "test-deployment-pipeline",
 					},
 				}
 				Expect(k8sClient.Create(ctx, dp)).To(Succeed())
@@ -210,7 +210,7 @@ var _ = Describe("Project Controller", func() {
 			}, time.Second*10, time.Millisecond*500).Should(Succeed())
 			Expect(project.Name).To(Equal(projectName))
 			Expect(project.Namespace).To(Equal(orgName))
-			Expect(project.Spec).To(Equal(apiv1.ProjectSpec{DeploymentPipelineRef: "test-pipeline"}))
+			Expect(project.Spec).To(Equal(apiv1.ProjectSpec{DeploymentPipelineRef: "test-deployment-pipeline"}))
 			Expect(project.Spec).NotTo(BeNil())
 		})
 

--- a/internal/controller/project/controller_test.go
+++ b/internal/controller/project/controller_test.go
@@ -238,17 +238,16 @@ var _ = Describe("Project Controller", func() {
 			}, time.Second*10, time.Millisecond*500).Should(BeTrue())
 
 			// Run the finalizer reconciliation
-			result, err := projectReconciler.Reconcile(ctx, reconcile.Request{
+			_, err := projectReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: projectNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Run the finalizer reconciliation again to complete deletion
-			result, err = projectReconciler.Reconcile(ctx, reconcile.Request{
+			_, err = projectReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: projectNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
 		})
 
 		By("Checking the project resource deletion", func() {

--- a/internal/controller/project/integrations/kubernetes/namespace_handler.go
+++ b/internal/controller/project/integrations/kubernetes/namespace_handler.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openchoreo/openchoreo/internal/dataplane"
+)
+
+type namespaceHandler struct {
+	kubernetesClient client.Client
+}
+
+var _ dataplane.ResourceHandler[dataplane.ProjectContext] = (*namespaceHandler)(nil)
+
+func NewNamespaceHandler(kubernetesClient client.Client) dataplane.ResourceHandler[dataplane.ProjectContext] {
+	return &namespaceHandler{
+		kubernetesClient: kubernetesClient,
+	}
+}
+
+func (h *namespaceHandler) Name() string {
+	return "KubernetesNamespace"
+}
+
+func (h *namespaceHandler) IsRequired(deployCtx *dataplane.ProjectContext) bool {
+	// Namespace is always required and the deletion of a namespace should be handled by the project deletion
+	// This will ensure the namespace is lazily created during the first deployment
+	return true
+}
+
+func (h *namespaceHandler) GetCurrentState(ctx context.Context, projectCtx *dataplane.ProjectContext) (interface{}, error) {
+	names := projectCtx.NamespaceNames
+	atLeastOneFound := false
+	var out *corev1.Namespace
+
+	for _, name := range names {
+		out = &corev1.Namespace{}
+		err := h.kubernetesClient.Get(ctx, client.ObjectKey{Name: name}, out)
+		if apierrors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		atLeastOneFound = true
+	}
+
+	if atLeastOneFound {
+		return out, nil
+	}
+	// If no namespace is found, return nil
+	return nil, nil
+}
+
+func (h *namespaceHandler) Create(ctx context.Context, deployCtx *dataplane.ProjectContext) error {
+	return nil
+}
+
+func (h *namespaceHandler) Update(ctx context.Context, deployCtx *dataplane.ProjectContext, currentState interface{}) error {
+	return nil
+}
+
+func (h *namespaceHandler) Delete(ctx context.Context, deployCtx *dataplane.ProjectContext) error {
+	for _, name := range deployCtx.NamespaceNames {
+		out := &corev1.Namespace{}
+		err := h.kubernetesClient.Get(ctx, client.ObjectKey{Name: name}, out)
+		if apierrors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return err
+		}
+
+		err = h.kubernetesClient.Delete(ctx, out)
+		if err != nil {
+			return fmt.Errorf("error while deleting Namespace: %w", err)
+		}
+		return nil
+	}
+	return nil
+}

--- a/internal/controller/project/project_context.go
+++ b/internal/controller/project/project_context.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package project
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	choreov1 "github.com/openchoreo/openchoreo/api/v1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/dataplane"
+	dpkubernetes "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
+)
+
+func (r *Reconciler) makeProjectContext(ctx context.Context, project *choreov1.Project) (*dataplane.ProjectContext, error) {
+	deploymentPipeline, err := r.findDeploymentPipeline(ctx, project)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the deployment pipeline: %w", err)
+	}
+
+	environmentNames := r.findEnvironmentNamesFromDeploymentPipeline(&deploymentPipeline)
+	if len(environmentNames) == 0 {
+		return nil, fmt.Errorf("no environments found for deployment pipeline %s", project.Spec.DeploymentPipelineRef)
+	}
+
+	namespaceNames := r.makeNamespaceNames(environmentNames, *project)
+
+	return &dataplane.ProjectContext{
+		DeploymentPipeline: &deploymentPipeline,
+		EnvironmentNames:   environmentNames,
+		Project:            project,
+		NamespaceNames:     namespaceNames,
+	}, nil
+}
+
+func (r *Reconciler) findDeploymentPipeline(ctx context.Context, project *choreov1.Project) (choreov1.DeploymentPipeline, error) {
+	logger := log.FromContext(ctx).WithValues("project", project.Name)
+
+	// Get deployment pipeline
+	var deploymentPipeline choreov1.DeploymentPipeline
+	err := r.Get(ctx, types.NamespacedName{
+		Namespace: project.Namespace,
+		Name:      project.Spec.DeploymentPipelineRef,
+	}, &deploymentPipeline)
+
+	if err != nil {
+		logger.Error(err, "Failed to get deployment pipeline",
+			"pipelineRef", project.Spec.DeploymentPipelineRef,
+			"namespace", project.Namespace)
+		return choreov1.DeploymentPipeline{}, err
+	}
+
+	return deploymentPipeline, nil
+}
+
+func (r *Reconciler) findEnvironmentNamesFromDeploymentPipeline(deploymentPipeline *choreov1.DeploymentPipeline) []string {
+	// Use a map to track unique environments
+	environmentMap := make(map[string]struct{})
+
+	// Iterate through all promotion paths
+	for _, path := range deploymentPipeline.Spec.PromotionPaths {
+		// Add source environment
+		environmentMap[path.SourceEnvironmentRef] = struct{}{}
+
+		// Add target environments
+		for _, target := range path.TargetEnvironmentRefs {
+			environmentMap[target.Name] = struct{}{}
+		}
+	}
+
+	// Convert the map keys to a slice
+	environments := make([]string, 0, len(environmentMap))
+	for env := range environmentMap {
+		environments = append(environments, env)
+	}
+
+	return environments
+}
+
+// NamespaceName has the format dp-<organization-name>-<project-name>-<environment-name>-<hash>
+func (r *Reconciler) makeNamespaceNames(environmentNames []string, project choreov1.Project) []string {
+	namespaceNames := make([]string, 0, len(environmentNames))
+
+	organizationName := controller.GetOrganizationName(&project)
+	projectName := controller.GetName(&project)
+	for _, env := range environmentNames {
+		environmentName := env
+		// Limit the name to 63 characters to comply with the K8s name length limit for Namespaces
+		namespaceName := dpkubernetes.GenerateK8sNameWithLengthLimit(dpkubernetes.MaxNamespaceNameLength,
+			"dp", organizationName, projectName, environmentName)
+		namespaceNames = append(namespaceNames, namespaceName)
+	}
+
+	return namespaceNames
+}

--- a/internal/dataplane/types.go
+++ b/internal/dataplane/types.go
@@ -48,3 +48,11 @@ type EndpointContext struct {
 	Environment     *choreov1.Environment
 	Endpoint        *choreov1.Endpoint
 }
+
+// ProjectContext is a struct that holds the all necessary data required for the resource handlers to perform their operations.
+type ProjectContext struct {
+	DeploymentPipeline *choreov1.DeploymentPipeline
+	Project            *choreov1.Project
+	EnvironmentNames   []string
+	NamespaceNames     []string
+}


### PR DESCRIPTION
## Purpose
Projects and their child and other related artifacts need to be cleaned up on delete.
- In the control plane - components are the immediate children to be cleaned. The resources beneath components will be cleaned up in a cascading manner utilizing each resource finalize function.
- A project refers to a deployment pipeline which lists environments in order of promotion. In the dataplane a namespace is created for each of these environments for a project. These also need to be cleaned up on Project delete.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/112

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)


