### PR TITLE
Add parameter support in component create request for openchoreo api server

### DIFF
--- a/internal/openchoreo-api/models/request.go
+++ b/internal/openchoreo-api/models/request.go
@@ -55,13 +55,24 @@ type ComponentWorkflowRepositoryRevision struct {
 	Commit string `json:"commit,omitempty"`
 }
 
+// ComponentTrait represents a trait instance attached to a component in API requests
+type ComponentTrait struct {
+	Name         string                `json:"name"`
+	InstanceName string                `json:"instanceName"`
+	Parameters   *runtime.RawExtension `json:"parameters,omitempty"`
+}
+
 // CreateComponentRequest represents the request to create a new component
 type CreateComponentRequest struct {
-	Name              string             `json:"name"`
-	DisplayName       string             `json:"displayName,omitempty"`
-	Description       string             `json:"description,omitempty"`
-	Type              string             `json:"type"`
-	ComponentWorkflow *ComponentWorkflow `json:"workflow,omitempty"`
+	Name              string                `json:"name"`
+	DisplayName       string                `json:"displayName,omitempty"`
+	Description       string                `json:"description,omitempty"`
+	Type              string                `json:"type,omitempty"`          // LEGACY: Use componentType instead
+	ComponentType     string                `json:"componentType,omitempty"` // Format: {workloadType}/{componentTypeName}
+	AutoDeploy        *bool                 `json:"autoDeploy,omitempty"`
+	Parameters        *runtime.RawExtension `json:"parameters,omitempty"`
+	Traits            []ComponentTrait      `json:"traits,omitempty"`
+	ComponentWorkflow *ComponentWorkflow    `json:"workflow,omitempty"`
 }
 
 // PromoteComponentRequest Promote from one environment to another
@@ -177,6 +188,12 @@ func (req *CreateComponentRequest) Sanitize() {
 	req.DisplayName = strings.TrimSpace(req.DisplayName)
 	req.Description = strings.TrimSpace(req.Description)
 	req.Type = strings.TrimSpace(req.Type)
+	req.ComponentType = strings.TrimSpace(req.ComponentType)
+
+	for i := range req.Traits {
+		req.Traits[i].Name = strings.TrimSpace(req.Traits[i].Name)
+		req.Traits[i].InstanceName = strings.TrimSpace(req.Traits[i].InstanceName)
+	}
 }
 
 // Sanitize sanitizes the CreateEnvironmentRequest by trimming whitespace

--- a/internal/openchoreo-api/services/component_service.go
+++ b/internal/openchoreo-api/services/component_service.go
@@ -1536,6 +1536,39 @@ func (s *ComponentService) createComponentResources(ctx context.Context, orgName
 		controller.AnnotationKeyDescription: req.Description,
 	}
 
+	componentSpec := openchoreov1alpha1.ComponentSpec{
+		Owner: openchoreov1alpha1.ComponentOwner{
+			ProjectName: projectName,
+		},
+	}
+
+	if req.ComponentType != "" {
+		// New format: {workloadType}/{componentTypeName} (e.g., "deployment/web-app")
+		componentSpec.ComponentType = req.ComponentType
+	} else if req.Type != "" {
+		// Legacy format: "Service", "WebApplication", etc.
+		componentSpec.Type = openchoreov1alpha1.DefinedComponentType(req.Type)
+	}
+
+	if req.AutoDeploy != nil {
+		componentSpec.AutoDeploy = *req.AutoDeploy
+	}
+
+	if req.Parameters != nil {
+		componentSpec.Parameters = req.Parameters
+	}
+
+	if len(req.Traits) > 0 {
+		componentSpec.Traits = make([]openchoreov1alpha1.ComponentTrait, len(req.Traits))
+		for i, trait := range req.Traits {
+			componentSpec.Traits[i] = openchoreov1alpha1.ComponentTrait{
+				Name:         trait.Name,
+				InstanceName: trait.InstanceName,
+				Parameters:   trait.Parameters,
+			}
+		}
+	}
+
 	componentCR := &openchoreov1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Component",
@@ -1546,12 +1579,7 @@ func (s *ComponentService) createComponentResources(ctx context.Context, orgName
 			Namespace:   orgName,
 			Annotations: annotations,
 		},
-		Spec: openchoreov1alpha1.ComponentSpec{
-			Owner: openchoreov1alpha1.ComponentOwner{
-				ProjectName: projectName,
-			},
-			ComponentType: req.Type,
-		},
+		Spec: componentSpec,
 	}
 
 	// Set component workflow configuration if provided (new preferred way)
@@ -1618,12 +1646,17 @@ func (s *ComponentService) toComponentResponse(component *openchoreov1alpha1.Com
 		}
 	}
 
+	componentType := component.Spec.ComponentType
+	if componentType == "" && component.Spec.Type != "" {
+		componentType = string(component.Spec.Type)
+	}
+
 	response := &models.ComponentResponse{
 		UID:               string(component.UID),
 		Name:              component.Name,
 		DisplayName:       component.Annotations[controller.AnnotationKeyDisplayName],
 		Description:       component.Annotations[controller.AnnotationKeyDescription],
-		Type:              component.Spec.ComponentType,
+		Type:              componentType,
 		AutoDeploy:        component.Spec.AutoDeploy,
 		ProjectName:       projectName,
 		OrgName:           component.Namespace,


### PR DESCRIPTION
## Purpose

This pull request introduces enhancements to the component creation API, focusing on supporting a new, more flexible component type format and adding traits to components. The changes improve backward compatibility, allow richer component definitions, and ensure proper data sanitization.

### API Model Improvements

* Added the `ComponentTrait` struct and a `traits` field to the `CreateComponentRequest` model, enabling users to attach trait instances with parameters to components.
* Introduced the new `componentType` field to `CreateComponentRequest`, supporting a structured format (`{workloadType}/{componentTypeName}`) and marked the legacy `type` field for backward compatibility. Also added `autoDeploy` and `parameters` fields for more flexible configuration.

### Data Sanitization

* Updated the `Sanitize` method for `CreateComponentRequest` to trim whitespace from the new `componentType` field and all trait names/instance names, ensuring clean input data.

### Service Layer Enhancements

* Modified the `createComponentResources` method to construct the component spec using both the new `componentType` and legacy `type` fields, set `autoDeploy`, `parameters`, and map trait definitions from the request to the spec.
* Refactored the component resource creation to use the assembled `componentSpec` instead of directly setting fields, improving maintainability and clarity.
* Updated response serialization to prefer the new `componentType` format, falling back to the legacy `type` if necessary, ensuring consistent API responses.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
