### PR TITLE
Implement schema aware cel expression validation for component and trait params

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.63.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.30.0
 	k8s.io/api v0.32.3
@@ -54,6 +55,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/microsoft/go-mssqldb v1.7.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230126093431-47fa9a501578 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gorm.io/driver/mysql v1.5.7 // indirect
@@ -161,7 +163,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	k8s.io/apiserver v0.32.3 // indirect
+	k8s.io/apiserver v0.32.3
 	k8s.io/component-base v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.1 // indirect

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -971,71 +971,71 @@ func TestFindCELExpressions(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    []celMatch
+		want    []CELMatch
 		wantErr bool
 	}{
 		{
 			name:  "Simple expression",
 			input: "${resource.field}",
-			want: []celMatch{
-				{fullExpr: "${resource.field}", innerExpr: "resource.field"},
+			want: []CELMatch{
+				{FullExpr: "${resource.field}", InnerExpr: "resource.field"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with function",
 			input: "${length(resource.list)}",
-			want: []celMatch{
-				{fullExpr: "${length(resource.list)}", innerExpr: "length(resource.list)"},
+			want: []CELMatch{
+				{FullExpr: "${length(resource.list)}", InnerExpr: "length(resource.list)"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with prefix",
 			input: "prefix-${resource.field}",
-			want: []celMatch{
-				{fullExpr: "${resource.field}", innerExpr: "resource.field"},
+			want: []CELMatch{
+				{FullExpr: "${resource.field}", InnerExpr: "resource.field"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with suffix",
 			input: "${resource.field}-suffix",
-			want: []celMatch{
-				{fullExpr: "${resource.field}", innerExpr: "resource.field"},
+			want: []CELMatch{
+				{FullExpr: "${resource.field}", InnerExpr: "resource.field"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Multiple expressions",
 			input: "${resource1.field}-middle-${resource2.field}",
-			want: []celMatch{
-				{fullExpr: "${resource1.field}", innerExpr: "resource1.field"},
-				{fullExpr: "${resource2.field}", innerExpr: "resource2.field"},
+			want: []CELMatch{
+				{FullExpr: "${resource1.field}", InnerExpr: "resource1.field"},
+				{FullExpr: "${resource2.field}", InnerExpr: "resource2.field"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with map access",
 			input: "${resource.map['key']}",
-			want: []celMatch{
-				{fullExpr: "${resource.map['key']}", innerExpr: "resource.map['key']"},
+			want: []CELMatch{
+				{FullExpr: "${resource.map['key']}", InnerExpr: "resource.map['key']"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with list index",
 			input: "${resource.list[0]}",
-			want: []celMatch{
-				{fullExpr: "${resource.list[0]}", innerExpr: "resource.list[0]"},
+			want: []CELMatch{
+				{FullExpr: "${resource.list[0]}", InnerExpr: "resource.list[0]"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Complex expression with operators",
 			input: "${resource.field == 'value' && resource.number > 5}",
-			want: []celMatch{
-				{fullExpr: "${resource.field == 'value' && resource.number > 5}", innerExpr: "resource.field == 'value' && resource.number > 5"},
+			want: []CELMatch{
+				{FullExpr: "${resource.field == 'value' && resource.number > 5}", InnerExpr: "resource.field == 'value' && resource.number > 5"},
 			},
 			wantErr: false,
 		},
@@ -1060,25 +1060,25 @@ func TestFindCELExpressions(t *testing.T) {
 		{
 			name:  "Expression with escaped quotes",
 			input: `${resource.field == "escaped\"quote"}`,
-			want: []celMatch{
-				{fullExpr: `${resource.field == "escaped\"quote"}`, innerExpr: `resource.field == "escaped\"quote"`},
+			want: []CELMatch{
+				{FullExpr: `${resource.field == "escaped\"quote"}`, InnerExpr: `resource.field == "escaped\"quote"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Multiple expressions with whitespace",
 			input: "  ${resource1.field}  ${resource2.field}  ",
-			want: []celMatch{
-				{fullExpr: "${resource1.field}", innerExpr: "resource1.field"},
-				{fullExpr: "${resource2.field}", innerExpr: "resource2.field"},
+			want: []CELMatch{
+				{FullExpr: "${resource1.field}", InnerExpr: "resource1.field"},
+				{FullExpr: "${resource2.field}", InnerExpr: "resource2.field"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with newlines",
 			input: "${resource.list.map(\n  x,\n  x * 2\n)}",
-			want: []celMatch{
-				{fullExpr: "${resource.list.map(\n  x,\n  x * 2\n)}", innerExpr: "resource.list.map(\n  x,\n  x * 2\n)"},
+			want: []CELMatch{
+				{FullExpr: "${resource.list.map(\n  x,\n  x * 2\n)}", InnerExpr: "resource.list.map(\n  x,\n  x * 2\n)"},
 			},
 			wantErr: false,
 		},
@@ -1091,58 +1091,58 @@ func TestFindCELExpressions(t *testing.T) {
 		{
 			name:  "Expression with nested-like string literal in double quotes",
 			input: `${outer("${inner}")}`,
-			want: []celMatch{
-				{fullExpr: `${outer("${inner}")}`, innerExpr: `outer("${inner}")`},
+			want: []CELMatch{
+				{FullExpr: `${outer("${inner}")}`, InnerExpr: `outer("${inner}")`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with nested-like string literal in single quotes",
 			input: "${outer('${inner}')}",
-			want: []celMatch{
-				{fullExpr: "${outer('${inner}')}", innerExpr: "outer('${inner}')"},
+			want: []CELMatch{
+				{FullExpr: "${outer('${inner}')}", InnerExpr: "outer('${inner}')"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "String literal with closing braces inside double quotes",
 			input: `${"text with }} inside"}`,
-			want: []celMatch{
-				{fullExpr: `${"text with }} inside"}`, innerExpr: `"text with }} inside"`},
+			want: []CELMatch{
+				{FullExpr: `${"text with }} inside"}`, InnerExpr: `"text with }} inside"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "String literal with opening brace inside double quotes",
 			input: `${"text with { inside"}`,
-			want: []celMatch{
-				{fullExpr: `${"text with { inside"}`, innerExpr: `"text with { inside"`},
+			want: []CELMatch{
+				{FullExpr: `${"text with { inside"}`, InnerExpr: `"text with { inside"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "String literal with opening brace inside single quotes",
 			input: "${'text with { inside'}",
-			want: []celMatch{
-				{fullExpr: "${'text with { inside'}", innerExpr: "'text with { inside'"},
+			want: []CELMatch{
+				{FullExpr: "${'text with { inside'}", InnerExpr: "'text with { inside'"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Expression with dictionary building",
 			input: "${true ? {'key': 'value'} : {'key': 'value2'}}",
-			want: []celMatch{
-				{fullExpr: "${true ? {'key': 'value'} : {'key': 'value2'}}", innerExpr: "true ? {'key': 'value'} : {'key': 'value2'}"},
+			want: []CELMatch{
+				{FullExpr: "${true ? {'key': 'value'} : {'key': 'value2'}}", InnerExpr: "true ? {'key': 'value'} : {'key': 'value2'}"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Multiple expressions with dictionary building",
 			input: "${true ? {'key': 'value'} : {'key': 'value2'}} somewhat ${resource.field} then ${false ? {'key': {'nestedKey':'value'}} : {'key': 'value2'}}",
-			want: []celMatch{
-				{fullExpr: "${true ? {'key': 'value'} : {'key': 'value2'}}", innerExpr: "true ? {'key': 'value'} : {'key': 'value2'}"},
-				{fullExpr: "${resource.field}", innerExpr: "resource.field"},
-				{fullExpr: "${false ? {'key': {'nestedKey':'value'}} : {'key': 'value2'}}", innerExpr: "false ? {'key': {'nestedKey':'value'}} : {'key': 'value2'}"},
+			want: []CELMatch{
+				{FullExpr: "${true ? {'key': 'value'} : {'key': 'value2'}}", InnerExpr: "true ? {'key': 'value'} : {'key': 'value2'}"},
+				{FullExpr: "${resource.field}", InnerExpr: "resource.field"},
+				{FullExpr: "${false ? {'key': {'nestedKey':'value'}} : {'key': 'value2'}}", InnerExpr: "false ? {'key': {'nestedKey':'value'}} : {'key': 'value2'}"},
 			},
 			wantErr: false,
 		},
@@ -1155,9 +1155,9 @@ func TestFindCELExpressions(t *testing.T) {
 		{
 			name:  "Mixed complete and incomplete - incomplete at end",
 			input: "${complete} ${complete2} ${incomplete",
-			want: []celMatch{
-				{fullExpr: "${complete}", innerExpr: "complete"},
-				{fullExpr: "${complete2}", innerExpr: "complete2"},
+			want: []CELMatch{
+				{FullExpr: "${complete}", InnerExpr: "complete"},
+				{FullExpr: "${complete2}", InnerExpr: "complete2"},
 			},
 			wantErr: false,
 		},
@@ -1170,72 +1170,72 @@ func TestFindCELExpressions(t *testing.T) {
 		{
 			name:  "String literal with just opening brace - the fix case",
 			input: `${"{"}`,
-			want: []celMatch{
-				{fullExpr: `${"{"}`, innerExpr: `"{"`},
+			want: []CELMatch{
+				{FullExpr: `${"{"}`, InnerExpr: `"{"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "String literal with closing brace",
 			input: `${"}"}`,
-			want: []celMatch{
-				{fullExpr: `${"}"}`, innerExpr: `"}"`},
+			want: []CELMatch{
+				{FullExpr: `${"}"}`, InnerExpr: `"}"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "String literal braces with concatenation",
 			input: `${"{metadata.name}=" + metadata.name}`,
-			want: []celMatch{
-				{fullExpr: `${"{metadata.name}=" + metadata.name}`, innerExpr: `"{metadata.name}=" + metadata.name`},
+			want: []CELMatch{
+				{FullExpr: `${"{metadata.name}=" + metadata.name}`, InnerExpr: `"{metadata.name}=" + metadata.name`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Merge function with nested braces",
 			input: "${merge({a: 1}, {b: 2})}",
-			want: []celMatch{
-				{fullExpr: "${merge({a: 1}, {b: 2})}", innerExpr: "merge({a: 1}, {b: 2})"},
+			want: []CELMatch{
+				{FullExpr: "${merge({a: 1}, {b: 2})}", InnerExpr: "merge({a: 1}, {b: 2})"},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Complex nested braces with strings",
 			input: `${data.map(x, {"key": x, "template": "value-{}" + x})}`,
-			want: []celMatch{
-				{fullExpr: `${data.map(x, {"key": x, "template": "value-{}" + x})}`, innerExpr: `data.map(x, {"key": x, "template": "value-{}" + x})`},
+			want: []CELMatch{
+				{FullExpr: `${data.map(x, {"key": x, "template": "value-{}" + x})}`, InnerExpr: `data.map(x, {"key": x, "template": "value-{}" + x})`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Escaped backslash before quote",
 			input: `${field == "test\\\"value"}`,
-			want: []celMatch{
-				{fullExpr: `${field == "test\\\"value"}`, innerExpr: `field == "test\\\"value"`},
+			want: []CELMatch{
+				{FullExpr: `${field == "test\\\"value"}`, InnerExpr: `field == "test\\\"value"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Single quote inside double quote",
 			input: `${field == "test'value"}`,
-			want: []celMatch{
-				{fullExpr: `${field == "test'value"}`, innerExpr: `field == "test'value"`},
+			want: []CELMatch{
+				{FullExpr: `${field == "test'value"}`, InnerExpr: `field == "test'value"`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Double quote inside single quote",
 			input: `${field == 'test"value'}`,
-			want: []celMatch{
-				{fullExpr: `${field == 'test"value'}`, innerExpr: `field == 'test"value'`},
+			want: []CELMatch{
+				{FullExpr: `${field == 'test"value'}`, InnerExpr: `field == 'test"value'`},
 			},
 			wantErr: false,
 		},
 		{
 			name:  "Escaped single quote in single quote string",
 			input: `${field == 'test\'value'}`,
-			want: []celMatch{
-				{fullExpr: `${field == 'test\'value'}`, innerExpr: `field == 'test\'value'`},
+			want: []CELMatch{
+				{FullExpr: `${field == 'test\'value'}`, InnerExpr: `field == 'test\'value'`},
 			},
 			wantErr: false,
 		},
@@ -1245,13 +1245,13 @@ func TestFindCELExpressions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := findCELExpressions(tt.input)
+			got, err := FindCELExpressions(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("findCELExpressions() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FindCELExpressions() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(celMatch{})); diff != "" {
-				t.Errorf("findCELExpressions() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("FindCELExpressions() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -6,6 +6,9 @@ package component
 import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model"
+	apiservercel "k8s.io/apiserver/pkg/cel"
 
 	"github.com/openchoreo/openchoreo/internal/template"
 )
@@ -47,49 +50,33 @@ var TraitAllowedVariables = []string{
 	VarMetadata,
 }
 
-// BuildComponentCELEnv creates a CEL environment for validating component resources.
-// This environment matches the context created by BuildComponentContext in the pipeline.
-func BuildComponentCELEnv() (*cel.Env, error) {
-	envOpts := []cel.EnvOption{
-		cel.OptionalTypes(),
+// ComponentCELEnvOptions configures the CEL environment for component validation.
+type ComponentCELEnvOptions struct {
+	// ParametersSchema is the structural schema for parameters (from ComponentType.Schema.Parameters).
+	// If nil, DynType will be used.
+	ParametersSchema *apiextschema.Structural
 
-		// Component context variables - matching internal/pipeline/component/context/component.go
-		cel.Variable(VarParameters, cel.DynType),                                  // Component parameters from Component.Spec.Parameters
-		cel.Variable(VarEnvOverrides, cel.DynType),                                // Environment overrides from ReleaseBinding
-		cel.Variable(VarWorkload, cel.MapType(cel.StringType, cel.DynType)),       // Workload spec
-		cel.Variable(VarConfigurations, cel.MapType(cel.StringType, cel.DynType)), // Config/secret refs
-		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)),      // Component metadata
-		cel.Variable(VarMetadata, cel.MapType(cel.StringType, cel.DynType)),       // Resource generation metadata
-		cel.Variable(VarDataplane, cel.MapType(cel.StringType, cel.DynType)),      // DataPlane context
-
-		// Standard CEL extensions
-		ext.Strings(),
-		ext.Encoders(),
-		ext.Math(),
-		ext.Lists(),
-		ext.Sets(),
-		ext.TwoVarComprehensions(),
-	}
-
-	// Add OpenChoreo custom functions
-	envOpts = append(envOpts, template.CustomFunctions()...)
-
-	return cel.NewEnv(envOpts...)
+	// EnvOverridesSchema is the structural schema for envOverrides (from ComponentType.Schema.EnvOverrides).
+	// If nil, DynType will be used.
+	EnvOverridesSchema *apiextschema.Structural
 }
 
-// BuildTraitCELEnv creates a CEL environment for validating trait resources.
-// This environment matches the context created by BuildTraitContext in the pipeline.
-func BuildTraitCELEnv() (*cel.Env, error) {
-	envOpts := []cel.EnvOption{
+// BuildComponentCELEnv creates a schema-aware CEL environment for component validation.
+// This provides better type checking by using actual types for fixed-structure
+// variables and user-defined schemas for parameters/envOverrides.
+//
+// The environment includes:
+//   - parameters: Schema-aware type from ComponentType.Schema.Parameters (or empty object if not provided)
+//   - envOverrides: Schema-aware type from ComponentType.Schema.EnvOverrides (or empty object if not provided)
+//   - metadata: Typed from context.MetadataContext
+//   - dataplane: Typed from context.DataPlaneData
+//   - workload: Typed from context.WorkloadData
+//   - configurations: Typed from context.ContainerConfigurationsMap
+//   - component: Object type with name field
+func BuildComponentCELEnv(opts ComponentCELEnvOptions) (*cel.Env, error) {
+	// Create base environment with standard extensions
+	baseEnvOpts := []cel.EnvOption{
 		cel.OptionalTypes(),
-
-		// Trait context variables - matching internal/pipeline/component/context/trait.go
-		// Note: Traits don't have access to workload, configurations, or dataplane
-		cel.Variable(VarParameters, cel.DynType),                             // Trait parameters from TraitInstance.Parameters
-		cel.Variable(VarEnvOverrides, cel.DynType),                           // Environment overrides from ReleaseBinding.TraitOverrides
-		cel.Variable(VarTrait, cel.MapType(cel.StringType, cel.DynType)),     // Trait metadata
-		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)), // Component reference
-		cel.Variable(VarMetadata, cel.MapType(cel.StringType, cel.DynType)),  // Resource generation metadata
 
 		// Standard CEL extensions
 		ext.Strings(),
@@ -101,7 +88,196 @@ func BuildTraitCELEnv() (*cel.Env, error) {
 	}
 
 	// Add OpenChoreo custom functions
-	envOpts = append(envOpts, template.CustomFunctions()...)
+	baseEnvOpts = append(baseEnvOpts, template.CustomFunctions()...)
 
-	return cel.NewEnv(envOpts...)
+	baseEnv, err := cel.NewEnv(baseEnvOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build variable declarations and collect DeclTypes for schema-aware variables
+	var declTypes []*apiservercel.DeclType
+	var varOpts []cel.EnvOption
+
+	// Parameters: use schema if provided, otherwise empty object (no fields allowed)
+	if opts.ParametersSchema != nil {
+		paramType := model.SchemaDeclType(opts.ParametersSchema, false)
+		if paramType != nil {
+			// Assign a type name so CEL can resolve fields properly
+			paramType = paramType.MaybeAssignTypeName("Parameters")
+			declTypes = append(declTypes, paramType)
+			varOpts = append(varOpts, cel.Variable(VarParameters, paramType.CelType()))
+		} else {
+			// Schema conversion failed, use empty object
+			emptyParams := buildEmptyObjectType("Parameters")
+			declTypes = append(declTypes, emptyParams)
+			varOpts = append(varOpts, cel.Variable(VarParameters, emptyParams.CelType()))
+		}
+	} else {
+		// No schema provided, use empty object (any parameters.* access will fail)
+		emptyParams := buildEmptyObjectType("Parameters")
+		declTypes = append(declTypes, emptyParams)
+		varOpts = append(varOpts, cel.Variable(VarParameters, emptyParams.CelType()))
+	}
+
+	// EnvOverrides: use schema if provided, otherwise empty object (no fields allowed)
+	if opts.EnvOverridesSchema != nil {
+		envOverridesType := model.SchemaDeclType(opts.EnvOverridesSchema, false)
+		if envOverridesType != nil {
+			// Assign a type name so CEL can resolve fields properly
+			envOverridesType = envOverridesType.MaybeAssignTypeName("EnvOverrides")
+			declTypes = append(declTypes, envOverridesType)
+			varOpts = append(varOpts, cel.Variable(VarEnvOverrides, envOverridesType.CelType()))
+		} else {
+			// Schema conversion failed, use empty object
+			emptyEnvOverrides := buildEmptyObjectType("EnvOverrides")
+			declTypes = append(declTypes, emptyEnvOverrides)
+			varOpts = append(varOpts, cel.Variable(VarEnvOverrides, emptyEnvOverrides.CelType()))
+		}
+	} else {
+		// No schema provided, use empty object (any envOverrides.* access will fail)
+		emptyEnvOverrides := buildEmptyObjectType("EnvOverrides")
+		declTypes = append(declTypes, emptyEnvOverrides)
+		varOpts = append(varOpts, cel.Variable(VarEnvOverrides, emptyEnvOverrides.CelType()))
+	}
+
+	// Other variables use DynType for now (could be enhanced with reflection-based types later)
+	varOpts = append(varOpts,
+		cel.Variable(VarWorkload, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarConfigurations, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarMetadata, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarDataplane, cel.MapType(cel.StringType, cel.DynType)),
+	)
+
+	// If we have schema-aware types, create a DeclTypeProvider and get its env options
+	if len(declTypes) > 0 {
+		provider := apiservercel.NewDeclTypeProvider(declTypes...)
+		providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
+		if err != nil {
+			return nil, err
+		}
+		varOpts = append(varOpts, providerOpts...)
+	}
+
+	// Extend base environment with variable declarations
+	return baseEnv.Extend(varOpts...)
+}
+
+// TraitCELEnvOptions configures the CEL environment for trait validation.
+type TraitCELEnvOptions struct {
+	// ParametersSchema is the structural schema for parameters (from Trait.Schema.Parameters).
+	// If nil, DynType will be used.
+	ParametersSchema *apiextschema.Structural
+
+	// EnvOverridesSchema is the structural schema for envOverrides (from Trait.Schema.EnvOverrides).
+	// If nil, DynType will be used.
+	EnvOverridesSchema *apiextschema.Structural
+}
+
+// BuildTraitCELEnv creates a schema-aware CEL environment for trait validation.
+// This provides better type checking by using actual types for fixed-structure
+// variables and user-defined schemas for parameters/envOverrides.
+//
+// The environment includes:
+//   - parameters: Schema-aware type from Trait.Schema.Parameters (or empty object if not provided)
+//   - envOverrides: Schema-aware type from Trait.Schema.EnvOverrides (or empty object if not provided)
+//   - trait: Typed from context.TraitMetadata
+//   - component: Object type with name field
+//   - metadata: Typed from context.MetadataContext
+//
+// Note: Traits don't have access to workload, configurations, or dataplane
+func BuildTraitCELEnv(opts TraitCELEnvOptions) (*cel.Env, error) {
+	// Create base environment with standard extensions
+	baseEnvOpts := []cel.EnvOption{
+		cel.OptionalTypes(),
+
+		// Standard CEL extensions
+		ext.Strings(),
+		ext.Encoders(),
+		ext.Math(),
+		ext.Lists(),
+		ext.Sets(),
+		ext.TwoVarComprehensions(),
+	}
+
+	// Add OpenChoreo custom functions
+	baseEnvOpts = append(baseEnvOpts, template.CustomFunctions()...)
+
+	baseEnv, err := cel.NewEnv(baseEnvOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build variable declarations and collect DeclTypes for schema-aware variables
+	var declTypes []*apiservercel.DeclType
+	var varOpts []cel.EnvOption
+
+	// Parameters: use schema if provided, otherwise empty object (no fields allowed)
+	if opts.ParametersSchema != nil {
+		paramType := model.SchemaDeclType(opts.ParametersSchema, false)
+		if paramType != nil {
+			// Assign a type name so CEL can resolve fields properly
+			paramType = paramType.MaybeAssignTypeName("Parameters")
+			declTypes = append(declTypes, paramType)
+			varOpts = append(varOpts, cel.Variable(VarParameters, paramType.CelType()))
+		} else {
+			// Schema conversion failed, use empty object
+			emptyParams := buildEmptyObjectType("Parameters")
+			declTypes = append(declTypes, emptyParams)
+			varOpts = append(varOpts, cel.Variable(VarParameters, emptyParams.CelType()))
+		}
+	} else {
+		// No schema provided, use empty object (any parameters.* access will fail)
+		emptyParams := buildEmptyObjectType("Parameters")
+		declTypes = append(declTypes, emptyParams)
+		varOpts = append(varOpts, cel.Variable(VarParameters, emptyParams.CelType()))
+	}
+
+	// EnvOverrides: use schema if provided, otherwise empty object (no fields allowed)
+	if opts.EnvOverridesSchema != nil {
+		envOverridesType := model.SchemaDeclType(opts.EnvOverridesSchema, false)
+		if envOverridesType != nil {
+			// Assign a type name so CEL can resolve fields properly
+			envOverridesType = envOverridesType.MaybeAssignTypeName("EnvOverrides")
+			declTypes = append(declTypes, envOverridesType)
+			varOpts = append(varOpts, cel.Variable(VarEnvOverrides, envOverridesType.CelType()))
+		} else {
+			// Schema conversion failed, use empty object
+			emptyEnvOverrides := buildEmptyObjectType("EnvOverrides")
+			declTypes = append(declTypes, emptyEnvOverrides)
+			varOpts = append(varOpts, cel.Variable(VarEnvOverrides, emptyEnvOverrides.CelType()))
+		}
+	} else {
+		// No schema provided, use empty object (any envOverrides.* access will fail)
+		emptyEnvOverrides := buildEmptyObjectType("EnvOverrides")
+		declTypes = append(declTypes, emptyEnvOverrides)
+		varOpts = append(varOpts, cel.Variable(VarEnvOverrides, emptyEnvOverrides.CelType()))
+	}
+
+	// Other variables use DynType for now (could be enhanced with reflection-based types later)
+	varOpts = append(varOpts,
+		cel.Variable(VarTrait, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarMetadata, cel.MapType(cel.StringType, cel.DynType)),
+	)
+
+	// If we have schema-aware types, create a DeclTypeProvider and get its env options
+	if len(declTypes) > 0 {
+		provider := apiservercel.NewDeclTypeProvider(declTypes...)
+		providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
+		if err != nil {
+			return nil, err
+		}
+		varOpts = append(varOpts, providerOpts...)
+	}
+
+	// Extend base environment with variable declarations
+	return baseEnv.Extend(varOpts...)
+}
+
+// buildEmptyObjectType builds an empty object DeclType with no fields.
+// Any field access on this type will fail validation.
+func buildEmptyObjectType(name string) *apiservercel.DeclType {
+	return apiservercel.NewObjectType(name, map[string]*apiservercel.DeclField{})
 }

--- a/internal/validation/component/cel_env_test.go
+++ b/internal/validation/component/cel_env_test.go
@@ -1,0 +1,218 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+func TestBuildComponentCELEnv_WithParametersSchema(t *testing.T) {
+	// Build a structural schema for parameters
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"replicas": {Generic: apiextschema.Generic{Type: "integer"}},
+			"port":     {Generic: apiextschema.Generic{Type: "integer"}},
+		},
+	}
+
+	env, err := BuildComponentCELEnv(ComponentCELEnvOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// Valid expression should compile
+	ast, issues := env.Compile("parameters.replicas")
+	assert.Nil(t, issues.Err())
+	assert.NotNil(t, ast)
+
+	// Invalid field should fail
+	_, issues = env.Compile("parameters.invalidField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+}
+
+func TestBuildComponentCELEnv_WithEnvOverridesSchema(t *testing.T) {
+	// Build a structural schema for envOverrides with nested structure
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"resources": {
+				Generic: apiextschema.Generic{Type: "object"},
+				Properties: map[string]apiextschema.Structural{
+					"limits": {
+						Generic: apiextschema.Generic{Type: "object"},
+						Properties: map[string]apiextschema.Structural{
+							"cpu":    {Generic: apiextschema.Generic{Type: "string"}},
+							"memory": {Generic: apiextschema.Generic{Type: "string"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	env, err := BuildComponentCELEnv(ComponentCELEnvOptions{
+		EnvOverridesSchema: structural,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// Valid nested field access should work
+	ast, issues := env.Compile("envOverrides.resources.limits.cpu")
+	assert.Nil(t, issues.Err())
+	assert.NotNil(t, ast)
+
+	// Invalid nested field should fail
+	_, issues = env.Compile("envOverrides.resources.limits.invalidField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+}
+
+func TestBuildComponentCELEnv_WithoutSchema(t *testing.T) {
+	// Without schema, parameters and envOverrides should be empty objects
+	env, err := BuildComponentCELEnv(ComponentCELEnvOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// With empty object, any field access should fail
+	_, issues := env.Compile("parameters.anyField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+
+	_, issues = env.Compile("envOverrides.anyField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+}
+
+func TestBuildComponentCELEnv_OtherVariables(t *testing.T) {
+	// Other variables (metadata, workload, etc.) should be accessible
+	env, err := BuildComponentCELEnv(ComponentCELEnvOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// These variables use MapType(StringType, DynType) so any field access is allowed
+	testCases := []string{
+		"metadata.name",
+		"metadata.namespace",
+		"workload.containers",
+		"configurations.app",
+		"component.name",
+		"dataplane.secretStore",
+	}
+
+	for _, expr := range testCases {
+		t.Run(expr, func(t *testing.T) {
+			ast, issues := env.Compile(expr)
+			assert.Nil(t, issues.Err(), "Expression '%s' should compile: %v", expr, issues)
+			assert.NotNil(t, ast)
+		})
+	}
+}
+
+func TestBuildComponentCELEnv_CustomFunctions(t *testing.T) {
+	// Verify custom functions are available
+	env, err := BuildComponentCELEnv(ComponentCELEnvOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// Test OpenChoreo custom functions
+	testCases := []string{
+		`oc_merge({}, {})`,
+		`oc_omit()`,
+		`oc_generate_name("prefix")`,
+	}
+
+	for _, expr := range testCases {
+		t.Run(expr, func(t *testing.T) {
+			ast, issues := env.Compile(expr)
+			assert.Nil(t, issues.Err(), "Expression '%s' should compile: %v", expr, issues)
+			assert.NotNil(t, ast)
+		})
+	}
+}
+
+func TestBuildTraitCELEnv_WithParametersSchema(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"volumeName":    {Generic: apiextschema.Generic{Type: "string"}},
+			"mountPath":     {Generic: apiextschema.Generic{Type: "string"}},
+			"containerName": {Generic: apiextschema.Generic{Type: "string"}},
+		},
+	}
+
+	env, err := BuildTraitCELEnv(TraitCELEnvOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// Valid field should work
+	ast, issues := env.Compile("parameters.volumeName")
+	assert.Nil(t, issues.Err())
+	assert.NotNil(t, ast)
+
+	// Invalid field should fail
+	_, issues = env.Compile("parameters.badField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+}
+
+func TestBuildTraitCELEnv_NoWorkloadVariables(t *testing.T) {
+	// Traits should not have access to workload, configurations, or dataplane
+	env, err := BuildTraitCELEnv(TraitCELEnvOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// These should fail to compile (variables don't exist)
+	invalidExprs := []string{
+		"workload.containers",
+		"configurations.app",
+		"dataplane.secretStore",
+	}
+
+	for _, expr := range invalidExprs {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			assert.NotNil(t, issues.Err(), "Expression '%s' should fail (trait context doesn't have this variable)", expr)
+		})
+	}
+
+	// These should work (trait-specific variables)
+	validExprs := []string{
+		"trait.instanceName",
+		"component.name",
+		"metadata.name",
+	}
+
+	for _, expr := range validExprs {
+		t.Run(expr, func(t *testing.T) {
+			ast, issues := env.Compile(expr)
+			assert.Nil(t, issues.Err(), "Expression '%s' should compile: %v", expr, issues)
+			assert.NotNil(t, ast)
+		})
+	}
+}
+
+func TestBuildTraitCELEnv_WithoutSchema(t *testing.T) {
+	// Without schema, parameters and envOverrides should be empty objects
+	env, err := BuildTraitCELEnv(TraitCELEnvOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// With empty object, any field access should fail
+	_, issues := env.Compile("parameters.anyField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+
+	_, issues = env.Compile("envOverrides.anyField")
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+}

--- a/internal/validation/component/cel_validator.go
+++ b/internal/validation/component/cel_validator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 )
 
 // ResourceType indicates which type of resource is being validated
@@ -27,20 +28,30 @@ type CELValidator struct {
 	allowedRoots map[string]bool
 }
 
+// CELValidatorSchemaOptions configures schema information for the validator.
+type CELValidatorSchemaOptions struct {
+	// ParametersSchema is the structural schema for parameters.
+	ParametersSchema *apiextschema.Structural
+
+	// EnvOverridesSchema is the structural schema for envOverrides.
+	EnvOverridesSchema *apiextschema.Structural
+}
+
 // NewCELValidator creates a validator for the specified resource type.
 // The validator uses different environments for ComponentType vs Trait resources
 // to enforce proper variable access (e.g., traits can't access workload).
-func NewCELValidator(resourceType ResourceType) (*CELValidator, error) {
+// Provides schema-aware type checking when schemas are provided in opts.
+func NewCELValidator(resourceType ResourceType, opts CELValidatorSchemaOptions) (*CELValidator, error) {
 	var env *cel.Env
 	var allowedRoots []string
 	var err error
 
 	switch resourceType {
 	case ComponentTypeResource:
-		env, err = BuildComponentCELEnv()
+		env, err = BuildComponentCELEnv(ComponentCELEnvOptions(opts))
 		allowedRoots = ComponentAllowedVariables
 	case TraitResource:
-		env, err = BuildTraitCELEnv()
+		env, err = BuildTraitCELEnv(TraitCELEnvOptions(opts))
 		allowedRoots = TraitAllowedVariables
 	default:
 		return nil, fmt.Errorf("unknown resource type: %v", resourceType)

--- a/internal/validation/component/cel_validator_test.go
+++ b/internal/validation/component/cel_validator_test.go
@@ -1,0 +1,314 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+func TestCELValidator_SchemaAwareValidation_InvalidFieldAccess(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"replicas": {Generic: apiextschema.Generic{Type: "integer"}},
+		},
+	}
+
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+
+	// This should fail - nonExistentField doesn't exist
+	err = validator.ValidateExpression("parameters.nonExistentField")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "undefined field")
+
+	// This should pass
+	err = validator.ValidateExpression("parameters.replicas")
+	assert.NoError(t, err)
+}
+
+func TestCELValidator_SchemaAwareValidation_NestedFields(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"resources": {
+				Generic: apiextschema.Generic{Type: "object"},
+				Properties: map[string]apiextschema.Structural{
+					"limits": {
+						Generic: apiextschema.Generic{Type: "object"},
+						Properties: map[string]apiextschema.Structural{
+							"cpu":    {Generic: apiextschema.Generic{Type: "string"}},
+							"memory": {Generic: apiextschema.Generic{Type: "string"}},
+						},
+					},
+					"requests": {
+						Generic: apiextschema.Generic{Type: "object"},
+						Properties: map[string]apiextschema.Structural{
+							"cpu":    {Generic: apiextschema.Generic{Type: "string"}},
+							"memory": {Generic: apiextschema.Generic{Type: "string"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{
+		EnvOverridesSchema: structural,
+	})
+	require.NoError(t, err)
+
+	// Valid nested access
+	err = validator.ValidateExpression("envOverrides.resources.limits.cpu")
+	assert.NoError(t, err)
+
+	err = validator.ValidateExpression("envOverrides.resources.requests.memory")
+	assert.NoError(t, err)
+
+	// Invalid nested field
+	err = validator.ValidateExpression("envOverrides.resources.limits.invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "undefined field")
+
+	// Invalid intermediate field
+	err = validator.ValidateExpression("envOverrides.resources.invalid.cpu")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "undefined field")
+}
+
+func TestCELValidator_BackwardCompatibility_NilSchema(t *testing.T) {
+	// Without schemas, should use empty objects
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{})
+	require.NoError(t, err)
+
+	// With empty objects, any field access should fail
+	err = validator.ValidateExpression("parameters.anyField")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "undefined field")
+
+	err = validator.ValidateExpression("envOverrides.anyField")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "undefined field")
+}
+
+func TestCELValidator_BooleanExpression_Valid(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"enabled": {Generic: apiextschema.Generic{Type: "boolean"}},
+			"count":   {Generic: apiextschema.Generic{Type: "integer"}},
+		},
+	}
+
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+
+	env := validator.GetBaseEnv()
+
+	// Valid boolean expressions
+	testCases := []string{
+		"parameters.enabled",
+		"parameters.count > 0",
+		"parameters.enabled && parameters.count > 5",
+		"!parameters.enabled",
+	}
+
+	for _, expr := range testCases {
+		t.Run(expr, func(t *testing.T) {
+			err := validator.ValidateBooleanExpression(expr, env)
+			assert.NoError(t, err, "Expression '%s' should be valid boolean", expr)
+		})
+	}
+}
+
+func TestCELValidator_BooleanExpression_Invalid(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"count": {Generic: apiextschema.Generic{Type: "integer"}},
+			"name":  {Generic: apiextschema.Generic{Type: "string"}},
+		},
+	}
+
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+
+	env := validator.GetBaseEnv()
+
+	// Invalid boolean expressions (return non-boolean types)
+	testCases := []struct {
+		expr        string
+		description string
+	}{
+		{"parameters.count", "integer is not boolean"},
+		{"parameters.name", "string is not boolean"},
+		{"parameters.count + 5", "arithmetic result is not boolean"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := validator.ValidateBooleanExpression(tc.expr, env)
+			assert.Error(t, err, "Expression '%s' should fail: %s", tc.expr, tc.description)
+		})
+	}
+}
+
+func TestCELValidator_IterableExpression_Valid(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"items": {
+				Generic: apiextschema.Generic{Type: "array"},
+				Items: &apiextschema.Structural{
+					Generic: apiextschema.Generic{Type: "string"},
+				},
+			},
+			"mappings": {
+				Generic: apiextschema.Generic{Type: "object"},
+				AdditionalProperties: &apiextschema.StructuralOrBool{
+					Structural: &apiextschema.Structural{
+						Generic: apiextschema.Generic{Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+
+	env := validator.GetBaseEnv()
+
+	// Valid iterable expressions
+	testCases := []string{
+		"parameters.items",
+		"parameters.mappings",
+		`["a", "b", "c"]`,
+		`{"key": "value"}`,
+	}
+
+	for _, expr := range testCases {
+		t.Run(expr, func(t *testing.T) {
+			err := validator.ValidateIterableExpression(expr, env)
+			assert.NoError(t, err, "Expression '%s' should be iterable", expr)
+		})
+	}
+}
+
+func TestCELValidator_IterableExpression_Invalid(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"count": {Generic: apiextschema.Generic{Type: "integer"}},
+			"name":  {Generic: apiextschema.Generic{Type: "string"}},
+		},
+	}
+
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{
+		ParametersSchema: structural,
+	})
+	require.NoError(t, err)
+
+	env := validator.GetBaseEnv()
+
+	// Invalid iterable expressions (not list or map)
+	testCases := []struct {
+		expr        string
+		description string
+	}{
+		{"parameters.count", "integer is not iterable"},
+		{"parameters.name", "string is not iterable"},
+		{"true", "boolean is not iterable"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := validator.ValidateIterableExpression(tc.expr, env)
+			assert.Error(t, err, "Expression '%s' should fail: %s", tc.expr, tc.description)
+		})
+	}
+}
+
+func TestCELValidator_TraitResource_NoWorkloadAccess(t *testing.T) {
+	// Trait validator should not allow access to workload-related variables
+	validator, err := NewCELValidator(TraitResource, CELValidatorSchemaOptions{})
+	require.NoError(t, err)
+
+	// These should fail - trait context doesn't have these variables
+	invalidExprs := []string{
+		"workload.containers",
+		"configurations.app",
+		"dataplane.secretStore",
+	}
+
+	for _, expr := range invalidExprs {
+		t.Run(expr, func(t *testing.T) {
+			err := validator.ValidateExpression(expr)
+			assert.Error(t, err, "Trait should not have access to '%s'", expr)
+		})
+	}
+
+	// These should work - trait has access to these
+	validExprs := []string{
+		"trait.instanceName",
+		"component.name",
+		"metadata.name",
+	}
+
+	for _, expr := range validExprs {
+		t.Run(expr, func(t *testing.T) {
+			err := validator.ValidateExpression(expr)
+			assert.NoError(t, err, "Trait should have access to '%s'", expr)
+		})
+	}
+}
+
+func TestCELValidator_ComponentTypeResource_AllVariables(t *testing.T) {
+	// ComponentType validator should allow access to all variables
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{})
+	require.NoError(t, err)
+
+	// All component context variables should be accessible
+	validExprs := []string{
+		"metadata.name",
+		"metadata.namespace",
+		"component.name",
+		"workload.containers",
+		"configurations.app",
+		"dataplane.secretStore",
+	}
+
+	for _, expr := range validExprs {
+		t.Run(expr, func(t *testing.T) {
+			err := validator.ValidateExpression(expr)
+			assert.NoError(t, err, "ComponentType should have access to '%s'", expr)
+		})
+	}
+}
+
+func TestCELValidator_WithoutSchema(t *testing.T) {
+	// Without schemas, parameters and envOverrides are empty objects
+	validator, err := NewCELValidator(ComponentTypeResource, CELValidatorSchemaOptions{})
+	require.NoError(t, err)
+
+	// Without schemas, parameters and envOverrides are empty objects
+	err = validator.ValidateExpression("parameters.anyField")
+	assert.Error(t, err)
+
+	// Other variables should work
+	err = validator.ValidateExpression("metadata.name")
+	assert.NoError(t, err)
+}

--- a/internal/validation/component/foreach_types.go
+++ b/internal/validation/component/foreach_types.go
@@ -20,9 +20,6 @@ const (
 	ForEachList
 	// ForEachMap indicates forEach iterates over a map
 	ForEachMap
-
-	// dynamicTypeString represents a type that cannot be determined statically
-	dynamicTypeString = "dynamic"
 )
 
 // String returns the string representation of ForEachType
@@ -147,36 +144,4 @@ func ExtendEnvWithForEach(env *cel.Env, info *ForEachInfo) (*cel.Env, error) {
 	return env.Extend(
 		cel.Variable(info.VarName, info.VarType),
 	)
-}
-
-// GetForEachDescription returns a human-readable description of the forEach variable
-func GetForEachDescription(info *ForEachInfo) string {
-	if info == nil {
-		return ""
-	}
-
-	switch info.Type {
-	case ForEachMap:
-		keyStr := dynamicTypeString
-		valueStr := dynamicTypeString
-		if info.KeyType != nil {
-			keyStr = info.KeyType.String()
-		}
-		if info.ValueType != nil {
-			valueStr = info.ValueType.String()
-		}
-		return fmt.Sprintf("forEach over map creates variable '%s' with fields: key (%s), value (%s)",
-			info.VarName, keyStr, valueStr)
-
-	case ForEachList:
-		elemStr := dynamicTypeString
-		if info.ElementType != nil && info.ElementType != cel.DynType {
-			elemStr = info.ElementType.String()
-		}
-		return fmt.Sprintf("forEach over list creates variable '%s' of type %s",
-			info.VarName, elemStr)
-
-	default:
-		return fmt.Sprintf("forEach creates variable '%s' of unknown type", info.VarName)
-	}
 }

--- a/internal/webhook/componenttype/webhook_test.go
+++ b/internal/webhook/componenttype/webhook_test.go
@@ -297,10 +297,8 @@ var _ = Describe("ComponentType Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("includeWhen must be wrapped in ${...}"))
 		})
 
-		// Note: forEach with non-iterable type (e.g., integer) is NOT caught at validation time
-		// because the webhook uses permissive CEL validation. This is caught at runtime instead.
-		// This test documents the current behavior.
-		It("should allow forEach with any expression (caught at runtime, not validation)", func() {
+		// Schema-aware validation catches forEach with non-iterable types at validation time
+		It("should reject forEach with non-iterable expression", func() {
 			obj.Spec.Schema = openchoreodevv1alpha1.ComponentTypeSchema{
 				Parameters: &runtime.RawExtension{
 					Raw: []byte(`{"replicas": "integer"}`),
@@ -318,8 +316,9 @@ var _ = Describe("ComponentType Webhook", func() {
 			}
 
 			_, err := validator.ValidateCreate(ctx, obj)
-			// Permissive mode allows this - type checking happens at runtime
-			Expect(err).ToNot(HaveOccurred())
+			// Schema-aware validation catches this error
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("forEach expression must return list or map"))
 		})
 	})
 


### PR DESCRIPTION
## Purpose
> Implement schema aware cel expression validation for component and trait parameters

```
Resource: "openchoreo.dev/v1alpha1, Resource=componenttypes", GroupVersionKind: "openchoreo.dev/v1alpha1, Kind=ComponentType"
Name: "web-app", Namespace: "default"
for: "samples/component-types/component-with-traits/component-with-traits.yaml": error when patching "samples/component-types/component-with-traits/component-with-traits.yaml": admission webhook "vcomponenttype-v1alpha1.kb.io" denied the request: spec.resources[1].template[spec][ports][0][targetPort]: Invalid value: "${parameters.port2}": invalid CEL expression 'parameters.port2': type check error: ERROR: <input>:1:11: undefined field 'port2'
 | parameters.port2
 | ..........^
 ```
 
 ```
 Resource: "openchoreo.dev/v1alpha1, Resource=componenttypes", GroupVersionKind: "openchoreo.dev/v1alpha1, Kind=ComponentType"
Name: "web-app", Namespace: "default"
for: "samples/component-types/component-with-traits/component-with-traits.yaml": error when patching "samples/component-types/component-with-traits/component-with-traits.yaml": admission webhook "vcomponenttype-v1alpha1.kb.io" denied the request: spec.resources[1].template[spec][ports][0][targetPort]: Invalid value: "${parameters.port.name}": invalid CEL expression 'parameters.port.name': type check error: ERROR: <input>:1:16: type 'int' does not support field selection
 | parameters.port.name
 | ...............^
chathuranga@chathurangada openchoreo3 % 
```

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1313

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
