### PR TITLE
Disable API platform gateway by default

### DIFF
--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -420,7 +420,7 @@ clusterAgent:
 
 # API Platform configuration
 api-platform:
-  enabled: true
+  enabled: false
   gateway:
     helm:
       chartName: "oci://ghcr.io/wso2/api-platform/helm-charts/gateway"


### PR DESCRIPTION
## Purpose
This PR disables the API platform gateway by default. With https://github.com/openchoreo/openchoreo/pull/1304, API platform gateway is enabled by default.
