### PR TITLE
Add gateway port information to Dataplane CRD

### DIFF
--- a/api/v1alpha1/dataplane_types.go
+++ b/api/v1alpha1/dataplane_types.go
@@ -42,6 +42,22 @@ type GatewaySpec struct {
 	PublicVirtualHost string `json:"publicVirtualHost"`
 	// Organization-specific virtual host for the gateway
 	OrganizationVirtualHost string `json:"organizationVirtualHost"`
+	// Public HTTP port for the gateway
+	// +optional
+	// +kubebuilder:default=19080
+	PublicHTTPPort int32 `json:"publicHTTPPort,omitempty"`
+	// Public HTTPS port for the gateway
+	// +optional
+	// +kubebuilder:default=19443
+	PublicHTTPSPort int32 `json:"publicHTTPSPort,omitempty"`
+	// Organization HTTP port for the gateway
+	// +optional
+	// +kubebuilder:default=19081
+	OrganizationHTTPPort int32 `json:"organizationHTTPPort,omitempty"`
+	// Organization HTTPS port for the gateway
+	// +optional
+	// +kubebuilder:default=19444
+	OrganizationHTTPSPort int32 `json:"organizationHTTPSPort,omitempty"`
 }
 
 // SecretStoreRef defines a reference to an External Secrets Operator ClusterSecretStore

--- a/config/crd/bases/openchoreo.dev_dataplanes.yaml
+++ b/config/crd/bases/openchoreo.dev_dataplanes.yaml
@@ -82,9 +82,29 @@ spec:
                 description: Gateway specifies the configuration for the API gateway
                   in this DataPlane.
                 properties:
+                  organizationHTTPPort:
+                    default: 19081
+                    description: Organization HTTP port for the gateway
+                    format: int32
+                    type: integer
+                  organizationHTTPSPort:
+                    default: 19444
+                    description: Organization HTTPS port for the gateway
+                    format: int32
+                    type: integer
                   organizationVirtualHost:
                     description: Organization-specific virtual host for the gateway
                     type: string
+                  publicHTTPPort:
+                    default: 19080
+                    description: Public HTTP port for the gateway
+                    format: int32
+                    type: integer
+                  publicHTTPSPort:
+                    default: 19443
+                    description: Public HTTPS port for the gateway
+                    format: int32
+                    type: integer
                   publicVirtualHost:
                     description: Public virtual host for the gateway
                     type: string

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_dataplanes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_dataplanes.yaml
@@ -81,9 +81,29 @@ spec:
                 description: Gateway specifies the configuration for the API gateway
                   in this DataPlane.
                 properties:
+                  organizationHTTPPort:
+                    default: 19081
+                    description: Organization HTTP port for the gateway
+                    format: int32
+                    type: integer
+                  organizationHTTPSPort:
+                    default: 19444
+                    description: Organization HTTPS port for the gateway
+                    format: int32
+                    type: integer
                   organizationVirtualHost:
                     description: Organization-specific virtual host for the gateway
                     type: string
+                  publicHTTPPort:
+                    default: 19080
+                    description: Public HTTP port for the gateway
+                    format: int32
+                    type: integer
+                  publicHTTPSPort:
+                    default: 19443
+                    description: Public HTTPS port for the gateway
+                    format: int32
+                    type: integer
                   publicVirtualHost:
                     description: Public virtual host for the gateway
                     type: string

