### PR TITLE
Use OP fluent bit in quick start instead of DP

### DIFF
--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -2,9 +2,6 @@
 # This file contains overrides for running the data plane in the quick-start k3d environment
 # Port mapping: k3d maps host ports 19080:19080 (HTTP) and 19443:19443 (HTTPS) for KGateway
 
-fluent-bit:
-  enabled: true
-
 # Gateway configuration for quick-start setup
 # Reuse the existing control plane's cluster gateway controller
 gatewayController:

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -6,6 +6,8 @@ global:
   commonLabels: {}
   installationMode: quickStart
 
+fluent-bit:
+  enabled: true
 
 opentelemetry-collector:
   enabled: false


### PR DESCRIPTION
## Purpose
Switch the active fluent bit deployment from data plane to observability plane

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
