### PR TITLE
Cleanup component resources on component and project deletion

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -57,7 +57,6 @@ rules:
   - organizations
   - projects
   - releasebindings
-  - releases
   - secretreferences
   - traits
   - workflowruns
@@ -131,3 +130,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - openchoreo.dev
+  resources:
+  - releases
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/controller-manager-role.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/controller-manager-role.yaml
@@ -59,7 +59,6 @@ rules:
     - organizations
     - projects
     - releasebindings
-    - releases
     - secretreferences
     - traits
     - workflowruns
@@ -131,3 +130,16 @@ rules:
     - get
     - patch
     - update
+- apiGroups:
+    - openchoreo.dev
+  resources:
+    - releases
+  verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch

--- a/internal/controller/component/controller_conditions.go
+++ b/internal/controller/component/controller_conditions.go
@@ -4,6 +4,8 @@
 package component
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
@@ -14,6 +16,9 @@ const (
 	// When autoDeploy is enabled, this means ComponentRelease and ReleaseBinding are created/updated.
 	// When autoDeploy is disabled, this means the Component has been validated.
 	ConditionReady controller.ConditionType = "Ready"
+
+	// ConditionFinalizing indicates that the Component is being finalized (deleted).
+	ConditionFinalizing controller.ConditionType = "Finalizing"
 )
 
 // Constants for condition reasons
@@ -48,4 +53,18 @@ const (
 
 	// ReasonAutoDeployFailed indicates failure to handle autoDeploy (ComponentRelease/ReleaseBinding creation)
 	ReasonAutoDeployFailed controller.ConditionReason = "AutoDeployFailed"
+
+	// ReasonFinalizing indicates the Component is being finalized
+	ReasonFinalizing controller.ConditionReason = "Finalizing"
 )
+
+// NewComponentFinalizingCondition creates a condition indicating the Component is being finalized.
+func NewComponentFinalizingCondition(generation int64) metav1.Condition {
+	return controller.NewCondition(
+		ConditionFinalizing,
+		metav1.ConditionTrue,
+		ReasonFinalizing,
+		"Component is finalizing",
+		generation,
+	)
+}

