### PR TITLE
Fix CRD pattern validation to allow multiline expressions for control fields

### DIFF
--- a/api/v1alpha1/componenttype_types.go
+++ b/api/v1alpha1/componenttype_types.go
@@ -102,12 +102,13 @@ type ResourceTemplate struct {
 	// If not specified, the resource is always created
 	// Example: "${spec.autoscaling.enabled}"
 	// +optional
+	// +kubebuilder:validation:Pattern=`^\$\{[\s\S]+\}\s*$`
 	IncludeWhen string `json:"includeWhen,omitempty"`
 
 	// ForEach enables generating multiple resources from a list using CEL expression
 	// Example: "${spec.configurations}" to iterate over a list
 	// +optional
-	// +kubebuilder:validation:Pattern=`^\$\{.+\}$`
+	// +kubebuilder:validation:Pattern=`^\$\{[\s\S]+\}\s*$`
 	ForEach string `json:"forEach,omitempty"`
 
 	// Var is the loop variable name when using forEach

--- a/api/v1alpha1/trait_types.go
+++ b/api/v1alpha1/trait_types.go
@@ -83,7 +83,7 @@ type TraitPatch struct {
 	// Requires 'var' to be set to name the binding used in operations
 	// Example: forEach: ${spec.mounts}
 	// +optional
-	// +kubebuilder:validation:Pattern=`^\$\{.+\}$`
+	// +kubebuilder:validation:Pattern=`^\$\{[\s\S]+\}\s*$`
 	ForEach string `json:"forEach,omitempty"`
 
 	// Var names the binding for forEach iterations
@@ -130,6 +130,7 @@ type PatchTarget struct {
 	// Where is an optional CEL expression to filter which resources to patch
 	// Example: ${resource.metadata.name.endsWith("-secret-envs")}
 	// +optional
+	// +kubebuilder:validation:Pattern=`^\$\{[\s\S]+\}\s*$`
 	Where string `json:"where,omitempty"`
 }
 

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -117,7 +117,7 @@ spec:
                           description: |-
                             ForEach enables generating multiple resources from a list using CEL expression
                             Example: "${spec.configurations}" to iterate over a list
-                          pattern: ^\$\{.+\}$
+                          pattern: ^\$\{[\s\S]+\}\s*$
                           type: string
                         id:
                           description: |-
@@ -130,6 +130,7 @@ spec:
                             IncludeWhen is a CEL expression that determines if this resource should be created
                             If not specified, the resource is always created
                             Example: "${spec.autoscaling.enabled}"
+                          pattern: ^\$\{[\s\S]+\}\s*$
                           type: string
                         targetPlane:
                           default: dataplane
@@ -273,7 +274,7 @@ spec:
                               ForEach repeats this patch for every item in a CEL-evaluated list
                               Requires 'var' to be set to name the binding used in operations
                               Example: forEach: ${spec.mounts}
-                            pattern: ^\$\{.+\}$
+                            pattern: ^\$\{[\s\S]+\}\s*$
                             type: string
                           operations:
                             description: Operations is the list of JSONPatch operations
@@ -333,6 +334,7 @@ spec:
                                 description: |-
                                   Where is an optional CEL expression to filter which resources to patch
                                   Example: ${resource.metadata.name.endsWith("-secret-envs")}
+                                pattern: ^\$\{[\s\S]+\}\s*$
                                 type: string
                             required:
                             - group

--- a/config/crd/bases/openchoreo.dev_componenttypes.yaml
+++ b/config/crd/bases/openchoreo.dev_componenttypes.yaml
@@ -69,7 +69,7 @@ spec:
                       description: |-
                         ForEach enables generating multiple resources from a list using CEL expression
                         Example: "${spec.configurations}" to iterate over a list
-                      pattern: ^\$\{.+\}$
+                      pattern: ^\$\{[\s\S]+\}\s*$
                       type: string
                     id:
                       description: |-
@@ -82,6 +82,7 @@ spec:
                         IncludeWhen is a CEL expression that determines if this resource should be created
                         If not specified, the resource is always created
                         Example: "${spec.autoscaling.enabled}"
+                      pattern: ^\$\{[\s\S]+\}\s*$
                       type: string
                     targetPlane:
                       default: dataplane

--- a/config/crd/bases/openchoreo.dev_traits.yaml
+++ b/config/crd/bases/openchoreo.dev_traits.yaml
@@ -83,7 +83,7 @@ spec:
                         ForEach repeats this patch for every item in a CEL-evaluated list
                         Requires 'var' to be set to name the binding used in operations
                         Example: forEach: ${spec.mounts}
-                      pattern: ^\$\{.+\}$
+                      pattern: ^\$\{[\s\S]+\}\s*$
                       type: string
                     operations:
                       description: Operations is the list of JSONPatch operations
@@ -143,6 +143,7 @@ spec:
                           description: |-
                             Where is an optional CEL expression to filter which resources to patch
                             Example: ${resource.metadata.name.endsWith("-secret-envs")}
+                          pattern: ^\$\{[\s\S]+\}\s*$
                           type: string
                       required:
                       - group

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -116,7 +116,7 @@ spec:
                           description: |-
                             ForEach enables generating multiple resources from a list using CEL expression
                             Example: "${spec.configurations}" to iterate over a list
-                          pattern: ^\$\{.+\}$
+                          pattern: ^\$\{[\s\S]+\}\s*$
                           type: string
                         id:
                           description: |-
@@ -129,6 +129,7 @@ spec:
                             IncludeWhen is a CEL expression that determines if this resource should be created
                             If not specified, the resource is always created
                             Example: "${spec.autoscaling.enabled}"
+                          pattern: ^\$\{[\s\S]+\}\s*$
                           type: string
                         targetPlane:
                           default: dataplane
@@ -272,7 +273,7 @@ spec:
                               ForEach repeats this patch for every item in a CEL-evaluated list
                               Requires 'var' to be set to name the binding used in operations
                               Example: forEach: ${spec.mounts}
-                            pattern: ^\$\{.+\}$
+                            pattern: ^\$\{[\s\S]+\}\s*$
                             type: string
                           operations:
                             description: Operations is the list of JSONPatch operations
@@ -332,6 +333,7 @@ spec:
                                 description: |-
                                   Where is an optional CEL expression to filter which resources to patch
                                   Example: ${resource.metadata.name.endsWith("-secret-envs")}
+                                pattern: ^\$\{[\s\S]+\}\s*$
                                 type: string
                             required:
                             - group

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componenttypes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componenttypes.yaml
@@ -68,7 +68,7 @@ spec:
                       description: |-
                         ForEach enables generating multiple resources from a list using CEL expression
                         Example: "${spec.configurations}" to iterate over a list
-                      pattern: ^\$\{.+\}$
+                      pattern: ^\$\{[\s\S]+\}\s*$
                       type: string
                     id:
                       description: |-
@@ -81,6 +81,7 @@ spec:
                         IncludeWhen is a CEL expression that determines if this resource should be created
                         If not specified, the resource is always created
                         Example: "${spec.autoscaling.enabled}"
+                      pattern: ^\$\{[\s\S]+\}\s*$
                       type: string
                     targetPlane:
                       default: dataplane

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_traits.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_traits.yaml
@@ -82,7 +82,7 @@ spec:
                         ForEach repeats this patch for every item in a CEL-evaluated list
                         Requires 'var' to be set to name the binding used in operations
                         Example: forEach: ${spec.mounts}
-                      pattern: ^\$\{.+\}$
+                      pattern: ^\$\{[\s\S]+\}\s*$
                       type: string
                     operations:
                       description: Operations is the list of JSONPatch operations
@@ -142,6 +142,7 @@ spec:
                           description: |-
                             Where is an optional CEL expression to filter which resources to patch
                             Example: ${resource.metadata.name.endsWith("-secret-envs")}
+                          pattern: ^\$\{[\s\S]+\}\s*$
                           type: string
                       required:
                       - group


### PR DESCRIPTION
## Purpose
Previously used below expression to validate forEach.
```
// +kubebuilder:validation:Pattern=`^\$\{.+\}$`
```
This didn't allow multiline expressions in yaml block.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
