### PR TITLE
Add openchoreo controlplane MCP server samples and setup guide

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -43,6 +43,21 @@ Reusable component workflow definitions for building applications from source co
 ### [GCP Microservices Demo](./gcp-microservices-demo)
 A complete microservices application based on Google's popular [microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo). This sample showcases how to deploy a full e-commerce application with multiple interconnected services using OpenChoreo.
 
+### [MCP Server - AI Assistant Integration](./mcp)
+Learn how to use OpenChoreo with AI assistants through the Model Context Protocol (MCP). Deploy and manage applications using natural language with AI assistants like Claude Code, Cursor, VS Code, and Claude Desktop.
+
+**Prerequisites:**
+- Running OpenChoreo instance
+- MCP server configured
+- AI assistant installed and configured
+
+**Available Guides:**
+- **[Getting Started](./mcp/getting-started/)** - Connect your AI assistant and explore OpenChoreo resources (10-15 min)
+- **[Service Deployment](./mcp/service-deployment/)** - Deploy services from source code to production using AI assistants (30-45 min)
+  - [Step-by-Step Guide](./mcp/service-deployment/step-by-step/) - Guided walkthrough with explicit prompts
+  - [Developer Chat](./mcp/service-deployment/developer-chat/) - Natural conversation-based deployment
+- **[Configuration Examples](./mcp/configs/)** - Setup instructions for different AI assistants
+
 ### [Platform Configuration](./platform-config)
 Configuration samples targeted at Platform Engineers. Learn how to set up deployment pipelines, configure environments, and establish platform governance using OpenChoreo's abstractions.
 