--- a/internal/controller/component/controller_finalize.go
+++ b/internal/controller/component/controller_finalize.go
@@ -1,0 +1,218 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+const (
+	// ComponentFinalizer is the finalizer that ensures owned resources are deleted before Component
+	ComponentFinalizer = "openchoreo.dev/component-cleanup"
+)
+
+// ensureFinalizer ensures that the finalizer is added to the Component.
+// The first return value indicates whether the finalizer was added to the Component.
+func (r *Reconciler) ensureFinalizer(ctx context.Context, comp *openchoreov1alpha1.Component) (bool, error) {
+	// If the Component is being deleted, no need to add the finalizer
+	if !comp.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+
+	if controllerutil.AddFinalizer(comp, ComponentFinalizer) {
+		return true, r.Update(ctx, comp)
+	}
+
+	return false, nil
+}
+
+// finalize cleans up the resources associated with the Component.
+func (r *Reconciler) finalize(ctx context.Context, old, comp *openchoreov1alpha1.Component) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("component", comp.Name)
+
+	if !controllerutil.ContainsFinalizer(comp, ComponentFinalizer) {
+		// Nothing to do if the finalizer is not present
+		return ctrl.Result{}, nil
+	}
+
+	// Mark the component condition as finalizing and return so that the component will indicate that it is being finalized.
+	// The actual finalization will be done in the next reconcile loop triggered by the status update.
+	if meta.SetStatusCondition(&comp.Status.Conditions, NewComponentFinalizingCondition(comp.Generation)) {
+		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, comp)
+	}
+
+	// Delete all owned resources in a single reconcile
+	hasReleases, err := r.hasOwnedComponentReleases(ctx, comp)
+	if err != nil {
+		logger.Error(err, "Failed to check for owned ComponentReleases")
+		return ctrl.Result{}, err
+	}
+
+	hasBindings, err := r.hasOwnedReleaseBindings(ctx, comp)
+	if err != nil {
+		logger.Error(err, "Failed to check for owned ReleaseBindings")
+		return ctrl.Result{}, err
+	}
+
+	hasWorkloads, err := r.hasOwnedWorkloads(ctx, comp)
+	if err != nil {
+		logger.Error(err, "Failed to check for owned Workloads")
+		return ctrl.Result{}, err
+	}
+
+	hasWorkflowRuns, err := r.hasOwnedComponentWorkflowRuns(ctx, comp)
+	if err != nil {
+		logger.Error(err, "Failed to check for owned ComponentWorkflowRuns")
+		return ctrl.Result{}, err
+	}
+
+	// Requeue if any children still exist
+	if hasReleases || hasBindings || hasWorkloads || hasWorkflowRuns {
+		logger.Info("Waiting for owned resources to be deleted")
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	}
+
+	// All children are deleted - remove the finalizer
+	if controllerutil.RemoveFinalizer(comp, ComponentFinalizer) {
+		if err := r.Update(ctx, comp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		}
+	}
+
+	logger.Info("Successfully finalized Component")
+	return ctrl.Result{}, nil
+}
+
+// hasOwnedComponentReleases checks if any ComponentReleases owned by this Component still exist,
+// and deletes them if they exist.
+func (r *Reconciler) hasOwnedComponentReleases(ctx context.Context, comp *openchoreov1alpha1.Component) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("component", comp.Name)
+
+	// List ComponentReleases owned by this Component using field index
+	releaseList := &openchoreov1alpha1.ComponentReleaseList{}
+	if err := r.List(ctx, releaseList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{"spec.owner.componentName": comp.Name}); err != nil {
+		return false, fmt.Errorf("failed to list component releases: %w", err)
+	}
+
+	if len(releaseList.Items) == 0 {
+		logger.Info("All ComponentReleases are deleted")
+		return false, nil
+	}
+
+	// Delete all ComponentReleases owned by this Component
+	logger.Info("Deleting owned ComponentReleases", "count", len(releaseList.Items))
+	for i := range releaseList.Items {
+		release := &releaseList.Items[i]
+		if err := client.IgnoreNotFound(r.Delete(ctx, release)); err != nil {
+			return false, fmt.Errorf("failed to delete component release %s: %w", release.Name, err)
+		}
+	}
+
+	return true, nil
+}
+
+// hasOwnedReleaseBindings checks if any ReleaseBindings owned by this Component still exist,
+// and deletes them if they exist.
+func (r *Reconciler) hasOwnedReleaseBindings(ctx context.Context, comp *openchoreov1alpha1.Component) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("component", comp.Name)
+
+	// List ReleaseBindings owned by this Component using shared field index
+	bindingList := &openchoreov1alpha1.ReleaseBindingList{}
+	if err := r.List(ctx, bindingList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{controller.IndexKeyReleaseBindingOwnerComponentName: comp.Name}); err != nil {
+		return false, fmt.Errorf("failed to list release bindings: %w", err)
+	}
+
+	if len(bindingList.Items) == 0 {
+		logger.Info("All ReleaseBindings are deleted")
+		return false, nil
+	}
+
+	// Delete all ReleaseBindings owned by this Component
+	logger.Info("Deleting owned ReleaseBindings", "count", len(bindingList.Items))
+	for i := range bindingList.Items {
+		binding := &bindingList.Items[i]
+		if err := client.IgnoreNotFound(r.Delete(ctx, binding)); err != nil {
+			return false, fmt.Errorf("failed to delete release binding %s: %w", binding.Name, err)
+		}
+	}
+
+	return true, nil
+}
+
+// hasOwnedWorkloads checks if any Workloads owned by this Component still exist,
+// and deletes them if they exist.
+func (r *Reconciler) hasOwnedWorkloads(ctx context.Context, comp *openchoreov1alpha1.Component) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("component", comp.Name)
+
+	// List Workloads owned by this Component using field index
+	// The workloadOwnerIndex uses composite key: projectName/componentName
+	ownerKey := fmt.Sprintf("%s/%s", comp.Spec.Owner.ProjectName, comp.Name)
+	workloadList := &openchoreov1alpha1.WorkloadList{}
+	if err := r.List(ctx, workloadList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{workloadOwnerIndex: ownerKey}); err != nil {
+		return false, fmt.Errorf("failed to list workloads: %w", err)
+	}
+
+	if len(workloadList.Items) == 0 {
+		logger.Info("All Workloads are deleted")
+		return false, nil
+	}
+
+	// Delete all Workloads owned by this Component
+	logger.Info("Deleting owned Workloads", "count", len(workloadList.Items))
+	for i := range workloadList.Items {
+		workload := &workloadList.Items[i]
+		if err := client.IgnoreNotFound(r.Delete(ctx, workload)); err != nil {
+			return false, fmt.Errorf("failed to delete workload %s: %w", workload.Name, err)
+		}
+	}
+
+	return true, nil
+}
+
+// hasOwnedComponentWorkflowRuns checks if any ComponentWorkflowRuns owned by this Component still exist,
+// and deletes them if they exist.
+func (r *Reconciler) hasOwnedComponentWorkflowRuns(ctx context.Context, comp *openchoreov1alpha1.Component) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("component", comp.Name)
+
+	// List ComponentWorkflowRuns owned by this Component using field index
+	workflowRunList := &openchoreov1alpha1.ComponentWorkflowRunList{}
+	if err := r.List(ctx, workflowRunList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{componentWorkflowRunOwnerIndex: comp.Name}); err != nil {
+		return false, fmt.Errorf("failed to list component workflow runs: %w", err)
+	}
+
+	if len(workflowRunList.Items) == 0 {
+		logger.Info("All ComponentWorkflowRuns are deleted")
+		return false, nil
+	}
+
+	// Delete all ComponentWorkflowRuns owned by this Component
+	logger.Info("Deleting owned ComponentWorkflowRuns", "count", len(workflowRunList.Items))
+	for i := range workflowRunList.Items {
+		workflowRun := &workflowRunList.Items[i]
+		if err := client.IgnoreNotFound(r.Delete(ctx, workflowRun)); err != nil {
+			return false, fmt.Errorf("failed to delete component workflow run %s: %w", workflowRun.Name, err)
+		}
+	}
+
+	return true, nil
+}

--- a/internal/controller/component/controller_test.go
+++ b/internal/controller/component/controller_test.go
@@ -5,11 +5,13 @@ package component
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -24,7 +26,7 @@ var _ = Describe("Component Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: "default",
 		}
 		component := &openchoreov1alpha1.Component{}
 
