### PR TITLE
Add ReleaseState field to support undeploy and suspend functionality

### DIFF
--- a/api/v1alpha1/apibinding_types.go
+++ b/api/v1alpha1/apibinding_types.go
@@ -23,6 +23,15 @@ type APIBindingSpec struct {
 	// Environment specifies the target environment for this binding
 	// +kubebuilder:validation:MinLength=1
 	EnvironmentName string `json:"environmentName"`
+
+	// ReleaseState controls the state of the Release created by this binding.
+	// Active: Resources are deployed normally
+	// Suspend: Resources are suspended (scaled to zero or paused)
+	// Undeploy: Resources are removed from the data plane
+	// +kubebuilder:default=Active
+	// +kubebuilder:validation:Enum=Active;Suspend;Undeploy
+	// +optional
+	ReleaseState ReleaseState `json:"releaseState,omitempty"`
 }
 
 // APIBindingStatus defines the observed state of APIBinding.

--- a/api/v1alpha1/scheduledtaskbinding_types.go
+++ b/api/v1alpha1/scheduledtaskbinding_types.go
@@ -27,6 +27,15 @@ type ScheduledTaskBindingSpec struct {
 
 	// Overrides contains scheduled task-specific overrides for this binding
 	Overrides map[string]bool `json:"overrides,omitempty"`
+
+	// ReleaseState controls the state of the Release created by this binding.
+	// Active: Resources are deployed normally
+	// Suspend: Resources are suspended (scaled to zero or paused)
+	// Undeploy: Resources are removed from the data plane
+	// +kubebuilder:default=Active
+	// +kubebuilder:validation:Enum=Active;Suspend;Undeploy
+	// +optional
+	ReleaseState ReleaseState `json:"releaseState,omitempty"`
 }
 
 // ScheduledTaskBindingStatus defines the observed state of ScheduledTaskBinding.

--- a/api/v1alpha1/servicebinding_types.go
+++ b/api/v1alpha1/servicebinding_types.go
@@ -24,6 +24,15 @@ type ServiceBindingSpec struct {
 	WorkloadSpec WorkloadTemplateSpec `json:"workloadSpec"`
 
 	APIs map[string]*ServiceAPI `json:"apis,omitempty"`
+
+	// ReleaseState controls the state of the Release created by this binding.
+	// Active: Resources are deployed normally
+	// Suspend: Resources are suspended (scaled to zero or paused)
+	// Undeploy: Resources are removed from the data plane
+	// +kubebuilder:default=Active
+	// +kubebuilder:validation:Enum=Active;Suspend;Undeploy
+	// +optional
+	ReleaseState ReleaseState `json:"releaseState,omitempty"`
 }
 
 // ServiceBindingStatus defines the observed state of ServiceBinding.

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -65,3 +65,24 @@ const (
 	// EndpointExposeLevelPublic exposes the endpoint publicly, accessible from outside the organization
 	EndpointExposeLevelPublic EndpointExposeLevel = "Public"
 )
+
+// ReleaseState defines the desired state of the Release created by a binding
+type ReleaseState string
+
+const (
+	// ReleaseStateActive indicates the Release should be actively deployed.
+	// Resources are deployed normally to the data plane.
+	ReleaseStateActive ReleaseState = "Active"
+
+	// ReleaseStateSuspend indicates the Release should be suspended.
+	// Resources are scaled to zero or paused but not deleted.
+	// - Deployments/StatefulSets: replicas set to 0
+	// - Jobs: spec.suspend set to true
+	// - CronJobs: spec.suspend set to true
+	// - HPA: minReplicas and maxReplicas set to 0
+	ReleaseStateSuspend ReleaseState = "Suspend"
+
+	// ReleaseStateUndeploy indicates the Release should be removed from the data plane.
+	// The Release resource is deleted, triggering cleanup of all data plane resources.
+	ReleaseStateUndeploy ReleaseState = "Undeploy"
+)

--- a/api/v1alpha1/webapplicationbinding_types.go
+++ b/api/v1alpha1/webapplicationbinding_types.go
@@ -27,6 +27,15 @@ type WebApplicationBindingSpec struct {
 
 	// Overrides contains web application-specific overrides for this binding
 	Overrides map[string]bool `json:"overrides,omitempty"`
+
+	// ReleaseState controls the state of the Release created by this binding.
+	// Active: Resources are deployed normally
+	// Suspend: Resources are suspended (scaled to zero or paused)
+	// Undeploy: Resources are removed from the data plane
+	// +kubebuilder:default=Active
+	// +kubebuilder:validation:Enum=Active;Suspend;Undeploy
+	// +optional
+	ReleaseState ReleaseState `json:"releaseState,omitempty"`
 }
 
 // WebApplicationBindingStatus defines the observed state of WebApplicationBinding.

