### PR TITLE
Fix choreoctl-install.sh

### DIFF
--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -207,7 +207,7 @@ You will see an output similar to the following:
 
 ```text
 NAME                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)         AGE
-choreo--external-gateway   LoadBalancer   10.96.75.106   <pending>     443:30807/TCP   55m
+choreo-external-gateway   LoadBalancer   10.96.75.106   <pending>     443:30807/TCP   55m
 ```
 
 You have two options to expose the DataPlane choreo-external-gateway service to your host machine.

--- a/install/choreoctl-install.sh
+++ b/install/choreoctl-install.sh
@@ -26,7 +26,7 @@ main() {
     local CHOREO_DIR=~/.choreoctl
     local CHOREO_BIN_DIR=$CHOREO_DIR/bin
     local CHOREO_CLI_EXEC=$CHOREO_BIN_DIR/choreoctl
-    local DIST_DIR="dist/choreoctl"
+    local DIST_DIR="bin/dist"
 
     mkdir -p $CHOREO_BIN_DIR
 
@@ -37,7 +37,7 @@ main() {
     fi
 
     # Check if binary exists for current platform
-    local PLATFORM_DIR="$DIST_DIR/$OS-$ARCH"
+    local PLATFORM_DIR="$DIST_DIR/$OS/$ARCH"
     if [ ! -d "$PLATFORM_DIR" ]; then
         echo "Error: No binary found for $OS-$ARCH platform"
         exit 1
@@ -86,7 +86,6 @@ export PATH=$CHOREO_DIR/bin:\${PATH}\\
 
         # Try to update PATH in current session
         export CHOREOCTL_DIR=$CHOREO_DIR
-        export PATH=$CHOREO_DIR/bin:${PATH}
 
         # Check if it's accessible in current session
         if command -v choreoctl >/dev/null 2>&1; then


### PR DESCRIPTION
## Purpose
Make the installation of `choreoctl` work.

## Approach
- Installation guides
    - Fix a path to `choreoctl-install.sh` (it's in another directory)
    - Fix name of `choreo-external-gateway` service
- Fix `choreoctl-install.sh`
    - Fix `DIST_DIR` and  `PLATFORM_DIR`
    - No longer add `choreoctl` to PATH of current session so that the "To use choreoctl in this terminal session..." message will be echoed

## Related Issues
none

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
1. @bprins and some colleagues of us are trying to get started with openchoreo, that's why you're seeing PRs from multiple people today 🤓. We aligned these changes, so combining our PRs should work.
2. Maybe removing the `export PATH` command is not what you intended, but then we need another solution. Because when the `choreoctl-install.sh` script completes on ubuntu, PATH no longer contains choreoctl.
