### PR TITLE
Update DataPlane API response with cluster-agent configuration support

### DIFF
--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -177,8 +177,9 @@ type DataPlaneResponse struct {
 	Description             string    `json:"description,omitempty"`
 	ImagePullSecretRefs     []string  `json:"imagePullSecretRefs,omitempty"`
 	SecretStoreRef          string    `json:"secretStoreRef,omitempty"`
+	AgentEnabled            bool      `json:"agentEnabled,omitempty"`
 	KubernetesClusterName   string    `json:"kubernetesClusterName"`
-	APIServerURL            string    `json:"apiServerURL"`
+	APIServerURL            string    `json:"apiServerURL,omitempty"`
 	PublicVirtualHost       string    `json:"publicVirtualHost"`
 	OrganizationVirtualHost string    `json:"organizationVirtualHost"`
 	ObserverURL             string    `json:"observerURL,omitempty"`

--- a/internal/openchoreo-api/services/dataplane_service.go
+++ b/internal/openchoreo-api/services/dataplane_service.go
@@ -219,6 +219,19 @@ func (s *DataPlaneService) toDataPlaneResponse(dp *openchoreov1alpha1.DataPlane)
 		secretStoreRef = dp.Spec.SecretStoreRef.Name
 	}
 
+	// Extract agent configuration
+	var agentEnabled bool
+	if dp.Spec.Agent != nil {
+		agentEnabled = dp.Spec.Agent.Enabled
+	}
+
+	// Extract KubernetesCluster fields if present (optional when agent mode is enabled)
+	// TODO: Implement a generic reflection-based utility function to handle extraction of values
+	var apiServerURL string
+	if dp.Spec.KubernetesCluster != nil {
+		apiServerURL = dp.Spec.KubernetesCluster.Server
+	}
+
 	response := &models.DataPlaneResponse{
 		Name:                    dp.Name,
 		Namespace:               dp.Namespace,
@@ -226,8 +239,9 @@ func (s *DataPlaneService) toDataPlaneResponse(dp *openchoreov1alpha1.DataPlane)
 		Description:             description,
 		ImagePullSecretRefs:     dp.Spec.ImagePullSecretRefs,
 		SecretStoreRef:          secretStoreRef,
+		AgentEnabled:            agentEnabled,
 		KubernetesClusterName:   dp.Name,
-		APIServerURL:            dp.Spec.KubernetesCluster.Server,
+		APIServerURL:            apiServerURL,
 		PublicVirtualHost:       dp.Spec.Gateway.PublicVirtualHost,
 		OrganizationVirtualHost: dp.Spec.Gateway.OrganizationVirtualHost,
 		CreatedAt:               dp.CreationTimestamp.Time,


### PR DESCRIPTION
## Purpose

Update DataPlane API to include cluster-agent configuration and handle optional fields when cluster-agent mode is enabled.

## Changes

  - Add `AgentEnabled` field to `DataPlaneResponse` to expose cluster-agent configuration
  - Handle optional `KubernetesCluster` field with nil checks (optional when cluster-agent mode is enabled)
  - Make `APIServerURL` field optional in response model (add `omitempty` tag)
  - Add TODO comment for future generic reflection-based utility to handle optional pointer fields

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/705

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
