### PR TITLE
Separate envOverrides from parameters in render contexts

### DIFF
--- a/api/v1alpha1/componenttype_types.go
+++ b/api/v1alpha1/componenttype_types.go
@@ -74,7 +74,6 @@ type ComponentTypeSchema struct {
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 
 	// EnvOverrides can be overridden per environment via ReleaseBinding by platform engineers.
-	// These are also exposed to developers but can be changed per environment.
 	// Same nested map structure and type definition format as Parameters.
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -169,7 +169,6 @@ spec:
                       envOverrides:
                         description: |-
                           EnvOverrides can be overridden per environment via ReleaseBinding by platform engineers.
-                          These are also exposed to developers but can be changed per environment.
                           Same nested map structure and type definition format as Parameters.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true

--- a/config/crd/bases/openchoreo.dev_componenttypes.yaml
+++ b/config/crd/bases/openchoreo.dev_componenttypes.yaml
@@ -121,7 +121,6 @@ spec:
                   envOverrides:
                     description: |-
                       EnvOverrides can be overridden per environment via ReleaseBinding by platform engineers.
-                      These are also exposed to developers but can be changed per environment.
                       Same nested map structure and type definition format as Parameters.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -168,7 +168,6 @@ spec:
                       envOverrides:
                         description: |-
                           EnvOverrides can be overridden per environment via ReleaseBinding by platform engineers.
-                          These are also exposed to developers but can be changed per environment.
                           Same nested map structure and type definition format as Parameters.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componenttypes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componenttypes.yaml
@@ -120,7 +120,6 @@ spec:
                   envOverrides:
                     description: |-
                       EnvOverrides can be overridden per environment via ReleaseBinding by platform engineers.
-                      These are also exposed to developers but can be changed per environment.
                       Same nested map structure and type definition format as Parameters.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/scheduled-task.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/scheduled-task.yaml
@@ -50,7 +50,7 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
-          schedule: ${parameters.schedule}
+          schedule: ${envOverrides.schedule}
           successfulJobsHistoryLimit: ${parameters.successfulJobsHistoryLimit}
           failedJobsHistoryLimit: ${parameters.failedJobsHistoryLimit}
           concurrencyPolicy: ${parameters.concurrencyPolicy}
@@ -75,11 +75,11 @@ spec:
                         ${has(workload.containers[parameters.containerName].args) ? workload.containers[parameters.containerName].args : oc_omit()}
                       resources:
                         requests:
-                          cpu: ${parameters.resources.requests.cpu}
-                          memory: ${parameters.resources.requests.memory}
+                          cpu: ${envOverrides.resources.requests.cpu}
+                          memory: ${envOverrides.resources.requests.memory}
                         limits:
-                          cpu: ${parameters.resources.limits.cpu}
-                          memory: ${parameters.resources.limits.memory}
+                          cpu: ${envOverrides.resources.limits.cpu}
+                          memory: ${envOverrides.resources.limits.memory}
                       envFrom: |
                         ${(has(configurations[parameters.containerName].configs.envs) && configurations[parameters.containerName].configs.envs.size() > 0 ?
                           [{

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
@@ -68,11 +68,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
                   envFrom: |
                     ${(has(configurations[parameters.containerName].configs.envs) && configurations[parameters.containerName].configs.envs.size() > 0 ?
                       [{

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
@@ -65,11 +65,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
                   envFrom: |
                     ${(has(configurations[parameters.containerName].configs.envs) && configurations[parameters.containerName].configs.envs.size() > 0 ?
                       [{

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -96,12 +96,6 @@ type ComponentContextInput struct {
 	// Metadata provides structured naming and labeling information.
 	// Required - controller must provide this.
 	Metadata MetadataContext `validate:"required"`
-
-	// DiscardComponentEnvOverrides when true, discards envOverride values from Component.Spec.Parameters
-	// and only uses values from ReleaseBinding.Spec.ComponentTypeEnvOverrides for envOverride fields.
-	// Component parameters are still used for fields defined in schema.parameters.
-	// Default: false
-	DiscardComponentEnvOverrides bool
 }
 
 // TraitContextInput contains all inputs needed to build a trait rendering context.
@@ -127,12 +121,6 @@ type TraitContextInput struct {
 	// Used to avoid rebuilding schemas for the same trait used multiple times.
 	// BuildTraitContext will check this cache before building and populate it after.
 	SchemaCache map[string]*apiextschema.Structural
-
-	// DiscardComponentEnvOverrides when true, discards envOverride values from trait instance parameters
-	// and only uses values from ReleaseBinding.Spec.TraitOverrides for envOverride fields.
-	// Trait instance parameters are still used for fields defined in trait's schema.parameters.
-	// Default: false
-	DiscardComponentEnvOverrides bool
 }
 
 // SchemaInput contains schema information for applying defaults.
@@ -161,9 +149,13 @@ type ComponentContext struct {
 	// Accessed via ${dataplane.secretStore}, ${dataplane.publicVirtualHost}
 	DataPlane DataPlaneData `json:"dataplane"`
 
-	// Parameters are merged component parameters with defaults applied.
-	// Dynamic - depends on ComponentType schema.
+	// Parameters from Component.Spec.Parameters, pruned to ComponentType.Schema.Parameters.
+	// Accessed via ${parameters.*}
 	Parameters map[string]any `json:"parameters"`
+
+	// EnvOverrides from ReleaseBinding.Spec.ComponentTypeEnvOverrides, pruned to ComponentType.Schema.EnvOverrides.
+	// Accessed via ${envOverrides.*}
+	EnvOverrides map[string]any `json:"envOverrides"`
 
 	// Workload contains workload specification (containers, endpoints, connections).
 	// Accessed via ${workload.name}, ${workload.containers}, etc.
@@ -241,9 +233,13 @@ type TraitContext struct {
 	// Accessed via ${trait.name}, ${trait.instanceName}
 	Trait TraitMetadata `json:"trait"`
 
-	// Parameters are merged trait instance parameters with defaults applied.
-	// Dynamic - depends on Trait schema.
+	// Parameters from TraitInstance.Parameters, pruned to Trait.Schema.Parameters.
+	// Accessed via ${parameters.*}
 	Parameters map[string]any `json:"parameters"`
+
+	// EnvOverrides from ReleaseBinding.Spec.TraitOverrides[instanceName], pruned to Trait.Schema.EnvOverrides.
+	// Accessed via ${envOverrides.*}
+	EnvOverrides map[string]any `json:"envOverrides"`
 }
 
 // TraitMetadata contains trait-specific metadata.

--- a/internal/pipeline/component/pipeline.go
+++ b/internal/pipeline/component/pipeline.go
@@ -69,14 +69,13 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 	// Build component context
 	componentContext, err := context.BuildComponentContext(&context.ComponentContextInput{
-		Component:                    input.Component,
-		ComponentType:                input.ComponentType,
-		Workload:                     input.Workload,
-		ReleaseBinding:               input.ReleaseBinding,
-		DataPlane:                    input.DataPlane,
-		SecretReferences:             input.SecretReferences,
-		Metadata:                     input.Metadata,
-		DiscardComponentEnvOverrides: p.options.DiscardComponentEnvOverrides,
+		Component:        input.Component,
+		ComponentType:    input.ComponentType,
+		Workload:         input.Workload,
+		ReleaseBinding:   input.ReleaseBinding,
+		DataPlane:        input.DataPlane,
+		SecretReferences: input.SecretReferences,
+		Metadata:         input.Metadata,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build component context: %w", err)
@@ -117,13 +116,12 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Build trait context (BuildTraitContext will handle schema caching)
 		traitContext, err := context.BuildTraitContext(&context.TraitContextInput{
-			Trait:                        t,
-			Instance:                     traitInstance,
-			Component:                    input.Component,
-			ReleaseBinding:               input.ReleaseBinding,
-			Metadata:                     input.Metadata,
-			SchemaCache:                  schemaCache,
-			DiscardComponentEnvOverrides: p.options.DiscardComponentEnvOverrides,
+			Trait:          t,
+			Instance:       traitInstance,
+			Component:      input.Component,
+			ReleaseBinding: input.ReleaseBinding,
+			Metadata:       input.Metadata,
+			SchemaCache:    schemaCache,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build trait context for %s/%s: %w",

--- a/internal/pipeline/component/testdata/configurations-and-secrets/snapshot-with-config-helpers.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/snapshot-with-config-helpers.yaml
@@ -3,8 +3,10 @@ spec:
   component:
     metadata:
       name: test-app
+    spec: {}
+  releaseBinding:
     spec:
-      parameters:
+      componentTypeEnvOverrides:
         replicas: 2
   componentType:
     spec:
@@ -19,7 +21,7 @@ spec:
             metadata:
               name: ${metadata.name}
             spec:
-              replicas: ${parameters.replicas}
+              replicas: ${envOverrides.replicas}
               template:
                 spec:
                   containers:

--- a/internal/pipeline/component/testdata/configurations-and-secrets/snapshot.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/snapshot.yaml
@@ -3,8 +3,10 @@ spec:
   component:
     metadata:
       name: test-app
+    spec: {}
+  releaseBinding:
     spec:
-      parameters:
+      componentTypeEnvOverrides:
         replicas: 2
   componentType:
     spec:
@@ -19,7 +21,7 @@ spec:
             metadata:
               name: ${metadata.name}
             spec:
-              replicas: ${parameters.replicas}
+              replicas: ${envOverrides.replicas}
               template:
                 spec:
                   containers:

--- a/internal/pipeline/component/types.go
+++ b/internal/pipeline/component/types.go
@@ -123,20 +123,13 @@ type RenderOptions struct {
 
 	// ResourceAnnotations are additional annotations to add to all rendered resources.
 	ResourceAnnotations map[string]string
-
-	// DiscardComponentEnvOverrides when true, discards envOverride values from Component.Spec.Parameters
-	// and only uses values from ReleaseBinding.Spec.ComponentTypeEnvOverrides for envOverride fields.
-	// Component parameters are still used for fields defined in schema.parameters.
-	// Default: false (current behavior - merge Component parameters with ReleaseBinding envOverrides)
-	DiscardComponentEnvOverrides bool
 }
 
 // DefaultRenderOptions returns the default rendering options.
 func DefaultRenderOptions() RenderOptions {
 	return RenderOptions{
-		EnableValidation:             true,
-		ResourceLabels:               map[string]string{},
-		ResourceAnnotations:          map[string]string{},
-		DiscardComponentEnvOverrides: false,
+		EnableValidation:    true,
+		ResourceLabels:      map[string]string{},
+		ResourceAnnotations: map[string]string{},
 	}
 }

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -13,6 +13,7 @@ import (
 // Variable names available in component rendering context
 const (
 	VarParameters     = "parameters"
+	VarEnvOverrides   = "envOverrides"
 	VarWorkload       = "workload"
 	VarConfigurations = "configurations"
 	VarComponent      = "component"
@@ -23,12 +24,13 @@ const (
 // Variable names specific to trait rendering context
 const (
 	VarTrait = "trait"
-	// VarParameters, VarComponent, VarMetadata are shared with component context
+	// VarParameters, VarEnvOverrides, VarComponent, VarMetadata are shared with component context
 )
 
 // ComponentAllowedVariables lists all variables available in component rendering
 var ComponentAllowedVariables = []string{
 	VarParameters,
+	VarEnvOverrides,
 	VarWorkload,
 	VarConfigurations,
 	VarComponent,
@@ -39,6 +41,7 @@ var ComponentAllowedVariables = []string{
 // TraitAllowedVariables lists all variables available in trait rendering
 var TraitAllowedVariables = []string{
 	VarParameters,
+	VarEnvOverrides,
 	VarTrait,
 	VarComponent,
 	VarMetadata,
@@ -51,7 +54,8 @@ func BuildComponentCELEnv() (*cel.Env, error) {
 		cel.OptionalTypes(),
 
 		// Component context variables - matching internal/pipeline/component/context/component.go
-		cel.Variable(VarParameters, cel.DynType),                                  // Component parameters merged with env overrides
+		cel.Variable(VarParameters, cel.DynType),                                  // Component parameters from Component.Spec.Parameters
+		cel.Variable(VarEnvOverrides, cel.DynType),                                // Environment overrides from ReleaseBinding
 		cel.Variable(VarWorkload, cel.MapType(cel.StringType, cel.DynType)),       // Workload spec
 		cel.Variable(VarConfigurations, cel.MapType(cel.StringType, cel.DynType)), // Config/secret refs
 		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)),      // Component metadata
@@ -81,7 +85,8 @@ func BuildTraitCELEnv() (*cel.Env, error) {
 
 		// Trait context variables - matching internal/pipeline/component/context/trait.go
 		// Note: Traits don't have access to workload, configurations, or dataplane
-		cel.Variable(VarParameters, cel.DynType),                             // Trait parameters merged with env overrides
+		cel.Variable(VarParameters, cel.DynType),                             // Trait parameters from TraitInstance.Parameters
+		cel.Variable(VarEnvOverrides, cel.DynType),                           // Environment overrides from ReleaseBinding.TraitOverrides
 		cel.Variable(VarTrait, cel.MapType(cel.StringType, cel.DynType)),     // Trait metadata
 		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)), // Component reference
 		cel.Variable(VarMetadata, cel.MapType(cel.StringType, cel.DynType)),  // Resource generation metadata

--- a/samples/component-types/component-http-service/http-service-component.yaml
+++ b/samples/component-types/component-http-service/http-service-component.yaml
@@ -51,11 +51,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
 
     - id: service
       template:

--- a/samples/component-types/component-web-app/webapp-component.yaml
+++ b/samples/component-types/component-web-app/webapp-component.yaml
@@ -51,11 +51,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
 
     - id: service
       template:

--- a/samples/component-types/component-with-configs/component-with-configs.yaml
+++ b/samples/component-types/component-with-configs/component-with-configs.yaml
@@ -80,11 +80,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
               volumes: |
                 ${has(configurations[parameters.containerName].configs.files) && configurations[parameters.containerName].configs.files.size() > 0 || has(configurations[parameters.containerName].secrets.files) && configurations[parameters.containerName].secrets.files.size() > 0 ?
                   (has(configurations[parameters.containerName].configs.files) && configurations[parameters.containerName].configs.files.size() > 0 ?

--- a/samples/component-types/component-with-traits/component-with-traits.yaml
+++ b/samples/component-types/component-with-traits/component-with-traits.yaml
@@ -51,11 +51,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
 
     - id: service
       template:
@@ -103,8 +103,8 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: ${parameters.size}
-          storageClassName: ${parameters.storageClass}
+              storage: ${envOverrides.size}
+          storageClassName: ${envOverrides.storageClass}
 
   patches:
     - target:
@@ -166,9 +166,9 @@ spec:
           value:
             name: ${parameters.volumeName}
             emptyDir: |
-              ${parameters.sizeLimit != "" || parameters.medium != "" ? {
-                "sizeLimit": parameters.sizeLimit != "" ? parameters.sizeLimit : oc_omit(),
-                "medium": parameters.medium != "" ? parameters.medium : oc_omit()
+              ${envOverrides.sizeLimit != "" || envOverrides.medium != "" ? {
+                "sizeLimit": envOverrides.sizeLimit != "" ? envOverrides.sizeLimit : oc_omit(),
+                "medium": envOverrides.medium != "" ? envOverrides.medium : oc_omit()
               } : {}}
 
     # Add volumeMounts to each specified container
@@ -214,8 +214,6 @@ spec:
         volumeName: app-data
         mountPath: /var/data
         containerName: app
-        size: "20Gi"
-        storageClass: "fast"
     - name: emptydir-volume
       instanceName: cache
       parameters:
@@ -232,8 +230,6 @@ spec:
           - containerName: app
             mountPath: /tmp/work
             readOnly: false
-        medium: ""
-        sizeLimit: 1Gi
 
 ---
 apiVersion: openchoreo.dev/v1alpha1
@@ -276,3 +272,5 @@ spec:
     data-storage:
       size: "5Gi"
       storageClass: "local-path"
+    workspace:
+      sizeLimit: "1Gi"


### PR DESCRIPTION
## Purpose
  - Separate component/trait contexts into parameters and envOverrides, applying defaults independently instead of merging.
  - Env overrides now come only from release bindings and are exposed as their own map for CEL checks and template rendering.
  - Updated samples and tests to reflect the new envOverrides flow and expected outputs.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/1243

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
