### PR TITLE
Disable cluster gateway for multi cluster setup

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -87,24 +87,7 @@ helm install openchoreo-observability-plane install/helm/openchoreo-observabilit
 
 ### 5. Create DataPlane Resource
 
-Create a DataPlane resource to enable workload deployment.
-
-**Using Cluster Agent (Recommended):**
-
-The cluster agent approach uses outbound WebSocket connections from the Data Plane to the Control Plane, eliminating the need for Control Plane to access Data Plane's Kubernetes API. This is the recommended approach for production deployments.
-
-```bash
-./install/add-data-plane.sh \
-  --enable-agent \
-  --control-plane-context k3d-openchoreo-cp \
-  --namespace default \
-  --agent-ca-namespace openchoreo-control-plane \
-  --name default
-```
-
-**Using Direct API Access (Alternative):**
-
-For simpler setups or when cluster agent is not available, you can use direct Kubernetes API access:
+Create a DataPlane resource to enable workload deployment:
 
 ```bash
 ./install/add-data-plane.sh \
@@ -126,19 +109,16 @@ Create a BuildPlane resource to enable building from source:
 
 ## Port Mappings
 
-| Plane               | Cluster           | Kube API Port | Port Range | Special Ports |
-|---------------------|-------------------|---------------|------------|---------------|
-| Control Plane       | k3d-openchoreo-cp | 6550          | 8xxx       | 30443 (Cluster Gateway NodePort) |
-| Data Plane          | k3d-openchoreo-dp | 6551          | 9xxx       | - |
-| Build Plane         | k3d-openchoreo-bp | 6552          | 10xxx      | - |
-| Observability Plane | k3d-openchoreo-op | 6553          | 11xxx      | - |
+| Plane               | Cluster           | Kube API Port | Port Range |
+|---------------------|-------------------|---------------|------------|
+| Control Plane       | k3d-openchoreo-cp | 6550          | 8xxx       |
+| Data Plane          | k3d-openchoreo-dp | 6551          | 9xxx       |
+| Build Plane         | k3d-openchoreo-bp | 6552          | 10xxx      |
+| Observability Plane | k3d-openchoreo-op | 6553          | 11xxx      |
 
 > [!NOTE]
 > Port ranges (e.g., 8xxx) indicate the ports exposed to your host machine for accessing services from that plane. Each
 > range uses ports like 8080 (HTTP) and 8443 (HTTPS) on localhost.
->
-> The Cluster Gateway (port 30443) is used by cluster agents in Data/Build Planes to establish WebSocket connections
-> to the Control Plane for agent-based communication.
 
 ## Access Services
 

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -1,18 +1,6 @@
 # Helm values for OpenChoreo Control Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the control plane in a k3d environment
 
-# Enable cluster gateway for agent-based communication
-clusterGateway:
-  enabled: true
-  service:
-    type: NodePort
-    port: 8443
-    nodePort: 30443  # Accessible from data plane via host.k3d.internal:30443
-
-controllerManager:
-  clusterGateway:
-    enabled: true
-
 openchoreoApi:
   ingress:
     enabled: true

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -1,17 +1,6 @@
 # Helm values for OpenChoreo Data Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the data plane in a k3d environment
 
-# Enable cluster agent for agent-based communication with control plane
-clusterAgent:
-  enabled: true
-  planeName: "default-data-plane"
-  # Gateway address uses host.k3d.internal to reach control plane cluster's NodePort
-  gatewayAddress: "host.k3d.internal:30443"
-  tls:
-    enabled: true
-    secretName: cluster-agent-tls
-  serverCANamespace: openchoreo-control-plane
-
 fluentBit:
   config:
     # OpenSearch connection for multi-cluster setup


### PR DESCRIPTION
## Purpose

Initially we will enable the cluster gateway for the single cluster and then in next release we support this for multi cluster

This pull request updates the OpenChoreo multi-cluster setup documentation and configuration files to simplify agent-based communication and remove references to deprecated gateway and agent settings. The changes streamline the recommended setup and clarify port mappings, making it easier to follow and maintain.

**Documentation and configuration simplification:**

* Removed detailed instructions and options for both agent-based and direct API access when creating a DataPlane resource in `README.md`, now presenting a single, simplified approach.
* Updated the port mapping table in `README.md` to remove the "Special Ports" column and the explanation for the Cluster Gateway, reflecting the removal of gateway-based communication.

**Configuration cleanup:**

* Removed `clusterGateway` and related agent-based communication settings from the Control Plane Helm values in `values-cp.yaml`.
* Removed `clusterAgent` and related gateway configuration from the Data Plane Helm values in `values-dp.yaml`.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