@@ -62,14 +64,14 @@ var _ = Describe("Component Controller", func() {
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &openchoreov1alpha1.Component{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Component")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			if err == nil {
+				By("Cleanup the specific resource instance Component")
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
 		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &Reconciler{
@@ -81,8 +83,407 @@ var _ = Describe("Component Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})
+
+var _ = Describe("Component Controller Finalization", func() {
+	const (
+		projectName   = "finalize-test-project"
+		componentName = "finalize-test-component"
+		namespace     = "default"
+		timeout       = time.Second * 10
+		interval      = time.Millisecond * 250
+	)
+
+	var (
+		ctx        context.Context
+		reconciler *Reconciler
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		reconciler = &Reconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	})
+
+	Context("When deleting a Component with no owned resources", func() {
+		It("should finalize and delete the Component immediately", func() {
+			compName := componentName + "-no-owned"
+			compNamespacedName := types.NamespacedName{Name: compName, Namespace: namespace}
+
+			By("Creating a Component")
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+					Type: openchoreov1alpha1.ComponentTypeService,
+				},
+			}
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+
+			By("Reconciling to add finalizer")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying finalizer is added")
+			Eventually(func() bool {
+				updated := &openchoreov1alpha1.Component{}
+				if err := k8sClient.Get(ctx, compNamespacedName, updated); err != nil {
+					return false
+				}
+				for _, f := range updated.Finalizers {
+					if f == ComponentFinalizer {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Deleting the Component")
+			Expect(k8sClient.Delete(ctx, comp)).To(Succeed())
+
+			By("Verifying Component is marked for deletion")
+			Eventually(func() bool {
+				updated := &openchoreov1alpha1.Component{}
+				if err := k8sClient.Get(ctx, compNamespacedName, updated); err != nil {
+					return false
+				}
+				return !updated.DeletionTimestamp.IsZero()
+			}, timeout, interval).Should(BeTrue())
+
+			By("Reconciling to set Finalizing condition")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling to complete finalization")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Component is deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, compNamespacedName, &openchoreov1alpha1.Component{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting a Component with all owned resource types", func() {
+		It("should wait for all children to be deleted before removing finalizer", func() {
+			compName := componentName + "-full-owned"
+			releaseName := compName + "-release-v1"
+			bindingName := compName + "-binding-dev"
+			workloadName := compName + "-workload"
+			workflowRunName := compName + "-build-01"
+			compNamespacedName := types.NamespacedName{Name: compName, Namespace: namespace}
+			releaseNamespacedName := types.NamespacedName{Name: releaseName, Namespace: namespace}
+			bindingNamespacedName := types.NamespacedName{Name: bindingName, Namespace: namespace}
+			workloadNamespacedName := types.NamespacedName{Name: workloadName, Namespace: namespace}
+			workflowRunNamespacedName := types.NamespacedName{Name: workflowRunName, Namespace: namespace}
+
+			By("Creating a Component")
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+					Type: openchoreov1alpha1.ComponentTypeService,
+				},
+			}
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+
+			By("Creating an owned ComponentRelease")
+			release := &openchoreov1alpha1.ComponentRelease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      releaseName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentReleaseSpec{
+					Owner: openchoreov1alpha1.ComponentReleaseOwner{
+						ProjectName:   projectName,
+						ComponentName: compName,
+					},
+					ComponentType: openchoreov1alpha1.ComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources: []openchoreov1alpha1.ResourceTemplate{
+							{
+								ID:       "deployment",
+								Template: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"apps/v1","kind":"Deployment"}`)},
+							},
+						},
+					},
+					ComponentProfile: openchoreov1alpha1.ComponentProfile{},
+					Workload: openchoreov1alpha1.WorkloadTemplateSpec{
+						Containers: map[string]openchoreov1alpha1.Container{
+							"app": {Image: "nginx:latest"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			By("Creating an owned ReleaseBinding")
+			binding := &openchoreov1alpha1.ReleaseBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ReleaseBindingSpec{
+					Owner: openchoreov1alpha1.ReleaseBindingOwner{
+						ProjectName:   projectName,
+						ComponentName: compName,
+					},
+					Environment: "development",
+				},
+			}
+			Expect(k8sClient.Create(ctx, binding)).To(Succeed())
+
+			By("Creating an owned Workload")
+			workload := &openchoreov1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workloadName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.WorkloadSpec{
+					Owner: openchoreov1alpha1.WorkloadOwner{
+						ProjectName:   projectName,
+						ComponentName: compName,
+					},
+					WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
+						Containers: map[string]openchoreov1alpha1.Container{
+							"app": {Image: "nginx:latest"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, workload)).To(Succeed())
+
+			By("Creating an owned ComponentWorkflowRun")
+			workflowRun := &openchoreov1alpha1.ComponentWorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workflowRunName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentWorkflowRunSpec{
+					Owner: openchoreov1alpha1.ComponentWorkflowOwner{
+						ProjectName:   projectName,
+						ComponentName: compName,
+					},
+					Workflow: openchoreov1alpha1.ComponentWorkflowRunConfig{
+						Name: "test-workflow",
+						SystemParameters: openchoreov1alpha1.SystemParametersValues{
+							Repository: openchoreov1alpha1.RepositoryValues{
+								URL: "https://github.com/test/repo",
+								Revision: openchoreov1alpha1.RepositoryRevisionValues{
+									Branch: "main",
+								},
+								AppPath: ".",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, workflowRun)).To(Succeed())
+
+			By("Reconciling to add finalizer")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying finalizer is present")
+			updated := &openchoreov1alpha1.Component{}
+			Expect(k8sClient.Get(ctx, compNamespacedName, updated)).To(Succeed())
+			Expect(updated.Finalizers).To(ContainElement(ComponentFinalizer))
+
+			By("Deleting the Component")
+			Expect(k8sClient.Delete(ctx, comp)).To(Succeed())
+
+			By("Verifying Component is marked for deletion but still exists due to finalizer")
+			Eventually(func() bool {
+				c := &openchoreov1alpha1.Component{}
+				if err := k8sClient.Get(ctx, compNamespacedName, c); err != nil {
+					return false
+				}
+				return !c.DeletionTimestamp.IsZero()
+			}, timeout, interval).Should(BeTrue())
+
+			By("First reconcile sets Finalizing condition")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Component still has finalizer while children exist")
+			compDuringFinalization := &openchoreov1alpha1.Component{}
+			Expect(k8sClient.Get(ctx, compNamespacedName, compDuringFinalization)).To(Succeed())
+			Expect(compDuringFinalization.Finalizers).To(ContainElement(ComponentFinalizer))
+			Expect(compDuringFinalization.DeletionTimestamp.IsZero()).To(BeFalse())
+
+			By("Reconciling to trigger deletion of all children")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying result requests requeue while children exist")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			By("Verifying Component still exists with finalizer during child deletion")
+			compStillPresent := &openchoreov1alpha1.Component{}
+			Expect(k8sClient.Get(ctx, compNamespacedName, compStillPresent)).To(Succeed())
+			Expect(compStillPresent.Finalizers).To(ContainElement(ComponentFinalizer))
+
+			By("Reconciling to complete finalization after all children are gone")
+			Eventually(func() bool {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+				if err != nil {
+					return false
+				}
+				c := &openchoreov1alpha1.Component{}
+				err = k8sClient.Get(ctx, compNamespacedName, c)
+				return errors.IsNotFound(err)
+			}, timeout*3, interval).Should(BeTrue())
+
+			By("Verifying all resources are deleted")
+			err = k8sClient.Get(ctx, releaseNamespacedName, &openchoreov1alpha1.ComponentRelease{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			err = k8sClient.Get(ctx, bindingNamespacedName, &openchoreov1alpha1.ReleaseBinding{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			err = k8sClient.Get(ctx, workloadNamespacedName, &openchoreov1alpha1.Workload{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			err = k8sClient.Get(ctx, workflowRunNamespacedName, &openchoreov1alpha1.ComponentWorkflowRun{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			err = k8sClient.Get(ctx, compNamespacedName, &openchoreov1alpha1.Component{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("When deleting a Component with slow-deleting child (blocked by finalizer)", func() {
+		const childFinalizer = "test.openchoreo.dev/block-deletion"
+
+		It("should wait for blocked child to finish terminating before removing Component finalizer", func() {
+			compName := componentName + "-blocked-child"
+			releaseName := compName + "-release-blocked"
+			compNamespacedName := types.NamespacedName{Name: compName, Namespace: namespace}
+			releaseNamespacedName := types.NamespacedName{Name: releaseName, Namespace: namespace}
+
+			By("Creating a Component")
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+					Type: openchoreov1alpha1.ComponentTypeService,
+				},
+			}
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+
+			By("Creating an owned ComponentRelease with a blocking finalizer")
+			release := &openchoreov1alpha1.ComponentRelease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       releaseName,
+					Namespace:  namespace,
+					Finalizers: []string{childFinalizer},
+				},
+				Spec: openchoreov1alpha1.ComponentReleaseSpec{
+					Owner: openchoreov1alpha1.ComponentReleaseOwner{
+						ProjectName:   projectName,
+						ComponentName: compName,
+					},
+					ComponentType: openchoreov1alpha1.ComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources: []openchoreov1alpha1.ResourceTemplate{
+							{
+								ID:       "deployment",
+								Template: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"apps/v1","kind":"Deployment"}`)},
+							},
+						},
+					},
+					ComponentProfile: openchoreov1alpha1.ComponentProfile{},
+					Workload: openchoreov1alpha1.WorkloadTemplateSpec{
+						Containers: map[string]openchoreov1alpha1.Container{
+							"app": {Image: "nginx:latest"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			By("Reconciling to add finalizer to Component")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the Component")
+			Expect(k8sClient.Delete(ctx, comp)).To(Succeed())
+
+			By("Reconciling to set Finalizing condition")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling to trigger child deletion")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying ComponentRelease is marked for deletion but still exists")
+			Eventually(func(g Gomega) {
+				blockedRelease := &openchoreov1alpha1.ComponentRelease{}
+				g.Expect(k8sClient.Get(ctx, releaseNamespacedName, blockedRelease)).To(Succeed())
+				g.Expect(blockedRelease.DeletionTimestamp.IsZero()).To(BeFalse())
+				g.Expect(blockedRelease.Finalizers).To(ContainElement(childFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying controller requeues while child is blocked")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			By("Verifying Component still exists with finalizer while child is terminating")
+			compBlocked := &openchoreov1alpha1.Component{}
+			Expect(k8sClient.Get(ctx, compNamespacedName, compBlocked)).To(Succeed())
+			Expect(compBlocked.Finalizers).To(ContainElement(ComponentFinalizer))
+			Expect(compBlocked.DeletionTimestamp.IsZero()).To(BeFalse())
+
+			By("Running multiple reconciles while child is blocked - Component should not be deleted")
+			for range 3 {
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+				compStillExists := &openchoreov1alpha1.Component{}
+				Expect(k8sClient.Get(ctx, compNamespacedName, compStillExists)).To(Succeed())
+				Expect(compStillExists.Finalizers).To(ContainElement(ComponentFinalizer))
+			}
+
+			By("Simulating child finalizer removal (external process completes cleanup)")
+			releaseToUnblock := &openchoreov1alpha1.ComponentRelease{}
+			Expect(k8sClient.Get(ctx, releaseNamespacedName, releaseToUnblock)).To(Succeed())
+			releaseToUnblock.Finalizers = nil
+			Expect(k8sClient.Update(ctx, releaseToUnblock)).To(Succeed())
+
+			By("Waiting for ComponentRelease to be fully deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, releaseNamespacedName, &openchoreov1alpha1.ComponentRelease{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Reconciling to complete finalization")
+			Eventually(func() bool {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: compNamespacedName})
+				if err != nil {
+					return false
+				}
+				c := &openchoreov1alpha1.Component{}
+				err = k8sClient.Get(ctx, compNamespacedName, c)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/internal/controller/component/controller_watch.go
+++ b/internal/controller/component/controller_watch.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
 const (
@@ -24,7 +25,14 @@ const (
 	workloadOwnerIndex = "spec.owner"
 	// releaseBindingIndex is the field index name for ReleaseBinding owner fields and environment
 	releaseBindingIndex = "spec.owner.projectName/spec.owner.componentName/spec.environment"
+	// componentWorkflowRunOwnerIndex is the field index name for ComponentWorkflowRun owner references
+	componentWorkflowRunOwnerIndex = "spec.owner.componentName"
 )
+
+// makeReleaseBindingIndexKey creates the index key for ReleaseBinding lookups.
+func makeReleaseBindingIndexKey(projectName, componentName, environment string) string {
+	return fmt.Sprintf("%s/%s/%s", projectName, componentName, environment)
+}
 
 // setupComponentTypeRefIndex sets up the field index for componentType references
 func (r *Reconciler) setupComponentTypeRefIndex(ctx context.Context, mgr ctrl.Manager) error {
@@ -69,11 +77,38 @@ func (r *Reconciler) setupReleaseBindingIndex(ctx context.Context, mgr ctrl.Mana
 	return mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
 		releaseBindingIndex, func(obj client.Object) []string {
 			releaseBinding := obj.(*openchoreov1alpha1.ReleaseBinding)
-			project := releaseBinding.Spec.Owner.ProjectName
-			component := releaseBinding.Spec.Owner.ComponentName
-			environment := releaseBinding.Spec.Environment
-			ownerKey := fmt.Sprintf("%s/%s/%s", project, component, environment)
-			return []string{ownerKey}
+			key := makeReleaseBindingIndexKey(
+				releaseBinding.Spec.Owner.ProjectName,
+				releaseBinding.Spec.Owner.ComponentName,
+				releaseBinding.Spec.Environment,
+			)
+			return []string{key}
+		})
+}
+
+// setupComponentReleaseOwnerIndex registers an index for ComponentRelease by owner component name.
+// This enables efficient lookup of ComponentReleases owned by a specific Component.
+func (r *Reconciler) setupComponentReleaseOwnerIndex(ctx context.Context, mgr ctrl.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ComponentRelease{},
+		"spec.owner.componentName", func(obj client.Object) []string {
+			release := obj.(*openchoreov1alpha1.ComponentRelease)
+			if release.Spec.Owner.ComponentName == "" {
+				return nil
+			}
+			return []string{release.Spec.Owner.ComponentName}
+		})
+}
+
+// setupComponentWorkflowRunOwnerIndex registers an index for ComponentWorkflowRun by owner component name.
+// This enables efficient lookup of ComponentWorkflowRuns owned by a specific Component.
+func (r *Reconciler) setupComponentWorkflowRunOwnerIndex(ctx context.Context, mgr ctrl.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ComponentWorkflowRun{},
+		componentWorkflowRunOwnerIndex, func(obj client.Object) []string {
+			workflowRun := obj.(*openchoreov1alpha1.ComponentWorkflowRun)
+			if workflowRun.Spec.Owner.ComponentName == "" {
+				return nil
+			}
+			return []string{workflowRun.Spec.Owner.ComponentName}
 		})
 }
 
@@ -140,4 +175,118 @@ func (r *Reconciler) listComponentsForWorkload(ctx context.Context, obj client.O
 			Namespace: workload.Namespace,
 		},
 	}}
+}
+
+// findComponentsForComponentRelease maps a ComponentRelease to its owner Component
+func (r *Reconciler) findComponentsForComponentRelease(ctx context.Context, obj client.Object) []ctrl.Request {
+	release := obj.(*openchoreov1alpha1.ComponentRelease)
+	if release.Spec.Owner.ComponentName == "" {
+		return nil
+	}
+	return []ctrl.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      release.Spec.Owner.ComponentName,
+			Namespace: release.Namespace,
+		},
+	}}
+}
+
+// findComponentsForReleaseBinding maps a ReleaseBinding to its owner Component
+func (r *Reconciler) findComponentsForReleaseBinding(ctx context.Context, obj client.Object) []ctrl.Request {
+	binding := obj.(*openchoreov1alpha1.ReleaseBinding)
+	if binding.Spec.Owner.ComponentName == "" {
+		return nil
+	}
+	return []ctrl.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      binding.Spec.Owner.ComponentName,
+			Namespace: binding.Namespace,
+		},
+	}}
+}
+
+// findComponentsForComponentWorkflowRun maps a ComponentWorkflowRun to its owner Component
+func (r *Reconciler) findComponentsForComponentWorkflowRun(ctx context.Context, obj client.Object) []ctrl.Request {
+	workflowRun := obj.(*openchoreov1alpha1.ComponentWorkflowRun)
+	if workflowRun.Spec.Owner.ComponentName == "" {
+		return nil
+	}
+	return []ctrl.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      workflowRun.Spec.Owner.ComponentName,
+			Namespace: workflowRun.Namespace,
+		},
+	}}
+}
+
+// listComponentsForProject returns reconcile requests for all Components owned by this Project.
+// This ensures Components are re-reconciled when their owning Project changes, particularly when
+// the deploymentPipelineRef is added or modified.
+func (r *Reconciler) listComponentsForProject(ctx context.Context, obj client.Object) []reconcile.Request {
+	project := obj.(*openchoreov1alpha1.Project)
+	logger := ctrl.LoggerFrom(ctx)
+
+	var components openchoreov1alpha1.ComponentList
+	if err := r.List(ctx, &components,
+		client.InNamespace(project.Namespace),
+		client.MatchingFields{controller.IndexKeyComponentOwnerProjectName: project.Name}); err != nil {
+		logger.Error(err, "Failed to list components for Project", "project", project.Name)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, len(components.Items))
+	for i, comp := range components.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      comp.Name,
+				Namespace: comp.Namespace,
+			},
+		}
+	}
+	return requests
+}
+
+// listComponentsForDeploymentPipeline returns reconcile requests for Components that belong to Projects
+// using the changed DeploymentPipeline. Components depend on the DeploymentPipeline's promotion paths
+// to determine the root environment for ReleaseBindings, so they need to be re-reconciled when the
+// pipeline changes.
+func (r *Reconciler) listComponentsForDeploymentPipeline(ctx context.Context, obj client.Object) []reconcile.Request {
+	pipeline := obj.(*openchoreov1alpha1.DeploymentPipeline)
+	logger := ctrl.LoggerFrom(ctx)
+
+	// Find Projects that reference this DeploymentPipeline
+	var projects openchoreov1alpha1.ProjectList
+	if err := r.List(ctx, &projects,
+		client.InNamespace(pipeline.Namespace),
+		client.MatchingFields{controller.IndexKeyProjectDeploymentPipelineRef: pipeline.Name}); err != nil {
+		logger.Error(err, "Failed to list projects for DeploymentPipeline", "deploymentPipeline", pipeline.Name)
+		return nil
+	}
+
+	if len(projects.Items) == 0 {
+		return nil
+	}
+
+	// For each Project, find its Components
+	var requests []reconcile.Request
+	for _, project := range projects.Items {
+		var components openchoreov1alpha1.ComponentList
+		if err := r.List(ctx, &components,
+			client.InNamespace(pipeline.Namespace),
+			client.MatchingFields{controller.IndexKeyComponentOwnerProjectName: project.Name}); err != nil {
+			logger.Error(err, "Failed to list components for Project",
+				"project", project.Name, "deploymentPipeline", pipeline.Name)
+			continue
+		}
+
+		for _, comp := range components.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      comp.Name,
+					Namespace: comp.Namespace,
+				},
+			})
+		}
+	}
+	return requests
 }

