### PR TITLE
Disable resolved alerts from Prometheus

### DIFF
--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1714,7 +1714,7 @@ prometheus:
         - name: 'openchoreo-alerts'
           webhook_configs:
             - url: 'http://observer.openchoreo-observability-plane.svc.cluster.local:8080/api/alerting/webhook/prometheus'
-              send_resolved: true
+              send_resolved: false
         - name: 'null'
 
   # @schema

--- a/internal/observer/handlers/handlers.go
+++ b/internal/observer/handlers/handlers.go
@@ -1043,7 +1043,7 @@ func (h *Handler) AlertingWebhook(w http.ResponseWriter, r *http.Request) {
 	ruleName, ruleNamespace, alertValue, timestamp, err := h.parseWebhookPayload(w, r)
 	if err != nil {
 		// Check if alert is not in firing state (ignore 'resolved' alerts from Prometheus)
-		if errors.Is(err, fmt.Errorf("alert is not in firing state")) {
+		if err.Error() == "alert is not in firing state" {
 			h.logger.Debug("Only alerts in firing state are processed. Non firing state (e.g. resolved alerts) are ignored.")
 			h.writeJSON(w, http.StatusOK, map[string]interface{}{
 				"message": "Alert ignored (not in firing state)",


### PR DESCRIPTION
## Purpose
- Set send_resolved to false in Prometheus webhook config to prevent resolved alerts from being sent to the observer
- Fix error comparison in AlertingWebhook handler to use direct string comparison instead of errors.Is with fmt.Errorf, which doesn't work correctly for error matching

Follow up for PR https://github.com/openchoreo/openchoreo/pull/1466

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1384

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
