### PR TITLE
Fix RBAC naming collision in the openchoreo-data-plane cluster-agent

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-{{ .Release.Namespace }}
   labels:
     {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrolebinding.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrolebinding.yaml
@@ -3,14 +3,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-{{ .Release.Namespace }}
   labels:
     {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}


### PR DESCRIPTION
## Purpose

### Problem

When multiple data planes are installed in the same cluster (e.g., `non-prod-dataplane` and `prod-dataplane`) in different namespaces, they create ClusterRole and ClusterRoleBinding resources with the same
name `cluster-agent`. Since these are cluster-scoped resources, the last installation overwrites the previous one, leaving only one data plane's service account bound.

due to this the first created dataplane's cluster agent can't create/update resources.

```
Error observed:
namespaces "dp-openchoreo-demo-project--development-a67fc1dd" is forbidden:
User "system:serviceaccount:non-prod-dataplane:cluster-agent" cannot patch
resource "namespaces" in API group "" in the namespace "..."
```

## Approach

1. Make ClusterRole name unique per data plane by including the release namespace:
   - Current: `name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}`
   - New: `name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-{{ .Release.Namespace }}`

2. Make ClusterRoleBinding name unique the same way

3. Update the ClusterRoleBinding's roleRef to reference the new unique ClusterRole name

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
