### PR TITLE
Add Default Single Cluster Installation Guide 

### DIFF
--- a/docs/contributors/contribute.md
+++ b/docs/contributors/contribute.md
@@ -54,13 +54,20 @@ For testing and development, we recommend using a KinD (Kubernetes in Docker) cl
 4. Once completed, you can verify the deployment by running:
 
    ```sh
-   ./install/check-status.sh --single-cluster
+   ./install/check-status.sh
    ```
 
 > [!IMPORTANT]
 > The KinD cluster will already have the manager running and if you need to run the manager locally, you need to scale down the existing manager deployment first. 
 You can do this by running: `kubectl -n choreo-system scale deployment choreo-controller-manager --replicas=0`
 
+5. Add default DataPlane to the cluster:
+
+    OpenChoreo requires a DataPlane to deploy and manage its resources.
+
+   ```sh
+   bash ./install/add-default-dataplane.sh
+   ```
 
 ### Building and Running the Binaries
 

--- a/docs/contributors/contribute.md
+++ b/docs/contributors/contribute.md
@@ -48,10 +48,13 @@ For testing and development, we recommend using a KinD (Kubernetes in Docker) cl
    ```
    This may take around 5-15 minutes to complete depending on the internet bandwidth.
 
+> [!NOTE]
+> This command installs both the control plane and data plane components in the same cluster.
+
 4. Once completed, you can verify the deployment by running:
 
    ```sh
