### PR TITLE
Support multi plane cr support in quick start guide

### DIFF
--- a/install/quick-start/.values-bp.yaml
+++ b/install/quick-start/.values-bp.yaml
@@ -36,7 +36,7 @@ fluentBit:
 clusterAgent:
   enabled: true
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  planeName: default
+  planeID: buildplane-default
   planeType: buildplane
   # TLS configuration for single-cluster setup
   # Helm post-install jobs will automatically copy the CA from control plane

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -21,7 +21,7 @@ gateway:
 clusterAgent:
   enabled: true
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  planeName: default
+  planeID: dataplane-default
   planeType: dataplane
   # TLS configuration for single-cluster setup
   # Helm post-install jobs will automatically copy the CA from control plane

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -32,5 +32,5 @@ observer:
 # Cluster Agent configuration for single-cluster setup
 clusterAgent:
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  planeName: default
+  planeID: observabilityplane-default
   planeType: observabilityplane

--- a/install/quick-start/install.sh
+++ b/install/quick-start/install.sh
@@ -126,7 +126,7 @@ fi
 
 # Step 9: Add default dataplane
 if [[ -f "${SCRIPT_DIR}/add-data-plane.sh" ]]; then
-    bash "${SCRIPT_DIR}/add-data-plane.sh" --name default
+    bash "${SCRIPT_DIR}/add-data-plane.sh" --name default --plane-id dataplane-default
 else
     log_warning "add-data-plane.sh not found, skipping dataplane configuration"
 fi
@@ -134,7 +134,7 @@ fi
 # Step 10: Add default buildplane (if build plane enabled)
 if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
     if [[ -f "${SCRIPT_DIR}/add-build-plane.sh" ]]; then
-        bash "${SCRIPT_DIR}/add-build-plane.sh" --name default
+        bash "${SCRIPT_DIR}/add-build-plane.sh" --name default --plane-id buildplane-default
     else
         log_warning "add-build-plane.sh not found, skipping buildplane configuration"
     fi
@@ -143,7 +143,7 @@ fi
 # Step 11: Add default observabilityplane (if observability plane enabled)
 if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
     if [[ -f "${SCRIPT_DIR}/add-observability-plane.sh" ]]; then
-        bash "${SCRIPT_DIR}/add-observability-plane.sh" --name default
+        bash "${SCRIPT_DIR}/add-observability-plane.sh" --name default --plane-id observabilityplane-default
     else
         log_warning "add-observability-plane.sh not found, skipping observabilityplane configuration"
     fi


### PR DESCRIPTION
## Purpose

This pull request updates the configuration of cluster agents across the build, data, and observability planes to use a new `planeID` field instead of `planeName`, and ensures that the correct `plane-id` is passed to the associated installation scripts. This change helps standardize and clarify the identification of each plane in the deployment process.

**Configuration updates:**

* Changed the cluster agent configuration in `.values-bp.yaml` to use `planeID: buildplane-default` instead of `planeName: default`.
* Changed the cluster agent configuration in `.values-dp.yaml` to use `planeID: dataplane-default` instead of `planeName: default`.
* Changed the cluster agent configuration in `.values-op.yaml` to use `planeID: observabilityplane-default` instead of `planeName: default`.

**Installation script updates:**

* Updated `install.sh` to pass the appropriate `--plane-id` flag when invoking `add-data-plane.sh`, `add-build-plane.sh`, and `add-observability-plane.sh` scripts, ensuring the correct plane ID is used during setup. [[1]](diffhunk://#diff-9b1bd194226687f7012b4f3afe4773f5128d0e83d023ef741cb07ca390ec0f8bL129-R137) [[2]](diffhunk://#diff-9b1bd194226687f7012b4f3afe4773f5128d0e83d023ef741cb07ca390ec0f8bL146-R146)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
