### PR TITLE
Enable traits to access dataplane configuration in templates

### DIFF
--- a/docs/templating/context.md
+++ b/docs/templating/context.md
@@ -9,7 +9,7 @@ OpenChoreo uses two context types depending on where the template is evaluated:
 | Context Type | Used In | Key Variables |
 |--------------|---------|---------------|
 | **ComponentContext** | ComponentType `resources` | `metadata`, `parameters`, `envOverrides`, `dataplane`, `workload`, `configurations` |
-| **TraitContext** | Trait `creates` and `patches` | `metadata`, `parameters`, `envOverrides`, `trait` |
+| **TraitContext** | Trait `creates` and `patches` | `metadata`, `parameters`, `envOverrides`, `dataplane`, `trait` |
 
 ## ComponentContext
 
@@ -439,6 +439,18 @@ metadata:
     instance: ${trait.instanceName}
 ```
 
+### dataplane
+
+DataPlane configuration for the target environment. Same structure as ComponentContext.
+
+```yaml
+# Access pattern: ${dataplane.<field>}
+
+dataplane:
+  secretStore: "my-secret-store"        # ${dataplane.secretStore}
+  publicVirtualHost: "app.example.com"  # ${dataplane.publicVirtualHost}
+```
+
 ### parameters
 
 Trait instance parameters from `Component.Spec.Traits[].Parameters`, pruned to the Trait's `schema.parameters` section with defaults applied. Use for static configuration that doesn't change across environments.
@@ -507,7 +519,7 @@ spec:
   storageClassName: ${envOverrides.storageClass}
 ```
 
-**Note:** TraitContext does NOT have access to `workload`, `configurations`, or `dataplane`. These are only available in ComponentContext.
+**Note:** TraitContext does NOT have access to `workload` or `configurations`. These are only available in ComponentContext.
 
 ## Special Variables
 
@@ -587,7 +599,7 @@ The entire rendered Kubernetes resource is available, including:
 | `metadata.*` | ✅ | ✅ |
 | `parameters.*` | ✅ (from Component.Spec.Parameters) | ✅ (from Trait instance) |
 | `envOverrides.*` | ✅ (from ReleaseBinding.ComponentTypeEnvOverrides) | ✅ (from ReleaseBinding.TraitOverrides) |
-| `dataplane.*` | ✅ | ❌ |
+| `dataplane.*` | ✅ | ✅ |
 | `workload.*` | ✅ | ❌ |
 | `configurations.*` | ✅ | ❌ |
 | `trait.*` | ❌ | ✅ |

--- a/internal/pipeline/component/context/builder_test.go
+++ b/internal/pipeline/component/context/builder_test.go
@@ -389,6 +389,10 @@ metadata:
 					"name":         "mysql-trait",
 					"instanceName": "db-1",
 				},
+				"dataplane": map[string]any{
+					"publicVirtualHost": "app.example.com",
+					"secretStore":       "test-secret-store",
+				},
 				"metadata": map[string]any{
 					"name":            "test-component-dev-12345678",
 					"namespace":       "test-namespace",
@@ -460,6 +464,10 @@ spec:
 					"name":         "mysql-trait",
 					"instanceName": "db-1",
 				},
+				"dataplane": map[string]any{
+					"publicVirtualHost": "app.example.com",
+					"secretStore":       "test-secret-store",
+				},
 				"metadata": map[string]any{
 					"name":            "test-component-dev-12345678",
 					"namespace":       "test-namespace",
@@ -506,6 +514,16 @@ spec:
 					Annotations: map[string]string{},
 					PodSelectors: map[string]string{
 						"openchoreo.dev/component-uid": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+					},
+				},
+				DataPlane: &v1alpha1.DataPlane{
+					Spec: v1alpha1.DataPlaneSpec{
+						Gateway: v1alpha1.GatewaySpec{
+							PublicVirtualHost: "app.example.com",
+						},
+						SecretStoreRef: &v1alpha1.SecretStoreRef{
+							Name: "test-secret-store",
+						},
 					},
 				},
 			}

--- a/internal/pipeline/component/context/trait.go
+++ b/internal/pipeline/component/context/trait.go
@@ -64,6 +64,15 @@ func BuildTraitContext(input *TraitContextInput) (*TraitContext, error) {
 			InstanceName: input.Instance.InstanceName,
 		},
 	}
