### PR TITLE
Update default helm values with cluster agent plane ID

### DIFF
--- a/install/add-build-plane.sh
+++ b/install/add-build-plane.sh
@@ -47,7 +47,7 @@ Options:
                                     Default: same as --namespace
 
   --plane-id ID                     (Optional) Logical plane identifier shared across multiple CRs
-                                    If not specified, each CR uses its own name as the effective planeID
+                                    Default: default-buildplane
                                     Use this for multi-tenant setups where multiple CRs share same physical plane
 
   --dry-run                         Preview the YAML without applying changes
@@ -92,7 +92,7 @@ CONTROL_PLANE_CONTEXT=""       # Control plane cluster (create resource here)
 BUILDPLANE_CONTEXT=""          # Build plane cluster for CA extraction
 BUILDPLANE_NAME="default"
 NAMESPACE="default"
-PLANE_ID=""                    # Optional logical plane identifier
+PLANE_ID="default-buildplane"  # Optional logical plane identifier
 DRY_RUN=false
 AGENT_CA_SECRET=""             # Empty by default - triggers auto-extract mode
 AGENT_CA_NAMESPACE=""

--- a/install/add-data-plane.sh
+++ b/install/add-data-plane.sh
@@ -47,7 +47,7 @@ Options:
                                     Default: same as --namespace
 
   --plane-id ID                     (Optional) Logical plane identifier shared across multiple CRs
-                                    If not specified, each CR uses its own name as the effective planeID
+                                    Default: default-dataplane
                                     Use this for multi-tenant setups where multiple CRs share same physical plane
 
   --dry-run                         Preview the YAML without applying changes
@@ -92,7 +92,7 @@ CONTROL_PLANE_CONTEXT=""       # Control plane cluster (create resource here)
 DATAPLANE_CONTEXT=""           # Data plane cluster for CA extraction
 DATAPLANE_NAME="default"
 NAMESPACE="default"
-PLANE_ID=""                    # Optional logical plane identifier
+PLANE_ID="default-dataplane"   # Optional logical plane identifier
 DRY_RUN=false
 AGENT_CA_SECRET=""             # Empty by default - triggers auto-extract mode
 AGENT_CA_NAMESPACE=""

--- a/install/add-observability-plane.sh
+++ b/install/add-observability-plane.sh
@@ -45,7 +45,7 @@ Options:
                                     Default: same as --namespace
 
   --plane-id ID                     (Optional) Logical plane identifier shared across multiple CRs
-                                    If not specified, each CR uses its own name as the effective planeID
+                                    Default: default-observabilityplane
                                     Use this for multi-tenant setups where multiple CRs share same physical plane
 
   --observabilityplane-context CONTEXT
@@ -98,7 +98,7 @@ CONTROL_PLANE_CONTEXT=""
 OBSERVABILITYPLANE_CONTEXT=""  # Observability plane cluster for CA extraction
 OBSERVABILITYPLANE_NAME="default"
 NAMESPACE="default"
-PLANE_ID=""                    # Optional logical plane identifier
+PLANE_ID="default-observabilityplane"  # Optional logical plane identifier
 OBSERVER_URL="http://observer.openchoreo-observability-plane.svc.cluster.local:8080" # Single cluster mode
 DRY_RUN=false
 AGENT_CA_SECRET=""             # Empty by default - triggers auto-extract mode

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -206,7 +206,7 @@ clusterAgent:
   # One agent per physical plane handles all CRs with the same planeID (multi-tenancy)
   # If not specified, defaults to Helm release name
   # Example: "shared-builder" - all BuildPlane CRs with planeID="shared-builder" share this agent
-  planeID: ""
+  planeID: default-buildplane
 
   # Type of plane (dataplane, buildplane, or observabilityplane)
   planeType: buildplane

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -350,7 +350,7 @@ clusterAgent:
   # One agent per physical plane handles all CRs with the same planeID (multi-tenancy)
   # If not specified, defaults to Helm release name
   # Example: "prod-cluster" - all DataPlane CRs with planeID="prod-cluster" share this agent
