### PR TITLE
Update from image sample readme file to get logs

### DIFF
--- a/samples/from-image/issue-reporter-schedule-task/README.md
+++ b/samples/from-image/issue-reporter-schedule-task/README.md
@@ -36,8 +36,9 @@ kubectl get cronjob -A -l openchoreo.dev/component=github-issue-reporter
 kubectl get jobs -A -l openchoreo.dev/component=github-issue-reporter
 
 # View logs from the latest job pod
-POD_NAMESPACE=$(kubectl get pods -A -l openchoreo.dev/component=github-issue-reporter -o jsonpath='{.items[0].metadata.namespace}')
-POD_NAME=$(kubectl get pods -A -l openchoreo.dev/component=github-issue-reporter -o jsonpath='{.items[0].metadata.name}')
+POD_NAMESPACE=$(kubectl get jobs -A -l openchoreo.dev/component=github-issue-reporter -o jsonpath='{.items[0].metadata.namespace}')
+JOB_NAME=$(kubectl get jobs -n $POD_NAMESPACE -l openchoreo.dev/component=github-issue-reporter --sort-by=.metadata.creationTimestamp --no-headers | tail -1 | awk '{print $1}')
+POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l job-name=$JOB_NAME -o jsonpath='{.items[0].metadata.name}')
 kubectl logs -n $POD_NAMESPACE $POD_NAME --tail=50
 ```
 

--- a/samples/from-image/react-starter-web-app/README.md
+++ b/samples/from-image/react-starter-web-app/README.md
@@ -59,7 +59,9 @@ If you cannot access the application:
 
 5. **Check pod logs for errors:**
    ```bash
-   kubectl logs -n $(kubectl get pods -A -l openchoreo.dev/component=react-starter -o jsonpath='{.items[0].metadata.namespace}') -l openchoreo.dev/component=react-starter --tail=50
+   POD_UUID=$(kubectl get pods -A -l "$(kubectl get deploy -A -l openchoreo.dev/component=react-starter -o jsonpath='{.items[0].spec.selector.matchLabels}' | jq -r 'to_entries|map("\(.key)=\(.value)")|join(",")')" -o jsonpath='{range .items[*]}{.metadata.labels.openchoreo\.dev/component-uid}{"\n"}{end}' | sort -u | head -n1)
+   POD_NAMESPACE=$(kubectl get deploy -A -l openchoreo.dev/component=react-starter -o jsonpath='{.items[0].metadata.namespace}')
+   kubectl logs -n $POD_NAMESPACE -l openchoreo.dev/component-uid=$POD_UUID --tail=50
    ```
 
 6. **Verify the web application URL:**


### PR DESCRIPTION
## Purpose

This pull request updates the troubleshooting instructions in two sample application README files to improve the accuracy and reliability of commands for viewing pod logs. The main changes focus on refining the logic for selecting the correct namespace and pod, especially for jobs and deployments with multiple possible pods.

**Improvements to log retrieval commands:**

* Updated the instructions in `samples/from-image/issue-reporter-schedule-task/README.md` to select the correct namespace and job name when retrieving logs for the latest job pod, ensuring that logs are fetched from the most recent job rather than an arbitrary pod.
* Refined the log retrieval steps in `samples/from-image/react-starter-web-app/README.md` to reliably identify the pod associated with the correct deployment using the `component-uid` label, improving the accuracy of troubleshooting steps for the React starter web app.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
