### PR TITLE
Fix gateway crashloopbackoff with rosetta emulation for mac users

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway-patch-job.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway-patch-job.yaml
@@ -1,0 +1,79 @@
+{{- if and .Values.gateway.enabled .Values.gateway.envoy.mountTmpVolume }}
+---
+# Job to patch gateway deployment with /tmp volume mount
+# This fixes Envoy crash on macOS with Rosetta/Colima. Ref: https://github.com/kgateway-dev/kgateway/issues/9800
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-gateway-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: gateway-patcher
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: gateway-patcher-sa
+      containers:
+      - name: patch-deployment
+        image: {{ .Values.waitJob.image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Patching gateway-default deployment with /tmp volume ==="
+
+          # Wait for deployment to exist
+          retries=0
+          max_retries=60
+          until kubectl get deployment gateway-default -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for gateway-default deployment"
+              exit 1
+            fi
+            echo "Waiting for gateway-default deployment... ($retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ gateway-default deployment found"
+
+          # Check if tmp volume already exists
+          if kubectl get deployment gateway-default -n {{ .Release.Namespace }} -o jsonpath='{.spec.template.spec.volumes[?(@.name=="tmp")]}' | grep -q "tmp"; then
+            echo "✓ /tmp volume already mounted, skipping patch"
+            exit 0
+          fi
+
+          echo "Applying patch to add /tmp volume..."
+
+          # Apply the patch
+          kubectl patch deployment gateway-default -n {{ .Release.Namespace }} --type='json' -p='[
+            {
+              "op": "add",
+              "path": "/spec/template/spec/volumes/-",
+              "value": {"name": "tmp", "emptyDir": {}}
+            },
+            {
+              "op": "add",
+              "path": "/spec/template/spec/containers/0/volumeMounts/-",
+              "value": {"name": "tmp", "mountPath": "/tmp"}
+            }
+          ]'
+
+          echo "✓ Patch applied successfully"
+
+          # Wait for new pods to be ready
+          echo "Waiting for gateway pod to be ready..."
+          kubectl rollout status deployment/gateway-default -n {{ .Release.Namespace }} --timeout=300s
+
+          echo "✓ Gateway deployment is ready"
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway-patch-rbac.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway-patch-rbac.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.gateway.enabled .Values.gateway.envoy.mountTmpVolume }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-patcher-sa
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "9"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-patcher-role
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "9"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments/status" ]
+    verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-patcher-rolebinding
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "9"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: gateway-patcher-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: gateway-patcher-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -4,10 +4,13 @@ kind: Gateway
 metadata:
   name: gateway-default
   namespace: {{ .Release.Namespace }}
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
   annotations:
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
     cert-manager.io/cluster-issuer: {{ .Values.gateway.tls.clusterIssuer | default "openchoreo-selfsigned-issuer" }}
 {{- end }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation
   labels:
     {{- include "openchoreo-data-plane.componentLabels" (dict "context" . "component" "gateway") | nindent 4 }}
 spec:

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -79,6 +79,10 @@ gateway:
   # Envoy - enabled by default for traffic routing
   envoy:
     enabled: true
+    # Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues
+    # Enable this if gateway pods crash with "Failed to create temporary file" errors
+    # Common on: macOS with Docker Desktop/Colima with Rosetta enabled.
+    mountTmpVolume: false
 
   # Image configuration
   image:

--- a/install/k3d/dev/values-dp.yaml
+++ b/install/k3d/dev/values-dp.yaml
@@ -12,3 +12,12 @@ gateway:
   # Use custom ports for k3d dev
   httpPort: 9080
   httpsPort: 9443
+
+  # Envoy - enabled by default for traffic routing
+  envoy:
+    enabled: true
+    # Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues
+    # Enable this if gateway pods crash with "Failed to create temporary file" errors
+    # Common on: macOS with Docker Desktop/Colima with Rosetta enabled.
+    # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
+    mountTmpVolume: true

--- a/install/k3d/single-cluster/values-dp.yaml
+++ b/install/k3d/single-cluster/values-dp.yaml
@@ -15,6 +15,15 @@ gateway:
   httpPort: 9080
   httpsPort: 9443
 
+  # Envoy - enabled by default for traffic routing
+  envoy:
+    enabled: true
+    # Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues
+    # Enable this if gateway pods crash with "Failed to create temporary file" errors
+    # Common on: macOS with Docker Desktop/Colima with Rosetta enabled.
+    # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
+    mountTmpVolume: true
+
 # Cluster Agent configuration for single-cluster setup
 clusterAgent:
   enabled: true

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -14,6 +14,14 @@ gateway:
   enabled: true
   httpPort: 9080
   httpsPort: 9443
+  # Envoy - enabled by default for traffic routing
+  envoy:
+    enabled: true
+    # Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues
+    # Enable this if gateway pods crash with "Failed to create temporary file" errors
+    # Common on: macOS with Docker Desktop/Colima with Rosetta enabled.
+    # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
+    mountTmpVolume: true
 
 # Disable cluster agent for quick-start (single-cluster mode)
 clusterAgent:


### PR DESCRIPTION
## Purpose
> With the current setup, Mac users who are using colima, rancher desktop or docker desktop with rosetta emulation enabled will face the issue of gateway proxy going to crashloopbackoff state due to the issue in https://github.com/kgateway-dev/kgateway/issues/9800.

## Approach
> Add an emptydir volume to the gateway proxy to fix the issue.

## Related Issues
> https://github.com/kgateway-dev/kgateway/issues/9800

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> This is only happening for Mac users with rosetta enabled.
