### PR TITLE
Make container registry endpoint configurable

### DIFF
--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/ballerina-buildpack.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/ballerina-buildpack.yaml
@@ -152,7 +152,32 @@ spec:
         args:
           - |-
             set -e
+            #####################################################################
+            # 1. Inputs
+            #####################################################################
             GIT_REVISION={{ "{{" }}inputs.parameters.git-revision{{ "}}" }}
+            IMAGE_NAME={{ "{{" }}workflow.parameters.image-name{{ "}}" }}
+            IMAGE_TAG={{ "{{" }}workflow.parameters.image-tag{{ "}}" }}
+            SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
+
+            #####################################################################
+            # 2. Registry endpoints from Helm values
+            #    - type: "local" or "external"
+            #    - choose the right push/pull endpoints
+            #####################################################################
+            REGISTRY_TYPE="{{ .Values.global.defaultResources.registry.type | default "local" }}"
+
+            if [ "${REGISTRY_TYPE}" = "local" ]; then
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.local.pullEndpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.local.pushEndpoint }}"
+            else
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+            fi
+
+            #####################################################################
+            # 3. Podman storage configuration
+            #####################################################################
             mkdir -p /etc/containers
             cat <<EOF > /etc/containers/storage.conf
             [storage]
@@ -163,11 +188,19 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            #####################################################################
+            # 4. Load the tarred image and push to the selected registry
+            #####################################################################
             podman load -i /mnt/vol/app-image.tar
