### PR TITLE
Add schema explaination MCP tool to controlplane MCP server

### DIFF
--- a/docs/configure-controlplane-mcp-server.md
+++ b/docs/configure-controlplane-mcp-server.md
@@ -21,6 +21,7 @@ Tools are organized into **Toolsets** - logical groupings of related functionali
 - `ToolsetBuild` (`build`) - Build operations (trigger builds, list builds, build templates, build planes)
 - `ToolsetDeployment` (`deployment`) - Deployment operations (deployment pipelines, observer URLs)
 - `ToolsetInfrastructure` (`infrastructure`) - Infrastructure operations (environments, data planes)
+- `ToolsetSchema` (`schema`) - Schema operations (describe a given kind)
 
 ## Configuring Enabled Toolsets
 
@@ -35,7 +36,7 @@ Set the `MCP_TOOLSETS` environment variable to a comma-separated list of toolset
 export MCP_TOOLSETS="organization,project"
 
 # Enable all toolsets (default)
-export MCP_TOOLSETS="organization,project,component,build,deployment,infrastructure"
+export MCP_TOOLSETS="organization,project,component,build,deployment,infrastructure,schema"
 
 # Enable specific toolsets for your use case
 export MCP_TOOLSETS="organization,project,component"
@@ -50,6 +51,7 @@ If `MCP_TOOLSETS` is not set, the system defaults to enabling all toolsets:
 - `build`
 - `deployment`
 - `infrastructure`
+- `schema`
 
 ### Kubernetes/Helm Configuration
 
@@ -59,7 +61,7 @@ In production deployments, configure toolsets via Helm values:
 openchoreoApi:
   mcp:
     # Enable all toolsets (default)
-    toolsets: "organization,project,component,build,deployment,infrastructure"
+    toolsets: "organization,project,component,build,deployment,infrastructure,schema"
     
     # Or enable specific toolsets based on your requirements
     # toolsets: "organization,project,component"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
+	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/gateway-api v1.2.1
@@ -144,7 +145,6 @@ require (
 	k8s.io/apiserver v0.32.3 // indirect
 	k8s.io/component-base v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.1 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -137,7 +137,8 @@ func getMCPServerToolsets(h *Handler) *mcp.Toolsets {
 			string(mcp.ToolsetComponent) + "," +
 			string(mcp.ToolsetBuild) + "," +
 			string(mcp.ToolsetDeployment) + "," +
-			string(mcp.ToolsetInfrastructure)
+			string(mcp.ToolsetInfrastructure) + "," +
+			string(mcp.ToolsetSchema)
 	}
 
 	// Parse toolsets
@@ -176,6 +177,9 @@ func getMCPServerToolsets(h *Handler) *mcp.Toolsets {
 		case mcp.ToolsetInfrastructure:
 			toolsets.InfrastructureToolset = handler
 			h.logger.Debug("Enabled MCP toolset", slog.String("toolset", "infrastructure"))
+		case mcp.ToolsetSchema:
+			toolsets.SchemaToolset = handler
+			h.logger.Debug("Enabled MCP toolset", slog.String("toolset", "schema"))
 		default:
 			h.logger.Warn("Unknown toolset type", slog.String("toolset", string(toolsetType)))
 		}

--- a/internal/openchoreo-api/mcphandlers/schema.go
+++ b/internal/openchoreo-api/mcphandlers/schema.go
@@ -1,0 +1,20 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+)
+
+// ExplainSchema explains the schema of a Kubernetes resource kind.
+// It accepts a kind (e.g., "Component") and an optional path (e.g., "spec" or "spec.build")
+// to drill down into nested fields.
+func (h *MCPHandler) ExplainSchema(ctx context.Context, kind, path string) (string, error) {
+	explanation, err := h.Services.SchemaService.ExplainSchema(ctx, kind, path)
+	if err != nil {
+		return "", err
+	}
+
+	return marshalResponse(explanation)
+}

