### PR TITLE
Deploy kgateway in Observability plane for multi-cluster deployment

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.54.0
+- name: kgateway
+  repository: oci://cr.kgateway.dev/kgateway-dev/charts
+  version: v2.1.2
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 78.3.0
@@ -20,5 +23,5 @@ dependencies:
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:58c0047a8b4ac997d7f527707203c2517daae1fec49d711b6bfe3d97c775fb42
-generated: "2025-11-27T23:03:57.998503+05:30"
+digest: sha256:4785a63cc363a18cc34c8a0e80e8814df9170b295ca6278f5c22212b2e857361
+generated: "2025-12-17T17:58:04.506155+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -41,6 +41,9 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     version: 0.54.0
     condition: fluentBit.enabled
+  - name: kgateway
+    repository: "oci://cr.kgateway.dev/kgateway-dev/charts"
+    version: v2.1.2
   - name: kube-prometheus-stack
     alias: prometheus
     repository: https://prometheus-community.github.io/helm-charts

--- a/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kgateway-envoy
+  namespace: {{ .Release.Namespace }}
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: {{ .Values.gateway.httpsPort | default 443 }}
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: openchoreo-observability-plane-wildcard
+            namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/observer/http-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/http-route.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: observer
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  - name: kgateway-envoy
+  hostnames:
+  - observer.{{ .Values.global.baseDomain }}
+  rules:
+  - filters:
+    backendRefs:
+    - name: observer
+      port: 8080
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/backend-config-policy.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/backend-config-policy.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.gateway.enabled .Values.openSearchCluster.enabled }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: BackendConfigPolicy
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: opensearch
+  tls:
+    sni: "opensearch"
+    insecureSkipVerify: true
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/http-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch-cluster/http-route.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.gateway.enabled .Values.openSearchCluster.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  - name: kgateway-envoy
+  hostnames:
+  - opensearch.{{ .Values.global.baseDomain }}
+  rules:
+  - filters:
+    - type: URLRewrite
+      urlRewrite:
+        hostname: "opensearch"
+    backendRefs:
+    - name: opensearch
+      port: 9200
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/opensearch/backend-config-policy.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opensearch/backend-config-policy.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.gateway.enabled .Values.openSearch.enabled }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: BackendConfigPolicy
+metadata:
+  name: opensearch
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: opensearch
+  tls:
+    sni: "opensearch"
+    insecureSkipVerify: true
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/tls/certificate.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/tls/certificate.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-observability-plane-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: "OpenChoreo Observability Plane CA"
+  subject:
+    organizations:
+      - OpenChoreo
+  secretName: openchoreo-observability-plane-ca
+  duration: 87600h # 10 years
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: self-signed-issuer
+    kind: Issuer
+    group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-observability-plane-wildcard
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: openchoreo-observability-plane-wildcard
+  issuerRef:
+    name: openchoreo-observability-plane-ca-issuer
+    kind: Issuer
+  dnsNames:
+  - "{{ .Values.global.baseDomain }}"
+  - "*.{{ .Values.global.baseDomain }}"
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/tls/issuer.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/tls/issuer.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: self-signed-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: openchoreo-observability-plane-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: openchoreo-observability-plane-ca
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1,5 +1,13 @@
+## STRUCTURE OF THE VALUES FILE
+# This values file has 2 main sections:
+# 1. Values passed to dependent helm charts (like opentelemetry-collector, kgateway, etc)
+# 2. Values passed to templates in the openchoreo-observability-plane chart itself
+
+
 # Global values shared across all components
 global:
+  baseDomain: ""
+
   # Common labels to add to all resources
   commonLabels: {}
 
@@ -66,7 +74,9 @@ controllerManager:
   # multiCluster: When deploying OpenChoreo planes in multiple Kubernetes clusters (To be supported in the future)
   # quickStart: Limited set of features for quick-start setup
   installationMode: singleCluster
+  
 
+## Values for dependent charts
 data-prepper:
   enabled: false
   fullnameOverride: "data-prepper"
@@ -117,6 +127,29 @@ fakeSecretStore:
     - key: RCA_LLM_API_KEY
       value: "fake-llm-api-key-for-development"
 
+# kgateway configurations
+kgateway:
+  enabled: false
+  fullnameOverride: "kgateway"
+
+  # KGateway controller configuration
+  controller:
+    image:
+      pullPolicy: IfNotPresent
+
+    service:
+      type: ClusterIP
+      ports:
+        agwGrpc: 9978
+
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
 
 opentelemetry-collector:
   enabled: true
