### PR TITLE
Remove label validation from project webhook

### DIFF
--- a/internal/webhook/project/webhook.go
+++ b/internal/webhook/project/webhook.go
@@ -6,7 +6,6 @@ package project
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
-	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
 // nolint:unused
@@ -49,7 +47,6 @@ var _ webhook.CustomDefaulter = &Defaulter{}
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Project.
 func (d *Defaulter) Default(ctx context.Context, obj runtime.Object) error {
 	project, ok := obj.(*openchoreov1alpha1.Project)
-
 	if !ok {
 		return fmt.Errorf("expected an Project object but got %T", obj)
 	}
@@ -86,12 +83,6 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	if err := v.validateProjectCommon(ctx, project); err != nil {
 		return nil, err
 	}
-
-	// Check whether project already exists using the lable name
-	if err := v.ensureNoDuplicateProjectInOrganization(ctx, project); err != nil {
-		return nil, err
-	}
-
 	return nil, nil
 }
 
@@ -102,7 +93,6 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 		return nil, fmt.Errorf("expected a Project object for the newObj but got %T", newObj)
 	}
 	projectlog.Info("Validation for Project upon update", "name", project.GetName())
-
 	if err := v.validateProjectCommon(ctx, project); err != nil {
 		return nil, err
 	}
@@ -123,101 +113,21 @@ func (v *Validator) ValidateDelete(ctx context.Context, obj runtime.Object) (adm
 }
 
 func (v *Validator) validateProjectCommon(ctx context.Context, project *openchoreov1alpha1.Project) error {
-	// First validate the required labels for the Project resource.
-	if err := validateProjectLabels(project); err != nil {
-		return err
-	}
-
-	// Validate that the name label matches the project's name
-	projectName := project.Labels[labels.LabelKeyName]
-	if projectName != project.Name {
-		return fmt.Errorf("project name '%s' does not match with the name label '%s'",
-			project.Name, projectName)
-	}
-
-	// Validate that the organization label matches the project's namespace
-	orgName := project.Labels[labels.LabelKeyOrganizationName]
-	if orgName != project.Namespace {
-		return fmt.Errorf("project namespace '%s' does not match with the organization label '%s'",
-			project.Namespace, orgName)
-	}
-
-	// Check whether the deploymentPipelineRef: <name> exists in the namespace
 	if err := v.ensureDeploymentPipelineExists(ctx, project.Spec.DeploymentPipelineRef, project); err != nil {
 		return err
 	}
-
-	return nil
-}
-
-// validateProjectLabels validates the required labels for the Project resource.
-func validateProjectLabels(project *openchoreov1alpha1.Project) error {
-	requiredLabels := []string{
-		labels.LabelKeyOrganizationName,
-		labels.LabelKeyName,
-	}
-
-	var missingLabels []string
-	for _, label := range requiredLabels {
-		if _, exists := project.Labels[label]; !exists {
-			missingLabels = append(missingLabels, label)
-		}
-	}
-
-	if len(missingLabels) > 0 {
-		return fmt.Errorf("required labels missing for the project '%s': %s", project.Name, strings.Join(missingLabels, ", "))
-	}
-
 	return nil
 }
 
 // ensureDeploymentPipelineExists checks whether the deployment pipeline specified in the project exists in the namespace.
 func (v *Validator) ensureDeploymentPipelineExists(ctx context.Context, pipelineName string, project *openchoreov1alpha1.Project) error {
-	pipelineList := &openchoreov1alpha1.DeploymentPipelineList{}
-
-	// Define label selector
-	listOpts := []client.ListOption{
-		client.InNamespace(project.Namespace),
-		client.MatchingLabels{
-			labels.LabelKeyName: pipelineName,
-		},
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{}
+	pipelineKey := client.ObjectKey{
+		Name:      pipelineName,
+		Namespace: project.Namespace,
 	}
-
-	// Get the deployment pipeline object from the namespace
-	if err := v.client.List(ctx, pipelineList, listOpts...); err != nil {
-		return fmt.Errorf("failed to get deployment pipeline '%s' specified in project '%s': %w", pipelineName, project.Labels[labels.LabelKeyName], err)
+	if err := v.client.Get(ctx, pipelineKey, pipeline); err != nil {
+		return fmt.Errorf("deployment pipeline '%s' specified in project '%s' not found: %w", pipelineName, project.Name, err)
 	}
-
-	// Check whether the deployment pipeline exists
-	if len(pipelineList.Items) == 0 {
-		return fmt.Errorf("deployment pipeline '%s' specified in project '%s' not found", pipelineName, project.Labels[labels.LabelKeyName])
-	}
-
-	return nil
-}
-
-func (v *Validator) ensureNoDuplicateProjectInOrganization(ctx context.Context, project *openchoreov1alpha1.Project) error {
-	// Create a list to hold the projects
-	projectList := &openchoreov1alpha1.ProjectList{}
-
-	// Define label selector
-	listOpts := []client.ListOption{
-		client.InNamespace(project.Namespace),
-		client.MatchingLabels{
-			labels.LabelKeyName:             project.Labels[labels.LabelKeyName],
-			labels.LabelKeyOrganizationName: project.Labels[labels.LabelKeyOrganizationName],
-		},
-	}
-
-	// List all projects with the specified label
-	if err := v.client.List(ctx, projectList, listOpts...); err != nil {
-		return fmt.Errorf("failed to get project '%s' specified in label '%s': %w", project.Labels[labels.LabelKeyName], labels.LabelKeyName, err)
-	}
-
-	// Check whether the project exists
-	if len(projectList.Items) > 0 {
-		return fmt.Errorf("project '%s' specified in label '%s' already exists in organization '%s'", project.Labels[labels.LabelKeyName], labels.LabelKeyName, project.Labels[labels.LabelKeyOrganizationName])
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Purpose
> An admission webhook for the Project CRD existed but had been disabled and was recently re-enabled. However, the label-validation logic it used has since been deprecated and is now redundant. This PR removes the obsolete validation logic.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
