### PR TITLE
Add componentreleases and releasebindings to clusterrole permissions

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
   - builds
   - componentdeployments
   - componentenvsnapshots
+  - componentreleases
   - components
   - componenttypes
   - dataplanes
@@ -29,6 +30,7 @@ rules:
   - gitcommitrequests
   - organizations
   - projects
+  - releasebindings
   - releases
   - scheduledtaskbindings
   - scheduledtaskclasses
@@ -61,6 +63,7 @@ rules:
   - builds/status
   - componentdeployments/status
   - componentenvsnapshots/status
+  - componentreleases/status
   - components/status
   - componenttypes/status
   - dataplanes/status
@@ -73,6 +76,7 @@ rules:
   - gitcommitrequests/status
   - organizations/status
   - projects/status
+  - releasebindings/status
   - releases/status
   - scheduledtaskbindings/status
   - scheduledtaskclasses/status


### PR DESCRIPTION
## Purpose
Add componentreleases and releasebindings to clusterrole permissions

## Related Issues
https://github.com/openchoreo/openchoreo/issues/881

## Remarks
https://github.com/openchoreo/backstage-plugins/pull/75 depends on this
