### PR TITLE
Refactor thunder post-install script to use `client_secret_post` as the token endpoint auth method

### DIFF
--- a/install/helm/openchoreo/templates/asgardeo-thunder/post-install-hook.yaml
+++ b/install/helm/openchoreo/templates/asgardeo-thunder/post-install-hook.yaml
@@ -87,10 +87,7 @@ spec:
                       "response_types": [
                         "code"
                       ],
-                      "token_endpoint_auth_methods": [
-                        "client_secret_basic",
-                        "client_secret_post"
-                      ],
+                      "token_endpoint_auth_method": "client_secret_post",
                       "pkce_required": false,
                       "public_client": false,
                       "token": {


### PR DESCRIPTION
## Purpose
Previously Thunder used an array called `token_endpoint_auth_methods` for application config, however now it is changed to `token_endpoint_auth_method`.
This PR updates this config

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
