### PR TITLE
Update helm condition used to create the OpenSearch Cluster

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/opensearch-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiCluster") }}
+{{- if .Values.openSearchCluster.enabled }}
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
 metadata:

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/secrets.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.installationMode "singleCluster" ) (eq .Values.global.installationMode "multiCluster") }}
+{{- if .Values.openSearchCluster.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -62,9 +62,8 @@ helm install openchoreo-observability-plane install/helm/openchoreo-observabilit
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --values install/k3d/single-cluster/values-op.yaml \
-  --set global.installationMode=singleClusterNoHa \
   --set openSearch.enabled=true \
-  --set openSearchCluster.enabled=false \
+  --set openSearchCluster.enabled=false
 
 ## HA mode
 


### PR DESCRIPTION
## Purpose
Update the Helm condition used to create the OpenSearch cluster

## Approach
Use .Values.openSearchCluster.enabled instead of using .Values.global.installationMode to decide whether to create the OpenSearch Cluster.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1127

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
