### PR TITLE
Exclude init/wait container logs from build logs query

### DIFF
--- a/internal/observer/labels/constants.go
+++ b/internal/observer/labels/constants.go
@@ -73,9 +73,10 @@ const (
 // OpenSearch field paths for querying Kubernetes labels in log documents
 const (
 	// KubernetesLabelsPrefix is the base path for all Kubernetes labels in OpenSearch documents
-	KubernetesPrefix       = "kubernetes"
-	KubernetesLabelsPrefix = KubernetesPrefix + ".labels"
-	KubernetesPodName      = KubernetesPrefix + ".pod_name"
+	KubernetesPrefix        = "kubernetes"
+	KubernetesLabelsPrefix  = KubernetesPrefix + ".labels"
+	KubernetesPodName       = KubernetesPrefix + ".pod_name"
+	KubernetesContainerName = KubernetesPrefix + ".container_name"
 
 	// Full field paths for OpenSearch queries
 	OSComponentID      = KubernetesLabelsPrefix + "." + ComponentID

--- a/internal/observer/opensearch/queries.go
+++ b/internal/observer/opensearch/queries.go
@@ -112,11 +112,26 @@ func (qb *QueryBuilder) BuildBuildLogsQuery(params BuildQueryParams) map[string]
 	}
 	mustConditions = addTimeRangeFilter(mustConditions, params.QueryParams.StartTime, params.QueryParams.EndTime)
 
+	// Logs from init and wait containers are not relevant to the build logs. Hence, excluded.
+	mustNotConditions := []map[string]interface{}{
+		{
+			"term": map[string]interface{}{
+				labels.KubernetesContainerName + ".keyword": "init",
+			},
+		},
+		{
+			"term": map[string]interface{}{
+				labels.KubernetesContainerName + ".keyword": "wait",
+			},
+		},
+	}
+
 	query := map[string]interface{}{
 		"size": params.QueryParams.Limit,
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{
-				"must": mustConditions,
+				"must":     mustConditions,
+				"must_not": mustNotConditions,
 			},
 		},
 		"sort": []map[string]interface{}{


### PR DESCRIPTION
## Purpose
Logs of init and wait containers in Argo workflow steps are not actually related to the build step. Hence logs from these containers are excluded when querying build logs to reduce the noise in build logs view.

## Approach
Build logs before the change: (cluttered with init/wait container logs)
<img width="1256" height="535" alt="image" src="https://github.com/user-attachments/assets/a3d23de5-0a52-4f70-97ad-af9f3f1a2b75" />

Build logs after the change: (less cluttered and provided with actual build step logs)
<img width="1257" height="554" alt="image" src="https://github.com/user-attachments/assets/e854ca7c-5af1-4aac-90e7-659c3fa66eda" />


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