--- a/samples/mcp/README.md
+++ b/samples/mcp/README.md
@@ -1,0 +1,53 @@
+# OpenChoreo MCP Server - AI Assistant Examples
+
+This directory contains practical guides for using the OpenChoreo MCP (Model Context Protocol) server with AI assistants like Claude Code, Cursor, VS Code, and Claude Desktop.
+
+## Prerequisites
+
+Before you begin, ensure you have completed the following prerequisites:
+
+### 1. Running OpenChoreo Instance
+
+You need a running OpenChoreo instance. If you haven't set one up yet:
+
+- Complete the [Quick Start Guide](https://openchoreo.dev/docs/getting-started/quick-start-guide/)
+- Or follow the [Installation Guide](https://openchoreo.dev/docs/getting-started/production/deployment-planning/) for your preferred setup method
+
+### 2. Configure MCP Server
+
+The OpenChoreo MCP server must be configured and accessible. See the [Configuration Guide](./configs/) for detailed instructions to obtain:
+
+- MCP server endpoint
+- An access token
+
+### 3. AI Assistant Setup
+
+Install an AI Assistant (AI Agent) and configure the OpenChoreo MCP server.
+- Transport: `http`
+- Authorization header
+
+## Guides
+
+### 1. [Getting Started](./getting-started/)
+Learn the basics of connecting your AI assistant to OpenChoreo and performing simple operations like listing organizations and projects.
+
+**Prerequisites:** All prerequisites above must be completed.
+
+**Time:** 2 minutes
+
+### 2. [Service Deployment](./service-deployment/)
+Deploy a complete service from source code to production using the OpenChoreo MCP server. Choose from:
+
+- **[Step-by-Step Guide](./service-deployment/step-by-step/)** - Guided walkthrough with explicit prompts
+- **[Developer Chat](./service-deployment/developer-chat/)** - Natural conversation-based deployment
+
+**Prerequisites:** All prerequisites above, plus:
+- At least two environments configured (development and production)
+- Component workflows configured (Docker or Buildpacks)
+
+**Time:** 15-20 minutes
+
+## Getting Help
+
+- [OpenChoreo Documentation](https://openchoreo.dev/)
+- [Discord Community](https://discord.gg/asqDFC8suT)

--- a/samples/mcp/configs/README.md
+++ b/samples/mcp/configs/README.md
@@ -1,0 +1,101 @@
+# AI Assistant Configuration for OpenChoreo MCP Server
+
+This guide shows how to configure different AI assistants to connect to the OpenChoreo MCP server.
+
+## Prerequisites
+
+Before configuring your AI assistant:
+
+1. **Running OpenChoreo instance** - Complete the [Quick Start Guide](https://openchoreo.dev/docs/getting-started/quick-start-guide/)
+2. **MCP Server Endpoint** - Know your OpenChoreo API endpoint (e.g., `http://api.openchoreo.localhost:8080/mcp`)
+3. **Authentication Token** - Obtain a JWT token for authenticating with the MCP server
+4. **AI Assistant Installed** - Have one of the supported AI assistants installed
+
+## MCP Server Configuration for AI assistants
+
+The OpenChoreo MCP server exposes an HTTP endpoint that AI assistants connect to. You'll need:
+
+- **Endpoint URL**: Typically `http://api.openchoreo.localhost:8080/mcp` (adjust based on your setup)
+- **Authentication**: Bearer token in the `Authorization` header
+- **Transport**: HTTP-based MCP transport (most assistants support this)
+
+## Obtaining an Authentication Token
+
+OpenChoreo uses an identity provider for authentication. The default identity provider is **Asgardeo Thunder** with the token endpoint at `http://thunder.openchoreo.localhost:8080/oauth2/token`.
+
+Follow these steps to obtain an authentication token if you're using the default identity provider:
+
+### Step 1: Get the Application ID
+
+1. Open your browser and navigate to http://thunder.openchoreo.localhost:8080/develop
+   > **Note**: Default credentials are `admin` / `admin`
+
+2. Open the `Sample App` application
+3. Copy the **Application ID**
+
+### Step 2: Obtain an Admin Token
+
+Replace `<application_id>` with your Sample App ID and run:
+
+```bash
+ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'http://thunder.openchoreo.localhost:8080/flow/execute' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "applicationId": "<application_id>",
+    "flowType": "AUTHENTICATION",
+    "inputs": {
+      "username": "admin",
+      "password": "admin",
+      "requested_permissions": "system"
+    }
+  }')
+
+ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
+```
+
+### Step 3: Create an OAuth2 Application
+
+Create a new OAuth2 application with client credentials grant:
+
+```bash
+curl -L 'http://thunder.openchoreo.localhost:8080/applications' \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -d '{
+    "name": "MCP client",
+    "description": "MCP client application to use openchoreo MCP server",
+    "auth_flow_graph_id": "auth_flow_config_basic",
+    "inbound_auth_config": [
+        {
+            "type": "oauth2",
+            "config": {
+                "client_id": "mcp_client",
+                "client_secret": "mcp_client_secret",
+                "grant_types": [
+                    "client_credentials"
+                ],
+                "token_endpoint_auth_method": "client_secret_basic",
+                "token": {
+                    "issuer": "thunder",
+                    "access_token": {
+                        "validity_period": 3600
+                    }
+                }
+            }
+        }
+    ]
+}'
+```
+
+### Step 4: Obtain Your Token
+
+Use the client credentials to get an access token:
+
+```bash
+curl -L 'http://thunder.openchoreo.localhost:8080/oauth2/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -u 'mcp_client:mcp_client_secret' \
+  -d 'grant_type=client_credentials'
+```
+
+The response will contain an `access_token` that you can use as the Bearer token for authenticating with the OpenChoreo MCP server.

--- a/samples/mcp/getting-started/README.md
+++ b/samples/mcp/getting-started/README.md
@@ -1,0 +1,53 @@
+# Getting Started with OpenChoreo MCP Server
+
+This guide walks you through basic operations using the OpenChoreo MCP server. You'll learn how to discover and explore your OpenChoreo resources using AI assistants.
+
+## Prerequisites
+
+Before starting this guide, ensure you have completed all [prerequisites](../README.md#prerequisites)
+
+## What You'll Learn
+
+In this guide, you'll learn:
+- How to prompt AI assistants to interact with OpenChoreo using MCP tools
+- How to discover and explore your OpenChoreo resources through natural language
+
+## Step 1: Verify MCP Connection
+
+First, verify that your AI assistant can connect to the OpenChoreo MCP server. In your AI assistant, try:
+
+```
+Do you have access to the OpenChoreo MCP server? List the available tools.
+```
+
+**Expected:** The assistant should confirm MCP access and list available OpenChoreo tools like `list_organizations`, `list_projects`, `create_component`, etc.
+
+If the connection isn't working, review the [Configuration Guide](../configs/) to ensure your setup is correct.
+
+## Step 2: Explore OpenChoreo Resources
+
+### Prompt 1: List Organizations
+
+```
+List all organizations in my OpenChoreo instance
+```
+
+**What agent will do:**
+1. Call `list_organizations` to retrieve all organizations
+2. Display organization details including name, display name, and status
+3. Suggest next steps for exploring projects
+
+### Prompt 2: Get Project Details
+
+```
+Show me details of all projects in the "default" organization
+```
+
+**What agent will do:**
+1. Call `list_projects` with the organization name
+2. Display project details including description, status, component count, and creation date
+3. Offer to show component details for any project
+
+## Next Steps
+
+You've successfully set up and tested the OpenChoreo MCP server! Continue with the [Service Deployment](../service-deployment/) guide to learn how to deploy applications using the MCP server.

--- a/samples/mcp/service-deployment/README.md
+++ b/samples/mcp/service-deployment/README.md
@@ -1,0 +1,54 @@
+# Service Deployment with OpenChoreo MCP Server
+
+This guide demonstrates how to deploy a REST API service from source code to production on OpenChoreo using the MCP server and AI assistants.
+
+## Prerequisites
+
+Before starting this guide, ensure you have completed all [prerequisites](../README.md#prerequisites)
+
+Additionally, for service deployment you need:
+
+1. **OpenChoreo instance** with at least two environments configured (development and production)
+   - If you need to create environments, see the [platform configuration samples](../../platform-config/new-environments/)
+2. **Component workflows** configured (Docker or Buildpacks)
+   - Make sure you've installed the build plane. See [Setup Build Plane](https://openchoreo.dev/docs/getting-started/production/single-cluster/#step-3-setup-build-plane-optional) guide.
+
+## Deployment Guides
+
+Choose the approach that best fits your workflow:
+
+### 1. [Step-by-Step Guide](./step-by-step/)
+
+A guided walkthrough with explicit prompts for each step. Perfect if you want:
+- Clear, structured instructions
+- Explicit prompts to copy and paste
+- Step-by-step verification checkpoints
+
+**Time:** 15-20 minutes
+
+### 2. [Developer Chat](./developer-chat/)
+
+A natural conversation-based deployment. Perfect if you want:
+- Conversational interaction with the AI assistant
+- More flexible, exploratory workflow
+- Natural language deployment process
+
+**Time:** 15-20 minutes
+
+## What You'll Learn
+
+Both guides will teach you how to:
+- Create projects and components using AI assistants
+- Configure Docker build workflows from source repositories
+- Trigger and monitor builds programmatically
+- Deploy services to development environments
+- Promote services through the deployment pipeline (development → staging → production)
+- Monitor component health and status
+- Manage the complete service lifecycle through natural language
+
+## Scenario Overview
+
+In both guides, you'll deploy a simple "greeter" service:
+- **Backend**: Go REST API service that responds with greeting messages
+- **Source**: GitHub repository with Dockerfile
+- **Deployment**: From source code to production through multiple environments

--- a/samples/mcp/service-deployment/developer-chat/README.md
+++ b/samples/mcp/service-deployment/developer-chat/README.md
@@ -1,0 +1,55 @@
+# Deploying Service Component from Source - Developer Chat Guide
+
+This guide demonstrates a natural conversation-based approach to deploying a service using the OpenChoreo MCP server. Instead of following explicit step-by-step instructions, you'll have a conversational interaction with your AI assistant to deploy your application.
+
+## Prerequisites
+
+Before starting, ensure you have completed all prerequisites from the [Service Deployment guide](../README.md).
+
+**Time required:** 15-20 minutes
+
+## Approach
+
+This guide uses a conversational workflow where you interact naturally with your AI assistant. The assistant will:
+- Ask clarifying questions when needed
+- Use only OpenChoreo MCP tools (no curl, kubectl, or other external commands)
+- Execute MCP tools efficiently and avoid unnecessary calls
+- Reply concisely and keep the conversation focused
+- Guide you through the deployment process through natural dialogue
+
+
+### Step 1: Enter the Agent's system prompt
+
+```
+You're a useful agent to help make OpenChoreo tasks easier for OpenChoreo users. You can use only the OpenChoreo MCP server. Specifically, you can't use curl and kubectl. You may refer to OpenChoreo docs: https://openchoreo.dev/docs/next/. You may ask back the user questions when you want further input for a task.
+
+You execute the MCP tools efficiently and avoid unnecessary tool calls. You reply concisely and keep the conversation clean. You don't generate .md files and other artifacts unless you're asked to.
+
+To confirm, let me know whether you have access to the OpenChoreo MCP server.
+```
+
+The Agent will respond with the available MCP tools
+
+### Step 2: Request Deployment
+
+```
+I want to deploy my Go REST API service on OpenChoreo. Source: https://github.com/openchoreo/sample-workloads/tree/main/service-go-greeter
+The source contains a Dockerfile. You can use it for the deployment.
+```
+
+The agent will guide you through:
+- Creating the project (if needed)
+- Creating the component with Docker workflow configuration
+- Triggering the build
+- Monitoring build progress
+- Verifying deployment
+- Promoting to production (if desired)
+
+The conversation will flow naturally based on your responses and the agent's questions.
+
+## Tips for Best Results
+
+1. **Be specific**: Provide clear answers to the agent's questions
+2. **Verify steps**: Ask the agent to confirm what it's doing at each stage
+3. **Monitor progress**: Request status updates on builds and deployments
+4. **Ask questions**: If something is unclear, ask the agent to explain

--- a/samples/mcp/service-deployment/step-by-step/README.md
+++ b/samples/mcp/service-deployment/step-by-step/README.md
@@ -1,0 +1,173 @@
+
+# Deploying Service Component from Source - Step-by-Step Guide
+
+This comprehensive guide walks you through the complete lifecycle of deploying an application using the OpenChoreo MCP server - from creating a project to deploying a REST API service to production.
+
+## Prerequisites
+
+Before starting, ensure you have completed all prerequisites from the [Service Deployment guide](../README.md).
+
+**Time required:** 15-20 minutes
+
+## Scenario Overview
+
+In this scenario, you'll deploy a simple "greeter" service:
+- **Backend**: Go REST API service that responds with greeting messages
+
+You'll learn to:
+1. Verify prerequisites and infrastructure
+2. Create a new project
+3. Create a service component and configure Docker build workflow
+4. Trigger builds from source
+5. Deploy to development environment
+6. Test the application
+7. Promote to production
+8. Monitor deployment status
+
+## Step 1: Verify Prerequisites
+
+First, verify that your OpenChoreo instance has the necessary infrastructure.
+Prompt:
+```
+List the environments in my "default" organization
+```
+
+**Expected:** You should see at least "development" environment. If not, create one following the [platform configuration samples](../../../platform-config/new-environments/).
+
+## Step 2: Create a New Project
+
+Let's create a project called "greeter" for our application.
+
+Prompt:
+```
+Create a new project called "greeter" in the "default" organization with description "Simple greeter service in Go"
+```
+
+**What agent will do:**
+1. Call `create_project` with the provided details
+2. Confirm project creation
+3. Show the project details
+
+## Step 3: Create Component and Configure Build Workflow
+
+Now let's create the greeter service component and configure its build workflow.
+
+Prompt:
+```
+Create a component called "greeter-service" in the greeter project. 
+It should be a deployment/service type, listening on port 9090, 
+with 1 replica, and publicly exposed. Configure it to build from 
+the GitHub repository https://github.com/openchoreo/sample-workloads,
+using the Docker workflow, with the source in /service-go-greeter directory.
+```
+
+**What agent will do:**
+1. Check `create_component` tool schema to understand required parameters
+2. Call `list_component_types`, `list_component_workflows`, `get_component_workflow_schema` to identify available component types and workflow schemas to generate component creation request
+3. Call `create_component` with generated configuration
+4. Show the component details 
+
+**Checkpoint:** The greeter-service component should be created with its build workflow configured.
+
+## Step 4: Trigger Build
+
+Now let's build the container image for our greeter service.
+
+### Build Greeter Service
+
+Prompt:
+```
+Trigger a build for the greeter-service component in the greeter project using the main branch
+```
+
+**What agent will do:**
+1. Call `trigger_component_workflow` with the component details
+2. Return a build ID for tracking
+3. Provide commands to monitor build progress
+
+### Monitor Build Progress
+
+Prompt:
+```
+What's the status of the greeter-service build? Check periodically until the build finishes
+```
+
+**What agent will do:**
+1. Call `list_component_workflow_runs` for the component
+2. Show build status, duration, and outcome
+3. Alert if the build failed
+
+**Checkpoint:** The build should complete successfully. If it fails, review build logs and fix issues.
+**Checkpoint:** Since the component creation tool enables automatic deployment, a release should be automatically triggered on the development environment
+
+## Step 5: Verify Deployment
+
+Let's verify that the greeter service is running correctly.
+
+### Check Component Status
+
+Prompt:
+```
+Show me the deployment status of the greeter-service in the greeter project
+```
+
+**What agent will do:**
+1. Call `get_component_workloads`, `list_release_bindings` for the component
+2. Show pod status, health, and resource usage
+3. Highlight any issues
+
+### Get Access URL
+
+Prompt:
+```
+What is the endpoint URL for my greeter service in development? The gateway is running on the port 19080
+```
+
+**What agent will do:**
+1. Extract endpoint information from component details
+2. Provide formatted URL for accessing the service
+
+### Test the Service
+
+**Sample Curl**
+```
+curl http://development.openchoreoapis.localhost:19080/greeter/greet?name=World
+```
+
+**Expected response:**
+```
+Hello, World
+```
+
+**Checkpoint:** The greeter service should be accessible and responding correctly.
+
+## Step 6: Promote to Production
+
+After testing in development, let's promote the greeter service to production.
+
+### Promote the Service
+
+Prompt:
+```
+Promote the greeter-service up to the production environment
+```
+
+**What agent will do:**
+1. Call `promote_component` with source and target environments 2 times (development --> staging --> production)
+2. Confirm the promotion
+3. Show deployment status in production
+
+**Checkpoint:** The greeter service should be running in production.
+
+## Congratulations! 🎉
+
+You've successfully deployed a service using the OpenChoreo MCP server! You now know how to:
+
+- Create projects and components using AI assistants
+- Configure Docker build workflows from source repositories
+- Trigger and monitor builds programmatically
+- Promote services through the deployment pipeline
+- Monitor component health and status
+- Manage the complete service lifecycle through natural language
+
+**Share your success** with the community on [Discord](https://discord.gg/asqDFC8suT)!


### PR DESCRIPTION
## Purpose
This PR adds openchoreo controlplane's MCP server samples and configuration guide

## Approach
MCP samples are added:
- MCP server configuration guide, including auth configs
- Quick start using basic tool invocation
- Service deployment full example with step-by-step guide and the natural language conversation mode

## Related Issues
https://github.com/openchoreo/openchoreo/issues/945

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
