### PR TITLE
Add TLS termination support to gateway

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -15,4 +15,17 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https
+      protocol: HTTPS
+      port: {{ .Values.gateway.httpsPort | default 443 }}
+      hostname: {{ .Values.gateway.tls.hostname | default "*.openchoreoapis.localhost" | quote }}
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: openchoreo-gateway-tls
+            namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
## Summary

Adds HTTPS listener with TLS termination to the data plane gateway:

- Adds HTTPS listener on configurable port (default 443)
- Configurable hostname pattern via `gateway.tls.hostname` (default `*.openchoreoapis.localhost`)
- Uses `openchoreo-gateway-tls` secret for certificate references
- Allows routes from all namespaces

This enables production deployments to terminate TLS at the gateway level.

## Test Plan

- [ ] Deploy with TLS secret and verify HTTPS traffic is properly terminated
- [ ] Verify HTTP listener continues to work alongside HTTPS
- [ ] Test with custom hostname configuration