### PR TITLE
Update quick fix to cater cluster gateway

### DIFF
--- a/install/quick-start/.values-bp.yaml
+++ b/install/quick-start/.values-bp.yaml
@@ -42,3 +42,16 @@ clusterAgent:
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
   planeName: default
   planeType: buildplane
+  # TLS configuration for single-cluster setup
+  # Helm post-install jobs will automatically copy the CA from control plane
+  tls:
+    enabled: true
+    # Don't generate certs locally - use CA from control plane (single-cluster mode)
+    generateCerts: false
+    # CA secret to copy from control plane namespace
+    caSecretName: cluster-gateway-ca
+    caSecretNamespace: openchoreo-control-plane
+    # Server CA will be copied from control plane (not provided inline)
+    serverCAValue: ""
+  # Namespace where cluster-gateway CA ConfigMap exists (control plane)
+  serverCANamespace: openchoreo-control-plane

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -29,6 +29,19 @@ clusterAgent:
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
   planeName: default
   planeType: dataplane
+  # TLS configuration for single-cluster setup
+  # Helm post-install jobs will automatically copy the CA from control plane
+  tls:
+    enabled: true
+    # Don't generate certs locally - use CA from control plane (single-cluster mode)
+    generateCerts: false
+    # CA secret to copy from control plane namespace
+    caSecretName: cluster-gateway-ca
+    caSecretNamespace: openchoreo-control-plane
+    # Server CA will be copied from control plane (not provided inline)
+    serverCAValue: ""
+  # Namespace where cluster-gateway CA ConfigMap exists (control plane)
+  serverCANamespace: openchoreo-control-plane
 
 networking:
   enabled: false

--- a/install/quick-start/install.sh
+++ b/install/quick-start/install.sh
@@ -123,7 +123,7 @@ fi
 
 # Step 8: Add default dataplane
 if [[ -f "${SCRIPT_DIR}/add-data-plane.sh" ]]; then
-    bash "${SCRIPT_DIR}/add-data-plane.sh" --enable-agent --control-plane-context "${CLUSTER_CONTEXT}" --name default
+    bash "${SCRIPT_DIR}/add-data-plane.sh" --enable-agent --name default
 else
     log_warning "add-data-plane.sh not found, skipping dataplane configuration"
 fi
@@ -131,7 +131,7 @@ fi
 # Step 9: Add default buildplane (if build plane enabled)
 if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
     if [[ -f "${SCRIPT_DIR}/add-build-plane.sh" ]]; then
-        bash "${SCRIPT_DIR}/add-build-plane.sh" --enable-agent --control-plane-context "${CLUSTER_CONTEXT}" --name default
+        bash "${SCRIPT_DIR}/add-build-plane.sh" --enable-agent --name default
     else
         log_warning "add-build-plane.sh not found, skipping buildplane configuration"
     fi


### PR DESCRIPTION
## Purpose
This pull request improves the single-cluster quick start experience by enhancing TLS configuration, updating documentation for troubleshooting, and simplifying installation scripts. The changes make it easier to set up secure communication between planes and help users resolve common issues during cluster creation and agent startup.

**Configuration improvements:**

* Added explicit TLS configuration options for the cluster agent in both `buildplane` and `dataplane` Helm values files, ensuring certificates are managed securely and automatically in single-cluster setups. [[1]](diffhunk://#diff-4b4cdc8a49f86b86da19a30b663955e9e7577e0dea9140f86e51d900b3c77748R45-R57) [[2]](diffhunk://#diff-e5925bba644ecf23e19124c8172e694d4f52a2f811267fbe7308da2b2c1c952eR32-R44)

**Documentation and troubleshooting:**

* Updated the `README.md` to require the `--privileged` flag when starting the container, clarifying its necessity for k3d and Docker-in-Docker scenarios.
* Added a new Troubleshooting section to the `README.md` with solutions for common issues like k3d cluster creation hanging and cluster agent pods stuck in Pending, including step-by-step recovery instructions.

**Script simplification:**

* Simplified the `install.sh` script by removing the unnecessary `--control-plane-context` argument when adding default dataplane and buildplane, streamlining the installation process.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
