### PR TITLE
Deploy Prometheus agents in data planes and forward metrics to Observability plane

### DIFF
--- a/install/helm/openchoreo-data-plane/Chart.lock
+++ b/install/helm/openchoreo-data-plane/Chart.lock
@@ -8,11 +8,14 @@ dependencies:
 - name: kgateway
   repository: oci://cr.kgateway.dev/kgateway-dev/charts
   version: v2.1.1
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 78.3.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.140.0
 - name: gateway-operator
   repository: oci://ghcr.io/wso2/api-platform/helm-charts
   version: 0.0.1
-digest: sha256:092497728ce8b9cf94bef70a32807bb16f2b3537fd416018c3f725028f288463
-generated: "2025-12-12T23:12:17.040575+05:30"
+digest: sha256:79124f078755eeecf29fecc9f506cfdb93d94fbbd55d1feed5ca5b9444475eed
+generated: "2025-12-19T14:11:59.090788+05:30"

--- a/install/helm/openchoreo-data-plane/Chart.yaml
+++ b/install/helm/openchoreo-data-plane/Chart.yaml
@@ -39,6 +39,10 @@ dependencies:
     repository: "oci://cr.kgateway.dev/kgateway-dev/charts"
     version: v2.1.1
     condition: gateway.enabled
+  - name: kube-prometheus-stack
+    repository: https://prometheus-community.github.io/helm-charts
+    version: 78.3.0
+    condition: kube-prometheus-stack.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     version: 0.140.0

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -6,6 +6,94 @@ global:
 
 kubernetesClusterDomain: cluster.local
 
+# Prometheus configurations
+kube-prometheus-stack:
+  enabled: false
+  fullnameOverride: openchoreo-observability
+
+  ## Manages Prometheus and Alertmanager components
+  prometheusOperator:
+    enabled: true
+    fullnameOverride: prometheus-operator
+
+    resources:
+      limits:
+        cpu: 40m
+        memory: 50Mi
+      requests:
+        cpu: 20m
+        memory: 30Mi
+
+  ## Install Prometheus Operator CRDs
+  crds:
+    enabled: true
+
+  ## Setting to produces cleaner resource names
+  cleanPrometheusOperatorObjectNames: true
+
+  ## Deploy a Prometheus instance (Prometheus Operator needs to be enabled for this to work)
+  prometheus:
+    enabled: true # This section needs to be further configured for Thanos backups, priorityClass etc.
+    agentMode: true
+    prometheusSpec:
+      remoteWrite:
+      - url: ""
+      # serviceMonitorNamespaceSelector: {}
+      # serviceMonitorSelector: {}
+      # serviceMonitorSelectorNilUsesHelmValues: false
+
+  ## Configuration for alertmanager
+  ## ref: https://prometheus.io/docs/alerting/alertmanager/
+  alertmanager:
+    enabled: false
+
+  ## Configuration for grafana
+  # Values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+  grafana:
+    enabled: false
+
+  ## Configuration for kube-state-metrics subchart
+  kube-state-metrics:
+    fullnameOverride: kube-state-metrics
+    collectors:
+      - pods
+      # Jobs and Services to be added later
+    metricAllowlist:
+      - kube_pod_completion_time
+      - kube_pod_container_resource_limits
+      - kube_pod_container_resource_requests
+      - kube_pod_info
+      - kube_pod_init_container_resource_limits
+      - kube_pod_init_container_resource_requests
+      - kube_pod_labels
+      - kube_pod_start_time
+      - kube_pod_status_phase
+      # Jobs and Services to be added later
+    metricLabelsAllowlist:
+      - pods=[openchoreo.dev/component-uid,openchoreo.dev/project-uid,openchoreo.dev/environment-uid]
+      # Jobs and Services to be added later
+
+  ## Create default rules for monitoring the cluster
+  defaultRules:
+    create: false
+
+  ## Openchoreo Observability is not meant for monitoring the kubernetes cluster
+  ## Hence, following kube components are disabled
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+  coreDns:
+    enabled: false
+  kubeEtcd:
+    enabled: false
+  kubeScheduler:
+    enabled: false
+  kubeProxy:
+    enabled: false
+  nodeExporter:
+    enabled: false
+
 # Wait job configuration for post-install hooks
 waitJob:
   image: bitnamilegacy/kubectl:1.32.4

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -69,8 +69,6 @@ spec:
           value: "8080"
         - name: LOG_LEVEL
           value: {{ if .Values.observer }}{{ .Values.observer.logLevel | default "info" | quote }}{{ else }}"info"{{ end }}