--- a/internal/controller/component/suite_test.go
+++ b/internal/controller/component/suite_test.go
@@ -14,12 +14,16 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -67,10 +71,112 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	// Create a manager with cache enabled only for types that need field index queries
+	// (ComponentRelease, ReleaseBinding, Workload, ComponentWorkflowRun for owner lookups during finalization)
+	// Other types bypass cache to avoid staleness issues in tests
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server in tests
+		},
+		Cache: cache.Options{
+			// Only cache types required for field index queries
+			ByObject: map[client.Object]cache.ByObject{
+				&openchoreov1alpha1.ComponentRelease{}:     {},
+				&openchoreov1alpha1.ReleaseBinding{}:       {},
+				&openchoreov1alpha1.Workload{}:             {},
+				&openchoreov1alpha1.ComponentWorkflowRun{}: {},
+			},
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				// Disable cache reads for types not requiring field indices
+				DisableFor: []client.Object{
+					&openchoreov1alpha1.Component{},
+				},
+			},
+		},
+	})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
 
+	// Register field indices used by the component controller for finalization
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ComponentRelease{},
+		"spec.owner.componentName", func(obj client.Object) []string {
+			release := obj.(*openchoreov1alpha1.ComponentRelease)
+			if release.Spec.Owner.ComponentName == "" {
+				return nil
+			}
+			return []string{release.Spec.Owner.ComponentName}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
+		controller.IndexKeyReleaseBindingOwnerComponentName, func(obj client.Object) []string {
+			binding := obj.(*openchoreov1alpha1.ReleaseBinding)
+			if binding.Spec.Owner.ComponentName == "" {
+				return nil
+			}
+			return []string{binding.Spec.Owner.ComponentName}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register field index for Workload by owner (projectName/componentName)
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Workload{},
+		workloadOwnerIndex, func(obj client.Object) []string {
+			workload := obj.(*openchoreov1alpha1.Workload)
+			ownerKey := fmt.Sprintf("%s/%s",
+				workload.Spec.Owner.ProjectName,
+				workload.Spec.Owner.ComponentName)
+			return []string{ownerKey}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register field index for ComponentWorkflowRun by owner component name
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ComponentWorkflowRun{},
+		componentWorkflowRunOwnerIndex, func(obj client.Object) []string {
+			workflowRun := obj.(*openchoreov1alpha1.ComponentWorkflowRun)
+			if workflowRun.Spec.Owner.ComponentName == "" {
+				return nil
+			}
+			return []string{workflowRun.Spec.Owner.ComponentName}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register field index for Project by deploymentPipelineRef
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},
+		controller.IndexKeyProjectDeploymentPipelineRef, func(obj client.Object) []string {
+			project := obj.(*openchoreov1alpha1.Project)
+			if project.Spec.DeploymentPipelineRef == "" {
+				return nil
+			}
+			return []string{project.Spec.DeploymentPipelineRef}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register field index for Component by owner project name
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Component{},
+		controller.IndexKeyComponentOwnerProjectName, func(obj client.Object) []string {
+			component := obj.(*openchoreov1alpha1.Component)
+			if component.Spec.Owner.ProjectName == "" {
+				return nil
+			}
+			return []string{component.Spec.Owner.ProjectName}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Start the manager in a goroutine
+	go func() {
+		defer GinkgoRecover()
+		err := mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// Wait for cache to sync before running tests
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+	// Use the manager's client which has field index support
+	k8sClient = mgr.GetClient()
+	Expect(k8sClient).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/project/controller.go
+++ b/internal/controller/project/controller.go
@@ -102,11 +102,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openchoreov1alpha1.Project{}).
 		Named("project").
-		// Watch for Component changes to reconcile the project
-		Watches(
-			&openchoreov1alpha1.Component{},
-			handler.EnqueueRequestsFromMapFunc(controller.HierarchyWatchHandler[*openchoreov1alpha1.Component, *openchoreov1alpha1.Project](
-				r.Client, controller.GetProject)),
-		).
+		Watches(&openchoreov1alpha1.Component{},
+			handler.EnqueueRequestsFromMapFunc(r.findProjectForComponent)).
 		Complete(r)
 }

--- a/internal/controller/project/controller_watch.go
+++ b/internal/controller/project/controller_watch.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package project
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// findProjectForComponent maps a Component to its owner Project
+func (r *Reconciler) findProjectForComponent(ctx context.Context, obj client.Object) []ctrl.Request {
+	component := obj.(*openchoreov1alpha1.Component)
+	if component.Spec.Owner.ProjectName == "" {
+		return nil
+	}
+	return []ctrl.Request{{
+		NamespacedName: client.ObjectKey{
+			Name:      component.Spec.Owner.ProjectName,
+			Namespace: component.Namespace,
+		},
+	}}
+}

--- a/internal/controller/project/suite_test.go
+++ b/internal/controller/project/suite_test.go
@@ -14,12 +14,16 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -68,10 +72,62 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	// Create a manager with cache enabled only for Component (needed for field index queries)
+	// All other types bypass cache to avoid staleness issues in tests
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server in tests
+		},
+		Cache: cache.Options{
+			// Only cache Component type (required for field index queries)
+			// All other types will read directly from API server
+			ByObject: map[client.Object]cache.ByObject{
+				&openchoreov1alpha1.Component{}: {},
+			},
+			// Disable default caching for all other types
+			DefaultNamespaces: map[string]cache.Config{},
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				// Disable cache reads for types not in ByObject
+				DisableFor: []client.Object{
+					&openchoreov1alpha1.Organization{},
+					&openchoreov1alpha1.Project{},
+					&openchoreov1alpha1.DataPlane{},
+					&openchoreov1alpha1.Environment{},
+					&openchoreov1alpha1.DeploymentPipeline{},
+				},
+			},
+		},
+	})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
 