+
+	// Populate DataPlane configuration
+	ctx.DataPlane = DataPlaneData{
+		PublicVirtualHost: input.DataPlane.Spec.Gateway.PublicVirtualHost,
+	}
+	if input.DataPlane.Spec.SecretStoreRef != nil {
+		ctx.DataPlane.SecretStore = input.DataPlane.Spec.SecretStoreRef.Name
+	}
+
 	return ctx, nil
 }
 

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -121,6 +121,10 @@ type TraitContextInput struct {
 	// Used to avoid rebuilding schemas for the same trait used multiple times.
 	// BuildTraitContext will check this cache before building and populate it after.
 	SchemaCache map[string]*apiextschema.Structural
+
+	// DataPlane contains the data plane configuration.
+	// Required - controller must provide this.
+	DataPlane *v1alpha1.DataPlane `validate:"required"`
 }
 
 // SchemaInput contains schema information for applying defaults.
@@ -240,6 +244,10 @@ type TraitContext struct {
 	// EnvOverrides from ReleaseBinding.Spec.TraitOverrides[instanceName], pruned to Trait.Schema.EnvOverrides.
 	// Accessed via ${envOverrides.*}
 	EnvOverrides map[string]any `json:"envOverrides"`
+
+	// DataPlane provides data plane configuration.
+	// Accessed via ${dataplane.secretStore}, ${dataplane.publicVirtualHost}
+	DataPlane DataPlaneData `json:"dataplane"`
 }
 
 // TraitMetadata contains trait-specific metadata.

--- a/internal/pipeline/component/pipeline.go
+++ b/internal/pipeline/component/pipeline.go
@@ -122,6 +122,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 			ReleaseBinding: input.ReleaseBinding,
 			Metadata:       input.Metadata,
 			SchemaCache:    schemaCache,
+			DataPlane:      input.DataPlane,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build trait context for %s/%s: %w",

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -48,6 +48,7 @@ var TraitAllowedVariables = []string{
 	VarTrait,
 	VarComponent,
 	VarMetadata,
+	VarDataplane,
 }
 
 // ComponentCELEnvOptions configures the CEL environment for component validation.
@@ -185,8 +186,9 @@ type TraitCELEnvOptions struct {
 //   - trait: Typed from context.TraitMetadata
 //   - component: Object type with name field
 //   - metadata: Typed from context.MetadataContext
+//   - dataplane: Typed from context.DataPlaneData
 //
-// Note: Traits don't have access to workload, configurations, or dataplane
+// Note: Traits don't have access to workload or configurations
 func BuildTraitCELEnv(opts TraitCELEnvOptions) (*cel.Env, error) {
 	// Create base environment with standard extensions
 	baseEnvOpts := []cel.EnvOption{
@@ -260,6 +262,7 @@ func BuildTraitCELEnv(opts TraitCELEnvOptions) (*cel.Env, error) {
 		cel.Variable(VarTrait, cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable(VarComponent, cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable(VarMetadata, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(VarDataplane, cel.MapType(cel.StringType, cel.DynType)),
 	)
 
 	// If we have schema-aware types, create a DeclTypeProvider and get its env options

--- a/internal/validation/component/cel_env_test.go
+++ b/internal/validation/component/cel_env_test.go
@@ -166,7 +166,7 @@ func TestBuildTraitCELEnv_WithParametersSchema(t *testing.T) {
 }
 
 func TestBuildTraitCELEnv_NoWorkloadVariables(t *testing.T) {
-	// Traits should not have access to workload, configurations, or dataplane
+	// Traits should not have access to workload or configurations
 	env, err := BuildTraitCELEnv(TraitCELEnvOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
@@ -175,7 +175,6 @@ func TestBuildTraitCELEnv_NoWorkloadVariables(t *testing.T) {
 	invalidExprs := []string{
 		"workload.containers",
 		"configurations.app",
-		"dataplane.secretStore",
 	}
 
 	for _, expr := range invalidExprs {
@@ -190,6 +189,7 @@ func TestBuildTraitCELEnv_NoWorkloadVariables(t *testing.T) {
 		"trait.instanceName",
 		"component.name",
 		"metadata.name",
+		"dataplane.secretStore",
 	}
 
 	for _, expr := range validExprs {

--- a/internal/validation/component/cel_validator_test.go
+++ b/internal/validation/component/cel_validator_test.go
@@ -251,7 +251,6 @@ func TestCELValidator_TraitResource_NoWorkloadAccess(t *testing.T) {
 	invalidExprs := []string{
 		"workload.containers",
 		"configurations.app",
-		"dataplane.secretStore",
 	}
 
 	for _, expr := range invalidExprs {
@@ -266,6 +265,7 @@ func TestCELValidator_TraitResource_NoWorkloadAccess(t *testing.T) {
 		"trait.instanceName",
 		"component.name",
 		"metadata.name",
+		"dataplane.secretStore",
 	}
 
 	for _, expr := range validExprs {


### PR DESCRIPTION
## Purpose

Enable traits to access dataplane configuration in their templates, providing the same dataplane.secretStore and dataplane.publicVirtualHost fields available to ComponentType templates.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1243

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
