### PR TITLE
Implement authorization server discovery for controlplane MCP server

### DIFF
--- a/install/dev/openchoreo-values.yaml
+++ b/install/dev/openchoreo-values.yaml
@@ -14,6 +14,9 @@ controllerManager:
 
 # OpenChoreo API configuration
 openchoreoApi:
+  urls:
+    serverBaseUrl: "http://api.openchoreo.localhost"
+    authServerBaseUrl: "http://sts.openchoreo.localhost"
   jwt:
     disabled: true
     issuer: thunder

--- a/install/helm/openchoreo/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo/templates/openchoreo-api/deployment.yaml
@@ -53,6 +53,10 @@ spec:
         env:
         - name: MCP_TOOLSETS
           value: {{ .Values.openchoreoApi.mcp.toolsets | quote }}
+        - name: SERVER_BASE_URL
+          value: {{ .Values.openchoreoApi.urls.serverBaseUrl | quote }}
+        - name: AUTH_SERVER_BASE_URL
+          value: {{ .Values.openchoreoApi.urls.authServerBaseUrl | quote }}
         - name: JWT_ISSUER
           value: {{ .Values.openchoreoApi.jwt.issuer | quote }}
         - name: JWKS_URL

--- a/install/helm/openchoreo/values.schema.json
+++ b/install/helm/openchoreo/values.schema.json
@@ -4647,6 +4647,38 @@
             "object"
           ]
         },
