### PR TITLE
Improve Thunder helm charts to work with latest thunder release

### DIFF
--- a/install/dev/openchoreo-values.yaml
+++ b/install/dev/openchoreo-values.yaml
@@ -56,16 +56,11 @@ backstage:
     authorizationUrl: "http://sts.openchoreo.localhost/oauth2/authorize"
   # Note: thunder.baseUrl and auth.tokenUrl use default K8s service URLs (not overridden)
 asgardeoThunder:
-  image:
-    repository: ghcr.io/brionmario/thunder
-    tag: 0.0.16
   env:
-    - name: NEXT_PUBLIC_AUTHORIZATION_ENDPOINT
-      value: "http://sts.openchoreo.localhost/oauth2/authorize"
-    - name: NEXT_PUBLIC_FLOW_EXECUTION_ENDPOINT
-      value: "http://sts.openchoreo.localhost/flow/execute"
     - name: ENABLE_HTTPS
       value: "false"
+    - name: PORT
+      value: "8090"
     - name: HOST
       value: "0.0.0.0"
   config:
@@ -74,12 +69,19 @@ asgardeoThunder:
       port: 8090
       httpOnly: true
     gateClient:
-      hostname: portal.sts.openchoreo.localhost
+      hostname: sts.openchoreo.localhost
       port: 80
       scheme: http
     oauth:
       jwt:
         issuer: "thunder"
+  runtimeConfig:
+    client:
+      base: "/signin"
+    server:
+      hostname: "sts.openchoreo.localhost"
+      port: 80
+      httpOnly: true
   ingress:
     enabled: true
     ingressClassName: cilium
@@ -90,11 +92,6 @@ asgardeoThunder:
           - path: /
             pathType: Prefix
             port: 8090
-      - host: portal.sts.openchoreo.localhost
-        paths:
-          - path: /
-            pathType: Prefix
-            port: 9090
   backstagePortal:
     redirectUrls:
       - "http://localhost:7007/api/auth/default-idp/handler/frame"

--- a/install/helm/openchoreo/templates/asgardeo-thunder/configmap.yaml
+++ b/install/helm/openchoreo/templates/asgardeo-thunder/configmap.yaml
@@ -54,4 +54,15 @@ data:
         - "http{{ if $.Values.asgardeoThunder.ingress.tls }}s{{ end }}://{{ .host }}"
         {{- end }}
         {{- end }}
+  config.js: |
+    window.__THUNDER_RUNTIME_CONFIG__ = {
+      client: {
+        base: {{ .Values.asgardeoThunder.runtimeConfig.client.base | quote }},
+      },
+      server: {
+        hostname: {{ .Values.asgardeoThunder.runtimeConfig.server.hostname | quote }},
+        port: {{ .Values.asgardeoThunder.runtimeConfig.server.port }},
+        http_only: {{ .Values.asgardeoThunder.runtimeConfig.server.httpOnly }},
+      },
+    };
 {{- end }}

--- a/install/helm/openchoreo/templates/asgardeo-thunder/deployment.yaml
+++ b/install/helm/openchoreo/templates/asgardeo-thunder/deployment.yaml
@@ -76,9 +76,6 @@ spec:
             - name: http
               containerPort: {{ .Values.asgardeoThunder.service.targetPort }}
               protocol: TCP
-            - name: gate
-              containerPort: {{ .Values.asgardeoThunder.service.gateTargetPort }}
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /health/liveness
@@ -107,6 +104,10 @@ spec:
             - name: config
               mountPath: /opt/thunder/repository/conf/deployment.yaml
               subPath: deployment.yaml
