### PR TITLE
Automate Workload Creation through CI

### DIFF
--- a/cmd/choreoctl/Dockerfile
+++ b/cmd/choreoctl/Dockerfile
@@ -1,0 +1,30 @@
+# Build stage
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+COPY ../../go.mod ../../go.sum ./
+RUN go mod download
+
+COPY ../.. .
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w" -o choreoctl cmd/choreoctl/main.go
+
+# Runtime stage
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+
+# Add non-root user
+RUN adduser -D choreoctl
+
+COPY --from=builder /app/choreoctl /usr/local/bin/choreoctl
+RUN chmod +x /usr/local/bin/choreoctl
+
+USER choreoctl
+
+ENTRYPOINT ["/usr/local/bin/choreoctl"]

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/ballerina-buildpack.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/ballerina-buildpack.yaml
@@ -27,7 +27,12 @@ spec:
               parameters:
                 - name: git-revision
                   value: '{{ "{{" }}steps.clone-step.outputs.parameters.git-revision{{ "}}" }}'
-
+        - - name: workload-create-step
+            template: workload-create-step
+            arguments:
+              parameters:
+                - name: image
+                  value: '{{ "{{" }}steps.push-step.outputs.parameters.image{{ "}}" }}'
     - name: clone-step
       outputs:
         parameters:
@@ -210,7 +215,45 @@ spec:
         volumeMounts:
           - mountPath: /mnt/vol
             name: workspace
+    - name: workload-create-step
+      inputs:
+        parameters:
+          - name: image
+      outputs:
+        parameters:
+          - name: workload-cr
+            valueFrom:
+              path: /mnt/vol/workload-cr.yaml
+      container:
+        image: ghcr.io/openchoreo/openchoreo-cli:v0.1
+        command: [ sh, -c ]
+        args:
+          - |-
+            set -e
 
+            #####################################################################
+            # 1. Initialize variables
+            #####################################################################
+            IMAGE={{ "{{" }}inputs.parameters.image{{ "}}" }}
+            PROJECT_NAME={{ "{{" }}workflow.parameters.project-name{{ "}}" }}
+            COMPONENT_NAME={{ "{{" }}workflow.parameters.component-name{{ "}}" }}
+            DESCRIPTOR_PATH="/mnt/vol/source/workload.yaml"
+            OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+
+            echo "Creating workload with image: $IMAGE"
+
+            #####################################################################
+            # 2. Create workload CR and export to output
+            #####################################################################
+            choreoctl create workload \
+              --project "$PROJECT_NAME" \
+              --component "$COMPONENT_NAME" \
+              --image "$IMAGE" \
+              --descriptor "$DESCRIPTOR_PATH" \
+              -o "$OUTPUT_PATH"
+        volumeMounts:
+          - name: workspace
+            mountPath: /mnt/vol
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -225,7 +268,6 @@ spec:
     secondsAfterSuccess: 3600
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         name: workspace
       spec:
         accessModes:

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/docker.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/docker.yaml
@@ -31,6 +31,12 @@ spec:
               parameters:
                 - name: git-revision
                   value: '{{ "{{" }}steps.clone-step.outputs.parameters.git-revision{{ "}}" }}'
+        - - name: workload-create-step
+            template: workload-create-step
+            arguments:
+              parameters:
+                - name: image
+                  value: '{{ "{{" }}steps.push-step.outputs.parameters.image{{ "}}" }}'
     - name: clone-step
       outputs:
         parameters:
@@ -182,7 +188,45 @@ spec:
         volumeMounts:
           - mountPath: /mnt/vol
             name: workspace
+    - name: workload-create-step
+      inputs:
+        parameters:
+          - name: image
+      outputs:
+        parameters:
+          - name: workload-cr
+            valueFrom:
+              path: /mnt/vol/workload-cr.yaml
+      container:
+        image: ghcr.io/openchoreo/openchoreo-cli:v0.1
+        command: [ sh, -c ]
+        args:
+          - |-
+            set -e
 
+            #####################################################################
+            # 1. Initialize variables
+            #####################################################################
+            IMAGE={{ "{{" }}inputs.parameters.image{{ "}}" }}
+            PROJECT_NAME={{ "{{" }}workflow.parameters.project-name{{ "}}" }}
+            COMPONENT_NAME={{ "{{" }}workflow.parameters.component-name{{ "}}" }}
+            DESCRIPTOR_PATH="/mnt/vol/source/workload.yaml"
+            OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+
+            echo "Creating workload with image: $IMAGE"
+
+            #####################################################################
+            # 2. Create workload CR and export to output
+            #####################################################################
+            choreoctl create workload \
+              --project "$PROJECT_NAME" \
+              --component "$COMPONENT_NAME" \
+              --image "$IMAGE" \
+              --descriptor "$DESCRIPTOR_PATH" \
+              -o "$OUTPUT_PATH"
+        volumeMounts:
+          - name: workspace
+            mountPath: /mnt/vol
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -197,7 +241,6 @@ spec:
     secondsAfterSuccess: 3600
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         name: workspace
       spec:
         accessModes:

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/google-cloud-buildpacks.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/google-cloud-buildpacks.yaml
@@ -27,7 +27,12 @@ spec:
               parameters:
                 - name: git-revision
                   value: '{{ "{{" }}steps.clone-step.outputs.parameters.git-revision{{ "}}" }}'
