### PR TITLE
Configure default jwks url for openchoreo-api

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - name: JWT_ISSUER
           value: {{ .Values.security.oidc.issuer | quote }}
         - name: JWKS_URL
-          value: {{ .Values.security.oidc.jwksUrl | quote }}
+          value: {{ .Values.security.oidc.jwksUrl | default (printf "http://%s-asgardeo-thunder.%s.svc.cluster.local:%d/oauth2/jwks" (include "openchoreo-control-plane.fullname" .) .Release.Namespace (.Values.asgardeoThunder.service.port | int)) | quote }}
         - name: JWT_AUDIENCE
           value: {{ .Values.security.jwt.audience | quote }}
         - name: JWT_DISABLED

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/networkpolicy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/networkpolicy.yaml
@@ -50,6 +50,15 @@ spec:
       ports:
         - protocol: UDP
           port: 53
+    # Allow egress to internet for external service invocations(ie. jwks fetch etc.)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
     {{- with .Values.openchoreoApi.networkPolicy.egress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
This pull request introduces improvements to the deployment and network policy configuration of the OpenChoreo API Helm chart. The key changes enhance the default behavior for JWKS URL configuration and ensure the API can reach external services over the internet, which is necessary for operations like JWKS fetching.

**Deployment configuration improvements:**

* The `JWKS_URL` environment variable in `deployment.yaml` now defaults to a sensible internal URL if not explicitly set, reducing the risk of misconfiguration and simplifying deployment in typical scenarios.

**Network policy enhancements:**

* The `networkpolicy.yaml` now allows egress traffic to the internet on ports 80 and 443, enabling the OpenChoreo API to access external services (such as for JWKS fetching) when needed.