### PR TITLE
Enable external-secrets CRD in quick start guide

### DIFF
--- a/install/quick-start/.values-dp.yaml
+++ b/install/quick-start/.values-dp.yaml
@@ -55,3 +55,6 @@ security:
 
 observability:
   enabled: false
+
+external-secrets:
+  enabled: true


### PR DESCRIPTION
## Purpose

This pull request makes a small change to the `install/quick-start/.values-dp.yaml` file by enabling the `external-secrets` feature in the configuration.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
