### PR TITLE
Update cert-manager repository url to oci registry #508

### DIFF
--- a/install/helm/openchoreo-control-plane/Chart.lock
+++ b/install/helm/openchoreo-control-plane/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
-  repository: https://charts.jetstack.io
+  repository: oci://quay.io/jetstack/charts/cert-manager
   version: v1.16.2
 digest: sha256:3355cf281dbbfda4f89395d8690ef95e76e8cf38769bcf4fbcb5b1c3650d49f0
 generated: "2025-07-13T15:19:18.792798+05:30"

--- a/install/helm/openchoreo-control-plane/Chart.lock
+++ b/install/helm/openchoreo-control-plane/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
-  repository: oci://quay.io/jetstack/charts/cert-manager
+  repository: oci://quay.io/jetstack/charts
   version: v1.16.2
-digest: sha256:3355cf281dbbfda4f89395d8690ef95e76e8cf38769bcf4fbcb5b1c3650d49f0
-generated: "2025-07-13T15:19:18.792798+05:30"
+digest: sha256:f59589c2378ce9a2f81613b2a6254b03e0524f5086f53140950cc5629b90e5c0
+generated: "2025-09-23T15:10:27.3347854+05:30"

--- a/install/helm/openchoreo-control-plane/Chart.yaml
+++ b/install/helm/openchoreo-control-plane/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
 
 dependencies:
   - name: cert-manager
-    repository: oci://quay.io/jetstack/charts/cert-manager
+    repository: oci://quay.io/jetstack/charts
     condition: cert-manager.enabled
     version: "v1.16.2"

--- a/install/helm/openchoreo-control-plane/Chart.yaml
+++ b/install/helm/openchoreo-control-plane/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
 
 dependencies:
   - name: cert-manager
-    repository: https://charts.jetstack.io
+    repository: oci://quay.io/jetstack/charts/cert-manager
     condition: cert-manager.enabled
     version: "v1.16.2"

--- a/install/helm/openchoreo-data-plane/Chart.lock
+++ b/install/helm/openchoreo-data-plane/Chart.lock
@@ -9,7 +9,7 @@ dependencies:
   repository: oci://registry-1.docker.io/envoyproxy
   version: 1.2.3
 - name: cert-manager
-  repository: https://charts.jetstack.io
+  repository: oci://quay.io/jetstack/charts/cert-manager
   version: v1.16.2
 digest: sha256:937ee41d26a39d8400481d659e741a33a2a202eb7f6169f81bc06e83703aa043
 generated: "2025-09-17T14:24:57.619961+05:30"

--- a/install/helm/openchoreo-data-plane/Chart.lock
+++ b/install/helm/openchoreo-data-plane/Chart.lock
@@ -9,7 +9,7 @@ dependencies:
   repository: oci://registry-1.docker.io/envoyproxy
   version: 1.2.3
 - name: cert-manager
-  repository: oci://quay.io/jetstack/charts/cert-manager
+  repository: oci://quay.io/jetstack/charts
   version: v1.16.2
-digest: sha256:937ee41d26a39d8400481d659e741a33a2a202eb7f6169f81bc06e83703aa043
-generated: "2025-09-17T14:24:57.619961+05:30"
+digest: sha256:3972396d04ecb68d5d94cda6024bedcd756ec8b70900435cb005630aff5c59b8
+generated: "2025-09-23T15:12:32.5921223+05:30"

--- a/install/helm/openchoreo-data-plane/Chart.yaml
+++ b/install/helm/openchoreo-data-plane/Chart.yaml
@@ -39,6 +39,6 @@ dependencies:
     repository: "oci://registry-1.docker.io/envoyproxy"
     version: 1.2.3
   - name: cert-manager
-    repository: oci://quay.io/jetstack/charts/cert-manager
+    repository: oci://quay.io/jetstack/charts
     condition: cert-manager.enabled
     version: "v1.16.2"

--- a/install/helm/openchoreo-data-plane/Chart.yaml
+++ b/install/helm/openchoreo-data-plane/Chart.yaml
@@ -39,6 +39,6 @@ dependencies:
     repository: "oci://registry-1.docker.io/envoyproxy"
     version: 1.2.3
   - name: cert-manager
-    repository: https://charts.jetstack.io
+    repository: oci://quay.io/jetstack/charts/cert-manager
     condition: cert-manager.enabled
     version: "v1.16.2"


### PR DESCRIPTION
## Purpose
The cert-manager Helm chart repository has moved from https://charts.jetstack.io to the OCI registry oci://quay.io/jetstack/charts/cert-manager.
This PR updates the repository URL in Chart.yaml and Chart.lock files for both the control-plane and data-plane Helm charts to reflect the new location.
Resolves issue [#480](https://github.com/openchoreo/openchoreo/issues/480).

## Approach
Manually updated the repository URL in all affected Chart.yaml and Chart.lock files.
No changes to chart versions or digests were made. Helm lock files can be regenerated by maintainers if needed.

## Related Issues
Closes #480.

## Checklist
- [ ] Tests added or updated (not applicable for repository URL update)
- [ ] Samples updated (not applicable)

## Remarks
Since this is a first-time contribution, Chart.lock files were updated manually to reflect the new repository URL.
I tried generating them using Helm, but it requires authentication for the OCI registry. Maintainers can regenerate the lock files if needed.