### PR TITLE
Make ComponentRelease fields immutable

### DIFF
--- a/api/v1alpha1/componentrelease_types.go
+++ b/api/v1alpha1/componentrelease_types.go
@@ -17,21 +17,25 @@ type ComponentReleaseSpec struct {
 	// ComponentType is a full embedded copy of the ComponentType
 	// This ensures the ComponentRelease has an immutable snapshot of the ComponentType at the time of component release
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.componentType is immutable"
 	ComponentType ComponentTypeSpec `json:"componentType"`
 
 	// Traits maps trait names to their frozen specifications
 	// at the time of ComponentRelease, ensuring immutability
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.traits is immutable"
 	Traits map[string]TraitSpec `json:"traits,omitempty"`
 
 	// ComponentProfile contains the immutable snapshot of parameter values and trait configs
 	// specified for this component at release time
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.componentProfile is immutable"
 	ComponentProfile ComponentProfile `json:"componentProfile"`
 
 	// Workload is a full embedded copy of the Workload
 	// This preserves the workload spec with the built image
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.workload is immutable"
 	Workload WorkloadTemplateSpec `json:"workload"`
 }
 

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -79,6 +79,9 @@ spec:
                       type: object
                     type: array
                 type: object
+                x-kubernetes-validations:
+                - message: spec.componentProfile is immutable
+                  rule: self == oldSelf
               componentType:
                 description: |-
                   ComponentType is a full embedded copy of the ComponentType
@@ -191,6 +194,8 @@ spec:
                 - workloadType
                 type: object
                 x-kubernetes-validations:
+                - message: spec.componentType is immutable
+                  rule: self == oldSelf
                 - message: resources must contain a primary resource with id matching
                     workloadType
                   rule: self.resources.exists(r, r.id == self.workloadType)
@@ -353,6 +358,9 @@ spec:
                   Traits maps trait names to their frozen specifications
                   at the time of ComponentRelease, ensuring immutability
                 type: object
+                x-kubernetes-validations:
+                - message: spec.traits is immutable
+                  rule: self == oldSelf
               workload:
                 description: |-
                   Workload is a full embedded copy of the Workload
@@ -573,6 +581,9 @@ spec:
                       The key is the endpoint name, and the value is the endpoint specification.
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: spec.workload is immutable
+                  rule: self == oldSelf
             required:
             - componentProfile
             - componentType

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -78,6 +78,9 @@ spec:
                       type: object
                     type: array
                 type: object
+                x-kubernetes-validations:
+                - message: spec.componentProfile is immutable
+                  rule: self == oldSelf
               componentType:
                 description: |-
                   ComponentType is a full embedded copy of the ComponentType
@@ -190,6 +193,8 @@ spec:
                 - workloadType
                 type: object
                 x-kubernetes-validations:
+                - message: spec.componentType is immutable
+                  rule: self == oldSelf
                 - message: resources must contain a primary resource with id matching
                     workloadType
                   rule: self.resources.exists(r, r.id == self.workloadType)
@@ -352,6 +357,9 @@ spec:
                   Traits maps trait names to their frozen specifications
                   at the time of ComponentRelease, ensuring immutability
                 type: object
+                x-kubernetes-validations:
+                - message: spec.traits is immutable
+                  rule: self == oldSelf
               workload:
                 description: |-
                   Workload is a full embedded copy of the Workload
@@ -572,6 +580,9 @@ spec:
                       The key is the endpoint name, and the value is the endpoint specification.
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: spec.workload is immutable
+                  rule: self == oldSelf
             required:
             - componentProfile
             - componentType


### PR DESCRIPTION
## Purpose
$subject

## Approach
Add kubebuilder CEL validation rules to each field in the ComponentRelease spec to make it immutable.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
