### PR TITLE
Enable OpenSearch security plugin and update CPU and memory resource

### DIFF
--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -222,8 +222,8 @@ fluentBit:
       authentication:
         basicauth:
           username: "admin"
-          password: "admin"
-      tls: false
+          password: "ThisIsTheOpenSearchPassword1"
+      tls: true
       tlsVerify: false
     
     parser:

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -29,13 +29,26 @@ spec:
         - -c
         - |
           echo "Waiting for OpenSearch to be ready..."
-          OPENSEARCH_URL="http://opensearch:9200"
-          echo "Checking OpenSearch at: $OPENSEARCH_URL"
-          until curl -s "$OPENSEARCH_URL/_cluster/health" | grep -q '"status":"green\|yellow"'; do
+          AUTH_TOKEN=$(echo -n "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" | base64)
+          echo "Checking OpenSearch at: $OPENSEARCH_ADDRESS"
+          until curl -s -H "Authorization: Basic $AUTH_TOKEN" "$OPENSEARCH_ADDRESS/_cluster/health" --insecure | grep -q '"status":"green\|yellow"'; do
             echo "OpenSearch not ready, waiting 10 seconds..."
             sleep 10
           done
           echo "OpenSearch is ready!"
+        env:
+        - name: OPENSEARCH_ADDRESS
+          value: "https://opensearch:9200"
+        - name: OPENSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: observer-opensearch
+              key: username
+        - name: OPENSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: observer-opensearch
+              key: password
         securityContext:
           runAsNonRoot: true
           runAsUser: 65532
@@ -57,7 +70,7 @@ spec:
         - name: LOG_LEVEL
           value: {{ if .Values.observer }}{{ .Values.observer.logLevel | default "info" | quote }}{{ else }}"info"{{ end }}
         - name: OPENSEARCH_ADDRESS
-          value: "http://opensearch:9200"
+          value: "https://opensearch:9200"
         - name: OPENSEARCH_USERNAME
           valueFrom:
             secretKeyRef:

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster-setup/job.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster-setup/job.yaml
@@ -13,6 +13,19 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: cluster-setup
+        env:
+        - name: OPENSEARCH_ADDRESS
+          value: "https://opensearch:9200"
+        - name: OPENSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: observer-opensearch
+              key: username
+        - name: OPENSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: observer-opensearch
+              key: password
         image: "{{ .Values.openSearchClusterSetup.image.repository }}:{{ .Values.openSearchClusterSetup.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.openSearchClusterSetup.image.pullPolicy | default "IfNotPresent" }}
         resources:

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
@@ -5,9 +5,15 @@ metadata:
   name: opensearch
   namespace: openchoreo-observability-plane
 spec:
+  bootstrap:
+    resources:
+      limits:
+        cpu: {{ .Values.openSearchCluster.bootstrap.resources.limits.cpu }}
+        memory: {{ .Values.openSearchCluster.bootstrap.resources.limits.memory }}
+      requests:
+        cpu: {{ .Values.openSearchCluster.bootstrap.resources.requests.cpu }}
+        memory: {{ .Values.openSearchCluster.bootstrap.resources.requests.memory }}
   general:
-    additionalConfig:
-      plugins.security.disabled: {{ .Values.openSearchCluster.general.additionalConfig.pluginsSecurityDisabled | quote }}
     serviceName: opensearch
     version: {{ .Values.openSearchCluster.general.version | quote }}
   nodePools:

--- a/install/helm/openchoreo-observability-plane/templates/opensearch/opensearch-readiness-job.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch/opensearch-readiness-job.yaml
@@ -16,15 +16,28 @@ spec:
       restartPolicy: Never
       containers:
       - name: opensearch-readiness
+        env:
+        - name: OPENSEARCH_ADDRESS
+          value: "https://opensearch:9200"
+        - name: OPENSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: observer-opensearch
+              key: username
+        - name: OPENSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: observer-opensearch
+              key: password
         image: curlimages/curl:latest
         command:
         - /bin/sh
         - -c
         - |
+          AUTH_TOKEN=$(echo -n "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" | base64)
           echo "Waiting for OpenSearch to be ready..."
-          until curl -s http://opensearch:9200/_cluster/health | grep -q '"status":"green\|yellow"'; do
+          until curl -s -H "Authorization: Basic $AUTH_TOKEN" "$OPENSEARCH_ADDRESS/_cluster/health" --insecure | grep -q '"status":"green\|yellow"'; do
             echo "OpenSearch not ready yet, waiting 10 seconds..."
             sleep 10
           done
           echo "OpenSearch is ready!"
