### PR TITLE
Update workload name generation to use component name from parameters

### DIFF
--- a/internal/choreoctl/resources/workload/converter.go
+++ b/internal/choreoctl/resources/workload/converter.go
@@ -194,7 +194,7 @@ func createBaseWorkload(workloadName string, params api.CreateWorkloadParams) *o
 
 func convertDescriptorToWorkload(descriptor *WorkloadDescriptor, params api.CreateWorkloadParams, descriptorPath string) (*openchoreov1alpha1.Workload, error) {
 	// Determine workload name
-	workloadName := descriptor.Metadata.Name
+	workloadName := params.ComponentName + "-workload"
 	if workloadName == "" {
 		return nil, fmt.Errorf("workload name must be provided either in params or descriptor metadata")
 	}


### PR DESCRIPTION
## Purpose
$subject
Using the metadata.name for workload causes an issue when creating two components with the same repository

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
