### PR TITLE
Add direct file mount support with deployable artifact

### DIFF
--- a/internal/controller/deployment/integrations/kubernetes/configmap_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/configmap_handler_test.go
@@ -133,4 +133,26 @@ var _ = Describe("makeConfigMaps", func() {
 		})
 	})
 
+	Context("for a direct file mount", func() {
+		BeforeEach(func() {
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				Application: &choreov1.Application{
+					FileMounts: []choreov1.FileMount{
+						{
+							MountPath: "/app/config.json",
+							Value:     "{\"key\":\"value\"}",
+						},
+					},
+				},
+			}
+		})
+
+		It("should create a ConfigMap with correct data", func() {
+			data := configMaps[0].Data
+			Expect(data).To(BeComparableTo(map[string]string{
+				"content": "{\"key\":\"value\"}",
+			}))
+		})
+	})
+
 })


### PR DESCRIPTION
## Purpose
Add direct file mount support with deployable artifact

## Approach
This PR introduces support for handling direct file mounts using DeployableArtifacts. This includes changes to generate ConfigMaps and Pod specifications for direct file mounts, where each file mount is converted into a configmap and mounted to the pod.

## Related Issues
- #25

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
