### PR TITLE
Add log level configuration to OpenChoreo API

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/authz"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/cmdutil"
 	k8s "github.com/openchoreo/openchoreo/internal/openchoreo-api/clients"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/handlers"
@@ -29,8 +30,8 @@ var (
 func main() {
 	flag.Parse()
 
-	slogHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-	baseLogger := slog.New(slogHandler)
+	// Get log level from environment variable, default to "info"
+	baseLogger := cmdutil.SetupLogger(os.Getenv(config.EnvLogLevel))
 	slog.SetDefault(baseLogger)
 
 	// Create shutdown context

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -72,6 +72,8 @@ spec:
           value: {{ .Values.openchoreoApi.database.path | quote }}
         - name: OPENCHOREO_API_CONFIG_PATH
           value: /etc/openchoreo/config.yaml
+        - name: LOG_LEVEL
+          value: {{ .Values.openchoreoApi.logLevel | default "info" | quote }}
         volumeMounts:
         - name: data
           mountPath: /var/lib/openchoreo/data

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -220,6 +220,7 @@ openchoreoApi:
     pullPolicy: IfNotPresent
   mcp:
     toolsets: "organization,project,component,build,deployment,infrastructure"
+  logLevel: info
   database:
     path: "/var/lib/openchoreo/data/controlplane.db"
     persistence:

--- a/internal/openchoreo-api/config/env.go
+++ b/internal/openchoreo-api/config/env.go
@@ -25,6 +25,9 @@ const (
 
 	// EnvJWTDisabled is the flag to disable JWT authentication
 	EnvJWTDisabled = "JWT_DISABLED"
+
+	// EnvLogLevel is the log level for the API server (debug, info, warn, error)
+	EnvLogLevel = "LOG_LEVEL"
 )
 
 // Default values for configuration


### PR DESCRIPTION
## Purpose
Adding the changes to pass the loglevel through control-plane Helm Chart to debug the openchoreo-api when deployed in a k8s cluster. 

## Approach
Changes from this PR includes;
- Introduced environment variable support for log level in main.go, defaulting to "info".
- Updated ControlPlane Helm chart values.yaml to include logLevel configuration.
- Modified deployment.yaml to pass log level as an environment variable.
- Defined EnvLogLevel constant in env.go for clarity on log level configuration.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
