### PR TITLE
Add configuration group get/list to the CLI

### DIFF
--- a/internal/choreoctl/cmd/get/configurationgroup/configurationgroup.go
+++ b/internal/choreoctl/cmd/get/configurationgroup/configurationgroup.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package configurationgroup
+
+import (
+	"fmt"
+
+	"github.com/openchoreo/openchoreo/internal/choreoctl/resources"
+	"github.com/openchoreo/openchoreo/internal/choreoctl/resources/kinds"
+	"github.com/openchoreo/openchoreo/internal/choreoctl/validation"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/types/api"
+)
+
+// GetConfigurationGroupImpl implements the GetConfigurationGroup command
+type GetConfigurationGroupImpl struct {
+	config constants.CRDConfig
+}
+
+// NewGetConfigurationGroupImpl creates a new GetConfigurationGroupImpl instance
+func NewGetConfigurationGroupImpl(config constants.CRDConfig) *GetConfigurationGroupImpl {
+	return &GetConfigurationGroupImpl{
+		config: config,
+	}
+}
+
+// GetConfigurationGroup gets the configuration groups based on the provided parameters
+func (i *GetConfigurationGroupImpl) GetConfigurationGroup(params api.GetConfigurationGroupParams) error {
+	if err := validation.ValidateParams(validation.CmdGet, validation.ResourceConfigurationGroup, params); err != nil {
+		return err
+	}
+
+	return getConfigurationGroups(params, i.config)
+}
+
+func getConfigurationGroups(params api.GetConfigurationGroupParams, config constants.CRDConfig) error {
+	configGroupRes, err := kinds.NewConfigurationGroupResource(config, params.Organization)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve ConfigurationGroup resource: %w", err)
+	}
+
+	filter := &resources.ResourceFilter{
+		Name: params.Name,
+	}
+
+	format := resources.OutputFormatTable
+	if params.OutputFormat == constants.OutputFormatYAML {
+		format = resources.OutputFormatYAML
+	}
+
+	return configGroupRes.Print(format, filter)
+}

--- a/internal/choreoctl/impl.go
+++ b/internal/choreoctl/impl.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/choreoctl/cmd/delete"
 	getbuild "github.com/openchoreo/openchoreo/internal/choreoctl/cmd/get/build"
 	getcomponent "github.com/openchoreo/openchoreo/internal/choreoctl/cmd/get/component"
+	getconfigurationgroup "github.com/openchoreo/openchoreo/internal/choreoctl/cmd/get/configurationgroup"
 	getdataplane "github.com/openchoreo/openchoreo/internal/choreoctl/cmd/get/dataplane"
 	getdeployartifcat "github.com/openchoreo/openchoreo/internal/choreoctl/cmd/get/deployableartifact"
 	getdeploy "github.com/openchoreo/openchoreo/internal/choreoctl/cmd/get/deployment"
