### PR TITLE
Add CI Namespace to Fluent Bit Configuration

### DIFF
--- a/docs/configure-build-plane.md
+++ b/docs/configure-build-plane.md
@@ -4,7 +4,7 @@ This guide walks you through setting up a **Build Plane** in OpenChoreo.
 
 ## Overview
 
-An organization can have only **one Build Plane**, which is responsible for executing build workloads. These workloads run in a dedicated namespace named: `choreo-ci-<your-org>`
+An organization can have only **one Build Plane**, which is responsible for executing build workloads. These workloads run in a dedicated namespace named: `openchoreo-ci-<your-org>`
 
 > [!NOTE]
 > `BuildPlane` CRD support is on the roadmap and will be available in a future release. Currently, the Build Plane runs within a **Data Plane** cluster.

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -47,7 +47,6 @@ fluentBit:
     input:
       name: tail
       tag: "kube.*"
-      # Updated path to include choreo-ci-* namespace logs for build workflows
       path: "/var/log/containers/*_openchoreo-*_*.log,/var/log/containers/*_openchoreo-ci-*_*.log"
       excludePath: "/var/log/containers/*opensearch*_openchoreo-observability-plane_*.log,/var/log/containers/*fluent-bit*_openchoreo-data-plane_*.log"
       parser: docker

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -31,7 +31,7 @@ argo-workflows:
     - argo-build
 
 fluentBit:
-  enabled: true
+  enabled: false
 
   image:
     repository: fluent/fluent-bit
@@ -47,7 +47,8 @@ fluentBit:
     input:
       name: tail
       tag: "kube.*"
-      path: "/var/log/containers/*_openchoreo-*_*.log,/var/log/containers/*_dp-*_*.log"
+      # Updated path to include choreo-ci-* namespace logs for build workflows
+      path: "/var/log/containers/*_openchoreo-*_*.log,/var/log/containers/*_openchoreo-ci-*_*.log"
       excludePath: "/var/log/containers/*opensearch*_openchoreo-observability-plane_*.log,/var/log/containers/*fluent-bit*_openchoreo-data-plane_*.log"
       parser: docker
       inotifyWatcher: false

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -150,7 +150,7 @@ fluentBit:
     input:
       name: tail
       tag: "kube.*"
-      path: "/var/log/containers/*_openchoreo-*_*.log,/var/log/containers/*_dp-*_*.log"
+      path: "/var/log/containers/*_openchoreo-*_*.log,/var/log/containers/*_dp-*_*.log,/var/log/containers/*_openchoreo-ci-*_*.log"
       excludePath: "/var/log/containers/*opensearch*_openchoreo-observability-plane_*.log,/var/log/containers/*fluent-bit*_openchoreo-data-plane_*.log"
       parser: docker
       inotifyWatcher: false

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -150,6 +150,8 @@ fluentBit:
     input:
       name: tail
       tag: "kube.*"
+      # TODO: The openchoreo-ci namespace should not be included in the Data Plane by default;
+      # it should be overridden in the single-cluster setup.
       path: "/var/log/containers/*_openchoreo-*_*.log,/var/log/containers/*_dp-*_*.log,/var/log/containers/*_openchoreo-ci-*_*.log"
       excludePath: "/var/log/containers/*opensearch*_openchoreo-observability-plane_*.log,/var/log/containers/*fluent-bit*_openchoreo-data-plane_*.log"
       parser: docker

