### PR TITLE
Change default service ports of Prometheus

### DIFF
--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -481,6 +481,9 @@ prometheus:
       serviceMonitorNamespaceSelector: {}
       serviceMonitorSelector: {}
       serviceMonitorSelectorNilUsesHelmValues: false
+    service:
+      port: 9091
+      reloaderWebPort: 8081
 
   ## Configuration for alertmanager
   ## ref: https://prometheus.io/docs/alerting/alertmanager/

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -24,8 +24,6 @@ prometheus:
       enableRemoteWriteReceiver: true
     service:
       type: LoadBalancer
-      port: 9091
-      reloaderWebPort: 8081
 
 
 ## Values for local templates


### PR DESCRIPTION
## Purpose
The default Prometheus port of 9090 is already used by Prometheus operator in the Observability plane. While this is not an issue when we communicate using the service FQDN, port conflicts arise when we expose them through k3d configs. Hence to be consistent everywhere, change the default port numbers

## Approach
Set the default port numbers in the Observability plane helm values file

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1252

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