@@ -230,4 +231,9 @@ func (c *CommandImplementation) UseContext(params api.UseContextParams) error {
 func (c *CommandImplementation) GetDeploymentPipeline(params api.GetDeploymentPipelineParams) error {
 	pipelineImpl := getdeploymentpipeline.NewGetDeploymentPipelineImpl(constants.DeploymentPipelineV1Config)
 	return pipelineImpl.GetDeploymentPipeline(params)
+}
+
+func (c *CommandImplementation) GetConfigurationGroup(params api.GetConfigurationGroupParams) error {
+	configurationGroupImpl := getconfigurationgroup.NewGetConfigurationGroupImpl(constants.ConfigurationGroupV1Config)
+	return configurationGroupImpl.GetConfigurationGroup(params)
 }

--- a/internal/choreoctl/resources/kinds/configurationgroup.go
+++ b/internal/choreoctl/resources/kinds/configurationgroup.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kinds
+
+import (
+	"fmt"
+
+	choreov1 "github.com/openchoreo/openchoreo/api/v1"
+	"github.com/openchoreo/openchoreo/internal/choreoctl/resources"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+)
+
+// ConfigurationGroupResource provides operations for ConfigurationGroup CRs.
+type ConfigurationGroupResource struct {
+	*resources.BaseResource[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList]
+}
+
+// NewConfigurationGroupResource constructs a ConfigurationGroupResource with CRDConfig and optionally sets organization.
+func NewConfigurationGroupResource(cfg constants.CRDConfig, org string) (*ConfigurationGroupResource, error) {
+	cli, err := resources.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	options := []resources.ResourceOption[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList]{
+		resources.WithClient[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList](cli),
+		resources.WithConfig[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList](cfg),
+	}
+
+	// Add organization namespace if provided
+	if org != "" {
+		options = append(options, resources.WithNamespace[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList](org))
+	}
+
+	// Create labels for filtering
+	labels := map[string]string{}
+	if org != "" {
+		labels[constants.LabelOrganization] = org
+	}
+
+	// Add labels if any were set
+	if len(labels) > 0 {
+		options = append(options, resources.WithLabels[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList](labels))
+	}
+
+	return &ConfigurationGroupResource{
+		BaseResource: resources.NewBaseResource[*choreov1.ConfigurationGroup, *choreov1.ConfigurationGroupList](options...),
+	}, nil
+}
+
+// WithNamespace sets the namespace for the configuration group resource (usually the organization name)
+func (d *ConfigurationGroupResource) WithNamespace(namespace string) {
+	d.BaseResource.WithNamespace(namespace)
+}
+
+// GetStatus returns the status of a ConfigurationGroup with detailed information.
+func (d *ConfigurationGroupResource) GetStatus(cg *choreov1.ConfigurationGroup) string {
+	// ConfigurationGroup uses the Available condition type
+	priorityConditions := []string{
+		controller.TypeAvailable,
+	}
+
+	return resources.GetResourceStatus(
+		cg.Status.Conditions,
+		priorityConditions,
+		StatusPending,
+		StatusReady,
+		StatusFailed,
+	)
+}
+
+// GetAge returns the age of a ConfigurationGroup.
+func (d *ConfigurationGroupResource) GetAge(cg *choreov1.ConfigurationGroup) string {
+	return resources.FormatAge(cg.GetCreationTimestamp().Time)
+}
+
+// PrintTableItems formats configuration groups into a table
+func (d *ConfigurationGroupResource) PrintTableItems(cgs []resources.ResourceWrapper[*choreov1.ConfigurationGroup]) error {
+	if len(cgs) == 0 {
+		namespaceName := d.GetNamespace()
+		message := "No configuration groups found"
+		if namespaceName != "" {
+			message += " in organization " + namespaceName
+		}
+		fmt.Println(message)
+		return nil
+	}
+
+	rows := make([][]string, 0, len(cgs))
+
+	for _, wrapper := range cgs {
+		cg := wrapper.Resource
+		rows = append(rows, []string{
+			cg.Name,
+			d.GetStatus(cg),
+			d.GetAge(cg),
+		})
+	}
+
+	headers := []string{"Name", "Status", "Age"}
+	return resources.PrintTable(headers, rows)
+}
+
+// Print overrides the base Print method to ensure our custom PrintTableItems is called
+func (d *ConfigurationGroupResource) Print(format resources.OutputFormat, filter *resources.ResourceFilter) error {
+	return d.BaseResource.Print(format, filter)
+}

--- a/internal/choreoctl/validation/commands.go
+++ b/internal/choreoctl/validation/commands.go
@@ -50,6 +50,7 @@ const (
 	ResourceLogs               ResourceType = "logs"
 	ResourceApply              ResourceType = "apply"
 	ResourceDeploymentPipeline ResourceType = "deploymentpipeline"
+	ResourceConfigurationGroup ResourceType = "configurationgroup"
 )
 
 // checkRequiredFields verifies if all required fields are populated

--- a/internal/choreoctl/validation/params.go
+++ b/internal/choreoctl/validation/params.go
@@ -54,6 +54,8 @@ func ValidateParams(cmdType CommandType, resource ResourceType, params interface
 		return validateApplyParams(cmdType, params)
 	case ResourceDeploymentPipeline:
 		return validateDeploymentPipelineParams(cmdType, params)
+	case ResourceConfigurationGroup:
+		return validateConfigurationGroupParams(cmdType, params)
 	default:
 		return fmt.Errorf("unknown resource type: %s", resource)
 	}
@@ -400,6 +402,20 @@ func validateDeploymentPipelineParams(cmdType CommandType, params interface{}) e
 
 			if !checkRequiredFields(fields) {
 				return generateHelpError(cmdType, ResourceDeploymentPipeline, fields)
+			}
+		}
+	}
+	return nil
+}
+
+func validateConfigurationGroupParams(cmdType CommandType, params interface{}) error {
+	if cmdType == CmdGet {
+		if p, ok := params.(api.GetConfigurationGroupParams); ok {
+			fields := map[string]string{
+				"organization": p.Organization,
+			}
+			if !checkRequiredFields(fields) {
+				return generateHelpError(cmdType, ResourceConfigurationGroup, fields)
 			}
 		}
 	}

--- a/pkg/cli/cmd/get/get.go
+++ b/pkg/cli/cmd/get/get.go
@@ -268,5 +268,24 @@ func NewListCmd(impl api.CommandImplementationInterface) *cobra.Command {
 	deploymentPipelineCmd.Args = cobra.MaximumNArgs(1)
 	listCmd.AddCommand(deploymentPipelineCmd)
 
+	// Configuration groups command
+	configurationGroupsCmd := (&builder.CommandBuilder{
+		Command: constants.ListConfigurationGroup,
+		Flags:   []flags.Flag{flags.Organization, flags.Output, flags.Interactive},
+		RunE: func(fg *builder.FlagGetter) error {
+			name := ""
+			if len(fg.GetArgs()) > 0 {
+				name = fg.GetArgs()[0]
+			}
+			return impl.GetConfigurationGroup(api.GetConfigurationGroupParams{
+				Name:         name,
+				Organization: fg.GetString(flags.Organization),
+				OutputFormat: fg.GetString(flags.Output),
+			})
+		},
+	}).Build()
+	configurationGroupsCmd.Args = cobra.MaximumNArgs(1)
+	listCmd.AddCommand(configurationGroupsCmd)
+
 	return listCmd
 }

--- a/pkg/cli/common/constants/crds.go
+++ b/pkg/cli/common/constants/crds.go
@@ -116,8 +116,13 @@ var (
 		Kind:    "Environment",
 	}
 	DeploymentPipelineV1Config = CRDConfig{
-		Group:   "core.choreo.dev",
+		Group:   ChoreoGroup,
 		Version: "v1",
 		Kind:    "DeploymentPipeline",
+	}
+	ConfigurationGroupV1Config = CRDConfig{
+		Group:   ChoreoGroup,
+		Version: "v1",
+		Kind:    "ConfigurationGroup",
 	}
 )

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -501,6 +501,21 @@ If no organization is specified, you will be prompted to select one interactivel
   choreoctl get deploymentpipeline --organization acme-corp -o yaml`,
 	}
 
+	ListConfigurationGroup = Command{
+		Use:     "configurationgroup [name]",
+		Aliases: []string{"cg", "configurationgroup"},
+		Short:   "List configuration groups",
+		Long:    `List all configuration groups or a specific configuration group in an organization.`,
+		Example: `  # List all configuration groups
+  choreoctl get configurationgroup --organization acme-corp
+
+  # List a specific configuration group
+  choreoctl get configurationgroup config-group-1 --organization acme-corp
+
+  # Output configuration group details in YAML format
+  choreoctl get configurationgroup --organization acme-corp -o yaml`,
+	}
+
 	// ------------------------------------------------------------------------
 	// Config Command Definitions
 	// ------------------------------------------------------------------------

--- a/pkg/cli/types/api/api.go
+++ b/pkg/cli/types/api/api.go
@@ -37,6 +37,7 @@ type CommandImplementationInterface interface {
 	EndpointAPI
 	ConfigContextAPI
 	DeploymentPipelineAPI
+	ConfigurationGroupAPI
 }
 
 // OrganizationAPI defines organization-related operations
@@ -128,4 +129,8 @@ type ConfigContextAPI interface {
 type DeploymentPipelineAPI interface {
 	CreateDeploymentPipeline(params CreateDeploymentPipelineParams) error
 	GetDeploymentPipeline(params GetDeploymentPipelineParams) error
+}
+
+type ConfigurationGroupAPI interface {
+	GetConfigurationGroup(params GetConfigurationGroupParams) error
 }

--- a/pkg/cli/types/api/params.go
+++ b/pkg/cli/types/api/params.go
@@ -335,3 +335,9 @@ type GetDeploymentPipelineParams struct {
 	Organization string
 	OutputFormat string
 }
+
+type GetConfigurationGroupParams struct {
+	Name         string
+	Organization string
+	OutputFormat string
+}


### PR DESCRIPTION
## Purpose
Add configuration group get/list to the CLI

## Approach
This PR includes the CLI changes related to the ConfigurationGroups, where it can get and list the config group resource.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
