### PR TITLE
Add Traefik configurations for Observability plane

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:58c0047a8b4ac997d7f527707203c2517daae1fec49d711b6bfe3d97c775fb42
-generated: "2025-11-27T23:03:57.998503+05:30"
+- name: traefik
+  repository: https://traefik.github.io/charts
+  version: 37.4.0
+digest: sha256:f109484e5b9eba485ef072b512c06323addfdb7823e00bbd1cb6dc40af6f6e2f
+generated: "2025-12-15T10:34:04.048424+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -60,3 +60,7 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     version: 3.3.0
     condition: openSearchDashboards.enabled
+  - name: traefik
+    repository: https://traefik.github.io/charts
+    version: "v37.4.0"
+    condition: traefik.enabled

--- a/install/helm/openchoreo-observability-plane/templates/cert-manager/certificate.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cert-manager/certificate.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.global.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-observability-plane-ca
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+spec:
+  isCA: true
+  commonName: "OpenChoreo Observability Plane CA"
+  subject:
+    organizations:
+      - OpenChoreo
+  secretName: openchoreo-observability-plane-ca
+  duration: 87600h # 10 years
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: self-signed-issuer
+    kind: Issuer
+    group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-observability-plane-wildcard
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+spec:
+  secretName: openchoreo-observability-plane-wildcard
+  issuerRef:
+    name: openchoreo-observability-plane-ca-issuer
+    kind: Issuer
+  dnsNames:
+  - "{{ .Values.global.baseDomain }}"
+  - "*.{{ .Values.global.baseDomain }}"
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/cert-manager/issuer.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cert-manager/issuer.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: self-signed-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: openchoreo-observability-plane-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: openchoreo-observability-plane-ca
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/observer/ingress-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/ingress-route.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: observer
+  namespace: {{ .Release.Namespace }}
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`observer.{{ .Values.global.baseDomain }}`)
+      kind: Rule
+      services:
+        - name: observer
+          port: 8080
+          scheme: http
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/ingress-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/ingress-route.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.openSearchCluster.enabled .Values.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`opensearch.{{ .Values.global.baseDomain }}`)
+      kind: Rule
+      services:
+        - name: opensearch
+          port: 9200
+          scheme: https
+          serversTransport: opensearch
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/servers-transport.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/servers-transport.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.openSearchCluster.enabled .Values.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  serverName: opensearch.{{ .Release.Namespace }}.svc.cluster.local 
+  insecureSkipVerify: true  # OpenSearch cluster uses self-signed certificates
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch/ingress-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch/ingress-route.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.openSearch.enabled .Values.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`opensearch.{{ .Values.global.baseDomain }}`)
+      kind: Rule
+      services:
+        - name: opensearch
+          port: 9200
+          scheme: https
+          serversTransport: opensearch
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch/servers-transport.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch/servers-transport.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.openSearch.enabled .Values.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  serverName: opensearch.{{ .Release.Namespace }}.svc.cluster.local 
+  insecureSkipVerify: true  # OpenSearch cluster uses self-signed certificates
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/traefik/tls-store.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/traefik/tls-store.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: openchoreo-observability-plane
+  namespace: {{ .Release.Namespace }}
+spec:
+  defaultCertificate:
+    secretName: openchoreo-observability-plane-wildcard
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1,5 +1,9 @@
 # Global values shared across all components
 global:
+
+  # To be used with Traefik for future IngressRoute configurations
+  baseDomain: "observability.openchoreo.localhost"
+
   # Common labels to add to all resources
   commonLabels: {}
 
@@ -9,6 +13,10 @@ global:
   # multiCluster: When deploying OpenChoreo planes in multiple Kubernetes clusters (To be supported in the future)
   # quickStart: Limited set of features for quick-start setup
   installationMode: singleCluster
+
+  # To be used with cert-manager for TLS certificates
+  tls:
+    enabled: false
 
 data-prepper:
   enabled: false
@@ -487,6 +495,27 @@ prometheus:
     enabled: false
   nodeExporter:
     enabled: false
+
+# Note - Currently disabled since more changes are needed to enable Traefik IngressRoute support
+traefik:
+  enabled: false
+  fullnameOverride: "traefik"
+  
+  providers:
+    kubernetesCRD:
+      enabled: true
+      allowCrossNamespace: false 
+
+  ports:
+    websecure:
+      port: 443
+      exposedPort: 443
+      tls:
+        enabled: true
+
+  service:
+    enabled: true
+    type: LoadBalancer
 
 # Wait job configuration for post-install hooks
 waitJob:

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -35,3 +35,15 @@ clusterAgent:
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
   planeName: default
   planeType: observabilityplane
+
+traefik:
+  # Don't create IngressClass - use existing one from K3d
+  ingressClass:
+    enabled: false
+  ports:
+    web:
+      port: 10080
+      exposedPort: 10080
+    websecure:
+      port: 10443
+      exposedPort: 10443 


### PR DESCRIPTION
## Purpose
Add configurations for Traefik ingress controller for the Observability plane

## Approach
Added traefik as a dependency to the openchoreo-observability-plane helm chart along with routing configurations

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1224

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
Note
1. Traefik will be used temporarily to provide support for the multi cluster setup. This will be replaced with kgateway when the TLS issue is resolved (Ref - https://github.com/openchoreo/openchoreo/issues/1125#issuecomment-3653158346)
2. This PR only adds the configurations for Traefik. 
