### PR TITLE
Fix boolean default handling in Helm templates

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -93,13 +93,13 @@ spec:
         {{- end }}
         # Feature flags for OpenChoreo functionality
         - name: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED
-          value: {{ .Values.backstage.features.workflows.enabled | default true | quote }}
+          value: {{ .Values.backstage.features.workflows.enabled | quote }}
         - name: OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED
-          value: {{ .Values.backstage.features.observability.enabled | default true | quote }}
+          value: {{ .Values.backstage.features.observability.enabled | quote }}
         - name: OPENCHOREO_FEATURES_AUTH_ENABLED
-          value: {{ .Values.security.enabled | default true | quote }}
+          value: {{ .Values.security.enabled | quote }}
         - name: OPENCHOREO_FEATURES_AUTHZ_ENABLED
-          value: {{ .Values.security.authz.enabled | default true | quote }}
+          value: {{ .Values.security.authz.enabled | quote }}
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -65,9 +65,9 @@ spec:
         - name: JWT_AUDIENCE
           value: {{ .Values.security.jwt.audience | quote }}
         - name: JWT_DISABLED
-          value: "{{ not .Values.security.enabled }}"
+          value: {{ not .Values.security.enabled | quote }}
         - name: AUTHZ_ENABLED
-          value: "{{ .Values.security.authz.enabled }}"
+          value: {{ .Values.security.authz.enabled | quote }}
         - name: AUTHZ_DATABASE_PATH
           value: {{ .Values.security.authz.databasePath | quote }}
         - name: AUTHZ_DEFAULT_AUTHZ_DATA_FILE_PATH


### PR DESCRIPTION
## Purpose  
Remove `| default` from boolean environment variables and use `| quote` function consistently across deployment templates. This fixes a bug where explicit `false` values were incorrectly converted to `true` by Helm's default function, which treats false as an empty value.


## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
