### PR TITLE
Add endpoint to get component schema

### DIFF
--- a/internal/openchoreo-api/handlers/components_test.go
+++ b/internal/openchoreo-api/handlers/components_test.go
@@ -301,6 +301,110 @@ func TestGetComponentReleaseSchema_PathParameters(t *testing.T) {
 	}
 }
 
+// TestGetComponentSchema_PathParameters tests path parameter extraction for GetComponentSchema
+func TestGetComponentSchema_PathParameters(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		orgName       string
+		projectName   string
+		componentName string
+	}{
+		{
+			name:          "Valid path with all parameters",
+			url:           "/api/v1/orgs/myorg/projects/myproject/components/mycomponent/schema",
+			orgName:       "myorg",
+			projectName:   "myproject",
+			componentName: "mycomponent",
+		},
+		{
+			name:          "Path with hyphens in names",
+			url:           "/api/v1/orgs/my-org/projects/my-project/components/my-component/schema",
+			orgName:       "my-org",
+			projectName:   "my-project",
+			componentName: "my-component",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			req.SetPathValue("orgName", tt.orgName)
+			req.SetPathValue("projectName", tt.projectName)
+			req.SetPathValue("componentName", tt.componentName)
+
+			// Verify all path values are set correctly
+			if req.PathValue("orgName") != tt.orgName {
+				t.Errorf("orgName = %v, want %v", req.PathValue("orgName"), tt.orgName)
+			}
+			if req.PathValue("projectName") != tt.projectName {
+				t.Errorf("projectName = %v, want %v", req.PathValue("projectName"), tt.projectName)
+			}
+			if req.PathValue("componentName") != tt.componentName {
+				t.Errorf("componentName = %v, want %v", req.PathValue("componentName"), tt.componentName)
+			}
+		})
+	}
+}
+
+// TestGetComponentSchema_MissingPathParameters tests validation for missing required parameters
+func TestGetComponentSchema_MissingPathParameters(t *testing.T) {
+	tests := []struct {
+		name          string
+		orgName       string
+		projectName   string
+		componentName string
+		wantValid     bool
+	}{
+		{
+			name:          "All parameters present",
+			orgName:       "myorg",
+			projectName:   "myproject",
+			componentName: "mycomponent",
+			wantValid:     true,
+		},
+		{
+			name:          "Missing org name",
+			orgName:       "",
+			projectName:   "myproject",
+			componentName: "mycomponent",
+			wantValid:     false,
+		},
+		{
+			name:          "Missing project name",
+			orgName:       "myorg",
+			projectName:   "",
+			componentName: "mycomponent",
+			wantValid:     false,
+		},
+		{
+			name:          "Missing component name",
+			orgName:       "myorg",
+			projectName:   "myproject",
+			componentName: "",
+			wantValid:     false,
+		},
+		{
+			name:          "All parameters missing",
+			orgName:       "",
+			projectName:   "",
+			componentName: "",
+			wantValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the validation logic from GetComponentSchema handler
+			isValid := tt.orgName != "" && tt.projectName != "" && tt.componentName != ""
+
+			if isValid != tt.wantValid {
+				t.Errorf("Validation result = %v, want %v", isValid, tt.wantValid)
+			}
+		})
+	}
+}
+
 // TestGetComponentReleaseSchema_MissingPathParameters tests validation for missing required parameters
 func TestGetComponentReleaseSchema_MissingPathParameters(t *testing.T) {
 	tests := []struct {

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -117,6 +117,7 @@ func (h *Handler) Routes() http.Handler {
 	api.HandleFunc("GET "+v1+"/orgs/{orgName}/projects/{projectName}/components", h.ListComponents)
 	api.HandleFunc("POST "+v1+"/orgs/{orgName}/projects/{projectName}/components", h.CreateComponent)
 	api.HandleFunc("GET "+v1+"/orgs/{orgName}/projects/{projectName}/components/{componentName}", h.GetComponent)
+	api.HandleFunc("GET "+v1+"/orgs/{orgName}/projects/{projectName}/components/{componentName}/schema", h.GetComponentSchema)
 
 	// Component bindings
 	api.HandleFunc("GET "+v1+"/orgs/{orgName}/projects/{projectName}/components/{componentName}/bindings", h.GetComponentBinding)


### PR DESCRIPTION
## Purpose
This pull request introduces a new API endpoint to retrieve the JSON schema for a component, along with supporting service logic and comprehensive unit tests. The changes are primarily focused on enabling clients to fetch the schema for a given component, improving code modularity, and ensuring robust validation and error handling.

### API and Routing

* Added a new handler method `GetComponentSchema` to expose the `/schema` endpoint for components, including validation and error handling for missing or invalid parameters. (`internal/openchoreo-api/handlers/components.go`)
* Registered the new route in the API router for `GET /orgs/{orgName}/projects/{projectName}/components/{componentName}/schema`. (`internal/openchoreo-api/handlers/handlers.go`)

### Service Layer Enhancements

* Implemented `GetComponentSchema` in `ComponentService` to fetch the latest schema for a component, including logic to validate ownership and extract the component type, and to wrap the result as a JSON schema. (`internal/openchoreo-api/services/component_service.go`)
* Refactored component type parsing into a reusable method `parseComponentTypeName` for better maintainability and error handling. (`internal/openchoreo-api/services/component_service.go`)
* Updated component release creation logic to use the new parsing method for component type names. (`internal/openchoreo-api/services/component_service.go`)

### Testing

* Added unit tests for the new schema endpoint, including path parameter extraction and validation for missing parameters to ensure correctness and reliability. (`internal/openchoreo-api/handlers/components_test.go`)

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/910

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