-   ./install/check-status.sh
+   ./install/check-status.sh --single-cluster
    ```
 
 > [!IMPORTANT]

--- a/docs/install-guide-multi-cluster.md
+++ b/docs/install-guide-multi-cluster.md
@@ -1,21 +1,21 @@
 # OpenChoreo Installation
 
 This guide walks you through the installation and setup of OpenChoreo on a multi-cluster Kubernetes environment. 
-The process involves creating and configuring two Kubernetes clusters: one for the **Control Plane** and another for the **DataPlane**. 
-After configuring the clusters, you will install OpenChoreo using Helm, verify the installation, and install the choreoctl CLI tool to manage OpenChoreo components.
+The process involves creating and configuring two Kubernetes clusters: one for the **Control Plane** and another for the **Data Plane**. 
+After configuring the clusters, you will install OpenChoreo using Helm, verify the installation, and install the `choreoctl` CLI tool to manage OpenChoreo components.
 
 By the end of this guide, you'll have a fully functional OpenChoreo deployment running on a multi-cluster setup.
 
 
 ## Create Compatible Kubernetes Clusters
 
-You need two Kubernetes clusters: one for the Control Plane and one for the Data Plane. The Data Plane cluster should have Cilium installed for compatibility with OpenChoreo.
+You need two Kubernetes clusters: one for the Control Plane and one for the Data Plane. The Data Plane cluster should have Cilium installed to be compatible with OpenChoreo.
 
 If you don’t have compatible Kubernetes clusters yet, you can create them using the following guide on your local machine.
 
 ### Kind
 
-In this section, you'll learn how to set up a [kind](https://kind.sigs.k8s.io/) clusters and install Cilium in the Data Plane cluster to make it compatible with OpenChoreo.
+In this section, you'll learn how to set up two [kind](https://kind.sigs.k8s.io/) clusters and install Cilium in the Data Plane cluster to make it compatible with OpenChoreo.
 
 #### Prerequisites
 
@@ -118,9 +118,6 @@ bash <(curl -sL https://raw.githubusercontent.com/openchoreo/openchoreo/main/ins
 The script will display the current status of OpenChoreo components across both clusters.
 
 Once you are done with the installation, you can try out our [samples](../samples) to get a better understanding of OpenChoreo.
-
-> [!TIP]
-> Refer to "Exposing the OpenChoreo Gateway" section to learn how to access the components you create in OpenChoreo via the external gateway.
 
 ## Add Default DataPlane
 

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -3,11 +3,9 @@
 This guide walks you through installing and setting up OpenChoreo on a single Kubernetes cluster using kind. 
 The *Control Plane* and *Data Plane* components will run on the same cluster. This is ideal for local development or trying out OpenChoreo quickly.
 
-You'll start by creating a compatible Kubernetes cluster with Cilium, install OpenChoreo using CP and DP Helm charts, and set up the choreoctl CLI.
+You'll start by creating a compatible Kubernetes cluster with Cilium as the CNI. Then, install OpenChoreo using the Control Plane (CP) and Data Plane (DP) Helm charts, and configure the `choreoctl` CLI tool..
 
-Additionally, the guide provides options to expose the OpenChoreo external gateway service to your host machine, enabling seamless access to the components you create.
-
-If you don't have a compatible kubernetes cluster, you can create one of following in your local machine and start testing.
+Additionally, the guide provides options to expose the OpenChoreo external gateway service to your host machine, enabling seamless access to the components deploy in OpenChoreo.
 
 ### Kind
 

--- a/install/add-default-dataplane.sh
+++ b/install/add-default-dataplane.sh
@@ -15,11 +15,11 @@ KUBECONFIG=${KUBECONFIG:-~/.kube/config}
 
 echo -e "\nSetting up Choreo DataPlane\n"
 
-SINGLE_CLUSTER=false
+SINGLE_CLUSTER=true
 
 # Detect if running in single-cluster mode via env var
-if [[ "$1" == "--single-cluster" ]]; then
-  SINGLE_CLUSTER=true
+if [[ "$1" == "--multi-cluster" ]]; then
+  SINGLE_CLUSTER=false
 fi
 
 if [[ "$SINGLE_CLUSTER" == "true" ]]; then

--- a/install/check-status.sh
+++ b/install/check-status.sh
@@ -18,7 +18,7 @@ cilium_deps=("app.kubernetes.io/name=cilium-agent" "app.kubernetes.io/name=ciliu
 vault_deps=("app.kubernetes.io/name=vault")
 argo_deps=("app.kubernetes.io/name=argo-workflows-server" "app.kubernetes.io/name=argo-workflows-workflow-controller")
 cert_manager_deps=("app.kubernetes.io/name=certmanager" "app.kubernetes.io/name=cainjector" "app.kubernetes.io/name=webhook")
-choreo_controller_deps=("app.kubernetes.io/name=choreo-cp")
+choreo_controller_deps=("app.kubernetes.io/name=choreo-control-plane")
 choreo_image_registry_deps=("app=registry")
 redis_deps=("app=redis")
 envoy_gateway_deps=("app.kubernetes.io/name=gateway-helm")

--- a/install/check-status.sh
+++ b/install/check-status.sh
@@ -107,9 +107,9 @@ print_component_status() {
 # Main
 # --------------------------
 
-SINGLE_CLUSTER=false
-if [[ "$1" == "--single-cluster" ]]; then
-    SINGLE_CLUSTER=true
+SINGLE_CLUSTER=true
+if [[ "$1" == "--multi-cluster" ]]; then
+    SINGLE_CLUSTER=false
 fi
 
 if [[ "$SINGLE_CLUSTER" == "true" ]]; then

--- a/install/helm/choreo-control-plane/Chart.lock
+++ b/install/helm/choreo-control-plane/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.jetstack.io
   version: v1.16.2
 digest: sha256:dd6953d54aeda0d8a27f5089a45eb6c7eff8de6a038c2c4a0128cec2129c53a1
-generated: "2025-05-09T09:36:17.45767+05:30"
+generated: "2025-05-26T14:39:59.596749+05:30"

--- a/install/helm/choreo-control-plane/templates/default-choreo-artifacts/wait-for-controller-hook.yaml
+++ b/install/helm/choreo-control-plane/templates/default-choreo-artifacts/wait-for-controller-hook.yaml
@@ -22,7 +22,7 @@ spec:
               echo "Waiting for choreo controller to be ready..."
               kubectl wait --namespace {{ .Release.Namespace }} \
               --for=condition=Ready pod \
-              -l app.kubernetes.io/name=choreo-cp,control-plane=controller-manager \
+              -l app.kubernetes.io/name=choreo-control-plane,control-plane=controller-manager \
               --timeout=900s
       restartPolicy: Never
   backoffLimit: 5

--- a/install/helm/choreo-dataplane/Chart.lock
+++ b/install/helm/choreo-dataplane/Chart.lock
@@ -15,4 +15,4 @@ dependencies:
   repository: https://argoproj.github.io/argo-helm
   version: 0.45.2
 digest: sha256:6ad8b563a12d6b8bd879f8e03756ce5d3e45ffb619475c01b3d4973a593651c8
-generated: "2025-05-09T09:36:22.089412+05:30"
+generated: "2025-05-27T11:12:37.475192+05:30"

--- a/install/helm/choreo-dataplane/templates/default-choreo-artifacts/vault-config-job.yaml
+++ b/install/helm/choreo-dataplane/templates/default-choreo-artifacts/vault-config-job.yaml
@@ -23,7 +23,7 @@ spec:
         - -c
         - |          
           # Set environment variables
-          export VAULT_ADDR=http://choreo-dp-vault.{{ .Release.Namespace }}.svc:8200
+          export VAULT_ADDR=http://choreo-dataplane-vault.{{ .Release.Namespace }}.svc:8200
           export VAULT_TOKEN={{ .Values.vault.server.dev.devRootToken }}
           
           # Enable Kubernetes authentication

--- a/internal/controller/deployment/integrations/kubernetes/secretproviderclass_handler.go
+++ b/internal/controller/deployment/integrations/kubernetes/secretproviderclass_handler.go
@@ -38,7 +38,7 @@ const (
 	// TODO: Make this configurable
 	hashicorpVaultProvider = "vault"
 	hashicorpVaultRoleName = "choreo-secret-reader-role"
-	hashicorpVaultAddress  = "http://choreo-dp-vault:8200"
+	hashicorpVaultAddress  = "http://choreo-dataplane-vault:8200"
 )
 
 type secretProviderClassHandler struct {

--- a/internal/controller/deployment/integrations/kubernetes/secretproviderclass_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/secretproviderclass_handler_test.go
@@ -88,7 +88,7 @@ var _ = Describe("makeSecretProviderClasses", func() {
 			By("checking the Parameters")
 			Expect(spec.Parameters).To(BeComparableTo(map[string]string{
 				"roleName":     "choreo-secret-reader-role",
-				"vaultAddress": "http://choreo-dp-vault:8200",
+				"vaultAddress": "http://choreo-dataplane-vault:8200",
 				"objects":      "- objectName: password\n  secretPath: secret/test/redis/password\n  secretKey: value\n",
 			}))
 
@@ -116,7 +116,7 @@ var _ = Describe("makeSecretProviderClasses", func() {
 			By("checking the Parameters")
 			Expect(spec.Parameters).To(BeComparableTo(map[string]string{
 				"roleName":     "choreo-secret-reader-role",
-				"vaultAddress": "http://choreo-dp-vault:8200",
+				"vaultAddress": "http://choreo-dataplane-vault:8200",
 				"objects":      "- objectName: password\n  secretPath: secret/test/mysql/password\n  secretKey: value\n",
 			}))
 
@@ -173,7 +173,7 @@ var _ = Describe("makeSecretProviderClasses", func() {
 			By("checking the Parameters")
 			Expect(spec.Parameters).To(BeComparableTo(map[string]string{
 				"roleName":     "choreo-secret-reader-role",
-				"vaultAddress": "http://choreo-dp-vault:8200",
+				"vaultAddress": "http://choreo-dataplane-vault:8200",
 				"objects":      "- objectName: client-secret\n  secretPath: secret/test/salesforce/client-secret\n  secretKey: value\n",
 			}))
 

--- a/make/kube.mk
+++ b/make/kube.mk
@@ -41,7 +41,7 @@ dev-deploy: ## Deploy the Choreo developer version to a Kind cluster configured 
 	helm upgrade --install choreo-control-plane $(HELM_CHARTS_OUTPUT_DIR)/choreo-control-plane-$(HELM_CHART_VERSION).tgz \
     	--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
 	helm upgrade --install choreo-dataplane $(HELM_CHARTS_OUTPUT_DIR)/choreo-dataplane-$(HELM_CHART_VERSION).tgz \
-		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
+		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m --set certmanager.enabled=false --set certmanager.crds.enabled=false
 
 .PHONY: dev-undeploy
 dev-undeploy: ## Undeploy the Choreo developer version from a Kind cluster configured in ~/.kube/config

--- a/make/kube.mk
+++ b/make/kube.mk
@@ -34,14 +34,17 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated 
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: dev-deploy
-dev-deploy: ## Deploy the Choreo developer version to a Kind cluster configured in ~/.kube/config
+dev-deploy: ## Deploy the Choreo developer version to a Kind cluster configured in ~/.kube/config (Single Cluster Mode)
 	@$(MAKE) helm-package
 	helm upgrade --install cilium $(HELM_CHARTS_OUTPUT_DIR)/cilium-$(HELM_CHART_VERSION).tgz \
 		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
-	helm upgrade --install choreo $(HELM_CHARTS_OUTPUT_DIR)/choreo-$(HELM_CHART_VERSION).tgz \
+	helm upgrade --install choreo-control-plane $(HELM_CHARTS_OUTPUT_DIR)/choreo-control-plane-$(HELM_CHART_VERSION).tgz \
     	--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
+	helm upgrade --install choreo-dataplane $(HELM_CHARTS_OUTPUT_DIR)/choreo-dataplane-$(HELM_CHART_VERSION).tgz \
+		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
 
 .PHONY: dev-undeploy
 dev-undeploy: ## Undeploy the Choreo developer version from a Kind cluster configured in ~/.kube/config
-	helm uninstall choreo --namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)"
 	helm uninstall cilium --namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)"
+	helm uninstall choreo-control-plane --namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)"
+	helm uninstall choreo-dataplane --namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)"


### PR DESCRIPTION
## Purpose
The default Helm chart installation was encountering errors. To address this, we need to provide a dedicated single cluster setup guide as the default installation method.

## Approach
The installation error was resolved by aligning the Helm release name with the chart name. When the names differ, their concatenation causes component names to exceed the 63-character limit. 

A separate single cluster setup guide has been added and set as the default. Additionally, installation scripts have been updated to work correctly with this setup.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/159

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
