### PR TITLE
Add flexible database configuration for Backstage

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -100,6 +100,29 @@ spec:
           value: {{ .Values.security.enabled | quote }}
         - name: OPENCHOREO_FEATURES_AUTHZ_ENABLED
           value: {{ .Values.security.authz.enabled | quote }}
+        # Database configuration
+        {{- if eq .Values.backstage.database.type "sqlite" }}
+        - name: DATABASE_CLIENT
+          value: "better-sqlite3"
+        - name: SQLITE_STORAGE_DIR
+          value: {{ .Values.backstage.database.sqlite.mountPath | quote }}
+        {{- else if eq .Values.backstage.database.type "postgresql" }}
+        - name: DATABASE_CLIENT
+          value: "pg"
+        - name: POSTGRES_HOST
+          value: {{ .Values.backstage.database.postgresql.host | quote }}
+        - name: POSTGRES_PORT
+          value: {{ .Values.backstage.database.postgresql.port | quote }}
+        - name: POSTGRES_USER
+          value: {{ .Values.backstage.database.postgresql.user | quote }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-secrets
+              key: postgres-password
+        - name: POSTGRES_DB
+          value: {{ .Values.backstage.database.postgresql.database | quote }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -118,4 +141,19 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if eq .Values.backstage.database.type "sqlite" }}
+        volumeMounts:
+        - name: backstage-db
+          mountPath: {{ .Values.backstage.database.sqlite.mountPath }}
+        {{- end }}
+      {{- if eq .Values.backstage.database.type "sqlite" }}
+      volumes:
+      - name: backstage-db
+        {{- if .Values.backstage.database.sqlite.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ include "openchoreo-control-plane.fullname" . }}-backstage-db
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/pvc.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.backstage.enabled (eq .Values.backstage.database.type "sqlite") .Values.backstage.database.sqlite.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+spec:
+  accessModes:
+    - {{ .Values.backstage.database.sqlite.persistence.accessMode }}
+  {{- if .Values.backstage.database.sqlite.persistence.storageClassName }}
+  storageClassName: {{ .Values.backstage.database.sqlite.persistence.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.backstage.database.sqlite.persistence.size }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/secret.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/secret.yaml
@@ -11,4 +11,7 @@ type: Opaque
 data:
   backend-secret: {{ (.Values.backstage.backendSecret | default (randAlphaNum 32)) | b64enc | quote }}
   client-secret: {{ .Values.backstage.auth.clientSecret | b64enc | quote }}
+  {{- if eq .Values.backstage.database.type "postgresql" }}
+  postgres-password: {{ .Values.backstage.database.postgresql.password | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -266,6 +266,125 @@
           "title": "containerSecurityContext",
           "type": "object"
         },
+        "database": {
+          "additionalProperties": false,
+          "description": "Database configuration for Backstage",
+          "properties": {
+            "postgresql": {
+              "additionalProperties": false,
+              "description": "PostgreSQL settings (only used when type is postgresql)",
+              "properties": {
+                "database": {
+                  "default": "backstage",
+                  "description": "PostgreSQL database name",
+                  "required": [],
+                  "title": "database",
+                  "type": "string"
+                },
+                "host": {
+                  "default": "",
+                  "description": "PostgreSQL host",
+                  "required": [],
+                  "title": "host",
+                  "type": "string"
+                },
+                "password": {
+                  "default": "",
+                  "description": "PostgreSQL password",
+                  "required": [],
+                  "title": "password",
+                  "type": "string"
+                },
+                "port": {
+                  "default": 5432,
+                  "description": "PostgreSQL port",
+                  "required": [],
+                  "title": "port",
+                  "type": "integer"
+                },
+                "user": {
+                  "default": "backstage",
+                  "description": "PostgreSQL username",
+                  "required": [],
+                  "title": "user",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "postgresql",
+              "type": "object"
+            },
+            "sqlite": {
+              "additionalProperties": false,
+              "description": "SQLite settings (only used when type is sqlite)",
+              "properties": {
+                "mountPath": {
+                  "default": "/app/.config/backstage",
+                  "description": "Mount path for database directory inside container",
+                  "required": [],
+                  "title": "mountPath",
+                  "type": "string"
+                },
+                "persistence": {
+                  "additionalProperties": false,
+                  "description": "Persistence settings for SQLite database",
+                  "properties": {
+                    "accessMode": {
+                      "default": "ReadWriteOnce",
+                      "description": "PVC access mode",
+                      "enum": [
+                        "ReadWriteOnce",
+                        "ReadWriteMany"
+                      ],
+                      "required": [],
+                      "title": "accessMode"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "description": "Enable PVC for persistence (false = emptyDir)",
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "size": {
+                      "default": "1Gi",
+                      "description": "PVC storage size",
+                      "required": [],
+                      "title": "size",
+                      "type": "string"
+                    },
+                    "storageClassName": {
+                      "default": "",
+                      "description": "Storage class name (empty = default storage class)",
+                      "required": [],
+                      "title": "storageClassName",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "persistence",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "sqlite",
+              "type": "object"
+            },
+            "type": {
+              "default": "sqlite",
+              "description": "Database type",
+              "enum": [
+                "sqlite",
+                "postgresql"
+              ],
+              "required": [],
+              "title": "type"
+            }
+          },
+          "required": [],
+          "title": "database",
+          "type": "object"
+        },
         "enabled": {
           "default": true,
           "description": "Enable Backstage UI deployment",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2327,6 +2327,95 @@ backstage:
       # @schema
       type: Unconfined
 
+  # @schema
+  # type: object
+  # description: Database configuration for Backstage
+  # @schema
+  database:
+    # @schema
+    # description: Database type
+    # enum: [sqlite, postgresql]
+    # default: sqlite
+    # @schema
+    type: sqlite
+
+    # @schema
+    # type: object
+    # description: SQLite settings (only used when type is sqlite)
+    # @schema
+    sqlite:
+      # @schema
+      # type: string
+      # description: Mount path for database directory inside container
+      # default: /app/.config/backstage
+      # @schema
+      mountPath: /app/.config/backstage
+      # @schema
+      # type: object
+      # description: Persistence settings for SQLite database
+      # @schema
+      persistence:
+        # @schema
+        # type: boolean
+        # description: Enable PVC for persistence (false = emptyDir)
+        # default: false
+        # @schema
+        enabled: false
+        # @schema
+        # type: string
+        # description: PVC storage size
+        # default: 1Gi
+        # @schema
+        size: 1Gi
+        # @schema
+        # type: string
+        # description: Storage class name (empty = default storage class)
+        # default: ""
+        # @schema
+        storageClassName: ""
+        # @schema
+        # description: PVC access mode
+        # enum: [ReadWriteOnce, ReadWriteMany]
+        # default: ReadWriteOnce
+        # @schema
+        accessMode: ReadWriteOnce
+
+    # @schema
+    # type: object
+    # description: PostgreSQL settings (only used when type is postgresql)
+    # @schema
+    postgresql:
+      # @schema
+      # type: string
+      # description: PostgreSQL host
+      # default: ""
+      # @schema
+      host: ""
+      # @schema
+      # type: integer
+      # description: PostgreSQL port
+      # default: 5432
+      # @schema
+      port: 5432
+      # @schema
+      # type: string
+      # description: PostgreSQL username
+      # default: backstage
+      # @schema
+      user: backstage
+      # @schema
+      # type: string
+      # description: PostgreSQL password
+      # default: ""
+      # @schema
+      password: ""
+      # @schema
+      # type: string
+      # description: PostgreSQL database name
+      # default: backstage
+      # @schema
+      database: backstage
+
 # @schema
 # type: object
 # additionalProperties: true


### PR DESCRIPTION
## Purpose
Add flexible database configuration options for Backstage UI to support both SQLite (with optional persistence) and external PostgreSQL databases.

## Approach
- Added `backstage.database` configuration section to values.yaml
- SQLite mode uses a mountable directory (emptyDir by default, optional PVC for persistence)
- PostgreSQL mode injects standard Backstage environment variables (POSTGRES_HOST, POSTGRES_PORT, etc.)
- PostgreSQL password stored securely in Kubernetes Secret

## Changes
- `install/helm/openchoreo-control-plane/values.yaml` - Added database configuration section
- `install/helm/openchoreo-control-plane/templates/backstage/pvc.yaml` - New PVC template for SQLite persistence
- `install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml` - Added volume mounts and PostgreSQL env vars
- `install/helm/openchoreo-control-plane/templates/backstage/secret.yaml` - Added PostgreSQL password secret
- `install/helm/openchoreo-control-plane/values.schema.json` - Regenerated schema

## Usage Examples

**Default (SQLite with emptyDir):**
```yaml
backstage:
  enabled: true
  # Uses emptyDir by default
```

**SQLite with PVC:**
```yaml
backstage:
  database:
    type: sqlite
    sqlite:
      persistence:
        enabled: true
        size: 2Gi
```

**External PostgreSQL:**
```yaml
backstage:
  database:
    type: postgresql
    postgresql:
      host: postgres.example.com
      port: 5432
      user: backstage
      password: secretpassword
      database: backstage
```

### Related PR
https://github.com/openchoreo/backstage-plugins/pull/180