### PR TITLE
Pin Alpine to 3.22 to fix ARM64 build failures

### DIFF
--- a/install/init/observability/opensearch/Dockerfile
+++ b/install/init/observability/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.22
 
 RUN apk upgrade && \
     apk add bash curl jq && \


### PR DESCRIPTION
## Purpose
Alpine:latest(3.23) has some significant changes to apk-tools. see : https://alpinelinux.org/posts/Alpine-3.23.0-released.html

Due to this, the multi-arch build fails for `init-observability-opensearch`

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
