### PR TITLE
Add OpenTelemetry collector to the observability plane for trace collection

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -14,8 +14,11 @@ dependencies:
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.140.0
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:5719357ff4581d3c4b5aa7f92ee6e130c3490f3625152196fb6f9c76cbcf55bb
-generated: "2025-11-21T08:32:18.094755+05:30"
+digest: sha256:58c0047a8b4ac997d7f527707203c2517daae1fec49d711b6bfe3d97c775fb42
+generated: "2025-11-27T23:03:57.998503+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -51,6 +51,10 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     version: 3.3.0
     condition: openSearch.enabled
+  - name: opentelemetry-collector
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    version: 0.140.0
+    condition: opentelemetry-collector.enabled
   - name: opensearch-dashboards
     alias: openSearchDashboards
     repository: https://opensearch-project.github.io/helm-charts/

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster-setup/job.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster-setup/job.yaml
@@ -48,5 +48,4 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: opensearch
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.installationMode "standard" }}
+{{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiCluster") }}
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
 metadata:
@@ -13,6 +13,10 @@ spec:
       requests:
         cpu: {{ .Values.openSearchCluster.bootstrap.resources.requests.cpu }}
         memory: {{ .Values.openSearchCluster.bootstrap.resources.requests.memory }}
+  dashboards:
+    enable: {{ .Values.openSearchCluster.dashboards.enable }}
+    version: {{ .Values.openSearchCluster.dashboards.version | quote }}
+    replicas: {{ .Values.openSearchCluster.dashboards.replicas }}
   general:
     serviceName: opensearch
     version: {{ .Values.openSearchCluster.general.version | quote }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/secrets.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.installationMode "standard" }}
+{{- if or (eq .Values.global.installationMode "singleCluster" ) (eq .Values.global.installationMode "multiCluster") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/helm/openchoreo-observability-plane/templates/opentelemetry-collector/configMap.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opentelemetry-collector/configMap.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentelemetry-collector-config
+  namespace: {{ .Release.Namespace }}
+data:
+  relay: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    exporters:
+      opensearch:
+        http:
+          auth:
+            authenticator: basicauth/opensearch
+          endpoint: https://opensearch.openchoreo-observability-plane.svc.cluster.local:9200
+          tls:
+            insecure_skip_verify: true
+        sending_queue:
+          num_consumers: {{ .Values.opentelemetryCollectorCustomizations.openSearchQueue.numConsumers }}
+          queue_size: {{ .Values.opentelemetryCollectorCustomizations.openSearchQueue.queueSize }}
+          sizer: {{ .Values.opentelemetryCollectorCustomizations.openSearchQueue.sizer }}
+        traces_index: "otel-traces"
+        traces_index_time_format: "yyyy-MM-dd"
+
+    extensions:
+      basicauth/opensearch:
+        client_auth: 
+          username: admin
+          password: ThisIsTheOpenSearchPassword1
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+  
+    processors:
+      {{- if eq .Values.global.installationMode "singleCluster" }}
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+
+        extract:
+          labels:
+            - key: openchoreo.dev/component-uid
+              tag_name: openchoreo.dev/component-uid
+            - key: openchoreo.dev/environment-uid
+              tag_name: openchoreo.dev/environment-uid
+            - key: openchoreo.dev/project-uid
+              tag_name: openchoreo.dev/project-uid
+            
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+      {{- end }}
+
+      tail_sampling:
+        decision_wait: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.decisionWait }}
+        num_traces: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.numTraces }}
+        expected_new_traces_per_sec: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.expectedNewTracesPerSec }}
+        decision_cache:
+          sampled_cache_size: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.decisionCache.sampledCacheSize }}
+          non_sampled_cache_size: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.decisionCache.nonSampledCacheSize }}
+        policies: [
+            {
+              name: rate_limiting,
+              type: rate_limiting,
+              rate_limiting: {spans_per_second: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.spansPerSecond }} }
+            },
+        ]
+
+    service:
+      extensions:
+        - basicauth/opensearch
+        - health_check
+      pipelines:
+        traces:
+          receivers:
+            - otlp
+          processors:
+            {{- if eq .Values.global.installationMode "singleCluster" }}
+            - k8sattributes
+            {{- end }}
+            - tail_sampling
+          exporters:
+            - opensearch

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -3,33 +3,15 @@ global:
   # Common labels to add to all resources
   commonLabels: {}
 
