### PR TITLE
Add command to generate machine id in quick start and enable fluent-bit

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -674,6 +674,11 @@ install_build_plane() {
 # Install OpenChoreo Observability Plane (optional)
 install_observability_plane() {
     log_info "Installing OpenChoreo Observability Plane..."
+
+    # Generate machine-id for fluent-bit
+    log_info "Generating machine-id for observability..."
+    docker exec "k3d-${CLUSTER_NAME}-server-0" sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+    
     install_helm_chart "openchoreo-observability-plane" "openchoreo-observability-plane" "$OBSERVABILITY_NS" "true" "true" "true" "1800" \
         "--values" "$HOME/.values-op.yaml" \
         "--set" "observer.image.tag=$OPENCHOREO_VERSION"

--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -2,6 +2,9 @@
 # This file contains overrides for running the data plane in the quick-start k3d environment
 # Port mapping: k3d maps host ports 19080:19080 (HTTP) and 19443:19443 (HTTPS) for KGateway
 
+fluent-bit:
+  enabled: true
+
 # Gateway configuration for quick-start setup
 # Reuse the existing control plane's cluster gateway controller
 gatewayController:


### PR DESCRIPTION
## Purpose
Generate random UUID as machine ID in quick start setup and enable fluent-bit by default

## Approach
1. Updated quick start helpers file to generate a random UUID as machine ID
2. Updated helm chart to enable fluent-bit

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
