### PR TITLE
Add per-commit Helm chart publishing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,9 +202,16 @@ jobs:
 
       - name: ${{ github.event_name == 'push' && 'Package and push' || 'Package' }} helm charts
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Packaging and pushing Helm charts..."
-            make helm-push
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # Push per-commit SHA version (main + release-v* branches)
+            echo "Packaging and pushing Helm charts with SHA ${{ env.GIT_SHA_SHORT }}..."
+            make helm-push TAG=${{ env.GIT_SHA_SHORT }} HELM_CHART_VERSION=0.0.0-${{ env.GIT_SHA_SHORT }}
+
+            # Also push latest-dev for main branch only
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              echo "Packaging and pushing Helm charts as latest-dev..."
+              make helm-push TAG=latest-dev HELM_CHART_VERSION=0.0.0-latest-dev
+            fi
           else
             echo "Packaging Helm charts for verification..."
             make helm-package


### PR DESCRIPTION
## Purpose
Enable per-commit Helm chart publishing to match the existing per-commit Docker image publishing behavior, providing version traceability for development builds.

## Approach
- Publish Helm charts versioned as 0.0.0-<sha> for each commit on main
  and release-v* branches
- Main branch also publishes 0.0.0-latest-dev (unchanged behavior)
- Quick-start now handles commit SHA versions, deriving chart version
  and using latest-dev for backstage (separate repo with different commits)

## Related Issues
- https://github.com/openchoreo/openchoreo/issues/1286

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