+              readOnly: true
+            - name: config
+              mountPath: /opt/thunder/apps/gate/config.js
+              subPath: config.js
               readOnly: true
             {{- with .Values.asgardeoThunder.volumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/install/helm/openchoreo/templates/asgardeo-thunder/networkpolicy.yaml
+++ b/install/helm/openchoreo/templates/asgardeo-thunder/networkpolicy.yaml
@@ -23,8 +23,6 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.asgardeoThunder.service.targetPort }}
-        - protocol: TCP
-          port: {{ .Values.asgardeoThunder.service.gateTargetPort }}
     {{- with .Values.asgardeoThunder.networkPolicy.ingress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/helm/openchoreo/templates/asgardeo-thunder/service.yaml
+++ b/install/helm/openchoreo/templates/asgardeo-thunder/service.yaml
@@ -16,13 +16,6 @@ spec:
       {{- end }}
       protocol: TCP
       name: http
-    - port: {{ .Values.asgardeoThunder.service.gatePort }}
-      targetPort: {{ .Values.asgardeoThunder.service.gateTargetPort }}
-      {{- if and (eq .Values.asgardeoThunder.service.type "NodePort") .Values.asgardeoThunder.service.gateNodePort }}
-      nodePort: {{ .Values.asgardeoThunder.service.gateNodePort }}
-      {{- end }}
-      protocol: TCP
-      name: gate
   selector:
     {{- include "openchoreo.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: asgardeo-thunder

--- a/install/helm/openchoreo/values.schema.json
+++ b/install/helm/openchoreo/values.schema.json
@@ -339,7 +339,7 @@
                   ]
                 },
                 "loginPath": {
-                  "default": "/login",
+                  "default": "/signin",
                   "description": "Login path",
                   "required": [],
                   "title": "loginPath",
@@ -582,7 +582,7 @@
               ]
             },
             "tag": {
-              "default": "0.10.0",
+              "default": "0.11.0",
               "description": "Image tag (overrides the chart appVersion)",
               "required": [],
               "title": "tag",
@@ -875,7 +875,7 @@
           "description": "Pod security context",
           "properties": {
             "fsGroup": {
-              "default": 1000,
+              "default": 802,
               "description": "Filesystem group",
               "required": [],
               "title": "fsGroup",
@@ -885,7 +885,7 @@
               ]
             },
             "runAsGroup": {
-              "default": 1000,
+              "default": 802,
               "description": "Group ID to run the container as",
               "required": [],
               "title": "runAsGroup",
@@ -905,7 +905,7 @@
               ]
             },
             "runAsUser": {
-              "default": 1000,
+              "default": 802,
               "description": "User ID to run the container as",
               "required": [],
               "title": "runAsUser",
@@ -1031,6 +1031,82 @@
             "object"
           ]
         },
