### PR TITLE
Add cluster agent scaler to scale after certs are ready

### DIFF
--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/clusterrole.yaml
@@ -16,6 +16,13 @@ rules:
   - daemonsets
   - replicasets
   verbs: ["*"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  - replicasets/scale
+  verbs: ["get", "update", "patch"]
 - apiGroups: [""]
   resources:
   - pods

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/deployment.yaml
@@ -9,7 +9,10 @@ metadata:
     app.kubernetes.io/component: cluster-agent
     app: cluster-agent
 spec:
-  replicas: {{ .Values.clusterAgent.replicas }}
+  # Start with 0 replicas to prevent Helm --wait deadlock
+  # The cluster-agent requires TLS secrets created by post-install hooks
+  # A separate post-install hook will scale this to desired replicas after certificates are ready
+  replicas: 0
   selector:
     matchLabels:
       app: cluster-agent

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/scale-deployment.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/scale-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
+---
+# Job to scale cluster-agent deployment after TLS certificates are ready
+# This prevents Helm --wait deadlock where deployment waits for secrets created by post-install hooks
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-scaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cluster-agent-scaler
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-build-plane.clusterAgent.serviceAccountName" . }}
+      containers:
+      - name: scaler
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Cluster Agent Deployment Scaler ==="
+          echo "Waiting for TLS certificates to be ready before scaling deployment..."
+
+          retries=0
+          max_retries=120  # 10 minutes
+
+          # Wait for cluster-agent-tls secret
+          echo "Waiting for cluster-agent TLS secret..."
+          until kubectl get secret {{ .Values.clusterAgent.tls.clientSecretName }} -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for secret {{ .Values.clusterAgent.tls.clientSecretName }}"
+              kubectl get secrets -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "Secret not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ TLS secret found"
+
+          # Wait for cluster-gateway-ca configmap
+          echo "Waiting for cluster-gateway CA configmap..."
+          retries=0
+          until kubectl get configmap {{ .Values.clusterAgent.tls.serverCAConfigMap }} -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for configmap {{ .Values.clusterAgent.tls.serverCAConfigMap }}"
+              kubectl get configmaps -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "ConfigMap not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ Server CA configmap found"
+
+          # Verify the secret has valid certificate data
+          echo "Verifying TLS secret has valid certificate data..."
+          if ! kubectl get secret {{ .Values.clusterAgent.tls.clientSecretName }} \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.data.tls\.crt}' | base64 -d | grep -q "BEGIN CERTIFICATE"; then
+            echo "ERROR: TLS secret exists but does not contain valid certificate"
+            kubectl get secret {{ .Values.clusterAgent.tls.clientSecretName }} -n {{ .Release.Namespace }} -o yaml
+            exit 1
+          fi
+
+          echo "✓ TLS certificate is valid"
+
+          # Scale the deployment to desired replicas
+          DESIRED_REPLICAS={{ .Values.clusterAgent.replicas }}
+          DEPLOYMENT_NAME={{ include "openchoreo-build-plane.clusterAgent.name" . }}
+
+          echo "Scaling deployment ${DEPLOYMENT_NAME} to ${DESIRED_REPLICAS} replicas..."
+
+          # Retry scaling in case RBAC permissions aren't immediately available
+          retries=0
+          max_retries=10
+          until kubectl scale deployment ${DEPLOYMENT_NAME} \
+            --replicas=${DESIRED_REPLICAS} \
+            -n {{ .Release.Namespace }}; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Failed to scale deployment after $max_retries attempts"
+              echo "Checking RBAC permissions..."
+              kubectl auth can-i patch deployments/scale --as=system:serviceaccount:{{ .Release.Namespace }}:{{ include "openchoreo-build-plane.clusterAgent.serviceAccountName" . }} -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "Scaling failed, waiting for RBAC to propagate... (attempt $retries/$max_retries)"
+            sleep 3
+          done
+
+          echo "✓ Deployment scaled successfully"
+
+          # Wait for deployment to be ready
+          echo "Waiting for deployment to be ready..."
+          kubectl wait deployment ${DEPLOYMENT_NAME} \
+            --for=condition=Available \
+            --timeout=300s \
+            -n {{ .Release.Namespace }} || true
+
+          # Show final status
+          echo ""
+          echo "=== Cluster Agent Deployment Status ==="
+          kubectl get deployment ${DEPLOYMENT_NAME} -n {{ .Release.Namespace }}
+          kubectl get pods -n {{ .Release.Namespace }} -l app=cluster-agent
+
+          echo ""
+          echo "=== Scaling Complete ==="
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -16,6 +16,13 @@ rules:
   - daemonsets
   - replicasets
   verbs: ["*"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  - replicasets/scale
+  verbs: ["get", "update", "patch"]
 - apiGroups: [""]
   resources:
   - pods

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -9,7 +9,10 @@ metadata:
     app.kubernetes.io/component: cluster-agent
     app: cluster-agent
 spec:
-  replicas: {{ .Values.clusterAgent.replicas }}
+  # Start with 0 replicas to prevent Helm --wait deadlock
+  # The cluster-agent requires TLS secrets created by post-install hooks
+  # A separate post-install hook will scale this to desired replicas after certificates are ready
+  replicas: 0
   selector:
     matchLabels:
       app: cluster-agent

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/scale-deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/scale-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.clusterAgent.enabled }}
+{{- if .Values.clusterAgent.tls.enabled }}
+---
+# Job to scale cluster-agent deployment after TLS certificates are ready
+# This prevents Helm --wait deadlock where deployment waits for secrets created by post-install hooks
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-scaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cluster-agent-scaler
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+      containers:
+      - name: scaler
+        image: bitnamilegacy/kubectl:1.32.4
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "=== Cluster Agent Deployment Scaler ==="
+          echo "Waiting for TLS certificates to be ready before scaling deployment..."
+
+          retries=0
+          max_retries=120  # 10 minutes
+
+          # Wait for cluster-agent-tls secret
+          echo "Waiting for cluster-agent TLS secret..."
+          until kubectl get secret {{ .Values.clusterAgent.tls.clientSecretName }} -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for secret {{ .Values.clusterAgent.tls.clientSecretName }}"
+              kubectl get secrets -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "Secret not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ TLS secret found"
+
+          # Wait for cluster-gateway-ca configmap
+          echo "Waiting for cluster-gateway CA configmap..."
+          retries=0
+          until kubectl get configmap {{ .Values.clusterAgent.tls.serverCAConfigMap }} -n {{ .Release.Namespace }} &> /dev/null; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Timeout waiting for configmap {{ .Values.clusterAgent.tls.serverCAConfigMap }}"
+              kubectl get configmaps -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "ConfigMap not ready yet... (attempt $retries/$max_retries)"
+            sleep 5
+          done
+
+          echo "✓ Server CA configmap found"
+
+          # Verify the secret has valid certificate data
+          echo "Verifying TLS secret has valid certificate data..."
+          if ! kubectl get secret {{ .Values.clusterAgent.tls.clientSecretName }} \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.data.tls\.crt}' | base64 -d | grep -q "BEGIN CERTIFICATE"; then
+            echo "ERROR: TLS secret exists but does not contain valid certificate"
+            kubectl get secret {{ .Values.clusterAgent.tls.clientSecretName }} -n {{ .Release.Namespace }} -o yaml
+            exit 1
+          fi
+
+          echo "✓ TLS certificate is valid"
+
+          # Scale the deployment to desired replicas
+          DESIRED_REPLICAS={{ .Values.clusterAgent.replicas }}
+          DEPLOYMENT_NAME={{ include "openchoreo-data-plane.clusterAgent.name" . }}
+
+          echo "Scaling deployment ${DEPLOYMENT_NAME} to ${DESIRED_REPLICAS} replicas..."
+
+          # Retry scaling in case RBAC permissions aren't immediately available
+          retries=0
+          max_retries=10
+          until kubectl scale deployment ${DEPLOYMENT_NAME} \
+            --replicas=${DESIRED_REPLICAS} \
+            -n {{ .Release.Namespace }}; do
+            retries=$((retries+1))
+            if [ $retries -gt $max_retries ]; then
+              echo "ERROR: Failed to scale deployment after $max_retries attempts"
+              echo "Checking RBAC permissions..."
+              kubectl auth can-i patch deployments/scale --as=system:serviceaccount:{{ .Release.Namespace }}:{{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }} -n {{ .Release.Namespace }}
+              exit 1
+            fi
+            echo "Scaling failed, waiting for RBAC to propagate... (attempt $retries/$max_retries)"
+            sleep 3
+          done
+
+          echo "✓ Deployment scaled successfully"
+
+          # Wait for deployment to be ready
+          echo "Waiting for deployment to be ready..."
+          kubectl wait deployment ${DEPLOYMENT_NAME} \
+            --for=condition=Available \
+            --timeout=300s \
+            -n {{ .Release.Namespace }} || true
+
+          # Show final status
+          echo ""
+          echo "=== Cluster Agent Deployment Status ==="
+          kubectl get deployment ${DEPLOYMENT_NAME} -n {{ .Release.Namespace }}
+          kubectl get pods -n {{ .Release.Namespace }} -l app=cluster-agent
+
+          echo ""
+          echo "=== Scaling Complete ==="
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Purpose
This pull request addresses a Helm deployment deadlock issue for the `cluster-agent` in both the build-plane and data-plane charts by ensuring deployments only start after required TLS secrets and configmaps are available. It introduces a post-install job to safely scale up the `cluster-agent` and updates RBAC permissions to allow scaling via Kubernetes subresources.