--- a/internal/openchoreo-api/services/schema_service.go
+++ b/internal/openchoreo-api/services/schema_service.go
@@ -1,0 +1,351 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/slog"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/openapi"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const objectType = "Object"
+
+// SchemaService handles Kubernetes schema explanation operations
+type SchemaService struct {
+	k8sClient       client.Client
+	discoveryClient *discovery.DiscoveryClient
+	logger          *slog.Logger
+}
+
+// NewSchemaService creates a new schema service
+func NewSchemaService(k8sClient client.Client, logger *slog.Logger) *SchemaService {
+	// Get REST config
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		logger.Error("Failed to get kubernetes config", "error", err)
+		panic(fmt.Sprintf("failed to get kubernetes config: %v", err))
+	}
+
+	// Create discovery client once
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		logger.Error("Failed to create discovery client", "error", err)
+		panic(fmt.Sprintf("failed to create discovery client: %v", err))
+	}
+
+	return &SchemaService{
+		k8sClient:       k8sClient,
+		discoveryClient: discoveryClient,
+		logger:          logger,
+	}
+}
+
+// SchemaExplanation represents the structured schema information
+type SchemaExplanation struct {
+	Group       string                `json:"group"`
+	Kind        string                `json:"kind"`
+	Version     string                `json:"version"`
+	Field       string                `json:"field,omitempty"`
+	Type        string                `json:"type"`
+	Description string                `json:"description,omitempty"`
+	Properties  []PropertyDescription `json:"properties,omitempty"`
+	Required    []string              `json:"required,omitempty"`
+}
+
+// PropertyDescription represents a single field/property in the schema
+type PropertyDescription struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required"`
+}
+
+// ExplainSchema explains the schema of a Kubernetes resource kind
+func (s *SchemaService) ExplainSchema(ctx context.Context, kind, path string) (*SchemaExplanation, error) {
+	s.logger.Debug("Explaining schema", "kind", kind, "path", path)
+
+	// Find the GVK for the given kind
+	gvk, err := s.findGVKForKind(kind)
+	if err != nil {
+		s.logger.Warn("Failed to find resource kind", "kind", kind, "error", err)
+		return nil, fmt.Errorf("failed to find resource for kind %s: %w", kind, err)
+	}
+
+	// Get OpenAPI v3 client
+	openAPIv3 := s.discoveryClient.OpenAPIV3()
+
+	// Get the group version paths
+	paths, err := openAPIv3.Paths()
+	if err != nil {
+		s.logger.Error("Failed to get OpenAPI paths", "error", err)
+		return nil, fmt.Errorf("failed to get OpenAPI paths: %w", err)
+	}
+
+	// Find the group version
+	gv := schema.GroupVersion{Group: gvk.Group, Version: gvk.Version}
+
+	// Try multiple possible path formats
+	var groupVersion openapi.GroupVersion
+	var ok bool
+
+	// Try the standard format first
+	groupVersion, ok = paths[gv.String()]
+	if !ok {
+		// Try with apis/ prefix
+		groupVersion, ok = paths["apis/"+gv.String()]
+	}
+	if !ok {
+		// Try just the version for core API
+		if gvk.Group == "" {
+			groupVersion, ok = paths[gvk.Version]
+			if !ok {
+				groupVersion, ok = paths["api/"+gvk.Version]
+			}
+		}
+	}
+
+	if !ok {
+		return nil, fmt.Errorf("group version %s not found in OpenAPI spec", gv.String())
+	}
+
+	// Get the OpenAPI spec bytes
+	openAPIBytes, err := groupVersion.Schema("application/json")
+	if err != nil {
+		s.logger.Error("Failed to get OpenAPI spec", "error", err)
+		return nil, fmt.Errorf("failed to get OpenAPI spec: %w", err)
+	}
+
+	// Parse the OpenAPI spec
+	var openAPISpec spec3.OpenAPI
+	if err := json.Unmarshal(openAPIBytes, &openAPISpec); err != nil {
+		s.logger.Error("Failed to parse OpenAPI spec", "error", err)
+		return nil, fmt.Errorf("failed to parse OpenAPI spec: %w", err)
+	}
+
+	// Find the schema for this kind
+	schemaRef, err := s.findSchemaForKind(&openAPISpec, gvk)
+	if err != nil {
+		s.logger.Warn("Failed to find schema", "kind", gvk.Kind, "error", err)
+		return nil, fmt.Errorf("failed to find schema for %s: %w", gvk.Kind, err)
+	}
+
+	// Navigate to the field if path is provided
+	fieldSchema := schemaRef
+	fieldPath := ""
+	if path != "" {
+		fieldPath = path
+		parts := strings.Split(path, ".")
+		for _, part := range parts {
+			if len(fieldSchema.Properties) == 0 {
+				return nil, fmt.Errorf("field %q not found - no properties in schema", part)
+			}
+
+			// Try exact match first
+			propSchema, ok := fieldSchema.Properties[part]
+			if !ok {
+				// Try case-insensitive match
+				for key, val := range fieldSchema.Properties {
+					if strings.EqualFold(key, part) {
+						propSchema = val
+						ok = true
+						break
+					}
+				}
+			}
+
+			if !ok {
+				return nil, fmt.Errorf("field %q not found in path", part)
+			}
+			fieldSchema = &propSchema
+		}
+	}
+
+	// Build the explanation
+	explanation := s.buildSchemaExplanation(gvk, fieldPath, fieldSchema)
+
+	s.logger.Debug("Schema explanation completed", "kind", kind, "path", path)
+	return explanation, nil
+}
+
+// findGVKForKind finds the GroupVersionKind for a given kind name
+func (s *SchemaService) findGVKForKind(kind string) (schema.GroupVersionKind, error) {
+	// Get all API resources
+	_, apiResourceLists, err := s.discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+
+	// Normalize kind for comparison (case-insensitive)
+	normalizedKind := strings.ToLower(kind)
+
+	// Search through all resources
+	for _, apiResourceList := range apiResourceLists {
+		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
+		if err != nil {
+			continue
+		}
+
+		for _, resource := range apiResourceList.APIResources {
+			if strings.ToLower(resource.Kind) == normalizedKind {
+				return schema.GroupVersionKind{
+					Group:   gv.Group,
+					Version: gv.Version,
+					Kind:    resource.Kind,
+				}, nil
+			}
+		}
+	}
+
+	return schema.GroupVersionKind{}, fmt.Errorf("resource kind %q not found", kind)
+}
+
+// findSchemaForKind locates the schema definition for a specific kind in the OpenAPI spec
+func (s *SchemaService) findSchemaForKind(openAPISpec *spec3.OpenAPI, gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	if openAPISpec.Components == nil || openAPISpec.Components.Schemas == nil {
+		return nil, fmt.Errorf("no schemas found in OpenAPI spec")
+	}
+
+	// Convert group to match Kubernetes OpenAPI schema naming convention
+	// e.g., "openchoreo.dev" becomes "dev.openchoreo"
+	groupParts := strings.Split(gvk.Group, ".")
+	reversedGroup := ""
+	if len(groupParts) > 0 {
+		// Reverse the parts: openchoreo.dev -> dev.openchoreo
+		for i := len(groupParts) - 1; i >= 0; i-- {
+			if reversedGroup != "" {
+				reversedGroup += "."
+			}
+			reversedGroup += groupParts[i]
+		}
+	}
+
+	// Common schema naming patterns in Kubernetes OpenAPI V3
+	possibleNames := []string{
+		// Standard k8s format: dev.openchoreo.v1alpha1.Component
+		fmt.Sprintf("%s.%s.%s", reversedGroup, gvk.Version, gvk.Kind),
+		// Alternative formats
+		fmt.Sprintf("%s.%s.%s.%s", gvk.Group, gvk.Version, gvk.Kind, gvk.Kind),
+		fmt.Sprintf("%s.%s.%s", gvk.Group, gvk.Version, gvk.Kind),
+		gvk.Kind,
+	}
+
+	for _, name := range possibleNames {
+		if schemaRef, ok := openAPISpec.Components.Schemas[name]; ok {
+			return schemaRef, nil
+		}
+	}
+
+	// If exact match failed, try partial match as fallback
+	for schemaName, schemaRef := range openAPISpec.Components.Schemas {
+		if strings.HasSuffix(schemaName, "."+gvk.Kind) {
+			return schemaRef, nil
+		}
+	}
+
+	return nil, fmt.Errorf("schema for kind %s not found", gvk.Kind)
+}
+
+// buildSchemaExplanation builds the schema explanation from the schema
+func (s *SchemaService) buildSchemaExplanation(gvk schema.GroupVersionKind, fieldPath string, fieldSchema *spec.Schema) *SchemaExplanation {
+	explanation := &SchemaExplanation{
+		Group:       gvk.Group,
+		Kind:        gvk.Kind,
+		Version:     gvk.Version,
+		Field:       fieldPath,
+		Type:        getSchemaType(fieldSchema),
+		Description: fieldSchema.Description,
+		Required:    fieldSchema.Required,
+	}
+
+	// Add properties if this is an object
+	if len(fieldSchema.Properties) > 0 {
+		explanation.Properties = s.extractProperties(fieldSchema)
+	}
+
+	return explanation
+}
+
+// extractProperties extracts property information from a schema
+func (s *SchemaService) extractProperties(schema *spec.Schema) []PropertyDescription {
+	if schema.Properties == nil {
+		return nil
+	}
+
+	// Sort field names for consistent output
+	fieldNames := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+
+	properties := make([]PropertyDescription, 0, len(fieldNames))
+	for _, name := range fieldNames {
+		propSchema := schema.Properties[name]
+
+		// Check if required
+		isRequired := false
+		if schema.Required != nil {
+			for _, req := range schema.Required {
+				if req == name {
+					isRequired = true
+					break
+				}
+			}
+		}
+
+		properties = append(properties, PropertyDescription{
+			Name:        name,
+			Type:        getSchemaType(&propSchema),
+			Description: propSchema.Description,
+			Required:    isRequired,
+		})
+	}
+
+	return properties
+}
+
+// getSchemaType determines the type string for a schema
+func getSchemaType(schema *spec.Schema) string {
+	if schema == nil {
+		return objectType
+	}
+
+	// Check for arrays
+	if schema.Type.Contains("array") {
+		if schema.Items != nil && schema.Items.Schema != nil {
+			itemType := getSchemaType(schema.Items.Schema)
+			return fmt.Sprintf("[]%s", itemType)
+		}
+		return "[]" + objectType
+	}
+
+	// Check for maps (additionalProperties)
+	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil {
+		valueType := getSchemaType(schema.AdditionalProperties.Schema)
+		return fmt.Sprintf("map[string]%s", valueType)
+	}
+
+	// Return the type or default to Object
+	if len(schema.Type) > 0 {
+		return schema.Type[0]
+	}
+
+	// If it has properties, it's an object
+	if len(schema.Properties) > 0 {
+		return objectType
+	}
+
+	return objectType
+}

