### PR TITLE
Update Observer to accept component, project and environment names in request for authorization

### DIFF
--- a/internal/observer/handlers/handlers.go
+++ b/internal/observer/handlers/handlers.go
@@ -108,6 +108,7 @@ func (h *Handler) writeErrorResponse(w http.ResponseWriter, status int, errorTyp
 // BuildLogsRequest represents the request body for build logs
 type BuildLogsRequest struct {
 	ComponentName string `json:"componentName,omitempty"`
+	OrgName       string `json:"orgName,omitempty"`
 	ProjectName   string `json:"projectName,omitempty"`
 	StartTime     string `json:"startTime" validate:"required"`
 	EndTime       string `json:"endTime" validate:"required"`
@@ -118,6 +119,7 @@ type BuildLogsRequest struct {
 // ComponentLogsRequest represents the request body for component logs
 type ComponentLogsRequest struct {
 	ComponentName   string   `json:"componentName,omitempty"`
+	OrgName         string   `json:"orgName,omitempty"`
 	StartTime       string   `json:"startTime" validate:"required"`
 	EndTime         string   `json:"endTime" validate:"required"`
 	EnvironmentName string   `json:"environmentName,omitempty"`
@@ -167,6 +169,7 @@ type MetricsRequest struct {
 	EndTime         string `json:"endTime,omitempty"`
 	EnvironmentName string `json:"environmentName,omitempty"`
 	EnvironmentID   string `json:"environmentId" validate:"required"`
+	OrgName         string `json:"orgName,omitempty"`
 	StartTime       string `json:"startTime,omitempty"`
 	ProjectName     string `json:"projectName,omitempty"`
 	ProjectID       string `json:"projectId" validate:"required"`

--- a/internal/observer/opensearch/types.go
+++ b/internal/observer/opensearch/types.go
@@ -252,6 +252,7 @@ type TracesRequestParams struct {
 	EnvironmentName string   `json:"environmentName,omitempty"`
 	EnvironmentUID  string   `json:"environmentUid,omitempty"`
 	Limit           int      `json:"limit,omitempty"`
+	OrgName         string   `json:"orgName,omitempty"`
 	ProjectName     string   `json:"projectName,omitempty"`
 	ProjectUID      string   `json:"projectUid"`
 	SortOrder       string   `json:"sortOrder,omitempty"`


### PR DESCRIPTION
## Purpose
component, project and environment names are required to authorize requests to the Observer. This PR enables Observer to accept them in the request body

## Approach
Updated the request structs in Observer to accept the above mentioned fields

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1307

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
