### PR TITLE
Fix backstage sign-in flow in k3d single cluster setup

### DIFF
--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -31,3 +31,13 @@ asgardeoThunder:
           - path: /
             pathType: Prefix
             port: 8090
+  config:
+    gateClient:
+      port: 8080
+  runtimeConfig:
+    server:
+      port: 8080
+  backstagePortal:
+    redirectUrls:
+      - http://openchoreo.localhost:8080/api/auth/default-idp/handler/frame
+      - http://localhost:7007/api/auth/default-idp/handler/frame


### PR DESCRIPTION
## Purpose
Add missing configs for thunder and backstage in k3d single cluster setup

## Approach
Added gateclient and runtimeconfigs needed to properly load thunder web app.
Configure backstage redirect URL

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
