### PR TITLE
Add option to discard env overrides from component spec

### DIFF
--- a/internal/pipeline/component/context/trait.go
+++ b/internal/pipeline/component/context/trait.go
@@ -6,8 +6,10 @@ package context
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openchoreo/openchoreo/internal/schema"
@@ -23,9 +25,9 @@ import (
 //   - metadata: Additional metadata
 //
 // Parameter precedence (highest to lowest):
-//  1. ComponentDeployment.Spec.TraitOverrides[instanceName] (environment-specific)
-//  2. TraitInstance.Parameters (instance parameters)
-//  3. Schema defaults from Trait
+//   - ComponentDeployment.Spec.TraitOverrides[instanceName] (environment-specific)
+//   - TraitInstance.Parameters (instance parameters)
+//   - Schema defaults from Trait
 //
 // Note: TraitOverrides is keyed by instanceName (not traitName), as instanceNames
 // must be unique across all traits in a component.
@@ -50,68 +52,21 @@ func BuildTraitContext(input *TraitContextInput) (map[string]any, error) {
 
 	ctx := make(map[string]any)
 
-	// 1. Get or build structural schema for defaulting
-	var structural *apiextschema.Structural
-	traitName := input.Trait.Name
-
-	// Check cache first
-	if input.SchemaCache != nil {
-		if cached, ok := input.SchemaCache[traitName]; ok {
-			structural = cached
-		}
-	}
-
-	// Build schema if not cached
-	if structural == nil {
-		schemaInput := &SchemaInput{
-			Types:              input.Trait.Spec.Schema.Types,
-			ParametersSchema:   input.Trait.Spec.Schema.Parameters,
-			EnvOverridesSchema: input.Trait.Spec.Schema.EnvOverrides,
-		}
-		var err error
-		structural, err = BuildStructuralSchema(schemaInput)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build trait schema: %w", err)
-		}
-
-		// Store in cache for next time
-		if input.SchemaCache != nil {
-			input.SchemaCache[traitName] = structural
-		}
-	}
-
-	// 2. Start with instance parameters (using Parameters field from ComponentTrait)
-	parameters, err := extractParameters(input.Instance.Parameters)
+	// Process parameters and envOverrides
+	finalParameters, err := processTraitParameters(input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract trait instance parameters: %w", err)
+		return nil, err
 	}
+	ctx["parameters"] = finalParameters
 
-	// 3. Merge environment overrides if present
-	if input.ReleaseBinding != nil && input.ReleaseBinding.Spec.TraitOverrides != nil {
-		// TraitOverrides structure: map[instanceName]overrides (flattened)
-		instanceName := input.Instance.InstanceName
-
-		if instanceOverride, ok := input.ReleaseBinding.Spec.TraitOverrides[instanceName]; ok {
-			envOverrides, err := extractParametersFromRawExtension(&instanceOverride)
-			if err != nil {
-				return nil, fmt.Errorf("failed to extract trait environment overrides: %w", err)
-			}
-			parameters = deepMerge(parameters, envOverrides)
-		}
-	}
-
-	// 4. Apply schema defaults
-	parameters = schema.ApplyDefaults(parameters, structural)
-	ctx["parameters"] = parameters
-
-	// 5. Add trait metadata
+	// 2. Add trait metadata
 	traitMeta := map[string]any{
 		"name":         input.Trait.Name,
 		"instanceName": input.Instance.InstanceName,
 	}
 	ctx["trait"] = traitMeta
 
-	// 6. Add structured metadata for resource generation
+	// 3. Add structured metadata for resource generation
 	// This is what templates and patches use via ${metadata.name}, ${metadata.namespace}, etc.
 	metadataMap := map[string]any{
 		"name":      input.Metadata.Name,
@@ -131,6 +86,105 @@ func BuildTraitContext(input *TraitContextInput) (map[string]any, error) {
 	return ctx, nil
 }
 
+// processTraitParameters processes trait parameters and envOverrides separately,
+// validates each against their respective schemas, merges them, and returns the final map.
+func processTraitParameters(input *TraitContextInput) (map[string]any, error) {
+	traitName := input.Trait.Name
+
+	// Build or retrieve separate structural schemas for parameters and envOverrides
+	// Use cache keys with suffixes to distinguish between parameters and envOverrides schemas
+	parametersSchema := getCachedSchema(input.SchemaCache, traitName+":parameters")
+	if parametersSchema == nil {
+		var err error
+		parametersSchema, err = BuildStructuralSchema(&SchemaInput{
+			Types:            input.Trait.Spec.Schema.Types,
+			ParametersSchema: input.Trait.Spec.Schema.Parameters,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build trait parameters schema: %w", err)
+		}
+		setCachedSchema(input.SchemaCache, traitName+":parameters", parametersSchema)
+	}
+
+	envOverridesSchema := getCachedSchema(input.SchemaCache, traitName+":envOverrides")
+	if envOverridesSchema == nil {
+		var err error
+		envOverridesSchema, err = BuildStructuralSchema(&SchemaInput{
+			Types:              input.Trait.Spec.Schema.Types,
+			EnvOverridesSchema: input.Trait.Spec.Schema.EnvOverrides,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build trait envOverrides schema: %w", err)
+		}
+		setCachedSchema(input.SchemaCache, traitName+":envOverrides", envOverridesSchema)
+	}
+
+	// Process parameters: extract from trait instance, prune to parameters schema, apply defaults
+	// Note: extractParameters() unmarshals into a new map, so no deep copy needed before pruning
+	parameters, err := extractParameters(input.Instance.Parameters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract trait instance parameters: %w", err)
+	}
+	if parametersSchema != nil {
+		pruning.Prune(parameters, parametersSchema, false)
+	}
+	parameters = schema.ApplyDefaults(parameters, parametersSchema)
+
+	// Process envOverrides: extract and merge based on DiscardComponentEnvOverrides flag
+	var envOverrides map[string]any
+
+	if input.DiscardComponentEnvOverrides {
+		// Discard trait instance envOverride values, use only ReleaseBinding
+		instanceName := input.Instance.InstanceName
+		if input.ReleaseBinding != nil && input.ReleaseBinding.Spec.TraitOverrides != nil {
+			if instanceOverride, ok := input.ReleaseBinding.Spec.TraitOverrides[instanceName]; ok {
+				envOverrides, err = extractParametersFromRawExtension(&instanceOverride)
+				if err != nil {
+					return nil, fmt.Errorf("failed to extract trait environment overrides: %w", err)
+				}
+			} else {
+				envOverrides = make(map[string]any)
+			}
+		} else {
+			envOverrides = make(map[string]any)
+		}
+	} else {
+		// Merge trait instance envOverride values with ReleaseBinding
+		envOverrides, err = extractParameters(input.Instance.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract trait instance parameters for envOverrides: %w", err)
+		}
+
+		// Merge with ReleaseBinding envOverrides
+		instanceName := input.Instance.InstanceName
+		if input.ReleaseBinding != nil && input.ReleaseBinding.Spec.TraitOverrides != nil {
+			if instanceOverride, ok := input.ReleaseBinding.Spec.TraitOverrides[instanceName]; ok {
+				rbEnvOverrides, err := extractParametersFromRawExtension(&instanceOverride)
+				if err != nil {
+					return nil, fmt.Errorf("failed to extract trait environment overrides: %w", err)
+				}
+				envOverrides = deepMerge(envOverrides, rbEnvOverrides)
+			}
+		}
+	}
+
+	// Prune merged result against schema
+	if envOverridesSchema != nil {
+		pruning.Prune(envOverrides, envOverridesSchema, false)
+	}
+
+	// Apply defaults
+	envOverrides = schema.ApplyDefaults(envOverrides, envOverridesSchema)
+
+	// Top-level merge: combine parameters and envOverrides
+	// Safe because parameter and envOverride schemas don't overlap
+	finalParameters := make(map[string]any)
+	maps.Copy(finalParameters, parameters)
+	maps.Copy(finalParameters, envOverrides)
+
+	return finalParameters, nil
+}
+
 // extractParametersFromRawExtension converts a runtime.RawExtension to a map[string]any.
 // This is similar to extractParameters but operates on a runtime.RawExtension directly.
 func extractParametersFromRawExtension(raw *runtime.RawExtension) (map[string]any, error) {
@@ -144,4 +198,19 @@ func extractParametersFromRawExtension(raw *runtime.RawExtension) (map[string]an
 	}
 
 	return params, nil
+}
+
+// getCachedSchema retrieves a structural schema from the cache
+func getCachedSchema(cache map[string]*apiextschema.Structural, key string) *apiextschema.Structural {
+	if cache == nil {
+		return nil
+	}
+	return cache[key]
+}
+
+// setCachedSchema stores a structural schema in the cache
+func setCachedSchema(cache map[string]*apiextschema.Structural, key string, schema *apiextschema.Structural) {
+	if cache != nil {
+		cache[key] = schema
+	}
 }

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -102,6 +102,12 @@ type ComponentContextInput struct {
 	// Metadata provides structured naming and labeling information.
 	// Required - controller must provide this.
 	Metadata MetadataContext
+
+	// DiscardComponentEnvOverrides when true, discards envOverride values from Component.Spec.Parameters
+	// and only uses values from ReleaseBinding.Spec.ComponentTypeEnvOverrides for envOverride fields.
+	// Component parameters are still used for fields defined in schema.parameters.
+	// Default: false
+	DiscardComponentEnvOverrides bool
 }
 
 // TraitContextInput contains all inputs needed to build a trait rendering context.
@@ -132,6 +138,12 @@ type TraitContextInput struct {
 	// Used to avoid rebuilding schemas for the same trait used multiple times.
 	// BuildTraitContext will check this cache before building and populate it after.
 	SchemaCache map[string]*apiextschema.Structural
+
+	// DiscardComponentEnvOverrides when true, discards envOverride values from trait instance parameters
+	// and only uses values from ReleaseBinding.Spec.TraitOverrides for envOverride fields.
+	// Trait instance parameters are still used for fields defined in trait's schema.parameters.
+	// Default: false
+	DiscardComponentEnvOverrides bool
 }
 
 // SchemaInput contains schema information for applying defaults.

--- a/internal/pipeline/component/renderer/renderer.go
+++ b/internal/pipeline/component/renderer/renderer.go
@@ -33,12 +33,12 @@ func NewRenderer(templateEngine *template.Engine) *Renderer {
 // RenderResources renders all resources from a ComponentType.
 //
 // The process:
-//  1. Iterate through ComponentType.Spec.Resources
-//  2. For each ResourceTemplate:
-//     - Evaluate includeWhen (skip if false)
-//     - Check forEach (render multiple times if present)
-//     - Render template field using template engine
-//  3. Return all rendered resources
+//   - Iterate through ComponentType.Spec.Resources
+//   - For each ResourceTemplate:
+//   - Evaluate includeWhen (skip if false)
+//   - Check forEach (render multiple times if present)
+//   - Render template field using template engine
+//   - Return all rendered resources
 //
 // Returns an error if any template fails to render (unless it's a missing data error
 // for includeWhen evaluation).
@@ -112,12 +112,12 @@ func (r *Renderer) shouldInclude(tmpl v1alpha1.ResourceTemplate, context map[str
 // renderWithForEach handles ResourceTemplate.forEach iteration.
 //
 // The process:
-//  1. Evaluate forEach expression to get array of items
-//  2. For each item:
-//     - Clone context
-//     - Bind item to variable (tmpl.var or "item")
-//     - Render template with item context
-//  3. Return all rendered resources
+//   - Evaluate forEach expression to get array of items
+//   - For each item:
+//   - Clone context
+//   - Bind item to variable (tmpl.var or "item")
+//   - Render template with item context
+//   - Return all rendered resources
 func (r *Renderer) renderWithForEach(
 	tmpl v1alpha1.ResourceTemplate,
 	context map[string]any,
@@ -162,10 +162,10 @@ func (r *Renderer) renderWithForEach(
 // renderSingleResource renders a single ResourceTemplate.
 //
 // The process:
-//  1. Extract template from runtime.RawExtension
-//  2. Render using template engine
-//  3. Remove omitted fields
-//  4. Validate basic structure (kind, apiVersion, metadata.name)
+//   - Extract template from runtime.RawExtension
+//   - Render using template engine
+//   - Remove omitted fields
+//   - Validate basic structure (kind, apiVersion, metadata.name)
 func (r *Renderer) renderSingleResource(
 	tmpl v1alpha1.ResourceTemplate,
 	context map[string]any,

--- a/internal/pipeline/component/trait/processor.go
+++ b/internal/pipeline/component/trait/processor.go
@@ -41,8 +41,8 @@ func NewProcessor(templateEngine *template.Engine) *Processor {
 // ProcessTraits applies all traits to the base resources.
 //
 // For each trait:
-//  1. Apply creates (new resources)
-//  2. Apply patches (modify existing resources)
+//   - Apply creates (new resources)
+//   - Apply patches (modify existing resources)
 //
 // The resources slice is modified in place by patches.
 func (p *Processor) ProcessTraits(
@@ -176,9 +176,9 @@ func (p *Processor) applyPatchWithForEach(
 	for i, item := range items {
 		// Shallow clone context for this iteration to avoid cross-iteration contamination.
 		// A shallow copy is sufficient because:
-		// 1. We only add one new key (the loop variable)
-		// 2. The template engine doesn't mutate map values (only reads them)
-		// 3. We need isolation so one iteration's loop variable doesn't affect another
+		//   - We only add one new key (the loop variable)
+		//   - The template engine doesn't mutate map values (only reads them)
+		//   - We need isolation so one iteration's loop variable doesn't affect another
 		iterContext := maps.Clone(baseContext)
 		iterContext[varName] = item
 
@@ -199,7 +199,7 @@ func (p *Processor) applyPatchOnce(
 	traitPatch v1alpha1.TraitPatch,
 	context map[string]any,
 ) error {
-	// 1. Find target resources based on Kind/Group/Version
+	// Find target resources based on Kind/Group/Version
 	target := TargetSpec{
 		Kind:    traitPatch.Target.Kind,
 		Group:   traitPatch.Target.Group,
@@ -213,7 +213,7 @@ func (p *Processor) applyPatchOnce(
 		return nil
 	}
 
-	// 2. Filter targets using where clause if specified
+	// Filter targets using where clause if specified
 	if target.Where != "" {
 		filtered, err := p.filterTargets(targets, target.Where, context, traitName, patchIndex)
 		if err != nil {
@@ -222,13 +222,13 @@ func (p *Processor) applyPatchOnce(
 		targets = filtered
 	}
 
-	// 3. Render patch operations with CEL
+	// Render patch operations with CEL
 	renderedOps, err := p.renderOperations(traitPatch.Operations, context, traitName, patchIndex)
 	if err != nil {
 		return err
 	}
 
-	// 4. Apply rendered operations to each target using the simple patch function
+	// Apply rendered operations to each target using the simple patch function
 	for _, target := range targets {
 		if err := patch.ApplyPatches(target, renderedOps); err != nil {
 			// Extract resource identity for better error message
@@ -358,10 +358,10 @@ func (p *Processor) renderOperations(
 
 // FindTargetResources filters resources based on Kind, Group, and Version.
 //
-// Matching is done in order:
-//  1. If target.Kind is set, resource.kind must match
-//  2. If target.Group is set, the group portion of resource.apiVersion must match
-//  3. If target.Version is set, the version portion of resource.apiVersion must match
+// Matching rules:
+//   - If target.Kind is set, resource.kind must match
+//   - If target.Group is set, the group portion of resource.apiVersion must match
+//   - If target.Version is set, the version portion of resource.apiVersion must match
 //
 // An empty field in the target spec means "match any value".
 //

--- a/internal/pipeline/component/types.go
+++ b/internal/pipeline/component/types.go
@@ -100,13 +100,20 @@ type RenderOptions struct {
 
 	// ResourceAnnotations are additional annotations to add to all rendered resources.
 	ResourceAnnotations map[string]string
+
+	// DiscardComponentEnvOverrides when true, discards envOverride values from Component.Spec.Parameters
+	// and only uses values from ReleaseBinding.Spec.ComponentTypeEnvOverrides for envOverride fields.
+	// Component parameters are still used for fields defined in schema.parameters.
+	// Default: false (current behavior - merge Component parameters with ReleaseBinding envOverrides)
+	DiscardComponentEnvOverrides bool
 }
 
 // DefaultRenderOptions returns the default rendering options.
 func DefaultRenderOptions() RenderOptions {
 	return RenderOptions{
-		EnableValidation:    true,
-		ResourceLabels:      map[string]string{},
-		ResourceAnnotations: map[string]string{},
+		EnableValidation:             true,
+		ResourceLabels:               map[string]string{},
+		ResourceAnnotations:          map[string]string{},
+		DiscardComponentEnvOverrides: false,
 	}
 }


### PR DESCRIPTION
## Purpose
Introduces `DiscardComponentEnvOverrides` flag to control how component/trait instance parameters are merged with ReleaseBinding environment-specific overrides.

Note: internal/pipeline/component/context/builder_test.go has a some stale references to previous envSetting/componentDeployment CRDs and assumes releasebinding is optional. Will clean up those in a spearate PR.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