--- a/config/crd/bases/openchoreo.dev_apibindings.yaml
+++ b/config/crd/bases/openchoreo.dev_apibindings.yaml
@@ -52,6 +52,18 @@ spec:
                   binding
                 minLength: 1
                 type: string
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
             required:
             - apiClassName
             - apiName

--- a/config/crd/bases/openchoreo.dev_scheduledtaskbindings.yaml
+++ b/config/crd/bases/openchoreo.dev_scheduledtaskbindings.yaml
@@ -68,6 +68,18 @@ spec:
                 - componentName
                 - projectName
                 type: object
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
               workloadSpec:
                 description: WorkloadSpec contains the copied workload specification
                   for this environment-specific binding

--- a/config/crd/bases/openchoreo.dev_servicebindings.yaml
+++ b/config/crd/bases/openchoreo.dev_servicebindings.yaml
@@ -93,6 +93,18 @@ spec:
                 - componentName
                 - projectName
                 type: object
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
               workloadSpec:
                 description: WorkloadTemplateSpec defines the desired state of Workload.
                 properties:

--- a/config/crd/bases/openchoreo.dev_webapplicationbindings.yaml
+++ b/config/crd/bases/openchoreo.dev_webapplicationbindings.yaml
@@ -68,6 +68,18 @@ spec:
                 - componentName
                 - projectName
                 type: object
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
               workloadSpec:
                 description: WorkloadSpec contains the copied workload specification
                   for this environment-specific binding

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_apibindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_apibindings.yaml
@@ -51,6 +51,18 @@ spec:
                   binding
                 minLength: 1
                 type: string
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
             required:
             - apiClassName
             - apiName

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_scheduledtaskbindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_scheduledtaskbindings.yaml
@@ -67,6 +67,18 @@ spec:
                 - componentName
                 - projectName
                 type: object
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
               workloadSpec:
                 description: WorkloadSpec contains the copied workload specification
                   for this environment-specific binding

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_servicebindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_servicebindings.yaml
@@ -92,6 +92,18 @@ spec:
                 - componentName
                 - projectName
                 type: object
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
               workloadSpec:
                 description: WorkloadTemplateSpec defines the desired state of Workload.
                 properties:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_webapplicationbindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_webapplicationbindings.yaml
@@ -67,6 +67,18 @@ spec:
                 - componentName
                 - projectName
                 type: object
