### PR TITLE
Update APIM trait to create unique backends for components

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-traits/api-management.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-traits/api-management.yaml
@@ -52,7 +52,7 @@ spec:
         apiVersion: gateway.kgateway.dev/v1alpha1
         kind: Backend
         metadata:
-          name: api-platform-default-gateway-router
+          name: ${metadata.componentName}-api-gw-backend
           namespace: ${metadata.namespace}
         spec:
           type: Static
@@ -96,7 +96,7 @@ spec:
           value:
             group: gateway.kgateway.dev
             kind: Backend
-            name: api-platform-default-gateway-router
+            name: ${metadata.componentName}-api-gw-backend
 
         # Update the URLRewrite filter to rewrite to the API context
         - op: replace


### PR DESCRIPTION
## Purpose
This PR updates the APIM trait to create unique backends for the APIM gateway router. This is required as a workaround for K8s Gateway API reference grants.

Related to https://github.com/openchoreo/openchoreo/pull/1304
