### PR TITLE
update GitHub Actions to latest stable versions

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -3,6 +3,6 @@ description: Sets up Go environment
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6.1.0
       with:
         go-version-file: go.mod

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -56,7 +56,7 @@ jobs:
     needs: [ lint, gen-check, test ]
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -70,37 +70,37 @@ jobs:
           make go.build-multiarch.choreoctl GO_TARGET_PLATFORMS="darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"
 
       - name: Upload choreoctl binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: choreoctl
           path: bin/dist/**/choreoctl
 
       - name: Upload manager binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: manager
           path: bin/dist/**/manager
 
       - name: Upload openchoreo-api binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: openchoreo-api
           path: bin/dist/**/openchoreo-api
 
       - name: Upload observer binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: observer
           path: bin/dist/**/observer
 
       - name: Upload cluster-gateway binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: cluster-gateway
           path: bin/dist/**/cluster-gateway
 
       - name: Upload cluster-agent binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: cluster-agent
           path: bin/dist/**/cluster-agent
@@ -113,43 +113,43 @@ jobs:
       packages: write
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Download choreoctl binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6.0.0
         with:
           name: choreoctl
           path: bin/dist
 
       - name: Download manager binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6.0.0
         with:
           name: manager
           path: bin/dist
 
       - name: Download openchoreo-api binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6.0.0
         with:
           name: openchoreo-api
           path: bin/dist
 
       - name: Download observer binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6.0.0
         with:
           name: observer
           path: bin/dist
 
       - name: Download cluster-gateway binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6.0.0
         with:
           name: cluster-gateway
           path: bin/dist
 
       - name: Download cluster-agent binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6.0.0
         with:
           name: cluster-agent
           path: bin/dist
@@ -174,7 +174,7 @@ jobs:
           
       - name: Login to GitHub container registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Login to GitHub container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -65,7 +65,7 @@ jobs:
           fi
 
       - name: Download choreoctl artifact from the build workflow
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v11
         with:
           workflow: build-and-test.yml
           commit: ${{ env.GIT_SHA_LONG }}
@@ -89,7 +89,7 @@ jobs:
           make helm-push HELM_CHART_VERSION=${{ env.RELEASE_TAG_WITHOUT_V }} TAG=${{ env.RELEASE_TAG }} HELM_CONTROLLER_IMAGE_PULL_POLICY=IfNotPresent
 
       - name: Upload GitHub release artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.5.0
         with:
           draft: true
           generate_release_notes: true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
 # TODO: Enable me once the e2e tests are ready
 #      - name: Setup Go
-#        uses: actions/setup-go@v5
+#        uses: actions/setup-go@v6.1.0
 #        with:
 #          go-version: '~1.23'
 #


### PR DESCRIPTION
This PR updates all GitHub Actions in CI/CD workflows to their latest stable versions. Updated actions include `actions/checkout@v6.0.1`, `actions/upload-artifact@v5.0.0`, `actions/download-artifact@v6.0.0`, `actions/setup-go@v6.1.0`, `docker/login-action@v3.6.0`, `dawidd6/action-download-artifact@v11`, and `softprops/action-gh-release@v2.5.0`. This ensures we're using the latest security patches, performance improvements, and features. The hardcoded test branch name has also been removed from workflow triggers.

**I would be happy to contribute to any DevOps related tasks.**

@sameerajayasoma @chalindukodikara 