### PR TITLE
Improve displayed user app port in quick start

### DIFF
--- a/install/quick-start/build-deploy-greeter.sh
+++ b/install/quick-start/build-deploy-greeter.sh
@@ -256,7 +256,7 @@ if [[ -z "$HOSTNAME" ]] || [[ "$HOSTNAME" == "null" ]]; then
 fi
 
 # Construct the full service URL
-BASE_URL="http://${HOSTNAME}:9080"
+BASE_URL="http://${HOSTNAME}:19080"
 SERVICE_URL="${BASE_URL}${PATH_PREFIX}/greeter/greet"
 
 echo ""

--- a/install/quick-start/deploy-gcp-demo.sh
+++ b/install/quick-start/deploy-gcp-demo.sh
@@ -182,7 +182,7 @@ log_info "  • Redis (Cache)"
 echo ""
 
 if [[ -n "$HOSTNAME" ]] && [[ "$HOSTNAME" != "null" ]]; then
-    FRONTEND_URL="http://${HOSTNAME}:9080"
+    FRONTEND_URL="http://${HOSTNAME}:19080"
     echo "🌍 Access the frontend application at: $FRONTEND_URL"
     echo "   Open this URL in your browser to explore the microservices demo."
 else


### PR DESCRIPTION
This pull request updates the default port used for the frontend and service URLs in the deployment scripts. The port is changed from 9080 to 19080 to ensure consistency across the deployment and service endpoints.

Port configuration updates:

* Changed the base URL port from 9080 to 19080 in `build-deploy-greeter.sh` to update the constructed service URL.
* Updated the frontend URL port from 9080 to 19080 in `deploy-gcp-demo.sh` to match the new service port.