### PR TITLE
Enable connection upgrades for websocket in dataplane gateway

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/gateway/httplistenerpolicy.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/httplistenerpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: default-httplistenerpolicy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.componentLabels" (dict "context" . "component" "gateway") | nindent 4 }}
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway-default
+  upgradeConfig:
+    enabledUpgrades:
+    - websocket
+{{- end }}


### PR DESCRIPTION
## Purpose
This PR enables connection upgrades for websocket connections in the dataplane gateway.

## Approach
Add a `HTTPListenerPolicy` for connection upgrades.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1478
