### PR TITLE
Make dataPlaneRef immutable once set on Environment CRD

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -11,11 +11,9 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // EnvironmentSpec defines the desired state of Environment.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.dataPlaneRef) || size(oldSelf.dataPlaneRef) == 0 || oldSelf.dataPlaneRef == self.dataPlaneRef",message="dataPlaneRef is immutable once set"
 type EnvironmentSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Foo is an example field of Environment. Edit environment_types.go to remove/update
+	// DataPlaneRef references the DataPlane for this environment. Immutable once set.
 	DataPlaneRef string        `json:"dataPlaneRef,omitempty"`
 	IsProduction bool          `json:"isProduction,omitempty"`
 	Gateway      GatewayConfig `json:"gateway,omitempty"`

--- a/config/crd/bases/openchoreo.dev_environments.yaml
+++ b/config/crd/bases/openchoreo.dev_environments.yaml
@@ -43,8 +43,8 @@ spec:
             description: EnvironmentSpec defines the desired state of Environment.
             properties:
               dataPlaneRef:
-                description: Foo is an example field of Environment. Edit environment_types.go
-                  to remove/update
+                description: DataPlaneRef references the DataPlane for this environment.
+                  Immutable once set.
                 type: string
               gateway:
                 properties:
@@ -64,6 +64,10 @@ spec:
               isProduction:
                 type: boolean
             type: object
+            x-kubernetes-validations:
+            - message: dataPlaneRef is immutable once set
+              rule: '!has(oldSelf.dataPlaneRef) || size(oldSelf.dataPlaneRef) == 0
+                || oldSelf.dataPlaneRef == self.dataPlaneRef'
           status:
             description: EnvironmentStatus defines the observed state of Environment.
             properties:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_environments.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_environments.yaml
@@ -42,8 +42,8 @@ spec:
             description: EnvironmentSpec defines the desired state of Environment.
             properties:
               dataPlaneRef:
-                description: Foo is an example field of Environment. Edit environment_types.go
-                  to remove/update
+                description: DataPlaneRef references the DataPlane for this environment.
+                  Immutable once set.
                 type: string
               gateway:
                 properties:
@@ -63,6 +63,10 @@ spec:
               isProduction:
                 type: boolean
             type: object
+            x-kubernetes-validations:
+            - message: dataPlaneRef is immutable once set
+              rule: '!has(oldSelf.dataPlaneRef) || size(oldSelf.dataPlaneRef) == 0
+                || oldSelf.dataPlaneRef == self.dataPlaneRef'
           status:
             description: EnvironmentStatus defines the observed state of Environment.
             properties:


### PR DESCRIPTION
## Purpose
The `dataPlaneRef` field on the Environment CRD should not be allowed to change once set, as changing the data plane for an existing
environment could lead to inconsistent state and resource conflicts. https://github.com/openchoreo/openchoreo/issues/1023#issuecomment-3584313248 
This PR adds validation to enforce immutability while still allowing
the field to be empty initially and set later.

## Approach
Add `+kubebuilder:validation:XValidation` CEL rule to the EnvironmentSpec type that prevents modification of `dataPlaneRef` once set to
a non-empty value. The validation is enforced at the API server level without requiring webhooks.

The CEL rule allows:
- Creating Environment without dataPlaneRef (empty initially)
- Setting dataPlaneRef from empty to a value
- Updating other fields while keeping dataPlaneRef unchanged

The rule rejects:
- Changing dataPlaneRef once set to a non-empty value

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1023

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
