### PR TITLE
Allow Any Data Plane Cluster to Act as a Build Plane

### DIFF
--- a/docs/configure-build-plane.md
+++ b/docs/configure-build-plane.md
@@ -1,0 +1,26 @@
+# Configuring the Build Plane in OpenChoreo
+
+This guide walks you through setting up a **Build Plane** in OpenChoreo.
+
+## Overview
+
+An organization can have only **one Build Plane**, which is responsible for executing build workloads. These workloads run in a dedicated namespace named: `choreo-ci-<your-org>`
+
+> [!NOTE]
+> `BuildPlane` CRD support is on the roadmap and will be available in a future release. Currently, the Build Plane runs within a **Data Plane** cluster.
+
+## Using a DataPlane as the Build Plane
+
+Until native support for the `BuildPlane` custom resource is available, you can designate a `DataPlane` to act as the Build Plane.
+
+### Steps
+
+1. Ensure Argo Workflows is installed in the target DataPlane cluster.
+2. Add the following label to the `DataPlane` resource:
+
+   ```yaml
+   core.choreo.dev/build-plane: "true"
+   ```
+
+> [!IMPORTANT]
+> You must configure only one DataPlane as the Build Plane.

--- a/docs/install-guide-multi-cluster.md
+++ b/docs/install-guide-multi-cluster.md
@@ -89,7 +89,7 @@ Install the Control Plane using Helm:
 
 ```shell
 helm install choreo-control-plane oci://ghcr.io/openchoreo/helm-charts/choreo-control-plane \
---kube-context kind-choreo-cp --namespace "choreo-system" --create-namespace --timeout 30m
+--kube-context kind-choreo-cp --namespace "choreo-system" --create-namespace --timeout 30m --version 0.0.0-latest-dev
 ```
 
  2. Install OpenChoreo DataPlane
@@ -98,8 +98,11 @@ Install the Data Plane using Helm:
 
 ```shell
 helm install choreo-dataplane oci://ghcr.io/openchoreo/helm-charts/choreo-dataplane \
---kube-context kind-choreo-dp --namespace "choreo-system" --create-namespace --timeout 30m
+--kube-context kind-choreo-dp --namespace "choreo-system" --create-namespace --timeout 30m --version 0.0.0-latest-dev
 ```
+
+> [!TIP]
+> To install the DataPlane without Argo Workflows, append the following flag: `--set argo-workflows.enabled=false`.
 
 3. Verify the Installation
 

--- a/docs/install-guide-multi-cluster.md
+++ b/docs/install-guide-multi-cluster.md
@@ -169,7 +169,7 @@ Once this is completed, it will have a `dist` directory created in the project r
 Run the following command to install the `choreoctl` CLI into your host machine.
 
 ```shell
-./dist/choreoctl/choreoctl-install.sh
+./install/choreoctl-install.sh
 ````
 
 To verify the installation, run:
@@ -229,14 +229,14 @@ Once you successfully [installed OpenChoreo](#install-openchoreo) into your clus
 You can see the service using the following command.
 
 ```shell
-kubectl --context=kind-choreo-dp get svc choreo-dataplane-external-gateway -n choreo-system
+kubectl --context=kind-choreo-dp get svc choreo-external-gateway -n choreo-system
 ```
 
 You will see an output similar to the following:
 
 ```text
 NAME                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)         AGE
-choreo-dataplane-external-gateway   LoadBalancer   10.96.75.106   <pending>     443:30807/TCP   55m
+choreo-external-gateway   LoadBalancer   10.96.75.106   <pending>     443:30807/TCP   55m
 ```
 
 You have two options to expose the DataPlane choreo-external-gateway service to your host machine.

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -141,7 +141,7 @@ Once this is completed, it will have a `dist` directory created in the project r
 Run the following command to install the `choreoctl` CLI into your host machine.
 
 ```shell
-./dist/choreoctl/choreoctl-install.sh
+./install/choreoctl-install.sh
 ````
 
 To verify the installation, run:
