### PR TITLE
Fix quickstart issues

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -65,7 +65,7 @@ fullnameOverride: openchoreo
 # Common security configuration shared across all components
 security:
   # Global security toggle - when disabled, authentication is turned off for all components
-  enabled: false
+  enabled: true
   oidc:
     issuer: ""
     wellKnownEndpoint: ""
@@ -563,10 +563,10 @@ thunder:
     server:
       port: 8090
       httpOnly: true
-      publicUrl: "http://thunder.openchoreo.localhost:8080"
+      publicUrl: ""
 
     gateClient:
-      hostname: "thunder.openchoreo.localhost"
+      hostname: ""
       port: 8080
       scheme: "http"
       loginPath: "/gate/signin"

--- a/install/k3d/dev/values-cp.yaml
+++ b/install/k3d/dev/values-cp.yaml
@@ -13,6 +13,9 @@ global:
 traefik:
   enabled: false
 
+security:
+  enabled: false
+
 controllerManager:
   image:
     repository: ghcr.io/openchoreo/controller

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -13,11 +13,6 @@ global:
 traefik:
   enabled: false
 
-# Common security configuration
-security:
-  oidc:
-    authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
-
 # Cluster Gateway configuration for agent-based communication
 # Exposes the cluster gateway for remote data/build plane agents to connect
 # Note: For k3d, we use Traefik IngressRouteTCP for TLS passthrough on shared port 8443
@@ -53,3 +48,12 @@ controllerManager:
     enabled: true
     # Use internal service DNS - controller manager runs inside the control plane cluster
     url: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443
+
+thunder:
+  configuration:
+    server:
+      publicUrl: "http://thunder.openchoreo.localhost:8080"
+    gateClient:
+      hostname: "thunder.openchoreo.localhost"
+      port: 8080
+      scheme: "http"

--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -22,3 +22,12 @@ clusterGateway:
 controllerManager:
   clusterGateway:
     enabled: true
+
+thunder:
+  configuration:
+    server:
+      publicUrl: "http://thunder.openchoreo.localhost:8080"
+    gateClient:
+      hostname: "thunder.openchoreo.localhost"
+      port: 8080
+      scheme: "http"

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -3,6 +3,7 @@
 
 global:
   baseDomain: openchoreo.localhost
+  port: ":8080"
   devMode: true
   # Use k3d's built-in Traefik ingress class
   ingressClassName: traefik
@@ -18,3 +19,12 @@ clusterGateway:
 controllerManager:
   clusterGateway:
     enabled: true
+
+thunder:
+  configuration:
+    server:
+      publicUrl: "http://thunder.openchoreo.localhost:8080"
+    gateClient:
+      hostname: "thunder.openchoreo.localhost"
+      port: 8080
+      scheme: "http"

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -7,6 +7,8 @@
 gateway:
   enabled: true
   # Envoy - enabled by default for traffic routing
+  httpPort: 19080
+  httpsPort: 19443
   envoy:
     enabled: true
     # Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues

--- a/install/quick-start/deploy-react-starter.sh
+++ b/install/quick-start/deploy-react-starter.sh
@@ -163,7 +163,7 @@ if [[ -z "$HOSTNAME" ]] || [[ "$HOSTNAME" == "null" ]]; then
     exit 1
 fi
 
-PUBLIC_URL="http://${HOSTNAME}:9080"
+PUBLIC_URL="http://${HOSTNAME}:19080"
 
 echo ""
 log_success "React Starter web application is ready!"


### PR DESCRIPTION
This pull request introduces several configuration changes across different deployment environments, mainly focusing on security settings and service configuration for the OpenChoreo control plane. The most significant updates include enabling global security by default, adding new service configuration for the Thunder component, and specifying a port for the base domain in the quick-start setup.

**Security configuration changes:**

* Enabled global security (`security.enabled: true`) in the Helm chart values, turning authentication on by default for all components.
* Added an explicit `security.enabled: false` override in the k3d development values to keep authentication disabled in the dev environment.

**Service and environment configuration:**

* Added a `port` field (`:8080`) to the `global` configuration in the quick-start values, clarifying the service endpoint for local development.
* Introduced configuration for the Thunder service under `thunder.configuration` in the quick-start values, including `publicUrl`, `gateClient.hostname`, `gateClient.port`, and `gateClient.scheme`, enabling easier integration and setup.