### PR TITLE
Set default OpenSearch in multi cluster setup to non-operator based one

### DIFF
--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -13,9 +13,13 @@ openSearchDashboards:
     type: LoadBalancer
 
 openSearch:
+  enabled: true
   # Expose OpenSearch API via LoadBalancer for Fluent Bit data pushing
   service:
     type: LoadBalancer
+
+openSearchCluster:
+  enabled: false
 
 prometheus:
   enabled: true


### PR DESCRIPTION
## Purpose
Set default OpenSearch deployment in multi cluster mode to non-operator based one

## Approach
Updated the multi cluster value file

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