@@ -201,14 +201,14 @@ Once you successfully [installed OpenChoreo](#install-openchoreo) into your clus
 You can see the service using the following command.
 
 ```shell
-kubectl --context=kind-choreo get svc choreo-dataplane-external-gateway -n choreo-system
+kubectl --context=kind-choreo get svc choreo-external-gateway -n choreo-system
 ```
 
 You will see an output similar to the following:
 
 ```text
 NAME                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)         AGE
-choreo-dataplane-external-gateway   LoadBalancer   10.96.75.106   <pending>     443:30807/TCP   55m
+choreo--external-gateway   LoadBalancer   10.96.75.106   <pending>     443:30807/TCP   55m
 ```
 
 You have two options to expose the DataPlane choreo-external-gateway service to your host machine.

--- a/install/add-default-dataplane.sh
+++ b/install/add-default-dataplane.sh
@@ -80,6 +80,7 @@ metadata:
   labels:
     core.choreo.dev/name: $DATAPLANE_KIND_NAME
     core.choreo.dev/organization: default-org
+    core.choreo.dev/build-plane: "true"
   name: $DATAPLANE_KIND_NAME
   namespace: default-org
 spec:

--- a/install/check-status.sh
+++ b/install/check-status.sh
@@ -125,8 +125,8 @@ else
     read -p "Enter Control Plane Kubernetes context (default: kind-choreo-cp): " control_plane_context
     control_plane_context=${control_plane_context:-"kind-choreo-cp"}
 
-    print_component_status "components_cp" "🧠Control Plane Components" "$control_plane_context"
-    print_component_status "components_dp" "🖥️Data Plane Components" "$dataplane_context"
+    print_component_status "components_cp" "Control Plane Components" "$control_plane_context"
+    print_component_status "components_dp" "Data Plane Components" "$dataplane_context"
 fi
 
 # Final Overall Status

--- a/install/check-status.sh
+++ b/install/check-status.sh
@@ -16,7 +16,7 @@ components_dp=("cilium" "vault" "argo" "cert_manager" "choreo_image_registry" "e
 # Labels
 cilium_deps=("app.kubernetes.io/name=cilium-agent" "app.kubernetes.io/name=cilium-operator")
 vault_deps=("app.kubernetes.io/name=vault")
-argo_deps=("app.kubernetes.io/name=argo-workflows-server" "app.kubernetes.io/name=argo-workflows-workflow-controller")
+argo_deps=("app.kubernetes.io/name=argo-workflows-workflow-controller")
 cert_manager_deps=("app.kubernetes.io/name=certmanager" "app.kubernetes.io/name=cainjector" "app.kubernetes.io/name=webhook")
 choreo_controller_deps=("app.kubernetes.io/name=choreo-control-plane")
 choreo_image_registry_deps=("app=registry")

--- a/install/helm/choreo-dataplane/values.yaml
+++ b/install/helm/choreo-dataplane/values.yaml
@@ -163,14 +163,7 @@ argo-workflows:
         memory: 32Mi
         cpu: 25m
   server:
-    # -- Resource limits and requests for the argo workflows server
-    resources:
-      limits:
-        memory: 64Mi
-        cpu: 50m
-      requests:
-        memory: 32Mi
-        cpu: 25m
+    enabled: false
   crds:
     keep: false
   workflow:

--- a/internal/controller/build/controller_finalize.go
+++ b/internal/controller/build/controller_finalize.go
@@ -59,16 +59,15 @@ func (r *Reconciler) finalize(ctx context.Context, oldBuild, build *choreov1.Bui
 	}
 
 	bpClient, err := r.getBPClient(ctx, build)
+	logger := log.FromContext(ctx)
 	if err != nil {
-		logger := log.FromContext(ctx)
 		logger.Error(err, "Error getting build plane client for finalizing")
-		return ctrl.Result{}, err
-	}
-
-	// Delete Workflow resource
-	if err := deleteWorkflow(ctx, build, bpClient); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to delete workflow resource: %w", err)
+	} else {
+		// Delete Workflow resource if build plane exists
+		if err := deleteWorkflow(ctx, build, bpClient); err != nil {
+			if !apierrors.IsNotFound(err) {
+				logger.Error(err, "Failed to delete workflow resource")
+			}
 		}
 	}
 

--- a/internal/controller/build/controller_finalize.go
+++ b/internal/controller/build/controller_finalize.go
@@ -58,15 +58,15 @@ func (r *Reconciler) finalize(ctx context.Context, oldBuild, build *choreov1.Bui
 		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, oldBuild, build)
 	}
 
-	dpClient, err := r.getDPClient(ctx, build)
+	bpClient, err := r.getBPClient(ctx, build)
 	if err != nil {
 		logger := log.FromContext(ctx)
-		logger.Error(err, "Error getting DP client for finalizing")
+		logger.Error(err, "Error getting build plane client for finalizing")
 		return ctrl.Result{}, err
 	}
 
 	// Delete Workflow resource
-	if err := deleteWorkflow(ctx, build, dpClient); err != nil {
+	if err := deleteWorkflow(ctx, build, bpClient); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to delete workflow resource: %w", err)
 		}

--- a/internal/controller/metadata.go
+++ b/internal/controller/metadata.go
@@ -56,11 +56,6 @@ func GetDataPlaneName(obj client.Object) string {
 	return getLabelValueOrEmpty(obj, labels.LabelKeyDataPlaneName)
 }
 