+        "urls": {
+          "additionalProperties": false,
+          "description": "URL configuration for the API server",
+          "properties": {
+            "serverBaseUrl": {
+              "default": "",
+              "description": "Base URL for the API server (used for OAuth metadata)\nExample: https://api.openchoreo.example.com",
+              "required": [],
+              "title": "serverBaseUrl",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "authServerBaseUrl": {
+              "default": "",
+              "description": "Base URL for Asgardeo Thunder (authorization server)\nExample: https://idp.openchoreo.example.com",
+              "required": [],
+              "title": "authServerBaseUrl",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "required": [],
+          "title": "urls",
+          "type": [
+            "null",
+            "object"
+          ]
+        },
         "metrics": {
           "additionalProperties": false,
           "description": "Metrics configuration",

--- a/install/helm/openchoreo/values.yaml
+++ b/install/helm/openchoreo/values.yaml
@@ -602,6 +602,23 @@ openchoreoApi:
   # @schema
   # type: [null, object]
   # @schema
+  # -- URL configuration for the API server
+  urls:
+    # @schema
+    # type: [null, string]
+    # @schema
+    # -- Base URL for the API server (used for OAuth metadata)
+    # -- Example: https://api.openchoreo.example.com
+    serverBaseUrl: ""
+    # @schema
+    # type: [null, string]
+    # @schema
+    # -- Base URL for authorization server
+    # -- Example: https://idp.openchoreo.example.com
+    authServerBaseUrl: ""
+  # @schema
+  # type: [null, object]
+  # @schema
   # -- JWT authentication configuration
   jwt:
     # @schema

--- a/internal/openchoreo-api/config/env.go
+++ b/internal/openchoreo-api/config/env.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+// Environment variable names for OpenChoreo API configuration
+const (
+	// EnvServerBaseURL is the base URL for the API server (used for OAuth metadata)
+	EnvServerBaseURL = "SERVER_BASE_URL"
+
+	// EnvAuthServerBaseURL is the base URL for Asgardeo Thunder (authorization server)
+	EnvAuthServerBaseURL = "AUTH_SERVER_BASE_URL"
+
+	// EnvJWKSURL is the JWKS URL for JWT validation
+	EnvJWKSURL = "JWKS_URL"
+
+	// EnvJWTIssuer is the expected JWT issuer
+	EnvJWTIssuer = "JWT_ISSUER"
+
+	// EnvJWTAudience is the expected JWT audience (optional)
+	EnvJWTAudience = "JWT_AUDIENCE"
+
+	// EnvMCPToolsets is the comma-separated list of enabled MCP toolsets
+	EnvMCPToolsets = "MCP_TOOLSETS"
+
+	// EnvJWTDisabled is the flag to disable JWT authentication
+	EnvJWTDisabled = "JWT_DISABLED"
+)
+
+// Default values for configuration
+const (
+	DefaultServerBaseURL  = "http://api.openchoreo.localhost"
+	DefaultThunderBaseURL = "http://sts.openchoreo.localhost"
+)

--- a/internal/openchoreo-api/handlers/oauth_metadata.go
+++ b/internal/openchoreo-api/handlers/oauth_metadata.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
+)
+
+// OAuthProtectedResourceMetadata handles requests for OAuth 2.0 protected resource metadata
+// as defined in RFC 8693 and related OAuth standards
+func (h *Handler) OAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	// Get configuration from environment variables
+	serverBaseURL := os.Getenv(config.EnvServerBaseURL)
+	if serverBaseURL == "" {
+		serverBaseURL = config.DefaultServerBaseURL
+	}
+
+	thunderBaseURL := os.Getenv(config.EnvAuthServerBaseURL)
+	if thunderBaseURL == "" {
+		thunderBaseURL = config.DefaultThunderBaseURL
+	}
+
+	// Build metadata response
+	metadata := map[string]interface{}{
+		"resource_name": "OpenChoreo MCP Server",
+		"resource":      serverBaseURL + "/mcp",
+		"authorization_servers": []string{
+			thunderBaseURL,
+		},
+		"bearer_methods_supported": []string{
+			"header",
+		},
+		"scopes_supported": []string{},
+	}
+
+	// Set response headers
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	// Encode and send response
+	if err := json.NewEncoder(w).Encode(metadata); err != nil {
+		h.logger.Error("Failed to encode OAuth metadata response", slog.Any("error", err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/server/middleware/mcp/auth401.go
+++ b/internal/server/middleware/mcp/auth401.go
@@ -1,0 +1,64 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"net/http"
+
+	"github.com/openchoreo/openchoreo/internal/server/middleware"
+)
+
+// responseWriter401Interceptor wraps http.ResponseWriter to intercept 401 status codes
+type responseWriter401Interceptor struct {
+	http.ResponseWriter
+	statusCode          int
+	headerWritten       bool
+	resourceMetadataURL string
+}
+
+// WriteHeader intercepts the status code and adds WWW-Authenticate header on 401
+func (rw *responseWriter401Interceptor) WriteHeader(statusCode int) {
+	if rw.headerWritten {
+		return
+	}
+
+	rw.statusCode = statusCode
+	rw.headerWritten = true
+
+	// Add WWW-Authenticate header if status is 401
+	if statusCode == http.StatusUnauthorized {
+		rw.ResponseWriter.Header().Set("WWW-Authenticate", "Bearer resource_metadata=\""+rw.resourceMetadataURL+"\"")
+	}
+
+	rw.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Write intercepts the write to ensure WriteHeader is called
+func (rw *responseWriter401Interceptor) Write(b []byte) (int, error) {
+	// If WriteHeader hasn't been called yet, call it with 200
+	// This handles cases where the handler writes directly without calling WriteHeader
+	if !rw.headerWritten {
+		rw.WriteHeader(http.StatusOK)
+	}
+	return rw.ResponseWriter.Write(b)
+}
+
+// Auth401Interceptor creates a middleware that adds WWW-Authenticate header on 401 responses
+// resourceMetadataURL is the URL to the OAuth protected resource metadata endpoint
+func Auth401Interceptor(resourceMetadataURL string) middleware.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Wrap the response writer to intercept status codes
+			interceptor := &responseWriter401Interceptor{
+				ResponseWriter:      w,
+				statusCode:          http.StatusOK,
+				headerWritten:       false,
+				resourceMetadataURL: resourceMetadataURL,
+			}
+
+			// Call the next handler with our wrapped response writer
+			next.ServeHTTP(interceptor, r)
+		})
+	}
+}

--- a/internal/server/middleware/mcp/auth401_test.go
+++ b/internal/server/middleware/mcp/auth401_test.go
@@ -1,0 +1,137 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuth401Interceptor(t *testing.T) {
+	resourceMetadataURL := "http://api.openchoreo.localhost/.well-known/oauth-protected-resource"
+	expectedHeader := "Bearer resource_metadata=\"http://api.openchoreo.localhost/.well-known/oauth-protected-resource\""
+
+	tests := []struct {
+		name             string
+		statusCode       int
+		shouldHaveHeader bool
+	}{
+		{
+			name:             "401 response should add WWW-Authenticate header",
+			statusCode:       http.StatusUnauthorized,
+			shouldHaveHeader: true,
+		},
+		{
+			name:             "200 response should not add WWW-Authenticate header",
+			statusCode:       http.StatusOK,
+			shouldHaveHeader: false,
+		},
+		{
+			name:             "403 response should not add WWW-Authenticate header",
+			statusCode:       http.StatusForbidden,
+			shouldHaveHeader: false,
+		},
+		{
+			name:             "500 response should not add WWW-Authenticate header",
+			statusCode:       http.StatusInternalServerError,
+			shouldHaveHeader: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test handler that returns the specified status code
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			// Wrap the handler with the middleware
+			middleware := Auth401Interceptor(resourceMetadataURL)
+			wrappedHandler := middleware(testHandler)
+
+			// Create a test request and response recorder
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rec := httptest.NewRecorder()
+
+			// Execute the handler
+			wrappedHandler.ServeHTTP(rec, req)
+
+			// Check the status code
+			if rec.Code != tt.statusCode {
+				t.Errorf("expected status code %d, got %d", tt.statusCode, rec.Code)
+			}
+
+			// Check for WWW-Authenticate header
+			wwwAuth := rec.Header().Get("WWW-Authenticate")
+			if tt.shouldHaveHeader {
+				if wwwAuth == "" {
+					t.Error("expected WWW-Authenticate header to be present, but it was not")
+				}
+				if wwwAuth != expectedHeader {
+					t.Errorf("expected WWW-Authenticate header to be %q, got %q", expectedHeader, wwwAuth)
+				}
+			} else {
+				if wwwAuth != "" {
+					t.Errorf("expected no WWW-Authenticate header, but got %q", wwwAuth)
+				}
+			}
+		})
+	}
+}
+
+func TestAuth401Interceptor_WithWrite(t *testing.T) {
+	resourceMetadataURL := "http://api.openchoreo.localhost/.well-known/oauth-protected-resource"
+	expectedHeader := "Bearer resource_metadata=\"http://api.openchoreo.localhost/.well-known/oauth-protected-resource\""
+
+	// Test handler that writes without explicitly calling WriteHeader
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This should trigger an implicit 200 OK
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	middleware := Auth401Interceptor(resourceMetadataURL)
+	wrappedHandler := middleware(testHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(rec, req)
+
+	// Should have 200 status and no WWW-Authenticate header
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status code 200, got %d", rec.Code)
+	}
+
+	wwwAuth := rec.Header().Get("WWW-Authenticate")
+	if wwwAuth != "" {
+		t.Errorf("expected no WWW-Authenticate header for 200 OK, but got %q", wwwAuth)
+	}
+
+	// Test handler that writes with 401
+	testHandler401 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Unauthorized"))
+	})
+
+	wrappedHandler401 := middleware(testHandler401)
+
+	req401 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec401 := httptest.NewRecorder()
+
+	wrappedHandler401.ServeHTTP(rec401, req401)
+
+	// Should have 401 status and WWW-Authenticate header
+	if rec401.Code != http.StatusUnauthorized {
+		t.Errorf("expected status code 401, got %d", rec401.Code)
+	}
+
+	wwwAuth401 := rec401.Header().Get("WWW-Authenticate")
+	if wwwAuth401 == "" {
+		t.Error("expected WWW-Authenticate header to be present for 401, but it was not")
+	}
+	if wwwAuth401 != expectedHeader {
+		t.Errorf("expected WWW-Authenticate header to be %q, got %q", expectedHeader, wwwAuth401)
+	}
+}


### PR DESCRIPTION
## Purpose
This PR adds the MCP auth middleware to handle 401 responses coming from the JWT middleware layer.
This is the implementation of [Authorization server discovery](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-discovery) for openchoreo controlplane MCP server

## Related Issues
https://github.com/openchoreo/openchoreo/issues/666

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
