### PR TITLE
Change installation mode in k3d single cluster for Observability plane

### DIFF
--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -2,7 +2,7 @@
 
 global:
   # Single-cluster non-HA mode uses standalone OpenSearch instead of operator
-  installationMode: singleClusterNoHa
+  installationMode: singleCluster
 
 # Use standalone OpenSearch (not operator-managed cluster)
 openSearch:


### PR DESCRIPTION
## Purpose
Change the default installation mode for k3d single cluster in Observability plane

## Approach
Changed the installation mode value in the helm values file

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1127

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
