### PR TITLE
Update k3d single cluster setup with cluster gateway and cluster agent

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -146,3 +146,21 @@ This keeps resource names clean and consistent (e.g., "openchoreo-api" instead o
 {{- define "openchoreo-control-plane.openchoreoApi.name" -}}
 {{- default "openchoreo-api" .Values.openchoreoApi.name }}
 {{- end }}
+
+{{/*
+Cluster Gateway resource name
+*/}}
+{{- define "openchoreo-control-plane.clusterGateway.name" -}}
+{{- default "cluster-gateway" .Values.clusterGateway.name }}
+{{- end }}
+
+{{/*
+Cluster Gateway service account name
+*/}}
+{{- define "openchoreo-control-plane.clusterGateway.serviceAccountName" -}}
+{{- if .Values.clusterGateway.serviceAccount.create }}
+{{- default "cluster-gateway" .Values.clusterGateway.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.clusterGateway.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-configmap-placeholder.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-configmap-placeholder.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.tls.enabled }}
+---
+# Placeholder ConfigMap for cluster-gateway CA certificate
+# This is created as a regular resource so the controller manager can mount it
+# The CA extractor hook job will populate it with the actual certificate
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-gateway-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+data:
+  # Empty placeholder - will be populated by the CA extractor job
+  ca.crt: |
+    # Placeholder certificate - will be replaced by actual CA certificate
+    # after cluster-gateway TLS secret is ready
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-configmap.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.tls.enabled }}
+---
+# Job to extract CA certificate from secret and create ConfigMap
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-ca-extractor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cluster-gateway-ca-extractor
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+      containers:
+      - name: ca-extractor
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Cluster Gateway CA Extractor ==="
+          echo "Waiting for cluster-gateway TLS secret to be ready..."
+
+          retries=0
+          max_retries=120  # Increased to 10 minutes (120 * 5s)
+
+          # Wait for secret to exist
+          until kubectl get secret {{ .Values.clusterGateway.tls.secretName }} -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for secret {{ .Values.clusterGateway.tls.secretName }}"
+              echo "Available secrets:"
+              kubectl get secrets -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "Secret not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ Secret {{ .Values.clusterGateway.tls.secretName }} found"
+
+          # Wait for certificate to be ready (have ca.crt field)
+          echo "Waiting for CA certificate data in secret..."
+          retries=0
+          until kubectl get secret {{ .Values.clusterGateway.tls.secretName }} -n {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}' | grep -q .; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for ca.crt data in secret"
+              echo "Secret content:"
+              kubectl get secret {{ .Values.clusterGateway.tls.secretName }} -n {{ .Release.Namespace }} -o yaml
+              exit 1
+            fi
+            echo "CA certificate data not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ CA certificate data found in secret"
+
+          # Extract CA certificate
+          CA_CERT=$(kubectl get secret {{ .Values.clusterGateway.tls.secretName }} -n {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}')
+
+          if [ -z "$CA_CERT" ]; then
+            echo "CA certificate field empty, using tls.crt as CA (self-signed certificate)"
+            CA_CERT=$(kubectl get secret {{ .Values.clusterGateway.tls.secretName }} -n {{ .Release.Namespace }} -o jsonpath='{.data.tls\.crt}')
+          fi
+
+          if [ -z "$CA_CERT" ]; then
+            echo "ERROR: No certificate data found in secret"
+            kubectl get secret {{ .Values.clusterGateway.tls.secretName }} -n {{ .Release.Namespace }} -o yaml
+            exit 1
+          fi
+
+          # Decode and validate certificate
+          echo "Validating certificate format..."
+          if ! echo "$CA_CERT" | base64 -d | grep -q "BEGIN CERTIFICATE"; then
+            echo "ERROR: Invalid certificate format (not a PEM certificate)"
+            echo "Decoded content:"
+            echo "$CA_CERT" | base64 -d
+            exit 1
+          fi
+
+          echo "✓ Certificate format valid"
+
+          # Update ConfigMap
+          echo "Updating cluster-gateway-ca ConfigMap..."
+          echo "$CA_CERT" | base64 -d | kubectl create configmap cluster-gateway-ca \
+            --from-file=ca.crt=/dev/stdin \
+            --namespace {{ .Release.Namespace }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          echo "✓ ConfigMap updated successfully"
+
+          # Verify ConfigMap content
+          echo "Verifying ConfigMap content..."
+          kubectl get configmap cluster-gateway-ca -n {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}' | head -5
+
+          echo ""
+          echo "=== CA Extraction Completed Successfully ==="
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-secret.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-secret.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.tls.enabled }}
+---
+# Job to create cluster-agent-ca secret from cluster-gateway-ca ConfigMap
+# The DataPlane CRD expects a secretRef, but we store the CA in a ConfigMap
+# This job creates a Secret with the same CA data for compatibility
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-ca-secret-creator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cluster-gateway-ca-secret-creator
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+      containers:
+      - name: ca-secret-creator
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Cluster Gateway CA Secret Creator ==="
+          echo "Creating cluster-agent-ca secret from cluster-gateway-ca ConfigMap..."
+
+          # Wait for ConfigMap to be ready with valid CA
+          retries=0
+          max_retries=60  # 5 minutes
+
+          until kubectl get configmap cluster-gateway-ca -n {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}' 2>/dev/null | grep -q "BEGIN CERTIFICATE"; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for cluster-gateway-ca ConfigMap with valid CA certificate"
+              exit 1
+            fi
+            echo "Waiting for cluster-gateway-ca ConfigMap... ($retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ ConfigMap found with valid CA certificate"
+
+          # Extract CA from ConfigMap
+          CA_CERT=$(kubectl get configmap cluster-gateway-ca -n {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}')
+
+          # Create or update the Secret
+          echo "Creating/updating cluster-agent-ca secret..."
+
+          # Delete existing secret if it exists (for idempotency)
+          kubectl delete secret cluster-agent-ca -n {{ .Release.Namespace }} 2>/dev/null || true
+
+          # Create new secret
+          kubectl create secret generic cluster-agent-ca \
+            -n {{ .Release.Namespace }} \
+            --from-literal=ca.crt="$CA_CERT"
+
+          # Label the secret for easy identification
+          kubectl label secret cluster-agent-ca \
+            -n {{ .Release.Namespace }} \
+            app.kubernetes.io/component=cluster-gateway \
+            app.kubernetes.io/managed-by=Helm \
+            --overwrite
+
+          echo "✓ cluster-agent-ca secret created successfully"
+          echo ""
+          echo "=== CA Secret Creation Complete ==="
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/certificate.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/certificate.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-4"
+spec:
+  secretName: {{ .Values.clusterGateway.tls.secretName }}
+  issuerRef:
+    {{- if .Values.clusterGateway.tls.issuerRef.kind }}
+    kind: {{ .Values.clusterGateway.tls.issuerRef.kind }}
+    {{- else }}
+    kind: Issuer
+    {{- end }}
+    name: {{ .Values.clusterGateway.tls.issuerRef.name }}
+  dnsNames:
+    {{- range .Values.clusterGateway.tls.dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- with .Values.clusterGateway.tls.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.clusterGateway.tls.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrole.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.clusterGateway.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+rules:
+# Allow reading DataPlane CRs to get client CA configuration
+- apiGroups: ["openchoreo.dev"]
+  resources: ["dataplanes"]
+  verbs: ["get", "list", "watch"]
+# Allow reading BuildPlane CRs to get client CA configuration
+- apiGroups: ["openchoreo.dev"]
+  resources: ["buildplanes"]
+  verbs: ["get", "list", "watch"]
+# Allow reading Secrets for client CA certificates
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrolebinding.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.clusterGateway.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.clusterGateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+    app: cluster-gateway
+spec:
+  replicas: {{ .Values.clusterGateway.replicas }}
+  selector:
+    matchLabels:
+      app: cluster-gateway
+      app.kubernetes.io/component: cluster-gateway
+      {{- include "openchoreo-control-plane.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: cluster-gateway
+        app.kubernetes.io/component: cluster-gateway
+        {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+      {{- if .Values.clusterGateway.priorityClass.create }}
+      priorityClassName: {{ .Values.clusterGateway.priorityClass.name }}
+      {{- end }}
+      {{- with .Values.clusterGateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterGateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterGateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterGateway.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: cluster-gateway
+        image: "{{ .Values.clusterGateway.image.repository }}:{{ .Values.clusterGateway.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.clusterGateway.image.pullPolicy }}
+        args:
+        - --port={{ .Values.clusterGateway.port }}
+        - --server-cert=/certs/tls.crt
+        - --server-key=/certs/tls.key
+        - --heartbeat-interval={{ .Values.clusterGateway.heartbeatInterval }}
+        - --heartbeat-timeout={{ .Values.clusterGateway.heartbeatTimeout }}
+        - --log-level={{ .Values.clusterGateway.logLevel }}
+        ports:
+        - name: websocket
+          containerPort: {{ .Values.clusterGateway.port }}
+          protocol: TCP
+        - name: health
+          containerPort: 8080
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.clusterGateway.resources | nindent 10 }}
+        {{- with .Values.clusterGateway.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: server-certs
+          mountPath: /certs
+          readOnly: true
+      volumes:
+      - name: server-certs
+        secret:
+          secretName: {{ .Values.clusterGateway.tls.secretName }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/issuer.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/issuer.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.clusterGateway.tls.issuerRef.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  selfSigned: {}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/role.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.clusterGateway.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+rules:
+# Allow reading TLS secrets for CA extraction and creating cluster-agent-ca secret
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "delete", "patch"]
+# Allow creating and updating ConfigMaps for CA certificate
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "create", "update", "patch"]
+# Allow checking cert-manager webhook readiness (for wait job)
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "list"]
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/rolebinding.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.clusterGateway.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/service.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.clusterGateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+    app: cluster-gateway
+spec:
+  type: {{ .Values.clusterGateway.service.type }}
+  {{- if .Values.clusterGateway.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.clusterGateway.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.clusterGateway.service.clusterIP }}
+  clusterIP: {{ .Values.clusterGateway.service.clusterIP }}
+  {{- end }}
+  ports:
+  - name: websocket
+    port: {{ .Values.clusterGateway.service.port }}
+    targetPort: {{ .Values.clusterGateway.port }}
+    protocol: TCP
+    {{- if and (eq .Values.clusterGateway.service.type "NodePort") .Values.clusterGateway.service.nodePort }}
+    nodePort: {{ .Values.clusterGateway.service.nodePort }}
+    {{- end }}
+  selector:
+    app: cluster-gateway
+    app.kubernetes.io/component: cluster-gateway
+    {{- include "openchoreo-control-plane.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/serviceaccount.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+  {{- with .Values.clusterGateway.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/wait-for-cert-manager.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/wait-for-cert-manager.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.tls.enabled }}
+---
+# Job to wait for cert-manager webhook to be ready
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wait-for-cert-manager-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: wait-cert-manager
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+      containers:
+      - name: wait-webhook
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Waiting for cert-manager webhook to be ready ==="
+
+          retries=0
+          max_retries=60  # 5 minutes
+
+          # Wait for cert-manager webhook deployment to exist
+          until kubectl get deployment cert-manager-webhook -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for cert-manager-webhook deployment"
+              exit 1
+            fi
+            echo "Waiting for cert-manager-webhook deployment... ($retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ cert-manager-webhook deployment found"
+
+          # Wait for webhook to be ready
+          echo "Waiting for cert-manager-webhook to be ready..."
+          kubectl wait --for=condition=available \
+            deployment/cert-manager-webhook \
+            -n {{ .Release.Namespace }} \
+            --timeout=300s
+
+          echo "✓ cert-manager-webhook is ready"
+
+          # Additional wait for webhook endpoint to be available
+          echo "Waiting for webhook endpoint..."
+          retries=0
+          until kubectl get endpoints cert-manager-webhook -n {{ .Release.Namespace }} -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; do
+            retries=$((retries+1))
+            if [ $retries -gt 30 ]; then
+              echo "ERROR: Timeout waiting for webhook endpoint"
+              exit 1
+            fi
+            echo "Waiting for webhook endpoint... ($retries/30)"
+            sleep 2
+          done
+
+          echo "✓ Webhook endpoint is available"
+          echo ""
+          echo "=== cert-manager is fully ready! ==="
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -42,6 +42,34 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 10
+      {{- if .Values.controllerManager.clusterGateway.enabled }}
+      initContainers:
+      - name: wait-for-cluster-gateway-ca
+        image: busybox:1.36
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for cluster-gateway CA certificate to be ready..."
+          retries=0
+          max_retries=60
+          until [ -f /etc/cluster-gateway/ca.crt ] && grep -q "BEGIN CERTIFICATE" /etc/cluster-gateway/ca.crt 2>/dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for valid CA certificate"
+              echo "ConfigMap content:"
+              cat /etc/cluster-gateway/ca.crt || echo "File not found"
+              exit 1
+            fi
+            echo "CA certificate not ready yet (attempt $retries/$max_retries)..."
+            sleep 5
+          done
+          echo "✓ Cluster gateway CA certificate is ready!"
+        volumeMounts:
+        - mountPath: /etc/cluster-gateway
+          name: cluster-gateway-ca
+          readOnly: true
+      {{- end }}
       containers:
       - name: manager
         image: {{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}
@@ -49,11 +77,21 @@ spec:
         command:
         - /manager
         args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        {{- if .Values.controllerManager.clusterGateway.enabled }}
+        - --agent-server-url={{ .Values.controllerManager.clusterGateway.url }}
+        - --agent-server-ca={{ .Values.controllerManager.clusterGateway.tls.caPath }}
+        {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
           value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        {{- if .Values.controllerManager.clusterGateway.enabled }}
+        - name: AGENT_SERVER_URL
+          value: {{ quote .Values.controllerManager.clusterGateway.url }}
+        - name: AGENT_SERVER_CA_PATH
+          value: {{ quote .Values.controllerManager.clusterGateway.tls.caPath }}
+        {{- end }}
         ports:
         - containerPort: 8080
           name: metrics
@@ -81,16 +119,26 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
         volumeMounts:
+        {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
         {{- end }}
-      {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
+        {{- if .Values.controllerManager.clusterGateway.enabled }}
+        - mountPath: /etc/cluster-gateway
+          name: cluster-gateway-ca
+          readOnly: true
+        {{- end }}
       volumes:
+      {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
       - name: cert
         secret:
           defaultMode: 420
           secretName: {{ .Values.controllerManager.name }}-webhook-server-cert
+      {{- end }}
+      {{- if .Values.controllerManager.clusterGateway.enabled }}
+      - name: cluster-gateway-ca
+        configMap:
+          name: {{ .Values.controllerManager.clusterGateway.tls.caConfigMap }}
       {{- end }}

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -150,6 +150,13 @@ controllerManager:
       - --health-probe-bind-address=:8081
     env:
       enableWebhooks: "false"
+  # Cluster Gateway configuration for agent-based data plane communication
+  clusterGateway:
+    enabled: false  # Set to true to enable cluster gateway integration
+    url: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443
+    tls:
+      caPath: /etc/cluster-gateway/ca.crt
+      caConfigMap: cluster-gateway-ca
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:
@@ -574,3 +581,63 @@ asgardeoThunder:
         given_name: "Admin"
         family_name: "User"
         group: "platformEngineer"
+
+# Cluster Gateway configuration
+# The gateway manages WebSocket connections from cluster agents
+clusterGateway:
+  enabled: false
+  name: cluster-gateway
+  replicas: 1
+  image:
+    repository: ghcr.io/openchoreo/cluster-gateway
+    tag: "" # If no value is set, use Chart.AppVersion
+    pullPolicy: IfNotPresent
+  port: 8443
+  heartbeatInterval: 30s
+  heartbeatTimeout: 90s
+  logLevel: info
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "64Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+  serviceAccount:
+    create: true
+    name: cluster-gateway
+    annotations: {}
+  priorityClass:
+    create: false
+    name: cluster-gateway
+    value: 900000
+  service:
+    type: ClusterIP
+    port: 8443
+    nodePort: null
+    loadBalancerIP: null
+    clusterIP: null
+  tls:
+    enabled: true
+    secretName: cluster-gateway-tls
+    issuerRef:
+      kind: Issuer
+      name: cluster-gateway-selfsigned-issuer
+    dnsNames:
+      - cluster-gateway.openchoreo-control-plane.svc
+      - cluster-gateway.openchoreo-control-plane.svc.cluster.local
+    duration: 2160h # 90 days
+    renewBefore: 360h # 15 days
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/install/helm/openchoreo-data-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-data-plane/templates/_helpers.tpl
@@ -121,3 +121,21 @@ Parameters:
 {{ include "openchoreo-data-plane.selectorLabels" .context }}
 app.kubernetes.io/component: {{ .component }}
 {{- end }}
+
+{{/*
+Cluster Agent name
+*/}}
+{{- define "openchoreo-data-plane.clusterAgent.name" -}}
+{{- default "cluster-agent" .Values.clusterAgent.name }}
+{{- end }}
+
+{{/*
+Cluster Agent service account name
+*/}}
+{{- define "openchoreo-data-plane.clusterAgent.serviceAccountName" -}}
+{{- if .Values.clusterAgent.serviceAccount.create }}
+{{- default "cluster-agent" .Values.clusterAgent.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.clusterAgent.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/certificate.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/certificate.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-4"
+spec:
+  secretName: {{ .Values.clusterAgent.tls.secretName }}
+  commonName: {{ .Values.clusterAgent.planeName }}
+  issuerRef:
+    kind: Issuer
+    name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-selfsigned-issuer
+  {{- with .Values.clusterAgent.tls.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.clusterAgent.tls.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+rules:
+# Core Kubernetes workload resources
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  - persistentvolumeclaims
+  - serviceaccounts
+  - namespaces
+  - endpoints
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods/log
+  - pods/status
+  verbs: ["get", "list"]
+# Batch jobs
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+# Networking
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs: ["*"]
+# RBAC (for service account management)
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - roles
+  - rolebindings
+  verbs: ["*"]
+# Autoscaling
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["*"]
+# Policy
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["*"]
+# Cilium network policies (if using Cilium)
+- apiGroups: ["cilium.io"]
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumclusterwidenetworkpolicies
+  verbs: ["*"]
+# Gateway API resources (if using Gateway API)
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - httproutes
+  - tcproutes
+  - grpcroutes
+  verbs: ["*"]
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrolebinding.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.clusterAgent.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+    app: cluster-agent
+spec:
+  replicas: {{ .Values.clusterAgent.replicas }}
+  selector:
+    matchLabels:
+      app: cluster-agent
+      app.kubernetes.io/component: cluster-agent
+      {{- include "openchoreo-data-plane.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: cluster-agent
+        app.kubernetes.io/component: cluster-agent
+        {{- include "openchoreo-data-plane.selectorLabels" . | nindent 8 }}
+      {{- with .Values.clusterAgent.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+      {{- if .Values.clusterAgent.priorityClass.create }}
+      priorityClassName: {{ .Values.clusterAgent.priorityClass.name }}
+      {{- end }}
+      {{- with .Values.clusterAgent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterAgent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterAgent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterAgent.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: agent
+        image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
+        args:
+        - --server-url={{ .Values.clusterAgent.serverUrl }}
+        - --plane-name={{ .Values.clusterAgent.planeName }}
+        - --plane-type={{ .Values.clusterAgent.planeType }}
+        - --client-cert=/certs/tls.crt
+        - --client-key=/certs/tls.key
+        - --server-ca=/ca-certs/ca.crt
+        - --heartbeat-interval={{ .Values.clusterAgent.heartbeatInterval }}
+        - --reconnect-delay={{ .Values.clusterAgent.reconnectDelay }}
+        - --log-level={{ .Values.clusterAgent.logLevel }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          {{- toYaml .Values.clusterAgent.resources | nindent 10 }}
+        {{- with .Values.clusterAgent.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: client-certs
+          mountPath: /certs
+          readOnly: true
+        - name: server-ca
+          mountPath: /ca-certs
+          readOnly: true
+      volumes:
+      - name: client-certs
+        secret:
+          secretName: {{ .Values.clusterAgent.tls.clientSecretName }}
+      - name: server-ca
+        configMap:
+          name: {{ .Values.clusterAgent.tls.serverCAConfigMap }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/issuer.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/issuer.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  selfSigned: {}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/server-ca-configmap.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/server-ca-configmap.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.clusterAgent.enabled }}
+---
+# Job to copy cluster-gateway CA certificate from control plane to data plane
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-ca-copier
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cluster-agent-ca-copier
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+      containers:
+      - name: ca-copier
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Cluster Agent Server CA Copier ==="
+          echo "Copying cluster-gateway CA from control plane to data plane..."
+
+          retries=0
+          max_retries=120  # 10 minutes
+
+          # Wait for source ConfigMap in control plane
+          echo "Waiting for cluster-gateway-ca ConfigMap in control plane..."
+          until kubectl get configmap cluster-gateway-ca -n {{ .Values.clusterAgent.serverCANamespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for cluster-gateway-ca in {{ .Values.clusterAgent.serverCANamespace }}"
+              kubectl get configmap -n {{ .Values.clusterAgent.serverCANamespace }}
+              exit 1
+            fi
+            echo "ConfigMap not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ Source ConfigMap found in control plane"
+
+          # Wait for valid certificate content
+          echo "Waiting for valid CA certificate content..."
+          retries=0
+          until kubectl get configmap cluster-gateway-ca -n {{ .Values.clusterAgent.serverCANamespace }} -o jsonpath='{.data.ca\.crt}' | grep -q "BEGIN CERTIFICATE"; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for valid CA certificate content"
+              kubectl get configmap cluster-gateway-ca -n {{ .Values.clusterAgent.serverCANamespace }} -o yaml
+              exit 1
+            fi
+            echo "Valid certificate not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ Valid CA certificate found"
+
+          # Copy ConfigMap to data plane namespace
+          echo "Copying ConfigMap to data plane namespace..."
+          kubectl get configmap cluster-gateway-ca -n {{ .Values.clusterAgent.serverCANamespace }} -o yaml | \
+            sed 's/namespace: {{ .Values.clusterAgent.serverCANamespace }}/namespace: {{ .Release.Namespace }}/' | \
+            sed '/resourceVersion:/d' | \
+            sed '/uid:/d' | \
+            sed '/creationTimestamp:/d' | \
+            kubectl apply -f -
+
+          echo "✓ ConfigMap copied successfully"
+
+          # Verify
+          echo "Verifying ConfigMap in data plane..."
+          kubectl get configmap cluster-gateway-ca -n {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}' | head -5
+
+          echo ""
+          echo "=== CA Copy Completed Successfully ==="
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/serviceaccount.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  {{- with .Values.clusterAgent.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/wait-for-cert-manager.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/wait-for-cert-manager.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
+---
+# Job to wait for cert-manager webhook to be ready (from control plane chart)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wait-for-cert-manager-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: wait-cert-manager
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+      containers:
+      - name: wait-webhook
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Waiting for cert-manager webhook to be ready ==="
+
+          # Note: cert-manager is installed in openchoreo-control-plane namespace
+          # but its webhook serves all namespaces
+          CERT_MANAGER_NS="openchoreo-control-plane"
+
+          retries=0
+          max_retries=60  # 5 minutes
+
+          # Wait for cert-manager webhook deployment to exist
+          until kubectl get deployment cert-manager-webhook -n $CERT_MANAGER_NS &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for cert-manager-webhook deployment in $CERT_MANAGER_NS"
+              exit 1
+            fi
+            echo "Waiting for cert-manager-webhook deployment... ($retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ cert-manager-webhook deployment found"
+
+          # Wait for webhook to be ready
+          echo "Waiting for cert-manager-webhook to be ready..."
+          kubectl wait --for=condition=available \
+            deployment/cert-manager-webhook \
+            -n $CERT_MANAGER_NS \
+            --timeout=300s
+
+          echo "✓ cert-manager-webhook is ready"
+
+          # Additional wait for webhook endpoint to be available
+          echo "Waiting for webhook endpoint..."
+          retries=0
+          until kubectl get endpoints cert-manager-webhook -n $CERT_MANAGER_NS -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; do
+            retries=$((retries+1))
+            if [ $retries -gt 30 ]; then
+              echo "ERROR: Timeout waiting for webhook endpoint"
+              exit 1
+            fi
+            echo "Waiting for webhook endpoint... ($retries/30)"
+            sleep 2
+          done
+
+          echo "✓ Webhook endpoint is available"
+          echo ""
+          echo "=== cert-manager is fully ready! ==="
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -241,5 +241,68 @@ fluentBit:
     varLog: /var/log
     dockerContainers: /var/lib/docker/containers
 
+# Cluster Agent configuration
+# The agent connects to the control plane cluster gateway via WebSocket
+clusterAgent:
+  enabled: false  # Set to true to enable cluster agent
+  name: cluster-agent
+  replicas: 1
+  image:
+    repository: ghcr.io/openchoreo/cluster-agent
+    tag: "" # If no value is set, use Chart.AppVersion
+    pullPolicy: IfNotPresent
+  # Server URL of the cluster gateway in control plane
+  serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
+  # Name of this data plane
+  planeName: default
+  # Type of plane (dataplane or buildplane)
+  planeType: dataplane
+  heartbeatInterval: 30s
+  reconnectDelay: 5s
+  logLevel: info
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "512Mi"
+  serviceAccount:
+    create: true
+    name: cluster-agent
+    annotations: {}
+  rbac:
+    create: true
+  priorityClass:
+    create: false
+    name: cluster-agent
+    value: 900000
+  tls:
+    enabled: true
+    # Secret containing client certificate and key
+    secretName: cluster-agent-tls
+    clientSecretName: cluster-agent-tls
+    # ConfigMap containing server CA certificate
+    serverCAConfigMap: cluster-gateway-ca
+    # Certificate duration and renewal
+    duration: 2160h # 90 days
+    renewBefore: 360h # 15 days
+  # Namespace where cluster-gateway CA exists (control plane namespace)
+  serverCANamespace: openchoreo-control-plane
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 
 

--- a/install/helm/openchoreo-observability-plane/addons/rca/templates/pre-install-check-job.yaml
+++ b/install/helm/openchoreo-observability-plane/addons/rca/templates/pre-install-check-job.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: {{ include "openchoreo-observer-rca.fullname" . }}-pre-install
       containers:
       - name: check-dependencies
-        image: bitnami/kubectl:latest
+        image: bitnamilegacy/kubectl:1.32.4
         command:
         - /bin/sh
         - -c

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -87,7 +87,24 @@ helm install openchoreo-observability-plane install/helm/openchoreo-observabilit
 
 ### 5. Create DataPlane Resource
 
-Create a DataPlane resource to enable workload deployment:
+Create a DataPlane resource to enable workload deployment.
+
+**Using Cluster Agent (Recommended):**
+
+The cluster agent approach uses outbound WebSocket connections from the Data Plane to the Control Plane, eliminating the need for Control Plane to access Data Plane's Kubernetes API. This is the recommended approach for production deployments.
+
+```bash
+./install/add-data-plane.sh \
+  --enable-agent \
+  --control-plane-context k3d-openchoreo-cp \
+  --namespace default \
+  --agent-ca-namespace openchoreo-control-plane \
+  --name default
+```
+
+**Using Direct API Access (Alternative):**
+
+For simpler setups or when cluster agent is not available, you can use direct Kubernetes API access:
 
 ```bash
 ./install/add-data-plane.sh \
@@ -109,16 +126,19 @@ Create a BuildPlane resource to enable building from source:
 
 ## Port Mappings
 
-| Plane               | Cluster           | Kube API Port | Port Range |
-|---------------------|-------------------|---------------|------------|
-| Control Plane       | k3d-openchoreo-cp | 6550          | 8xxx       |
-| Data Plane          | k3d-openchoreo-dp | 6551          | 9xxx       |
-| Build Plane         | k3d-openchoreo-bp | 6552          | 10xxx      |
-| Observability Plane | k3d-openchoreo-op | 6553          | 11xxx      |
+| Plane               | Cluster           | Kube API Port | Port Range | Special Ports |
+|---------------------|-------------------|---------------|------------|---------------|
+| Control Plane       | k3d-openchoreo-cp | 6550          | 8xxx       | 30443 (Cluster Gateway NodePort) |
+| Data Plane          | k3d-openchoreo-dp | 6551          | 9xxx       | - |
+| Build Plane         | k3d-openchoreo-bp | 6552          | 10xxx      | - |
+| Observability Plane | k3d-openchoreo-op | 6553          | 11xxx      | - |
 
 > [!NOTE]
 > Port ranges (e.g., 8xxx) indicate the ports exposed to your host machine for accessing services from that plane. Each
 > range uses ports like 8080 (HTTP) and 8443 (HTTPS) on localhost.
+>
+> The Cluster Gateway (port 30443) is used by cluster agents in Data/Build Planes to establish WebSocket connections
+> to the Control Plane for agent-based communication.
 
 ## Access Services
 

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -1,6 +1,18 @@
 # Helm values for OpenChoreo Control Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the control plane in a k3d environment
 
+# Enable cluster gateway for agent-based communication
+clusterGateway:
+  enabled: true
+  service:
+    type: NodePort
+    port: 8443
+    nodePort: 30443  # Accessible from data plane via host.k3d.internal:30443
+
+controllerManager:
+  clusterGateway:
+    enabled: true
+
 openchoreoApi:
   ingress:
     enabled: true

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -1,6 +1,17 @@
 # Helm values for OpenChoreo Data Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the data plane in a k3d environment
 
+# Enable cluster agent for agent-based communication with control plane
+clusterAgent:
+  enabled: true
+  planeName: "default-data-plane"
+  # Gateway address uses host.k3d.internal to reach control plane cluster's NodePort
+  gatewayAddress: "host.k3d.internal:30443"
+  tls:
+    enabled: true
+    secretName: cluster-agent-tls
+  serverCANamespace: openchoreo-control-plane
+
 fluentBit:
   config:
     # OpenSearch connection for multi-cluster setup

--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -1,6 +1,14 @@
 # Helm values for OpenChoreo Control Plane in k3d single-cluster setup
 # This file contains overrides specific to running the control plane in a k3d environment
 
+# Enable cluster gateway for agent-based data plane communication
+clusterGateway:
+  enabled: true
+
+controllerManager:
+  clusterGateway:
+    enabled: true
+
 openchoreoApi:
   ingress:
     enabled: true

--- a/install/k3d/single-cluster/values-dp.yaml
+++ b/install/k3d/single-cluster/values-dp.yaml
@@ -14,3 +14,10 @@ gateway:
   # Use custom ports for single-cluster setup
   httpPort: 9080
   httpsPort: 9443
+
+# Cluster Agent configuration for single-cluster setup
+clusterAgent:
+  enabled: true
+  serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
+  planeName: default
+  planeType: dataplane

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -1,6 +1,15 @@
 # Helm values for OpenChoreo Control Plane in quick-start container
 # This file contains overrides for running the control plane in the quick-start k3d environment
 
+# Disable cluster gateway for quick-start (single-cluster mode)
+clusterGateway:
+  enabled: false
+
+# Disable cluster gateway integration in controller manager
+controllerManager:
+  clusterGateway:
+    enabled: false
+
 openchoreoApi:
   ingress:
     enabled: true

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -15,6 +15,10 @@ gateway:
   httpPort: 9080
   httpsPort: 9443
 
+# Disable cluster agent for quick-start (single-cluster mode)
+clusterAgent:
+  enabled: false
+
 networking:
   enabled: false
 


### PR DESCRIPTION
## Purpose

This pull request introduces agent-based communication for the data plane and adds a new `cluster-gateway` component to the Helm chart for secure connectivity between clusters. The main changes are the addition of agent mode to the data plane installation script and the complete Helm chart setup for the `cluster-gateway`, including RBAC, deployment, and certificate management. These changes improve security, simplify multi-cluster setups, and automate certificate handling for secure connections.

**Agent Mode for Data Plane Setup**
- Added support for agent-based communication to the `install/add-data-plane.sh` script, including new flags (`--enable-agent`, `--agent-ca-secret`, `--agent-ca-namespace`) and logic to generate the DataPlane manifest accordingly. This allows secure communication via a cluster agent and skips manual Kubernetes credential extraction. [[1]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L43-R52) [[2]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R80-R89) [[3]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R100-R102) [[4]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R111-R130) [[5]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L169-R214) [[6]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L185-R230) [[7]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R239-R281)

**Helm Chart: Cluster Gateway Component**
- Added `cluster-gateway` deployment, service account, RBAC (Role, RoleBinding, ClusterRole, ClusterRoleBinding), and helper template functions to the Helm chart, enabling secure, agent-based connectivity and proper access control for resources and secrets. [[1]](diffhunk://#diff-cc9be2ad96ae5dce5184683e0c3adbeabcc2810ffa6eec66d05ff25268f930b2R149-R166) [[2]](diffhunk://#diff-23a8c6e9a3264fa69964c0ec98f7fb413d3c2beb4f0aa0bcbab8b75398081a79R1-R22) [[3]](diffhunk://#diff-da602011f45a08dd326a1ae9f1683e61d2dcd5dba58edc997d42fe447fb6166cR1-R17) [[4]](diffhunk://#diff-e6fcc026ad685459d9fd53c05f1fe216287a269236d6bf57c97d7b9e444abec6R1-R26) [[5]](diffhunk://#diff-4a06a35e621b927f3459b048ddd33530f9db0e6cb51401356c12e61ac1c9e02dR1-R18) [[6]](diffhunk://#diff-a45d2be7e0c8d7a460e3ebfa78e9bb2c3215f5acc06e0f2b7f5b865fc287a7deR1-R89)

**Certificate Management Automation**
- Introduced Helm templates for automated certificate issuance (`issuer.yaml`, `certificate.yaml`) using cert-manager, and a CA extractor job (`ca-configmap.yaml`) to populate the CA ConfigMap from the generated secret, ensuring the cluster gateway has the correct CA for secure communication. [[1]](diffhunk://#diff-3077db231de60691c0cf847570bd631ff951a2a7e9cd3f183705e9d106cfc4abR1-R34) [[2]](diffhunk://#diff-b7742c1b043936ad19b4688b87b392dd547b4469872cebad7333b4c2c7d59e54R1-R17) [[3]](diffhunk://#diff-6c136cac03e206eb72a2bcf9f770d0f6f2661cff4397f13130d307a77dda6a8cR1-R112)

**Placeholder ConfigMap for CA Certificate**
- Added a placeholder ConfigMap (`ca-configmap-placeholder.yaml`) for the cluster gateway CA certificate, which is later populated by the CA extractor job. This ensures the controller manager can mount the CA certificate as soon as it is available.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
