### PR TITLE
Allow CEL expressions as standalone trait patch values

### DIFF
--- a/api/v1alpha1/trait_types.go
+++ b/api/v1alpha1/trait_types.go
@@ -179,8 +179,11 @@ type JSONPatchOperation struct {
 
 	// Value is the value to set (for add/replace operations)
 	// Not used for remove operations
+	// Can be a literal value, a structure with embedded CEL expressions,
+	// or a standalone CEL expression.
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Value *runtime.RawExtension `json:"value,omitempty"`
 }
 

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -323,7 +323,8 @@ spec:
                                   description: |-
                                     Value is the value to set (for add/replace operations)
                                     Not used for remove operations
-                                  type: object
+                                    Can be a literal value, a structure with embedded CEL expressions,
+                                    or a standalone CEL expression.
                                   x-kubernetes-preserve-unknown-fields: true
                               required:
                               - op

--- a/config/crd/bases/openchoreo.dev_traits.yaml
+++ b/config/crd/bases/openchoreo.dev_traits.yaml
@@ -133,7 +133,8 @@ spec:
                             description: |-
                               Value is the value to set (for add/replace operations)
                               Not used for remove operations
-                            type: object
+                              Can be a literal value, a structure with embedded CEL expressions,
+                              or a standalone CEL expression.
                             x-kubernetes-preserve-unknown-fields: true
                         required:
                         - op

--- a/docs/templating/patching.md
+++ b/docs/templating/patching.md
@@ -56,10 +56,29 @@ CEL expressions (enclosed in `${...}`) can be used in the following patch fields
   path: /spec/containers[?(@.name=='${metadata.name}')]/env/-
   ```
 
-- **`value`** - Dynamic values from parameters, metadata, or computations
+- **`value`** - The value to set. Can be:
+
+  Literal value:
   ```yaml
-  value: ${parameters.port}
+  value: "enabled"
+  ```
+
+  String interpolation:
+  ```yaml
   value: ${metadata.name}-sidecar
+  ```
+
+  Structure with embedded CEL:
+  ```yaml
+  value:
+    name: ${parameters.volumeName}
+    persistentVolumeClaim:
+      claimName: ${metadata.name}-pvc
+  ```
+
+  Standalone CEL expression:
+  ```yaml
+  value: ${configurations.toContainerEnvFrom(container.key)}
   ```
 
 ## Supported Operations

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -322,7 +322,8 @@ spec:
                                   description: |-
                                     Value is the value to set (for add/replace operations)
                                     Not used for remove operations
-                                  type: object
+                                    Can be a literal value, a structure with embedded CEL expressions,
+                                    or a standalone CEL expression.
                                   x-kubernetes-preserve-unknown-fields: true
                               required:
                               - op

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_traits.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_traits.yaml
@@ -132,7 +132,8 @@ spec:
                             description: |-
                               Value is the value to set (for add/replace operations)
                               Not used for remove operations
-                            type: object
+                              Can be a literal value, a structure with embedded CEL expressions,
+                              or a standalone CEL expression.
                             x-kubernetes-preserve-unknown-fields: true
                         required:
                         - op

--- a/internal/webhook/trait/webhook_test.go
+++ b/internal/webhook/trait/webhook_test.go
@@ -269,5 +269,27 @@ var _ = Describe("Trait Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid CEL expression"))
 		})
+
+		It("should admit patches with CEL expression as entire value", func() {
+			obj.Spec.Patches = []openchoreodevv1alpha1.TraitPatch{
+				{
+					Target: openchoreodevv1alpha1.PatchTarget{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+					Operations: []openchoreodevv1alpha1.JSONPatchOperation{
+						{
+							Op:    "add",
+							Path:  "/metadata/labels",
+							Value: &runtime.RawExtension{Raw: []byte(`"${metadata.labels}"`)},
+						},
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
## Purpose
Add Schemaless marker to JSONPatchOperation.Value field, enabling patches like: `value: ${configurations.toContainerEnvFrom(key)`

## Approach
> Summarize the solution and implementation details.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/1517

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