-            podman tag {{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
-            podman push --tls-verify=false {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
 
-            echo -n "localhost:30003/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION" > /tmp/image.txt
+            podman tag $SRC_IMAGE $REGISTRY_PUSH/$SRC_IMAGE
+            podman push --tls-verify=false $REGISTRY_PUSH/$SRC_IMAGE
+
+            #####################################################################
+            # 5. Emit image reference (for later steps/kubelet pulls)
+            #####################################################################
+            echo -n "$REGISTRY_PULL/$SRC_IMAGE" > /tmp/image.txt
+
         command:
           - sh
           - -c

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/docker.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/docker.yaml
@@ -125,7 +125,32 @@ spec:
         args:
           - |-
             set -e
+            #####################################################################
+            # 1. Inputs
+            #####################################################################
             GIT_REVISION={{ "{{" }}inputs.parameters.git-revision{{ "}}" }}
+            IMAGE_NAME={{ "{{" }}workflow.parameters.image-name{{ "}}" }}
+            IMAGE_TAG={{ "{{" }}workflow.parameters.image-tag{{ "}}" }}
+            SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
+
+            #####################################################################
+            # 2. Registry endpoints from Helm values
+            #    - type: "local" or "external"
+            #    - choose the right push/pull endpoints
+            #####################################################################
+            REGISTRY_TYPE="{{ .Values.global.defaultResources.registry.type | default "local" }}"
+
+            if [ "${REGISTRY_TYPE}" = "local" ]; then
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.local.pullEndpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.local.pushEndpoint }}"
+            else
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+            fi
+
+            #####################################################################
+            # 3. Podman storage configuration
+            #####################################################################
             mkdir -p /etc/containers
             cat <<EOF > /etc/containers/storage.conf
             [storage]
@@ -136,11 +161,18 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            #####################################################################
+            # 4. Load the tarred image and push to the selected registry
+            #####################################################################
             podman load -i /mnt/vol/app-image.tar
-            podman tag {{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
-            podman push --tls-verify=false {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
 
-            echo -n "localhost:30003/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION" > /tmp/image.txt
+            podman tag $SRC_IMAGE $REGISTRY_PUSH/$SRC_IMAGE
+            podman push --tls-verify=false $REGISTRY_PUSH/$SRC_IMAGE
+
+            #####################################################################
+            # 5. Emit image reference (for later steps/kubelet pulls)
+            #####################################################################
+            echo -n "$REGISTRY_PULL/$SRC_IMAGE" > /tmp/image.txt
         command:
           - sh
           - -c

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/google-cloud-buildpacks.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/google-cloud-buildpacks.yaml
@@ -153,7 +153,33 @@ spec:
         args:
           - |-
             set -e
+
+            #####################################################################
+            # 1. Inputs
+            #####################################################################
             GIT_REVISION={{ "{{" }}inputs.parameters.git-revision{{ "}}" }}
+            IMAGE_NAME={{ "{{" }}workflow.parameters.image-name{{ "}}" }}
+            IMAGE_TAG={{ "{{" }}workflow.parameters.image-tag{{ "}}" }}
+            SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
+
+            #####################################################################
+            # 2. Registry endpoints from Helm values
+            #    - type: "local" or "external"
+            #    - choose the right push/pull endpoints
+            #####################################################################
+            REGISTRY_TYPE="{{ .Values.global.defaultResources.registry.type | default "local" }}"
+
+            if [ "${REGISTRY_TYPE}" = "local" ]; then
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.local.pullEndpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.local.pushEndpoint }}"
+            else
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+            fi
+
+            #####################################################################
+            # 3. Podman storage configuration
+            #####################################################################
             mkdir -p /etc/containers
             cat <<EOF > /etc/containers/storage.conf
             [storage]
@@ -164,11 +190,18 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            #####################################################################
+            # 4. Load the tarred image and push to the selected registry
+            #####################################################################
             podman load -i /mnt/vol/app-image.tar
-            podman tag {{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
-            podman push --tls-verify=false {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
 
-            echo -n "localhost:30003/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION" > /tmp/image.txt
+            podman tag $SRC_IMAGE $REGISTRY_PUSH/$SRC_IMAGE
+            podman push --tls-verify=false $REGISTRY_PUSH/$SRC_IMAGE
+
+            #####################################################################
+            # 5. Emit image reference (for later steps/kubelet pulls)
+            #####################################################################
+            echo -n "$REGISTRY_PULL/$SRC_IMAGE" > /tmp/image.txt
         command:
           - sh
           - -c

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/react.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/react.yaml
@@ -157,7 +157,33 @@ spec:
         args:
           - |-
             set -e
+
+            #####################################################################
+            # 1. Inputs
+            #####################################################################
             GIT_REVISION={{ "{{" }}inputs.parameters.git-revision{{ "}}" }}
+            IMAGE_NAME={{ "{{" }}workflow.parameters.image-name{{ "}}" }}
+            IMAGE_TAG={{ "{{" }}workflow.parameters.image-tag{{ "}}" }}
+            SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
+
+            #####################################################################
+            # 2. Registry endpoints from Helm values
+            #    - type: "local" or "external"
+            #    - choose the right push/pull endpoints
+            #####################################################################
+            REGISTRY_TYPE="{{ .Values.global.defaultResources.registry.type | default "local" }}"
+
+            if [ "${REGISTRY_TYPE}" = "local" ]; then
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.local.pullEndpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.local.pushEndpoint }}"
+            else
+              REGISTRY_PULL="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+              REGISTRY_PUSH="{{ .Values.global.defaultResources.registry.external.endpoint }}"
+            fi
+
+            #####################################################################
+            # 3. Podman storage configuration
+            #####################################################################
             mkdir -p /etc/containers
             cat <<EOF > /etc/containers/storage.conf
             [storage]
@@ -168,11 +194,19 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            #####################################################################
+            # 4. Load the tarred image and push to the selected registry
+            #####################################################################
             podman load -i /mnt/vol/app-image.tar
-            podman tag {{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
-            podman push --tls-verify=false {{ .Values.global.defaultResources.registryEndpoint }}/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION
 
-            echo -n "localhost:30003/{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-$GIT_REVISION" > /tmp/image.txt
+            podman tag $SRC_IMAGE $REGISTRY_PUSH/$SRC_IMAGE
+            podman push --tls-verify=false $REGISTRY_PUSH/$SRC_IMAGE
+
+            #####################################################################
+            # 5. Emit image reference (for later steps/kubelet pulls)
+            #####################################################################
+            echo -n "$REGISTRY_PULL/$SRC_IMAGE" > /tmp/image.txt
+
         command:
           - sh
           - -c

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -1,12 +1,34 @@
 # Global configuration
 global:
-  # Common labels applied to all resources
+  # -- Common labels to add to every resource.
   commonLabels: {}
-  # Default build plane resources and configuration
+  # -- Configuration for the default workflow templates required for building container images.
   defaultResources:
+    # -- If true, applies the workflow templates.
     enabled: true
-    # Container registry endpoint for pushing images
-    registryEndpoint: "registry.openchoreo-data-plane.svc.cluster.local:5000"
+      # -- Container registry configuration
+    registry:
+      # -- Type of registry to use. Supported values: "local", "external".
+      # "local": Deploys a built-in registry managed by data plane Helm chart.
+      # "external": Connects to a pre-existing registry you provide.
+      type: local
+
+      # -- Settings for the built-in registry.
+      # These values are ONLY used if registry.type is "local".
+      local:
+        # -- The internal cluster address used by build pipelines (e.g., Podman) to push images.
+        pushEndpoint: "registry.openchoreo-data-plane.svc.cluster.local:5000"
+
+        # -- The public-facing address used by cluster nodes (kubelet) to pull images.
+        # This could be a NodePort, LoadBalancer, or Ingress address.
+        pullEndpoint: "localhost:30003"
+
+      # -- Settings for using your own external registry.
+      # These values are ONLY used if registry.type is "external".
+      external:
+        # -- The full address of your external registry.
+        # (e.g., "gcr.io/my-project", "docker.io/my-org", "my-harbor.corp:5000")
+        endpoint: ""
 
 # customizing the argo workflows configurations
 argo-workflows:


### PR DESCRIPTION
## Purpose
Make the container registry endpoint configurable instead of hard-coded, allowing users to switch between the built‑in/local registry and an external registry.

## Approach
- Introduced `global.defaultResources.registry.*` values to define in the build plane helm chart values yaml:
  - `type` (`local` or `external`)
  - `local.pushEndpoint` / `local.pullEndpoint`
  - `external.endpoint`
- Updated Argo workflow step to read these values and tag/push accordingly.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
