### PR TITLE
Fix Requeue Logic to Work with Updated Build Conditions

### DIFF
--- a/internal/controller/build/controller.go
+++ b/internal/controller/build/controller.go
@@ -139,7 +139,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		requeue := r.handleBuildSteps(build, existingWorkflow.Status.Nodes)
 
 		if requeue {
-			return r.handleRequeueAfterBuild(ctx, oldBuild, build, existingWorkflow)
+			return r.handleRequeueAfterBuild(ctx, oldBuild, build)
 		}
 
 		// When ci workflow is completed, it is required to update conditions
@@ -352,10 +352,7 @@ func isBuildStepRunning(build *choreov1.Build) bool {
 }
 
 // handleRequeueAfterBuild manages the requeue process after a build step.
-// This function is specific to Argo Workflows.
-func (r *Reconciler) handleRequeueAfterBuild(
-	ctx context.Context, old, build *choreov1.Build, workflow *argoproj.Workflow,
-) (ctrl.Result, error) {
+func (r *Reconciler) handleRequeueAfterBuild(ctx context.Context, old, build *choreov1.Build) (ctrl.Result, error) {
 	// Check if the build step is running and has not yet succeeded.
 	if isBuildStepRunning(build) {
 		// Requeue after 20 seconds to provide a controlled interval instead of exponential backoff.


### PR DESCRIPTION
## Purpose
The build conditions were not being updated promptly upon workflow completion. This issue was introduced after recent changes to how build conditions are handled. To ensure timely updates, the requeue logic needed to be updated accordingly.

## Approach
Revised the requeue logic to be compatible with the updated build condition structure, ensuring build status reflects the actual state of the workflow on time.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/142

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
