### PR TITLE
Use Server-Side Apply to prevent race conditions in samples

### DIFF
--- a/samples/component-types/component-http-service/README.md
+++ b/samples/component-types/component-http-service/README.md
@@ -62,7 +62,7 @@ The OpenChoreo controller manager uses these resources and generates the Kuberne
 Apply the sample:
 
 ```bash
-kubectl apply -f http-service-component.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-http-service/http-service-component.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -97,7 +97,7 @@ Hello, Alice!
 Remove all resources:
 
 ```bash
-kubectl delete -f http-service-component.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-http-service/http-service-component.yaml
 ```
 
 ## Troubleshooting

--- a/samples/component-types/component-web-app/README.md
+++ b/samples/component-types/component-web-app/README.md
@@ -59,7 +59,7 @@ The controller reads these resources and generates the Kubernetes resources (Dep
 Apply the sample:
 
 ```bash
-kubectl apply -f webapp-component.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-web-app/webapp-component.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -77,7 +77,7 @@ Open your web browser and go to http://demo-app-web-service-development-3135937b
 Remove all resources:
 
 ```bash
-kubectl delete -f webapp-component.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-web-app/webapp-component.yaml
 ```
 
 ## Troubleshooting

--- a/samples/component-types/component-with-configs/README.md
+++ b/samples/component-types/component-with-configs/README.md
@@ -74,7 +74,7 @@ The OpenChoreo controller manager uses these resources and generates the Kuberne
 Apply the sample:
 
 ```bash
-kubectl apply -f component-with-configs.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-configs/component-with-configs.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -146,7 +146,7 @@ schema_generation:
 Remove all resources:
 
 ```bash
-kubectl delete -f component-with-configs.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-configs/component-with-configs.yaml
 ```
 
 ## Troubleshooting

--- a/samples/component-types/component-with-traits/README.md
+++ b/samples/component-types/component-with-traits/README.md
@@ -83,7 +83,7 @@ All resources will have:
 ### Step 1: Apply resources
 
 ```bash
-kubectl apply -f component-with-traits.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-traits/component-with-traits.yaml
 ```
 
 ### Step 3: Verify ReleaseBinding status
@@ -217,7 +217,7 @@ spec:
 Remove all resources:
 
 ```bash
-kubectl delete -f component-with-traits.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-traits/component-with-traits.yaml
 ```
 
 ## Troubleshooting

--- a/samples/from-image/issue-reporter-schedule-task/README.md
+++ b/samples/from-image/issue-reporter-schedule-task/README.md
@@ -18,7 +18,7 @@ Features:
 The following command will create the relevant resources in OpenChoreo:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Purpose

### Problem

When applying samples which has ReleaseBinding like http-service-component.yaml, users can intermittently encounter a race condition that results in a failed kubectl apply command with the following error:

```
1 Error from server (AlreadyExists): error when creating "some-resource.yaml": releasebindings.openchoreo.dev "demo-app-http-service-development" already exists
```

This error occurs because both kubectl apply and the OpenChoreo Component controller are attempting to create the same ReleaseBinding resource at the same time. Whichever process reaches the Kubernetes API server second will fail, leading to a confusing and unreliable user experience when first trying out the samples.

### How does this PR solve it?

This PR updates our documentation and sample usage instructions to recommend using Server-Side Apply (--server-side flag) for these kinds of samples.

### How Server-Side Apply Works

Instead of having the client (kubectl) figure out the changes, Server-Side Apply moves the logic to the Kubernetes API server. Here's a simple breakdown:

   1. Field Ownership: The API server tracks which "manager" (e.g., the Component controller, a user running kubectl) is responsible for each field on a resource.
   2. Intelligent Merging: When two different managers try to apply changes to the same object, the server doesn't just fail. It intelligently merges their changes together.
       * The Component controller can own the spec.releaseName field.
       * The user applying the YAML can own the spec.componentTypeEnvOverrides field.
   3. Conflict Resolution: The server merges the fields from both sources into a single, valid resource. An actual conflict only occurs if two managers try to edit the exact same field,
      which is not the case here.

  By using kubectl apply --server-side, we eliminate the race condition entirely, ensuring that applying our samples is a reliable and deterministic process for all users.

## Approach
use kubectl apply --server-side

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
