### PR TITLE
Fix typo in URL to point to the correct location

### DIFF
--- a/samples/from-source/services/go-docker-greeter/README.md
+++ b/samples/from-source/services/go-docker-greeter/README.md
@@ -21,7 +21,7 @@ https://github.com/wso2/choreo-samples/tree/main/greeting-service-go
 The following command will create the relevant resources in OpenChoreo. It will also trigger a build by creating a build resource.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.3/samples/from-source/services/go-docker-greeter/greeter-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.3/samples/from-source/services/go-docker-greeter/greeting-service.yaml
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Purpose
During the release process a url seems to be changed the wrong way. This issue does not exist on main, therefore I create a hotfix for the release-v0.3 branch
#526

## Approach
Point to the correct location of the file

## Related Issues
#526

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
