### PR TITLE
fix: set devcontainer.json to disable moby support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
   "name": "Kubebuilder DevContainer",
   "image": "golang:1.24",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    },
     "ghcr.io/devcontainers/features/git:1": {}
   },
 


### PR DESCRIPTION
## Purpose
Disabled Moby support in the Docker-in-Docker feature to prevent compatibility issues in the development container environment. Moby can cause conflicts with certain Docker operations and configurations, particularly when using docker-in-docker scenarios.

## Approach
Modified .devcontainer/devcontainer.json to explicitly set "moby": false in the ghcr.io/devcontainers/features/docker-in-docker:2 feature configuration (.devcontainer/devcontainer.json:6). This ensures the container uses the standard Docker implementation instead of Moby, providing better compatibility and stability for the kubebuilder development environment.

## Related Issues
N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.) - It has worked in Github codespaces
- [ ] Samples updated (if applicable) - - Not applicable

## Remarks
This is a configuration-only change that affects the development container setup. Developers will need to rebuild their devcontainer after pulling this change to apply the new Docker-in-Docker configuration. The change specifically addresses potential issues with Moby's implementation that could affect Kubernetes development workflows using k3d or similar tools.