--- a/internal/openchoreo-api/services/services.go
+++ b/internal/openchoreo-api/services/services.go
@@ -22,6 +22,7 @@ type Services struct {
 	BuildService              *BuildService
 	BuildPlaneService         *BuildPlaneService
 	DeploymentPipelineService *DeploymentPipelineService
+	SchemaService             *SchemaService
 	k8sClient                 client.Client // Direct access to K8s client for apply operations
 }
 
@@ -60,6 +61,9 @@ func NewServices(k8sClient client.Client, k8sBPClientMgr *kubernetesClient.KubeM
 	// Create Workflow service
 	workflowService := NewWorkflowService(k8sClient, logger.With("service", "workflow"))
 
+	// Create Schema service
+	schemaService := NewSchemaService(k8sClient, logger.With("service", "schema"))
+
 	return &Services{
 		ProjectService:            projectService,
 		ComponentService:          componentService,
@@ -72,6 +76,7 @@ func NewServices(k8sClient client.Client, k8sBPClientMgr *kubernetesClient.KubeM
 		BuildService:              buildService,
 		BuildPlaneService:         buildPlaneService,
 		DeploymentPipelineService: deploymentPipelineService,
+		SchemaService:             schemaService,
 		k8sClient:                 k8sClient,
 	}
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -21,6 +21,7 @@ const (
 	ToolsetBuild          ToolsetType = "build"
 	ToolsetDeployment     ToolsetType = "deployment"
 	ToolsetInfrastructure ToolsetType = "infrastructure"
+	ToolsetSchema         ToolsetType = "schema"
 )
 
 type Toolsets struct {
@@ -30,6 +31,7 @@ type Toolsets struct {
 	BuildToolset          BuildToolsetHandler
 	DeploymentToolset     DeploymentToolsetHandler
 	InfrastructureToolset InfrastructureToolsetHandler
+	SchemaToolset         SchemaToolsetHandler
 }
 
 // OrganizationToolsetHandler handles organization operations
@@ -88,6 +90,11 @@ type InfrastructureToolsetHandler interface {
 	ListDataPlanes(ctx context.Context, orgName string) (string, error)
 	GetDataPlane(ctx context.Context, orgName, dpName string) (string, error)
 	CreateDataPlane(ctx context.Context, orgName string, req *models.CreateDataPlaneRequest) (string, error)
+}
+
+// SchemaToolsetHandler handles schema and resource explanation operations
+type SchemaToolsetHandler interface {
+	ExplainSchema(ctx context.Context, kind, path string) (string, error)
 }
 
 // RegisterFunc is a function type for registering MCP tools
@@ -478,6 +485,28 @@ func (t *Toolsets) RegisterGetDeploymentPipeline(s *mcp.Server) {
 	})
 }
 
+func (t *Toolsets) RegisterExplainSchema(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "explain_schema",
+		Description: "Get the schema definition of a Kubernetes resource in structured JSON format. " +
+			"Returns detailed information about resource fields including types, descriptions, and required status. " +
+			"Use this to understand OpenChoreo resources like Component, Project, Environment, etc. " +
+			"Optionally provide a path to drill down into nested fields (e.g., 'spec', 'spec.build'). " +
+			"The response includes: group, kind, version, field (if path specified), type, description, " +
+			"properties array with field details, and required fields list.",
+		InputSchema: createSchema(map[string]any{
+			"kind": stringProperty("The Kubernetes resource kind to explain (e.g., 'Component', 'Project', 'Environment')"),
+			"path": stringProperty("Optional: field path to drill down into (e.g., 'spec', 'spec.build', 'metadata')"),
+		}, []string{"kind"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		Kind string `json:"kind"`
+		Path string `json:"path"`
+	}) (*mcp.CallToolResult, map[string]string, error) {
+		result, err := t.SchemaToolset.ExplainSchema(ctx, args.Kind, args.Path)
+		return handleToolResult(result, err)
+	})
+}
+
 // organizationToolRegistrations returns the list of organization toolset registration functions
 func (t *Toolsets) organizationToolRegistrations() []RegisterFunc {
 	return []RegisterFunc{
@@ -534,6 +563,13 @@ func (t *Toolsets) infrastructureToolRegistrations() []RegisterFunc {
 	}
 }
 
+// schemaToolRegistrations returns the list of schema toolset registration functions
+func (t *Toolsets) schemaToolRegistrations() []RegisterFunc {
+	return []RegisterFunc{
+		t.RegisterExplainSchema,
+	}
+}
+
 func (t *Toolsets) Register(s *mcp.Server) {
 	// Register organization tools if OrganizationToolset is enabled
 	if t.OrganizationToolset != nil {
@@ -573,6 +609,13 @@ func (t *Toolsets) Register(s *mcp.Server) {
 	// Register infrastructure tools if InfrastructureToolset is enabled
 	if t.InfrastructureToolset != nil {
 		for _, registerFunc := range t.infrastructureToolRegistrations() {
+			registerFunc(s)
+		}
+	}
+
+	// Register schema tools if SchemaToolset is enabled
+	if t.SchemaToolset != nil {
+		for _, registerFunc := range t.schemaToolRegistrations() {
 			registerFunc(s)
 		}
 	}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -180,6 +180,11 @@ func (m *MockCoreToolsetHandler) GetProjectDeploymentPipeline(
 	return `{"stages":[]}`, nil
 }
 
+func (m *MockCoreToolsetHandler) ExplainSchema(ctx context.Context, kind, path string) (string, error) {
+	m.recordCall("ExplainSchema", kind, path)
+	return `{"group":"openchoreo.dev","kind":"Component","version":"v1alpha1","type":"Object"}`, nil
+}
+
 func setupTestServer(t *testing.T) (*mcp.ClientSession, *MockCoreToolsetHandler) {
 	t.Helper()
 	mockHandler := NewMockCoreToolsetHandler()
@@ -190,6 +195,7 @@ func setupTestServer(t *testing.T) (*mcp.ClientSession, *MockCoreToolsetHandler)
 		BuildToolset:          mockHandler,
 		DeploymentToolset:     mockHandler,
 		InfrastructureToolset: mockHandler,
+		SchemaToolset:         mockHandler,
 	}
 	clientSession := setupTestServerWithToolset(t, toolsets)
 	return clientSession, mockHandler
@@ -605,6 +611,24 @@ var allToolSpecs = []toolTestSpec{
 		validateCall: func(t *testing.T, args []interface{}) {
 			if args[0] != testOrgName || args[1] != testProjectName {
 				t.Errorf("Expected (%s, %s), got (%v, %v)", testOrgName, testProjectName, args[0], args[1])
+			}
+		},
+	},
+	{
+		name:                "explain_schema",
+		toolset:             "schema",
+		descriptionKeywords: []string{"schema", "resource"},
+		descriptionMinLen:   10,
+		requiredParams:      []string{"kind"},
+		optionalParams:      []string{"path"},
+		testArgs: map[string]any{
+			"kind": "Component",
+			"path": "spec",
+		},
+		expectedMethod: "ExplainSchema",
+		validateCall: func(t *testing.T, args []interface{}) {
+			if args[0] != "Component" || args[1] != "spec" {
+				t.Errorf("Expected (Component, spec), got (%v, %v)", args[0], args[1])
 			}
 		},
 	},


### PR DESCRIPTION
## Purpose
This PR adds an MCP tool to the controlplane MCP server. The tool: `explain_schema` can be used to explain a kind, similar to `kubectl explain`. Further this tool accepts a param: `path` using which the schema explaination can be drilled further down.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/661

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
