### PR TITLE
Refactor subject type handling to use string literals instead of custom SubjectType

### DIFF
--- a/internal/authz/casbin/casbin_test.go
+++ b/internal/authz/casbin/casbin_test.go
@@ -18,6 +18,7 @@ const (
 	testRoleName         = "test-role"
 	testEntitlementType  = "group"
 	testEntitlementValue = "test-group"
+	user                 = "user"
 )
 
 // setupTestEnforcer creates a test CasbinEnforcer with temporary database
@@ -151,13 +152,13 @@ func TestCasbinEnforcer_Evaluate(t *testing.T) {
 		},
 		{
 			name:              "access denied - hierarchy out of scope",
-			entitlementValues: []string{"project-group"},
+			entitlementValues: []string{"test-group"},
 			resource: authzcore.ResourceHierarchy{
-				Organization: "acme",
+				Organization: "acme-v2",
 				Project:      "p2",
 				Component:    "c1",
 			},
-			action: "component:write",
+			action: "component:read",
 			want:   false,
 			reason: "project-writer role only applies to p1, NOT p2",
 		},
@@ -820,7 +821,7 @@ func TestCasbinEnforcer_filterPoliciesBySubjectAndScope(t *testing.T) {
 		{
 			name: "filter policies within scope",
 			subjectCtx: &authzcore.SubjectContext{
-				Type:              authzcore.SubjectTypeUser,
+				Type:              user,
 				EntitlementClaim:  "group",
 				EntitlementValues: []string{"group1"},
 			},
@@ -830,7 +831,7 @@ func TestCasbinEnforcer_filterPoliciesBySubjectAndScope(t *testing.T) {
 		{
 			name: "filter policies within project scope",
 			subjectCtx: &authzcore.SubjectContext{
-				Type:              authzcore.SubjectTypeUser,
+				Type:              user,
 				EntitlementClaim:  "group",
 				EntitlementValues: []string{"group1"},
 			},
@@ -840,7 +841,7 @@ func TestCasbinEnforcer_filterPoliciesBySubjectAndScope(t *testing.T) {
 		{
 			name: "no matching entitlements",
 			subjectCtx: &authzcore.SubjectContext{
-				Type:              authzcore.SubjectTypeUser,
+				Type:              user,
 				EntitlementClaim:  "group",
 				EntitlementValues: []string{"nonexistent-group"},
 			},
@@ -945,7 +946,7 @@ func TestCasbinEnforcer_GetSubjectProfile(t *testing.T) {
 			name: "get profile with org scope",
 			request: &authzcore.ProfileRequest{
 				SubjectContext: &authzcore.SubjectContext{
-					Type:              authzcore.SubjectTypeUser,
+					Type:              user,
 					EntitlementClaim:  "groups",
 					EntitlementValues: []string{"dev-group"},
 				},
@@ -955,7 +956,7 @@ func TestCasbinEnforcer_GetSubjectProfile(t *testing.T) {
 			},
 			wantErr: false,
 			expectedUser: authzcore.SubjectContext{
-				Type:              authzcore.SubjectTypeUser,
+				Type:              user,
 				EntitlementClaim:  "groups",
 				EntitlementValues: []string{"dev-group"},
 			},
@@ -972,7 +973,7 @@ func TestCasbinEnforcer_GetSubjectProfile(t *testing.T) {
 			name: "get profile for scope within an organization",
 			request: &authzcore.ProfileRequest{
 				SubjectContext: &authzcore.SubjectContext{
-					Type:              authzcore.SubjectTypeUser,
+					Type:              user,
 					EntitlementClaim:  "groups",
 					EntitlementValues: []string{"dev-group"},
 				},
@@ -983,7 +984,7 @@ func TestCasbinEnforcer_GetSubjectProfile(t *testing.T) {
 			},
 			wantErr: false,
 			expectedUser: authzcore.SubjectContext{
-				Type:              authzcore.SubjectTypeUser,
+				Type:              user,
 				EntitlementClaim:  "groups",
 				EntitlementValues: []string{"dev-group"},
 			},
@@ -1000,7 +1001,7 @@ func TestCasbinEnforcer_GetSubjectProfile(t *testing.T) {
 			name: "get profile for user with no permissions",
 			request: &authzcore.ProfileRequest{
 				SubjectContext: &authzcore.SubjectContext{
-					Type:              authzcore.SubjectTypeUser,
+					Type:              user,
 					EntitlementClaim:  "groups",
 					EntitlementValues: []string{"no-permissions-group"},
 				},
@@ -1011,7 +1012,7 @@ func TestCasbinEnforcer_GetSubjectProfile(t *testing.T) {
 			wantErr:             false,
 			wantEmptyCapability: true,
 			expectedUser: authzcore.SubjectContext{
-				Type:              authzcore.SubjectTypeUser,
+				Type:              user,
 				EntitlementClaim:  "groups",
 				EntitlementValues: []string{"no-permissions-group"},
 			},

--- a/internal/authz/casbin/helpers_test.go
+++ b/internal/authz/casbin/helpers_test.go
@@ -422,7 +422,7 @@ func TestValidateProfileRequest(t *testing.T) {
 			name: "valid profile request",
 			request: &authzcore.ProfileRequest{
 				SubjectContext: &authzcore.SubjectContext{
-					Type:              authzcore.SubjectTypeUser,
+					Type:              "user",
 					EntitlementClaim:  "groups",
 					EntitlementValues: []string{"test-group"},
 				},

--- a/internal/authz/core/converter.go
+++ b/internal/authz/core/converter.go
@@ -14,7 +14,7 @@ func GetAuthzSubjectContext(authCtx *auth.SubjectContext) *SubjectContext {
 	}
 
 	return &SubjectContext{
-		Type:              SubjectType(authCtx.Type),
+		Type:              authCtx.Type,
 		EntitlementClaim:  authCtx.EntitlementClaim,
 		EntitlementValues: authCtx.EntitlementValues,
 	}

--- a/internal/authz/core/types.go
+++ b/internal/authz/core/types.go
@@ -8,14 +8,6 @@ import (
 	"time"
 )
 
-// SubjectType defines the type of subject making the authorization request
-type SubjectType string
-
-const (
-	SubjectTypeUser           SubjectType = "user"
-	SubjectTypeServiceAccount SubjectType = "service_account"
-)
-
 // PolicyEffectType defines the effect of a policy: allow or deny
 type PolicyEffectType string
 
@@ -26,9 +18,9 @@ const (
 
 // SubjectContext represents the authenticated subject making the authorization request
 type SubjectContext struct {
-	Type              SubjectType `json:"type"`
-	EntitlementClaim  string      `json:"entitlement_claim"`
-	EntitlementValues []string    `json:"entitlement_values"`
+	Type              string   `json:"type"`
+	EntitlementClaim  string   `json:"entitlement_claim"`
+	EntitlementValues []string `json:"entitlement_values"`
 }
 
 // ResourceHierarchy represents a single item in a resource hierarchy

--- a/internal/server/middleware/auth/interface.go
+++ b/internal/server/middleware/auth/interface.go
@@ -8,19 +8,11 @@ import (
 	"net/http"
 )
 
-// SubjectType represents the type of authenticated subject
-type SubjectType string
-
-const (
-	SubjectTypeUser           SubjectType = "user"
-	SubjectTypeServiceAccount SubjectType = "service_account"
-)
-
 // SubjectContext contains the authenticated subject's type and entitlements
 type SubjectContext struct {
-	Type              SubjectType // Type of subject (user, service_account, etc.)
-	EntitlementClaim  string      // The claim name used for entitlements (e.g., "groups", "scopes")
-	EntitlementValues []string    // The entitlement values extracted from the claim
+	Type              string   // Type of subject (user, service_account, etc.)
+	EntitlementClaim  string   // The claim name used for entitlements (e.g., "groups", "scopes")
+	EntitlementValues []string // The entitlement values extracted from the claim
 }
 
 // Middleware defines the interface that all authentication middlewares must implement

--- a/internal/server/middleware/auth/jwt/resolver_test.go
+++ b/internal/server/middleware/auth/jwt/resolver_test.go
@@ -8,8 +8,12 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth/subject"
+)
+
+const (
+	user           = "user"
+	serviceAccount = "service_account"
 )
 
 func createTestJWT(claims jwt.MapClaims) string {
@@ -21,7 +25,7 @@ func createTestJWT(claims jwt.MapClaims) string {
 func TestJWTDetectorUserTypeDetection(t *testing.T) {
 	userTypes := []subject.UserTypeConfig{
 		{
-			Type:        auth.SubjectTypeUser,
+			Type:        user,
 			DisplayName: "Human User",
 			Priority:    1,
 			AuthMechanisms: []subject.AuthMechanismConfig{
@@ -35,7 +39,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 			},
 		},
 		{
-			Type:        auth.SubjectTypeServiceAccount,
+			Type:        serviceAccount,
 			DisplayName: "Service Account",
 			Priority:    2,
 			AuthMechanisms: []subject.AuthMechanismConfig{
@@ -58,7 +62,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 	tests := []struct {
 		name           string
 		claims         jwt.MapClaims
-		expectedType   auth.SubjectType
+		expectedType   string
 		expectedClaim  string
 		expectedValues []string
 		wantErr        bool
@@ -68,7 +72,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 			claims: jwt.MapClaims{
 				"group": "admin",
 			},
-			expectedType:   auth.SubjectTypeUser,
+			expectedType:   "user",
 			expectedClaim:  "group",
 			expectedValues: []string{"admin"},
 			wantErr:        false,
@@ -78,7 +82,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 			claims: jwt.MapClaims{
 				"group": []interface{}{"admin", "developer"},
 			},
-			expectedType:   auth.SubjectTypeUser,
+			expectedType:   "user",
 			expectedClaim:  "group",
 			expectedValues: []string{"admin", "developer"},
 			wantErr:        false,
@@ -88,7 +92,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 			claims: jwt.MapClaims{
 				"service_account": "api-service",
 			},
-			expectedType:   auth.SubjectTypeServiceAccount,
+			expectedType:   "service_account",
 			expectedClaim:  "service_account",
 			expectedValues: []string{"api-service"},
 			wantErr:        false,
@@ -99,7 +103,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 				"group":           "admin",
 				"service_account": "api-service",
 			},
-			expectedType:   auth.SubjectTypeUser,
+			expectedType:   "user",
 			expectedClaim:  "group",
 			expectedValues: []string{"admin"},
 			wantErr:        false,
@@ -116,7 +120,7 @@ func TestJWTDetectorUserTypeDetection(t *testing.T) {
 			claims: jwt.MapClaims{
 				"group": "",
 			},
-			expectedType:   auth.SubjectTypeUser,
+			expectedType:   "user",
 			expectedClaim:  "group",
 			expectedValues: []string{},
 			wantErr:        false,
@@ -158,7 +162,7 @@ func TestJWTDetectorWithoutJWTMechanism(t *testing.T) {
 	// User type without OAuth2 mechanism (using API key instead)
 	userTypes := []subject.UserTypeConfig{
 		{
-			Type:        auth.SubjectTypeUser,
+			Type:        "user",
 			DisplayName: "API Key User",
 			Priority:    1,
 			AuthMechanisms: []subject.AuthMechanismConfig{
@@ -186,7 +190,7 @@ func TestJWTDetectorFiltersNonJWTUserTypes(t *testing.T) {
 	// Mix of OAuth2 and non-OAuth2 user types
 	userTypes := []subject.UserTypeConfig{
 		{
-			Type:        auth.SubjectTypeUser,
+			Type:        "user",
 			DisplayName: "OAuth2 User",
 			Priority:    1,
 			AuthMechanisms: []subject.AuthMechanismConfig{
@@ -227,7 +231,7 @@ func TestJWTDetectorFiltersNonJWTUserTypes(t *testing.T) {
 		t.Fatalf("DetectUserType() error = %v", err)
 	}
 
-	if result.Type != auth.SubjectTypeUser {
-		t.Errorf("Type = %v, want %v", result.Type, auth.SubjectTypeUser)
+	if result.Type != "user" {
+		t.Errorf("Type = %v, want %v", result.Type, "user")
 	}
 }

--- a/internal/server/middleware/auth/subject/config.go
+++ b/internal/server/middleware/auth/subject/config.go
@@ -6,13 +6,11 @@ package subject
 import (
 	"fmt"
 	"sort"
-
-	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
 
 // UserTypeConfig represents configuration for a single user type
 type UserTypeConfig struct {
-	Type           auth.SubjectType      `yaml:"type" json:"type"`                      // "user" or "service_account"
+	Type           string                `yaml:"type" json:"type"`                      // "user" or "service_account"
 	DisplayName    string                `yaml:"display_name" json:"displayName"`       // Human-readable name for user type
 	Priority       int                   `yaml:"priority" json:"priority"`              // Check order (lower = higher priority)
 	AuthMechanisms []AuthMechanismConfig `yaml:"auth_mechanisms" json:"authMechanisms"` // Supported authentication mechanisms
@@ -36,7 +34,7 @@ func ValidateConfig(userTypes []UserTypeConfig) error {
 		return fmt.Errorf("at least one user type must be configured")
 	}
 
-	typesSeen := make(map[auth.SubjectType]bool)
+	typesSeen := make(map[string]bool)
 	prioritiesSeen := make(map[int]bool)
 
 	for i, ut := range userTypes {


### PR DESCRIPTION

## Purpose
This pull request refactors how subject types (such as "user" and "service_account") are represented throughout the authorization and authentication codebase. Instead of using custom `SubjectType` types and constants, 
the code now uses plain strings for subject type values. This change ensure that we honour user provided types instead of our own types.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