+              releaseState:
+                default: Active
+                description: |-
+                  ReleaseState controls the state of the Release created by this binding.
+                  Active: Resources are deployed normally
+                  Suspend: Resources are suspended (scaled to zero or paused)
+                  Undeploy: Resources are removed from the data plane
+                enum:
+                - Active
+                - Suspend
+                - Undeploy
+                type: string
               workloadSpec:
                 description: WorkloadSpec contains the copied workload specification
                   for this environment-specific binding

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -79,6 +79,7 @@ func (r *Reconciler) reconcileServiceBinding(ctx context.Context, service *openc
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, serviceBinding, func() error {
 		desired := r.makeServiceBinding(service, workload)
+		desired.Spec.ReleaseState = serviceBinding.Spec.ReleaseState // Keep the existing release state
 		serviceBinding.Labels = desired.Labels
 		serviceBinding.Spec = desired.Spec
 		return controllerutil.SetControllerReference(service, serviceBinding, r.Scheme)

--- a/internal/controller/servicebinding/controller_conditions.go
+++ b/internal/controller/servicebinding/controller_conditions.go
@@ -17,12 +17,14 @@ const (
 // Constants for condition reasons
 
 const (
-	// Reasons for the Ready condition type when status is True
+	// Reasons for the Ready condition based on ReleaseState
 
-	// ReasonAllResourcesReady indicates all resources are deployed and healthy
-	ReasonAllResourcesReady controller.ConditionReason = "AllResourcesReady"
-	// ReasonResourcesReadyWithSuspended indicates all resources are ready (some intentionally suspended)
-	ReasonResourcesReadyWithSuspended controller.ConditionReason = "ResourcesReadyWithSuspended"
+	// ReasonResourcesActive indicates all resources are deployed and actively running (ReleaseState=Active)
+	ReasonResourcesActive controller.ConditionReason = "ResourcesActive"
+	// ReasonResourcesSuspended indicates resources are intentionally suspended (ReleaseState=Suspend)
+	ReasonResourcesSuspended controller.ConditionReason = "ResourcesSuspended"
+	// ReasonResourcesUndeployed indicates resources are intentionally undeployed (ReleaseState=Undeploy)
+	ReasonResourcesUndeployed controller.ConditionReason = "ResourcesUndeployed"
 
 	// Reasons for the Ready condition type when status is False - Resource Health Issues
 
@@ -46,4 +48,6 @@ const (
 	ReasonReleaseCreationFailed controller.ConditionReason = "ReleaseCreationFailed"
 	// ReasonReleaseUpdateFailed indicates failure to update the Release
 	ReasonReleaseUpdateFailed controller.ConditionReason = "ReleaseUpdateFailed"
+	// ReasonReleaseDeletionFailed indicates failure to delete the Release during undeploy
+	ReasonReleaseDeletionFailed controller.ConditionReason = "ReleaseDeletionFailed"
 )

--- a/internal/controller/servicebinding/controller_status.go
+++ b/internal/controller/servicebinding/controller_status.go
@@ -22,7 +22,7 @@ func (r *Reconciler) setReadyStatus(ctx context.Context, serviceBinding *opencho
 	// Handle the case where there are no resources
 	if totalResources == 0 {
 		message := "No resources to deploy"
-		controller.MarkTrueCondition(serviceBinding, ConditionReady, ReasonAllResourcesReady, message)
+		controller.MarkTrueCondition(serviceBinding, ConditionReady, ReasonResourcesActive, message)
 		return nil
 	}
 
@@ -49,19 +49,20 @@ func (r *Reconciler) setReadyStatus(ctx context.Context, serviceBinding *opencho
 		}
 	}
 
-	// Check if all resources are ready (healthy or suspended)
-	allResourcesReady := (healthyCount + suspendedCount) == totalResources
+	// Check ReleaseState and suspended resources
+	if serviceBinding.Spec.ReleaseState == openchoreov1alpha1.ReleaseStateSuspend && suspendedCount > 0 {
+		message := "Resources suspended"
+		controller.MarkFalseCondition(serviceBinding, ConditionReady, ReasonResourcesSuspended, message)
+		return nil
+	}
+
+	// Check if all resources are ready (only healthy counts as ready now)
+	allResourcesReady := healthyCount == totalResources
 
 	// Set the ready condition based on resource health status
 	if allResourcesReady {
-		// Use appropriate ready reason
-		if suspendedCount > 0 {
-			message := fmt.Sprintf("All %d resources are ready (%d suspended)", totalResources, suspendedCount)
-			controller.MarkTrueCondition(serviceBinding, ConditionReady, ReasonResourcesReadyWithSuspended, message)
-		} else {
-			message := fmt.Sprintf("All %d resources are deployed and healthy", totalResources)
-			controller.MarkTrueCondition(serviceBinding, ConditionReady, ReasonAllResourcesReady, message)
-		}
+		message := fmt.Sprintf("All %d resources are deployed and healthy", totalResources)
+		controller.MarkTrueCondition(serviceBinding, ConditionReady, ReasonResourcesActive, message)
 	} else {
 		// Build a status message with counts
 		var statusParts []string

--- a/internal/controller/servicebinding/render/deployment.go
+++ b/internal/controller/servicebinding/render/deployment.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	dpkubernetes "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
@@ -34,6 +35,11 @@ func Deployment(rCtx Context) *openchoreov1alpha1.Resource {
 			Labels:    makeServiceLabels(rCtx),
 		},
 		Spec: *mergedSpec,
+	}
+
+	// Apply to suspend modifications if ReleaseState is Suspend
+	if rCtx.ServiceBinding.Spec.ReleaseState == openchoreov1alpha1.ReleaseStateSuspend {
+		deployment.Spec.Replicas = ptr.To(int32(0))
 	}
 
 	rawExt := &runtime.RawExtension{}

--- a/internal/controller/webapplication/controller.go
+++ b/internal/controller/webapplication/controller.go
@@ -79,6 +79,7 @@ func (r *Reconciler) reconcileWebApplicationBinding(ctx context.Context, webAppl
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, webApplicationBinding, func() error {
 		desired := r.makeWebApplicationBinding(webApplication, workload)
+		desired.Spec.ReleaseState = webApplicationBinding.Spec.ReleaseState // Keep the existing release state
 		webApplicationBinding.Labels = desired.Labels
 		webApplicationBinding.Spec = desired.Spec
 		return controllerutil.SetControllerReference(webApplication, webApplicationBinding, r.Scheme)
@@ -141,12 +142,12 @@ func (r *Reconciler) makeLabels(webApplication *openchoreov1alpha1.WebApplicatio
 	for k, v := range webApplication.Labels {
 		result[k] = v
 	}
-	
+
 	// Add/overwrite component-specific labels
 	result[labels.LabelKeyOrganizationName] = webApplication.Namespace // namespace = organization
 	result[labels.LabelKeyProjectName] = webApplication.Spec.Owner.ProjectName
 	result[labels.LabelKeyComponentName] = webApplication.Spec.Owner.ComponentName
 	result[labels.LabelKeyEnvironmentName] = "development" // TODO: This should come from the actual environment when creating bindings
-	
+
 	return result
 }

--- a/internal/controller/webapplicationbinding/controller_conditions.go
+++ b/internal/controller/webapplicationbinding/controller_conditions.go
@@ -17,12 +17,14 @@ const (
 // Constants for condition reasons
 
 const (
-	// Reasons for the Ready condition type when status is True
+	// Reasons for the Ready condition based on ReleaseState
 
-	// ReasonAllResourcesReady indicates all resources are deployed and healthy
-	ReasonAllResourcesReady controller.ConditionReason = "AllResourcesReady"
-	// ReasonResourcesReadyWithSuspended indicates all resources are ready (some intentionally suspended)
-	ReasonResourcesReadyWithSuspended controller.ConditionReason = "ResourcesReadyWithSuspended"
+	// ReasonResourcesActive indicates all resources are deployed and actively running (ReleaseState=Active)
+	ReasonResourcesActive controller.ConditionReason = "ResourcesActive"
+	// ReasonResourcesSuspended indicates resources are intentionally suspended (ReleaseState=Suspend)
+	ReasonResourcesSuspended controller.ConditionReason = "ResourcesSuspended"
+	// ReasonResourcesUndeployed indicates resources are intentionally undeployed (ReleaseState=Undeploy)
+	ReasonResourcesUndeployed controller.ConditionReason = "ResourcesUndeployed"
 
 	// Reasons for the Ready condition type when status is False - Resource Health Issues
 
@@ -46,4 +48,6 @@ const (
 	ReasonReleaseCreationFailed controller.ConditionReason = "ReleaseCreationFailed"
 	// ReasonReleaseUpdateFailed indicates failure to update the Release
 	ReasonReleaseUpdateFailed controller.ConditionReason = "ReleaseUpdateFailed"
+	// ReasonReleaseDeletionFailed indicates failure to delete the Release
+	ReasonReleaseDeletionFailed controller.ConditionReason = "ReleaseDeletionFailed"
 )

--- a/internal/controller/webapplicationbinding/render/deployment.go
+++ b/internal/controller/webapplicationbinding/render/deployment.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	dpkubernetes "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
@@ -34,6 +35,11 @@ func Deployment(rCtx Context) *openchoreov1alpha1.Resource {
 			Labels:    makeWebApplicationLabels(rCtx),
 		},
 		Spec: *mergedSpec,
+	}
+
+	// Handle suspend state by setting replicas to 0
+	if rCtx.WebApplicationBinding.Spec.ReleaseState == openchoreov1alpha1.ReleaseStateSuspend {
+		deployment.Spec.Replicas = ptr.To(int32(0))
 	}
 
 	rawExt := &runtime.RawExtension{}

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -71,11 +71,11 @@ type BindingResponse struct {
 type BindingStatusType string
 
 const (
-	BindingStatusTypePending    BindingStatusType = "InProgress"
+	BindingStatusTypeInProgress BindingStatusType = "InProgress"
 	BindingStatusTypeReady      BindingStatusType = "Active"
 	BindingStatusTypeFailed     BindingStatusType = "Failed"
 	BindingStatusTypeSuspended  BindingStatusType = "Suspended"
-	BindingStatusTypeInProgress BindingStatusType = "NotYetDeployed"
+	BindingStatusTypeUndeployed BindingStatusType = "NotYetDeployed"
 )
 
 type BindingStatus struct {


### PR DESCRIPTION
## Purpose
Add ReleaseState field to binding CRDs to enable undeploy and suspend functionality for data plane resources

## Approach

## Related Issues

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks