### PR TITLE
Fix testdata for BenchmarkPipeline_RenderWithRealSample

### DIFF
--- a/internal/pipeline/component/benchmark_test.go
+++ b/internal/pipeline/component/benchmark_test.go
@@ -463,6 +463,13 @@ metadata:
   name: test-type
 spec:
   workloadType: deployment
+  schema:
+    types:
+      EnvVar:
+        name: string
+        value: string
+    parameters:
+      envVars: "[]EnvVar"
   resources:
     - id: configmaps
       forEach: ${parameters.envVars}

--- a/internal/pipeline/component/testdata/component-with-traits.yaml
+++ b/internal/pipeline/component/testdata/component-with-traits.yaml
@@ -49,11 +49,11 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      cpu: ${parameters.resources.requests.cpu}
-                      memory: ${parameters.resources.requests.memory}
+                      cpu: ${envOverrides.resources.requests.cpu}
+                      memory: ${envOverrides.resources.requests.memory}
                     limits:
-                      cpu: ${parameters.resources.limits.cpu}
-                      memory: ${parameters.resources.limits.memory}
+                      cpu: ${envOverrides.resources.limits.cpu}
+                      memory: ${envOverrides.resources.limits.memory}
 
     - id: service
       template:
@@ -100,8 +100,8 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: ${parameters.size}
-          storageClassName: ${parameters.storageClass}
+              storage: ${envOverrides.size}
+          storageClassName: ${envOverrides.storageClass}
 
   patches:
     - target:
@@ -163,9 +163,9 @@ spec:
           value:
             name: ${parameters.volumeName}
             emptyDir: |
-              ${parameters.sizeLimit != "" || parameters.medium != "" ? {
-                "sizeLimit": parameters.sizeLimit != "" ? parameters.sizeLimit : oc_omit(),
-                "medium": parameters.medium != "" ? parameters.medium : oc_omit()
+              ${envOverrides.sizeLimit != "" || envOverrides.medium != "" ? {
+                "sizeLimit": envOverrides.sizeLimit != "" ? envOverrides.sizeLimit : oc_omit(),
+                "medium": envOverrides.medium != "" ? envOverrides.medium : oc_omit()
               } : {}}
 
     # Add volumeMounts to each specified container
@@ -202,13 +202,6 @@ spec:
   parameters:
     replicas: 2
     port: 8080
-    resources:
-      requests:
-        cpu: "200m"
-        memory: "512Mi"
-      limits:
-        cpu: "1000m"
-        memory: "1Gi"
 
   traits:
     - name: persistent-volume
@@ -217,8 +210,6 @@ spec:
         volumeName: app-data
         mountPath: /var/data
         containerName: app
-        size: "20Gi"
-        storageClass: "fast"
     - name: emptydir-volume
       instanceName: cache
       parameters:
@@ -235,8 +226,6 @@ spec:
           - containerName: app
             mountPath: /tmp/work
             readOnly: false
-        medium: ""
-        sizeLimit: 1Gi
 
 ---
 apiVersion: openchoreo.dev/v1alpha1
@@ -279,6 +268,9 @@ spec:
     data-storage:
       size: "5Gi"
       storageClass: "standard"
+    workspace:
+      medium: ""
+      sizeLimit: "1Gi"
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Environment


### PR DESCRIPTION
## Purpose
The testdata had mismatched schema and template variable usage. Fields defined under envOverrides in schemas were being accessed as ${parameters.*} in templates.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
