### PR TITLE
Remove post-upgrade hook from default project

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/project.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/project.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     openchoreo.dev/display-name: {{ .Values.global.defaultResources.project.displayName }}
     openchoreo.dev/description: {{ .Values.global.defaultResources.project.description }}
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "7"
   labels:
     openchoreo.dev/organization: default


### PR DESCRIPTION
## Purpose

### Problem
Helm hooks use before-hook-creation as their default deletion policy. This means that during helm upgrade, the existing hook resource is deleted before the new one is created.
For the default Project resource (defined as a hook), this triggers the finalizer cleanup logic, which cascades deletion to all Components belonging to that project. As a result, any user-created Components in the default project are unintentionally removed during upgrades.

### Solution
Remove the hook annotation from the default Project resource so it's managed as a regular Helm resource rather than a hook. This prevents the delete-and-recreate cycle during upgrades, preserving user Components in the default project.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
