### PR TITLE
Disable API, UI, and identity provider for v0.4 release

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -171,7 +171,7 @@ metricsServer:
   kubeletInsecureTlsEnabled: true
 openchoreoApi:
   name: openchoreo-api # Static name for all openchoreo-api resources (Service, Deployment, ClusterRole, etc.)
-  enabled: true
+  enabled: false # TODO: Enable on v0.5.0 release
   replicas: 1
   image:
     repository: ghcr.io/openchoreo/openchoreo-api
@@ -312,7 +312,7 @@ cert-manager:
         memory: 64Mi
 # Backstage UI configuration
 backstage:
-  enabled: true
+  enabled: false # TODO: Enable on v0.5.0 release
   replicas: 1
   image:
     repository: ghcr.io/openchoreo/openchoreo-ui
@@ -436,7 +436,7 @@ backstage:
       type: Unconfined
 # Asgardeo Thunder (Platform Identity Provider) configuration
 asgardeoThunder:
-  enabled: true
+  enabled: false # TODO: Enable on v0.5.0 release
   replicaCount: 1
   image:
     repository: ghcr.io/asgardeo/thunder


### PR DESCRIPTION
## Purpose
Disable OpenChoreo API, Backstage UI, and Asgardeo Thunder for v0.4 release.

## Approach
Disabled the following components in control plane Helm chart values:

- **OpenChoreo API**: Set `openchoreoApi.enabled` to false
- **Backstage UI**: Set `backstage.enabled` to false
- **Asgardeo Thunder**: Set `asgardeoThunder.enabled` to false

All components are marked with TODO comments to re-enable in v0.5.0 release. This allows v0.4 to focus on core controller functionality and kubectl-based workflows.

## Related Issues
- Related to https://github.com/openchoreo/openchoreo/issues/849

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
These components will be re-enabled in v0.5.0 release after further stabilization.