### PR TITLE
Include component,project,env uid in api responses and pod selectors

### DIFF
--- a/internal/controller/componentdeployment/controller.go
+++ b/internal/controller/componentdeployment/controller.go
@@ -306,9 +306,9 @@ func (r *Reconciler) buildMetadataContext(
 
 	// Build pod selectors (used for Deployment selectors, Service selectors, etc.)
 	podSelectors := map[string]string{
-		"openchoreo.org/component":   componentName,
-		"openchoreo.org/environment": environmentName,
-		"openchoreo.org/project":     projectName,
+		"openchoreo.dev/component-uid":   componentUID,
+		"openchoreo.dev/environment-uid": environmentUID,
+		"openchoreo.dev/project-uid":     projectUID,
 	}
 
 	return pipelinecontext.MetadataContext{

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -27,6 +27,7 @@ type ListResponse[T any] struct {
 
 // ProjectResponse represents a project in API responses
 type ProjectResponse struct {
+	UID                string    `json:"uid"`
 	Name               string    `json:"name"`
 	OrgName            string    `json:"orgName"`
 	DisplayName        string    `json:"displayName,omitempty"`
@@ -38,6 +39,7 @@ type ProjectResponse struct {
 
 // ComponentResponse represents a component in API responses
 type ComponentResponse struct {
+	UID            string                                 `json:"uid"`
 	Name           string                                 `json:"name"`
 	DisplayName    string                                 `json:"displayName,omitempty"`
 	Description    string                                 `json:"description,omitempty"`
@@ -154,6 +156,7 @@ type OrganizationResponse struct {
 
 // EnvironmentResponse represents an environment in API responses
 type EnvironmentResponse struct {
+	UID          string    `json:"uid"`
 	Name         string    `json:"name"`
 	Namespace    string    `json:"namespace"`
 	DisplayName  string    `json:"displayName,omitempty"`

--- a/internal/openchoreo-api/services/environment_service.go
+++ b/internal/openchoreo-api/services/environment_service.go
@@ -188,6 +188,7 @@ func (s *EnvironmentService) toEnvironmentResponse(env *openchoreov1alpha1.Envir
 	}
 
 	return &models.EnvironmentResponse{
+		UID:          string(env.UID),
 		Name:         env.Name,
 		Namespace:    env.Namespace,
 		DisplayName:  displayName,

--- a/internal/openchoreo-api/services/project_service.go
+++ b/internal/openchoreo-api/services/project_service.go
@@ -173,6 +173,7 @@ func (s *ProjectService) toProjectResponse(project *openchoreov1alpha1.Project) 
 	}
 
 	return &models.ProjectResponse{
+		UID:                string(project.UID),
 		Name:               project.Name,
 		OrgName:            project.Namespace,
 		DisplayName:        displayName,


### PR DESCRIPTION
## Purpose
> In order to differentiate logs of components (and projects/environments) that are deleted and recreated with the same name, we need to include the component, project, and environment UIDs in the pod lables. ( Adding them to pod selectors as this would ensure that same uids are present in labels as well. )
> Adding the UIDs to the API responses, as the frontend requires them to query logs correctly.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
