### PR TITLE
Fix multi cluster setup gateway HTTPS listener issue with cert manager 

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/gateway/clusterissuer.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/clusterissuer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gateway.enabled }}
-{{- if index .Values "cert-manager" "enabled" }}
+{{- if or (index .Values "cert-manager" "enabled") (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gateway-default
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if index .Values "cert-manager" "enabled" }}
+{{- if or (index .Values "cert-manager" "enabled") (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
     cert-manager.io/cluster-issuer: {{ .Values.gateway.tls.clusterIssuer | default "openchoreo-selfsigned-issuer" }}
 {{- end }}
     helm.sh/hook: post-install,post-upgrade
@@ -22,7 +22,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-{{- if index .Values "cert-manager" "enabled" }}
+{{- if or (index .Values "cert-manager" "enabled") (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
     - name: https
       protocol: HTTPS
       port: {{ .Values.gateway.httpsPort | default 443 }}


### PR DESCRIPTION
## Purpose
This PR fixes the issue with multi cluster certificate management. Previously we have used `.Capabilities.APIVersions.Has "cert-manager.io/v1"` variable to decide whether to add a HTTPS listener or not. This works for single cluster scenarios as the control plane cert manager is already there when we deploy the dataplane. The capabilities check happens at the helm template rendering phase before the installation. The issue with this approach is for multi cluster, we install the cert manager in the dataplane helm chart. During the dataplane installation, helm render ignores the HTTPS listener as the K8s API server is not aware of the cert manager CRDs by that time. This PR fixes the issue by considering both `or (index .Values "cert-manager" "enabled") (.Capabilities.APIVersions.Has "cert-manager.io/v1")`.
