### PR TITLE
Refactor: Extract shared status constants to dedicated package

### DIFF
--- a/internal/openchoreo-api/services/dataplane_service.go
+++ b/internal/openchoreo-api/services/dataplane_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	apistatus "github.com/openchoreo/openchoreo/internal/openchoreo-api/status"
 )
 
 // DataPlaneService handles dataplane-related business logic
@@ -219,14 +220,14 @@ func (s *DataPlaneService) toDataPlaneResponse(dp *openchoreov1alpha1.DataPlane)
 	description := dp.Annotations[controller.AnnotationKeyDescription]
 
 	// Get status from conditions
-	status := statusUnknown
+	status := apistatus.Unknown
 	if len(dp.Status.Conditions) > 0 {
 		// Get the latest condition
 		latestCondition := dp.Status.Conditions[len(dp.Status.Conditions)-1]
 		if latestCondition.Status == metav1.ConditionTrue {
-			status = statusReady
+			status = apistatus.Ready
 		} else {
-			status = statusNotReady
+			status = apistatus.NotReady
 		}
 	}
 

--- a/internal/openchoreo-api/services/deployment_pipeline_service.go
+++ b/internal/openchoreo-api/services/deployment_pipeline_service.go
@@ -14,6 +14,7 @@ import (
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	apistatus "github.com/openchoreo/openchoreo/internal/openchoreo-api/status"
 )
 
 const (
@@ -103,13 +104,13 @@ func (s *DeploymentPipelineService) toDeploymentPipelineResponse(pipeline *openc
 	}
 
 	// Determine status from conditions
-	status := statusUnknown
+	status := apistatus.Unknown
 	for _, condition := range pipeline.Status.Conditions {
-		if condition.Type == statusReady {
+		if condition.Type == apistatus.Ready {
 			if condition.Status == "True" {
-				status = statusReady
+				status = apistatus.Ready
 			} else {
-				status = statusNotReady
+				status = apistatus.NotReady
 			}
 			break
 		}

--- a/internal/openchoreo-api/services/environment_service.go
+++ b/internal/openchoreo-api/services/environment_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	apistatus "github.com/openchoreo/openchoreo/internal/openchoreo-api/status"
 )
 
 // EnvironmentService handles environment-related business logic
@@ -206,14 +207,14 @@ func (s *EnvironmentService) toEnvironmentResponse(env *openchoreov1alpha1.Envir
 	description := env.Annotations[controller.AnnotationKeyDescription]
 
 	// Get status from conditions
-	status := statusUnknown
+	status := apistatus.Unknown
 	if len(env.Status.Conditions) > 0 {
 		// Get the latest condition
 		latestCondition := env.Status.Conditions[len(env.Status.Conditions)-1]
 		if latestCondition.Status == metav1.ConditionTrue {
-			status = statusReady
+			status = apistatus.Ready
 		} else {
-			status = statusNotReady
+			status = apistatus.NotReady
 		}
 	}
 

--- a/internal/openchoreo-api/services/organization_service.go
+++ b/internal/openchoreo-api/services/organization_service.go
@@ -16,6 +16,7 @@ import (
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	apistatus "github.com/openchoreo/openchoreo/internal/openchoreo-api/status"
 )
 
 // OrganizationService handles organization-related business logic
@@ -98,14 +99,14 @@ func (s *OrganizationService) toOrganizationResponse(org *openchoreov1alpha1.Org
 	description := org.Annotations[controller.AnnotationKeyDescription]
 
 	// Get status from conditions
-	status := statusUnknown
+	status := apistatus.Unknown
 	if len(org.Status.Conditions) > 0 {
 		// Get the latest condition
 		latestCondition := org.Status.Conditions[len(org.Status.Conditions)-1]
 		if latestCondition.Status == metav1.ConditionTrue {
-			status = statusReady
+			status = apistatus.Ready
 		} else {
-			status = statusNotReady
+			status = apistatus.NotReady
 		}
 	}
 

--- a/internal/openchoreo-api/services/project_service.go
+++ b/internal/openchoreo-api/services/project_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	apistatus "github.com/openchoreo/openchoreo/internal/openchoreo-api/status"
 )
 
 // ProjectService handles project-related business logic
@@ -192,14 +193,14 @@ func (s *ProjectService) toProjectResponse(project *openchoreov1alpha1.Project) 
 	description := project.Annotations[controller.AnnotationKeyDescription]
 
 	// Get status from conditions
-	status := statusUnknown
+	status := apistatus.Unknown
 	if len(project.Status.Conditions) > 0 {
 		// Get the latest condition
 		latestCondition := project.Status.Conditions[len(project.Status.Conditions)-1]
 		if latestCondition.Status == metav1.ConditionTrue {
-			status = statusReady
+			status = apistatus.Ready
 		} else {
-			status = statusNotReady
+			status = apistatus.NotReady
 		}
 	}
 

--- a/internal/openchoreo-api/services/secretreference_service.go
+++ b/internal/openchoreo-api/services/secretreference_service.go
@@ -17,6 +17,7 @@ import (
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	apistatus "github.com/openchoreo/openchoreo/internal/openchoreo-api/status"
 )
 
 // SecretReferenceService handles secret reference-related business logic
@@ -114,14 +115,14 @@ func (s *SecretReferenceService) toSecretReferenceResponse(secretRef *openchoreo
 	}
 
 	// Get status from conditions
-	status := statusUnknown
+	status := apistatus.Unknown
 	if len(secretRef.Status.Conditions) > 0 {
 		// Get the latest condition
 		latestCondition := secretRef.Status.Conditions[len(secretRef.Status.Conditions)-1]
 		if latestCondition.Status == metav1.ConditionTrue {
-			status = statusReady
+			status = apistatus.Ready
 		} else {
-			status = statusNotReady
+			status = apistatus.NotReady
 		}
 	}
 

--- a/internal/openchoreo-api/status/status.go
+++ b/internal/openchoreo-api/status/status.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package status provides shared status constants for the OpenChoreo API service layer.
+package status
+
+// Resource status values used across API services.
+const (
+	Ready    = "Ready"
+	NotReady = "NotReady"
+	Unknown  = "Unknown"
+	Failed   = "Failed"
+)


### PR DESCRIPTION
## Summary
- Created a new `status` package under `internal/openchoreo-api/status/` to consolidate duplicated status constants
- Updated 7 service files to use the shared status package instead of local constants
- Addresses the TODO comment in `component_service.go:32` requesting constants be moved to a shared package

## Changes
| File | Description |
|------|-------------|
| `status/status.go` | New shared status constants package |
| `component_service.go` | Removed local constants, uses `apistatus` |
| `dataplane_service.go` | Uses `apistatus` package |
| `environment_service.go` | Uses `apistatus` package |
| `organization_service.go` | Uses `apistatus` package |
| `project_service.go` | Uses `apistatus` package |
| `secretreference_service.go` | Uses `apistatus` package |
| `deployment_pipeline_service.go` | Uses `apistatus` package |

## Test plan
- [x] All unit tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`go build ./internal/openchoreo-api/...`)