### PR TITLE
Add file-system mode support for occ workload create

### DIFF
--- a/internal/occ/cmd/create/workload/workload.go
+++ b/internal/occ/cmd/create/workload/workload.go
@@ -5,11 +5,17 @@ package workload
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/config"
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode/output"
 	"github.com/openchoreo/openchoreo/internal/occ/resources/kinds"
 	"github.com/openchoreo/openchoreo/internal/occ/validation"
+	configContext "github.com/openchoreo/openchoreo/pkg/cli/cmd/config"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
 	"github.com/openchoreo/openchoreo/pkg/cli/types/api"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/cache"
 )
 
 type CreateWorkloadImpl struct {
@@ -27,11 +33,37 @@ func (i *CreateWorkloadImpl) CreateWorkload(params api.CreateWorkloadParams) err
 		return err
 	}
 
-	return createWorkload(params, i.config)
+	// Load config to check current mode
+	cfg, err := config.LoadStoredConfig()
+	if err != nil {
+		// If no config, default to API server mode (existing behavior)
+		return i.createWorkloadAPIServerMode(params)
+	}
+
+	// Get current context
+	var ctx *configContext.Context
+	if cfg.CurrentContext != "" {
+		for _, c := range cfg.Contexts {
+			if c.Name == cfg.CurrentContext {
+				ctxCopy := c
+				ctx = &ctxCopy
+				break
+			}
+		}
+	}
+
+	// Route to appropriate implementation based on mode
+	if ctx != nil && ctx.Mode == configContext.ModeFileSystem {
+		return i.createWorkloadFileSystemMode(ctx, params)
+	}
+
+	// Default: API server mode (existing implementation)
+	return i.createWorkloadAPIServerMode(params)
 }
 
