### PR TITLE
Add version to helm install commands

### DIFF
--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -75,13 +75,13 @@ Run the following two Helm commands to install OpenChoreo into your cluster:
 
 ```shell
 helm install choreo-control-plane oci://ghcr.io/openchoreo/helm-charts/choreo-control-plane \
---kube-context kind-choreo --namespace "choreo-system" --create-namespace --timeout 30m
+--kube-context kind-choreo --namespace "choreo-system" --create-namespace --timeout 30m --version 0.0.0-latest-dev
 ```
 
 ```shell
 helm install choreo-dataplane oci://ghcr.io/openchoreo/helm-charts/choreo-dataplane \
 --kube-context kind-choreo  --namespace "choreo-system" --create-namespace --timeout 30m \
---set certmanager.enabled=false --set certmanager.crds.enabled=false
+--set certmanager.enabled=false --set certmanager.crds.enabled=false --version 0.0.0-latest-dev
 ```
 
 2. Verify the Installation


### PR DESCRIPTION
## Purpose
Currently the helm install commands in [install-guide.md](https://github.com/openchoreo/openchoreo/blob/main/docs/install-guide.md) fail because a version argument is missing.

Could this issue be caused by the current `0.0.0-latest-dev` version as `helm install` should normally install the latest version if no version is provided?

## Approach
Add a version argument.

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
N/A
