### PR TITLE
Add optimizations for Prometheus sub chart

### DIFF
--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -358,7 +358,6 @@ prometheus:
   thanosRuler:
     enabled: false # This section needs to be further configured for queryEndpoints etc.
 
-  ## Set the following flags to false when custom recording rules are added to templates
   ## Create default rules for monitoring the cluster
   defaultRules:
     create: false
@@ -384,6 +383,3 @@ prometheus:
     enabled: false
   nodeExporter:
     enabled: false
-
-  windowsMonitoring:
-    enabled: false # This is the base chart default, can be removed from values.yaml


### PR DESCRIPTION
## Purpose
Initial prometheus sub-chart was added with most of the default configs which kube-prometheus-stack provide out of the box to monitor a kubernetes cluster. This PR adds the changes to remove the unused kube-monitoring tools (pods, sidecars, and some metrics as well) and collect only the required metrics needed to monitor openchoreo workloads. This will provide a minimal, yet functional metrics collection infrastructure for openchoreo observability plane 

## Approach
- Configure Prometheus instance settings, including datasource for Grafana.
- Disable Kubernetes component scrapers as OpenChoreo Observability is not intended for monitoring the Kubernetes cluster.
- Set default rules creation to false.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/782

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
