### PR TITLE
Add SecretReference watch to ReleaseBinding controller

### DIFF
--- a/internal/controller/releasebinding/controller_watch.go
+++ b/internal/controller/releasebinding/controller_watch.go
@@ -1,0 +1,130 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	pipelinecontext "github.com/openchoreo/openchoreo/internal/pipeline/component/context"
+)
+
+const (
+	// secretReferencesIndex is the field index name for SecretReference names used in ReleaseBinding
+	// This index tracks all SecretReferences from both ComponentRelease workload and ReleaseBinding workloadOverrides
+	secretReferencesIndex = "spec.secretReferences"
+)
+
+// setupSecretReferencesIndex sets up the field index for SecretReference names used by ReleaseBinding.
+// This index extracts all SecretReference names from the merged workload
+// (ComponentRelease.Spec.Workload merged with ReleaseBinding.Spec.WorkloadOverrides).
+func (r *Reconciler) setupSecretReferencesIndex(ctx context.Context, mgr ctrl.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
+		secretReferencesIndex, func(obj client.Object) []string {
+			releaseBinding := obj.(*openchoreov1alpha1.ReleaseBinding)
+			logger := log.FromContext(ctx)
+
+			// Fetch ComponentRelease to get the base workload
+			if releaseBinding.Spec.ReleaseName == "" {
+				return []string{}
+			}
+
+			componentRelease := &openchoreov1alpha1.ComponentRelease{}
+			if err := r.Get(ctx, types.NamespacedName{
+				Name:      releaseBinding.Spec.ReleaseName,
+				Namespace: releaseBinding.Namespace,
+			}, componentRelease); err != nil {
+				logger.Info("Failed to get ComponentRelease for index",
+					"releaseBinding", releaseBinding.Name,
+					"componentRelease", releaseBinding.Spec.ReleaseName,
+					"error", err)
+				return []string{}
+			}
+
+			// Build workload from ComponentRelease
+			baseWorkload := &openchoreov1alpha1.Workload{
+				Spec: openchoreov1alpha1.WorkloadSpec{
+					WorkloadTemplateSpec: componentRelease.Spec.Workload,
+				},
+			}
+
+			// Merge workload with overrides using the shared function
+			mergedWorkload := pipelinecontext.MergeWorkloadOverrides(baseWorkload, releaseBinding.Spec.WorkloadOverrides)
+			if mergedWorkload == nil {
+				return []string{}
+			}
+
+			// Extract SecretReferences from the merged workload
+			var secretRefNames []string
+			for _, container := range mergedWorkload.Spec.Containers {
+				// Extract from Env variables
+				for _, env := range container.Env {
+					if env.ValueFrom != nil && env.ValueFrom.SecretRef != nil && env.ValueFrom.SecretRef.Name != "" {
+						secretRefNames = append(secretRefNames, env.ValueFrom.SecretRef.Name)
+					}
+				}
+
+				// Extract from Files
+				for _, file := range container.Files {
+					if file.ValueFrom != nil && file.ValueFrom.SecretRef != nil && file.ValueFrom.SecretRef.Name != "" {
+						secretRefNames = append(secretRefNames, file.ValueFrom.SecretRef.Name)
+					}
+				}
+			}
+
+			return secretRefNames
+		})
+}
+
+// listReleaseBindingsForSecretReference returns reconcile requests for all ReleaseBindings
+// that use the changed SecretReference (either in ComponentRelease's workload or ReleaseBinding's workloadOverrides)
+func (r *Reconciler) listReleaseBindingsForSecretReference(ctx context.Context, obj client.Object) []reconcile.Request {
+	secretRef := obj.(*openchoreov1alpha1.SecretReference)
+	logger := log.FromContext(ctx)
+
+	logger.Info("SecretReference changed, finding affected ReleaseBindings",
+		"secretReference", secretRef.Name,
+		"namespace", secretRef.Namespace)
+
+	// Find all ReleaseBindings in the same namespace that use this SecretReference
+	var releaseBindings openchoreov1alpha1.ReleaseBindingList
+	if err := r.List(ctx, &releaseBindings,
+		client.InNamespace(secretRef.Namespace),
+		client.MatchingFields{secretReferencesIndex: secretRef.Name}); err != nil {
+		logger.Error(err, "Failed to list ReleaseBindings for SecretReference",
+			"secretReference", secretRef.Name)
+		return nil
+	}
+
+	if len(releaseBindings.Items) == 0 {
+		logger.Info("No ReleaseBindings found using this SecretReference",
+			"secretReference", secretRef.Name)
+		return nil
+	}
+
+	logger.Info("Found ReleaseBindings using SecretReference",
+		"secretReference", secretRef.Name,
+		"count", len(releaseBindings.Items))
+
+	requests := make([]reconcile.Request, len(releaseBindings.Items))
+	for i, rb := range releaseBindings.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      rb.Name,
+				Namespace: rb.Namespace,
+			},
+		}
+		logger.Info("Enqueuing ReleaseBinding for reconciliation due to SecretReference change",
+			"releaseBinding", rb.Name,
+			"secretReference", secretRef.Name)
+	}
+
+	return requests
+}