-          curl -s http://opensearch:9200/_cluster/health

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -64,8 +64,6 @@ openSearch:
   extraEnvs:
     - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
       value: ThisIsTheOpenSearchPassword1
-    - name: DISABLE_SECURITY_PLUGIN
-      value: "true"
   nameOverride: "opensearch"
   image:
     tag: "3.3.0"
@@ -75,17 +73,24 @@ openSearch:
     create: true
     serviceAccountName: "opensearch"
 
-  securityConfig:
-    enabled: false
   singleNode: true
 
 # OpenSearch configuration for operator based OpenSearch deployment
 openSearchCluster:
   enabled: true
+
+  bootstrap:
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1000Mi
+      requests:
+        cpu: 100m
+        memory: 1000Mi
+
   general:
+    setVMMaxMapCount: true
     version: 3.3.0
-    additionalConfig:
-      pluginsSecurityDisabled: "true"
 
   dashboard:
     enabled: false
@@ -95,28 +100,28 @@ openSearchCluster:
   nodePools:
     data:
       replicas: 2
-      diskSize: 1Gi
+      diskSize: 5Gi
       resources:
         limits:
           cpu: 1000m
-          memory: 1Gi
+          memory: 1000Mi
         requests:
           cpu: 100m
-          memory: 700Mi
+          memory: 1000Mi
     master:
       replicas: 3
       diskSize: 1Gi
       resources:
         limits:
           cpu: 1000m
-          memory: 1Gi
+          memory: 900Mi
         requests:
           cpu: 100m
-          memory: 512Mi
+          memory: 900Mi
 
   # Secrets
   adminUsername: admin
-  adminUserPassword: admin
+  adminUserPassword: ThisIsTheOpenSearchPassword1
   internalUsers: |
     # This is the internal user database
     # The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh

--- a/install/init/observability/opensearch/setup-opensearch-cluster.sh
+++ b/install/init/observability/opensearch/setup-opensearch-cluster.sh
@@ -6,14 +6,16 @@
 # 1. Check OpenSearch cluster status and wait for it to become ready. Any API calls to configure
 #    the cluster should be made only after the cluster is ready.
 
-openSearchHost="${OPENSEARCH_HOST:-http://opensearch:9200}"
+openSearchHost="${OPENSEARCH_ADDRESS:-https://opensearch:9200}"
+authnToken=$(echo -n "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" | base64)
 
 echo "Checking OpenSearch cluster status"
 attempt=1
 max_attempts=30
 
 while [ $attempt -le $max_attempts ]; do
-    clusterHealth=$(curl --insecure \
+    clusterHealth=$(curl --header "Authorization: Basic $authnToken" \
+                         --insecure \
                          --location "$openSearchHost/_cluster/health" \
                          --show-error \
                          --silent)
@@ -74,6 +76,7 @@ for ((i=0; i<${#indexTemplates[@]}; i+=2)); do
     templateContent="${!templateDefinition}"
     
     response=$(curl --data "$templateContent" \
+                    --header "Authorization: Basic $authnToken" \
                     --header "Content-Type: application/json" \
                     --request PUT \
                     --show-error \

--- a/internal/observer/opensearch/client.go
+++ b/internal/observer/opensearch/client.go
@@ -5,8 +5,10 @@ package opensearch
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"net/http"
 
 	"github.com/opensearch-project/opensearch-go"
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
@@ -23,14 +25,15 @@ type Client struct {
 
 // NewClient creates a new OpenSearch client with the provided configuration
 func NewClient(cfg *config.OpenSearchConfig, logger *slog.Logger) (*Client, error) {
-	// Configure OpenSearch client
 	opensearchConfig := opensearch.Config{
 		Addresses: []string{cfg.Address},
-		Username:  cfg.Username,
-		Password:  cfg.Password,
-		// TODO: Add configurable TLS settings with proper certificate verification
-		// Consider adding TLSInsecureSkipVerify config option for development environments
-		// while defaulting to secure certificate verification in production
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // G402: Using self-signed cert
+			},
+		},
+		Username: cfg.Username,
+		Password: cfg.Password,
 	}
 
 	client, err := opensearch.NewClient(opensearchConfig)


### PR DESCRIPTION
## Purpose
Enable the security plugin in OpenSearch
Update CPU and memory resources of the operator based OpenSearch deployment

## Approach
1. Enabled the security plugin through the helm values file of the openchoreo-observability-plane
2. Changed API calls to OpenSearch to use TLS with verification turned off (As self-signed certificates are used)
3. Updated CPU and memory resources

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1034

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
