### PR TITLE
Improve openchoreo logger middleware to log access logs

### DIFF
--- a/internal/openchoreo-api/middleware/logger/middleware.go
+++ b/internal/openchoreo-api/middleware/logger/middleware.go
@@ -6,18 +6,72 @@ package logger
 import (
 	"log/slog"
 	"net/http"
+	"time"
+
+	"github.com/google/uuid"
 )
+
+// responseWriter wraps http.ResponseWriter to capture status code and bytes written
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	bytes      int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	n, err := rw.ResponseWriter.Write(b)
+	rw.bytes += n
+	return n, err
+}
 
 func LoggerMiddleware(baseLogger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+
+			// Get or generate request ID (UUID v7 for time-ordered tracing)
+			requestID := r.Header.Get("X-Request-ID")
+			if requestID == "" {
+				if id, err := uuid.NewV7(); err == nil {
+					requestID = id.String()
+				} else {
+					// Fallback to v4 if v7 generation fails
+					requestID = uuid.New().String()
+				}
+			}
+
+			// Wrap response writer to capture status and bytes
+			rw := &responseWriter{
+				ResponseWriter: w,
+				statusCode:     http.StatusOK, // Default status if WriteHeader is not called
+				bytes:          0,
+			}
+
+			// Create context logger with minimal fields
 			reqLogger := baseLogger.With(
+				slog.String("request_id", requestID),
+			)
+
+			ctx := WithLogger(r.Context(), reqLogger)
+			next.ServeHTTP(rw, r.WithContext(ctx))
+
+			// Log access log with additional fields after request completes
+			duration := time.Since(start)
+			baseLogger.Info("ACCESS-LOG",
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
-				slog.String("request_id", r.Header.Get("X-Request-ID")),
+				slog.String("remote_addr", r.RemoteAddr),
+				slog.String("user_agent", r.UserAgent()),
+				slog.String("request_id", requestID),
+				slog.Int("status", rw.statusCode),
+				slog.Int("bytes", rw.bytes),
+				slog.Duration("duration", duration),
 			)
-			ctx := WithLogger(r.Context(), reqLogger)
-			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the logging middleware in `internal/openchoreo-api/middleware/logger/middleware.go`. The changes enhance request tracing, log completeness, and observability by capturing additional metadata and ensuring consistent request identification.

**Logging and request tracing enhancements:**

* Introduced a custom `responseWriter` type to capture HTTP response status codes and the number of bytes written, enabling more detailed access logs.
* Implemented generation of a time-ordered UUID v7 for request IDs when unavailable, with a fallback to UUID v4 for robust request tracing.
* Updated the access log to include new fields: remote address, user agent, response status, bytes written, and request duration, improving log completeness and observability.
* Ensured request-specific loggers are injected into the context with the request ID for consistent tracing across middleware and handlers.