### PR TITLE
Update README with instructions to configure dataplane and buildplane to use Observer

### DIFF
--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -93,6 +93,16 @@ helm install openchoreo-observability-plane install/helm/openchoreo-observabilit
   --values install/k3d/single-cluster/values-op.yaml
 ```
 
+Configure DataPlane to use Observer
+```
+kubectl patch dataplane default -n default --type merge -p '{"spec":{"observer":{"url":"http://observer.openchoreo-observability-plane:8080","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}'
+```
+
+Configure BuildPlane (if installed) to use Observer
+```
+kubectl patch buildplane default -n default --type merge -p '{"spec":{"observer":{"url":"http://observer.openchoreo-observability-plane:8080","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}'
+```
+
 ### 3. Create DataPlane Resource
 
 Create a DataPlane resource to enable workload deployment.


### PR DESCRIPTION
## Purpose
Add instructions to patch dataplane and buildplane resources to enable Observability

## Approach
Added the kubectl patch commands required to enable Observability

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
