### PR TITLE
Add observer configuration for dataplane and buildplane in quick start

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -326,6 +326,15 @@ install_data_plane() {
         "--set" "observability.enabled=${ENABLE_OBSERVABILITY:-false}"
 }
 
+# Configure the dataplane and buildplane with observer reference
+configure_observer_reference() {
+    log_info "Configuring OpenChoreo Data Plane with observer reference..."
+    kubectl patch dataplane default -n default --type merge -p '{"spec":{"observer":{"url":"http://observer.openchoreo-observability-plane:8080","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}'
+    if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
+        log_info "Configuring OpenChoreo Build Plane with observer reference..."
+        kubectl patch buildplane default -n default --type merge -p '{"spec":{"observer":{"url":"http://observer.openchoreo-observability-plane:8080","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}'
+    fi
+}
 
 # Install OpenChoreo Build Plane (optional)
 install_build_plane() {

--- a/install/quick-start/install.sh
+++ b/install/quick-start/install.sh
@@ -137,6 +137,11 @@ if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
     fi
 fi
 
+# Step 10: Configure the dataplane and buildplane with observer reference
+if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
+    configure_observer_reference
+fi
+
 log_success "OpenChoreo installation completed successfully!"
 log_info "Access URLs:"
 log_info "  Backstage UI: http://openchoreo.localhost:8080/"


### PR DESCRIPTION
## Purpose
Current Quick start script miss the patch commands for DataPlane and BuildPlane once the ObservabilityPlane is installed. These steps are explained in single cluster installation guide: https://openchoreo.dev/docs/getting-started/single-cluster/#configure-observer-integration.
This PR adds the observer integration commands to quick start script

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
