### PR TITLE
Move authServerBaseUrl helm value

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SERVER_BASE_URL
           value: {{ .Values.openchoreoApi.serverBaseUrl | default (printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.apiHost" .) (include "openchoreo.port" .)) | quote }}
         - name: AUTH_SERVER_BASE_URL
-          value: {{ .Values.openchoreoApi.authServerBaseUrl | default (printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.thunderHost" .) (include "openchoreo.port" .)) | quote }}
+          value: {{ .Values.security.authServerBaseUrl | default (printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.thunderHost" .) (include "openchoreo.port" .)) | quote }}
         - name: JWT_ISSUER
           value: {{ .Values.security.oidc.issuer | quote }}
         - name: JWKS_URL

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2974,13 +2974,6 @@
           "title": "affinity",
           "type": "object"
         },
-        "authServerBaseUrl": {
-          "default": "",
-          "description": "Base URL for the authorization server (used for OAuth metadata). If not set, defaults to protocol://thunder.baseDomain:port",
-          "required": [],
-          "title": "authServerBaseUrl",
-          "type": "string"
-        },
         "autoscaling": {
           "additionalProperties": false,
           "description": "Horizontal Pod Autoscaler configuration",
@@ -3955,6 +3948,13 @@
           "required": [],
           "title": "oidc",
           "type": "object"
+        },
+        "authServerBaseUrl": {
+          "default": "",
+          "description": "Base URL for the authorization server (used for OAuth metadata). If not set, defaults to protocol://thunder.baseDomain:port",
+          "required": [],
+          "title": "authServerBaseUrl",
+          "type": "string"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -293,6 +293,12 @@ security:
     # default: /etc/openchoreo/authz/default-roles-mappings.yaml
     # @schema
     defaultAuthzDataFilePath: "/etc/openchoreo/authz/default-roles-mappings.yaml"
+  # @schema
+  # type: string
+  # description: Base URL for the authorization server (used for OAuth metadata). If not set, defaults to protocol://thunder.baseDomain:port
+  # default: ""
+  # @schema
+  authServerBaseUrl: ""
 
 # @schema
 # type: object
@@ -1070,13 +1076,6 @@ openchoreoApi:
   # default: ""
   # @schema
   serverBaseUrl: ""
-
-  # @schema
-  # type: string
-  # description: Base URL for the authorization server (used for OAuth metadata). If not set, defaults to protocol://thunder.baseDomain:port
-  # default: ""
-  # @schema
-  authServerBaseUrl: ""
 
   # @schema
   # type: object


### PR DESCRIPTION
## Purpose
Moving `Values.openchoreoApi.authServerBaseUrl` to `.Values.security.authServerBaseUrl` in the openchoreo-control-plane helm values.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/570

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

