### PR TITLE
Add cert-manager wait job for checking readiness in dataplane cert manager

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/cert-manager/wait-for-cert-manager-rbac.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cert-manager/wait-for-cert-manager-rbac.yaml
@@ -1,0 +1,50 @@
+{{- if ".Values.cert-manager.enabled" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-wait-sa
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-weight: "-11"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-wait-role
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-weight: "-11"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "endpoints" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "cert-manager.io" ]
+    resources: [ "issuers" ]
+    verbs: [ "get", "list", "create", "delete", "patch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-wait-rolebinding
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-weight: "-11"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-wait-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: cert-manager-wait-role
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/install/helm/openchoreo-data-plane/templates/cert-manager/wait-for-cert-manager.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cert-manager/wait-for-cert-manager.yaml
@@ -1,0 +1,111 @@
+{{- if ".Values.cert-anager.enabled" }}
+---
+# Job to wait for cert-manager webhook to be ready
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wait-for-cert-manager-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: wait-cert-manager
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: cert-manager-wait-sa
+      containers:
+      - name: wait-webhook
+        image: {{ .Values.waitJob.image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Waiting for cert-manager webhook to be ready ==="
+
+          retries=0
+          max_retries=60  # 5 minutes
+
+          # Wait for cert-manager webhook deployment to exist
+          until kubectl get deployment cert-manager-webhook -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for cert-manager-webhook deployment"
+              exit 1
+            fi
+            echo "Waiting for cert-manager-webhook deployment... ($retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ cert-manager-webhook deployment found"
+
+          # Wait for webhook to be ready
+          echo "Waiting for cert-manager-webhook to be ready..."
+          kubectl wait --for=condition=available \
+            deployment/cert-manager-webhook \
+            -n {{ .Release.Namespace }} \
+            --timeout=300s
+
+          echo "✓ cert-manager-webhook is ready"
+
+          # Additional wait for webhook endpoint to be available
+          echo "Waiting for webhook endpoint..."
+          retries=0
+          until kubectl get endpoints cert-manager-webhook -n {{ .Release.Namespace }} -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; do
+            retries=$((retries+1))
+            if [ $retries -gt 30 ]; then
+              echo "ERROR: Timeout waiting for webhook endpoint"
+              exit 1
+            fi
+            echo "Waiting for webhook endpoint... ($retries/30)"
+            sleep 2
+          done
+
+          echo "✓ Webhook endpoint is available"
+
+          # Wait for webhook to accept requests (TLS verification)
+
+          echo "Waiting for webhook TLS to be trusted by API server..."
+          retries=0
+          max_test_retries=60  # 2 minutes with 2s sleeps
+
+          while [ $retries -lt $max_test_retries ]; do
+            # Try to create a test issuer to verify webhook works
+            if kubectl apply -f - <<EOF 2>&1 | tee /tmp/test-result.txt && ! grep -q "error" /tmp/test-result.txt; then
+          apiVersion: cert-manager.io/v1
+          kind: Issuer
+          metadata:
+            name: test-webhook-validation
+            namespace: {{ .Release.Namespace }}
+          spec:
+            selfSigned: {}
+          EOF
+              echo "✓ Test issuer created successfully"
+              # Clean up test resource
+              kubectl delete issuer test-webhook-validation -n {{ .Release.Namespace }} --ignore-not-found=true
+              break
+            fi
+
+            retries=$((retries+1))
+            if [ $retries -ge $max_test_retries ]; then
+              echo "ERROR: Timeout waiting for webhook to accept requests"
+              echo "Last error:"
+              cat /tmp/test-result.txt
+              exit 1
+            fi
+            echo "Waiting for webhook TLS validation... ($retries/$max_test_retries)"
+            sleep 2
+          done
+
+          echo "✓ Webhook TLS is trusted and operational"
+          echo ""
+          echo "=== cert-manager is fully ready! ==="
+{{- end }}


### PR DESCRIPTION
## Purpose
This PR adds a post installation hook for checking the readiness of the cert manager in the dataplane.

Related to https://github.com/openchoreo/openchoreo/pull/1053