+        "runtimeConfig": {
+          "additionalProperties": false,
+          "description": "Runtime configuration for Thunder Gate UI",
+          "properties": {
+            "client": {
+              "additionalProperties": false,
+              "description": "Client configuration",
+              "properties": {
+                "base": {
+                  "default": "/signin",
+                  "description": "Base path for signin",
+                  "required": [],
+                  "title": "base",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "required": [],
+              "title": "client",
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "server": {
+              "additionalProperties": false,
+              "description": "Server configuration",
+              "properties": {
+                "hostname": {
+                  "default": "localhost",
+                  "description": "Server hostname",
+                  "required": [],
+                  "title": "hostname",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "httpOnly": {
+                  "default": false,
+                  "description": "HTTP only mode (disable HTTPS)",
+                  "required": [],
+                  "title": "httpOnly",
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                },
+                "port": {
+                  "default": 8090,
+                  "description": "Server port",
+                  "required": [],
+                  "title": "port",
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [],
+              "title": "server",
+              "type": [
+                "null",
+                "object"
+              ]
+            }
+          },
+          "required": [],
+          "title": "runtimeConfig",
+          "type": [
+            "null",
+            "object"
+          ]
+        },
         "securityContext": {
           "additionalProperties": false,
           "description": "Container security context",
@@ -1086,7 +1162,7 @@
               ]
             },
             "runAsUser": {
-              "default": 1000,
+              "default": 802,
               "description": "User ID to run the container as",
               "required": [],
               "title": "runAsUser",
@@ -1107,36 +1183,6 @@
           "additionalProperties": false,
           "description": "Service configuration",
           "properties": {
-            "gateNodePort": {
-              "default": "null",
-              "description": "Node port for gate service (when type is NodePort)",
-              "required": [],
-              "title": "gateNodePort",
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "gatePort": {
-              "default": 9090,
-              "description": "Gate service port",
-              "required": [],
-              "title": "gatePort",
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "gateTargetPort": {
-              "default": 9090,
-              "description": "Target port for gate service",
-              "required": [],
-              "title": "gateTargetPort",
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
             "nodePort": {
               "default": "null",
               "description": "Node port for main service (when type is NodePort)",
@@ -4532,8 +4578,8 @@
           "description": "MCP (Model Context Protocol) Server Configuration",
           "properties": {
             "toolsets": {
-              "default": "core",
-              "description": "Comma-separated list of enabled toolsets\nAvailable toolsets: core",
+              "default": "organization,project,component,build,deployment,infrastructure",
+              "description": "Comma-separated list of enabled toolsets\nAvailable toolsets: organization, project, component, build, deployment, infrastructure",
               "required": [],
               "title": "toolsets",
               "type": [

--- a/install/helm/openchoreo/values.yaml
+++ b/install/helm/openchoreo/values.yaml
@@ -1535,7 +1535,7 @@ asgardeoThunder:
     # type: [null, string]
     # @schema
     # -- Image tag (overrides the chart appVersion)
-    tag: "0.10.0"
+    tag: "0.11.0"
   # @schema
   # type: [null, array]
   # @schema
@@ -1647,21 +1647,6 @@ asgardeoThunder:
     # @schema
     # -- Node port for main service (when type is NodePort)
     nodePort: null
-    # @schema
-    # type: [null, integer]
-    # @schema
-    # -- Gate service port
-    gatePort: 9090
-    # @schema
-    # type: [null, integer]
-    # @schema
-    # -- Target port for gate service
-    gateTargetPort: 9090
-    # @schema
-    # type: [null, integer]
-    # @schema
-    # -- Node port for gate service (when type is NodePort)
-    gateNodePort: null
   # @schema
   # type: [null, object]
   # @schema
@@ -1771,7 +1756,7 @@ asgardeoThunder:
       # type: [null, string]
       # @schema
       # -- Login path
-      loginPath: "/login"
+      loginPath: "/signin"
       # @schema
       # type: [null, string]
       # @schema
@@ -1892,6 +1877,41 @@ asgardeoThunder:
         # @schema
         # -- Default authentication flow
         defaultFlow: "auth_flow_config_basic"
+  # @schema
+  # type: [null, object]
+  # @schema
+  # -- Runtime configuration for Thunder Gate UI
+  runtimeConfig:
+    # @schema
+    # type: [null, object]
+    # @schema
+    # -- Client configuration
+    client:
+      # @schema
+      # type: [null, string]
+      # @schema
+      # -- Base path for signin
+      base: "/signin"
+    # @schema
+    # type: [null, object]
+    # @schema
+    # -- Server configuration
+    server:
+      # @schema
+      # type: [null, string]
+      # @schema
+      # -- Server hostname
+      hostname: "localhost"
+      # @schema
+      # type: [null, integer]
+      # @schema
+      # -- Server port
+      port: 8090
+      # @schema
+      # type: [null, boolean]
+      # @schema
+      # -- HTTP only mode (disable HTTPS)
+      httpOnly: false
   # @schema
   # type: [null, object]
   # @schema


### PR DESCRIPTION
## Purpose
> $subject

## Approach
This pull request introduces significant updates to the Thunder Gate UI and its deployment configuration. The main changes include the removal of the legacy "gate" service and related ports, consolidation and simplification of service configuration, the addition of a new runtime configuration for the Thunder Gate UI, and updates to default values and resource settings. These changes improve maintainability, standardize configuration, and enable better runtime customization.

**Thunder Gate UI Runtime Configuration:**

* Added a new `runtimeConfig` section to the Thunder Gate UI values and schema, allowing runtime customization of client and server settings (base path, hostname, port, HTTP only mode) (`install/helm/openchoreo/values.schema.json`, `install/helm/openchoreo/values.yaml`, `install/dev/openchoreo-values.yaml`, [[1]](diffhunk://#diff-03df3ab998201bcd5da88ee052b6bcf4b1c72cb4626cca63b37a4aa35f0d4d29L77-R84) [[2]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527R1034-R1109) [[3]](diffhunk://#diff-c2d23d097b3dd1e08a8b976ff1bb18ef7f0335a2a238eba211ebe1c4498e6bbeR1883-R1917).
* Injected the runtime configuration as a `config.js` file into the Thunder Gate UI container, enabling dynamic client/server config at runtime (`install/helm/openchoreo/templates/asgardeo-thunder/configmap.yaml`, `install/helm/openchoreo/templates/asgardeo-thunder/deployment.yaml`, [[1]](diffhunk://#diff-2e9b70836aaee3449405684c689928a1800ebfbb2ef5d9bae00c3b3821b87215R57-R67) [[2]](diffhunk://#diff-fc10561876c7b8f289809f59b91c66898010361d6c1c4fe4e490b6bbac6e280eR108-R111).

**Service and Network Configuration Simplification:**

* Removed the legacy "gate" service, ports, network policy rules, and related configuration fields from all manifests and schemas, consolidating service exposure to a single HTTP port (`install/helm/openchoreo/values.schema.json`, `install/helm/openchoreo/values.yaml`, `install/helm/openchoreo/templates/asgardeo-thunder/service.yaml`, `install/helm/openchoreo/templates/asgardeo-thunder/networkpolicy.yaml`, [[1]](diffhunk://#diff-fc10561876c7b8f289809f59b91c66898010361d6c1c4fe4e490b6bbac6e280eL79-L81) [[2]](diffhunk://#diff-5ac10d1ae62ea51db2c8bd15d5f690ddcae27c36b6e135535bc247db9af36eb4L26-L27) [[3]](diffhunk://#diff-270ec5f345a4de2c6ec67ca5d74862e222bac168c496c752e9d98a6564e2a22bL19-L25) [[4]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L1110-L1139) [[5]](diffhunk://#diff-c2d23d097b3dd1e08a8b976ff1bb18ef7f0335a2a238eba211ebe1c4498e6bbeL1651-L1665).
* Updated ingress and gate client hostname references for consistency and correctness (`install/dev/openchoreo-values.yaml`, [[1]](diffhunk://#diff-03df3ab998201bcd5da88ee052b6bcf4b1c72cb4626cca63b37a4aa35f0d4d29L77-R84) [[2]](diffhunk://#diff-03df3ab998201bcd5da88ee052b6bcf4b1c72cb4626cca63b37a4aa35f0d4d29L93-L97).

**Default Value Updates and Resource Configuration:**

* Changed the default login path from `/login` to `/signin` for improved clarity and alignment with runtime config (`install/helm/openchoreo/values.schema.json`, `install/helm/openchoreo/values.yaml`, [[1]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L342-R342) [[2]](diffhunk://#diff-c2d23d097b3dd1e08a8b976ff1bb18ef7f0335a2a238eba211ebe1c4498e6bbeL1774-R1759).
* Updated default image tag for Thunder Gate UI from `0.10.0` to `0.11.0` to use the latest version (`install/helm/openchoreo/values.schema.json`, `install/helm/openchoreo/values.yaml`, [[1]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L585-R585) [[2]](diffhunk://#diff-c2d23d097b3dd1e08a8b976ff1bb18ef7f0335a2a238eba211ebe1c4498e6bbeL1538-R1538).
* Changed default storage class name to `standard` and updated default security context user/group IDs to `802` for better compatibility (`install/helm/openchoreo/values.schema.json`, `install/helm/openchoreo/values.yaml`, [[1]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L786-R786) [[2]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L878-R878) [[3]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L888-R888) [[4]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L908-R908) [[5]](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L1089-R1165) [[6]](diffhunk://#diff-c2d23d097b3dd1e08a8b976ff1bb18ef7f0335a2a238eba211ebe1c4498e6bbeL1914-R1934).

**Other Updates:**

* Expanded default toolsets for MCP server configuration to include organization, project, component, build, deployment, and infrastructure (`install/helm/openchoreo/values.schema.json`, [install/helm/openchoreo/values.schema.jsonL4535-R4582](diffhunk://#diff-e07ad6dded460a07c978a9bf938547ac58a259f062e13377cd98913ea2a2b527L4535-R4582)).

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/763

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
