### PR TITLE
Add support to provide default role-mappings at installation time in authz initialization flow

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -63,11 +63,11 @@ func main() {
 
 	// Initialize authorization
 	authzConfig := authz.AuthZConfig{
-		Enabled:              os.Getenv("AUTHZ_ENABLED") == "true",
-		DatabasePath:         os.Getenv("AUTHZ_DATABASE_PATH"),
-		DefaultRolesFilePath: os.Getenv("AUTHZ_DEFAULT_ROLES_FILE_PATH"),
-		UserTypeConfigs:      cfg.Authz.UserTypes,
-		EnableCache:          false,
+		Enabled:                  os.Getenv("AUTHZ_ENABLED") == "true",
+		DatabasePath:             os.Getenv("AUTHZ_DATABASE_PATH"),
+		DefaultAuthzDataFilePath: os.Getenv("AUTHZ_DEFAULT_AUTHZ_DATA_FILE_PATH"),
+		UserTypeConfigs:          cfg.Authz.UserTypes,
+		EnableCache:              false,
 	}
 	pap, pdp, err := authz.Initialize(authzConfig, baseLogger.With("component", "authz"))
 	if err != nil {

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -66,8 +66,8 @@ spec:
           value: "{{ .Values.security.authz.enabled }}"
         - name: AUTHZ_DATABASE_PATH
           value: {{ .Values.security.authz.databasePath | quote }}
-        - name: AUTHZ_DEFAULT_ROLES_FILE_PATH
-          value: {{ .Values.security.authz.defaultRolesFilePath | quote }}
+        - name: AUTHZ_DEFAULT_AUTHZ_DATA_FILE_PATH
+          value: {{ .Values.security.authz.defaultAuthzDataFilePath | quote }}
         - name: DATABASE_PATH
           value: {{ .Values.openchoreoApi.database.path | quote }}
         - name: OPENCHOREO_API_CONFIG_PATH

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -78,9 +78,9 @@ security:
   authz:
     enabled: false
     databasePath: "/var/lib/openchoreo/data/casbin.db"
-    # defaultRolesFilePath is optional - if not set, embedded default roles will be used
-    # To use custom roles, set this path and mount a ConfigMap with your roles
-    defaultRolesFilePath: ""
+    # defaultAuthzDataFilePath is optional - if not set, embedded default authz data will be used
+    # To use custom authz data (roles and mappings), set this path and mount a ConfigMap with your data
+    defaultAuthzDataFilePath: ""
 controllerManager:
   name: controller-manager
   replicas: 1

--- a/internal/authz/casbin/casbin.go
+++ b/internal/authz/casbin/casbin.go
@@ -35,7 +35,7 @@ type CasbinEnforcer struct {
 // CasbinConfig holds configuration for the Casbin enforcer
 type CasbinConfig struct {
 	DatabasePath      string                     // Required: Path to SQLite database path
-	RolesFilePath     string                     // Optional: Path to roles YAML file (falls back to embedded if empty)
+	AuthzDataFilePath string                     // Optional: Path to authz data YAML file containing roles and mappings (falls back to embedded if empty)
 	UserTypeConfigs   []authzcore.UserTypeConfig // Required: User type detection configuration
 	EnableCache       bool                       // Optional: Enable policy cache (default: false)
 	CacheTTLInSeconds int                        // Optional: Cache TTL in seconds (default: 300)
@@ -57,7 +57,7 @@ func NewCasbinEnforcer(config CasbinConfig, logger *slog.Logger) (*CasbinEnforce
 		return nil, fmt.Errorf("UserTypeConfigs is required in CasbinConfig")
 	}
 
-	// RolesFilePath is optional - will use embedded default if not provided
+	// AuthzDataFilePath is optional - will use embedded default if not provided
 	if config.CacheTTLInSeconds == 0 {
 		config.CacheTTLInSeconds = 300 // Default: 5 minutes
 	}
@@ -74,8 +74,8 @@ func NewCasbinEnforcer(config CasbinConfig, logger *slog.Logger) (*CasbinEnforce
 		return nil, fmt.Errorf("failed to load embedded casbin model: %w", err)
 	}
 
-	// Create adapter with configured database path and roles file
-	adapter, db, err := newAdapter(config.DatabasePath, config.RolesFilePath, logger)
+	// Create adapter with configured database path and authz data file
+	adapter, db, err := newAdapter(config.DatabasePath, config.AuthzDataFilePath, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create casbin adapter: %w", err)
 	}

--- a/internal/authz/core/types.go
+++ b/internal/authz/core/types.go
@@ -110,10 +110,10 @@ type Role struct {
 // Entitlement represents an entitlement with its claim and value
 type Entitlement struct {
 	// Claim is the JWT claim name (e.g., "group", "sub")
-	Claim string `json:"claim"`
+	Claim string `json:"claim" yaml:"claim"`
 
 	// Value is the entitlement value (e.g., "admin-group", "service-123")
-	Value string `json:"value"`
+	Value string `json:"value" yaml:"value"`
 }
 
 // EntitlementClaimInfo represents information about an entitlement claim
@@ -143,25 +143,25 @@ type UserTypeInfo struct {
 // RoleEntitlementMapping represents the assignment of a role to an entitlement within a hierarchical scope
 type RoleEntitlementMapping struct {
 	// ID is the unique identifier for the mapping
-	ID uint `json:"id"`
+	ID uint `json:"id" yaml:"id,omitempty"`
 
 	// RoleName is the name of the role being assigned
-	RoleName string `json:"role_name"`
+	RoleName string `json:"role_name" yaml:"role_name"`
 
 	// Entitlement contains the claim and value for this mapping
-	Entitlement Entitlement `json:"entitlement"`
+	Entitlement Entitlement `json:"entitlement" yaml:"entitlement"`
 
 	// Hierarchy defines the resource hierarchy scope where this role applies
-	Hierarchy ResourceHierarchy `json:"hierarchy"`
+	Hierarchy ResourceHierarchy `json:"hierarchy" yaml:"hierarchy,omitempty"`
 
 	// Effect indicates whether the mapping is to allow or deny access
-	Effect PolicyEffectType `json:"effect"`
+	Effect PolicyEffectType `json:"effect" yaml:"effect,omitempty"`
 
 	// Context provides optional additional context metadata for this mapping
-	Context Context `json:"context"`
+	Context Context `json:"context" yaml:"context,omitempty"`
 
 	// IsInternal indicates if this mapping should be hidden from public listings
-	IsInternal bool `json:"-"`
+	IsInternal bool `json:"-" yaml:"-"`
 }
 
 // ActionCapability represents capabilities for a specific action

--- a/internal/authz/data/default_authz_data.yaml
+++ b/internal/authz/data/default_authz_data.yaml
@@ -1,0 +1,15 @@
+# Default roles and mappings that can be seeded at installation time
+
+# Default roles
+roles:
+  - name: super-admin
+    actions:
+      - "*"
+
+# Default entitlement-to-role mappings
+mappings:
+  - role_name: super-admin
+    entitlement:
+      claim: groups
+      value: platformEngineer
+    effect: allow

--- a/internal/authz/data/default_roles.yaml
+++ b/internal/authz/data/default_roles.yaml
@@ -1,7 +1,0 @@
-# Default roles that can be seeded at installation time
-# This file can be customized per deployment
-
-roles:
-  - name: super-admin
-    actions:
-      - "*" 

--- a/internal/authz/init.go
+++ b/internal/authz/init.go
@@ -13,11 +13,11 @@ import (
 
 // AuthZConfig holds configuration for authorization initialization
 type AuthZConfig struct {
-	Enabled              bool                       // Enable or disable authorization
-	DatabasePath         string                     // Path to database
-	DefaultRolesFilePath string                     // Path to default roles YAML file (optional)
-	UserTypeConfigs      []authzcore.UserTypeConfig // Required: User type detection configuration
-	EnableCache          bool                       // Enable authz caching
+	Enabled                  bool                       // Enable or disable authorization
+	DatabasePath             string                     // Path to database
+	DefaultAuthzDataFilePath string                     // Path to default authz data YAML file containing roles and mappings (optional)
+	UserTypeConfigs          []authzcore.UserTypeConfig // Required: User type detection configuration
+	EnableCache              bool                       // Enable authz caching
 }
 
 // Initialize creates and returns PAP and PDP implementations based on configuration.
@@ -41,10 +41,10 @@ func Initialize(config AuthZConfig, logger *slog.Logger) (authzcore.PAP, authzco
 	}
 
 	casbinConfig := casbin.CasbinConfig{
-		DatabasePath:    config.DatabasePath,
-		RolesFilePath:   config.DefaultRolesFilePath, // Can be empty, will use embedded default
-		UserTypeConfigs: config.UserTypeConfigs,
-		EnableCache:     config.EnableCache,
+		DatabasePath:      config.DatabasePath,
+		AuthzDataFilePath: config.DefaultAuthzDataFilePath, // Can be empty, will use embedded default
+		UserTypeConfigs:   config.UserTypeConfigs,
+		EnableCache:       config.EnableCache,
 	}
 
 	casbinAuthz, err := casbin.NewCasbinEnforcer(casbinConfig, logger.With("component", "authz.casbin"))


### PR DESCRIPTION
## Purpose
This PR is to update authz initialization process to include role mappings as well on top of the support to specify default roles.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1231
## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
