### PR TITLE
Create a global security configuration for openchoreo

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -72,9 +72,9 @@ spec:
           value: {{ .Values.backstage.thunder.token | quote }}
         {{- end }}
         - name: OPENCHOREO_AUTH_AUTHORIZATION_URL
-          value: {{ .Values.backstage.auth.authorizationUrl | default (printf "%s/oauth2/authorize" (.Values.backstage.thunder.baseUrl | default (printf "http://%s-asgardeo-thunder.%s.svc.cluster.local:%d" (include "openchoreo-control-plane.fullname" .) .Release.Namespace (.Values.asgardeoThunder.service.port | int)))) }}
+          value: {{ .Values.security.oidc.authorizationUrl }}
         - name: OPENCHOREO_AUTH_TOKEN_URL
-          value: {{ .Values.backstage.auth.tokenUrl | default (printf "http://%s-asgardeo-thunder.%s.svc.cluster.local:%d/oauth2/token" (include "openchoreo-control-plane.fullname" .) .Release.Namespace (.Values.asgardeoThunder.service.port | int)) }}
+          value: {{ .Values.security.oidc.tokenUrl }}
         {{- if .Values.asgardeoThunder.backstagePortal.enabled }}
         - name: OPENCHOREO_AUTH_CLIENT_ID
           value: {{ .Values.asgardeoThunder.backstagePortal.clientId | quote }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -55,13 +55,13 @@ spec:
         - name: MCP_TOOLSETS
           value: {{ .Values.openchoreoApi.mcp.toolsets | quote }}
         - name: JWT_ISSUER
-          value: {{ .Values.openchoreoApi.jwt.issuer | quote }}
+          value: {{ .Values.security.oidc.issuer | quote }}
         - name: JWKS_URL
-          value: {{ .Values.openchoreoApi.jwt.jwksUrl | quote }}
+          value: {{ .Values.security.oidc.jwksUrl | quote }}
         - name: JWT_AUDIENCE
-          value: {{ .Values.openchoreoApi.jwt.audience | quote }}
+          value: {{ .Values.security.jwt.audience | quote }}
         - name: JWT_DISABLED
-          value: "{{ .Values.openchoreoApi.jwt.disabled }}"
+          value: "{{ not .Values.security.enabled }}"
         livenessProbe:
           httpGet:
             path: /health

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -43,6 +43,24 @@ global:
               requiresApproval: false
 # Override the full name of the chart release
 fullnameOverride: openchoreo
+# Common security configuration shared across all components
+security:
+  # Global security toggle - when disabled, authentication is turned off for all components
+  enabled: false
+  oidc:
+    # OIDC issuer URL - typically the identity provider's base URL
+    issuer: ""
+    # OIDC well-known configuration endpoint (auto-constructed from issuer if not set)
+    wellKnownEndpoint: ""
+    # JWKS URL for JWT signature verification (auto-constructed from issuer if not set)
+    jwksUrl: ""
+    # OAuth2 authorization endpoint
+    authorizationUrl: ""
+    # OAuth2 token endpoint
+    tokenUrl: ""
+  jwt:
+    # Expected audience claim in JWT tokens
+    audience: ""
 controllerManager:
   name: controller-manager
   replicas: 1
@@ -186,11 +204,6 @@ openchoreoApi:
     pullPolicy: IfNotPresent
   mcp:
     toolsets: "organization,project,component,build,deployment,infrastructure"
-  jwt:
-    disabled: true
-    issuer: ""
-    jwksUrl: ""
-    audience: ""
   resources:
     requests:
       cpu: "200m"
@@ -364,9 +377,6 @@ backstage:
   thunder:
     baseUrl: ""
     token: ""
-  auth:
-    authorizationUrl: ""
-    tokenUrl: ""
   autoscaling:
     enabled: false
     minReplicas: 1

--- a/install/k3d/dev/values-cp.yaml
+++ b/install/k3d/dev/values-cp.yaml
@@ -19,8 +19,6 @@ openchoreoApi:
   containerSecurityContext:
     appArmorProfile:
       type: Unconfined
-  jwt:
-    disabled: true
 
 # Disable UI and auth for dev
 backstage:

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -1,6 +1,11 @@
 # Helm values for OpenChoreo Control Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the control plane in a k3d environment
 
+# Common security configuration
+security:
+  oidc:
+    authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
+
 openchoreoApi:
   ingress:
     enabled: true
@@ -19,8 +24,6 @@ backstage:
           - path: /
             pathType: Prefix
   baseUrl: http://openchoreo.localhost:8080
-  auth:
-    authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
 
 asgardeoThunder:
   ingress:

--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -1,6 +1,11 @@
 # Helm values for OpenChoreo Control Plane in k3d single-cluster setup
 # This file contains overrides specific to running the control plane in a k3d environment
 
+# Common security configuration
+security:
+  oidc:
+    authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
+
 # Enable cluster gateway for agent-based data plane communication
 clusterGateway:
   enabled: true
@@ -27,8 +32,6 @@ backstage:
           - path: /
             pathType: Prefix
   baseUrl: http://openchoreo.localhost:8080
-  auth:
-    authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
 
 asgardeoThunder:
   ingress:


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/664

This pull request introduces a significant refactor of the authentication and security configuration for the OpenChoreo control plane Helm charts. The main change is the centralization of security and OIDC/JWT settings into a new global `security` section, simplifying configuration and improving consistency across all components. Component-specific authentication settings have been removed in favor of referencing the global security configuration. The changes also update development and multi-cluster environment values files to use the new security structure.

**Centralization of Security Configuration:**

* Added a new global `security` section in `values.yaml` with options for enabling/disabling authentication, OIDC endpoints, and JWT claims, replacing previous component-scoped settings.

**Refactoring Component Environment Variables:**

* Updated environment variable references in `openchoreo-api/deployment.yaml` to use values from the global `security` section instead of `openchoreoApi.jwt`, and changed how JWT disabling is handled.
* Updated environment variable references in `backstage/deployment.yaml` to use values from the global `security.oidc` section instead of `backstage.auth`.

**Cleanup of Deprecated Component Settings:**

* Removed the old `jwt` section from `openchoreoApi` and the `auth` section from `backstage` in `values.yaml`, as these are now handled globally. [[1]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L189-L193) [[2]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L367-L369)

**Updates for Development and Multi-Cluster Environments:**

* Updated `values-cp.yaml` files for k3d dev, single-cluster, and multi-cluster setups to use the new global `security` configuration, and removed legacy `jwt` and `auth` settings from component sections. [[1]](diffhunk://#diff-7ca242e010454f8c10920fc21dced5386f352a0f13824a86d07af6c097180d35R4-R7) [[2]](diffhunk://#diff-7ca242e010454f8c10920fc21dced5386f352a0f13824a86d07af6c097180d35L22-L23) [[3]](diffhunk://#diff-23c73f915556aa1475d1f2ca87686cebf1f2e3b33baf85f4154ccec564f60331R4-R8) [[4]](diffhunk://#diff-23c73f915556aa1475d1f2ca87686cebf1f2e3b33baf85f4154ccec564f60331L22-L23) [[5]](diffhunk://#diff-fde84ce95e655883843fa9b6e6b406caeb78f9505babd2de8483a25799cb5babR4-R8) [[6]](diffhunk://#diff-fde84ce95e655883843fa9b6e6b406caeb78f9505babd2de8483a25799cb5babL30-L31)