-func createWorkload(params api.CreateWorkloadParams, config constants.CRDConfig) error {
-	workloadRes, err := kinds.NewWorkloadResource(config, params.OrganizationName)
+// createWorkloadAPIServerMode handles the existing API server mode logic
+func (i *CreateWorkloadImpl) createWorkloadAPIServerMode(params api.CreateWorkloadParams) error {
+	workloadRes, err := kinds.NewWorkloadResource(i.config, params.OrganizationName)
 	if err != nil {
 		return fmt.Errorf("failed to create Workload resource: %w", err)
 	}
@@ -40,5 +72,59 @@ func createWorkload(params api.CreateWorkloadParams, config constants.CRDConfig)
 		return fmt.Errorf("failed to create workload from descriptor '%s': %w", params.FilePath, err)
 	}
 
+	return nil
+}
+
+// createWorkloadFileSystemMode handles file-system mode for GitOps repos
+func (i *CreateWorkloadImpl) createWorkloadFileSystemMode(ctx *configContext.Context, params api.CreateWorkloadParams) error {
+	// Determine repo path
+	repoPath := ctx.RootDirectoryPath
+	if repoPath == "" {
+		var err error
+		repoPath, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+	}
+
+	// Load or build index
+	fmt.Println("Loading index...")
+	persistentIndex, err := cache.LoadOrBuild(repoPath)
+	if err != nil {
+		return fmt.Errorf("failed to build filesystem index: %w", err)
+	}
+
+	// Wrap generic index with OpenChoreo-specific functionality
+	idx := fsmode.WrapIndex(persistentIndex.Index)
+
+	// Generate workload CR using existing logic
+	workloadRes, err := kinds.NewWorkloadResource(i.config, params.OrganizationName)
+	if err != nil {
+		return fmt.Errorf("failed to create Workload resource: %w", err)
+	}
+
+	workloadCR, err := workloadRes.GenerateWorkloadCR(params)
+	if err != nil {
+		return fmt.Errorf("failed to generate workload: %w", err)
+	}
+
+	// Create writer and write workload
+	writer := output.NewWorkloadWriter(idx)
+	writtenPath, err := writer.WriteWorkload(output.WorkloadWriteParams{
+		Namespace:     params.OrganizationName,
+		RepoPath:      repoPath,
+		ProjectName:   params.ProjectName,
+		ComponentName: params.ComponentName,
+		OutputPath:    params.OutputPath,
+		WorkloadCR:    workloadCR,
+		DryRun:        params.DryRun,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !params.DryRun {
+		fmt.Printf("Workload written to: %s\n", writtenPath)
+	}
 	return nil
 }

--- a/internal/occ/fsmode/output/workload_writer.go
+++ b/internal/occ/fsmode/output/workload_writer.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	synth "github.com/openchoreo/openchoreo/internal/occ/resources/workload"
+)
+
+// WorkloadWriteParams contains parameters for writing a workload in file-system mode
+type WorkloadWriteParams struct {
+	Namespace     string
+	RepoPath      string
+	ProjectName   string
+	ComponentName string
+	OutputPath    string                       // If specified, always use this path
+	WorkloadCR    *openchoreov1alpha1.Workload // The generated workload CR
+	DryRun        bool
+}
+
+// WorkloadWriter handles writing workloads in file-system mode
+type WorkloadWriter struct {
+	index *fsmode.Index
+}
+
+// NewWorkloadWriter creates a new WorkloadWriter
+func NewWorkloadWriter(idx *fsmode.Index) *WorkloadWriter {
+	return &WorkloadWriter{index: idx}
+}
+
+// WriteWorkload writes a workload to the appropriate location
+func (w *WorkloadWriter) WriteWorkload(params WorkloadWriteParams) (string, error) {
+	// Convert workload to YAML
+	yamlContent, err := synth.ConvertWorkloadCRToYAML(params.WorkloadCR)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert workload to YAML: %w", err)
+	}
+
+	// Determine output path
+	outputPath := w.resolveOutputPath(params)
+
+	// Handle dry-run mode
+	if params.DryRun {
+		fmt.Println(string(yamlContent))
+		return outputPath, nil
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	// Write file
+	if err := os.WriteFile(outputPath, yamlContent, 0600); err != nil {
+		return "", fmt.Errorf("failed to write workload to %s: %w", outputPath, err)
+	}
+
+	return outputPath, nil
+}
+
+// resolveOutputPath determines where to write the workload
+func (w *WorkloadWriter) resolveOutputPath(params WorkloadWriteParams) string {
+	// Priority 1: Explicit output path from CLI flag
+	if params.OutputPath != "" {
+		if filepath.IsAbs(params.OutputPath) {
+			return params.OutputPath
+		}
+		return filepath.Join(params.RepoPath, params.OutputPath)
+	}
+
+	// Priority 2: Check if workload already exists for this component
+	existingWorkload, ok := w.index.GetWorkloadForComponent(params.ProjectName, params.ComponentName)
+	if ok && existingWorkload != nil {
+		// Replace existing workload file
+		return existingWorkload.FilePath
+	}
+
+	workloadFileName := "workload.yaml"
+
+	// Priority 3: Find component location and write alongside it
+	component, ok := w.index.GetComponent(params.Namespace, params.ComponentName)
+	if ok && component != nil {
+		componentDir := filepath.Dir(component.FilePath)
+		return filepath.Join(componentDir, workloadFileName)
+	}
+
+	// Priority 4: Default path structure
+	return filepath.Join(
+		params.RepoPath,
+		"projects",
+		params.ProjectName,
+		"components",
+		params.ComponentName,
+		workloadFileName,
+	)
+}

--- a/internal/occ/resources/kinds/workload.go
+++ b/internal/occ/resources/kinds/workload.go
@@ -147,3 +147,40 @@ func (w *WorkloadResource) Print(format resources.OutputFormat, filter *resource
 	// For now, return a helpful message
 	return fmt.Errorf("workload listing not yet implemented - use 'occ get workload' command instead")
 }
+
+// GenerateWorkloadCR generates a Workload CR without writing it (used in file-system mode)
+func (w *WorkloadResource) GenerateWorkloadCR(params api.CreateWorkloadParams) (*openchoreov1alpha1.Workload, error) {
+	// Validate required parameters
+	if params.OrganizationName == "" {
+		return nil, fmt.Errorf("organization name is required (--organization)")
+	}
+	if params.ProjectName == "" {
+		return nil, fmt.Errorf("project name is required (--project)")
+	}
+	if params.ComponentName == "" {
+		return nil, fmt.Errorf("component name is required (--component)")
+	}
+	if params.ImageURL == "" {
+		return nil, fmt.Errorf("image URL is required (--image)")
+	}
+
+	var workloadCR *openchoreov1alpha1.Workload
+	var err error
+
+	// Check if a descriptor file is provided
+	if params.FilePath != "" {
+		// Create workload from descriptor file
+		workloadCR, err = synth.ConvertWorkloadDescriptorToWorkloadCR(params.FilePath, params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert workload descriptor: %w", err)
+		}
+	} else {
+		// Create basic workload from command line parameters
+		workloadCR, err = synth.CreateBasicWorkload(params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create basic workload CR: %w", err)
+		}
+	}
+
+	return workloadCR, nil
+}

--- a/internal/occ/resources/workload/converter.go
+++ b/internal/occ/resources/workload/converter.go
@@ -172,7 +172,8 @@ func createBaseWorkload(workloadName string, params api.CreateWorkloadParams) *o
 			Kind:       "Workload",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: workloadName,
+			Name:      workloadName,
+			Namespace: params.OrganizationName,
 		},
 		Spec: openchoreov1alpha1.WorkloadSpec{
 			Owner: openchoreov1alpha1.WorkloadOwner{
@@ -390,7 +391,8 @@ func ConvertWorkloadCRToYAML(workload *openchoreov1alpha1.Workload) ([]byte, err
 		APIVersion string `json:"apiVersion" yaml:"apiVersion"`
 		Kind       string `json:"kind" yaml:"kind"`
 		Metadata   struct {
-			Name string `json:"name" yaml:"name"`
+			Name      string `json:"name" yaml:"name"`
+			Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 		} `json:"metadata" yaml:"metadata"`
 		Spec struct {
 			Owner       openchoreov1alpha1.WorkloadOwner                 `json:"owner" yaml:"owner"`
@@ -398,16 +400,15 @@ func ConvertWorkloadCRToYAML(workload *openchoreov1alpha1.Workload) ([]byte, err
 			Endpoints   map[string]openchoreov1alpha1.WorkloadEndpoint   `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 			Connections map[string]openchoreov1alpha1.WorkloadConnection `json:"connections,omitempty" yaml:"connections,omitempty"`
 		} `json:"spec" yaml:"spec"`
-		Status openchoreov1alpha1.WorkloadStatus `json:"status,omitempty" yaml:"status,omitempty"`
 	}
 
 	// Create the ordered structure
 	ordered := orderedWorkload{
 		APIVersion: workload.APIVersion,
 		Kind:       workload.Kind,
-		Status:     workload.Status,
 	}
 	ordered.Metadata.Name = workload.Name
+	ordered.Metadata.Namespace = workload.Namespace
 	ordered.Spec.Owner = workload.Spec.Owner
 	ordered.Spec.Containers = workload.Spec.Containers
 	ordered.Spec.Endpoints = workload.Spec.Endpoints

--- a/pkg/cli/cmd/create/create.go
+++ b/pkg/cli/cmd/create/create.go
@@ -111,6 +111,7 @@ func newCreateWorkloadCmd(impl api.CommandImplementationInterface) *cobra.Comman
 		flags.Image,
 		flags.Output,
 		flags.WorkloadDescriptor,
+		flags.DryRun,
 	)
 
 	return (&builder.CommandBuilder{
@@ -124,6 +125,7 @@ func newCreateWorkloadCmd(impl api.CommandImplementationInterface) *cobra.Comman
 				ComponentName:    fg.GetString(flags.Component),
 				ImageURL:         fg.GetString(flags.Image),
 				OutputPath:       fg.GetString(flags.Output),
+				DryRun:           fg.GetBool(flags.DryRun),
 			})
 		},
 	}).Build()

--- a/pkg/cli/types/api/params.go
+++ b/pkg/cli/types/api/params.go
@@ -316,6 +316,7 @@ type CreateWorkloadParams struct {
 	ComponentName    string
 	ImageURL         string
 	OutputPath       string
+	DryRun           bool
 }
 
 // ScaffoldComponentParams defines parameters for scaffolding a component


### PR DESCRIPTION
## Purpose

### Summary

Adds file-system mode support for `occ workload create` command, enabling management of workloads in GitOps repositories where the CLI operates against the local filesystem.

### Motivation

When using OpenChoreo in GitOps mode, users need to generate and manage Workload CRs in their Git repository without connecting to an API server. This PR implements that capability following the same patterns used by `occ component-release generate`.

### Example Usage                                                                                                                                                                           

```shell                                                                                                                                                                                
# Set file-system mode context                                                                                                                                                          
occ config set-context --mode file-system --root-directory /path/to/gitops-repo                                                                                                         
                                                                                                                                                                                          
# Create workload (auto-detects location)                                                                                                                                               
occ create workload --project myproject --component myservice --image nginx:latest                                                                                                      
                                                                                                                                                                                          
# Create with explicit output                                                                                                                                                           
occ create workload --project myproject --component myservice \ 
--image nginx:latest --output custom/path.yaml                                                                                                                                        
                                                                                                                                                                                          
# Create with descriptor                                                                                                                                                                
occ create workload --project myproject --component myservice \ 
--image nginx:latest --descriptor workload-descriptor.yaml                                                                                                                            
                                                                                                                                                                                          
# Preview without writing (dry-run)                                                                                                                                                     
occ create workload --project myproject --component myservice \ 
--image nginx:latest --dry-run 
```                                                                                                                                                                                    

### Design Decisions                                                                                                                                                                        
                                                                                                                                                                                          
  1. Follows existing patterns: Implementation mirrors component-release generate for consistency                                                                                         
  2. Intelligent path resolution: 4-level priority system matches user expectations                                                                                                       
  3. Separation of concerns: GenerateWorkloadCR() separates CR generation from I/O operations                                                                                             
  4. Backward compatible: API server mode unchanged, file-system mode only active when context is set                                                                                     
  5. Index-based: Uses existing filesystem index for efficient lookups

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
