### PR TITLE
Update gateway ports in values-dp for different k3d setups

### DIFF
--- a/install/k3d/dev/config.yaml
+++ b/install/k3d/dev/config.yaml
@@ -20,13 +20,13 @@ ports:
   - port: 8443:443
     nodeFilters:
       - loadbalancer
-  # Data Plane uses port range 9xxx
-  # HTTP traffic to workloads via Envoy Gateway
-  - port: 9080:9080
+  # Data Plane uses port range 19xxx
+  # HTTP traffic to workloads via Gateway
+  - port: 19080:19080
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic to workloads via Envoy Gateway
-  - port: 9443:9443
+  # HTTPS traffic to workloads via Gateway
+  - port: 19443:19443
     nodeFilters:
       - loadbalancer
   # Build Plane uses port range 10xxx

--- a/install/k3d/dev/values-dp.yaml
+++ b/install/k3d/dev/values-dp.yaml
@@ -1,7 +1,9 @@
 # Data Plane values for k3d dev environment
 
-# Gateway configuration for k3d dev environment (default ports 9080/9443)
+# Gateway configuration for k3d dev environment
 gateway:
+  httpPort: 19080
+  httpsPort: 19443
   # Envoy - enabled by default for traffic routing
   envoy:
     enabled: true
@@ -10,3 +12,7 @@ gateway:
     # Common on: macOS with Docker Desktop/Colima with Rosetta enabled.
     # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
     mountTmpVolume: true
+
+# External Secrets Operator configuration
+external-secrets:
+  enabled: true

--- a/install/k3d/multi-cluster/config-dp.yaml
+++ b/install/k3d/multi-cluster/config-dp.yaml
@@ -7,14 +7,14 @@ servers: 1
 agents: 0
 kubeAPI:
   hostPort: "6551"
-# Data Plane uses port range 9xxx
+# Data Plane uses port range 19xxx
 ports:
-  # HTTP traffic to workloads via Envoy Gateway
-  - port: 9080:9080
+  # HTTP traffic to workloads via Gateway
+  - port: 19080:19080
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic to workloads via Envoy Gateway
-  - port: 9443:9443
+  # HTTPS traffic to workloads via Gateway
+  - port: 19443:19443
     nodeFilters:
       - loadbalancer
 options:

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -44,8 +44,10 @@ fluentBit:
       port: "11082"
 
 gateway:
-  # Enable gateway (uses default ports 9080/9443)
+  # Enable gateway
   enabled: true
+  httpPort: 19080
+  httpsPort: 19443
 
   # Envoy - enabled by default for traffic routing
   envoy:
@@ -55,3 +57,7 @@ gateway:
     # Common on: macOS with Docker Desktop/Colima with Rosetta enabled.
     # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
     mountTmpVolume: true
+
+# External Secrets Operator configuration
+external-secrets:
+  enabled: true

--- a/install/k3d/single-cluster/config.yaml
+++ b/install/k3d/single-cluster/config.yaml
@@ -19,11 +19,11 @@ ports:
     nodeFilters:
       - loadbalancer
   # Data Plane uses port range 19xxx (matches kind and other cluster setups)
-  # HTTP traffic to workloads via Envoy Gateway
+  # HTTP traffic to workloads via Gateway
   - port: 19080:19080
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic to workloads via Envoy Gateway
+  # HTTPS traffic to workloads via Gateway
   - port: 19443:19443
     nodeFilters:
       - loadbalancer

--- a/install/k3d/single-cluster/values-dp.yaml
+++ b/install/k3d/single-cluster/values-dp.yaml
@@ -1,8 +1,14 @@
 # Helm values for OpenChoreo Data Plane in k3d single-cluster setup
 
-# Gateway configuration for single-cluster setup (default ports 9080/9443)
+# Gateway configuration for single-cluster setup
 gateway:
+  httpPort: 19080
+  httpsPort: 19443
   envoy:
     # Mount /tmp as emptyDir to fix Envoy temp file issues on macOS Docker/Colima
     # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
     mountTmpVolume: true
+
+# External Secrets Operator configuration
+external-secrets:
+  enabled: true


### PR DESCRIPTION
## Purpose

This pull request updates the default ports used for HTTP and HTTPS traffic to workloads via the Envoy Gateway across all k3d environment configurations, changing them from 9080/9443 to 19080/19443. Additionally, it introduces configuration to enable the External Secrets Operator by default in all relevant Helm values files. These changes ensure port consistency and improved secret management across single-cluster, multi-cluster, and dev setups.