--- a/internal/choreoctl/cmd/logs/logs.go
+++ b/internal/choreoctl/cmd/logs/logs.go
@@ -104,7 +104,7 @@ func getBuildLogs(params api.LogParams) error {
 
 	// Get the Kubernetes name directly from the wrapper
 	buildK8sName := buildWrapper.GetKubernetesName()
-	buildNamespace := fmt.Sprintf("choreo-ci-%s", params.Organization)
+	buildNamespace := fmt.Sprintf("openchoreo-ci-%s", params.Organization)
 
 	// Get k8s client
 	k8sClient, err := resources.GetClient()

--- a/internal/controller/buildv2/workflow.go
+++ b/internal/controller/buildv2/workflow.go
@@ -152,7 +152,7 @@ func makeWorkflowName(build *openchoreov1alpha1.BuildV2) string {
 // makeNamespaceName generates the namespace name for the workflow based on organization
 func makeNamespaceName(build *openchoreov1alpha1.BuildV2) string {
 	orgName := normalizeForK8s(build.Namespace)
-	return fmt.Sprintf("choreo-ci-%s", orgName)
+	return fmt.Sprintf("openchoreo-ci-%s", orgName)
 }
 
 // makeWorkflowLabels creates labels for the workflow

--- a/internal/controller/buildv2/workflow.go
+++ b/internal/controller/buildv2/workflow.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/openchoreo/openchoreo/internal/labels"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,12 +157,12 @@ func makeNamespaceName(build *openchoreov1alpha1.BuildV2) string {
 // makeWorkflowLabels creates labels for the workflow
 func makeWorkflowLabels(build *openchoreov1alpha1.BuildV2) map[string]string {
 	labels := map[string]string{
-		labels.LabelKeyOrganizationName: normalizeForK8s(build.Namespace),
-		labels.LabelKeyProjectName:      normalizeForK8s(build.Spec.Owner.ProjectName),
-		labels.LabelKeyComponentName:    normalizeForK8s(build.Spec.Owner.ComponentName),
-		labels.LabelKeyBuildName:        build.Name,
-		labels.LabelKeyUUID:             string(build.UID),
-		labels.LabelKeyTarget:           labels.LabelValueBuildTarget,
+		dpkubernetes.LabelKeyOrganizationName: build.Namespace,
+		dpkubernetes.LabelKeyProjectName:      build.Spec.Owner.ProjectName,
+		dpkubernetes.LabelKeyComponentName:    build.Spec.Owner.ComponentName,
+		dpkubernetes.LabelKeyBuildName:        build.Name,
+		dpkubernetes.LabelKeyUUID:             string(build.UID),
+		dpkubernetes.LabelKeyTarget:           dpkubernetes.LabelValueBuildTarget,
 	}
 	return labels
 }

--- a/internal/dataplane/kubernetes/labels.go
+++ b/internal/dataplane/kubernetes/labels.go
@@ -5,23 +5,34 @@ package kubernetes
 
 const (
 	LabelKeyOrganizationName    = "organization-name"
+	LabelKeyEnvironmentName     = "environment-name"
+	LabelKeyEnvironmentID       = "environment-id"
 	LabelKeyProjectName         = "project-name"
 	LabelKeyProjectID           = "project-id"
 	LabelKeyComponentName       = "component-name"
 	LabelKeyComponentID         = "component-id"
 	LabelKeyDeploymentTrackName = "deployment-track-name"
 	LabelKeyDeploymentTrackID   = "deployment-track-id"
-	LabelKeyEnvironmentName     = "environment-name"
-	LabelKeyEnvironmentID       = "environment-id"
+	LabelKeyBuildName           = "build-name"
 	LabelKeyDeploymentName      = "deployment-name"
 	LabelKeyDeploymentID        = "deployment-id"
 	LabelKeyManagedBy           = "managed-by"
 	LabelKeyBelongTo            = "belong-to"
 	LabelKeyComponentType       = "component-type"
 	LabelKeyVisibility          = "gateway-visibility"
+	
+	// LabelKeyUUID stores the Kubernetes UID (metadata.uid) of the resource.
+	LabelKeyUUID = "uuid"
+
+	// LabelKeyTarget identifies which logical target a resource belongs to
+	// Allowed values: build | runtime | gateway | <future‑targets>
+	LabelKeyTarget = "target"
+
+	// Predefined values for LabelKeyTarget.
+	LabelValueBuildTarget   = "build"
+	LabelValueRuntimeTarget = "runtime"
+	LabelValueGatewayTarget = "gateway"
 
 	LabelValueManagedBy = "choreo-deployment-controller"
 	LabelValueBelongTo  = "user-workloads"
-
-	LabelBuildControllerCreated = "openchoreo-build-controller"
 )

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -39,17 +39,5 @@ const (
 	// LabelKeyReleaseNamespace tracks the namespace of the release that manages a resource.
 	LabelKeyReleaseNamespace = "openchoreo.dev/release-namespace"
 
-	// LabelKeyTarget identifies which logical target a resource belongs to
-	// Allowed values: build | runtime | gateway | <future‑targets>
-	LabelKeyTarget = "openchoreo.dev/target"
-
-	// Predefined values for LabelKeyTarget.
-	LabelValueBuildTarget   = "build"
-	LabelValueRuntimeTarget = "runtime"
-	LabelValueGatewayTarget = "gateway"
-
-	// LabelKeyUUID stores the Kubernetes UID (metadata.uid) of the resource.
-	LabelKeyUUID = "openchoreo.dev/uuid"
-
 	LabelValueManagedBy = "openchoreo-control-plane"
 )


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Added the ci namespace to the Data Plane Fluent Bit installation.
- Removed runtime-related logs from the Build Plane Fluent Bit configuration.
- Renamed the CI namespace from `choreo-ci-*` to `openchoreo-ci-*.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/320

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
