### PR TITLE
Add OpenSearch data prepper as a subchart of the Observability chart

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -1,4 +1,7 @@
 dependencies:
+- name: data-prepper
+  repository: https://opensearch-project.github.io/helm-charts/
+  version: 0.3.1
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.54.0
@@ -11,5 +14,5 @@ dependencies:
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:56c5229126ddb9f5c9c865e7e306dd52c8346458b7eeb012ba54c31bc3deb74e
-generated: "2025-10-27T16:51:01.838237+05:30"
+digest: sha256:2ec9c5f106ffc327c39294a55e565c6ced337823f4597496c39641fe9b905078
+generated: "2025-10-28T11:47:46.433045+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -28,6 +28,10 @@ maintainers:
     url: https://github.com/openchoreo/openchoreo
 
 dependencies:
+  - name: data-prepper
+    repository: https://opensearch-project.github.io/helm-charts/
+    version: 0.3.1
+    condition: data-prepper.enabled
   - name: fluent-bit
     alias: fluentBit
     repository: https://fluent.github.io/helm-charts

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -8,6 +8,36 @@ global:
   # minimal: Single replica OpenSearch instance will be deployed
   installationMode: minimal
 
+data-prepper:
+  enabled: true
+  fullnameOverride: "data-prepper"
+
+  pipelineConfig:
+    enabled: true
+    config:
+      trace-pipeline:
+        delay: "100"
+        source:
+          otel_trace_source:
+            ssl: false
+        buffer:
+          bounded_blocking:
+            buffer_size: 12800
+            batch_size: 200
+        sink:
+          - opensearch:
+              hosts: ["http://opensearch:9200"]
+              insecure: true
+              index_type: trace-analytics-raw
+  
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 500Mi
+    requests:
+      cpu: 1000m
+      memory: 500Mi
+
 openSearch:
   enabled: true
 


### PR DESCRIPTION
## Purpose
To allow components to publish traces in OpenTelemetry format

## Approach
Added OpenSearch data prepper as a subchart to the Observability helm chart. Includes a data prepper pipeline to ingest OTLP traces and publish them to OpenSearch

## Related Issues
https://github.com/openchoreo/openchoreo/issues/588

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
