### PR TITLE
Add version endpoint to OpenChoreo API and CLI

### DIFF
--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"os"
@@ -12,10 +13,12 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/mcphandlers"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/middleware/logger"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	"github.com/openchoreo/openchoreo/internal/server/middleware"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth/jwt"
 	mcpmiddleware "github.com/openchoreo/openchoreo/internal/server/middleware/mcp"
+	"github.com/openchoreo/openchoreo/internal/version"
 	"github.com/openchoreo/openchoreo/pkg/mcp"
 	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
 )
@@ -54,6 +57,9 @@ func (h *Handler) Routes() http.Handler {
 	// Health & Readiness checks
 	routes.HandleFunc("GET /health", h.Health)
 	routes.HandleFunc("GET /ready", h.Ready)
+
+	// Version endpoint
+	routes.HandleFunc("GET /version", h.Version)
 
 	// OAuth Protected Resource Metadata endpoint
 	routes.HandleFunc("GET /.well-known/oauth-protected-resource", h.OAuthProtectedResourceMetadata)
@@ -250,6 +256,23 @@ func (h *Handler) Ready(w http.ResponseWriter, r *http.Request) {
 	// Add readiness checks (K8s connections, etc.)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("Ready")) // Ignore write errors for health checks
+}
+
+// Version handles version information requests
+func (h *Handler) Version(w http.ResponseWriter, r *http.Request) {
+	v := version.Get()
+	response := models.VersionResponse{
+		Name:        v.Name,
+		Version:     v.Version,
+		GitRevision: v.GitRevision,
+		BuildTime:   v.BuildTime,
+		GoOS:        v.GoOS,
+		GoArch:      v.GoArch,
+		GoVersion:   v.GoVersion,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 func getMCPServerToolsets(h *Handler) *tools.Toolsets {

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -364,3 +364,14 @@ type ObservabilityPlaneResponse struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	Status      string    `json:"status,omitempty"`
 }
+
+// VersionResponse represents the server version information in API responses.
+type VersionResponse struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	GitRevision string `json:"gitRevision"`
+	BuildTime   string `json:"buildTime"`
+	GoOS        string `json:"goOS"`
+	GoArch      string `json:"goArch"`
+	GoVersion   string `json:"goVersion"`
+}


### PR DESCRIPTION
## Purpose
Add a metadata API endpoint to retrieve OpenChoreo deployment details, enabling external tools (Backstage plugin, CLI) to discover and display server version information.

## Approach
- Add `GET /version` public endpoint (no auth required) to openchoreo-api
- Update CLI `version` command to fetch and display both client and server versions

 ### Example Output

   **API Response (`GET /version`):**
   ```json
   {
     "name": "openchoreo-api",
     "version": "0.10.0",
     "gitRevision": "83a99a3b",
     "buildTime": "2026-01-06T14:49:02+0530",
     "goOS": "linux",
     "goArch": "arm64",
     "goVersion": "go1.24.3"
   }
   ```

   **CLI (`occ version`):**
   ```
   Client:
     Version:      0.10.0
     Git Revision: 83a99a3b
     Build Time:   2026-01-06T14:49:06+0530
     Go Version:   go1.24.3 darwin/arm64

   Server:
     Version:      0.10.0
     Git Revision: 83a99a3b
     Build Time:   2026-01-06T14:49:02+0530
     Go Version:   go1.24.3 linux/arm64
   ```

## Related Issues
- https://github.com/openchoreo/openchoreo/issues/1395

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> The version response format is designed to be extensible for future additions like connected planes status and health details.