### PR TITLE
Add workload and configurations to trait CEL context

### DIFF
--- a/internal/pipeline/component/context/configuration.go
+++ b/internal/pipeline/component/context/configuration.go
@@ -7,12 +7,12 @@ import (
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 )
 
-// extractConfigurationsFromWorkload extracts env and file configurations from all containers
+// ExtractConfigurationsFromWorkload extracts env and file configurations from all containers
 // and organizes them by container name with configs vs secrets separation.
 // Returns a map where each key is a container name, and the value contains configs and secrets.
 // Always initializes empty slices for envs and files to ensure they're never nil.
 // Example structure: {"app": {"configs": {"envs": [...], "files": [...]}, "secrets": {"envs": [...], "files": [...]}}}
-func extractConfigurationsFromWorkload(secretReferences map[string]*v1alpha1.SecretReference, workload *v1alpha1.Workload) ContainerConfigurationsMap {
+func ExtractConfigurationsFromWorkload(secretReferences map[string]*v1alpha1.SecretReference, workload *v1alpha1.Workload) ContainerConfigurationsMap {
 	result := make(ContainerConfigurationsMap)
 
 	// Process all containers in the workload

--- a/internal/pipeline/component/context/configuration_test.go
+++ b/internal/pipeline/component/context/configuration_test.go
@@ -545,7 +545,7 @@ func TestExtractConfigurationsFromWorkload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractConfigurationsFromWorkload(tt.secretReferences, tt.workload)
+			got := ExtractConfigurationsFromWorkload(tt.secretReferences, tt.workload)
 
 			// Convert to map[string]any for comparison with expected values
 			gotAny, err := structToMap(got)
@@ -554,7 +554,7 @@ func TestExtractConfigurationsFromWorkload(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tt.want, gotAny, sortSliceByName()); diff != "" {
-				t.Errorf("extractConfigurationsFromWorkload() mismatch (-want +got):\n%s", diff)
+				t.Errorf("ExtractConfigurationsFromWorkload() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/pipeline/component/context/trait.go
+++ b/internal/pipeline/component/context/trait.go
@@ -65,6 +65,8 @@ func BuildTraitContext(input *TraitContextInput) (*TraitContext, error) {
 	}
 
 	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
+	ctx.Workload = input.WorkloadData
+	ctx.Configurations = input.Configurations
 
 	return ctx, nil
 }

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -82,11 +82,9 @@ func BuildComponentCELEnv(opts SchemaOptions) (*cel.Env, error) {
 // BuildTraitCELEnv creates a schema-aware CEL environment for trait validation.
 // Variables are derived from TraitContext struct fields:
 //   - parameters, envOverrides: Schema-aware types (or empty object if not provided)
-//   - trait, metadata, dataplane: Types derived via reflection
-//
-// Note: Traits don't have access to workload or configurations (not in TraitContext)
+//   - trait, metadata, dataplane, workload, configurations: Types derived via reflection
 func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, error) {
-	baseEnv, err := createBaseEnv(false)
+	baseEnv, err := createBaseEnv(true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/validation/component/cel_validator_test.go
+++ b/internal/validation/component/cel_validator_test.go
@@ -242,29 +242,19 @@ func TestCELValidator_IterableExpression_Invalid(t *testing.T) {
 	}
 }
 
-func TestCELValidator_TraitResource_NoWorkloadAccess(t *testing.T) {
-	// Trait validator should not allow access to workload-related variables
+func TestCELValidator_TraitResource_AllVariables(t *testing.T) {
+	// Trait validator should allow access to all variables including workload and configurations
 	validator, err := NewCELValidator(TraitResource, SchemaOptions{})
 	require.NoError(t, err)
 
-	// These should fail - trait context doesn't have these variables
-	invalidExprs := []string{
-		"workload.containers",
-		"configurations.app",
-	}
-
-	for _, expr := range invalidExprs {
-		t.Run(expr, func(t *testing.T) {
-			err := validator.ValidateExpression(expr)
-			assert.Error(t, err, "Trait should not have access to '%s'", expr)
-		})
-	}
-
-	// These should work - trait has access to these
+	// All trait context variables should be accessible
 	validExprs := []string{
 		"trait.instanceName",
 		"metadata.name",
 		"dataplane.secretStore",
+		"workload.containers",
+		"workload.endpoints",
+		"configurations.app",
 	}
 
 	for _, expr := range validExprs {
@@ -285,6 +275,7 @@ func TestCELValidator_ComponentTypeResource_AllVariables(t *testing.T) {
 		"metadata.name",
 		"metadata.namespace",
 		"workload.containers",
+		"workload.endpoints",
 		"configurations.app",
 		"dataplane.secretStore",
 	}


### PR DESCRIPTION
## Purpose
Traits now have access to the same workload and configurations variables as ComponentTypes, including workload.endpoints and all configuration helper methods.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> closes https://github.com/openchoreo/openchoreo/issues/1517

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
