### PR TITLE
Proposal: Introduce Component Type Definitions with Addons

### DIFF
--- a/docs/proposals/0537-introduce-component-type-definitions.md
+++ b/docs/proposals/0537-introduce-component-type-definitions.md
@@ -63,7 +63,7 @@ As a result, platform engineers lack the control needed to enforce organizationa
 This proposal introduces new CRDs and controller support:
 
 - New CRDs: `ComponentTypeDefinition` (v1alpha1), `Addon` (v1alpha1), and `EnvSettings` (v1alpha1)
-- New `v1alpha2` version of the `Component` CRD with `componentType` and `addons[]` fields
+- New `v1alpha1` version of the `Component` CRD with `componentType` and `addons[]` fields
 - New controllers for rendering ComponentTypeDefinitions with CEL templating and applying addon composition
 
 ---
@@ -234,7 +234,7 @@ Addons can:
 Instead of generating multiple CRDs, developers use a single **Component** CRD with a `componentType` field and `addons[]` array:
 
 ```yaml
-apiVersion: openchoreo.dev/v1alpha2
+apiVersion: openchoreo.dev/v1alpha1
 kind: Component
 metadata:
   name: checkout-service
@@ -612,7 +612,7 @@ spec:
       resources: { ... }
 
   component:
-    apiVersion: openchoreo.dev/v1alpha2
+    apiVersion: openchoreo.dev/v1alpha1
     kind: Component
     metadata:
       name: checkout-service
@@ -634,7 +634,7 @@ spec:
         patches: [...]
 
   workload:
-    apiVersion: openchoreo.dev/v1alpha2
+    apiVersion: openchoreo.dev/v1alpha1
     kind: Workload
     metadata:
       name: checkout-service


### PR DESCRIPTION
## Purpose
Proposes ComponentTypeDefinitions with Addons to enable platform engineers to define extensible, composable component
  types using CEL-based templates.

  Key concepts:
  - New CRDs: ComponentTypeDefinition, Addon, EnvSettings, and ComponentEnvSnapshot
  - Component CRD v1alpha2 with componentType and addons[] fields
  - Workload CRD v1alpha2 with updated schema (TBD) for endpoints, connections, and config (https://github.com/openchoreo/openchoreo/discussions/524)
  - CEL-based templating for dynamic resource generation
  - Structured environment-specific overrides via EnvSettings
  - Snapshot-based deployment and promotion workflow

  This design maintains a simplified developer experience through a single Component CRD while giving platform engineers
   full control and extensibility.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/537

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
