### PR TITLE
Add opensearch-operator to the observability helm chart

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -14,11 +14,14 @@ dependencies:
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
+- name: opensearch-operator
+  repository: https://opensearch-project.github.io/opensearch-k8s-operator/
+  version: 2.8.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.140.0
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:58c0047a8b4ac997d7f527707203c2517daae1fec49d711b6bfe3d97c775fb42
-generated: "2025-11-27T23:03:57.998503+05:30"
+digest: sha256:cb2b072e21e8ba5aa3acaabad2f4791eda610ca252c9602d05a10fd899ecb73c
+generated: "2025-11-30T06:13:41.983379+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -51,6 +51,10 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     version: 3.3.0
     condition: openSearch.enabled
+  - name: opensearch-operator
+    repository: https://opensearch-project.github.io/opensearch-k8s-operator/
+    version: 2.8.0
+    condition: opensearch-operator.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     version: 0.140.0

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
@@ -1,9 +1,12 @@
-{{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiCluster") }}
+{{- if and (or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiCluster")) (index .Values "opensearch-operator" "enabled") }}
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
 metadata:
   name: opensearch
   namespace: openchoreo-observability-plane
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   bootstrap:
     resources:

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/secrets.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.installationMode "singleCluster" ) (eq .Values.global.installationMode "multiCluster") }}
+{{- if and (or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiCluster")) (index .Values "opensearch-operator" "enabled") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -10,6 +10,11 @@ global:
   # quickStart: Limited set of features for quick-start setup
   installationMode: singleCluster
 
+opensearch-operator:
+  # This must be enabled for `singleCluster` and `multiCluster` installation modes
+  enabled: true
+  fullnameOverride: "opensearch-operator"
+
 data-prepper:
   enabled: false
   fullnameOverride: "data-prepper"

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -59,6 +59,7 @@ helm install openchoreo-observability-plane install/helm/openchoreo-observabilit
   --kube-context k3d-openchoreo \
   --namespace openchoreo-observability-plane \
   --create-namespace \
+  --timeout 15m \
   --values install/k3d/single-cluster/values-op.yaml
 ```
 

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -6,6 +6,8 @@ global:
   commonLabels: {}
   installationMode: quickStart
 
+opensearch-operator:
+  enabled: false
 
 opentelemetry-collector:
   enabled: false


### PR DESCRIPTION
## Purpose
Add opensearach-operator as a dependency to the observability helm chart.

- This will be enabled by default as we need to enable it for singleCluster and multiCluster installation topologies.
- Will be disabled for the quick-start

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