-
+        - - name: workload-create-step
+            template: workload-create-step
+            arguments:
+              parameters:
+                - name: image
+                  value: '{{ "{{" }}steps.push-step.outputs.parameters.image{{ "}}" }}'
     - name: clone-step
       outputs:
         parameters:
@@ -211,7 +216,45 @@ spec:
         volumeMounts:
           - mountPath: /mnt/vol
             name: workspace
+    - name: workload-create-step
+      inputs:
+        parameters:
+          - name: image
+      outputs:
+        parameters:
+          - name: workload-cr
+            valueFrom:
+              path: /mnt/vol/workload-cr.yaml
+      container:
+        image: ghcr.io/openchoreo/openchoreo-cli:v0.1
+        command: [ sh, -c ]
+        args:
+          - |-
+            set -e
 
+            #####################################################################
+            # 1. Initialize variables
+            #####################################################################
+            IMAGE={{ "{{" }}inputs.parameters.image{{ "}}" }}
+            PROJECT_NAME={{ "{{" }}workflow.parameters.project-name{{ "}}" }}
+            COMPONENT_NAME={{ "{{" }}workflow.parameters.component-name{{ "}}" }}
+            DESCRIPTOR_PATH="/mnt/vol/source/workload.yaml"
+            OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+
+            echo "Creating workload with image: $IMAGE"
+
+            #####################################################################
+            # 2. Create workload CR and export to output
+            #####################################################################
+            choreoctl create workload \
+              --project "$PROJECT_NAME" \
+              --component "$COMPONENT_NAME" \
+              --image "$IMAGE" \
+              --descriptor "$DESCRIPTOR_PATH" \
+              -o "$OUTPUT_PATH"
+        volumeMounts:
+          - name: workspace
+            mountPath: /mnt/vol
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/react.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/react.yaml
@@ -30,7 +30,12 @@ spec:
               parameters:
                 - name: git-revision
                   value: '{{ "{{" }}steps.clone-step.outputs.parameters.git-revision{{ "}}" }}'
-
+        - - name: workload-create-step
+            template: workload-create-step
+            arguments:
+              parameters:
+                - name: image
+                  value: '{{ "{{" }}steps.push-step.outputs.parameters.image{{ "}}" }}'
     - name: clone-step
       outputs:
         parameters:
@@ -216,7 +221,45 @@ spec:
         volumeMounts:
           - mountPath: /mnt/vol
             name: workspace
+    - name: workload-create-step
+      inputs:
+        parameters:
+          - name: image
+      outputs:
+        parameters:
+          - name: workload-cr
+            valueFrom:
+              path: /mnt/vol/workload-cr.yaml
+      container:
+        image: ghcr.io/openchoreo/openchoreo-cli:v0.1
+        command: [ sh, -c ]
+        args:
+          - |-
+            set -e
 
+            #####################################################################
+            # 1. Initialize variables
+            #####################################################################
+            IMAGE={{ "{{" }}inputs.parameters.image{{ "}}" }}
+            PROJECT_NAME={{ "{{" }}workflow.parameters.project-name{{ "}}" }}
+            COMPONENT_NAME={{ "{{" }}workflow.parameters.component-name{{ "}}" }}
+            DESCRIPTOR_PATH="/mnt/vol/source/workload.yaml"
+            OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+
+            echo "Creating workload with image: $IMAGE"
+
+            #####################################################################
+            # 2. Create workload CR and export to output
+            #####################################################################
+            choreoctl create workload \
+              --project "$PROJECT_NAME" \
+              --component "$COMPONENT_NAME" \
+              --image "$IMAGE" \
+              --descriptor "$DESCRIPTOR_PATH" \
+              -o "$OUTPUT_PATH"
+        volumeMounts:
+          - name: workspace
+            mountPath: /mnt/vol
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/internal/controller/build/controller_conditions.go
+++ b/internal/controller/build/controller_conditions.go
@@ -212,7 +212,7 @@ func isBuildCompleted(build *openchoreov1alpha1.Build) bool {
 	return false
 }
 
-func isBuildSucceeded(build *openchoreov1alpha1.Build) bool {
+func isBuildWorkflowSucceeded(build *openchoreov1alpha1.Build) bool {
 	cond := meta.FindStatusCondition(build.Status.Conditions, string(ConditionBuildCompleted))
 	if cond == nil {
 		return false

--- a/internal/controller/build/workflow.go
+++ b/internal/controller/build/workflow.go
@@ -60,6 +60,8 @@ func makeWorkflowSpec(build *openchoreov1alpha1.Build) argoproj.WorkflowSpec {
 func buildWorkflowParameters(build *openchoreov1alpha1.Build) []argoproj.Parameter {
 
 	parameters := []argoproj.Parameter{
+		createParameter("project-name", build.Spec.Owner.ProjectName),
+		createParameter("component-name", build.Spec.Owner.ComponentName),
 		createParameter("git-repo", build.Spec.Repository.URL),
 		createParameter("app-path", build.Spec.Repository.AppPath),
 		createParameter("image-name", makeImageName(build)),


### PR DESCRIPTION
## Purpose
Automate the creation of Workload Custom Resources (CRs) as part of the CI pipeline using the output image from the build process.

## Approach
- Introduced a Dockerfile to build an image for the OpenChoreo CLI (choreoctl).
- Added a new workload-create-step to the Argo workflow templates, which uses the OpenChoreo CLI to generate and output a workload CR.
- Updated the Build controller logic to use the generated workload CR and apply it to the cluster as part of the post-build process.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/344

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
