### PR TITLE
Add setVMMaxMapCount parameter to OpenSearch cluster

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
@@ -23,6 +23,7 @@ spec:
   general:
     serviceName: opensearch
     version: {{ .Values.openSearchCluster.general.version | quote }}
+    setVMMaxMapCount: {{ .Values.openSearchCluster.general.setVMMaxMapCount }}
   nodePools:
   - component: data
     diskSize: {{ .Values.openSearchCluster.nodePools.data.diskSize }}


### PR DESCRIPTION
## Purpose
OpenSearch cluster requires the vm.max_map_count to be increased otherwise it wont start correctly.
<img width="2628" height="474" alt="image" src="https://github.com/user-attachments/assets/d5ac769f-6ffb-4e82-b22d-c2f456990136" />

Changes from this PR is to refer to the `setVMMaxMapCount` config introduced to observability-plane helm chart into the opensearchcluster values.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