-  planeID: ""
+  planeID: default-dataplane
 
   # Type of plane (dataplane, buildplane, or observabilityplane)
   planeType: dataplane

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -531,7 +531,7 @@ clusterAgent:
   # One agent per physical plane handles all CRs with the same planeID (multi-tenancy)
   # If not specified, defaults to Helm release name
   # Example: "shared-obs" - all ObservabilityPlane CRs with planeID="shared-obs" share this agent
-  planeID: ""
+  planeID: default-observabilityplane
 
   # Type of plane (dataplane, buildplane, or observabilityplane)
   planeType: observabilityplane

--- a/install/k3d/multi-cluster/values-bp.yaml
+++ b/install/k3d/multi-cluster/values-bp.yaml
@@ -7,7 +7,7 @@
 clusterAgent:
   enabled: true
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
-  planeName: "default"
+  planeID: "default-buildplane"
   planeType: "buildplane"
 
   # DNS rewrite configuration for multi-cluster k3d setup

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -7,7 +7,7 @@
 clusterAgent:
   enabled: true
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
-  planeName: "default"
+  planeID: "default-dataplane"
   planeType: "dataplane"
 
   # DNS rewrite configuration for multi-cluster k3d setup

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -41,7 +41,7 @@ prometheus:
 
 clusterAgent:
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"  # Control plane cluster gateway URL
-  planeName: "default"
+  planeID: "default-observabilityplane"
   planeType: "observabilityplane"
 
   # DNS rewrite configuration for multi-cluster k3d setup

--- a/install/k3d/single-cluster/values-bp.yaml
+++ b/install/k3d/single-cluster/values-bp.yaml
@@ -32,12 +32,3 @@ external-secrets:
 # including openchoreo-build-plane and openchoreo-ci-* (Argo Workflows build jobs).
 fluentBit:
   enabled: false
-
-# Cluster Agent configuration for single-cluster setup
-clusterAgent:
-  enabled: true
-  serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  # Logical plane identifier - can be shared across multiple BuildPlane CRs
-  # If not specified, defaults to Helm release name
-  planeID: ""
-  planeType: buildplane

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -41,10 +41,3 @@ external-secrets:
 
 fakeSecretStore:
   enabled: false
-
-clusterAgent:
-  serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  # Logical plane identifier - can be shared across multiple ObservabilityPlane CRs
-  # If not specified, defaults to Helm release name
-  planeID: ""
-  planeType: observabilityplane

--- a/install/quick-start/.values-bp.yaml
+++ b/install/quick-start/.values-bp.yaml
@@ -36,7 +36,7 @@ fluentBit:
 clusterAgent:
   enabled: true
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  planeID: buildplane-default
+  planeID: default-buildplane
   planeType: buildplane
   # TLS configuration for single-cluster setup
   # Helm post-install jobs will automatically copy the CA from control plane

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -21,7 +21,7 @@ gateway:
 clusterAgent:
   enabled: true
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  planeID: dataplane-default
+  planeID: default-dataplane
   planeType: dataplane
   # TLS configuration for single-cluster setup
   # Helm post-install jobs will automatically copy the CA from control plane

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -43,5 +43,5 @@ observer:
 # Cluster Agent configuration for single-cluster setup
 clusterAgent:
   serverUrl: wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws
-  planeID: observabilityplane-default
+  planeID: default-observabilityplane
   planeType: observabilityplane

--- a/install/quick-start/install.sh
+++ b/install/quick-start/install.sh
@@ -126,7 +126,7 @@ fi
 
 # Step 9: Add default dataplane
 if [[ -f "${SCRIPT_DIR}/add-data-plane.sh" ]]; then
-    bash "${SCRIPT_DIR}/add-data-plane.sh" --name default --plane-id dataplane-default
+    bash "${SCRIPT_DIR}/add-data-plane.sh" --name default
 else
     log_warning "add-data-plane.sh not found, skipping dataplane configuration"
 fi
@@ -134,7 +134,7 @@ fi
 # Step 10: Add default buildplane (if build plane enabled)
 if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
     if [[ -f "${SCRIPT_DIR}/add-build-plane.sh" ]]; then
