### PR TITLE
Fix hardcoded Helm chart .tgz names in dev-deploy Makefile target (kube.mk)

### DIFF
--- a/make/kube.mk
+++ b/make/kube.mk
@@ -38,10 +38,11 @@ dev-deploy: ## Deploy the Choreo developer version to a Kind cluster configured 
 	@$(MAKE) helm-package
 	helm upgrade --install cilium $(HELM_CHARTS_OUTPUT_DIR)/cilium-$(HELM_CHART_VERSION).tgz \
 		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
-	helm upgrade --install choreo-control-plane $(HELM_CHARTS_OUTPUT_DIR)/choreo-control-plane-$(HELM_CHART_VERSION).tgz \
-    	--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m
-	helm upgrade --install choreo-dataplane $(HELM_CHARTS_OUTPUT_DIR)/choreo-dataplane-$(HELM_CHART_VERSION).tgz \
-		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m --set certmanager.enabled=false
+	helm upgrade --install choreo-control-plane $(HELM_CHARTS_OUTPUT_DIR)/openchoreo-control-plane-$(HELM_CHART_VERSION).tgz \
+    	--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m --set cert-manager.enabled=false
+
+	helm upgrade --install choreo-dataplane $(HELM_CHARTS_OUTPUT_DIR)/openchoreo-data-plane-$(HELM_CHART_VERSION).tgz \
+		--namespace "$(KUBE_DEV_DEPLOY_NAMESPACE)" --create-namespace --timeout 30m --set cert-manager.enabled=false
 
 .PHONY: dev-undeploy
 dev-undeploy: ## Undeploy the Choreo developer version from a Kind cluster configured in ~/.kube/config


### PR DESCRIPTION
## Purpose
> The dev-deploy target in the kube.mk Makefile references Helm chart .tgz files using hardcoded or incorrect names. This causes the deployment to fail when the actual chart filenames differ.

## Approach
> The fix updates the dev-deploy target in kube.mk to reference the correct Helm chart .tgz filenames that actually exist in the bin/dist/charts directory. Previously, some charts were hardcoded with incorrect or outdated names, which caused make dev-deploy to fail.
No dynamic detection or renaming of files is introduced; the PR ensures that the Makefile matches the current chart filenames exactly, restoring the expected deployment workflow.

## Related Issues
> #512 

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
