### PR TITLE
Fixes delete inconsistencies

### DIFF
--- a/internal/controller/deploymenttrack/controller_finalize.go
+++ b/internal/controller/deploymenttrack/controller_finalize.go
@@ -100,14 +100,14 @@ func (r *Reconciler) finalize(ctx context.Context, old, deploymentTrack *choreov
 func (r *Reconciler) deleteChildResources(ctx context.Context, deploymentTrack *choreov1.DeploymentTrack) (bool, error) {
 	logger := log.FromContext(ctx).WithValues("deploymentTrack", deploymentTrack.Name)
 
-	// Clean up builds
-	buildsDeleted, err := r.deleteBuildsAndWait(ctx, deploymentTrack)
+	// Clean up deployments
+	deploymentsDeleted, err := r.deleteDeploymentsAndWait(ctx, deploymentTrack)
 	if err != nil {
-		logger.Error(err, "Failed to delete builds")
+		logger.Error(err, "Failed to delete deployments")
 		return false, err
 	}
-	if !buildsDeleted {
-		logger.Info("Builds are still being deleted", "name", deploymentTrack.Name)
+	if !deploymentsDeleted {
+		logger.Info("Deployments are still being deleted", "name", deploymentTrack.Name)
 		return false, nil
 	}
 
@@ -122,14 +122,14 @@ func (r *Reconciler) deleteChildResources(ctx context.Context, deploymentTrack *
 		return false, nil
 	}
 
-	// Clean up deployments
-	deploymentsDeleted, err := r.deleteDeploymentsAndWait(ctx, deploymentTrack)
+	// Clean up builds
+	buildsDeleted, err := r.deleteBuildsAndWait(ctx, deploymentTrack)
 	if err != nil {
-		logger.Error(err, "Failed to delete deployments")
+		logger.Error(err, "Failed to delete builds")
 		return false, err
 	}
-	if !deploymentsDeleted {
-		logger.Info("Deployments are still being deleted", "name", deploymentTrack.Name)
+	if !buildsDeleted {
+		logger.Info("Builds are still being deleted", "name", deploymentTrack.Name)
 		return false, nil
 	}
 

--- a/internal/controller/watch.go
+++ b/internal/controller/watch.go
@@ -22,7 +22,6 @@ import (
 	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -34,7 +33,6 @@ func HierarchyWatchHandler[From client.Object, To client.Object](
 	hierarchyFunc HierarchyFunc[To],
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		logger := log.FromContext(ctx)
 
 		fromObj, ok := obj.(From)
 		if !ok {
@@ -43,7 +41,6 @@ func HierarchyWatchHandler[From client.Object, To client.Object](
 
 		toObj, err := hierarchyFunc(ctx, c, fromObj)
 		if err != nil {
-			logger.Error(err, "failed to resolve target object", "source", fromObj)
 			return nil
 		}
 

--- a/internal/controller/watch.go
+++ b/internal/controller/watch.go
@@ -33,7 +33,6 @@ func HierarchyWatchHandler[From client.Object, To client.Object](
 	hierarchyFunc HierarchyFunc[To],
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-
 		fromObj, ok := obj.(From)
 		if !ok {
 			return nil


### PR DESCRIPTION
## Purpose
1. The finalize at deploymenttrack delete child resources builds, deployableartifacts and deployments. The delete order matters since deployments build a context for deletion. 
This PR arranges the order as deployments - deployableartifacts - builds.

2. Due to timing issues within the K8s ecosystem events which were triggered due to a delete were being detected at the controller watch after the parents were deleted. However, there is no error in the delete - all resources are cleaned up properly. This error was removed since it was not actually an error.



