### PR TITLE
Fix Resource Deletion

### DIFF
--- a/internal/controller/component/controller_finalize.go
+++ b/internal/controller/component/controller_finalize.go
@@ -103,7 +103,7 @@ func (r *Reconciler) deleteDeploymentTracksAndWait(ctx context.Context, componen
 		client.MatchingLabels{
 			labels.LabelKeyOrganizationName: controller.GetOrganizationName(component),
 			labels.LabelKeyProjectName:      controller.GetProjectName(component),
-			labels.LabelKeyComponentName:    component.Name,
+			labels.LabelKeyComponentName:    controller.GetName(component),
 		},
 	}
 

--- a/internal/controller/deployment/controller_finalize.go
+++ b/internal/controller/deployment/controller_finalize.go
@@ -145,11 +145,11 @@ func (r *Reconciler) cleanupEndpoints(ctx context.Context, deployment *choreov1.
 	listOpts := []client.ListOption{
 		client.InNamespace(deployment.Namespace),
 		client.MatchingLabels{
-			labels.LabelKeyDeploymentName:      deployment.Name,
-			labels.LabelKeyOrganizationName:    deployment.Labels[labels.LabelKeyOrganizationName],
-			labels.LabelKeyProjectName:         deployment.Labels[labels.LabelKeyProjectName],
-			labels.LabelKeyComponentName:       deployment.Labels[labels.LabelKeyComponentName],
-			labels.LabelKeyDeploymentTrackName: deployment.Labels[labels.LabelKeyDeploymentTrackName],
+			labels.LabelKeyOrganizationName:    controller.GetOrganizationName(deployment),
+			labels.LabelKeyProjectName:         controller.GetProjectName(deployment),
+			labels.LabelKeyComponentName:       controller.GetComponentName(deployment),
+			labels.LabelKeyDeploymentTrackName: controller.GetDeploymentTrackName(deployment),
+			labels.LabelKeyDeploymentName:      controller.GetName(deployment),
 		},
 	}
 

--- a/internal/controller/deploymenttrack/controller_finalize.go
+++ b/internal/controller/deploymenttrack/controller_finalize.go
@@ -150,7 +150,7 @@ func (r *Reconciler) deleteBuildsAndWait(ctx context.Context, deploymentTrack *c
 			labels.LabelKeyOrganizationName:    controller.GetOrganizationName(deploymentTrack),
 			labels.LabelKeyProjectName:         controller.GetProjectName(deploymentTrack),
 			labels.LabelKeyComponentName:       controller.GetComponentName(deploymentTrack),
-			labels.LabelKeyDeploymentTrackName: deploymentTrack.Name,
+			labels.LabelKeyDeploymentTrackName: controller.GetName(deploymentTrack),
 		},
 	}
 
@@ -215,7 +215,7 @@ func (r *Reconciler) deleteDeployableArtifactsAndWait(ctx context.Context, deplo
 			labels.LabelKeyOrganizationName:    controller.GetOrganizationName(deploymentTrack),
 			labels.LabelKeyProjectName:         controller.GetProjectName(deploymentTrack),
 			labels.LabelKeyComponentName:       controller.GetComponentName(deploymentTrack),
-			labels.LabelKeyDeploymentTrackName: deploymentTrack.Name,
+			labels.LabelKeyDeploymentTrackName: controller.GetName(deploymentTrack),
 		},
 	}
 
@@ -283,7 +283,7 @@ func (r *Reconciler) deleteDeploymentsAndWait(ctx context.Context, deploymentTra
 			labels.LabelKeyOrganizationName:    controller.GetOrganizationName(deploymentTrack),
 			labels.LabelKeyProjectName:         controller.GetProjectName(deploymentTrack),
 			labels.LabelKeyComponentName:       controller.GetComponentName(deploymentTrack),
-			labels.LabelKeyDeploymentTrackName: deploymentTrack.Name,
+			labels.LabelKeyDeploymentTrackName: controller.GetName(deploymentTrack),
 		},
 	}
 

--- a/internal/controller/hierarchy.go
+++ b/internal/controller/hierarchy.go
@@ -206,7 +206,6 @@ func GetDeployableArtifact(ctx context.Context, c client.Client, obj client.Obje
 			labels.LabelKeyProjectName:         GetProjectName(obj),
 			labels.LabelKeyComponentName:       GetComponentName(obj),
 			labels.LabelKeyDeploymentTrackName: GetDeploymentTrackName(obj),
-			labels.LabelKeyBuildName:           GetBuildName(obj),
 		},
 	}
 

--- a/internal/controller/project/controller_finalize.go
+++ b/internal/controller/project/controller_finalize.go
@@ -138,7 +138,7 @@ func (r *Reconciler) deleteComponentsAndWait(ctx context.Context, project *chore
 		client.InNamespace(project.Namespace),
 		client.MatchingLabels{
 			labels.LabelKeyOrganizationName: controller.GetOrganizationName(project),
-			labels.LabelKeyProjectName:      project.Name,
+			labels.LabelKeyProjectName:      controller.GetName(project),
 		},
 	}
 


### PR DESCRIPTION
## Purpose
Currently, when a Component is deleted, only the Component and its associated DeploymentTrack are removed immediately. However, other related resources such as DeployableArtifacts, Deployments, and similar are left behind, resulting in inconsistent cleanup behavior. This PR fixes this bug.

## Approach
Refactored the deletion logic to retrieve and handle related resources using the resource label name (rather than relying on Kubernetes object names). This ensures all associated resources are correctly identified and cleaned up during the deletion.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/180

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
