### PR TITLE
Fix intermittent OpenSearchCluster CRD race condition in obs-plane

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-failed
 spec:
   bootstrap:
     resources:


### PR DESCRIPTION
## Purpose

### Problem
The observability-plane Helm chart installation fails intermittently with the following error:

```text
Error: INSTALLATION FAILED: failed post-install: unable to build kubernetes object for deleting hook
openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml: resource mapping
not found for name: "opensearch" namespace: "openchoreo-observability-plane" from "": no matches for
kind "OpenSearchCluster" in version "opensearch.opster.io/v1"
ensure CRDs are installed first
```

### Root Cause

The `OpenSearchCluster` resource is defined as a `post-install` hook without an explicit delete policy.
Helm's default behavior sets `before-hook-creation` as the delete policy, which means:

1. Before creating the hook resource, Helm attempts to delete any existing resource with the same name
2. To check if the resource exists, Helm builds the Kubernetes object from the manifest
3. Building the object requires the API server to recognize the `OpenSearchCluster` CRD

However, there's a timing gap between when:
- The CRD is installed and passes Helm's wait check
- The Kubernetes API server fully registers the CRD for API discovery

This creates a race condition that manifests inconsistently depending on API server performance.

## Approach
Set an explicit `hook-delete-policy: hook-failed` on the OpenSearchCluster resource. This:

- Prevents the before-hook-creation deletion attempt (avoiding the CRD lookup)
- Keeps the OpenSearchCluster resource after successful creation
- Cleans up the resource automatically if creation fails

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
