### PR TITLE
Update multi cluster setup for support cluster gateway

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,7 +110,7 @@ func main() {
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&clusterGatewayURL, "cluster-gateway-url",
-		getEnv("CLUSTER_GATEWAY_URL", "https://cluster-agent-server.openchoreo-control-plane.svc.cluster.local:8443"),
+		getEnv("CLUSTER_GATEWAY_URL", "https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443"),
 		"The URL of the cluster gateway for HTTP proxy communication with data planes. "+
 			"Required for agent mode. Example: https://localhost:8443")
 	flag.StringVar(&clusterGatewayCACert, "cluster-gateway-ca-cert", getEnv("CLUSTER_GATEWAY_CA_CERT", ""),

--- a/install/extract-agent-cas.sh
+++ b/install/extract-agent-cas.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+
+# OpenChoreo Agent CA Certificate Extraction Script
+# Extracts CA certificates for cluster agent mTLS configuration
+
+set -e
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RESET='\033[0m'
+
+# Helper functions
+error() {
+  echo -e "${RED}Error: $*${RESET}" >&2
+}
+
+success() {
+  echo -e "${GREEN}$*${RESET}"
+}
+
+info() {
+  echo -e "${BLUE}$*${RESET}"
+}
+
+warn() {
+  echo -e "${YELLOW}$*${RESET}"
+}
+
+show_help() {
+  cat << EOF
+Extract CA certificates for OpenChoreo cluster agent configuration.
+
+Usage:
+  $(basename "$0") [OPTIONS] COMMAND
+
+Commands:
+  server-ca              Extract cluster-gateway server CA from control plane
+  dataplane-client-ca    Extract data plane agent client CA
+  buildplane-client-ca   Extract build plane agent client CA
+  all                    Extract all CAs (requires all contexts)
+
+Options:
+  --control-plane-context CONTEXT    Kubernetes context for control plane
+                                     Default: k3d-openchoreo-cp
+
+  --dataplane-context CONTEXT        Kubernetes context for data plane
+                                     Default: k3d-openchoreo-dp
+
+  --buildplane-context CONTEXT       Kubernetes context for build plane
+                                     Default: k3d-openchoreo-bp
+
+  --output-dir DIR                   Directory to save extracted certificates
+                                     Default: ./agent-cas
+
+  --verify                           Verify extracted certificates
+
+  --help, -h                         Show this help message
+
+Examples:
+  # Extract server CA from control plane
+  $(basename "$0") server-ca
+
+  # Extract all CAs with custom contexts
+  $(basename "$0") --control-plane-context prod-cp --dataplane-context prod-dp all
+
+  # Extract and verify data plane client CA
+  $(basename "$0") --verify dataplane-client-ca
+
+  # Save to custom directory
+  $(basename "$0") --output-dir /tmp/cas server-ca
+
+EOF
+}
+
+# Defaults
+CONTROL_PLANE_CONTEXT="k3d-openchoreo-cp"
+DATAPLANE_CONTEXT="k3d-openchoreo-dp"
+BUILDPLANE_CONTEXT="k3d-openchoreo-bp"
+OUTPUT_DIR="./agent-cas"
+VERIFY=false
+COMMAND=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --control-plane-context)
+      CONTROL_PLANE_CONTEXT="$2"
+      shift 2
+      ;;
+    --dataplane-context)
+      DATAPLANE_CONTEXT="$2"
+      shift 2
+      ;;
+    --buildplane-context)
+      BUILDPLANE_CONTEXT="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --verify)
+      VERIFY=true
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    server-ca|dataplane-client-ca|buildplane-client-ca|all)
+      COMMAND="$1"
+      shift
+      ;;
+    *)
+      error "Unknown option: $1"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate command
+if [ -z "$COMMAND" ]; then
+  error "No command specified"
+  show_help
+  exit 1
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Verify certificate function
+verify_cert() {
+  local cert_file="$1"
+  local cert_type="$2"
+
+  if [ ! -f "$cert_file" ]; then
+    error "Certificate file not found: $cert_file"
+    return 1
+  fi
+
+  info "Verifying $cert_type..."
+  echo ""
+
+  if ! openssl x509 -in "$cert_file" -text -noout > /dev/null 2>&1; then
+    error "Invalid certificate format"
+    return 1
+  fi
+
+  openssl x509 -in "$cert_file" -text -noout | grep -E "Subject:|Issuer:|Not Before|Not After|CA:"
+  echo ""
+  success "✓ Certificate is valid"
+  echo ""
+}
+
+# Extract server CA
+extract_server_ca() {
+  info "Extracting cluster-gateway server CA from control plane..."
+
+  if ! kubectl --context="$CONTROL_PLANE_CONTEXT" get secret cluster-gateway-ca \
+    -n openchoreo-control-plane > /dev/null 2>&1; then
+    error "Cluster gateway CA secret not found in control plane"
+    echo ""
+    echo "Please ensure:"
+    echo "  1. Control plane context '$CONTROL_PLANE_CONTEXT' is correct"
+    echo "  2. Cluster gateway is installed and running"
+    echo "  3. The cluster-gateway-ca secret exists in openchoreo-control-plane namespace"
+    echo ""
+    exit 1
+  fi
+
+  kubectl --context="$CONTROL_PLANE_CONTEXT" get secret cluster-gateway-ca \
+    -n openchoreo-control-plane \
+    -o jsonpath='{.data.ca\.crt}' | base64 -d > "$OUTPUT_DIR/server-ca.crt"
+
+  success "✓ Extracted server CA to: $OUTPUT_DIR/server-ca.crt"
+
+  if [ "$VERIFY" = true ]; then
+    verify_cert "$OUTPUT_DIR/server-ca.crt" "Server CA"
+  fi
+
+  echo ""
+  info "Usage:"
+  echo "  Add this certificate to agent Helm values under 'clusterAgent.tls.serverCAValue'"
+  echo ""
+}
+
+# Extract dataplane client CA
+extract_dataplane_client_ca() {
+  info "Extracting data plane agent client CA..."
+
+  if ! kubectl --context="$DATAPLANE_CONTEXT" get secret cluster-agent-ca \
+    -n openchoreo-data-plane > /dev/null 2>&1; then
+    error "Cluster agent CA secret not found in data plane"
+    echo ""
+    echo "Please ensure:"
+    echo "  1. Data plane context '$DATAPLANE_CONTEXT' is correct"
+    echo "  2. Data plane with cluster agent is installed and running"
+    echo "  3. The cluster-agent-ca secret exists in openchoreo-data-plane namespace"
+    echo ""
+    echo "Hint: The cluster agent must be deployed first to generate its CA certificate"
+    echo ""
+    exit 1
+  fi
+
+  kubectl --context="$DATAPLANE_CONTEXT" get secret cluster-agent-ca \
+    -n openchoreo-data-plane \
+    -o jsonpath='{.data.ca\.crt}' | base64 -d > "$OUTPUT_DIR/dataplane-client-ca.crt"
+
+  success "✓ Extracted data plane client CA to: $OUTPUT_DIR/dataplane-client-ca.crt"
+
+  if [ "$VERIFY" = true ]; then
+    verify_cert "$OUTPUT_DIR/dataplane-client-ca.crt" "Data Plane Client CA"
+  fi
+
+  echo ""
+  info "Next steps:"
+  echo "  1. Create secret in control plane:"
+  echo "     kubectl --context=$CONTROL_PLANE_CONTEXT create secret generic dataplane-default-ca \\"
+  echo "       --from-file=ca.crt=$OUTPUT_DIR/dataplane-client-ca.crt -n default"
+  echo ""
+  echo "  2. Add to DataPlane CR spec:"
+  echo "     agent:"
+  echo "       enabled: true"
+  echo "       clientCA:"
+  echo "         secretRef:"
+  echo "           name: dataplane-default-ca"
+  echo "           namespace: default"
+  echo "           key: ca.crt"
+  echo ""
+}
+
+# Extract buildplane client CA
+extract_buildplane_client_ca() {
+  info "Extracting build plane agent client CA..."
+
+  if ! kubectl --context="$BUILDPLANE_CONTEXT" get secret cluster-agent-ca \
+    -n openchoreo-build-plane > /dev/null 2>&1; then
+    error "Cluster agent CA secret not found in build plane"
+    echo ""
+    echo "Please ensure:"
+    echo "  1. Build plane context '$BUILDPLANE_CONTEXT' is correct"
+    echo "  2. Build plane with cluster agent is installed and running"
+    echo "  3. The cluster-agent-ca secret exists in openchoreo-build-plane namespace"
+    echo ""
+    echo "Hint: The cluster agent must be deployed first to generate its CA certificate"
+    echo ""
+    exit 1
+  fi
+
+  kubectl --context="$BUILDPLANE_CONTEXT" get secret cluster-agent-ca \
+    -n openchoreo-build-plane \
+    -o jsonpath='{.data.ca\.crt}' | base64 -d > "$OUTPUT_DIR/buildplane-client-ca.crt"
+
+  success "✓ Extracted build plane client CA to: $OUTPUT_DIR/buildplane-client-ca.crt"
+
+  if [ "$VERIFY" = true ]; then
+    verify_cert "$OUTPUT_DIR/buildplane-client-ca.crt" "Build Plane Client CA"
+  fi
+
+  echo ""
+  info "Next steps:"
+  echo "  1. Create secret in control plane:"
+  echo "     kubectl --context=$CONTROL_PLANE_CONTEXT create secret generic buildplane-default-ca \\"
+  echo "       --from-file=ca.crt=$OUTPUT_DIR/buildplane-client-ca.crt -n default"
+  echo ""
+  echo "  2. Add to BuildPlane CR spec:"
+  echo "     agent:"
+  echo "       enabled: true"
+  echo "       clientCA:"
+  echo "         secretRef:"
+  echo "           name: buildplane-default-ca"
+  echo "           namespace: default"
+  echo "           key: ca.crt"
+  echo ""
+}
+
+# Execute command
+case $COMMAND in
+  server-ca)
+    extract_server_ca
+    ;;
+  dataplane-client-ca)
+    extract_dataplane_client_ca
+    ;;
+  buildplane-client-ca)
+    extract_buildplane_client_ca
+    ;;
+  all)
+    extract_server_ca
+    extract_dataplane_client_ca
+    extract_buildplane_client_ca
+    success "✓ All certificates extracted successfully"
+    echo ""
+    info "Summary:"
+    ls -lh "$OUTPUT_DIR"/*.crt
+    ;;
+esac

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/copy-ca-secret.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/copy-ca-secret.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.clusterAgent.enabled }}
 {{- if .Values.clusterAgent.tls.enabled }}
-{{- if and .Values.clusterAgent.tls.caSecretName (not .Values.clusterAgent.tls.caValue) }}
+{{- if and .Values.clusterAgent.tls.caSecretName (not .Values.clusterAgent.tls.serverCAValue) (not .Values.clusterAgent.tls.generateCerts) }}
 ---
-# Job to copy cluster-gateway-ca secret from control plane to data plane namespace
-# Only runs when caValue is not provided (single-cluster setup)
+# Job to copy cluster-gateway-ca secret from control plane to build plane namespace
+# Only runs in single-cluster setup (when serverCAValue is not provided and certs are not generated locally)
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/coredns-custom.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/coredns-custom.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.dnsRewrite.enabled }}
+---
+# CoreDNS custom hosts for cluster gateway resolution
+# Maps cluster-gateway.openchoreo.localhost to host.k3d.internal for multi-cluster communication
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+  labels:
+    {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent-dns
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-10"
+data:
+  cluster-gateway.override: |
+    # Rewrite cluster gateway hostname to use host.k3d.internal
+    # This allows agents in multi-cluster k3d setups to reach the control plane
+    rewrite stop {
+      name exact cluster-gateway.openchoreo.localhost host.k3d.internal
+      answer auto
+    }
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/server-ca-configmap.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/server-ca-configmap.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
 {{- if not .Values.clusterAgent.tls.serverCAValue }}
 ---
-# Job to copy cluster-gateway CA certificate from control plane to data plane
-# Only runs when serverCAValue is not provided (single-cluster setup)
+# Job to copy cluster-gateway CA ConfigMap from control plane to build plane
+# Only runs in single-cluster setup (when serverCAValue is not provided inline)
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -85,5 +86,6 @@ spec:
 
           echo ""
           echo "=== CA Copy Completed Successfully ==="
+{{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -235,6 +235,10 @@ clusterAgent:
   planeName: default
   # Type of plane (dataplane or buildplane)
   planeType: buildplane
+  # DNS rewrite configuration (for multi-cluster k3d setups)
+  # When enabled, configures CoreDNS to rewrite *.openchoreo.localhost to host.k3d.internal
+  dnsRewrite:
+    enabled: false
   heartbeatInterval: 30s
   reconnectDelay: 5s
   logLevel: info
@@ -257,6 +261,10 @@ clusterAgent:
     value: 900000
   tls:
     enabled: true
+    # Generate client certificates locally using cert-manager (multi-cluster setup)
+    # Set to true when the build plane is in a different cluster from control plane
+    # When true, cert-manager will generate the client certificates instead of copying CA from control plane
+    generateCerts: false
     # Secret containing client certificate and key
     secretName: cluster-agent-tls
     clientSecretName: cluster-agent-tls

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/ingressroutetcp.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/ingressroutetcp.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.clusterGateway.enabled }}
+{{- if .Values.clusterGateway.ingress.enabled }}
+{{- if eq .Values.clusterGateway.ingress.ingressClassName "traefik" }}
+{{- if .Capabilities.APIVersions.Has "traefik.io/v1alpha1/IngressRouteTCP" }}
+---
+# Traefik IngressRouteTCP for TLS passthrough
+# Required for end-to-end mTLS with cluster agents
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-tcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: HostSNI(`{{ (index .Values.clusterGateway.ingress.hosts 0).host }}`)
+    services:
+    - name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+      port: {{ .Values.clusterGateway.service.port }}
+  tls:
+    passthrough: true
+{{- else }}
+{{- fail "IngressRouteTCP CRD not found. Please wait for Traefik CRDs to be installed: kubectl wait --for=condition=complete job -l app.kubernetes.io/name=traefik-crd -n kube-system --timeout=120s" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/issuer.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/issuer.yaml
@@ -10,8 +10,9 @@ metadata:
     app.kubernetes.io/component: cluster-gateway
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "-5"
+    helm.sh/hook-weight: "-3"
 spec:
-  selfSigned: {}
+  ca:
+    secretName: cluster-gateway-ca
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -78,8 +78,8 @@ spec:
         - /manager
         args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         {{- if .Values.controllerManager.clusterGateway.enabled }}
-        - --agent-server-url={{ .Values.controllerManager.clusterGateway.url }}
-        - --agent-server-ca={{ .Values.controllerManager.clusterGateway.tls.caPath }}
+        - --cluster-gateway-url={{ .Values.controllerManager.clusterGateway.url }}
+        - --cluster-gateway-ca-cert={{ .Values.controllerManager.clusterGateway.tls.caPath }}
         {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
@@ -87,9 +87,9 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         {{- if .Values.controllerManager.clusterGateway.enabled }}
-        - name: AGENT_SERVER_URL
+        - name: CLUSTER_GATEWAY_URL
           value: {{ quote .Values.controllerManager.clusterGateway.url }}
-        - name: AGENT_SERVER_CA_PATH
+        - name: CLUSTER_GATEWAY_CA_CERT
           value: {{ quote .Values.controllerManager.clusterGateway.tls.caPath }}
         {{- end }}
         ports:

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -648,6 +648,11 @@ clusterGateway:
     nodePort: null
     loadBalancerIP: null
     clusterIP: null
+  ingress:
+    enabled: false
+    ingressClassName: ""
+    annotations: {}
+    hosts: []
   tls:
     enabled: true
     secretName: cluster-gateway-tls

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/copy-ca-secret.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/copy-ca-secret.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.clusterAgent.enabled }}
 {{- if .Values.clusterAgent.tls.enabled }}
-{{- if and .Values.clusterAgent.tls.caSecretName (not .Values.clusterAgent.tls.caValue) }}
+{{- if and .Values.clusterAgent.tls.caSecretName (not .Values.clusterAgent.tls.serverCAValue) (not .Values.clusterAgent.tls.generateCerts) }}
 ---
 # Job to copy cluster-gateway-ca secret from control plane to data plane namespace
-# Only runs when caValue is not provided (single-cluster setup)
+# Only runs in single-cluster setup (when serverCAValue is not provided and certs are not generated locally)
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/coredns-custom.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/coredns-custom.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.dnsRewrite.enabled }}
+---
+# CoreDNS custom hosts for cluster gateway resolution
+# Maps cluster-gateway.openchoreo.localhost to host.k3d.internal for multi-cluster communication
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent-dns
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-10"
+data:
+  cluster-gateway.override: |
+    # Rewrite cluster gateway hostname to use host.k3d.internal
+    # This allows agents in multi-cluster k3d setups to reach the control plane
+    rewrite stop {
+      name exact cluster-gateway.openchoreo.localhost host.k3d.internal
+      answer auto
+    }
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/server-ca-configmap.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/server-ca-configmap.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
 {{- if not .Values.clusterAgent.tls.serverCAValue }}
 ---
-# Job to copy cluster-gateway CA certificate from control plane to data plane
-# Only runs when serverCAValue is not provided (single-cluster setup)
+# Job to copy cluster-gateway CA ConfigMap from control plane to data plane
+# Only runs in single-cluster setup (when serverCAValue is not provided inline)
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -85,5 +86,6 @@ spec:
 
           echo ""
           echo "=== CA Copy Completed Successfully ==="
+{{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -301,6 +301,10 @@ clusterAgent:
   planeName: default
   # Type of plane (dataplane or buildplane)
   planeType: dataplane
+  # DNS rewrite configuration (for multi-cluster k3d setups)
+  # When enabled, configures CoreDNS to rewrite *.openchoreo.localhost to host.k3d.internal
+  dnsRewrite:
+    enabled: false
   heartbeatInterval: 30s
   reconnectDelay: 5s
   logLevel: info
@@ -323,6 +327,10 @@ clusterAgent:
     value: 900000
   tls:
     enabled: true
+    # Generate client certificates locally using cert-manager (multi-cluster setup)
+    # Set to true when the data plane is in a different cluster from control plane
+    # When true, cert-manager will generate the client certificates instead of copying CA from control plane
+    generateCerts: false
     # Secret containing client certificate and key
     secretName: cluster-agent-tls
     clientSecretName: cluster-agent-tls

--- a/install/k3d/multi-cluster/config-cp.yaml
+++ b/install/k3d/multi-cluster/config-cp.yaml
@@ -9,11 +9,11 @@ kubeAPI:
   hostPort: "6550"
 # Control Plane uses port range 8xxx
 ports:
-  # HTTP traffic to OpenChoreo UI and API
+  # HTTP traffic to OpenChoreo UI, API
   - port: 8080:80
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic to OpenChoreo UI and API
+  # HTTPS traffic to OpenChoreo UI, API, and Cluster Gateway (via ingress)
   - port: 8443:443
     nodeFilters:
       - loadbalancer

--- a/install/k3d/multi-cluster/values-bp.yaml
+++ b/install/k3d/multi-cluster/values-bp.yaml
@@ -1,6 +1,40 @@
 # Helm values for OpenChoreo Build Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the build plane in a k3d environment
 
+# Cluster Agent configuration for secure communication with control plane
+# IMPORTANT: Before installing, run ./install/extract-agent-cas.sh server-ca
+# and paste the server CA certificate below
+clusterAgent:
+  enabled: true
+  serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
+  planeName: "default"
+  planeType: "buildplane"
+
+  # DNS rewrite configuration for multi-cluster k3d setup
+  # Rewrites *.openchoreo.localhost to host.k3d.internal for cross-cluster communication
+  dnsRewrite:
+    enabled: true
+
+  # Client certificate auto-generation via cert-manager
+  tls:
+    enabled: true
+    generateCerts: true
+    # For multi-cluster, don't set caSecretName - use self-signed certs
+    # The cluster gateway will verify the client cert via mTLS
+    caSecretName: ""
+    caSecretNamespace: ""
+    # Server CA certificate for TLS verification
+    # Extract from control plane: kubectl --context k3d-openchoreo-cp get secret cluster-gateway-ca -n openchoreo-control-plane -o jsonpath='{.data.ca\.crt}' | base64 -d
+    # Or use: ./install/extract-agent-cas.sh server-ca
+    serverCAValue: |
+      -----BEGIN CERTIFICATE-----
+      <PASTE_SERVER_CA_CERTIFICATE_HERE>
+      -----END CERTIFICATE-----
+
+  # RBAC for cluster agent
+  rbac:
+    create: true
+
 argo-workflows:
   server:
     # Argo Workflows UI is enabled only for testing/development purposes.

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -15,3 +15,39 @@ traefik:
 security:
   oidc:
     authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
+
+# Cluster Gateway configuration for agent-based communication
+# Exposes the cluster gateway for remote data/build plane agents to connect
+# Note: For k3d, we use Traefik IngressRouteTCP for TLS passthrough on shared port 8443
+# Alternative: Add dedicated port mapping in k3d config (requires cluster recreation)
+clusterGateway:
+  enabled: true
+  service:
+    type: ClusterIP
+    port: 8443
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    hosts:
+      - host: cluster-gateway.openchoreo.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+  tls:
+    enabled: true  # mTLS for secure agent communication
+    issuerRef:
+      kind: Issuer
+      name: cluster-gateway-server-issuer  # CA issuer for server certificates
+    dnsNames:
+      - cluster-gateway.openchoreo-control-plane.svc
+      - cluster-gateway.openchoreo-control-plane.svc.cluster.local
+      - cluster-gateway.openchoreo.localhost  # External hostname for multi-cluster access
+
+# Controller Manager cluster gateway configuration
+# Enables controllers to communicate with data/build planes via cluster gateway
+# Uses internal service DNS (controller runs inside the cluster)
+controllerManager:
+  clusterGateway:
+    enabled: true
+    # Use internal service DNS - controller manager runs inside the control plane cluster
+    url: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -1,6 +1,40 @@
 # Helm values for OpenChoreo Data Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the data plane in a k3d environment
 
+# Cluster Agent configuration for secure communication with control plane
+# IMPORTANT: Before installing, run ./install/extract-agent-cas.sh server-ca
+# and paste the server CA certificate below
+clusterAgent:
+  enabled: true
+  serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
+  planeName: "default"
+  planeType: "dataplane"
+
+  # DNS rewrite configuration for multi-cluster k3d setup
+  # Rewrites *.openchoreo.localhost to host.k3d.internal for cross-cluster communication
+  dnsRewrite:
+    enabled: true
+
+  # Client certificate auto-generation via cert-manager
+  tls:
+    enabled: true
+    generateCerts: true
+    # For multi-cluster, don't set caSecretName - use self-signed certs
+    # The cluster gateway will verify the client cert via mTLS
+    caSecretName: ""
+    caSecretNamespace: ""
+    # Server CA certificate for TLS verification
+    # Extract from control plane: kubectl --context k3d-openchoreo-cp get secret cluster-gateway-ca -n openchoreo-control-plane -o jsonpath='{.data.ca\.crt}' | base64 -d
+    # Or use: ./install/extract-agent-cas.sh server-ca
+    serverCAValue: |
+      -----BEGIN CERTIFICATE-----
+      <PASTE_SERVER_CA_CERTIFICATE_HERE>
+      -----END CERTIFICATE-----
+
+  # RBAC for cluster agent
+  rbac:
+    create: true
+
 fluentBit:
   config:
     # OpenSearch connection for multi-cluster setup

--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -15,3 +15,13 @@ traefik:
 security:
   oidc:
     authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
+
+# Enable cluster gateway for agent-based data plane communication
+clusterGateway:
+  enabled: true
+
+# Controller Manager cluster gateway configuration
+# Enables controllers to communicate with data/build planes via cluster gateway
+controllerManager:
+  clusterGateway:
+    enabled: true

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -504,6 +504,15 @@ install_control_plane() {
         "--set" "controllerManager.image.tag=$OPENCHOREO_VERSION" \
         "--set" "openchoreoApi.image.tag=$OPENCHOREO_VERSION" \
         "--set" "backstage.image.tag=$OPENCHOREO_VERSION"
+
+    # Wait for cluster-gateway to be ready (required for agent connections)
+    log_info "Waiting for cluster-gateway to be ready..."
+    if kubectl wait --for=condition=available deployment/cluster-gateway \
+        -n "$CONTROL_PLANE_NS" --timeout=120s >/dev/null 2>&1; then
+        log_success "Cluster gateway is ready"
+    else
+        log_warning "Cluster gateway readiness check timed out, but continuing..."
+    fi
 }
 
 # Install OpenChoreo Data Plane

--- a/install/quick-start/.values-bp.yaml
+++ b/install/quick-start/.values-bp.yaml
@@ -1,6 +1,10 @@
 # Helm values for OpenChoreo Build Plane in quick-start environment
 # Based on single-cluster setup, optimized for containerized quick-start experience
 
+# Disable cert-manager since it's already installed by Control Plane
+cert-manager:
+  enabled: false
+
 # Argo Workflows configuration
 argo-workflows:
   server:
@@ -31,3 +35,10 @@ external-secrets:
 # from ALL namespaces including openchoreo-build-plane and openchoreo-ci-*
 fluentBit:
   enabled: false
+
+# Cluster Agent configuration for single-cluster setup
+clusterAgent:
+  enabled: true
+  serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
+  planeName: default
+  planeType: buildplane

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -13,8 +13,8 @@ traefik:
 
 # Disable cluster gateway for quick-start (direct access mode)
 clusterGateway:
-  enabled: false
+  enabled: true
 
 controllerManager:
   clusterGateway:
-    enabled: false
+    enabled: true

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -23,9 +23,12 @@ gateway:
     # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
     mountTmpVolume: true
 
-# Disable cluster agent for quick-start (single-cluster mode)
+# Enable cluster agent for secure communication with control plane
 clusterAgent:
-  enabled: false
+  enabled: true
+  serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
+  planeName: default
+  planeType: dataplane
 
 networking:
   enabled: false

--- a/install/quick-start/install.sh
+++ b/install/quick-start/install.sh
@@ -123,7 +123,7 @@ fi
 
 # Step 8: Add default dataplane
 if [[ -f "${SCRIPT_DIR}/add-data-plane.sh" ]]; then
-    bash "${SCRIPT_DIR}/add-data-plane.sh"
+    bash "${SCRIPT_DIR}/add-data-plane.sh" --enable-agent --control-plane-context "${CLUSTER_CONTEXT}" --name default
 else
     log_warning "add-data-plane.sh not found, skipping dataplane configuration"
 fi
@@ -131,7 +131,7 @@ fi
 # Step 9: Add default buildplane (if build plane enabled)
 if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
     if [[ -f "${SCRIPT_DIR}/add-build-plane.sh" ]]; then
-        bash "${SCRIPT_DIR}/add-build-plane.sh"
+        bash "${SCRIPT_DIR}/add-build-plane.sh" --enable-agent --control-plane-context "${CLUSTER_CONTEXT}" --name default
     else
         log_warning "add-build-plane.sh not found, skipping buildplane configuration"
     fi

--- a/internal/observer/service/service.go
+++ b/internal/observer/service/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -297,12 +298,21 @@ func (s *LoggingService) GetTraces(ctx context.Context, params opensearch.Traces
 		}
 	}
 
-	// Convert map to traces array
+	// Convert map to traces array and sort by traceID for consistent ordering
 	traces := make([]opensearch.Trace, 0, len(traceMap))
-	for traceID, spans := range traceMap {
+	traceIDs := make([]string, 0, len(traceMap))
+
+	for traceID := range traceMap {
+		traceIDs = append(traceIDs, traceID)
+	}
+
+	// Sort trace IDs to ensure deterministic ordering
+	sort.Strings(traceIDs)
+
+	for _, traceID := range traceIDs {
 		traces = append(traces, opensearch.Trace{
 			TraceID: traceID,
-			Spans:   spans,
+			Spans:   traceMap[traceID],
 		})
 	}
 


### PR DESCRIPTION
## Purpose
This pull request introduces significant improvements to the agent-based cluster communication setup in OpenChoreo's install scripts and updates the default cluster gateway URL in the main application. The most important changes are the addition of auto-extraction support for the client CA certificate, enhanced argument parsing and help documentation, and stricter enforcement of agent mode for BuildPlane resources. These changes make multi-cluster setups easier and reduce manual steps for secure agent configuration.

**Agent CA certificate extraction and configuration improvements:**

* Both `install/add-build-plane.sh` and `install/add-data-plane.sh` now support two modes for specifying the client CA certificate: referencing an existing secret in the control plane (`secretRef` mode) or automatically extracting the CA certificate from the build or data plane cluster (`inline value` mode). This is controlled by the presence or absence of the `--agent-ca-secret` argument. [[1]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L174-R243) [[2]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R264-R312)
* New arguments (`--buildplane-context` and `--dataplane-context`) allow users to specify the context from which to extract the CA certificate, making multi-cluster scenarios easier to configure. Defaults are set to the current context if not specified. [[1]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L39-R92) [[2]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991R122-R129) [[3]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L48-R58) [[4]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R146-R153)

**Help and documentation enhancements:**

* The help output and usage examples in both scripts have been updated to clarify agent mode, secret reference, auto-extract options, and multi-cluster scenarios. Examples now show single- and multi-cluster setups, with and without explicit CA secrets. [[1]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L22-R22) [[2]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L39-R92) [[3]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991R101-R111) [[4]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R92-R97)

**Stricter agent mode enforcement for BuildPlane resources:**

* The `install/add-build-plane.sh` script now requires `--enable-agent` and will error out if agent mode is not used, enforcing secure communication via the cluster agent.

**Default values and argument parsing improvements:**

* Improved default handling for agent CA namespace, build/data plane context, and explicit secret detection. Argument parsing now tracks whether `--agent-ca-secret` was explicitly set and adjusts behavior accordingly. [[1]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L39-R92) [[2]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991R101-R111) [[3]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L161-R182) [[4]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R108-R116) [[5]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762R135) [[6]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L208-R233)

**Cluster gateway URL update:**

* The default value for `CLUSTER_GATEWAY_URL` in `cmd/main.go` has been changed to point to `cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443`, reflecting the updated service name and endpoint.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
