### PR TITLE
Invert schema default validation to be safe-by-default

### DIFF
--- a/internal/openchoreo-api/services/component_workflow_service.go
+++ b/internal/openchoreo-api/services/component_workflow_service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/schema"
+	"github.com/openchoreo/openchoreo/internal/schema/extractor"
 )
 
 // ComponentWorkflowService handles component workflow-related business logic
@@ -312,6 +313,9 @@ func (s *ComponentWorkflowService) GetComponentWorkflowSchema(ctx context.Contex
 
 	def := schema.Definition{
 		Schemas: []map[string]any{schemaMap},
+		Options: extractor.Options{
+			SkipDefaultValidation: true,
+		},
 	}
 
 	jsonSchema, err := schema.ToJSONSchema(def)

--- a/internal/openchoreo-api/services/componenttype_service.go
+++ b/internal/openchoreo-api/services/componenttype_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/schema"
+	"github.com/openchoreo/openchoreo/internal/schema/extractor"
 )
 
 // ComponentTypeService handles ComponentType-related business logic
@@ -109,6 +110,9 @@ func (s *ComponentTypeService) GetComponentTypeSchema(ctx context.Context, orgNa
 	// Build schema definition
 	def := schema.Definition{
 		Types: types,
+		Options: extractor.Options{
+			SkipDefaultValidation: true,
+		},
 	}
 
 	// Extract parameters schema from RawExtension

--- a/internal/openchoreo-api/services/trait_service.go
+++ b/internal/openchoreo-api/services/trait_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/schema"
+	"github.com/openchoreo/openchoreo/internal/schema/extractor"
 )
 
 // TraitService handles Trait-related business logic
@@ -109,6 +110,9 @@ func (s *TraitService) GetTraitSchema(ctx context.Context, orgName, traitName st
 	// Build schema definition
 	def := schema.Definition{
 		Types: types,
+		Options: extractor.Options{
+			SkipDefaultValidation: true,
+		},
 	}
 
 	// Extract parameters schema from RawExtension

--- a/internal/openchoreo-api/services/workflow_service.go
+++ b/internal/openchoreo-api/services/workflow_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/schema"
+	"github.com/openchoreo/openchoreo/internal/schema/extractor"
 )
 
 // WorkflowService handles Workflow-related business logic
@@ -105,6 +106,9 @@ func (s *WorkflowService) GetWorkflowSchema(ctx context.Context, orgName, wfName
 
 	def := schema.Definition{
 		Schemas: []map[string]any{schemaMap},
+		Options: extractor.Options{
+			SkipDefaultValidation: true,
+		},
 	}
 
 	jsonSchema, err := schema.ToJSONSchema(def)


### PR DESCRIPTION
## Purpose
Change schema validation to be enabled by default for better safety. The new SkipDefaultValidation option must be explicitly set to true to disable validation (previously ValidateDefaults had to be enabled and wasn't done for webhooks).

Changes:
- Rename ValidateDefaults → SkipDefaultValidation option
- Invert validation logic: validation now enabled by default
- Update all tests to reflect new default behavior
- Add test for validation skip functionality
- Disable validation in API services for performance (already validated by webhooks)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
