### PR TITLE
Add Web App and HTTP Service samples

### DIFF
--- a/samples/http-service-component/README.md
+++ b/samples/http-service-component/README.md
@@ -15,7 +15,7 @@ Defines a reusable component type template for HTTP services. It:
 - Declares environment-specific overrides for resource limits
 - Templates the underlying Kubernetes resources (Deployment, Service, HTTPRoute)
 - Configures path-based routing with specific HTTP methods:
-  - `GET /{component-name}/greeter/greet`
+  - `GET /{component-name}/{resource-paths}`
 - Uses CEL expressions to dynamically populate values from component metadata and parameters
 
 This allows you to create multiple HTTP service components using the same template with different configurations.
@@ -54,9 +54,9 @@ Represents a deployment instance of the component to a specific environment:
 3. **Workload** specifies what container(s) to run (echo server for testing)
 4. **ComponentDeployment** creates an actual deployment to an environment with optional overrides
 
-The controller reads these resources and generates the Kubernetes resources (Deployment, Service, HTTPRoute) based on the templates and parameters.
+The OpenChoreo controller manager uses these resources and generates the Kubernetes resources (Deployment, Service, HTTPRoute) based on the templates and parameters.
 
-## Apply resources
+## Deploy the sample
 
 Apply the sample:
 
@@ -75,4 +75,11 @@ kubectl get release demo-app-development -n default -o yaml
 
 # Check the rendered resources
 kubectl get release demo-app-development -n default -o jsonpath='{.spec.resources[*].id}'
+```
+
+## Test the Service by invoking
+
+```bash
+curl http://demo-app-development-e040c964-development.openchoreoapis.localhost:9080/demo-app-development-e040c964/greeter/greet
+Hello, Stranger!
 ```

--- a/samples/http-service-component/http-service-component.yaml
+++ b/samples/http-service-component/http-service-component.yaml
@@ -83,7 +83,7 @@ spec:
         spec:
           parentRefs:
             - name: gateway-external
-              namespace: openchoreo
+              namespace: openchoreo-data-plane
           hostnames:
             - ${metadata.name}-${environment.name}.${environment.vhost}
           rules:

--- a/samples/webapp-component/README.md
+++ b/samples/webapp-component/README.md
@@ -74,3 +74,7 @@ kubectl get release demo-app-development -n default -o yaml
 # Check the rendered resources
 kubectl get release demo-app-development -n default -o jsonpath='{.spec.resources[*].id}'
 ```
+
+# Test the Web App by opening it via a web browser
+
+Open your web browser and go to `http://demo-app-development-e040c964-development.openchoreoapis.localhost:9080/`.

--- a/samples/webapp-component/webapp-component.yaml
+++ b/samples/webapp-component/webapp-component.yaml
@@ -83,7 +83,7 @@ spec:
         spec:
           parentRefs:
             - name: gateway-external
-              namespace: openchoreo
+              namespace: openchoreo-data-plane
           hostnames:
             - ${metadata.name}-${environment.name}.${environment.vhost}
           rules:


### PR DESCRIPTION
## Purpose
This PR adds Web App and HTTP service samples with related to the OpenChoreo ComponentTypeDefinition introduced with https://github.com/openchoreo/openchoreo/pull/783.

## Approach
> Define web-service and http-service components with required `HTTPRoute` configuration for exposing via the gateway.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/671

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
> This is required to support Envoy Gateway with the release 0.4.0 only. Eventually with the release 0.9.0, Envoy Gateway will get replaced by WSO2 API Platform Gateway.