-// GetBuildPlaneLabelFromDataPlane returns the build plane label from the data plane.
-func GetBuildPlaneLabelFromDataPlane(obj client.Object) string {
-	return getLabelValueOrEmpty(obj, labels.LabelKeyBuildPlane)
-}
-
 // GetName returns the name of the object. This is specific to the Choreo, and it is not the Kubernetes object name.
 func GetName(obj client.Object) string {
 	return getLabelValueOrEmpty(obj, labels.LabelKeyName)

--- a/internal/controller/metadata.go
+++ b/internal/controller/metadata.go
@@ -56,6 +56,11 @@ func GetDataPlaneName(obj client.Object) string {
 	return getLabelValueOrEmpty(obj, labels.LabelKeyDataPlaneName)
 }
 
+// GetBuildPlaneLabelFromDataPlane returns the build plane label from the data plane.
+func GetBuildPlaneLabelFromDataPlane(obj client.Object) string {
+	return getLabelValueOrEmpty(obj, labels.LabelKeyBuildPlane)
+}
+
 // GetName returns the name of the object. This is specific to the Choreo, and it is not the Kubernetes object name.
 func GetName(obj client.Object) string {
 	return getLabelValueOrEmpty(obj, labels.LabelKeyName)

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -16,6 +16,7 @@ const (
 	LabelKeyDeployableArtifactName = "core.choreo.dev/deployable-artifact"
 	LabelKeyDeploymentName         = "core.choreo.dev/deployment"
 	LabelKeyDataPlaneName          = "core.choreo.dev/dataplane"
+	LabelKeyBuildPlane             = "core.choreo.dev/build-plane"
 
 	LabelKeyManagedBy = "managed-by"
 

--- a/samples/configuring-choreo/create-new-organization/README.md
+++ b/samples/configuring-choreo/create-new-organization/README.md
@@ -24,7 +24,7 @@ organization.core.choreo.dev/acme created
 If you want to create the organization along with all the necessary resources, use the following command:
 
 > [!NOTE]
-> Make sure to add the cluster credentials into dataplane kind before applying
+> Make sure to add the cluster credentials into dataplane kind before applying.
 
 ```bash
 choreoctl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/configuring-choreo/create-new-organization/complete-organization.yaml

--- a/samples/configuring-choreo/create-new-organization/README.md
+++ b/samples/configuring-choreo/create-new-organization/README.md
@@ -23,6 +23,9 @@ organization.core.choreo.dev/acme created
 
 If you want to create the organization along with all the necessary resources, use the following command:
 
+> [!NOTE]
+> Make sure to add the cluster credentials into dataplane kind before applying
+
 ```bash
 choreoctl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/configuring-choreo/create-new-organization/complete-organization.yaml
 ``` 

--- a/samples/configuring-choreo/create-new-organization/complete-organization.yaml
+++ b/samples/configuring-choreo/create-new-organization/complete-organization.yaml
@@ -11,7 +11,7 @@ metadata:
 spec: {}
 ---
 
-## Sample DataPlane kind (Namespaced) - add cluster credentials before applyin g
+## Sample DataPlane kind (Namespaced) - add cluster credentials before applying
 apiVersion: core.choreo.dev/v1
 kind: DataPlane
 metadata:

--- a/samples/configuring-choreo/create-new-organization/complete-organization.yaml
+++ b/samples/configuring-choreo/create-new-organization/complete-organization.yaml
@@ -11,7 +11,7 @@ metadata:
 spec: {}
 ---
 
-## Sample DataPlane kind (Namespaced)
+## Sample DataPlane kind (Namespaced) - add cluster credentials before applyin g
 apiVersion: core.choreo.dev/v1
 kind: DataPlane
 metadata:
@@ -21,19 +21,23 @@ metadata:
     core.choreo.dev/display-name: Local Data Plane
     core.choreo.dev/description: Data plane in Kind cluster
   labels:
-    core.choreo.dev/organization: acme
+    core.choreo.dev/build-plane: "true"
     core.choreo.dev/name: dp-local
+    core.choreo.dev/organization: acme
 spec:
-  kubernetesCluster:
-    name: kind-cluster-1
-    connectionConfigRef: kind-cluster-1-connection-config
-    featureFlags:
-      cilium: true
-      scaleToZero: true
-      gatewayType: envoy
   gateway:
-    publicVirtualHost: choreoapis.local
-    organizationVirtualHost: internal.choreoapis.local
+    organizationVirtualHost: choreoapis.internal
+    publicVirtualHost: choreoapis.localhost
+  kubernetesCluster:
+    credentials:
+      apiServerURL: https://127.0.0.1:63321
+      caCert: xxx
+      clientCert: xxx
+      clientKey: xxx
+    name: kind-choreo
+  registry:
+    unauthenticated:
+      - registry.choreo-system:5000
 ---
 
 ## Sample DeploymentPipeline kind (Namespaced)


### PR DESCRIPTION
## Purpose

Currently, Argo Workflows are always executed on a hardcoded DataPlane (`default-dataplane`). To enable more flexibility, this behavior should be configurable—allowing builds to be scheduled on different DataPlanes based on user input. This gives platform engineers (PEs) the ability to route builds to specific clusters, for example, based on workload distribution or team requirements.

## Approach

A custom node label will be added to the `DataPlane` resource. The Build Controller will retrieve this label and use it to determine where to schedule the build workloads.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/217

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
