### PR TITLE
Add command to install single cluster Observability plane without HA

### DIFF
--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -54,9 +54,8 @@ helm install openchoreo-build-plane install/helm/openchoreo-build-plane \
   --values install/k3d/single-cluster/values-bp.yaml
 
 # Observability Plane (optional)
-## OpenSearch Kubernetes Operator (Prerequisite)
 
-### Non-HA mode
+## Non-HA mode
 helm install openchoreo-observability-plane install/helm/openchoreo-observability-plane \
   --dependency-update \
   --kube-context k3d-openchoreo \
@@ -67,7 +66,9 @@ helm install openchoreo-observability-plane install/helm/openchoreo-observabilit
   --set openSearch.enabled=true \
   --set openSearchCluster.enabled=false \
 
-### HA mode
+## HA mode
+
+### OpenSearch Kubernetes Operator (Prerequisite)
 helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 
 helm repo update


### PR DESCRIPTION
## Purpose
The default values file of the single cluster Observability plane deploys an OpenSearch cluster. This requires more resources as it runs with high availability enabled. This PR adds a helm command with overrides to disable the OpenSearch cluster and deploy a single replica OpenSearch

## Approach
Override the values file to enable the OpenSearch deployment and disable the operator based OpenSearch cluster deployment

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1050

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
