### PR TITLE
Change make target for choreoctl

### DIFF
--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -131,7 +131,7 @@ Once you are done with the installation, you can try out our [samples](../sample
 From the root level of the repo, run:
 
 ```shell
-make choreoctl-release
+make go.build
 ```
 
 Once this is completed, it will have a `dist` directory created in the project root directory.


### PR DESCRIPTION
## Purpose
The `choreoctl-release` make target does not exist so when following the [install-guide.md](https://github.com/openchoreo/openchoreo/blob/main/docs/install-guide.md) you currently get an error:
```
make: *** No rule to make target `choreoctl-release'.  Stop.
```

## Approach
Change the make target to one that exists.

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
N/A