+	// Register the shared field index used by the project controller for Component lookups
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Component{},
+		controller.IndexKeyComponentOwnerProjectName, func(obj client.Object) []string {
+			component := obj.(*openchoreov1alpha1.Component)
+			if component.Spec.Owner.ProjectName == "" {
+				return nil
+			}
+			return []string{component.Spec.Owner.ProjectName}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Start the manager in a goroutine
+	go func() {
+		defer GinkgoRecover()
+		err := mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// Wait for cache to sync before running tests
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+	// Use the manager's client which has field index support for Component
+	// but reads directly from API server for other types
+	k8sClient = mgr.GetClient()
+	Expect(k8sClient).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/releasebinding/controller_conditions.go
+++ b/internal/controller/releasebinding/controller_conditions.go
@@ -4,6 +4,8 @@
 package releasebinding
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
@@ -21,6 +23,9 @@ const (
 	// ConditionReady indicates the overall readiness of the ReleaseBinding
 	// This is the top-level condition that aggregates ReleaseSynced and ResourcesReady
 	ConditionReady controller.ConditionType = "Ready"
+
+	// ConditionFinalizing indicates that the ReleaseBinding is being finalized (deleted).
+	ConditionFinalizing controller.ConditionType = "Finalizing"
 )
 
 // Constants for condition reasons
@@ -97,4 +102,18 @@ const (
 	ReasonCronJobScheduled controller.ConditionReason = "CronJobScheduled"
 	// ReasonCronJobSuspended indicates CronJob is suspended
 	ReasonCronJobSuspended controller.ConditionReason = "CronJobSuspended"
+
+	// ReasonFinalizing indicates the ReleaseBinding is being finalized
+	ReasonFinalizing controller.ConditionReason = "Finalizing"
 )
+
+// NewReleaseBindingFinalizingCondition creates a condition indicating the ReleaseBinding is being finalized.
+func NewReleaseBindingFinalizingCondition(generation int64) metav1.Condition {
+	return controller.NewCondition(
+		ConditionFinalizing,
+		metav1.ConditionTrue,
+		ReasonFinalizing,
+		"ReleaseBinding is finalizing",
+		generation,
+	)
+}

--- a/internal/controller/releasebinding/controller_finalize.go
+++ b/internal/controller/releasebinding/controller_finalize.go
@@ -1,0 +1,111 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+const (
+	// ReleaseBindingFinalizer is the finalizer that ensures Releases are deleted before ReleaseBinding
+	ReleaseBindingFinalizer = "openchoreo.dev/releasebinding-cleanup"
+)
+
+// ensureFinalizer ensures that the finalizer is added to the ReleaseBinding.
+// The first return value indicates whether the finalizer was added to the ReleaseBinding.
+func (r *Reconciler) ensureFinalizer(ctx context.Context, releaseBinding *openchoreov1alpha1.ReleaseBinding) (bool, error) {
+	// If the ReleaseBinding is being deleted, no need to add the finalizer
+	if !releaseBinding.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+
+	if controllerutil.AddFinalizer(releaseBinding, ReleaseBindingFinalizer) {
+		return true, r.Update(ctx, releaseBinding)
+	}
+
+	return false, nil
+}
+
+// finalize cleans up the resources associated with the ReleaseBinding.
+func (r *Reconciler) finalize(ctx context.Context, old, releaseBinding *openchoreov1alpha1.ReleaseBinding) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("releaseBinding", releaseBinding.Name)
+
+	if !controllerutil.ContainsFinalizer(releaseBinding, ReleaseBindingFinalizer) {
+		// Nothing to do if the finalizer is not present
+		return ctrl.Result{}, nil
+	}
+
+	// Mark the releaseBinding condition as finalizing and return so that the releaseBinding will indicate that it is being finalized.
+	// The actual finalization will be done in the next reconcile loop triggered by the status update.
+	if meta.SetStatusCondition(&releaseBinding.Status.Conditions, NewReleaseBindingFinalizingCondition(releaseBinding.Generation)) {
+		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, releaseBinding)
+	}
+
+	// Check if any Releases owned by this ReleaseBinding still exist
+	hasReleases, err := r.hasOwnedReleases(ctx, releaseBinding)
+	if err != nil {
+		logger.Error(err, "Failed to check for owned Releases")
+		return ctrl.Result{}, err
+	}
+
+	if hasReleases {
+		logger.Info("Waiting for Releases to be deleted")
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	}
+
+	// All Releases are deleted - remove the finalizer
+	if controllerutil.RemoveFinalizer(releaseBinding, ReleaseBindingFinalizer) {
+		if err := r.Update(ctx, releaseBinding); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		}
+	}
+
+	logger.Info("Successfully finalized ReleaseBinding")
+	return ctrl.Result{}, nil
+}
+
+// hasOwnedReleases checks if any Releases owned by this ReleaseBinding still exist,
+// and deletes them if they exist.
+func (r *Reconciler) hasOwnedReleases(ctx context.Context, releaseBinding *openchoreov1alpha1.ReleaseBinding) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("releaseBinding", releaseBinding.Name)
+
+	// List Releases owned by this ReleaseBinding using label selectors
+	matchingLabels := client.MatchingLabels{
+		labels.LabelKeyProjectName:     releaseBinding.Spec.Owner.ProjectName,
+		labels.LabelKeyComponentName:   releaseBinding.Spec.Owner.ComponentName,
+		labels.LabelKeyEnvironmentName: releaseBinding.Spec.Environment,
+	}
+	releaseList := &openchoreov1alpha1.ReleaseList{}
+	if err := r.List(ctx, releaseList,
+		client.InNamespace(releaseBinding.Namespace),
+		matchingLabels); err != nil {
+		return false, fmt.Errorf("failed to list releases: %w", err)
+	}
+
+	if len(releaseList.Items) == 0 {
+		return false, nil
+	}
+
+	// Delete all Releases owned by this ReleaseBinding
+	logger.Info("Deleting owned Releases", "count", len(releaseList.Items))
+	if err := r.DeleteAllOf(ctx, &openchoreov1alpha1.Release{},
+		client.InNamespace(releaseBinding.Namespace),
+		matchingLabels); err != nil {
+		return false, fmt.Errorf("failed to delete releases: %w", err)
+	}
+
+	return true, nil
+}

