### PR TITLE
Add RCA handler in the observer API and provision the required resources

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -68,6 +68,28 @@ spec:
             secretKeyRef:
               name: observer-opensearch
               key: password
+        {{- if .Values.observer.rca.enabled }}
+        - name: RCA_ENABLED
+          value: "true"
+        - name: RCA_NAMESPACE
+          value: {{ .Values.observer.rca.jobsNamespace | quote }}
+        - name: RCA_IMAGE_REPOSITORY
+          value: {{ .Values.observer.rca.jobSpec.image.repository | quote }}
+        - name: RCA_IMAGE_TAG
+          value: {{ .Values.observer.rca.jobSpec.image.tag | default .Chart.AppVersion | quote }}
+        - name: RCA_IMAGE_PULL_POLICY
+          value: {{ .Values.observer.rca.jobSpec.image.pullPolicy | quote }}
+        - name: RCA_TTL_SECONDS_AFTER_FINISHED
+          value: {{ .Values.observer.rca.jobSpec.ttlSecondsAfterFinished | quote }}
+        - name: RCA_RESOURCE_LIMITS_CPU
+          value: {{ .Values.observer.rca.jobSpec.resources.limits.cpu | quote }}
+        - name: RCA_RESOURCE_LIMITS_MEMORY
+          value: {{ .Values.observer.rca.jobSpec.resources.limits.memory | quote }}
+        - name: RCA_RESOURCE_REQUESTS_CPU
+          value: {{ .Values.observer.rca.jobSpec.resources.requests.cpu | quote }}
+        - name: RCA_RESOURCE_REQUESTS_MEMORY
+          value: {{ .Values.observer.rca.jobSpec.resources.requests.memory | quote }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-service-account.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-service-account.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" "observer") | nindent 4 }}
-automountServiceAccountToken: false
+automountServiceAccountToken: {{ .Values.observer.rca.enabled | default false }}

--- a/install/helm/openchoreo-observability-plane/templates/rca/rca-namespace.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/rca/rca-namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.observer.rca.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.observer.rca.jobsNamespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" "observer-rca") | nindent 4 }}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/rca/rca-resourcequota.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/rca/rca-resourcequota.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.observer.rca.enabled .Values.observer.rca.resourceQuota }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: rca-jobs-quota
+  namespace: {{ .Values.observer.rca.jobsNamespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" "observer-rca") | nindent 4 }}
+spec:
+  hard:
+    count/jobs.batch: "{{ .Values.observer.rca.resourceQuota.maxJobs }}"
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/rca/rca-role.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/rca/rca-role.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.observer.rca.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rca-job-manager
+  namespace: {{ .Values.observer.rca.jobsNamespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" "observer-rca") | nindent 4 }}
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "get", "list", "watch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["resourcequotas"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "list", "delete"]
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/rca/rca-rolebinding.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/rca/rca-rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.observer.rca.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rca-manager-binding
+  namespace: {{ .Values.observer.rca.jobsNamespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" "observer-rca") | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rca-job-manager
+subjects:
+- kind: ServiceAccount
+  name: observer
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -160,6 +160,27 @@ observer:
   openSearchUsername: admin
   openSearchPassword: ThisIsTheOpenSearchPassword1
 
+  # RCA (Root Cause Analysis) configuration
+  rca:
+    enabled: false
+    jobsNamespace: openchoreo-rca-jobs # This is used by the ResourceQuota to limit jobs
+    jobSpec:
+      image:
+        repository: ghcr.io/openchoreo/rca-agent
+        tag: ""
+        pullPolicy: IfNotPresent
+      ttlSecondsAfterFinished: 600
+      # Resource limits and requests for RCA job pods
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    resourceQuota:
+      maxJobs: 5
+
 # Fluent Bit configuration
 fluentBit:
   enabled: false

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	OpenSearch OpenSearchConfig `koanf:"opensearch"`
 	Auth       AuthConfig       `koanf:"auth"`
 	Logging    LoggingConfig    `koanf:"logging"`
+	RCA        RCAConfig        `koanf:"rca"`
 	LogLevel   string           `koanf:"loglevel"`
 }
 
@@ -57,6 +58,20 @@ type LoggingConfig struct {
 	MaxLogLinesPerFile   int `koanf:"max.log.lines.per.file"`
 }
 
+// RCAConfig holds AI RCA (Root Cause Analysis) job configuration
+type RCAConfig struct {
+	Enabled                 bool   `koanf:"enabled"`
+	Namespace               string `koanf:"namespace"`
+	ImageRepository         string `koanf:"image.repository"`
+	ImageTag                string `koanf:"image.tag"`
+	ImagePullPolicy         string `koanf:"image.pull.policy"`
+	TTLSecondsAfterFinished int32  `koanf:"ttl.seconds.after.finished"`
+	ResourceLimitsCPU       string `koanf:"resource.limits.cpu"`
+	ResourceLimitsMemory    string `koanf:"resource.limits.memory"`
+	ResourceRequestsCPU     string `koanf:"resource.requests.cpu"`
+	ResourceRequestsMemory  string `koanf:"resource.requests.memory"`
+}
+
 // Load loads configuration from environment variables and defaults
 func Load() (*Config, error) {
 	k := koanf.New(".")
@@ -90,6 +105,16 @@ func Load() (*Config, error) {
 		"LOGGING_DEFAULT_LOG_LIMIT":       "logging.default.log.limit",
 		"LOGGING_DEFAULT_BUILD_LOG_LIMIT": "logging.default.build.log.limit",
 		"LOGGING_MAX_LOG_LINES_PER_FILE":  "logging.max.log.lines.per.file",
+		"RCA_ENABLED":                     "rca.enabled",
+		"RCA_NAMESPACE":                   "rca.namespace",
+		"RCA_IMAGE_REPOSITORY":            "rca.image.repository",
+		"RCA_IMAGE_TAG":                   "rca.image.tag",
+		"RCA_IMAGE_PULL_POLICY":           "rca.image.pull.policy",
+		"RCA_TTL_SECONDS_AFTER_FINISHED":  "rca.ttl.seconds.after.finished",
+		"RCA_RESOURCE_LIMITS_CPU":         "rca.resource.limits.cpu",
+		"RCA_RESOURCE_LIMITS_MEMORY":      "rca.resource.limits.memory",
+		"RCA_RESOURCE_REQUESTS_CPU":       "rca.resource.requests.cpu",
+		"RCA_RESOURCE_REQUESTS_MEMORY":    "rca.resource.requests.memory",
 		"LOG_LEVEL":                       "loglevel",
 		"PORT":                            "server.port",           // Common alias
 		"JWT_SECRET":                      "auth.jwt.secret",       // Common alias
@@ -175,6 +200,9 @@ func getDefaults() map[string]interface{} {
 			"default.build.log.limit": 3000,
 			"max.log.lines.per.file":  600000,
 		},
+		"rca": map[string]interface{}{
+			"enabled": false,
+		},
 		"loglevel": "info",
 	}
 }
@@ -194,6 +222,33 @@ func (c *Config) validate() error {
 
 	if c.Logging.MaxLogLimit <= 0 {
 		return fmt.Errorf("max log limit must be positive")
+	}
+
+	if c.RCA.Enabled {
+		if c.RCA.Namespace == "" {
+			return fmt.Errorf("rca.namespace is required when RCA is enabled")
+		}
+		if c.RCA.ImageRepository == "" {
+			return fmt.Errorf("rca.image.repository is required when RCA is enabled")
+		}
+		if c.RCA.ImageTag == "" {
+			return fmt.Errorf("rca.image.tag is required when RCA is enabled")
+		}
+		if c.RCA.ImagePullPolicy == "" {
+			return fmt.Errorf("rca.image.pull.policy is required when RCA is enabled")
+		}
+		if c.RCA.ResourceLimitsCPU == "" {
+			return fmt.Errorf("rca.resource.limits.cpu is required when RCA is enabled")
+		}
+		if c.RCA.ResourceLimitsMemory == "" {
+			return fmt.Errorf("rca.resource.limits.memory is required when RCA is enabled")
+		}
+		if c.RCA.ResourceRequestsCPU == "" {
+			return fmt.Errorf("rca.resource.requests.cpu is required when RCA is enabled")
+		}
+		if c.RCA.ResourceRequestsMemory == "" {
+			return fmt.Errorf("rca.resource.requests.memory is required when RCA is enabled")
+		}
 	}
 
 	return nil

--- a/internal/observer/rca/job.go
+++ b/internal/observer/rca/job.go
@@ -1,0 +1,126 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rca
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// JobSpec defines the specification for creating an RCA job
+type JobSpec struct {
+	Name                    string
+	Namespace               string
+	ImageRepository         string
+	ImageTag                string
+	ImagePullPolicy         string
+	TTLSecondsAfterFinished *int32
+	ResourceLimitsCPU       string
+	ResourceLimitsMemory    string
+	ResourceRequestsCPU     string
+	ResourceRequestsMemory  string
+}
+
+// RCAContext defines the runtime context for an RCA job
+type RCAContext struct {
+	RCAID    string          `json:"rca_id"`
+	Metadata json.RawMessage `json:"metadata"`
+}
+
+// CreateJob creates a Kubernetes job for RCA analysis
+func CreateJob(ctx context.Context, k8sClient client.Client, spec JobSpec, rcaCtx RCAContext) (*batchv1.Job, error) {
+	// Marshal the entire RCA context to JSON
+	contextJSON, err := json.Marshal(rcaCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal RCA context: %w", err)
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spec.Name,
+			Namespace: spec.Namespace,
+			Labels:    map[string]string{},
+		},
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: spec.TTLSecondsAfterFinished,
+			BackoffLimit:            ptr.To[int32](3),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:            "observability-rca-agent",
+							Image:           fmt.Sprintf("%s:%s", spec.ImageRepository, spec.ImageTag),
+							ImagePullPolicy: corev1.PullPolicy(spec.ImagePullPolicy),
+							Resources:       buildResourceRequirements(spec),
+							Args: []string{
+								"--context", string(contextJSON),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := k8sClient.Create(ctx, job); err != nil {
+		if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "exceeded quota") {
+			return nil, fmt.Errorf("exceeded quota: %w", err)
+		}
+		return nil, fmt.Errorf("failed to create job: %w", err)
+	}
+
+	return job, nil
+}
+
+// buildResourceRequirements creates ResourceRequirements from JobSpec
+func buildResourceRequirements(spec JobSpec) corev1.ResourceRequirements {
+	requirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+
+	// Parse and set CPU requests
+	if spec.ResourceRequestsCPU != "" {
+		if qty, err := resource.ParseQuantity(spec.ResourceRequestsCPU); err == nil {
+			requirements.Requests[corev1.ResourceCPU] = qty
+		}
+	}
+
+	// Parse and set Memory requests
+	if spec.ResourceRequestsMemory != "" {
+		if qty, err := resource.ParseQuantity(spec.ResourceRequestsMemory); err == nil {
+			requirements.Requests[corev1.ResourceMemory] = qty
+		}
+	}
+
+	// Parse and set CPU limits
+	if spec.ResourceLimitsCPU != "" {
+		if qty, err := resource.ParseQuantity(spec.ResourceLimitsCPU); err == nil {
+			requirements.Limits[corev1.ResourceCPU] = qty
+		}
+	}
+
+	// Parse and set Memory limits
+	if spec.ResourceLimitsMemory != "" {
+		if qty, err := resource.ParseQuantity(spec.ResourceLimitsMemory); err == nil {
+			requirements.Limits[corev1.ResourceMemory] = qty
+		}
+	}
+
+	return requirements
+}


### PR DESCRIPTION
## Purpose
> To provide an interface for external sources to trigger the RCA agent

## Approach
> Provisioned the roles, rolebindings, resource quotas etc and scaffolded the `/analyze` endpoint which spawns the RCA job.

## Related Issues
> #710 

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
