### PR TITLE
Add printer columns to ComponentType-related CRDs

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -11,6 +11,9 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=comp;comps
+// +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
+// +kubebuilder:printcolumn:name="ComponentType",type=string,JSONPath=`.spec.componentType`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Component is the Schema for the components API.
 type Component struct {

--- a/api/v1alpha1/componentrelease_types.go
+++ b/api/v1alpha1/componentrelease_types.go
@@ -61,6 +61,9 @@ type ComponentReleaseStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
+// +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ComponentRelease is the Schema for the componentreleases API.
 type ComponentRelease struct {

--- a/api/v1alpha1/releasebinding_types.go
+++ b/api/v1alpha1/releasebinding_types.go
@@ -85,6 +85,10 @@ type ReleaseBindingStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
+// +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
+// +kubebuilder:printcolumn:name="Environment",type=string,JSONPath=`.spec.environment`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ReleaseBinding is the Schema for the releasebindings API.
 type ReleaseBinding struct {

--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -232,6 +232,9 @@ type WorkloadStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
+// +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Workload is the Schema for the workloads API.
 type Workload struct {

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -14,7 +14,17 @@ spec:
     singular: componentrelease
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ComponentRelease is the Schema for the componentreleases API.

--- a/config/crd/bases/openchoreo.dev_components.yaml
+++ b/config/crd/bases/openchoreo.dev_components.yaml
@@ -17,7 +17,17 @@ spec:
     singular: component
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.componentType
+      name: ComponentType
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Component is the Schema for the components API.

--- a/config/crd/bases/openchoreo.dev_releasebindings.yaml
+++ b/config/crd/bases/openchoreo.dev_releasebindings.yaml
@@ -14,7 +14,20 @@ spec:
     singular: releasebinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .spec.environment
+      name: Environment
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ReleaseBinding is the Schema for the releasebindings API.

--- a/config/crd/bases/openchoreo.dev_workloads.yaml
+++ b/config/crd/bases/openchoreo.dev_workloads.yaml
@@ -14,7 +14,17 @@ spec:
     singular: workload
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Workload is the Schema for the workloads API.

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -13,7 +13,17 @@ spec:
     singular: componentrelease
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ComponentRelease is the Schema for the componentreleases API.

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_components.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_components.yaml
@@ -16,7 +16,17 @@ spec:
     singular: component
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.componentType
+      name: ComponentType
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Component is the Schema for the components API.

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
@@ -13,7 +13,20 @@ spec:
     singular: releasebinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .spec.environment
+      name: Environment
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ReleaseBinding is the Schema for the releasebindings API.

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
@@ -13,7 +13,17 @@ spec:
     singular: workload
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Workload is the Schema for the workloads API.


### PR DESCRIPTION
## Purpose
Add additionalPrinterColumns to Component, ComponentRelease, ReleaseBinding, and Workload CRDs for better visibility when using kubectl get:

```bash
chathuranga@chathurangada ~ % kubectl get components
NAME       PROJECT   COMPONENTTYPE                         AGE
demo-app   default   deployment/web-service-with-configs   14h
```
```bash
chathuranga@chathurangada ~ % kubectl get workloads
NAME                            PROJECT   COMPONENT              AGE
demo-app-with-traits-workload   default   demo-app-with-traits   3d18h
demo-app-workload               default   demo-app               14h
test-app-workload               default   test-app               36h
```
```bash
chathuranga@chathurangada ~ % kubectl get releasebindings
NAME                   PROJECT   COMPONENT   ENVIRONMENT   AGE
demo-app-development   default   demo-app    development   14h
```
```bash
chathuranga@chathurangada ~ % kubectl get componentreleases
NAME                  PROJECT   COMPONENT   AGE
demo-app-5b7b5c8dfd   default   demo-app    14h
chathuranga@chathurangada ~ % 
```

## Approach
> Summarize the solution and implementation details.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/1221

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
