### PR TITLE
Add field selectors for spec.owner fields

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -11,6 +11,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=comp;comps
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.projectName`
 // +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
 // +kubebuilder:printcolumn:name="ComponentType",type=string,JSONPath=`.spec.componentType`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha1/componentrelease_types.go
+++ b/api/v1alpha1/componentrelease_types.go
@@ -61,6 +61,8 @@ type ComponentReleaseStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.projectName`
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.componentName`
 // +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
 // +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -54,6 +54,13 @@ type ReleaseStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.projectName`
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.componentName`
+// +kubebuilder:selectablefield:JSONPath=`.spec.environmentName`
+// +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
+// +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
+// +kubebuilder:printcolumn:name="Environment",type=string,JSONPath=`.spec.environmentName`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Release is the Schema for the releases API.
 type Release struct {

--- a/api/v1alpha1/releasebinding_types.go
+++ b/api/v1alpha1/releasebinding_types.go
@@ -85,6 +85,9 @@ type ReleaseBindingStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.projectName`
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.componentName`
+// +kubebuilder:selectablefield:JSONPath=`.spec.environment`
 // +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
 // +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
 // +kubebuilder:printcolumn:name="Environment",type=string,JSONPath=`.spec.environment`

--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -232,6 +232,8 @@ type WorkloadStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.projectName`
+// +kubebuilder:selectablefield:JSONPath=`.spec.owner.componentName`
 // +kubebuilder:printcolumn:name="Project",type=string,JSONPath=`.spec.owner.projectName`
 // +kubebuilder:printcolumn:name="Component",type=string,JSONPath=`.spec.owner.componentName`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -628,6 +628,9 @@ spec:
             description: ComponentReleaseStatus defines the observed state of ComponentRelease.
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/openchoreo.dev_components.yaml
+++ b/config/crd/bases/openchoreo.dev_components.yaml
@@ -286,6 +286,8 @@ spec:
                 type: integer
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/openchoreo.dev_releasebindings.yaml
+++ b/config/crd/bases/openchoreo.dev_releasebindings.yaml
@@ -283,6 +283,10 @@ spec:
                 type: array
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
+    - jsonPath: .spec.environment
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/openchoreo.dev_releases.yaml
+++ b/config/crd/bases/openchoreo.dev_releases.yaml
@@ -14,7 +14,20 @@ spec:
     singular: release
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .spec.environmentName
+      name: Environment
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Release is the Schema for the releases API.
@@ -211,6 +224,10 @@ spec:
                 type: array
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
+    - jsonPath: .spec.environmentName
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/openchoreo.dev_workloads.yaml
+++ b/config/crd/bases/openchoreo.dev_workloads.yaml
@@ -279,6 +279,9 @@ spec:
             description: WorkloadStatus defines the observed state of Workload.
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
     served: true
     storage: true
     subresources:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -627,6 +627,9 @@ spec:
             description: ComponentReleaseStatus defines the observed state of ComponentRelease.
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
     served: true
     storage: true
     subresources:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_components.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_components.yaml
@@ -285,6 +285,8 @@ spec:
                 type: integer
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
     served: true
     storage: true
     subresources:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
@@ -282,6 +282,10 @@ spec:
                 type: array
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
+    - jsonPath: .spec.environment
     served: true
     storage: true
     subresources:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releases.yaml
@@ -13,7 +13,20 @@ spec:
     singular: release
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.owner.projectName
+      name: Project
+      type: string
+    - jsonPath: .spec.owner.componentName
+      name: Component
+      type: string
+    - jsonPath: .spec.environmentName
+      name: Environment
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Release is the Schema for the releases API.
@@ -210,6 +223,10 @@ spec:
                 type: array
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
+    - jsonPath: .spec.environmentName
     served: true
     storage: true
     subresources:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
@@ -278,6 +278,9 @@ spec:
             description: WorkloadStatus defines the observed state of Workload.
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.owner.projectName
+    - jsonPath: .spec.owner.componentName
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
## Purpose
> $subject to provide server side filtering

```bash
chathuranga@chathurangada openchoreo_cluade % kubectl get components --field-selector spec.owner.projectName=default
NAME                   PROJECT   COMPONENTTYPE        AGE
demo-app-with-traits   default   deployment/web-app   4h3m
chathuranga@chathurangada openchoreo_cluade % kubectl get componentreleases --field-selector spec.owner.projectName=default
NAME                             PROJECT   COMPONENT              AGE
demo-app-with-traits-5c8fdb7b6   default   demo-app-with-traits   4h3m
chathuranga@chathurangada openchoreo_cluade % kubectl get componentreleases --field-selector spec.owner.componentName=demo-app-with-traits
NAME                             PROJECT   COMPONENT              AGE
demo-app-with-traits-5c8fdb7b6   default   demo-app-with-traits   4h4m
chathuranga@chathurangada openchoreo_cluade % kubectl get componentreleases --field-selector spec.owner.projectName=default,spec.owner.componentName=demo-app-with-traits
NAME                             PROJECT   COMPONENT              AGE
demo-app-with-traits-5c8fdb7b6   default   demo-app-with-traits   4h4m
chathuranga@chathurangada openchoreo_cluade % kubectl get releasebindings --field-selector spec.owner.projectName=default
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h4m
chathuranga@chathurangada openchoreo_cluade % kubectl get releasebindings --field-selector spec.owner.componentName=demo-app-with-traits
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h4m
chathuranga@chathurangada openchoreo_cluade % kubectl get releasebindings --field-selector spec.environment=production
No resources found in default namespace.
chathuranga@chathurangada openchoreo_cluade % kubectl get releasebindings --field-selector spec.environment=development
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h4m
chathuranga@chathurangada openchoreo_cluade % kubectl get releasebindings --field-selector spec.owner.projectName=default,spec.environment=development
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h5m
chathuranga@chathurangada openchoreo_cluade % kubectl get releases --field-selector spec.owner.projectName=default
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h5m
chathuranga@chathurangada openchoreo_cluade % kubectl get releases --field-selector spec.owner.componentName=demo-app-with-traits
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h5m
chathuranga@chathurangada openchoreo_cluade % kubectl get releases --field-selector spec.environmentName=development
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h5m
chathuranga@chathurangada openchoreo_cluade % kubectl get releases --field-selector spec.owner.componentName=demo-app-with-traits,spec.environmentName=development
NAME                               PROJECT   COMPONENT              ENVIRONMENT   AGE
demo-app-with-traits-development   default   demo-app-with-traits   development   4h5m
chathuranga@chathurangada openchoreo_cluade % kubectl get workloads --field-selector spec.owner.projectName=default
NAME                            PROJECT   COMPONENT              AGE
demo-app-with-traits-workload   default   demo-app-with-traits   4h5m
demo-app-workload               default   demo-app               24h
test-app-workload               default   test-app               46h
chathuranga@chathurangada openchoreo_cluade % kubectl get workloads --field-selector spec.owner.componentName=demo-app-with-traits
NAME                            PROJECT   COMPONENT              AGE
demo-app-with-traits-workload   default   demo-app-with-traits   4h5m
chathuranga@chathurangada openchoreo_cluade % kubectl get workloads --field-selector spec.owner.projectName=default,spec.owner.componentName=demo-app-with-traits
NAME                            PROJECT   COMPONENT              AGE
demo-app-with-traits-workload   default   demo-app-with-traits   4h6m
chathuranga@chathurangada openchoreo_cluade % 
```

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
