### PR TITLE
Update otel collector endpoints in multi-cluster setup

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/observability/opentelemetry-collector-configmap.yaml
+++ b/install/helm/openchoreo-data-plane/templates/observability/opentelemetry-collector-configmap.yaml
@@ -21,7 +21,7 @@ data:
 
     exporters:
       otlp:
-        endpoint: {{ .Values.observability.observabilityPlaneUrl }}:4317
+        endpoint: {{ .Values.observability.observabilityPlaneUrl }}
         tls:
           insecure: true # TODO: Enable mTLS between collectors
 

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -89,7 +89,7 @@ Create cluster and install components:
 # Create Data Plane cluster
 k3d cluster create --config install/k3d/multi-cluster/config-dp.yaml
 
-# Generate a machine-id (Required for Fluent Bit when running k3d on macOS)
+# Generate a machine-id (Required for Fluent Bit when running k3d)
 docker exec k3d-openchoreo-dp-server-0 sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
 
 # Install Cert Manager (required for TLS certificates)
@@ -144,7 +144,7 @@ Create cluster and install components:
 # Create Build Plane cluster
 k3d cluster create --config install/k3d/multi-cluster/config-bp.yaml
 
-# Generate a machine-id (Required for Fluent Bit when running k3d on macOS)
+# Generate a machine-id (Required for Fluent Bit when running k3d)
 docker exec k3d-openchoreo-bp-server-0 sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
 
 # Install Cert Manager (required for TLS certificates)
@@ -183,7 +183,7 @@ Create cluster and install components:
 # Create Observability Plane cluster
 k3d cluster create --config install/k3d/multi-cluster/config-op.yaml
 
-# Generate a machine-id (Required for Fluent Bit when running k3d on macOS)
+# Generate a machine-id (Required for Fluent Bit when running k3d)
 docker exec k3d-openchoreo-op-server-0 sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
 
 # Install Cert Manager (required for TLS certificates)

--- a/install/k3d/multi-cluster/config-op.yaml
+++ b/install/k3d/multi-cluster/config-op.yaml
@@ -32,6 +32,10 @@ ports:
   - port: 11085:443
     nodeFilters:
       - loadbalancer
+  # OpenTelemetry Collector
+  - port: 11086:4317
+    nodeFilters:
+      - loadbalancer
     
 options:
   k3s:

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -82,3 +82,6 @@ kube-prometheus-stack:
 # External Secrets Operator configuration
 external-secrets:
   enabled: true
+
+observability:
+  observabilityPlaneUrl: "http://host.k3d.internal:11086"

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -62,6 +62,10 @@ openSearch:
 openSearchCluster:
   enabled: true
 
+opentelemetry-collector:
+  service:
+    type: LoadBalancer
+
 prometheus:
   enabled: true
   prometheus:

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -22,6 +22,9 @@ lower resource requirements.
 ```bash
 # Create single OpenChoreo cluster
 k3d cluster create --config install/k3d/single-cluster/config.yaml
+
+# Generate a machine-id (Required for Fluent Bit when running k3d)
+docker exec k3d-openchoreo-cp-server-0 sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
 ```
 
 ### 2. Install cert-manager (Prerequisite)


### PR DESCRIPTION
## Purpose
1. Expose OpenTelemetry collector as a LoadBalancer service in multi cluster setup
2. Update README file with the command to create machine-id required for fluent-bit

## Approach
Updated the helm value override files in the multi cluster setup

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
