### PR TITLE
Add helm hooks to ensure default resources are created after controller is ready

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/scheduled-task.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/scheduled-task.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: default
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   workloadType: cronjob
 

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: default
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   workloadType: deployment
 

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: default
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   workloadType: deployment
 

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/ballerina-buildpack.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/ballerina-buildpack.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.defaultResources.enabled }}
 apiVersion: openchoreo.dev/v1alpha1
 kind: ComponentWorkflow
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Ballerina build workflow for containerized builds using Ballerina Buildpack"
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   # Schema definition for component workflows
   schema:
@@ -55,3 +58,4 @@ spec:
       workflowTemplateRef:
         clusterScope: true
         name: ballerina-buildpack
+{{ end }}

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/docker.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/docker.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.defaultResources.enabled }}
 apiVersion: openchoreo.dev/v1alpha1
 kind: ComponentWorkflow
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Docker build workflow for containerized builds using Dockerfile"
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   # Schema definition for component workflows
   schema:
@@ -63,3 +66,4 @@ spec:
       workflowTemplateRef:
         clusterScope: true
         name: docker
+{{ end }}

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/google-cloud-buildpacks.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/google-cloud-buildpacks.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.defaultResources.enabled }}
 apiVersion: openchoreo.dev/v1alpha1
 kind: ComponentWorkflow
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Google Cloud Buildpacks workflow for containerized builds"
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   # Schema definition for component workflows
   schema:
@@ -55,3 +58,4 @@ spec:
       workflowTemplateRef:
         clusterScope: true
         name: google-cloud-buildpacks
+{{ end }}

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/react.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-workflows/react.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.defaultResources.enabled }}
 apiVersion: openchoreo.dev/v1alpha1
 kind: ComponentWorkflow
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Build workflow for React web applications"
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "7"
 spec:
   # Schema definition for component workflows
   schema:
@@ -59,3 +62,4 @@ spec:
       workflowTemplateRef:
         clusterScope: true
         name: react
+{{ end }}

--- a/install/helm/openchoreo-control-plane/templates/default-resources/wait-for-controller-hook-sa.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/wait-for-controller-hook-sa.yaml
@@ -5,8 +5,9 @@ kind: ServiceAccount
 metadata:
   name: controller-wait-sa
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,8 +15,9 @@ kind: Role
 metadata:
   name: controller-wait-role
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
@@ -27,8 +29,9 @@ kind: RoleBinding
 metadata:
   name: controller-wait-rolebinding
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount

--- a/make/k3d.mk
+++ b/make/k3d.mk
@@ -190,7 +190,6 @@ k3d.install.control-plane: ## Install Control Plane
 		--values $(K3D_DEV_DIR)/values-cp.yaml \
 		--kube-context k3d-$(K3D_CLUSTER_NAME) \
 		--create-namespace \
-		--wait \
 		--timeout=10m
 	@$(call log_success, Control Plane installed!)
 
@@ -203,7 +202,6 @@ k3d.install.data-plane: ## Install Data Plane
 		--values $(K3D_DEV_DIR)/values-dp.yaml \
 		--kube-context k3d-$(K3D_CLUSTER_NAME) \
 		--create-namespace \
-		--wait \
 		--timeout=10m
 	@$(call log_success, Data Plane installed!)
 	@$(call log_info, Setting up default DataPlane resource...)
@@ -239,7 +237,6 @@ k3d.install.build-plane: ## Install Build Plane
 		--values $(K3D_DEV_DIR)/values-bp.yaml \
 		--kube-context k3d-$(K3D_CLUSTER_NAME) \
 		--create-namespace \
-		--wait \
 		--timeout=10m
 	@$(call log_success, Build Plane installed!)
 	@$(call log_info, Setting up default BuildPlane resource...)
@@ -263,7 +260,6 @@ k3d.install.observability-plane: ## Install Observability Plane
 		--values $(K3D_DEV_DIR)/values-op.yaml \
 		--kube-context k3d-$(K3D_CLUSTER_NAME) \
 		--create-namespace \
-		--wait \
 		--timeout=10m
 	@$(call log_success, Observability Plane installed!)
 


### PR DESCRIPTION
## Purpose
- Add helm hook annotations to ComponentType and ComponentWorkflow resources with weight "7" to ensure they are created after the
controller is ready (weight "6")
- Update wait-for-controller-hook SA/Role/RoleBinding to also run on `post-upgrade`
- Wrap ComponentWorkflow resources with `defaultResources.enabled` conditional
- Remove `--wait` flag from k3d helm install commands (hooks handle ordering)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