-        - name: OPENSEARCH_ADDRESS
-          value: "https://opensearch:9200"
         - name: OPENSEARCH_USERNAME
           valueFrom:
             secretKeyRef:
@@ -81,10 +79,9 @@ spec:
             secretKeyRef:
               name: observer-opensearch
               key: password
-        - name: PROMETHEUS_ADDRESS
-          value: "http://openchoreo-observability-prometheus:9090"
-        - name: PROMETHEUS_TIMEOUT
-          value: {{ .Values.observer.prometheus.timeout | default "30s" | quote }}
+        {{- if .Values.observer.extraEnvs }}
+        {{- toYaml .Values.observer.extraEnvs | nindent 8 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -215,6 +215,14 @@ openSearchDashboards:
 observer:
   replicas: 1
 
+  extraEnvs:
+  - name: OPENSEARCH_ADDRESS
+    value: "https://opensearch:9200"
+  - name: PROMETHEUS_ADDRESS
+    value: "http://openchoreo-observability-prometheus:9091"
+  - name: PROMETHEUS_TIMEOUT
+    value: "30s"
+
   image:
     repository: ghcr.io/openchoreo/observer
     tag: ""  # If no value is set, use Chart.AppVersion
@@ -427,7 +435,7 @@ prometheus:
           - name: Prometheus
             type: prometheus
             access: proxy
-            url: http://openchoreo-observability-prometheus:9090
+            url: http://openchoreo-observability-prometheus:9091
             isDefault: true
 
   ## Flag to disable all the kubernetes component scrapers

--- a/install/k3d/multi-cluster/config-op.yaml
+++ b/install/k3d/multi-cluster/config-op.yaml
@@ -21,6 +21,14 @@ ports:
   - port: 11082:9200
     nodeFilters:
       - loadbalancer
+  # Prometheus
+  - port: 11083:8081
+    nodeFilters:
+      - loadbalancer
+  - port: 11084:9091
+    nodeFilters:
+      - loadbalancer
+    
 options:
   k3s:
     extraArgs:

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -58,6 +58,14 @@ gateway:
     # Ref: https://github.com/kgateway-dev/kgateway/issues/9800
     mountTmpVolume: true
 
+kube-prometheus-stack:
+  enabled: true
+  prometheus:
+    prometheusSpec:
+      remoteWrite:
+      - url: "http://host.k3d.internal:11084/api/v1/write"
+      ## TODO: Enable mTLS
+
 # External Secrets Operator configuration
 external-secrets:
   enabled: true

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -14,6 +14,16 @@ openSearch:
   service:
     type: LoadBalancer
 
+prometheus:
+  enabled: true
+  prometheus:
+    prometheusSpec:
+      enableRemoteWriteReceiver: true
+    service:
+      type: LoadBalancer
+      port: 9091
+      reloaderWebPort: 8081
+
 clusterAgent:
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
   planeName: "default"


### PR DESCRIPTION
## Purpose
This PR implements metric collection in an OpenChoreo setup where the Observability plane runs in a separate Kubernetes cluster. 

## Approach
This deploys Prometheus in agent mode in data planes. The agent collects metrics of workloads running in that data plane and publishes them to the central Prometheus deployed in the Observability plane. Remote Write capability of Prometheus is used to publish the metrics to the Observability plane

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1252

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