**Deployment orchestration improvements:**

* In both `openchoreo-build-plane` and `openchoreo-data-plane` charts, the `cluster-agent` deployment now starts with `replicas: 0` to prevent Helm `--wait` deadlock until TLS secrets are ready. Scaling to the desired replica count is handled by a post-install hook job. [[1]](diffhunk://#diff-0348de604d72db6becd8aa43d13caba82b8304647f19dcac32351eca33416a3aL12-R15) [[2]](diffhunk://#diff-4894598c663ef3d5b6f8fff89e3329f33b56289f60b00279cb76b1a8552b3f10L12-R15)

* New `scale-deployment.yaml` job templates for both build-plane and data-plane run after TLS secrets and configmaps are created, verify certificate validity, and then scale the deployment to the configured replica count. These jobs include retries and readiness checks for robust orchestration. [[1]](diffhunk://#diff-07cf5e821411d19f05faa1bcd7fd10b1fbe478b159662266887612c0fbd4556fR1-R124) [[2]](diffhunk://#diff-ac44ca5197e1f2904e4970460b989526cb7510cfc482df1bef55cc92fa9968a9R1-R124)

**RBAC permission enhancements:**

* The `clusterrole.yaml` files for both build-plane and data-plane charts now grant permissions for the `deployments/scale`, `statefulsets/scale`, and `replicasets/scale` subresources, enabling the scaler job to perform scaling operations. [[1]](diffhunk://#diff-a223dcbc73cc16f8f4d66a75779bb6f3a258f515b8644a9ddb341eae1f42c3c8R19-R25) [[2]](diffhunk://#diff-8c99e76b280d8dd4833712eb2f62fe8e3d0b86d5aedfad3704a5b81cfcaf41ffR19-R25)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
