### PR TITLE
Update Backstage OAuth callback URL and add OIDC discovery support

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -71,6 +71,12 @@ spec:
         - name: THUNDER_TOKEN
           value: {{ .Values.backstage.thunder.token | quote }}
         {{- end }}
+        # OIDC Discovery URL (optional) - enables auto-discovery of OAuth endpoints
+        {{- if .Values.security.oidc.wellKnownEndpoint }}
+        - name: OPENCHOREO_AUTH_METADATA_URL
+          value: {{ .Values.security.oidc.wellKnownEndpoint | quote }}
+        {{- end }}
+        # Explicit OAuth2 endpoints (fallback if OIDC discovery not configured)
         - name: OPENCHOREO_AUTH_AUTHORIZATION_URL
           value: {{ .Values.security.oidc.authorizationUrl | default (printf "%s://%s%s/oauth2/authorize" (include "openchoreo.protocol" .) (include "openchoreo.thunderHost" .) (include "openchoreo.port" .)) }}
         - name: OPENCHOREO_AUTH_TOKEN_URL

--- a/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
@@ -44,7 +44,7 @@ data:
               "{{ $url }}"
               {{- end }}
               {{- else }}
-              "{{ include "openchoreo.protocol" . }}://{{ include "openchoreo.consoleHost" . }}{{ include "openchoreo.port" . }}/api/auth/default-idp/handler/frame"
+              "{{ include "openchoreo.protocol" . }}://{{ include "openchoreo.consoleHost" . }}{{ include "openchoreo.port" . }}/api/auth/openchoreo-auth/handler/frame"
               {{- end }}
             ],
             "grant_types": [

--- a/install/helm/openchoreo-control-plane/templates/thunder/update-backstage-hook.yaml
+++ b/install/helm/openchoreo-control-plane/templates/thunder/update-backstage-hook.yaml
@@ -58,7 +58,7 @@ data:
       "{{ $url }}"
       {{- end }}
       {{- else }}
-      "{{ include "openchoreo.protocol" . }}://{{ include "openchoreo.consoleHost" . }}{{ include "openchoreo.port" . }}/api/auth/default-idp/handler/frame"
+      "{{ include "openchoreo.protocol" . }}://{{ include "openchoreo.consoleHost" . }}{{ include "openchoreo.port" . }}/api/auth/openchoreo-auth/handler/frame"
       {{- end }}
     ]'
 


### PR DESCRIPTION
  - Update redirect URI from /api/auth/default-idp/handler/frame to /api/auth/openchoreo-auth/handler/frame in Thunder bootstrap scripts
  - Add OPENCHOREO_AUTH_METADATA_URL env var sourced from security.oidc.wellKnownEndpoint for OIDC discovery
  - Simplify backstage deployment to use security.oidc.* values directly with Thunder defaults as fallback

  Backstage runtime handles configuration priority:
  1. If metadataUrl set → OIDC discovery
  2. Falls back to explicit authorizationUrl/tokenUrl

Related to: https://github.com/openchoreo/openchoreo/issues/1198
Backstage PR: https://github.com/openchoreo/backstage-plugins/pull/161