-  # Installation mode for the OpenChoreo Observability Plane
-  # standard: Operator managed OpenSearch cluster will be deployed
-  # minimal: Single replica OpenSearch instance will be deployed
-  installationMode: standard
-
-# Wait job configuration for post-install hooks
-waitJob:
-  image: bitnamilegacy/kubectl:1.32.4
-
-# External Secrets Operator configuration for secret management
-# Single cluster: Set to false to use data plane's ESO
-# Multi-cluster: Set to true to install dedicated ESO in observability plane
-external-secrets:
-  enabled: false
-  fullnameOverride: external-secrets
-  nameOverride: external-secrets
-
-# Fake Secret Store configuration for local development
-fakeSecretStore:
-  enabled: false
-  name: default
-  secrets:
-    - key: RCA_LLM_API_KEY
-      value: "fake-llm-api-key-for-development"
+  # Installation mode of OpenChoreo
+  # Supported values:
+  # singleCluster: When deploying all OpenChoreo planes in a single Kubernetes cluster
+  # multiCluster: When deploying OpenChoreo planes in multiple Kubernetes clusters (To be supported in the future)
+  # quickStart: Limited set of features for quick-start setup
+  installationMode: singleCluster
 
 data-prepper:
-  enabled: true
+  enabled: false
   fullnameOverride: "data-prepper"
 
   pipelineConfig:
@@ -46,9 +28,11 @@ data-prepper:
             batch_size: 200
         sink:
           - opensearch:
-              hosts: ["http://opensearch:9200"]
+              hosts: ["https://opensearch:9200"]
+              password: ThisIsTheOpenSearchPassword1
               insecure: true
-              index_type: trace-analytics-raw
+              index: otel-traces-%{yyyy-MM-dd}
+              username: admin
 
   resources:
     limits:
@@ -57,6 +41,73 @@ data-prepper:
     requests:
       cpu: 700m
       memory: 500Mi
+
+
+# External Secrets Operator configuration for secret management
+# Single cluster: Set to false to use data plane's ESO
+# Multi-cluster: Set to true to install dedicated ESO in observability plane
+external-secrets:
+  enabled: false
+  fullnameOverride: external-secrets
+  nameOverride: external-secrets
+
+
+# Fake Secret Store configuration for local development
+fakeSecretStore:
+  enabled: false
+  name: default
+  secrets:
+    - key: RCA_LLM_API_KEY
+      value: "fake-llm-api-key-for-development"
+
+
+opentelemetry-collector:
+  enabled: true
+  clusterRole:
+    create: true
+    rules:
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["list", "watch"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["list","watch"]
+      
+  configMap:
+    create: false
+    existingName: "opentelemetry-collector-config"
+  
+  fullnameOverride: "opentelemetry-collector"
+
+  image:
+    repository: otel/opentelemetry-collector-contrib
+
+  mode: deployment
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200Mi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+
+## opentelemetryCollectorCustomizations aren't passed to the opentelemetry-collector helm values file directly.
+# They are to be used by openchoreo specific templates
+opentelemetryCollectorCustomizations:
+  openSearchQueue:
+    numConsumers: 5
+    queueSize: 1000
+    sizer: items
+  tailSampling:
+    decisionWait: 10s
+    numTraces: 100
+    expectedNewTracesPerSec: 10
+    decisionCache:
+      sampledCacheSize: 10000
+      nonSampledCacheSize: 1000
+    spansPerSecond: 10
+
 
 openSearch:
   enabled: false
@@ -92,8 +143,8 @@ openSearchCluster:
     setVMMaxMapCount: true
     version: 3.3.0
 
-  dashboard:
-    enabled: false
+  dashboards:
+    enable: false
     replicas: 1
     version: 3.3.0
 
@@ -436,3 +487,7 @@ prometheus:
     enabled: false
   nodeExporter:
     enabled: false
+
+# Wait job configuration for post-install hooks
+waitJob:
+  image: bitnamilegacy/kubectl:1.32.4

--- a/install/k3d/dev/values-op.yaml
+++ b/install/k3d/dev/values-op.yaml
@@ -7,9 +7,9 @@ observer:
     tag: latest-dev
     pullPolicy: Never
 
-# Use minimal installation mode for dev
+# Use quickStart installation mode for dev
 global:
-  installationMode: minimal
+  installationMode: quickStart
 
 # OpenSearch configuration for dev
 openSearch:

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -3,18 +3,12 @@
 
 # Global values shared across all components
 global:
-  # Common labels to add to all resources
   commonLabels: {}
-
-  # Installation mode for the OpenChoreo Observability Plane
-  # standard: Operator managed OpenSearch cluster will be deployed
-  # minimal: Single replica OpenSearch instance will be deployed
-  installationMode: minimal
+  installationMode: quickStart
 
 
-data-prepper:
+opentelemetry-collector:
   enabled: false
-
 
 openSearch:
   enabled: true


### PR DESCRIPTION
## Purpose
Add OpenTelemetry collector to the Osbervability plane to collect traces

## Approach
1. Added opentelemetry-collector as a subchart of the openchoreo-observability-plane
2. Disabled the data-prepper and enabled the opentelemetry-collector by default
3. Added a default set of values and configurations to be passed to the opentelemetry-collector 
4. Added an OpenSearch Index Template to be used for tracing indices

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1033

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
