### PR TITLE
Add support for external registry image pulling

### DIFF
--- a/install/helm/choreo-dataplane/Chart.lock
+++ b/install/helm/choreo-dataplane/Chart.lock
@@ -11,8 +11,8 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.16.2
-- name: argo-workflows
-  repository: https://argoproj.github.io/argo-helm
-  version: 0.45.2
-digest: sha256:6ad8b563a12d6b8bd879f8e03756ce5d3e45ffb619475c01b3d4973a593651c8
-generated: "2025-05-27T11:12:37.475192+05:30"
+- name: kubernetes-replicator
+  repository: https://helm.mittwald.de
+  version: 2.11.1
+digest: sha256:0f3b98a141a5eff37a9bcf5ae01ef1dad18dc022f5a8b488f7b6e8a0e73bcf41
+generated: "2025-06-19T10:13:30.246089+05:30"

--- a/install/helm/choreo-dataplane/Chart.yaml
+++ b/install/helm/choreo-dataplane/Chart.yaml
@@ -36,6 +36,6 @@ dependencies:
     condition: certmanager.enabled
     alias: certmanager
     version: "v1.16.2"
-  - name: argo-workflows
-    repository: "https://argoproj.github.io/argo-helm"
-    version: 0.45.2
+  - name: kubernetes-replicator
+    version: 2.11.1
+    repository: "https://helm.mittwald.de"

--- a/install/helm/choreo-dataplane/values.yaml
+++ b/install/helm/choreo-dataplane/values.yaml
@@ -218,6 +218,9 @@ opensearch:
   
   replicas: 1
 
+kubernetes-replicator:
+  fullnameOverride: kubernetes-replicator
+
 # Customizing OpenSearch Dashboards configurations
 opensearchDashboard:
   image:

--- a/internal/controller/deployment/integrations/kubernetes/pod.go
+++ b/internal/controller/deployment/integrations/kubernetes/pod.go
@@ -28,6 +28,13 @@ func makePodSpec(deployCtx *dataplane.DeploymentContext) *corev1.PodSpec {
 	// Create the main container
 	mainContainer := makeMainContainer(deployCtx)
 
+	// Add image pull secret, if provided
+	if deployCtx.SecretRef != "" {
+		ps.ImagePullSecrets = []corev1.LocalObjectReference{
+			{Name: deployCtx.SecretRef},
+		}
+	}
+
 	// Add file volumes and mounts
 	fileVolumes, fileMounts := makeFileVolumes(deployCtx)
 	mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, fileMounts...)

--- a/internal/dataplane/types.go
+++ b/internal/dataplane/types.go
@@ -21,6 +21,7 @@ type DeploymentContext struct {
 	ConfigurationGroups []*choreov1.ConfigurationGroup
 
 	ContainerImage string
+	SecretRef      string
 }
 
 // EndpointContext is a struct that holds the all necessary data required for the resource handlers to perform their operations.


### PR DESCRIPTION
## Purpose
Currently, OpenChoreo does not support configuring external container registries for image pulling, whether authenticated or unauthenticated. This functionality is essential for supporting multi-dataplane deployments where images may reside in external registries such as Docker Hub, GHCR, or private registries.

## Approach
This PR adds support for configuring an external container registry in the DataPlane custom resource, allowing each DataPlane to specify a single registry for pulling images. To enable secret propagation across dynamically created namespaces, the [kubernetes-replicator](https://github.com/mittwald/kubernetes-replicator) has been integrated into the DataPlane Helm chart.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/246

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