--- a/internal/openchoreo-api/models/request.go
+++ b/internal/openchoreo-api/models/request.go
@@ -138,6 +138,10 @@ type CreateDataPlaneRequest struct {
 	ClusterAgentClientCA    string `json:"clusterAgentClientCA"`
 	PublicVirtualHost       string `json:"publicVirtualHost"`
 	OrganizationVirtualHost string `json:"organizationVirtualHost"`
+	PublicHTTPPort          *int32 `json:"publicHTTPPort,omitempty"`
+	PublicHTTPSPort         *int32 `json:"publicHTTPSPort,omitempty"`
+	OrganizationHTTPPort    *int32 `json:"organizationHTTPPort,omitempty"`
+	OrganizationHTTPSPort   *int32 `json:"organizationHTTPSPort,omitempty"`
 	ObservabilityPlaneRef   string `json:"observabilityPlaneRef,omitempty"`
 }
 

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -175,6 +175,10 @@ type DataPlaneResponse struct {
 	SecretStoreRef          string    `json:"secretStoreRef,omitempty"`
 	PublicVirtualHost       string    `json:"publicVirtualHost"`
 	OrganizationVirtualHost string    `json:"organizationVirtualHost"`
+	PublicHTTPPort          int32     `json:"publicHTTPPort"`
+	PublicHTTPSPort         int32     `json:"publicHTTPSPort"`
+	OrganizationHTTPPort    int32     `json:"organizationHTTPPort"`
+	OrganizationHTTPSPort   int32     `json:"organizationHTTPSPort"`
 	ObservabilityPlaneRef   string    `json:"observabilityPlaneRef,omitempty"`
 	CreatedAt               time.Time `json:"createdAt"`
 	Status                  string    `json:"status,omitempty"`

--- a/internal/openchoreo-api/services/dataplane_service.go
+++ b/internal/openchoreo-api/services/dataplane_service.go
@@ -158,16 +158,32 @@ func (s *DataPlaneService) buildDataPlaneCR(orgName string, req *models.CreateDa
 		description = fmt.Sprintf("DataPlane for %s", req.Name)
 	}
 
+	gatewaySpec := openchoreov1alpha1.GatewaySpec{
+		PublicVirtualHost:       req.PublicVirtualHost,
+		OrganizationVirtualHost: req.OrganizationVirtualHost,
+	}
+
+	// Set port values if provided, otherwise CRD defaults will be used
+	if req.PublicHTTPPort != nil {
+		gatewaySpec.PublicHTTPPort = *req.PublicHTTPPort
+	}
+	if req.PublicHTTPSPort != nil {
+		gatewaySpec.PublicHTTPSPort = *req.PublicHTTPSPort
+	}
+	if req.OrganizationHTTPPort != nil {
+		gatewaySpec.OrganizationHTTPPort = *req.OrganizationHTTPPort
+	}
+	if req.OrganizationHTTPSPort != nil {
+		gatewaySpec.OrganizationHTTPSPort = *req.OrganizationHTTPSPort
+	}
+
 	spec := openchoreov1alpha1.DataPlaneSpec{
 		ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
 			ClientCA: openchoreov1alpha1.ValueFrom{
 				Value: req.ClusterAgentClientCA,
 			},
 		},
-		Gateway: openchoreov1alpha1.GatewaySpec{
-			PublicVirtualHost:       req.PublicVirtualHost,
-			OrganizationVirtualHost: req.OrganizationVirtualHost,
-		},
+		Gateway: gatewaySpec,
 	}
 
 	// Set observability plane reference if provided
@@ -229,6 +245,10 @@ func (s *DataPlaneService) toDataPlaneResponse(dp *openchoreov1alpha1.DataPlane)
 		SecretStoreRef:          secretStoreRef,
 		PublicVirtualHost:       dp.Spec.Gateway.PublicVirtualHost,
 		OrganizationVirtualHost: dp.Spec.Gateway.OrganizationVirtualHost,
+		PublicHTTPPort:          dp.Spec.Gateway.PublicHTTPPort,
+		PublicHTTPSPort:         dp.Spec.Gateway.PublicHTTPSPort,
+		OrganizationHTTPPort:    dp.Spec.Gateway.OrganizationHTTPPort,
+		OrganizationHTTPSPort:   dp.Spec.Gateway.OrganizationHTTPSPort,
 		CreatedAt:               dp.CreationTimestamp.Time,
 		Status:                  status,
 	}


### PR DESCRIPTION
## Purpose
This PR updates the Dataplane CRD to include gateway ports. This is added to enable developers to define the dataplane port. Default values are added to make this a non-breaking change for the previous versions.

```sh
curl  -X GET \
  'http://localhost:8888/api/v1/orgs/default/dataplanes/default' \
  --header 'Authorization: Bearer TOKEN'

{
  "success": true,
  "data": {
    "name": "default",
    "namespace": "default",
    "displayName": "DataPlane default",
    "description": "DataPlane created via add-data-plane.sh script with cluster agent",
    "secretStoreRef": "default",
    "publicVirtualHost": "openchoreoapis.localhost",
    "organizationVirtualHost": "openchoreoapis.internal",
    "publicHTTPPort": 8888,
    "publicHTTPSPort": 19443,
    "organizationHTTPPort": 19082,
    "organizationHTTPSPort": 19444,
    "createdAt": "2026-01-07T04:42:33Z",
    "status": "Ready"
  }
}
```

## Approach
Add gateway ports to the Dataplane gateway section with default values.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1388

## Remarks
This is done temporarily until we refactor the Dataplane CRD with the upcoming changes related to suborgs, gateway granularity etc.
