### PR TITLE
Add OPENCHOREO_FEATURES_AUTHZ_ENABLED env var for Backstage

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -92,6 +92,8 @@ spec:
           value: {{ .Values.backstage.features.observability.enabled | default true | quote }}
         - name: OPENCHOREO_FEATURES_AUTH_ENABLED
           value: {{ .Values.security.enabled | default true | quote }}
+        - name: OPENCHOREO_FEATURES_AUTHZ_ENABLED
+          value: {{ .Values.security.authz.enabled | default true | quote }}
         livenessProbe:
           httpGet:
             path: /healthcheck


### PR DESCRIPTION
  Map security.authz.enabled helm value to Backstage environment variable
  to control Access Control UI visibility. Defaults to true when not set.

Related to https://github.com/openchoreo/openchoreo/issues/606
