### PR TITLE
Update observer OpenSearch query time range to use exclusive bounds

### DIFF
--- a/internal/observer/opensearch/queries.go
+++ b/internal/observer/opensearch/queries.go
@@ -29,8 +29,8 @@ func addTimeRangeFilter(mustConditions []map[string]interface{}, startTime, endT
 		timeFilter := map[string]interface{}{
 			"range": map[string]interface{}{
 				"@timestamp": map[string]interface{}{
-					"gte": startTime,
-					"lte": endTime,
+					"gt": startTime,
+					"lt": endTime,
 				},
 			},
 		}


### PR DESCRIPTION
## Purpose
With the change to backstage UI of Runtime Logs view (https://github.com/openchoreo/backstage-plugins/pull/66), it expects to return the logs 'greater than' or 'less than' for start and end time respectively to avoid duplicated logs in the UI. This PR it to make the necessary change to the related OpenSearch query.  

## Approach
Observer will not provide the logs within the given start and end time, without including the exact start and end timestamps.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
