### PR TITLE
Add ctd addon schema get endpoints to oc API

### DIFF
--- a/internal/openchoreo-api/handlers/addons.go
+++ b/internal/openchoreo-api/handlers/addons.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/middleware/logger"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+)
+
+func (h *Handler) ListAddons(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logger.GetLogger(ctx)
+	logger.Debug("ListAddons handler called")
+
+	// Extract organization name from URL path
+	orgName := r.PathValue("orgName")
+	if orgName == "" {
+		logger.Warn("Organization name is required")
+		writeErrorResponse(w, http.StatusBadRequest, "Organization name is required", services.CodeInvalidInput)
+		return
+	}
+
+	// Call service to list Addons
+	addons, err := h.services.AddonService.ListAddons(ctx, orgName)
+	if err != nil {
+		logger.Error("Failed to list Addons", "error", err)
+		writeErrorResponse(w, http.StatusInternalServerError, "Internal server error", services.CodeInternalError)
+		return
+	}
+
+	// Convert to slice of values for the list response
+	addonValues := make([]*models.AddonResponse, len(addons))
+	copy(addonValues, addons)
+
+	// Success response with pagination info (simplified for now)
+	logger.Debug("Listed Addons successfully", "org", orgName, "count", len(addons))
+	writeListResponse(w, addonValues, len(addons), 1, len(addons))
+}
+
+func (h *Handler) GetAddonSchema(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logger.GetLogger(ctx)
+	logger.Debug("GetAddonSchema handler called")
+
+	// Extract path parameters
+	orgName := r.PathValue("orgName")
+	addonName := r.PathValue("addonName")
+	if orgName == "" || addonName == "" {
+		logger.Warn("Organization name and Addon name are required")
+		writeErrorResponse(w, http.StatusBadRequest, "Organization name and Addon name are required", services.CodeInvalidInput)
+		return
+	}
+
+	// Call service to get Addon schema
+	schema, err := h.services.AddonService.GetAddonSchema(ctx, orgName, addonName)
+	if err != nil {
+		if errors.Is(err, services.ErrAddonNotFound) {
+			logger.Warn("Addon not found", "org", orgName, "name", addonName)
+			writeErrorResponse(w, http.StatusNotFound, "Addon not found", services.CodeAddonNotFound)
+			return
+		}
+		logger.Error("Failed to get Addon schema", "error", err)
+		writeErrorResponse(w, http.StatusInternalServerError, "Internal server error", services.CodeInternalError)
+		return
+	}
+
+	// Success response
+	logger.Debug("Retrieved Addon schema successfully", "org", orgName, "name", addonName)
+	writeSuccessResponse(w, http.StatusOK, schema)
+}

--- a/internal/openchoreo-api/handlers/componenttypedefinitions.go
+++ b/internal/openchoreo-api/handlers/componenttypedefinitions.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/middleware/logger"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+)
+
+func (h *Handler) ListComponentTypeDefinitions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logger.GetLogger(ctx)
+	logger.Debug("ListComponentTypeDefinitions handler called")
+
+	// Extract organization name from URL path
+	orgName := r.PathValue("orgName")
+	if orgName == "" {
+		logger.Warn("Organization name is required")
+		writeErrorResponse(w, http.StatusBadRequest, "Organization name is required", services.CodeInvalidInput)
+		return
+	}
+
+	// Call service to list ComponentTypeDefinitions
+	ctds, err := h.services.ComponentTypeDefinitionService.ListComponentTypeDefinitions(ctx, orgName)
+	if err != nil {
+		logger.Error("Failed to list ComponentTypeDefinitions", "error", err)
+		writeErrorResponse(w, http.StatusInternalServerError, "Internal server error", services.CodeInternalError)
+		return
+	}
+
+	// Convert to slice of values for the list response
+	ctdValues := make([]*models.ComponentTypeDefinitionResponse, len(ctds))
+	copy(ctdValues, ctds)
+
+	// Success response with pagination info (simplified for now)
+	logger.Debug("Listed ComponentTypeDefinitions successfully", "org", orgName, "count", len(ctds))
+	writeListResponse(w, ctdValues, len(ctds), 1, len(ctds))
+}
+
+func (h *Handler) GetComponentTypeDefinitionSchema(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logger.GetLogger(ctx)
+	logger.Debug("GetComponentTypeDefinitionSchema handler called")
+
+	// Extract path parameters
+	orgName := r.PathValue("orgName")
+	ctdName := r.PathValue("ctdName")
+	if orgName == "" || ctdName == "" {
+		logger.Warn("Organization name and ComponentTypeDefinition name are required")
+		writeErrorResponse(w, http.StatusBadRequest, "Organization name and ComponentTypeDefinition name are required", services.CodeInvalidInput)
+		return
+	}
+
+	// Call service to get ComponentTypeDefinition schema
+	schema, err := h.services.ComponentTypeDefinitionService.GetComponentTypeDefinitionSchema(ctx, orgName, ctdName)
+	if err != nil {
+		if errors.Is(err, services.ErrComponentTypeDefinitionNotFound) {
+			logger.Warn("ComponentTypeDefinition not found", "org", orgName, "name", ctdName)
+			writeErrorResponse(w, http.StatusNotFound, "ComponentTypeDefinition not found", services.CodeComponentTypeDefinitionNotFound)
+			return
+		}
+		logger.Error("Failed to get ComponentTypeDefinition schema", "error", err)
+		writeErrorResponse(w, http.StatusInternalServerError, "Internal server error", services.CodeInternalError)
+		return
+	}
+
+	// Success response
+	logger.Debug("Retrieved ComponentTypeDefinition schema successfully", "org", orgName, "name", ctdName)
+	writeSuccessResponse(w, http.StatusOK, schema)
+}

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -65,6 +65,14 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/buildplanes", h.ListBuildPlanes)
 	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/build-templates", h.ListBuildTemplates)
 
