### PR TITLE
Fix local registry url

### DIFF
--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -17,7 +17,7 @@ global:
       # These values are ONLY used if registry.type is "local".
       local:
         # -- The internal cluster address used by build pipelines (e.g., Podman) to push images.
-        pushEndpoint: "registry.openchoreo-data-plane.svc.cluster.local:5000"
+        pushEndpoint: "registry.openchoreo-data-plane:5000"
 
         # -- The public-facing address used by cluster nodes (kubelet) to pull images.
         # This could be a NodePort, LoadBalancer, or Ingress address.


### PR DESCRIPTION
## Purpose
On certain environments, image push operations fail when the registry endpoint includes the full domain (e.g., registry.openchoreo-data-plane.svc.cluster.local). This update simplifies the push endpoint to rely on Kubernetes internal DNS resolution, improving compatibility across machines.

## Approach
Relies on Kubernetes' internal service DNS for name resolution.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
