### PR TITLE
Retrieve server URL from kubeconfig in scripts

### DIFF
--- a/install/add-build-plane.sh
+++ b/install/add-build-plane.sh
@@ -23,16 +23,12 @@ if [[ "$SEPARATE" == false ]]; then
   CONTEXT=$(kubectl config current-context)
   TARGET_CONTEXT=$CONTEXT
   BUILDPLANE_KIND_NAME=$DEFAULT_BUILDPLANE_KIND_NAME
-  NODE_NAME_PREFIX=${CONTEXT#kind-}
-  SERVER_URL="https://$NODE_NAME_PREFIX-control-plane:6443"
 else
   read -p "Enter BuildPlane Kubernetes context (default: $DEFAULT_CONTEXT): " INPUT_CONTEXT
   CONTEXT=${INPUT_CONTEXT:-$DEFAULT_CONTEXT}
   TARGET_CONTEXT=$DEFAULT_TARGET_CONTEXT
 
   echo -e "\n${DARK_YELLOW}Using Kubernetes context '$CONTEXT' as BuildPlane.${RESET}"
-  NODE_NAME_PREFIX=${CONTEXT#kind-}
-  SERVER_URL="https://$NODE_NAME_PREFIX-control-plane:6443"
 
   read -p "Enter BuildPlane kind name (default: $DEFAULT_BUILDPLANE_KIND_NAME): " INPUT_BUILDPLANE_NAME
   BUILDPLANE_KIND_NAME=${INPUT_BUILDPLANE_NAME:-$DEFAULT_BUILDPLANE_KIND_NAME}
@@ -41,6 +37,7 @@ fi
 # Extract info from chosen context
 CLUSTER_NAME=$(kubectl config view -o jsonpath="{.contexts[?(@.name=='$CONTEXT')].context.cluster}")
 USER_NAME=$(kubectl config view -o jsonpath="{.contexts[?(@.name=='$CONTEXT')].context.user}")
+SERVER_URL=$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CLUSTER_NAME')].cluster.server}")
 
 # Try to get base64-encoded values directly
 CA_CERT=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='$CLUSTER_NAME')].cluster.certificate-authority-data}")

--- a/install/add-default-dataplane.sh
+++ b/install/add-default-dataplane.sh
@@ -26,8 +26,6 @@ if [[ "$SINGLE_CLUSTER" == "true" ]]; then
   CONTEXT=$(kubectl config current-context)
   TARGET_CONTEXT=$CONTEXT
   DATAPLANE_KIND_NAME=$DEFAULT_DATAPLANE_KIND_NAME
-  NODE_NAME_PREFIX=${CONTEXT#kind-}
-  SERVER_URL="https://$NODE_NAME_PREFIX-control-plane:6443"
   echo "Running in single-cluster mode using context '$CONTEXT'"
 else
   read -p "Enter DataPlane Kubernetes context (default: $DEFAULT_CONTEXT): " INPUT_CONTEXT
@@ -35,8 +33,6 @@ else
   TARGET_CONTEXT=$DEFAULT_TARGET_CONTEXT
 
   echo -e "\nUsing Kubernetes context '$CONTEXT' as DataPlane."
-  NODE_NAME_PREFIX=${CONTEXT#kind-}
-  SERVER_URL="https://$NODE_NAME_PREFIX-control-plane:6443"
 
   read -p "Enter DataPlane kind name (default: $DEFAULT_DATAPLANE_KIND_NAME): " INPUT_DATAPLANE_NAME
   DATAPLANE_KIND_NAME=${INPUT_DATAPLANE_NAME:-$DEFAULT_DATAPLANE_KIND_NAME}
@@ -45,6 +41,7 @@ fi
 # Extract info from chosen context
 CLUSTER_NAME=$(kubectl config view -o jsonpath="{.contexts[?(@.name=='$CONTEXT')].context.cluster}")
 USER_NAME=$(kubectl config view -o jsonpath="{.contexts[?(@.name=='$CONTEXT')].context.user}")
+SERVER_URL=$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CLUSTER_NAME')].cluster.server}")
 echo " "
 
 # Try to get base64-encoded values directly


### PR DESCRIPTION
## Purpose
The server URL is currently hardcoded to support only kind clusters. This limits compatibility with other Kubernetes environments.

## Approach
Update the implementation to read the server URL from the kubeconfig file, ensuring support across different cluster types.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/408

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
