### PR TITLE
Add envOverrides schemas to componenttype,trait schema endpoints

### DIFF
--- a/internal/openchoreo-api/services/componenttype_service.go
+++ b/internal/openchoreo-api/services/componenttype_service.go
@@ -117,7 +117,17 @@ func (s *ComponentTypeService) GetComponentTypeSchema(ctx context.Context, orgNa
 		if err := json.Unmarshal(ct.Spec.Schema.Parameters.Raw, &params); err != nil {
 			return nil, fmt.Errorf("failed to extract parameters: %w", err)
 		}
-		def.Schemas = []map[string]any{params}
+		def.Schemas = append(def.Schemas, params)
+	}
+
+	// Extract envOverrides schema from RawExtension
+	// TODO: Remove as envOverrides will only be available at ReleaseBinding level.
+	if ct.Spec.Schema.EnvOverrides != nil && ct.Spec.Schema.EnvOverrides.Raw != nil {
+		var envOverrides map[string]any
+		if err := json.Unmarshal(ct.Spec.Schema.EnvOverrides.Raw, &envOverrides); err != nil {
+			return nil, fmt.Errorf("failed to extract envOverrides: %w", err)
+		}
+		def.Schemas = append(def.Schemas, envOverrides)
 	}
 
 	// Convert to JSON Schema

--- a/internal/openchoreo-api/services/trait_service.go
+++ b/internal/openchoreo-api/services/trait_service.go
@@ -117,7 +117,17 @@ func (s *TraitService) GetTraitSchema(ctx context.Context, orgName, traitName st
 		if err := json.Unmarshal(trait.Spec.Schema.Parameters.Raw, &params); err != nil {
 			return nil, fmt.Errorf("failed to extract parameters: %w", err)
 		}
-		def.Schemas = []map[string]any{params}
+		def.Schemas = append(def.Schemas, params)
+	}
+
+	// Extract envOverrides schema from RawExtension
+	// TODO: Remove as envOverrides will only be available at ReleaseBinding level.
+	if trait.Spec.Schema.EnvOverrides != nil && trait.Spec.Schema.EnvOverrides.Raw != nil {
+		var envOverrides map[string]any
+		if err := json.Unmarshal(trait.Spec.Schema.EnvOverrides.Raw, &envOverrides); err != nil {
+			return nil, fmt.Errorf("failed to extract envOverrides: %w", err)
+		}
+		def.Schemas = append(def.Schemas, envOverrides)
 	}
 
 	// Convert to JSON Schema


### PR DESCRIPTION
## Purpose
> Temporarily add envOverrides schemas to the ComponentType and Trait schema endpoints to allow deploying without envOverrides in ReleaseBinding. The current implementation merges values provided at both levels.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
