### PR TITLE
Include observabilityPlaneRef in template rendering context

### DIFF
--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -67,12 +67,7 @@ func BuildComponentContext(input *ComponentContextInput) (*ComponentContext, err
 		ctx.Metadata.PodSelectors = make(map[string]string)
 	}
 
-	ctx.DataPlane = DataPlaneData{
-		PublicVirtualHost: input.DataPlane.Spec.Gateway.PublicVirtualHost,
-	}
-	if input.DataPlane.Spec.SecretStoreRef != nil {
-		ctx.DataPlane.SecretStore = input.DataPlane.Spec.SecretStoreRef.Name
-	}
+	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
 
 	return ctx, nil
 }
@@ -172,6 +167,18 @@ func extractParameters(raw *runtime.RawExtension) (map[string]any, error) {
 	}
 
 	return params, nil
+}
+
+// extractDataPlaneData extracts DataPlaneData from a DataPlane resource.
+func extractDataPlaneData(dp *v1alpha1.DataPlane) DataPlaneData {
+	data := DataPlaneData{
+		PublicVirtualHost:     dp.Spec.Gateway.PublicVirtualHost,
+		ObservabilityPlaneRef: dp.Spec.ObservabilityPlaneRef,
+	}
+	if dp.Spec.SecretStoreRef != nil {
+		data.SecretStore = dp.Spec.SecretStoreRef.Name
+	}
+	return data
 }
 
 // extractWorkloadData extracts relevant workload information for the rendering context.

--- a/internal/pipeline/component/context/trait.go
+++ b/internal/pipeline/component/context/trait.go
@@ -64,13 +64,7 @@ func BuildTraitContext(input *TraitContextInput) (*TraitContext, error) {
 		},
 	}
 
-	// Populate DataPlane configuration
-	ctx.DataPlane = DataPlaneData{
-		PublicVirtualHost: input.DataPlane.Spec.Gateway.PublicVirtualHost,
-	}
-	if input.DataPlane.Spec.SecretStoreRef != nil {
-		ctx.DataPlane.SecretStore = input.DataPlane.Spec.SecretStoreRef.Name
-	}
+	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
 
 	return ctx, nil
 }

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -170,8 +170,9 @@ type ComponentContext struct {
 
 // DataPlaneData provides data plane configuration in templates.
 type DataPlaneData struct {
-	SecretStore       string `json:"secretStore,omitempty"`
-	PublicVirtualHost string `json:"publicVirtualHost,omitempty"`
+	SecretStore           string `json:"secretStore,omitempty"`
+	PublicVirtualHost     string `json:"publicVirtualHost,omitempty"`
+	ObservabilityPlaneRef string `json:"observabilityPlaneRef,omitempty"`
 }
 
 // WorkloadData contains workload information for templates.


### PR DESCRIPTION
## Purpose
> Include observabilityPlaneRef in template rendering context as an optional field.
Can be used with `has` to check existence
e.g: `includeWhen: has(dataplane.observabilityPlaneRef)`

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
