### PR TITLE
Provide permissions to opensearch for writing data

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/opensearch/opensearch-statefulset.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch/opensearch-statefulset.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" "opensearch") | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - name: opensearch
         image: "{{ .Values.opensearch.image.repository }}:{{ .Values.opensearch.image.tag }}"


### PR DESCRIPTION
## Purpose
OpenSearch pods fail to start with AccessDeniedException: /usr/share/opensearch/data when deployed on cloud Kubernetes clusters using storage classes other than local-path.

## Approach
Happens due to:
  1. OpenSearch runs as user opensearch (uid=1000, gid=1000)
  2. Cloud storage providers mount volumes with root ownership and restrictive permissions
  3. The StatefulSet template lacks proper securityContext configuration
  
Added securityContext configuration to the OpenSearch StatefulSet template in install/helm/openchoreo-observability-plane/templates/opensearch/opensearch-statefulset.yaml:

## Related Issues
https://github.com/openchoreo/openchoreo/issues/443

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
