### PR TITLE
Add post-upgrade hook for default Project resource

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/project.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/project.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.global.defaultResources.enabled }}
+{{- if .Values.global.defaultResources.enabled }}
+{{- if not (lookup "openchoreo.dev/v1alpha1" "Project" "default" "default") }}
 apiVersion: openchoreo.dev/v1alpha1
 kind: Project
 metadata:
@@ -7,11 +8,13 @@ metadata:
   annotations:
     openchoreo.dev/display-name: {{ .Values.global.defaultResources.project.displayName }}
     openchoreo.dev/description: {{ .Values.global.defaultResources.project.description }}
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "7"
+    "helm.sh/hook-delete-policy": hook-failed
   labels:
     openchoreo.dev/organization: default
     openchoreo.dev/name: default
 spec:
   deploymentPipelineRef: default
-{{ end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Purpose
### Problem
The default Project resource was only created via a `post-install` hook. This caused issues in scenarios where:

1. The initial `helm install` timed out before the post-install hook could run
2. Users couldn't recover by running `helm upgrade` since there was no `post-upgrade` hook to create the missing resource

### Solution
Added `post-upgrade` to the Helm hook annotation so the default Project resource can be created during upgrades if it doesn't exist.

### Additional fixes required:
1. **Hook deletion policy**: Helm's default hook deletion policy (`before-hook-creation`) deletes the resource before each upgrade, causing the Project to be deleted and recreated unnecessarily. Added `"helm.sh/hook-delete-policy": hook-failed` to only delete the hook resource if it fails.

2. **Duplicate resource error**: With `post-upgrade` enabled, subsequent upgrades fail with `projects.openchoreo.dev "default" already exists`. Added a `lookup` check to skip creation if the resource already exists.

## Approach
### Changes
- Add `post-upgrade` to the Helm hook annotation
- Add `hook-delete-policy: hook-failed` to prevent resource deletion on successful upgrades
- Added `lookup` check to skip Project creation if it already exists

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
