### PR TITLE
Rename type openchoreov1alpha1.ComponentType

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -40,7 +40,7 @@ type ComponentSpec struct {
 	// Type specifies the component type (e.g., Service, WebApplication, etc.)
 	// LEGACY FIELD: Use componentType instead for new components with ComponentTypeDefinitions
 	// +optional
-	Type ComponentType `json:"type,omitempty"`
+	Type CompType `json:"type,omitempty"`
 
 	// ComponentType specifies the component type in the format: {workloadType}/{componentTypeDefinitionName}
 	// Example: "deployment/web-app", "cronjob/scheduled-task"
@@ -133,18 +133,18 @@ type ComponentStatus struct {
 	Conditions         []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// ComponentType defines how the component is deployed.
-type ComponentType string
+// CompType defines how the component is deployed.
+type CompType string
 
 const (
-	ComponentTypeService        ComponentType = "Service"
-	ComponentTypeManualTask     ComponentType = "ManualTask"
-	ComponentTypeScheduledTask  ComponentType = "ScheduledTask"
-	ComponentTypeWebApplication ComponentType = "WebApplication"
-	ComponentTypeWebhook        ComponentType = "Webhook"
-	ComponentTypeAPIProxy       ComponentType = "APIProxy"
-	ComponentTypeTestRunner     ComponentType = "TestRunner"
-	ComponentTypeEventHandler   ComponentType = "EventHandler"
+	ComponentTypeService        CompType = "Service"
+	ComponentTypeManualTask     CompType = "ManualTask"
+	ComponentTypeScheduledTask  CompType = "ScheduledTask"
+	ComponentTypeWebApplication CompType = "WebApplication"
+	ComponentTypeWebhook        CompType = "Webhook"
+	ComponentTypeAPIProxy       CompType = "APIProxy"
+	ComponentTypeTestRunner     CompType = "TestRunner"
+	ComponentTypeEventHandler   CompType = "EventHandler"
 )
 
 // ComponentSource defines the source information of the component where the code or image is retrieved.

--- a/internal/choreoctl/cmd/create/component/interactive.go
+++ b/internal/choreoctl/cmd/create/component/interactive.go
@@ -33,7 +33,7 @@ const (
 
 type componentModel struct {
 	interactive.BaseModel // Reuses common organization/project selection logic
-	types                 []openchoreov1alpha1.ComponentType
+	types                 []openchoreov1alpha1.CompType
 	typeCursor            int
 
 	// Component fields
@@ -317,7 +317,7 @@ func createComponentInteractive(config constants.CRDConfig) error {
 	}
 
 	// Initialize all supported component types
-	componentTypes := []openchoreov1alpha1.ComponentType{
+	componentTypes := []openchoreov1alpha1.CompType{
 		openchoreov1alpha1.ComponentTypeScheduledTask,
 		openchoreov1alpha1.ComponentTypeWebApplication,
 		openchoreov1alpha1.ComponentTypeService,

--- a/internal/controller/endpoint/integrations/kubernetes/http_route_test.go
+++ b/internal/controller/endpoint/integrations/kubernetes/http_route_test.go
@@ -603,7 +603,7 @@ var _ = Describe("HTTPRoute Handler", func() {
 
 // Helper function to create test endpoint context
 func createTestEndpointContext(endpoint *openchoreov1alpha1.Endpoint, componentName, envDNSPrefix string,
-	componentType openchoreov1alpha1.ComponentType) *dataplane.EndpointContext {
+	componentType openchoreov1alpha1.CompType) *dataplane.EndpointContext {
 	return &dataplane.EndpointContext{
 		Endpoint: endpoint,
 		Component: &openchoreov1alpha1.Component{

--- a/internal/openchoreo-api/services/component_service.go
+++ b/internal/openchoreo-api/services/component_service.go
@@ -272,7 +272,7 @@ func (s *ComponentService) createComponentResources(ctx context.Context, orgName
 			Owner: openchoreov1alpha1.ComponentOwner{
 				ProjectName: projectName,
 			},
-			Type: openchoreov1alpha1.ComponentType(req.Type),
+			Type: openchoreov1alpha1.CompType(req.Type),
 		},
 	}
 
@@ -417,7 +417,7 @@ func (s *ComponentService) getComponentBinding(ctx context.Context, orgName, pro
 	// Determine binding type based on component type
 	var bindingResponse *models.BindingResponse
 	var err error
-	switch openchoreov1alpha1.ComponentType(componentType) {
+	switch openchoreov1alpha1.CompType(componentType) {
 	case openchoreov1alpha1.ComponentTypeService:
 		bindingResponse, err = s.getServiceBinding(ctx, orgName, componentName, environment)
 	case openchoreov1alpha1.ComponentTypeWebApplication:
@@ -783,7 +783,7 @@ func (s *ComponentService) validatePromotionPath(ctx context.Context, orgName, p
 
 // createOrUpdateTargetBinding creates or updates the binding in the target environment
 func (s *ComponentService) createOrUpdateTargetBinding(ctx context.Context, req *PromoteComponentPayload, componentType string) error {
-	switch openchoreov1alpha1.ComponentType(componentType) {
+	switch openchoreov1alpha1.CompType(componentType) {
 	case openchoreov1alpha1.ComponentTypeService:
 		return s.createOrUpdateServiceBinding(ctx, req)
 	case openchoreov1alpha1.ComponentTypeWebApplication:
@@ -1459,7 +1459,7 @@ func (s *ComponentService) CreateComponentWorkload(ctx context.Context, orgName,
 }
 
 // createTypeSpecificResource creates the appropriate resource (Service, WebApplication, or ScheduledTask) based on component type
-func (s *ComponentService) createTypeSpecificResource(ctx context.Context, orgName, projectName, componentName, workloadName string, componentType openchoreov1alpha1.ComponentType) error {
+func (s *ComponentService) createTypeSpecificResource(ctx context.Context, orgName, projectName, componentName, workloadName string, componentType openchoreov1alpha1.CompType) error {
 	switch componentType {
 	case openchoreov1alpha1.ComponentTypeService:
 		return s.createServiceResource(ctx, orgName, projectName, componentName, workloadName)

--- a/pkg/cli/cmd/create/create.go
+++ b/pkg/cli/cmd/create/create.go
@@ -133,7 +133,7 @@ func newCreateComponentCmd(impl api.CommandImplementationInterface) *cobra.Comma
 				Project:          fg.GetString(flags.Project),
 				DisplayName:      fg.GetString(flags.DisplayName),
 				GitRepositoryURL: fg.GetString(flags.GitRepositoryURL),
-				Type:             openchoreov1alpha1.ComponentType(fg.GetString(flags.ComponentType)),
+				Type:             openchoreov1alpha1.CompType(fg.GetString(flags.ComponentType)),
 				Interactive:      fg.GetBool(flags.Interactive),
 				Branch:           fg.GetString(flags.Branch),
 				Path:             fg.GetString(flags.Path),

--- a/pkg/cli/types/api/params.go
+++ b/pkg/cli/types/api/params.go
@@ -52,7 +52,7 @@ type CreateProjectParams struct {
 type CreateComponentParams struct {
 	Name             string
 	DisplayName      string
-	Type             openchoreov1alpha1.ComponentType
+	Type             openchoreov1alpha1.CompType
 	Organization     string
 	Project          string
 	Description      string


### PR DESCRIPTION
## Purpose
> Rename type openchoreov1alpha1.ComponentType to avoid conflicts with the proposed CRD 'ComponentType'.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/838

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
