### PR TITLE
Rename ctd to componenttype in openchoreo-api

### DIFF
--- a/internal/openchoreo-api/handlers/componenttypedefinitions.go
+++ b/internal/openchoreo-api/handlers/componenttypedefinitions.go
@@ -12,10 +12,10 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
 
-func (h *Handler) ListComponentTypeDefinitions(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ListComponentTypes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := logger.GetLogger(ctx)
-	logger.Debug("ListComponentTypeDefinitions handler called")
+	logger.Debug("ListComponentTypes handler called")
 
 	// Extract organization name from URL path
 	orgName := r.PathValue("orgName")
@@ -25,51 +25,51 @@ func (h *Handler) ListComponentTypeDefinitions(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Call service to list ComponentTypeDefinitions
-	ctds, err := h.services.ComponentTypeDefinitionService.ListComponentTypeDefinitions(ctx, orgName)
+	// Call service to list ComponentTypes
+	ctds, err := h.services.ComponentTypeService.ListComponentTypes(ctx, orgName)
 	if err != nil {
-		logger.Error("Failed to list ComponentTypeDefinitions", "error", err)
+		logger.Error("Failed to list ComponentTypes", "error", err)
 		writeErrorResponse(w, http.StatusInternalServerError, "Internal server error", services.CodeInternalError)
 		return
 	}
 
 	// Convert to slice of values for the list response
-	ctdValues := make([]*models.ComponentTypeDefinitionResponse, len(ctds))
+	ctdValues := make([]*models.ComponentTypeResponse, len(ctds))
 	copy(ctdValues, ctds)
 
 	// Success response with pagination info (simplified for now)
-	logger.Debug("Listed ComponentTypeDefinitions successfully", "org", orgName, "count", len(ctds))
+	logger.Debug("Listed ComponentTypes successfully", "org", orgName, "count", len(ctds))
 	writeListResponse(w, ctdValues, len(ctds), 1, len(ctds))
 }
 
-func (h *Handler) GetComponentTypeDefinitionSchema(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) GetComponentTypeSchema(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := logger.GetLogger(ctx)
-	logger.Debug("GetComponentTypeDefinitionSchema handler called")
+	logger.Debug("GetComponentTypeSchema handler called")
 
 	// Extract path parameters
 	orgName := r.PathValue("orgName")
 	ctdName := r.PathValue("ctdName")
 	if orgName == "" || ctdName == "" {
-		logger.Warn("Organization name and ComponentTypeDefinition name are required")
-		writeErrorResponse(w, http.StatusBadRequest, "Organization name and ComponentTypeDefinition name are required", services.CodeInvalidInput)
+		logger.Warn("Organization name and ComponentType name are required")
+		writeErrorResponse(w, http.StatusBadRequest, "Organization name and ComponentType name are required", services.CodeInvalidInput)
 		return
 	}
 
-	// Call service to get ComponentTypeDefinition schema
-	schema, err := h.services.ComponentTypeDefinitionService.GetComponentTypeDefinitionSchema(ctx, orgName, ctdName)
+	// Call service to get ComponentType schema
+	schema, err := h.services.ComponentTypeService.GetComponentTypeSchema(ctx, orgName, ctdName)
 	if err != nil {
-		if errors.Is(err, services.ErrComponentTypeDefinitionNotFound) {
-			logger.Warn("ComponentTypeDefinition not found", "org", orgName, "name", ctdName)
-			writeErrorResponse(w, http.StatusNotFound, "ComponentTypeDefinition not found", services.CodeComponentTypeDefinitionNotFound)
+		if errors.Is(err, services.ErrComponentTypeNotFound) {
+			logger.Warn("ComponentType not found", "org", orgName, "name", ctdName)
+			writeErrorResponse(w, http.StatusNotFound, "ComponentType not found", services.CodeComponentTypeNotFound)
 			return
 		}
-		logger.Error("Failed to get ComponentTypeDefinition schema", "error", err)
+		logger.Error("Failed to get ComponentType schema", "error", err)
 		writeErrorResponse(w, http.StatusInternalServerError, "Internal server error", services.CodeInternalError)
 		return
 	}
 
 	// Success response
-	logger.Debug("Retrieved ComponentTypeDefinition schema successfully", "org", orgName, "name", ctdName)
+	logger.Debug("Retrieved ComponentType schema successfully", "org", orgName, "name", ctdName)
 	writeSuccessResponse(w, http.StatusOK, schema)
 }

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -65,9 +65,9 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/buildplanes", h.ListBuildPlanes)
 	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/build-templates", h.ListBuildTemplates)
 
-	// ComponentTypeDefinition endpoints
-	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/component-types", h.ListComponentTypeDefinitions)
-	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/component-types/{ctdName}/schema", h.GetComponentTypeDefinitionSchema)
+	// ComponentType endpoints
+	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/component-types", h.ListComponentTypes)
+	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/component-types/{ctdName}/schema", h.GetComponentTypeSchema)
 
 	// Addon endpoints
 	mux.HandleFunc("GET "+v1+"/orgs/{orgName}/addons", h.ListAddons)

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -250,8 +250,8 @@ func ErrorResponse(message, code string) APIResponse[any] {
 	}
 }
 
-// ComponentTypeDefinitionResponse represents a ComponentTypeDefinition in API responses
-type ComponentTypeDefinitionResponse struct {
+// ComponentTypeResponse represents a ComponentType in API responses
+type ComponentTypeResponse struct {
 	Name         string    `json:"name"`
 	DisplayName  string    `json:"displayName,omitempty"`
 	Description  string    `json:"description,omitempty"`

--- a/internal/openchoreo-api/services/errors.go
+++ b/internal/openchoreo-api/services/errors.go
@@ -7,42 +7,42 @@ import "errors"
 
 // Common service errors
 var (
-	ErrProjectAlreadyExists                 = errors.New("project already exists")
-	ErrProjectNotFound                      = errors.New("project not found")
-	ErrComponentAlreadyExists               = errors.New("component already exists")
-	ErrComponentNotFound                    = errors.New("component not found")
-	ErrComponentTypeDefinitionAlreadyExists = errors.New("component type definition already exists")
-	ErrComponentTypeDefinitionNotFound      = errors.New("component type definition not found")
-	ErrAddonAlreadyExists                   = errors.New("addon already exists")
-	ErrAddonNotFound                        = errors.New("addon not found")
-	ErrOrganizationNotFound                 = errors.New("organization not found")
-	ErrEnvironmentNotFound                  = errors.New("environment not found")
-	ErrEnvironmentAlreadyExists             = errors.New("environment already exists")
-	ErrDataPlaneNotFound                    = errors.New("dataplane not found")
-	ErrDataPlaneAlreadyExists               = errors.New("dataplane already exists")
-	ErrBindingNotFound                      = errors.New("binding not found")
-	ErrDeploymentPipelineNotFound           = errors.New("deployment pipeline not found")
-	ErrInvalidPromotionPath                 = errors.New("invalid promotion path")
+	ErrProjectAlreadyExists       = errors.New("project already exists")
+	ErrProjectNotFound            = errors.New("project not found")
+	ErrComponentAlreadyExists     = errors.New("component already exists")
+	ErrComponentNotFound          = errors.New("component not found")
+	ErrComponentTypeAlreadyExists = errors.New("component type already exists")
+	ErrComponentTypeNotFound      = errors.New("component type not found")
+	ErrAddonAlreadyExists         = errors.New("addon already exists")
+	ErrAddonNotFound              = errors.New("addon not found")
+	ErrOrganizationNotFound       = errors.New("organization not found")
+	ErrEnvironmentNotFound        = errors.New("environment not found")
+	ErrEnvironmentAlreadyExists   = errors.New("environment already exists")
+	ErrDataPlaneNotFound          = errors.New("dataplane not found")
+	ErrDataPlaneAlreadyExists     = errors.New("dataplane already exists")
+	ErrBindingNotFound            = errors.New("binding not found")
+	ErrDeploymentPipelineNotFound = errors.New("deployment pipeline not found")
+	ErrInvalidPromotionPath       = errors.New("invalid promotion path")
 )
 
 // Error codes for API responses
 const (
-	CodeProjectExists                   = "PROJECT_EXISTS"
-	CodeProjectNotFound                 = "PROJECT_NOT_FOUND"
-	CodeComponentExists                 = "COMPONENT_EXISTS"
-	CodeComponentNotFound               = "COMPONENT_NOT_FOUND"
-	CodeComponentTypeDefinitionExists   = "COMPONENT_TYPE_DEFINITION_EXISTS"
-	CodeComponentTypeDefinitionNotFound = "COMPONENT_TYPE_DEFINITION_NOT_FOUND"
-	CodeAddonExists                     = "ADDON_EXISTS"
-	CodeAddonNotFound                   = "ADDON_NOT_FOUND"
-	CodeOrganizationNotFound            = "ORGANIZATION_NOT_FOUND"
-	CodeEnvironmentNotFound             = "ENVIRONMENT_NOT_FOUND"
-	CodeEnvironmentExists               = "ENVIRONMENT_EXISTS"
-	CodeDataPlaneNotFound               = "DATAPLANE_NOT_FOUND"
-	CodeDataPlaneExists                 = "DATAPLANE_EXISTS"
-	CodeBindingNotFound                 = "BINDING_NOT_FOUND"
-	CodeDeploymentPipelineNotFound      = "DEPLOYMENT_PIPELINE_NOT_FOUND"
-	CodeInvalidPromotionPath            = "INVALID_PROMOTION_PATH"
-	CodeInvalidInput                    = "INVALID_INPUT"
-	CodeInternalError                   = "INTERNAL_ERROR"
+	CodeProjectExists              = "PROJECT_EXISTS"
+	CodeProjectNotFound            = "PROJECT_NOT_FOUND"
+	CodeComponentExists            = "COMPONENT_EXISTS"
+	CodeComponentNotFound          = "COMPONENT_NOT_FOUND"
+	CodeComponentTypeExists        = "COMPONENT_TYPE_EXISTS"
+	CodeComponentTypeNotFound      = "COMPONENT_TYPE_NOT_FOUND"
+	CodeAddonExists                = "ADDON_EXISTS"
+	CodeAddonNotFound              = "ADDON_NOT_FOUND"
+	CodeOrganizationNotFound       = "ORGANIZATION_NOT_FOUND"
+	CodeEnvironmentNotFound        = "ENVIRONMENT_NOT_FOUND"
+	CodeEnvironmentExists          = "ENVIRONMENT_EXISTS"
+	CodeDataPlaneNotFound          = "DATAPLANE_NOT_FOUND"
+	CodeDataPlaneExists            = "DATAPLANE_EXISTS"
+	CodeBindingNotFound            = "BINDING_NOT_FOUND"
+	CodeDeploymentPipelineNotFound = "DEPLOYMENT_PIPELINE_NOT_FOUND"
+	CodeInvalidPromotionPath       = "INVALID_PROMOTION_PATH"
+	CodeInvalidInput               = "INVALID_INPUT"
+	CodeInternalError              = "INTERNAL_ERROR"
 )

--- a/internal/openchoreo-api/services/services.go
+++ b/internal/openchoreo-api/services/services.go
@@ -11,17 +11,17 @@ import (
 )
 
 type Services struct {
-	ProjectService                 *ProjectService
-	ComponentService               *ComponentService
-	ComponentTypeDefinitionService *ComponentTypeDefinitionService
-	AddonService                   *AddonService
-	OrganizationService            *OrganizationService
-	EnvironmentService             *EnvironmentService
-	DataPlaneService               *DataPlaneService
-	BuildService                   *BuildService
-	BuildPlaneService              *BuildPlaneService
-	DeploymentPipelineService      *DeploymentPipelineService
-	k8sClient                      client.Client // Direct access to K8s client for apply operations
+	ProjectService            *ProjectService
+	ComponentService          *ComponentService
+	ComponentTypeService      *ComponentTypeService
+	AddonService              *AddonService
+	OrganizationService       *OrganizationService
+	EnvironmentService        *EnvironmentService
+	DataPlaneService          *DataPlaneService
+	BuildService              *BuildService
+	BuildPlaneService         *BuildPlaneService
+	DeploymentPipelineService *DeploymentPipelineService
+	k8sClient                 client.Client // Direct access to K8s client for apply operations
 }
 
 // NewServices creates and initializes all services
@@ -50,24 +50,24 @@ func NewServices(k8sClient client.Client, k8sBPClientMgr *kubernetesClient.KubeM
 	// Create deployment pipeline service (depends on project service)
 	deploymentPipelineService := NewDeploymentPipelineService(k8sClient, projectService, logger.With("service", "deployment-pipeline"))
 
-	// Create ComponentTypeDefinition service
-	componentTypeDefinitionService := NewComponentTypeDefinitionService(k8sClient, logger.With("service", "componenttypedefinition"))
+	// Create ComponentType service
+	componentTypeService := NewComponentTypeService(k8sClient, logger.With("service", "componenttype"))
 
 	// Create Addon service
 	addonService := NewAddonService(k8sClient, logger.With("service", "addon"))
 
 	return &Services{
-		ProjectService:                 projectService,
-		ComponentService:               componentService,
-		ComponentTypeDefinitionService: componentTypeDefinitionService,
-		AddonService:                   addonService,
-		OrganizationService:            organizationService,
-		EnvironmentService:             environmentService,
-		DataPlaneService:               dataplaneService,
-		BuildService:                   buildService,
-		BuildPlaneService:              buildPlaneService,
-		DeploymentPipelineService:      deploymentPipelineService,
-		k8sClient:                      k8sClient,
+		ProjectService:            projectService,
+		ComponentService:          componentService,
+		ComponentTypeService:      componentTypeService,
+		AddonService:              addonService,
+		OrganizationService:       organizationService,
+		EnvironmentService:        environmentService,
+		DataPlaneService:          dataplaneService,
+		BuildService:              buildService,
+		BuildPlaneService:         buildPlaneService,
+		DeploymentPipelineService: deploymentPipelineService,
+		k8sClient:                 k8sClient,
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Rename any ComponentTypeDefintion references in internal/openchoreo-api to ComponentType. Renaming the CRD types will be done in a separate PR to avoid conflicts with currently open PRs.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
