### PR TITLE
Validate component and trait envOverrides against schema before rendering

### DIFF
--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -4,7 +4,6 @@
 package context
 
 import (
-	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -117,17 +116,18 @@ type TraitContextInput struct {
 	// Required - controller must provide this.
 	Metadata MetadataContext `validate:"required"`
 
-	// SchemaCache is an optional cache for structural schemas, keyed by trait name.
+	// SchemaCache is an optional cache for schema bundles, keyed by trait name with suffix.
 	// Used to avoid rebuilding schemas for the same trait used multiple times.
 	// BuildTraitContext will check this cache before building and populate it after.
-	SchemaCache map[string]*apiextschema.Structural
+	// Cache keys use format "{traitName}:parameters" and "{traitName}:envOverrides".
+	SchemaCache map[string]*SchemaBundle
 
 	// DataPlane contains the data plane configuration.
 	// Required - controller must provide this.
 	DataPlane *v1alpha1.DataPlane `validate:"required"`
 }
 
-// SchemaInput contains schema information for applying defaults.
+// SchemaInput contains schema information for building structural and JSON schemas.
 type SchemaInput struct {
 	// Types defines reusable type definitions.
 	Types *runtime.RawExtension
@@ -137,9 +137,6 @@ type SchemaInput struct {
 
 	// EnvOverridesSchema is the envOverrides schema definition.
 	EnvOverridesSchema *runtime.RawExtension
-
-	// Structural is the compiled structural schema (cached).
-	Structural *apiextschema.Structural
 }
 
 // ComponentContext represents the evaluated context for rendering component resources.

--- a/internal/pipeline/component/pipeline.go
+++ b/internal/pipeline/component/pipeline.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 
 	"github.com/go-playground/validator/v10"
-	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/labels"
@@ -105,7 +104,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 	}
 
 	// Create schema cache for trait reuse within this render
-	schemaCache := make(map[string]*apiextschema.Structural)
+	schemaCache := make(map[string]*context.SchemaBundle)
 
 	// Process each trait instance from the component
 	for _, traitInstance := range input.Component.Spec.Traits {

--- a/internal/schema/definition.go
+++ b/internal/schema/definition.go
@@ -356,10 +356,11 @@ func ValidateWithJSONSchema(values map[string]any, jsonSchema *extv1.JSONSchemaP
 	// Validate the values
 	result := validator.Validate(values)
 	if !result.IsValid() {
-		// Collect all validation errors
+		// Collect all validation errors, removing "in body" which is HTTP API terminology
 		var errMsgs []string
 		for _, err := range result.Errors {
-			errMsgs = append(errMsgs, err.Error())
+			msg := strings.ReplaceAll(err.Error(), " in body", "")
+			errMsgs = append(errMsgs, msg)
 		}
 		return fmt.Errorf("%s", strings.Join(errMsgs, "; "))
 	}


### PR DESCRIPTION
## Purpose
Previously, invalid envOverrides (missing required fields, type mismatches, constraint violations) would only surface as cryptic errors during CEL template rendering. By validating against the schema immediately after pruning and defaulting, users now get clear, actionable error messages that pinpoint exactly which field failed validation and why.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