--- a/internal/controller/releasebinding/suite_test.go
+++ b/internal/controller/releasebinding/suite_test.go
@@ -52,8 +52,8 @@ var _ = BeforeSuite(func() {
 		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "tools", "k8s",
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/controller/watch.go
+++ b/internal/controller/watch.go
@@ -5,10 +5,66 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 )
+
+// Shared field index keys for use across controllers.
+// These constants ensure consistency when multiple controllers need to use the same field index.
+const (
+	// IndexKeyReleaseBindingOwnerComponentName indexes ReleaseBinding by owner component name.
+	IndexKeyReleaseBindingOwnerComponentName = "releasebinding.spec.owner.componentName"
+
+	// IndexKeyComponentOwnerProjectName indexes Component by owner project name.
+	IndexKeyComponentOwnerProjectName = "component.spec.owner.projectName"
+
+	// IndexKeyProjectDeploymentPipelineRef indexes Project by deploymentPipelineRef.
+	IndexKeyProjectDeploymentPipelineRef = "project.spec.deploymentPipelineRef"
+)
+
+// SetupSharedIndexes registers field indexes that are shared across multiple controllers.
+// This must be called before any controllers are set up with the manager.
+func SetupSharedIndexes(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
+		IndexKeyReleaseBindingOwnerComponentName, func(obj client.Object) []string {
+			binding := obj.(*openchoreov1alpha1.ReleaseBinding)
+			if binding.Spec.Owner.ComponentName == "" {
+				return nil
+			}
+			return []string{binding.Spec.Owner.ComponentName}
+		}); err != nil {
+		return fmt.Errorf("failed to setup ReleaseBinding owner index: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Component{},
+		IndexKeyComponentOwnerProjectName, func(obj client.Object) []string {
+			component := obj.(*openchoreov1alpha1.Component)
+			if component.Spec.Owner.ProjectName == "" {
+				return nil
+			}
+			return []string{component.Spec.Owner.ProjectName}
+		}); err != nil {
+		return fmt.Errorf("failed to setup Component owner project index: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},
+		IndexKeyProjectDeploymentPipelineRef, func(obj client.Object) []string {
+			project := obj.(*openchoreov1alpha1.Project)
+			if project.Spec.DeploymentPipelineRef == "" {
+				return nil
+			}
+			return []string{project.Spec.DeploymentPipelineRef}
+		}); err != nil {
+		return fmt.Errorf("failed to setup Project deploymentPipelineRef index: %w", err)
+	}
+
+	return nil
+}
 
 // HierarchyWatchHandler is a function that creates a watch handler for a specific hierarchy.
 // It can be used to watch from parent object for child object updates.

--- a/samples/component-types/component-with-traits/component-with-traits.yaml
+++ b/samples/component-types/component-with-traits/component-with-traits.yaml
@@ -204,7 +204,7 @@ spec:
   autoDeploy: true
 
   parameters:
-    replicas: "e"
+    replicas: 1
     port: 8080
 
   traits:


### PR DESCRIPTION
## Purpose

Deletes following resources with finalizers
- componenet (on project deletion)
- componenetrelease
- releasebinding
- componenetworkflowrun
- release (already handled by releasebinding controller )

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1148

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
