### PR TITLE
Add observability plane script to quick-start Dockerfile

### DIFF
--- a/install/quick-start/Dockerfile
+++ b/install/quick-start/Dockerfile
@@ -65,6 +65,7 @@ RUN cp /tmp/install/quick-start/.bash_profile ${USER_HOME}/.bash_profile && \
     cp /tmp/install/k3d/preload-images.sh ${USER_HOME}/.preload-images.sh && \
     cp /tmp/install/add-data-plane.sh ${USER_HOME}/add-data-plane.sh && \
     cp /tmp/install/add-build-plane.sh ${USER_HOME}/add-build-plane.sh && \
+    cp /tmp/install/add-observability-plane.sh ${USER_HOME}/add-observability-plane.sh && \
     cp -r /tmp/samples ${USER_HOME}/samples && \
     chown -R openchoreo:openchoreo ${USER_HOME} && \
     rm -rf /tmp/install /tmp/samples && \


### PR DESCRIPTION
## Purpose
Following https://github.com/openchoreo/openchoreo/pull/1208, this change is to resolve the following error in quick start setup.
```
[WARNING] add-observability-plane.sh not found, skipping observabilityplane configuration
[INFO] Configuring OpenChoreo Data Plane with observabilityplane reference...
dataplane.openchoreo.dev/default patched
[INFO] Configuring OpenChoreo Build Plane with observabilityplane reference...
buildplane.openchoreo.dev/default patched
```
Since the dataplane and buildplane patches do not work correctly without observabilityPlane CR, observability is broken in quick-start. This PR is to fix it.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
