### PR TITLE
Add hook-failed delete policy to build-plane workflow templates

### DIFF
--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/ballerina-buildpack.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/ballerina-buildpack.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "15"
+    "helm.sh/delete-policy": hook-failed
   labels:
     {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
 spec:

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/docker.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/docker.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "15"
+    "helm.sh/delete-policy": hook-failed
   labels:
     {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
 spec:

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/google-cloud-buildpacks.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/google-cloud-buildpacks.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "15"
+    "helm.sh/delete-policy": hook-failed
   labels:
     {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
 spec:

--- a/install/helm/openchoreo-build-plane/templates/workflow-templates/react.yaml
+++ b/install/helm/openchoreo-build-plane/templates/workflow-templates/react.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "15"
+    "helm.sh/delete-policy": hook-failed
   labels:
     {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Purpose
- This is to explicitly define the hook deletion policy to overwrite default deletion policy : `before-hook-creation`.
- This avoids race conditions for initial helm installation.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
