### PR TITLE
Add planeId to observability plane installation

### DIFF
--- a/install/add-observability-plane.sh
+++ b/install/add-observability-plane.sh
@@ -296,6 +296,7 @@ metadata:
     openchoreo.dev/description: "ObservabilityPlane created via $(basename $0) script with cluster agent"
     openchoreo.dev/display-name: "ObservabilityPlane $OBSERVABILITYPLANE_NAME"
 spec:
+$PLANE_ID_FIELD
   clusterAgent:
 $CLIENT_CA_CONFIG
   observerURL: $OBSERVER_URL

--- a/internal/clients/kubernetes/client.go
+++ b/internal/clients/kubernetes/client.go
@@ -175,9 +175,14 @@ func GetK8sClientFromObservabilityPlane(
 			return nil, fmt.Errorf("gatewayURL is required for agent mode")
 		}
 
+		planeID := observabilityPlane.Spec.PlaneID
+		if planeID == "" {
+			planeID = observabilityPlane.Name
+		}
+
 		// Use planeType/planeName format to match agent registration
 		// Agent registers as "observabilityplane/<name>", so we use the same identifier
-		planeIdentifier := fmt.Sprintf("observabilityplane/%s", observabilityPlane.Name)
+		planeIdentifier := fmt.Sprintf("observabilityplane/%s", planeID)
 
 		// Use GetOrAddClient to cache the proxy client
 		return clientMgr.GetOrAddClient(key, func() (client.Client, error) {


### PR DESCRIPTION
## Purpose
This pull request introduces improvements to how the ObservabilityPlane's identifier is managed and referenced throughout the codebase. The main change is the addition of a configurable `PlaneID` field, which allows for more flexible and consistent identification of ObservabilityPlane resources, especially when interacting with the Kubernetes client.

### ObservabilityPlane identifier improvements

* Added support for a `$PLANE_ID_FIELD` in the ObservabilityPlane manifest, enabling custom plane IDs to be specified during installation (`install/add-observability-plane.sh`).
* Updated the Kubernetes client logic to use the `PlaneID` from the ObservabilityPlane spec if provided, falling back to the resource name if not. This ensures that the client uses the correct identifier format for agent registration (`internal/clients/kubernetes/client.go`).

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