@@ -148,22 +181,6 @@ opentelemetry-collector:
     requests:
       cpu: 50m
       memory: 100Mi
-
-## opentelemetryCollectorCustomizations aren't passed to the opentelemetry-collector helm values file directly.
-# They are to be used by openchoreo specific templates
-opentelemetryCollectorCustomizations:
-  openSearchQueue:
-    numConsumers: 5
-    queueSize: 1000
-    sizer: items
-  tailSampling:
-    decisionWait: 10s
-    numTraces: 100
-    expectedNewTracesPerSec: 10
-    decisionCache:
-      sampledCacheSize: 10000
-      nonSampledCacheSize: 1000
-    spansPerSecond: 10
 
 
 openSearch:
@@ -557,9 +574,8 @@ prometheus:
   nodeExporter:
     enabled: false
 
-# Wait job configuration for post-install hooks
-waitJob:
-  image: bitnamilegacy/kubectl:1.32.4
+
+## Values for local templates
 
 # Cluster Agent configuration for agent-based communication with control plane
 clusterAgent:
@@ -644,3 +660,99 @@ clusterAgent:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+
+gateway:
+  enabled: false
+  httpsPort: 443
+
+# OpenSearch configuration for operator based OpenSearch deployment
+openSearchCluster:
+  enabled: true
+
+  bootstrap:
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1000Mi
+      requests:
+        cpu: 100m
+        memory: 1000Mi
+
+  general:
+    setVMMaxMapCount: true
+    version: 3.3.0
+
+  dashboards:
+    enable: false
+    replicas: 1
+    version: 3.3.0
+
+  nodePools:
+    data:
+      replicas: 2
+      diskSize: 5Gi
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1000Mi
+        requests:
+          cpu: 100m
+          memory: 1000Mi
+    master:
+      replicas: 3
+      diskSize: 1Gi
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 900Mi
+        requests:
+          cpu: 100m
+          memory: 900Mi
+
+  # Secrets
+  adminUsername: admin
+  adminUserPassword: ThisIsTheOpenSearchPassword1
+  internalUsers: |
+    # This is the internal user database
+    # The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+    _meta:
+      type: "internalusers"
+      config_version: 2
+
+    admin:
+      hash: "%s"
+      reserved: true
+      backend_roles:
+      - "admin"
+      description: "Admin user"
+
+openSearchClusterSetup:
+  image:
+    repository: ghcr.io/openchoreo/init-observability-opensearch
+    tag: ""
+
+
+## opentelemetryCollectorCustomizations aren't passed to the opentelemetry-collector helm values file directly.
+# They are to be used by openchoreo specific templates
+opentelemetryCollectorCustomizations:
+  openSearchQueue:
+    numConsumers: 5
+    queueSize: 1000
+    sizer: items
+  tailSampling:
+    decisionWait: 10s
+    numTraces: 100
+    expectedNewTracesPerSec: 10
+    decisionCache:
+      sampledCacheSize: 10000
+      nonSampledCacheSize: 1000
+    spansPerSecond: 10
+
+tls:
+  enabled: false
+
+# Wait job configuration for post-install hooks
+waitJob:
+  image: bitnamilegacy/kubectl:1.32.4

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -1,6 +1,9 @@
 # Helm values for OpenChoreo Observability Plane in k3d multi-cluster setup
 # This file contains overrides specific to running the observability plane in a k3d environment
 
+kgateway:
+  enabled: true
+
 observer:
   service:
     type: LoadBalancer
@@ -23,6 +26,9 @@ prometheus:
       type: LoadBalancer
       port: 9091
       reloaderWebPort: 8081
+
+
+## Values for local templates
 
 clusterAgent:
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
@@ -52,3 +58,9 @@ clusterAgent:
   # RBAC for cluster agent
   rbac:
     create: true
+
+gateway:
+  enabled: true
+
+tls:
+  enabled: true


### PR DESCRIPTION
## Purpose
Deploy kgateway in Observability plane for multi cluster deployments

## Approach
1. Created a gateway resource
2. Added HTTP Routes for OpenSearch and Observer (HTTP Routes for other services will be added in the future)
3. Added helm value overrides to the multi-cluster Observability plane values file

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1125

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
TLS termination happens at the kgateway. Currently a self signed CA for Observability plane is used which in turn generates a certificate for use in kgateway. This will be extended to allow users to bring in their own TLS certificates in the future