### PR TITLE
Add explicit values in Observability Plane helm chart for security configurations

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -65,6 +65,16 @@ spec:
           containerPort: 8080
           protocol: TCP
         env:
+        - name: JWT_ISSUER
+          value: {{ .Values.security.oidc.issuer | quote }}
+        - name: JWKS_URL
+          value: {{ .Values.security.oidc.jwksUrl | quote }}
+        - name: JWKS_URL_TLS_INSECURE_SKIP_VERIFY
+          value: {{ .Values.security.oidc.jwksUrlTlsInsecureSkipVerify | default "false" | quote }}
+        - name: JWT_AUDIENCE
+          value: {{ .Values.security.jwt.audience | quote }}
+        - name: JWT_DISABLED
+          value: "{{ not .Values.security.enabled }}"
         - name: PORT
           value: "8080"
         - name: LOG_LEVEL

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -695,6 +695,20 @@ opentelemetryCollectorCustomizations:
       nonSampledCacheSize: 1000
     spansPerSecond: 10
 
+
+# Common security configuration shared across all components
+security:
+  # Global security toggle - when disabled, authentication is turned off for all components
+  enabled: true
+  oidc:
+    issuer: ""
+    jwksUrl: ""
+    jwksUrlTlsInsecureSkipVerify: "false"
+  jwt:
+    # Expected audience claim in JWT tokens
+    audience: ""
+
+
 tls:
   enabled: false
 

--- a/install/k3d/dev/values-op.yaml
+++ b/install/k3d/dev/values-op.yaml
@@ -3,10 +3,6 @@
 
 observer:
   extraEnvs:
-  - name: JWKS_URL
-    value: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
-  - name: JWKS_URL_TLS_INSECURE_SKIP_VERIFY
-    value: "true"
   - name: OPENSEARCH_ADDRESS
     value: "https://opensearch:9200"
   - name: PROMETHEUS_ADDRESS
@@ -30,3 +26,8 @@ openSearch:
 rca:
   oauth:
     tokenUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/token"
+
+security:
+  oidc:
+    jwksUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
+    jwksUrlTlsInsecureSkipVerify: true

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -6,10 +6,6 @@ kgateway:
 
 observer:
   extraEnvs:
-  - name: JWKS_URL
-    value: "https://thunder.openchoreo.localhost:8443/oauth2/jwks"
-  - name: JWKS_URL_TLS_INSECURE_SKIP_VERIFY
-    value: "false"
   - name: OPENSEARCH_ADDRESS
     value: "https://opensearch:9200"
   - name: PROMETHEUS_ADDRESS
@@ -70,6 +66,10 @@ clusterAgent:
 
 gateway:
   enabled: true
+
+security:
+  oidc:
+    jwksUrl: "https://thunder.openchoreo.localhost:8443/oauth2/jwks"
 
 tls:
   enabled: true

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -17,10 +17,6 @@ openSearchCluster:
 # Observer API - REST API for querying logs and metrics
 observer:
   extraEnvs:
-  - name: JWKS_URL
-    value: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
-  - name: JWKS_URL_TLS_INSECURE_SKIP_VERIFY
-    value: "false"
   - name: OPENSEARCH_ADDRESS
     value: "https://opensearch:9200"
   - name: PROMETHEUS_ADDRESS
@@ -45,3 +41,8 @@ fakeSecretStore:
 rca:
   oauth:
     tokenUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/token"
+
+security:
+  oidc:
+    jwksUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
+    jwksUrlTlsInsecureSkipVerify: true


### PR DESCRIPTION
## Purpose
Having explicit fields in the helm values file to configure security would be easier than passing environment variables. Hence this PR adds such fields and does the environment variable passing part automatically.

## Approach
Adds a `security` section to the Observability plane helm values file and passes those field values to environment variables.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1306

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