--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -77,7 +77,7 @@ func BuildComponentContext(input *ComponentContextInput) (map[string]any, error)
 
 	workload := input.Workload
 	if input.Workload != nil && input.ReleaseBinding != nil && input.ReleaseBinding.Spec.WorkloadOverrides != nil {
-		workload = mergeWorkloadOverrides(input.Workload, input.ReleaseBinding.Spec.WorkloadOverrides)
+		workload = MergeWorkloadOverrides(input.Workload, input.ReleaseBinding.Spec.WorkloadOverrides)
 	}
 
 	if workload != nil {

--- a/internal/pipeline/component/context/workload.go
+++ b/internal/pipeline/component/context/workload.go
@@ -7,9 +7,9 @@ import (
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 )
 
-// mergeWorkloadOverrides merges workload overrides into the base workload.
-// Currently supports merging container env and file configurations.
-func mergeWorkloadOverrides(baseWorkload *openchoreov1alpha1.Workload, overrides *openchoreov1alpha1.WorkloadOverrideTemplateSpec) *openchoreov1alpha1.Workload {
+// MergeWorkloadOverrides merges workload overrides into the base workload.
+// Currently, supports merging container env and file configurations.
+func MergeWorkloadOverrides(baseWorkload *openchoreov1alpha1.Workload, overrides *openchoreov1alpha1.WorkloadOverrideTemplateSpec) *openchoreov1alpha1.Workload {
 	if baseWorkload == nil {
 		return nil
 	}

--- a/internal/pipeline/component/context/workload_test.go
+++ b/internal/pipeline/component/context/workload_test.go
@@ -730,9 +730,9 @@ func TestMergeWorkloadOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mergeWorkloadOverrides(tt.baseWorkload, tt.overrides)
+			got := MergeWorkloadOverrides(tt.baseWorkload, tt.overrides)
 			if diff := cmp.Diff(tt.want, got, sortEnvsByKey(), sortFilesByKey()); diff != "" {
-				t.Errorf("mergeWorkloadOverrides() mismatch (-want +got):\n%s", diff)
+				t.Errorf("MergeWorkloadOverrides() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Purpose

### Description:

Implement index-based watch mechanism to trigger ReleaseBinding reconciliation when SecretReferences change. The watch monitors SecretReferences used in the merged workload (ComponentRelease workload + ReleaseBinding workloadOverrides).

### Changes:
  - Export MergeWorkloadOverrides function for reuse across packages
  - Add field index that extracts SecretReference names from merged workloads
  - Register SecretReference watch with handler to enqueue affected ReleaseBindings
  - Add RBAC permissions for SecretReference resources

This follows the established patterns in the codebase and ensures ReleaseBindings are automatically reconciled when their referenced secrets change.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