+	// ComponentTypeDefinition endpoints
+	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/component-types", h.ListComponentTypeDefinitions)
+	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/component-types/{ctdName}/schema", h.GetComponentTypeDefinitionSchema)
+
+	// Addon endpoints
+	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/addons", h.ListAddons)
+	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/addons/{addonName}/schema", h.GetAddonSchema)
+
 	// Project endpoints
 	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/projects", h.ListProjects)
 	mux.HandleFunc("POST "+v1+"/orgs/{orgName}/projects", h.CreateProject)

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -249,3 +249,20 @@ func ErrorResponse(message, code string) APIResponse[any] {
 		Code:    code,
 	}
 }
+
+// ComponentTypeDefinitionResponse represents a ComponentTypeDefinition in API responses
+type ComponentTypeDefinitionResponse struct {
+	Name         string    `json:"name"`
+	DisplayName  string    `json:"displayName,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	WorkloadType string    `json:"workloadType"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
+
+// AddonResponse represents an Addon in API responses
+type AddonResponse struct {
+	Name        string    `json:"name"`
+	DisplayName string    `json:"displayName,omitempty"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+}

--- a/internal/openchoreo-api/services/addon_service.go
+++ b/internal/openchoreo-api/services/addon_service.go
@@ -1,0 +1,145 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/exp/slog"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/schema"
+)
+
+// AddonService handles Addon-related business logic
+type AddonService struct {
+	k8sClient client.Client
+	logger    *slog.Logger
+}
+
+// NewAddonService creates a new Addon service
+func NewAddonService(k8sClient client.Client, logger *slog.Logger) *AddonService {
+	return &AddonService{
+		k8sClient: k8sClient,
+		logger:    logger,
+	}
+}
+
+// ListAddons lists all Addons in the given organization
+func (s *AddonService) ListAddons(ctx context.Context, orgName string) ([]*models.AddonResponse, error) {
+	s.logger.Debug("Listing Addons", "org", orgName)
+
+	var addonList openchoreov1alpha1.AddonList
+	listOpts := []client.ListOption{
+		client.InNamespace(orgName),
+	}
+
+	if err := s.k8sClient.List(ctx, &addonList, listOpts...); err != nil {
+		s.logger.Error("Failed to list Addons", "error", err)
+		return nil, fmt.Errorf("failed to list Addons: %w", err)
+	}
+
+	addons := make([]*models.AddonResponse, 0, len(addonList.Items))
+	for i := range addonList.Items {
+		addons = append(addons, s.toAddonResponse(&addonList.Items[i]))
+	}
+
+	s.logger.Debug("Listed Addons", "org", orgName, "count", len(addons))
+	return addons, nil
+}
+
+// GetAddon retrieves a specific Addon
+func (s *AddonService) GetAddon(ctx context.Context, orgName, addonName string) (*models.AddonResponse, error) {
+	s.logger.Debug("Getting Addon", "org", orgName, "name", addonName)
+
+	addon := &openchoreov1alpha1.Addon{}
+	key := client.ObjectKey{
+		Name:      addonName,
+		Namespace: orgName,
+	}
+
+	if err := s.k8sClient.Get(ctx, key, addon); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("Addon not found", "org", orgName, "name", addonName)
+			return nil, ErrAddonNotFound
+		}
+		s.logger.Error("Failed to get Addon", "error", err)
+		return nil, fmt.Errorf("failed to get Addon: %w", err)
+	}
+
+	return s.toAddonResponse(addon), nil
+}
+
+// GetAddonSchema retrieves the JSON schema for an Addon
+func (s *AddonService) GetAddonSchema(ctx context.Context, orgName, addonName string) (*extv1.JSONSchemaProps, error) {
+	s.logger.Debug("Getting Addon schema", "org", orgName, "name", addonName)
+
+	// First get the Addon
+	addon := &openchoreov1alpha1.Addon{}
+	key := client.ObjectKey{
+		Name:      addonName,
+		Namespace: orgName,
+	}
+
+	if err := s.k8sClient.Get(ctx, key, addon); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("Addon not found", "org", orgName, "name", addonName)
+			return nil, ErrAddonNotFound
+		}
+		s.logger.Error("Failed to get Addon", "error", err)
+		return nil, fmt.Errorf("failed to get Addon: %w", err)
+	}
+
+	// Extract types from RawExtension
+	var types map[string]any
+	if addon.Spec.Schema.Types != nil && addon.Spec.Schema.Types.Raw != nil {
+		if err := yaml.Unmarshal(addon.Spec.Schema.Types.Raw, &types); err != nil {
+			return nil, fmt.Errorf("failed to extract types: %w", err)
+		}
+	}
+
+	// Build schema definition
+	def := schema.Definition{
+		Types: types,
+	}
+
+	// Extract parameters schema from RawExtension
+	if addon.Spec.Schema.Parameters != nil && addon.Spec.Schema.Parameters.Raw != nil {
+		var params map[string]any
+		if err := json.Unmarshal(addon.Spec.Schema.Parameters.Raw, &params); err != nil {
+			return nil, fmt.Errorf("failed to extract parameters: %w", err)
+		}
+		def.Schemas = []map[string]any{params}
+	}
+
+	// Convert to JSON Schema
+	jsonSchema, err := schema.ToJSONSchema(def)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to JSON schema: %w", err)
+	}
+
+	s.logger.Debug("Retrieved Addon schema successfully", "org", orgName, "name", addonName)
+	return jsonSchema, nil
+}
+
+// toAddonResponse converts an Addon CR to an AddonResponse
+func (s *AddonService) toAddonResponse(addon *openchoreov1alpha1.Addon) *models.AddonResponse {
+	// Extract display name and description from annotations
+	displayName := addon.Annotations[controller.AnnotationKeyDisplayName]
+	description := addon.Annotations[controller.AnnotationKeyDescription]
+
+	return &models.AddonResponse{
+		Name:        addon.Name,
+		DisplayName: displayName,
+		Description: description,
+		CreatedAt:   addon.CreationTimestamp.Time,
+	}
+}

--- a/internal/openchoreo-api/services/componenttypedefinition_service.go
+++ b/internal/openchoreo-api/services/componenttypedefinition_service.go
@@ -1,0 +1,146 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/exp/slog"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/schema"
+)
+
+// ComponentTypeDefinitionService handles ComponentTypeDefinition-related business logic
+type ComponentTypeDefinitionService struct {
+	k8sClient client.Client
+	logger    *slog.Logger
+}
+
+// NewComponentTypeDefinitionService creates a new ComponentTypeDefinition service
+func NewComponentTypeDefinitionService(k8sClient client.Client, logger *slog.Logger) *ComponentTypeDefinitionService {
+	return &ComponentTypeDefinitionService{
+		k8sClient: k8sClient,
+		logger:    logger,
+	}
+}
+
+// ListComponentTypeDefinitions lists all ComponentTypeDefinitions in the given organization
+func (s *ComponentTypeDefinitionService) ListComponentTypeDefinitions(ctx context.Context, orgName string) ([]*models.ComponentTypeDefinitionResponse, error) {
+	s.logger.Debug("Listing ComponentTypeDefinitions", "org", orgName)
+
+	var ctdList openchoreov1alpha1.ComponentTypeDefinitionList
+	listOpts := []client.ListOption{
+		client.InNamespace(orgName),
+	}
+
+	if err := s.k8sClient.List(ctx, &ctdList, listOpts...); err != nil {
+		s.logger.Error("Failed to list ComponentTypeDefinitions", "error", err)
+		return nil, fmt.Errorf("failed to list ComponentTypeDefinitions: %w", err)
+	}
+
+	ctds := make([]*models.ComponentTypeDefinitionResponse, 0, len(ctdList.Items))
+	for i := range ctdList.Items {
+		ctds = append(ctds, s.toComponentTypeDefinitionResponse(&ctdList.Items[i]))
+	}
+
+	s.logger.Debug("Listed ComponentTypeDefinitions", "org", orgName, "count", len(ctds))
+	return ctds, nil
+}
+
+// GetComponentTypeDefinition retrieves a specific ComponentTypeDefinition
+func (s *ComponentTypeDefinitionService) GetComponentTypeDefinition(ctx context.Context, orgName, ctdName string) (*models.ComponentTypeDefinitionResponse, error) {
+	s.logger.Debug("Getting ComponentTypeDefinition", "org", orgName, "name", ctdName)
+
+	ctd := &openchoreov1alpha1.ComponentTypeDefinition{}
+	key := client.ObjectKey{
+		Name:      ctdName,
+		Namespace: orgName,
+	}
+
+	if err := s.k8sClient.Get(ctx, key, ctd); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("ComponentTypeDefinition not found", "org", orgName, "name", ctdName)
+			return nil, ErrComponentTypeDefinitionNotFound
+		}
+		s.logger.Error("Failed to get ComponentTypeDefinition", "error", err)
+		return nil, fmt.Errorf("failed to get ComponentTypeDefinition: %w", err)
+	}
+
+	return s.toComponentTypeDefinitionResponse(ctd), nil
+}
+
+// GetComponentTypeDefinitionSchema retrieves the JSON schema for a ComponentTypeDefinition
+func (s *ComponentTypeDefinitionService) GetComponentTypeDefinitionSchema(ctx context.Context, orgName, ctdName string) (*extv1.JSONSchemaProps, error) {
+	s.logger.Debug("Getting ComponentTypeDefinition schema", "org", orgName, "name", ctdName)
+
+	// First get the CTD
+	ctd := &openchoreov1alpha1.ComponentTypeDefinition{}
+	key := client.ObjectKey{
+		Name:      ctdName,
+		Namespace: orgName,
+	}
+
+	if err := s.k8sClient.Get(ctx, key, ctd); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("ComponentTypeDefinition not found", "org", orgName, "name", ctdName)
+			return nil, ErrComponentTypeDefinitionNotFound
+		}
+		s.logger.Error("Failed to get ComponentTypeDefinition", "error", err)
+		return nil, fmt.Errorf("failed to get ComponentTypeDefinition: %w", err)
+	}
+
+	// Extract types from RawExtension
+	var types map[string]any
+	if ctd.Spec.Schema.Types != nil && ctd.Spec.Schema.Types.Raw != nil {
+		if err := yaml.Unmarshal(ctd.Spec.Schema.Types.Raw, &types); err != nil {
+			return nil, fmt.Errorf("failed to extract types: %w", err)
+		}
+	}
+
+	// Build schema definition
+	def := schema.Definition{
+		Types: types,
+	}
+
+	// Extract parameters schema from RawExtension
+	if ctd.Spec.Schema.Parameters != nil && ctd.Spec.Schema.Parameters.Raw != nil {
+		var params map[string]any
+		if err := json.Unmarshal(ctd.Spec.Schema.Parameters.Raw, &params); err != nil {
+			return nil, fmt.Errorf("failed to extract parameters: %w", err)
+		}
+		def.Schemas = []map[string]any{params}
+	}
+
+	// Convert to JSON Schema
+	jsonSchema, err := schema.ToJSONSchema(def)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to JSON schema: %w", err)
+	}
+
+	s.logger.Debug("Retrieved ComponentTypeDefinition schema successfully", "org", orgName, "name", ctdName)
+	return jsonSchema, nil
+}
+
+// toComponentTypeDefinitionResponse converts a ComponentTypeDefinition CR to a ComponentTypeDefinitionResponse
+func (s *ComponentTypeDefinitionService) toComponentTypeDefinitionResponse(ctd *openchoreov1alpha1.ComponentTypeDefinition) *models.ComponentTypeDefinitionResponse {
+	// Extract display name and description from annotations
+	displayName := ctd.Annotations[controller.AnnotationKeyDisplayName]
+	description := ctd.Annotations[controller.AnnotationKeyDescription]
+
+	return &models.ComponentTypeDefinitionResponse{
+		Name:         ctd.Name,
+		DisplayName:  displayName,
+		Description:  description,
+		WorkloadType: ctd.Spec.WorkloadType,
+		CreatedAt:    ctd.CreationTimestamp.Time,
+	}
+}

--- a/internal/openchoreo-api/services/errors.go
+++ b/internal/openchoreo-api/services/errors.go
@@ -7,34 +7,42 @@ import "errors"
 
 // Common service errors
 var (
-	ErrProjectAlreadyExists       = errors.New("project already exists")
-	ErrProjectNotFound            = errors.New("project not found")
-	ErrComponentAlreadyExists     = errors.New("component already exists")
-	ErrComponentNotFound          = errors.New("component not found")
-	ErrOrganizationNotFound       = errors.New("organization not found")
-	ErrEnvironmentNotFound        = errors.New("environment not found")
-	ErrEnvironmentAlreadyExists   = errors.New("environment already exists")
-	ErrDataPlaneNotFound          = errors.New("dataplane not found")
-	ErrDataPlaneAlreadyExists     = errors.New("dataplane already exists")
-	ErrBindingNotFound            = errors.New("binding not found")
-	ErrDeploymentPipelineNotFound = errors.New("deployment pipeline not found")
-	ErrInvalidPromotionPath       = errors.New("invalid promotion path")
+	ErrProjectAlreadyExists                 = errors.New("project already exists")
+	ErrProjectNotFound                      = errors.New("project not found")
+	ErrComponentAlreadyExists               = errors.New("component already exists")
+	ErrComponentNotFound                    = errors.New("component not found")
+	ErrComponentTypeDefinitionAlreadyExists = errors.New("component type definition already exists")
+	ErrComponentTypeDefinitionNotFound      = errors.New("component type definition not found")
+	ErrAddonAlreadyExists                   = errors.New("addon already exists")
+	ErrAddonNotFound                        = errors.New("addon not found")
+	ErrOrganizationNotFound                 = errors.New("organization not found")
+	ErrEnvironmentNotFound                  = errors.New("environment not found")
+	ErrEnvironmentAlreadyExists             = errors.New("environment already exists")
+	ErrDataPlaneNotFound                    = errors.New("dataplane not found")
+	ErrDataPlaneAlreadyExists               = errors.New("dataplane already exists")
+	ErrBindingNotFound                      = errors.New("binding not found")
+	ErrDeploymentPipelineNotFound           = errors.New("deployment pipeline not found")
+	ErrInvalidPromotionPath                 = errors.New("invalid promotion path")
 )
 
 // Error codes for API responses
 const (
-	CodeProjectExists              = "PROJECT_EXISTS"
-	CodeProjectNotFound            = "PROJECT_NOT_FOUND"
-	CodeComponentExists            = "COMPONENT_EXISTS"
-	CodeComponentNotFound          = "COMPONENT_NOT_FOUND"
-	CodeOrganizationNotFound       = "ORGANIZATION_NOT_FOUND"
-	CodeEnvironmentNotFound        = "ENVIRONMENT_NOT_FOUND"
-	CodeEnvironmentExists          = "ENVIRONMENT_EXISTS"
-	CodeDataPlaneNotFound          = "DATAPLANE_NOT_FOUND"
-	CodeDataPlaneExists            = "DATAPLANE_EXISTS"
-	CodeBindingNotFound            = "BINDING_NOT_FOUND"
-	CodeDeploymentPipelineNotFound = "DEPLOYMENT_PIPELINE_NOT_FOUND"
-	CodeInvalidPromotionPath       = "INVALID_PROMOTION_PATH"
-	CodeInvalidInput               = "INVALID_INPUT"
-	CodeInternalError              = "INTERNAL_ERROR"
+	CodeProjectExists                   = "PROJECT_EXISTS"
+	CodeProjectNotFound                 = "PROJECT_NOT_FOUND"
+	CodeComponentExists                 = "COMPONENT_EXISTS"
+	CodeComponentNotFound               = "COMPONENT_NOT_FOUND"
+	CodeComponentTypeDefinitionExists   = "COMPONENT_TYPE_DEFINITION_EXISTS"
+	CodeComponentTypeDefinitionNotFound = "COMPONENT_TYPE_DEFINITION_NOT_FOUND"
+	CodeAddonExists                     = "ADDON_EXISTS"
+	CodeAddonNotFound                   = "ADDON_NOT_FOUND"
+	CodeOrganizationNotFound            = "ORGANIZATION_NOT_FOUND"
+	CodeEnvironmentNotFound             = "ENVIRONMENT_NOT_FOUND"
+	CodeEnvironmentExists               = "ENVIRONMENT_EXISTS"
+	CodeDataPlaneNotFound               = "DATAPLANE_NOT_FOUND"
+	CodeDataPlaneExists                 = "DATAPLANE_EXISTS"
+	CodeBindingNotFound                 = "BINDING_NOT_FOUND"
+	CodeDeploymentPipelineNotFound      = "DEPLOYMENT_PIPELINE_NOT_FOUND"
+	CodeInvalidPromotionPath            = "INVALID_PROMOTION_PATH"
+	CodeInvalidInput                    = "INVALID_INPUT"
+	CodeInternalError                   = "INTERNAL_ERROR"
 )

--- a/internal/openchoreo-api/services/services.go
+++ b/internal/openchoreo-api/services/services.go
@@ -11,15 +11,17 @@ import (
 )
 
 type Services struct {
-	ProjectService            *ProjectService
-	ComponentService          *ComponentService
-	OrganizationService       *OrganizationService
-	EnvironmentService        *EnvironmentService
-	DataPlaneService          *DataPlaneService
-	BuildService              *BuildService
-	BuildPlaneService         *BuildPlaneService
-	DeploymentPipelineService *DeploymentPipelineService
-	k8sClient                 client.Client // Direct access to K8s client for apply operations
+	ProjectService                 *ProjectService
+	ComponentService               *ComponentService
+	ComponentTypeDefinitionService *ComponentTypeDefinitionService
+	AddonService                   *AddonService
+	OrganizationService            *OrganizationService
+	EnvironmentService             *EnvironmentService
+	DataPlaneService               *DataPlaneService
+	BuildService                   *BuildService
+	BuildPlaneService              *BuildPlaneService
+	DeploymentPipelineService      *DeploymentPipelineService
+	k8sClient                      client.Client // Direct access to K8s client for apply operations
 }
 
 // NewServices creates and initializes all services
@@ -48,16 +50,24 @@ func NewServices(k8sClient client.Client, k8sBPClientMgr *kubernetesClient.KubeM
 	// Create deployment pipeline service (depends on project service)
 	deploymentPipelineService := NewDeploymentPipelineService(k8sClient, projectService, logger.With("service", "deployment-pipeline"))
 
+	// Create ComponentTypeDefinition service
+	componentTypeDefinitionService := NewComponentTypeDefinitionService(k8sClient, logger.With("service", "componenttypedefinition"))
+
+	// Create Addon service
+	addonService := NewAddonService(k8sClient, logger.With("service", "addon"))
+
 	return &Services{
-		ProjectService:            projectService,
-		ComponentService:          componentService,
-		OrganizationService:       organizationService,
-		EnvironmentService:        environmentService,
-		DataPlaneService:          dataplaneService,
-		BuildService:              buildService,
-		BuildPlaneService:         buildPlaneService,
-		DeploymentPipelineService: deploymentPipelineService,
-		k8sClient:                 k8sClient,
+		ProjectService:                 projectService,
+		ComponentService:               componentService,
+		ComponentTypeDefinitionService: componentTypeDefinitionService,
+		AddonService:                   addonService,
+		OrganizationService:            organizationService,
+		EnvironmentService:             environmentService,
+		DataPlaneService:               dataplaneService,
+		BuildService:                   buildService,
+		BuildPlaneService:              buildPlaneService,
+		DeploymentPipelineService:      deploymentPipelineService,
+		k8sClient:                      k8sClient,
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Adds below endpoints
```
  1. GET /api/v1/orgs/{orgName}/component-type-definitions - List all CTDs
  2. GET /api/v1/orgs/{orgName}/component-type-definitions/{ctdName}/schema - Get CTD schema
  3. GET /api/v1/orgs/{orgName}/addons - List all Addons
  4. GET /api/v1/orgs/{orgName}/addons/{addonName}/schema - Get Addon schema
```

## Approach
> Summarize the solution and implementation details.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/786

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