-        bash "${SCRIPT_DIR}/add-build-plane.sh" --name default --plane-id buildplane-default
+        bash "${SCRIPT_DIR}/add-build-plane.sh" --name default
     else
         log_warning "add-build-plane.sh not found, skipping buildplane configuration"
     fi
@@ -143,7 +143,7 @@ fi
 # Step 11: Add default observabilityplane (if observability plane enabled)
 if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
     if [[ -f "${SCRIPT_DIR}/add-observability-plane.sh" ]]; then
-        bash "${SCRIPT_DIR}/add-observability-plane.sh" --name default --plane-id observabilityplane-default
+        bash "${SCRIPT_DIR}/add-observability-plane.sh" --name default
     else
         log_warning "add-observability-plane.sh not found, skipping observabilityplane configuration"
     fi


### PR DESCRIPTION
## Purpose
This pull request standardizes the default values for the `planeID` parameter across build, data, and observability plane installation scripts and Helm chart values. The main goal is to ensure that each plane type has a consistent and explicit default logical identifier, improving clarity and multi-tenancy support. Additionally, outdated or redundant configuration blocks are removed from single-cluster k3d values files.

**Default planeID standardization:**

* Updated the default value for `planeID` in `install/add-build-plane.sh`, `install/add-data-plane.sh`, and `install/add-observability-plane.sh` scripts to `buildplane-default`, `dataplane-default`, and `observabilityplane-default` respectively, both in option descriptions and variable initialization. [[1]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L50-R50) [[2]](diffhunk://#diff-fa8bb8ff2c7f02d4e83fce015807c04c32ebda5400ffbdf842d5f9c93c0f1991L95-R95) [[3]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L50-R50) [[4]](diffhunk://#diff-197f0dca594a71a377f75c2b10610634f249a1c913777ac47260fd3f3698c762L95-R95) [[5]](diffhunk://#diff-c9ca053716f41f0aed16fb23715e9887677244cb0700c1689ff79c404634f5caL48-R48) [[6]](diffhunk://#diff-c9ca053716f41f0aed16fb23715e9887677244cb0700c1689ff79c404634f5caL101-R101)
* Set explicit default `planeID` values in Helm chart values files: `openchoreo-build-plane/values.yaml`, `openchoreo-data-plane/values.yaml`, and `openchoreo-observability-plane/values.yaml`. [[1]](diffhunk://#diff-442bf9dde4241ceb55b74d638aa90b74f8fb084d0887a7b532d507cdfa6964c9L209-R209) [[2]](diffhunk://#diff-342c1aa422ad171ca7d2aa5cce28fe8b0ff13365fc7ea11116b99fc679cc876eL353-R353) [[3]](diffhunk://#diff-94d6c293793c60fc65baa0fcff151f7d1c0b5127349cc1b09a01d232e1d6ffefL534-R534)
* Updated k3d multi-cluster values files (`values-bp.yaml`, `values-dp.yaml`, `values-op.yaml`) to use the new default `planeID` values for each plane type. [[1]](diffhunk://#diff-439e3317ff67a9b823eae434364d7f09da7dce2174435ff011b3df843b3dd18cL10-R10) [[2]](diffhunk://#diff-8a3d602ee0932a7f45b08243303f1efc71b6b0c96463f79a3b62b6b9e8c78757L10-R10) [[3]](diffhunk://#diff-0c5f76a6c06bbf5de3f552bf35c7ae8dcaa66fcffe4b5729971898b08cc1f3a6L44-R44)

**Configuration cleanup:**

* Removed the obsolete `clusterAgent` configuration block from single-cluster k3d values files: `values-bp.yaml` and `values-op.yaml`, as these are now redundant with the standardized defaults. [[1]](diffhunk://#diff-122c8dba821b91c2b9e104fb458500018ac09d97522e3e3b6e795520f455048cL35-L43) [[2]](diffhunk://#diff-86cef85b0ba7761388c65e3a4e7fb5849aa25b7b6ed7dc3e786197a3eae74368L44-L50)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
