### PR TITLE
Fix release binding status bug

### DIFF
--- a/internal/openchoreo-api/services/component_service_test.go
+++ b/internal/openchoreo-api/services/component_service_test.go
@@ -465,8 +465,8 @@ func TestDetermineReleaseBindingStatus(t *testing.T) {
 							Type:               "ResourcesReady",
 							Status:             metav1.ConditionFalse,
 							ObservedGeneration: 3,
-							Reason:             "ResourcesNotReady",
-							Message:            "Some resources are not ready",
+							Reason:             "ResourcesDegraded",
+							Message:            "Some resources are degraded",
 						},
 						{
 							Type:               "Ready",


### PR DESCRIPTION
## Purpose

This pull request refines the logic for determining the status of release bindings in the `ComponentService` and updates related test cases. The main improvement is to ensure that a release binding is only marked as failed if a condition with the reason `ResourcesDegraded` is present, making the status determination more precise.

**Release binding status logic improvements:**

* The `determineReleaseBindingStatus` method now checks specifically for conditions with `Status == False` and `Reason == ResourcesDegraded` before marking the status as failed, rather than any false condition.
* The `releasebinding` package is imported to provide the `ReasonResourcesDegraded` constant for the status check.

**Test updates:**

* The test case in `component_service_test.go` is updated to use the `ResourcesDegraded` reason, ensuring the test matches the new status determination logic.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
