### PR TITLE
Add helm-schema generation to helm charts

### DIFF
--- a/install/helm/openchoreo-build-plane/values.schema.json
+++ b/install/helm/openchoreo-build-plane/values.schema.json
@@ -21,14 +21,12 @@
                     "cpu": {
                       "default": "50m",
                       "description": "CPU limit for the controller",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "64Mi",
                       "description": "Memory limit for the controller",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -44,14 +42,12 @@
                     "cpu": {
                       "default": "25m",
                       "description": "CPU request for the controller",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "32Mi",
                       "description": "Memory request for the controller",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -77,7 +73,6 @@
             "keep": {
               "default": false,
               "description": "Keep CRDs on chart uninstall",
-              "required": [],
               "title": "keep",
               "type": "boolean"
             }
@@ -89,7 +84,6 @@
         "fullnameOverride": {
           "default": "argo",
           "description": "Override the full name of Argo Workflows resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -100,7 +94,6 @@
             "enabled": {
               "default": false,
               "description": "Enable the Argo Workflows server UI",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -120,7 +113,6 @@
                 "create": {
                   "default": true,
                   "description": "Create service account for workflows",
-                  "required": [],
                   "title": "create",
                   "type": "boolean"
                 }
@@ -137,10 +129,8 @@
         "workflowNamespaces": {
           "description": "Namespaces where Argo Workflows can submit workflows",
           "items": {
-            "required": [],
             "type": "string"
           },
-          "required": [],
           "title": "workflowNamespaces",
           "type": "array"
         }
@@ -167,7 +157,6 @@
             "enabled": {
               "default": false,
               "description": "Enable DNS rewrite for k3d setups",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -179,14 +168,12 @@
         "enabled": {
           "default": true,
           "description": "Enable the cluster agent for control plane communication",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "heartbeatInterval": {
           "default": "30s",
           "description": "Heartbeat interval for control plane connection",
-          "required": [],
           "title": "heartbeatInterval",
           "type": "string"
         },
@@ -208,14 +195,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/cluster-agent",
               "description": "Image repository for cluster agent",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. If empty, uses Chart.AppVersion.",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -239,7 +224,6 @@
         "name": {
           "default": "cluster-agent-buildplane",
           "description": "Name of the cluster agent deployment",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -253,7 +237,6 @@
         "planeID": {
           "default": "default-buildplane",
           "description": "Logical plane identifier. Shared across multiple CRs connecting to the same physical plane for multi-tenancy.",
-          "required": [],
           "title": "planeID",
           "type": "string"
         },
@@ -281,19 +264,16 @@
           "properties": {
             "fsGroup": {
               "default": 1000,
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
             "runAsUser": {
               "default": 1000,
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -313,21 +293,18 @@
             "create": {
               "default": false,
               "description": "Create priority class",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-agent-buildplane",
               "description": "Priority class name",
-              "required": [],
               "title": "name",
               "type": "string"
             },
             "value": {
               "default": 900000,
               "description": "Priority value",
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -343,7 +320,6 @@
             "create": {
               "default": true,
               "description": "Create RBAC resources",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -355,7 +331,6 @@
         "reconnectDelay": {
           "default": "5s",
           "description": "Delay before reconnecting on disconnection",
-          "required": [],
           "title": "reconnectDelay",
           "type": "string"
         },
@@ -363,7 +338,6 @@
           "default": 1,
           "description": "Number of cluster agent replicas",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -377,13 +351,11 @@
               "properties": {
                 "cpu": {
                   "default": "100m",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -401,13 +373,11 @@
               "properties": {
                 "cpu": {
                   "default": "50m",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -430,7 +400,6 @@
           "properties": {
             "allowPrivilegeEscalation": {
               "default": false,
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -441,13 +410,11 @@
                   "items": {
                     "anyOf": [
                       {
-                        "required": [],
                         "type": "string"
                       }
                     ],
                     "required": []
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -460,7 +427,6 @@
             },
             "readOnlyRootFilesystem": {
               "default": true,
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             }
@@ -476,14 +442,12 @@
         "serverCANamespace": {
           "default": "openchoreo-control-plane",
           "description": "Namespace where cluster-gateway CA exists",
-          "required": [],
           "title": "serverCANamespace",
           "type": "string"
         },
         "serverUrl": {
           "default": "wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws",
           "description": "WebSocket URL of the cluster gateway in control plane",
-          "required": [],
           "title": "serverUrl",
           "type": "string"
         },
@@ -501,14 +465,12 @@
             "create": {
               "default": true,
               "description": "Create service account",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-agent-buildplane",
               "description": "Service account name",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -524,77 +486,66 @@
             "caSecretName": {
               "default": "cluster-gateway-ca",
               "description": "CA secret name for signing agent client certificates. If empty, self-signed certs will be generated (required for multi-cluster setup).",
-              "required": [],
               "title": "caSecretName",
               "type": "string"
             },
             "caSecretNamespace": {
               "default": "openchoreo-control-plane",
               "description": "Namespace where the CA secret exists. If empty, self-signed certs will be generated (required for multi-cluster setup).",
-              "required": [],
               "title": "caSecretNamespace",
               "type": "string"
             },
             "caValue": {
               "default": "",
               "description": "Inline CA certificate value (PEM format) for multi-cluster setup",
-              "required": [],
               "title": "caValue",
               "type": "string"
             },
             "clientSecretName": {
               "default": "cluster-agent-tls",
               "description": "Client certificate secret name",
-              "required": [],
               "title": "clientSecretName",
               "type": "string"
             },
             "duration": {
               "default": "2160h",
               "description": "Certificate duration",
-              "required": [],
               "title": "duration",
               "type": "string"
             },
             "enabled": {
               "default": true,
               "description": "Enable TLS for agent communication",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "generateCerts": {
               "default": false,
               "description": "Generate client certificates locally using cert-manager. Set to true for multi-cluster setup.",
-              "required": [],
               "title": "generateCerts",
               "type": "boolean"
             },
             "renewBefore": {
               "default": "360h",
               "description": "Certificate renewal window",
-              "required": [],
               "title": "renewBefore",
               "type": "string"
             },
             "secretName": {
               "default": "cluster-agent-tls",
               "description": "Secret containing client certificate and key",
-              "required": [],
               "title": "secretName",
               "type": "string"
             },
             "serverCAConfigMap": {
               "default": "cluster-gateway-ca",
               "description": "ConfigMap containing server CA certificate for verifying gateway",
-              "required": [],
               "title": "serverCAConfigMap",
               "type": "string"
             },
             "serverCAValue": {
               "default": "",
               "description": "Inline server CA certificate value (PEM format) for multi-cluster setup",
-              "required": [],
               "title": "serverCAValue",
               "type": "string"
             }
@@ -610,7 +561,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         }
@@ -626,21 +576,18 @@
         "enabled": {
           "default": false,
           "description": "Install External Secrets Operator in the build plane",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "external-secrets",
           "description": "Override the full name of External Secrets resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
         "nameOverride": {
           "default": "external-secrets",
           "description": "Override the name of External Secrets resources",
-          "required": [],
           "title": "nameOverride",
           "type": "string"
         }
@@ -656,14 +603,12 @@
         "enabled": {
           "default": true,
           "description": "Enable the fake secret store for development",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "name": {
           "default": "default",
           "description": "Name of the ClusterSecretStore resource",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -674,12 +619,10 @@
             "properties": {
               "key": {
                 "description": "Secret key name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Secret value (fake/development only)",
-                "required": [],
                 "type": "string"
               }
             },
@@ -689,7 +632,6 @@
             ],
             "type": "object"
           },
-          "required": [],
           "title": "secrets",
           "type": "array"
         }
@@ -709,28 +651,24 @@
             "customParsers": {
               "default": "[PARSER]\n    Name docker_no_time\n    Format json\n    Time_Keep Off\n    Time_Key time\n    Time_Format %Y-%m-%dT%H:%M:%S.%L\n",
               "description": "Custom parser definitions in Fluent Bit configuration format",
-              "required": [],
               "title": "customParsers",
               "type": "string"
             },
             "filters": {
               "default": "[FILTER]\n    Name kubernetes\n    Buffer_Size 32MB\n    K8S-Logging.Parser On\n    K8S-Logging.Exclude On\n    Keep_Log On\n    Match kube.*\n    Merge_Log Off\n    tls.verify Off\n    Use_Kubelet true\n",
               "description": "Filter plugin configuration for log processing",
-              "required": [],
               "title": "filters",
               "type": "string"
             },
             "inputs": {
               "default": "[INPUT]\n    Name tail\n    Buffer_Chunk_Size 32KB\n    Buffer_Max_Size 2MB\n    DB /var/lib/fluent-bit/db/tail-container-logs.db\n    Exclude_Path /var/log/containers/fluent-bit-*_openchoreo-build-plane_*.log\n    Inotify_Watcher false\n    Mem_Buf_Limit 256MB\n    Path /var/log/containers/*.log\n    multiline.parser docker, cri\n    Read_from_Head On\n    Refresh_Interval 5\n    Skip_Long_Lines On\n    Tag kube.*\n",
               "description": "Input plugin configuration for log collection",
-              "required": [],
               "title": "inputs",
               "type": "string"
             },
             "outputs": {
               "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
               "description": "Output plugin configuration for log forwarding to OpenSearch",
-              "required": [],
               "title": "outputs",
               "type": "string"
             }
@@ -754,7 +692,6 @@
         "enabled": {
           "default": false,
           "description": "Enable Fluent Bit log collector deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -764,7 +701,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraVolumeMounts",
           "type": "array"
         },
@@ -774,21 +710,18 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraVolumes",
           "type": "array"
         },
         "fullnameOverride": {
           "default": "fluent-bit",
           "description": "Override the full name of Fluent Bit resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
         "hostNetwork": {
           "default": true,
           "description": "Use host network for Fluent Bit pods (required for node log access)",
-          "required": [],
           "title": "hostNetwork",
           "type": "boolean"
         },
@@ -798,7 +731,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "initContainers",
           "type": "array"
         },
@@ -807,7 +739,6 @@
           "description": "Port for Fluent Bit metrics endpoint",
           "maximum": 65535,
           "minimum": 1,
-          "required": [],
           "title": "metricsPort",
           "type": "integer"
         },
@@ -818,7 +749,6 @@
             "nodeAccess": {
               "default": true,
               "description": "Enable node-level access for reading container logs",
-              "required": [],
               "title": "nodeAccess",
               "type": "boolean"
             }
@@ -838,14 +768,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU limit for Fluent Bit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit for Fluent Bit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -861,14 +789,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request for Fluent Bit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request for Fluent Bit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -889,7 +815,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -900,10 +825,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -915,14 +838,12 @@
             "readOnlyRootFilesystem": {
               "default": true,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run container as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
@@ -930,7 +851,6 @@
               "default": 10000,
               "description": "User ID to run the container",
               "minimum": 0,
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -948,7 +868,6 @@
               "description": "Service port for Fluent Bit metrics",
               "maximum": 65535,
               "minimum": 1,
-              "required": [],
               "title": "port",
               "type": "integer"
             }
@@ -964,7 +883,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Fluent Bit test framework",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -988,7 +906,6 @@
           "examples": [
             "openchoreo.example.com"
           ],
-          "required": [],
           "title": "baseDomain",
           "type": "string"
         },
@@ -1010,7 +927,6 @@
                 "enabled": {
                   "default": true,
                   "description": "Enable buildpack image caching hook",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 },
@@ -1021,12 +937,10 @@
                     "properties": {
                       "cacheName": {
                         "description": "Local cache name for the image in the build plane registry",
-                        "required": [],
                         "type": "string"
                       },
                       "source": {
                         "description": "Source image to pull from remote registry",
-                        "required": [],
                         "type": "string"
                       }
                     },
@@ -1036,7 +950,6 @@
                     ],
                     "type": "object"
                   },
-                  "required": [],
                   "title": "images",
                   "type": "array"
                 }
@@ -1048,7 +961,6 @@
             "enabled": {
               "default": true,
               "description": "If true, applies the workflow templates",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1059,14 +971,12 @@
                 "size": {
                   "default": "10Gi",
                   "description": "Size of the persistent volume for podman image layer cache",
-                  "required": [],
                   "title": "size",
                   "type": "string"
                 },
                 "storageClass": {
                   "default": "",
                   "description": "Storage class for the cache PVC. Uses cluster default if not set.",
-                  "required": [],
                   "title": "storageClass",
                   "type": "string"
                 }
@@ -1082,14 +992,12 @@
                 "endpoint": {
                   "default": "registry.openchoreo-build-plane.svc.cluster.local:5000",
                   "description": "Registry endpoint for pushing and pulling images. For external registry with baseDomain, automatically uses registry.\u003cbaseDomain\u003e.",
-                  "required": [],
                   "title": "endpoint",
                   "type": "string"
                 },
                 "tlsVerify": {
                   "default": false,
                   "description": "Enable TLS verification when pushing images to the registry. Set to false for self-signed certificates or local development.",
-                  "required": [],
                   "title": "tlsVerify",
                   "type": "boolean"
                 }
@@ -1106,7 +1014,6 @@
         "ingressClassName": {
           "default": "openchoreo-traefik",
           "description": "Ingress class name for registry ingress",
-          "required": [],
           "title": "ingressClassName",
           "type": "string"
         },
@@ -1117,14 +1024,12 @@
             "enabled": {
               "default": false,
               "description": "Enable TLS for registry ingress",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "secretName": {
               "default": "registry-tls",
               "description": "Secret containing TLS certificate for registry",
-              "required": [],
               "title": "secretName",
               "type": "string"
             }
@@ -1145,7 +1050,6 @@
         "fullnameOverride": {
           "default": "registry",
           "description": "Override the full name of registry resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -1163,14 +1067,12 @@
             "className": {
               "default": "",
               "description": "Ingress class name. Falls back to global.ingressClassName if not set.",
-              "required": [],
               "title": "className",
               "type": "string"
             },
             "enabled": {
               "default": false,
               "description": "Enable ingress for external registry access",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1181,14 +1083,12 @@
                 "enabled": {
                   "default": false,
                   "description": "Enable TLS for registry ingress",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 },
                 "secretName": {
                   "default": "",
                   "description": "Secret containing TLS certificate",
-                  "required": [],
                   "title": "secretName",
                   "type": "string"
                 }
@@ -1209,14 +1109,12 @@
             "enabled": {
               "default": true,
               "description": "Enable persistent storage for registry",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "size": {
               "default": "10Gi",
               "description": "Size of the persistent volume for registry storage",
-              "required": [],
               "title": "size",
               "type": "string"
             }
@@ -1237,7 +1135,6 @@
         "image": {
           "default": "bitnamilegacy/kubectl:1.32.4",
           "description": "Container image used for wait jobs (must contain kubectl)",
-          "required": [],
           "title": "image",
           "type": "string"
         }

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -21,14 +21,12 @@
             "clientId": {
               "default": "openchoreo-backstage-client",
               "description": "OAuth client ID",
-              "required": [],
               "title": "clientId",
               "type": "string"
             },
             "clientSecret": {
               "default": "backstage-portal-secret",
               "description": "OAuth client secret",
-              "required": [],
               "title": "clientSecret",
               "type": "string"
             },
@@ -36,10 +34,8 @@
               "default": [],
               "description": "OAuth redirect URLs",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "redirectUrls",
               "type": "array"
             }
@@ -66,14 +62,12 @@
                         "required": [],
                         "type": "object"
                       },
-                      "required": [],
                       "title": "policies",
                       "type": "array"
                     },
                     "stabilizationWindowSeconds": {
                       "default": 300,
                       "description": "Stabilization window in seconds",
-                      "required": [],
                       "title": "stabilizationWindowSeconds",
                       "type": "integer"
                     }
@@ -92,7 +86,6 @@
                         "required": [],
                         "type": "object"
                       },
-                      "required": [],
                       "title": "policies",
                       "type": "array"
                     },
@@ -110,7 +103,6 @@
                     "stabilizationWindowSeconds": {
                       "default": 0,
                       "description": "Stabilization window in seconds",
-                      "required": [],
                       "title": "stabilizationWindowSeconds",
                       "type": "integer"
                     }
@@ -127,7 +119,6 @@
             "enabled": {
               "default": false,
               "description": "Enable HPA",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -135,7 +126,6 @@
               "default": 3,
               "description": "Maximum replicas",
               "minimum": 1,
-              "required": [],
               "title": "maxReplicas",
               "type": "integer"
             },
@@ -143,7 +133,6 @@
               "default": 1,
               "description": "Minimum replicas",
               "minimum": 1,
-              "required": [],
               "title": "minReplicas",
               "type": "integer"
             },
@@ -152,7 +141,6 @@
               "description": "Target CPU utilization percentage",
               "maximum": 100,
               "minimum": 1,
-              "required": [],
               "title": "targetCPUUtilizationPercentage",
               "type": "integer"
             },
@@ -161,7 +149,6 @@
               "description": "Target memory utilization percentage",
               "maximum": 100,
               "minimum": 1,
-              "required": [],
               "title": "targetMemoryUtilizationPercentage",
               "type": "integer"
             }
@@ -173,14 +160,12 @@
         "backendSecret": {
           "default": "",
           "description": "Backend secret for Backstage encryption. If empty, a random secret is generated",
-          "required": [],
           "title": "backendSecret",
           "type": "string"
         },
         "baseUrl": {
           "default": "",
           "description": "Backstage public base URL. If empty, auto-derived from global.baseDomain",
-          "required": [],
           "title": "baseUrl",
           "type": "string"
         },
@@ -191,7 +176,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -222,10 +206,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -237,7 +219,6 @@
             "readOnlyRootFilesystem": {
               "default": false,
               "description": "Read-only root filesystem",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
@@ -277,35 +258,30 @@
                 "database": {
                   "default": "backstage",
                   "description": "PostgreSQL database name",
-                  "required": [],
                   "title": "database",
                   "type": "string"
                 },
                 "host": {
                   "default": "",
                   "description": "PostgreSQL host",
-                  "required": [],
                   "title": "host",
                   "type": "string"
                 },
                 "password": {
                   "default": "",
                   "description": "PostgreSQL password",
-                  "required": [],
                   "title": "password",
                   "type": "string"
                 },
                 "port": {
                   "default": 5432,
                   "description": "PostgreSQL port",
-                  "required": [],
                   "title": "port",
                   "type": "integer"
                 },
                 "user": {
                   "default": "backstage",
                   "description": "PostgreSQL username",
-                  "required": [],
                   "title": "user",
                   "type": "string"
                 }
@@ -321,7 +297,6 @@
                 "mountPath": {
                   "default": "/app/.config/backstage",
                   "description": "Mount path for database directory inside container",
-                  "required": [],
                   "title": "mountPath",
                   "type": "string"
                 },
@@ -342,21 +317,18 @@
                     "enabled": {
                       "default": false,
                       "description": "Enable PVC for persistence (false = emptyDir)",
-                      "required": [],
                       "title": "enabled",
                       "type": "boolean"
                     },
                     "size": {
                       "default": "1Gi",
                       "description": "PVC storage size",
-                      "required": [],
                       "title": "size",
                       "type": "string"
                     },
                     "storageClassName": {
                       "default": "",
                       "description": "Storage class name (empty = default storage class)",
-                      "required": [],
                       "title": "storageClassName",
                       "type": "string"
                     }
@@ -388,7 +360,6 @@
         "enabled": {
           "default": true,
           "description": "Enable Backstage UI deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -398,19 +369,16 @@
             "properties": {
               "name": {
                 "description": "Environment variable name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Environment variable value",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "env",
           "type": "array"
         },
@@ -425,7 +393,6 @@
                 "enabled": {
                   "default": true,
                   "description": "Enable observability feature",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 }
@@ -441,7 +408,6 @@
                 "enabled": {
                   "default": true,
                   "description": "Enable workflows feature",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 }
@@ -473,14 +439,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/openchoreo-ui",
               "description": "Docker image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. If empty, uses Chart.AppVersion",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -506,7 +470,6 @@
             "enabled": {
               "default": true,
               "description": "Enable ingress",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -517,14 +480,12 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "hosts",
               "type": "array"
             },
             "ingressClassName": {
               "default": "",
               "description": "Ingress class name",
-              "required": [],
               "title": "ingressClassName",
               "type": "string"
             },
@@ -535,7 +496,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "tls",
               "type": "array"
             }
@@ -551,7 +511,6 @@
             "enabled": {
               "default": true,
               "description": "Enable Prometheus metrics",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -562,14 +521,12 @@
                 "enabled": {
                   "default": false,
                   "description": "Create ServiceMonitor resource",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 },
                 "interval": {
                   "default": "30s",
                   "description": "Scrape interval",
-                  "required": [],
                   "title": "interval",
                   "type": "string"
                 },
@@ -581,7 +538,6 @@
                   "properties": {
                     "prometheus": {
                       "default": "kube-prometheus",
-                      "required": [],
                       "title": "prometheus",
                       "type": "string"
                     }
@@ -595,7 +551,6 @@
                 "namespace": {
                   "default": "monitoring",
                   "description": "Namespace for ServiceMonitor",
-                  "required": [],
                   "title": "namespace",
                   "type": "string"
                 },
@@ -606,14 +561,12 @@
                     "required": [],
                     "type": "object"
                   },
-                  "required": [],
                   "title": "relabelings",
                   "type": "array"
                 },
                 "scrapeTimeout": {
                   "default": "10s",
                   "description": "Scrape timeout",
-                  "required": [],
                   "title": "scrapeTimeout",
                   "type": "string"
                 }
@@ -638,14 +591,12 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "egress",
               "type": "array"
             },
             "enabled": {
               "default": false,
               "description": "Enable NetworkPolicy",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -656,7 +607,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "ingress",
               "type": "array"
             }
@@ -682,7 +632,6 @@
             "url": {
               "default": "",
               "description": "OpenChoreo API URL. If empty, auto-derived from internal service",
-              "required": [],
               "title": "url",
               "type": "string"
             }
@@ -698,7 +647,6 @@
             "enabled": {
               "default": false,
               "description": "Enable PDB",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -706,7 +654,6 @@
               "default": 1,
               "description": "Minimum available pods",
               "minimum": 0,
-              "required": [],
               "title": "minAvailable",
               "type": "integer"
             }
@@ -722,28 +669,24 @@
             "fsGroup": {
               "default": 1000,
               "description": "Filesystem group",
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsGroup": {
               "default": 1000,
               "description": "Group ID",
-              "required": [],
               "title": "runAsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
             "runAsUser": {
               "default": 1000,
               "description": "User ID",
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             },
@@ -779,21 +722,18 @@
             "create": {
               "default": false,
               "description": "Create a priority class",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "openchoreo-backstage",
               "description": "Priority class name",
-              "required": [],
               "title": "name",
               "type": "string"
             },
             "value": {
               "default": 800000,
               "description": "Priority class value",
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -806,7 +746,6 @@
           "default": 1,
           "description": "Number of Backstage replicas",
           "minimum": 1,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -821,14 +760,12 @@
                 "cpu": {
                   "default": "2000m",
                   "description": "CPU limit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "2Gi",
                   "description": "Memory limit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -844,14 +781,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU request",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory request",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -882,7 +817,6 @@
             "port": {
               "default": 7007,
               "description": "Service port",
-              "required": [],
               "title": "port",
               "type": "integer"
             },
@@ -919,7 +853,6 @@
             "name": {
               "default": "openchoreo-backstage",
               "description": "Service account name",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -935,14 +868,12 @@
             "baseUrl": {
               "default": "",
               "description": "Thunder public base URL. If empty, auto-derived from global.baseDomain",
-              "required": [],
               "title": "baseUrl",
               "type": "string"
             },
             "token": {
               "default": "",
               "description": "Thunder API token for authentication",
-              "required": [],
               "title": "token",
               "type": "string"
             }
@@ -958,7 +889,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         },
@@ -968,7 +898,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
         }
@@ -992,21 +921,18 @@
         "enabled": {
           "default": true,
           "description": "Enable the cluster gateway",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "heartbeatInterval": {
           "default": "30s",
           "description": "Heartbeat interval for agent connections",
-          "required": [],
           "title": "heartbeatInterval",
           "type": "string"
         },
         "heartbeatTimeout": {
           "default": "90s",
           "description": "Heartbeat timeout for agent connections",
-          "required": [],
           "title": "heartbeatTimeout",
           "type": "string"
         },
@@ -1028,14 +954,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/cluster-gateway",
               "description": "Docker image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. If empty, uses Chart.AppVersion",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -1059,7 +983,6 @@
         "name": {
           "default": "cluster-gateway",
           "description": "Name of the cluster gateway deployment",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -1080,21 +1003,18 @@
             "fsGroup": {
               "default": 1000,
               "description": "Filesystem group",
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
             "runAsUser": {
               "default": 1000,
               "description": "User ID",
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -1106,7 +1026,6 @@
         "port": {
           "default": 8443,
           "description": "WebSocket port for agent connections",
-          "required": [],
           "title": "port",
           "type": "integer"
         },
@@ -1117,21 +1036,18 @@
             "create": {
               "default": false,
               "description": "Create a priority class",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-gateway",
               "description": "Priority class name",
-              "required": [],
               "title": "name",
               "type": "string"
             },
             "value": {
               "default": 900000,
               "description": "Priority class value",
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -1144,7 +1060,6 @@
           "default": 1,
           "description": "Number of cluster gateway replicas",
           "minimum": 1,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -1159,14 +1074,12 @@
                 "cpu": {
                   "default": "500m",
                   "description": "CPU limit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1182,14 +1095,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "64Mi",
                   "description": "Memory request",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1210,7 +1121,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -1221,10 +1131,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -1236,7 +1144,6 @@
             "readOnlyRootFilesystem": {
               "default": true,
               "description": "Read-only root filesystem",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             }
@@ -1282,7 +1189,6 @@
             "port": {
               "default": 8443,
               "description": "Service port",
-              "required": [],
               "title": "port",
               "type": "integer"
             },
@@ -1319,14 +1225,12 @@
             "create": {
               "default": true,
               "description": "Create a service account",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-gateway",
               "description": "Service account name",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -1342,24 +1246,20 @@
             "dnsNames": {
               "description": "DNS names for the certificate",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "dnsNames",
               "type": "array"
             },
             "duration": {
               "default": "2160h",
               "description": "Certificate validity duration (90 days)",
-              "required": [],
               "title": "duration",
               "type": "string"
             },
             "enabled": {
               "default": true,
               "description": "Enable TLS",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1380,7 +1280,6 @@
                 "name": {
                   "default": "cluster-gateway-selfsigned-issuer",
                   "description": "Issuer name",
-                  "required": [],
                   "title": "name",
                   "type": "string"
                 }
@@ -1392,14 +1291,12 @@
             "renewBefore": {
               "default": "360h",
               "description": "Certificate renewal threshold (15 days before expiry)",
-              "required": [],
               "title": "renewBefore",
               "type": "string"
             },
             "secretName": {
               "default": "cluster-gateway-tls",
               "description": "TLS secret name",
-              "required": [],
               "title": "secretName",
               "type": "string"
             }
@@ -1415,7 +1312,6 @@
             "enabled": {
               "default": false,
               "description": "Enable TLSRoute for cluster gateway",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1426,7 +1322,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "hosts",
               "type": "array"
             }
@@ -1442,7 +1337,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         }
@@ -1480,7 +1374,6 @@
                       "items": {
                         "properties": {
                           "periodSeconds": {
-                            "required": [],
                             "type": "integer"
                           },
                           "type": {
@@ -1488,25 +1381,21 @@
                               "Percent",
                               "Pods"
                             ],
-                            "required": [],
-                            "type": "string"
+                            "required": []
                           },
                           "value": {
-                            "required": [],
                             "type": "integer"
                           }
                         },
                         "required": [],
                         "type": "object"
                       },
-                      "required": [],
                       "title": "policies",
                       "type": "array"
                     },
                     "stabilizationWindowSeconds": {
                       "default": 300,
                       "description": "Stabilization window in seconds before scaling down",
-                      "required": [],
                       "title": "stabilizationWindowSeconds",
                       "type": "integer"
                     }
@@ -1524,7 +1413,6 @@
                       "items": {
                         "properties": {
                           "periodSeconds": {
-                            "required": [],
                             "type": "integer"
                           },
                           "type": {
@@ -1532,18 +1420,15 @@
                               "Percent",
                               "Pods"
                             ],
-                            "required": [],
-                            "type": "string"
+                            "required": []
                           },
                           "value": {
-                            "required": [],
                             "type": "integer"
                           }
                         },
                         "required": [],
                         "type": "object"
                       },
-                      "required": [],
                       "title": "policies",
                       "type": "array"
                     },
@@ -1561,7 +1446,6 @@
                     "stabilizationWindowSeconds": {
                       "default": 0,
                       "description": "Stabilization window in seconds before scaling up",
-                      "required": [],
                       "title": "stabilizationWindowSeconds",
                       "type": "integer"
                     }
@@ -1578,7 +1462,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Horizontal Pod Autoscaler",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1586,7 +1469,6 @@
               "default": 3,
               "description": "Maximum number of replicas",
               "minimum": 1,
-              "required": [],
               "title": "maxReplicas",
               "type": "integer"
             },
@@ -1594,7 +1476,6 @@
               "default": 1,
               "description": "Minimum number of replicas",
               "minimum": 1,
-              "required": [],
               "title": "minReplicas",
               "type": "integer"
             },
@@ -1603,7 +1484,6 @@
               "description": "Target CPU utilization percentage for scaling",
               "maximum": 100,
               "minimum": 1,
-              "required": [],
               "title": "targetCPUUtilizationPercentage",
               "type": "integer"
             },
@@ -1612,7 +1492,6 @@
               "description": "Target memory utilization percentage for scaling",
               "maximum": 100,
               "minimum": 1,
-              "required": [],
               "title": "targetMemoryUtilizationPercentage",
               "type": "integer"
             }
@@ -1628,7 +1507,6 @@
             "enabled": {
               "default": true,
               "description": "Enable cluster gateway integration for remote data plane communication",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1639,14 +1517,12 @@
                 "caPath": {
                   "default": "/etc/cluster-gateway/ca.crt",
                   "description": "Path to the CA certificate file",
-                  "required": [],
                   "title": "caPath",
                   "type": "string"
                 },
                 "caSecret": {
                   "default": "cluster-gateway-ca",
                   "description": "Name of the secret containing the CA certificate",
-                  "required": [],
                   "title": "caSecret",
                   "type": "string"
                 }
@@ -1658,7 +1534,6 @@
             "url": {
               "default": "https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443",
               "description": "Cluster gateway service URL",
-              "required": [],
               "title": "url",
               "type": "string"
             }
@@ -1674,7 +1549,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -1705,10 +1579,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -1720,7 +1592,6 @@
             "readOnlyRootFilesystem": {
               "default": false,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
@@ -1767,14 +1638,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/controller",
               "description": "Docker image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. If empty, uses Chart.AppVersion",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -1790,10 +1659,8 @@
             "args": {
               "description": "Command-line arguments for the controller-manager",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "args",
               "type": "array"
             },
@@ -1828,7 +1695,6 @@
             "enabled": {
               "default": true,
               "description": "Enable Prometheus metrics endpoint",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1839,14 +1705,12 @@
                 "enabled": {
                   "default": false,
                   "description": "Create a ServiceMonitor resource for Prometheus Operator",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 },
                 "interval": {
                   "default": "30s",
                   "description": "Scrape interval",
-                  "required": [],
                   "title": "interval",
                   "type": "string"
                 },
@@ -1858,7 +1722,6 @@
                   "properties": {
                     "prometheus": {
                       "default": "kube-prometheus",
-                      "required": [],
                       "title": "prometheus",
                       "type": "string"
                     }
@@ -1872,7 +1735,6 @@
                 "namespace": {
                   "default": "monitoring",
                   "description": "Namespace where ServiceMonitor should be created",
-                  "required": [],
                   "title": "namespace",
                   "type": "string"
                 },
@@ -1883,14 +1745,12 @@
                     "required": [],
                     "type": "object"
                   },
-                  "required": [],
                   "title": "relabelings",
                   "type": "array"
                 },
                 "scrapeTimeout": {
                   "default": "10s",
                   "description": "Scrape timeout",
-                  "required": [],
                   "title": "scrapeTimeout",
                   "type": "string"
                 }
@@ -1907,7 +1767,6 @@
         "name": {
           "default": "controller-manager",
           "description": "Name of the controller-manager deployment",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -1922,14 +1781,12 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "egress",
               "type": "array"
             },
             "enabled": {
               "default": false,
               "description": "Enable NetworkPolicy",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1940,7 +1797,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "ingress",
               "type": "array"
             }
@@ -1966,7 +1822,6 @@
             "enabled": {
               "default": false,
               "description": "Enable PodDisruptionBudget",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1974,7 +1829,6 @@
               "default": 1,
               "description": "Minimum number of pods that must be available",
               "minimum": 0,
-              "required": [],
               "title": "minAvailable",
               "type": "integer"
             }
@@ -1990,28 +1844,24 @@
             "fsGroup": {
               "default": 1000,
               "description": "Filesystem group for volumes",
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsGroup": {
               "default": 1000,
               "description": "Group ID to run the container as",
-              "required": [],
               "title": "runAsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run container as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
             "runAsUser": {
               "default": 1000,
               "description": "User ID to run the container as",
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             },
@@ -2047,21 +1897,18 @@
             "create": {
               "default": false,
               "description": "Create a priority class for the controller-manager",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "openchoreo-controller-manager",
               "description": "Priority class name",
-              "required": [],
               "title": "name",
               "type": "string"
             },
             "value": {
               "default": 1000000,
               "description": "Priority class value (higher = more priority)",
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -2074,7 +1921,6 @@
           "default": 1,
           "description": "Number of controller-manager replicas",
           "minimum": 1,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -2089,14 +1935,12 @@
                 "cpu": {
                   "default": "1000m",
                   "description": "CPU limit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "1Gi",
                   "description": "Memory limit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2112,14 +1956,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU request",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory request",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2150,7 +1992,6 @@
             "port": {
               "default": 8080,
               "description": "Service port",
-              "required": [],
               "title": "port",
               "type": "integer"
             },
@@ -2187,7 +2028,6 @@
             "create": {
               "default": true,
               "description": "Create a service account for the controller-manager",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -2207,11 +2047,9 @@
                   "PreferNoSchedule",
                   "NoExecute"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               },
               "key": {
-                "required": [],
                 "type": "string"
               },
               "operator": {
@@ -2219,18 +2057,15 @@
                   "Exists",
                   "Equal"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               },
               "value": {
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         },
@@ -2253,12 +2088,10 @@
               },
               "maxSkew": {
                 "description": "Maximum allowed difference in pod count",
-                "required": [],
                 "type": "integer"
               },
               "topologyKey": {
                 "description": "Node label key for topology",
-                "required": [],
                 "type": "string"
               },
               "whenUnsatisfiable": {
@@ -2266,14 +2099,12 @@
                   "DoNotSchedule",
                   "ScheduleAnyway"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
         }
@@ -2285,7 +2116,6 @@
     "fullnameOverride": {
       "default": "openchoreo",
       "description": "Override the full name of the chart release",
-      "required": [],
       "title": "fullnameOverride",
       "type": "string"
     },
@@ -2300,7 +2130,6 @@
             "enabled": {
               "default": false,
               "description": "Enable agent gateway",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -2331,21 +2160,18 @@
                 "registry": {
                   "default": "",
                   "description": "Image registry",
-                  "required": [],
                   "title": "registry",
                   "type": "string"
                 },
                 "repository": {
                   "default": "kgateway",
                   "description": "Image repository",
-                  "required": [],
                   "title": "repository",
                   "type": "string"
                 },
                 "tag": {
                   "default": "",
                   "description": "Image tag (defaults to chart appVersion)",
-                  "required": [],
                   "title": "tag",
                   "type": "string"
                 }
@@ -2369,7 +2195,6 @@
             "replicaCount": {
               "default": 1,
               "description": "Number of controller replicas",
-              "required": [],
               "title": "replicaCount",
               "type": "integer"
             },
@@ -2384,14 +2209,12 @@
                     "cpu": {
                       "default": "200m",
                       "description": "CPU limit",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "256Mi",
                       "description": "Memory limit",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -2407,14 +2230,12 @@
                     "cpu": {
                       "default": "100m",
                       "description": "CPU request",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "128Mi",
                       "description": "Memory request",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -2439,28 +2260,24 @@
                     "agwGrpc": {
                       "default": 9978,
                       "description": "Agent gateway gRPC port",
-                      "required": [],
                       "title": "agwGrpc",
                       "type": "integer"
                     },
                     "grpc": {
                       "default": 9977,
                       "description": "gRPC port",
-                      "required": [],
                       "title": "grpc",
                       "type": "integer"
                     },
                     "health": {
                       "default": 9093,
                       "description": "Health check port",
-                      "required": [],
                       "title": "health",
                       "type": "integer"
                     },
                     "metrics": {
                       "default": 9092,
                       "description": "Metrics port",
-                      "required": [],
                       "title": "metrics",
                       "type": "integer"
                     }
@@ -2493,7 +2310,6 @@
         "enabled": {
           "default": true,
           "description": "Enable Gateway CR creation",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -2504,14 +2320,12 @@
             "enabled": {
               "default": true,
               "description": "Enable Envoy proxy",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "mountTmpVolume": {
               "default": false,
               "description": "Mount /tmp as emptyDir volume (required for macOS Docker Desktop/Colima)",
-              "required": [],
               "title": "mountTmpVolume",
               "type": "boolean"
             }
@@ -2523,14 +2337,12 @@
         "httpPort": {
           "default": 80,
           "description": "HTTP listener port",
-          "required": [],
           "title": "httpPort",
           "type": "integer"
         },
         "httpsPort": {
           "default": 443,
           "description": "HTTPS listener port",
-          "required": [],
           "title": "httpsPort",
           "type": "integer"
         },
@@ -2552,14 +2364,12 @@
             "registry": {
               "default": "cr.kgateway.dev/kgateway-dev",
               "description": "Default registry for gateway images",
-              "required": [],
               "title": "registry",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Default image tag (defaults to chart appVersion)",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -2575,7 +2385,6 @@
             "enabled": {
               "default": true,
               "description": "Create self-signed ClusterIssuer (set to false in single cluster mode for data-plane)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -2591,21 +2400,18 @@
             "certName": {
               "default": "{{ .Values.global.tls.secretName }}",
               "description": "Certificate secret name",
-              "required": [],
               "title": "certName",
               "type": "string"
             },
             "clusterIssuer": {
               "default": "",
               "description": "ClusterIssuer for certificate generation (empty uses default self-signed issuer)",
-              "required": [],
               "title": "clusterIssuer",
               "type": "string"
             },
             "hostname": {
               "default": "*.{{ .Values.global.baseDomain }}",
               "description": "Hostname pattern for TLS certificate",
-              "required": [],
               "title": "hostname",
               "type": "string"
             }
@@ -2626,7 +2432,6 @@
         "enabled": {
           "default": true,
           "description": "Enable kgateway controller installation (set to false in single cluster mode for data-plane)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         }
@@ -2642,14 +2447,12 @@
         "baseDomain": {
           "default": "openchoreo.local",
           "description": "Base domain for all services. Console will be at baseDomain, API at api.baseDomain",
-          "required": [],
           "title": "baseDomain",
           "type": "string"
         },
         "clusterName": {
           "default": "openchoreo",
           "description": "Kubernetes cluster name identifier",
-          "required": [],
           "title": "clusterName",
           "type": "string"
         },
@@ -2674,14 +2477,12 @@
                 "description": {
                   "default": "Standard deployment pipeline with dev, staging, and prod environments",
                   "description": "Description for the default pipeline",
-                  "required": [],
                   "title": "description",
                   "type": "string"
                 },
                 "displayName": {
                   "default": "Default Pipeline",
                   "description": "Display name for the default pipeline",
-                  "required": [],
                   "title": "displayName",
                   "type": "string"
                 },
@@ -2691,32 +2492,27 @@
                     "properties": {
                       "sourceEnvironmentRef": {
                         "description": "Source environment name",
-                        "required": [],
                         "type": "string"
                       },
                       "targetEnvironmentRefs": {
                         "items": {
                           "properties": {
                             "name": {
-                              "required": [],
                               "type": "string"
                             },
                             "requiresApproval": {
-                              "required": [],
                               "type": "boolean"
                             }
                           },
                           "required": [],
                           "type": "object"
                         },
-                        "required": [],
                         "type": "array"
                       }
                     },
                     "required": [],
                     "type": "object"
                   },
-                  "required": [],
                   "title": "promotionOrder",
                   "type": "array"
                 }
@@ -2728,7 +2524,6 @@
             "enabled": {
               "default": true,
               "description": "Enable creation of default resources (organization, project, environments, pipeline)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -2738,34 +2533,28 @@
                 "properties": {
                   "description": {
                     "description": "Environment description",
-                    "required": [],
                     "type": "string"
                   },
                   "displayName": {
                     "description": "Human-readable environment name",
-                    "required": [],
                     "type": "string"
                   },
                   "dnsPrefix": {
                     "description": "DNS prefix for the environment",
-                    "required": [],
                     "type": "string"
                   },
                   "isCritical": {
                     "description": "Whether this is a critical/production environment",
-                    "required": [],
                     "type": "boolean"
                   },
                   "name": {
                     "description": "Environment identifier (lowercase, no spaces)",
-                    "required": [],
                     "type": "string"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "environments",
               "type": "array"
             },
@@ -2776,14 +2565,12 @@
                 "description": {
                   "default": "Getting started with your first organization",
                   "description": "Description for the default organization",
-                  "required": [],
                   "title": "description",
                   "type": "string"
                 },
                 "displayName": {
                   "default": "Default Organization",
                   "description": "Display name for the default organization",
-                  "required": [],
                   "title": "displayName",
                   "type": "string"
                 }
@@ -2799,14 +2586,12 @@
                 "description": {
                   "default": "Your first project to get started",
                   "description": "Description for the default project",
-                  "required": [],
                   "title": "description",
                   "type": "string"
                 },
                 "displayName": {
                   "default": "Default Project",
                   "description": "Display name for the default project",
-                  "required": [],
                   "title": "displayName",
                   "type": "string"
                 }
@@ -2827,21 +2612,18 @@
             "properties": {
               "name": {
                 "description": "Name of the image pull secret",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "imagePullSecrets",
           "type": "array"
         },
         "port": {
           "default": "",
           "description": "Port suffix for URLs (e.g., \":8080\" for non-standard ports). Include the colon. Leave empty for standard ports (80/443)",
-          "required": [],
           "title": "port",
           "type": "string"
         },
@@ -2852,14 +2634,12 @@
             "enabled": {
               "default": false,
               "description": "Enable TLS/HTTPS for all ingresses",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "secretName": {
               "default": "control-plane-tls",
               "description": "Secret containing TLS certificate (must have all hosts - baseDomain, api.baseDomain, thunder.baseDomain)",
-              "required": [],
               "title": "secretName",
               "type": "string"
             }
@@ -2883,7 +2663,6 @@
     "kubernetesClusterDomain": {
       "default": "cluster.local",
       "description": "Kubernetes cluster domain suffix",
-      "required": [],
       "title": "kubernetesClusterDomain",
       "type": "string"
     },
@@ -2894,14 +2673,12 @@
         "enabled": {
           "default": false,
           "description": "Enable metrics server deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "kubeletInsecureTlsEnabled": {
           "default": true,
           "description": "Allow insecure TLS connections to kubelet",
-          "required": [],
           "title": "kubeletInsecureTlsEnabled",
           "type": "boolean"
         }
@@ -2919,11 +2696,9 @@
           "items": {
             "properties": {
               "name": {
-                "required": [],
                 "type": "string"
               },
               "port": {
-                "required": [],
                 "type": "integer"
               },
               "protocol": {
@@ -2931,18 +2706,15 @@
                   "TCP",
                   "UDP"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               },
               "targetPort": {
-                "required": [],
                 "type": "integer"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "ports",
           "type": "array"
         },
@@ -2992,14 +2764,12 @@
                         "required": [],
                         "type": "object"
                       },
-                      "required": [],
                       "title": "policies",
                       "type": "array"
                     },
                     "stabilizationWindowSeconds": {
                       "default": 300,
                       "description": "Stabilization window in seconds",
-                      "required": [],
                       "title": "stabilizationWindowSeconds",
                       "type": "integer"
                     }
@@ -3018,7 +2788,6 @@
                         "required": [],
                         "type": "object"
                       },
-                      "required": [],
                       "title": "policies",
                       "type": "array"
                     },
@@ -3036,7 +2805,6 @@
                     "stabilizationWindowSeconds": {
                       "default": 0,
                       "description": "Stabilization window in seconds",
-                      "required": [],
                       "title": "stabilizationWindowSeconds",
                       "type": "integer"
                     }
@@ -3053,7 +2821,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Horizontal Pod Autoscaler",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -3061,7 +2828,6 @@
               "default": 3,
               "description": "Maximum number of replicas",
               "minimum": 1,
-              "required": [],
               "title": "maxReplicas",
               "type": "integer"
             },
@@ -3069,7 +2835,6 @@
               "default": 1,
               "description": "Minimum number of replicas",
               "minimum": 1,
-              "required": [],
               "title": "minReplicas",
               "type": "integer"
             },
@@ -3078,7 +2843,6 @@
               "description": "Target CPU utilization percentage",
               "maximum": 100,
               "minimum": 1,
-              "required": [],
               "title": "targetCPUUtilizationPercentage",
               "type": "integer"
             },
@@ -3087,7 +2851,6 @@
               "description": "Target memory utilization percentage",
               "maximum": 100,
               "minimum": 1,
-              "required": [],
               "title": "targetMemoryUtilizationPercentage",
               "type": "integer"
             }
@@ -3103,7 +2866,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -3134,10 +2896,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -3149,7 +2909,6 @@
             "readOnlyRootFilesystem": {
               "default": false,
               "description": "Read-only root filesystem",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
@@ -3185,7 +2944,6 @@
             "path": {
               "default": "/var/lib/openchoreo/data/controlplane.db",
               "description": "Path to the SQLite database file",
-              "required": [],
               "title": "path",
               "type": "string"
             },
@@ -3196,21 +2954,18 @@
                 "enabled": {
                   "default": true,
                   "description": "Enable persistent storage for the database",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 },
                 "size": {
                   "default": "500Mi",
                   "description": "Size of the persistent volume",
-                  "required": [],
                   "title": "size",
                   "type": "string"
                 },
                 "storageClassName": {
                   "default": "",
                   "description": "Storage class name. If empty, uses the default storage class",
-                  "required": [],
                   "title": "storageClassName",
                   "type": "string"
                 }
@@ -3227,7 +2982,6 @@
         "enabled": {
           "default": true,
           "description": "Enable the OpenChoreo API server",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -3249,14 +3003,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/openchoreo-api",
               "description": "Docker image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. If empty, uses Chart.AppVersion",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -3282,7 +3034,6 @@
             "enabled": {
               "default": true,
               "description": "Enable ingress",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -3292,7 +3043,6 @@
               "items": {
                 "properties": {
                   "host": {
-                    "required": [],
                     "type": "string"
                   },
                   "paths": {
@@ -3300,21 +3050,18 @@
                       "required": [],
                       "type": "object"
                     },
-                    "required": [],
                     "type": "array"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "hosts",
               "type": "array"
             },
             "ingressClassName": {
               "default": "",
               "description": "Ingress class name. If empty, uses global.ingressClassName",
-              "required": [],
               "title": "ingressClassName",
               "type": "string"
             },
@@ -3325,21 +3072,17 @@
                 "properties": {
                   "hosts": {
                     "items": {
-                      "required": [],
                       "type": "string"
                     },
-                    "required": [],
                     "type": "array"
                   },
                   "secretName": {
-                    "required": [],
                     "type": "string"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "tls",
               "type": "array"
             }
@@ -3367,7 +3110,6 @@
             "toolsets": {
               "default": "organization,project,component,build,deployment,infrastructure",
               "description": "Comma-separated list of enabled MCP toolsets",
-              "required": [],
               "title": "toolsets",
               "type": "string"
             }
@@ -3383,7 +3125,6 @@
             "enabled": {
               "default": true,
               "description": "Enable Prometheus metrics",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -3394,14 +3135,12 @@
                 "enabled": {
                   "default": false,
                   "description": "Create ServiceMonitor resource",
-                  "required": [],
                   "title": "enabled",
                   "type": "boolean"
                 },
                 "interval": {
                   "default": "30s",
                   "description": "Scrape interval",
-                  "required": [],
                   "title": "interval",
                   "type": "string"
                 },
@@ -3413,7 +3152,6 @@
                   "properties": {
                     "prometheus": {
                       "default": "kube-prometheus",
-                      "required": [],
                       "title": "prometheus",
                       "type": "string"
                     }
@@ -3427,7 +3165,6 @@
                 "namespace": {
                   "default": "monitoring",
                   "description": "Namespace for ServiceMonitor",
-                  "required": [],
                   "title": "namespace",
                   "type": "string"
                 },
@@ -3438,14 +3175,12 @@
                     "required": [],
                     "type": "object"
                   },
-                  "required": [],
                   "title": "relabelings",
                   "type": "array"
                 },
                 "scrapeTimeout": {
                   "default": "10s",
                   "description": "Scrape timeout",
-                  "required": [],
                   "title": "scrapeTimeout",
                   "type": "string"
                 }
@@ -3462,7 +3197,6 @@
         "name": {
           "default": "openchoreo-api",
           "description": "Static name for all openchoreo-api resources (Service, Deployment, ClusterRole, etc.)",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -3477,14 +3211,12 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "egress",
               "type": "array"
             },
             "enabled": {
               "default": false,
               "description": "Enable NetworkPolicy",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -3495,7 +3227,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "ingress",
               "type": "array"
             }
@@ -3521,7 +3252,6 @@
             "enabled": {
               "default": false,
               "description": "Enable PodDisruptionBudget",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -3529,7 +3259,6 @@
               "default": 1,
               "description": "Minimum available pods",
               "minimum": 0,
-              "required": [],
               "title": "minAvailable",
               "type": "integer"
             }
@@ -3545,28 +3274,24 @@
             "fsGroup": {
               "default": 1000,
               "description": "Filesystem group",
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsGroup": {
               "default": 1000,
               "description": "Group ID",
-              "required": [],
               "title": "runAsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
             "runAsUser": {
               "default": 1000,
               "description": "User ID",
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             },
@@ -3602,21 +3327,18 @@
             "create": {
               "default": false,
               "description": "Create a priority class",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "openchoreo-api",
               "description": "Priority class name",
-              "required": [],
               "title": "name",
               "type": "string"
             },
             "value": {
               "default": 900000,
               "description": "Priority class value",
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -3629,7 +3351,6 @@
           "default": 1,
           "description": "Number of API server replicas",
           "minimum": 1,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -3644,14 +3365,12 @@
                 "cpu": {
                   "default": "1000m",
                   "description": "CPU limit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "1Gi",
                   "description": "Memory limit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -3667,14 +3386,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU request",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory request",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -3702,11 +3419,9 @@
                         "entitlement": {
                           "properties": {
                             "claim": {
-                              "required": [],
                               "type": "string"
                             },
                             "display_name": {
-                              "required": [],
                               "type": "string"
                             }
                           },
@@ -3714,36 +3429,30 @@
                           "type": "object"
                         },
                         "type": {
-                          "required": [],
                           "type": "string"
                         }
                       },
                       "required": [],
                       "type": "object"
                     },
-                    "required": [],
                     "type": "array"
                   },
                   "display_name": {
                     "description": "Human-readable name",
-                    "required": [],
                     "type": "string"
                   },
                   "priority": {
                     "description": "Priority order",
-                    "required": [],
                     "type": "integer"
                   },
                   "type": {
                     "description": "User type identifier",
-                    "required": [],
                     "type": "string"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "userTypes",
               "type": "array"
             }
@@ -3755,7 +3464,6 @@
         "serverBaseUrl": {
           "default": "",
           "description": "Base URL for the API server (used for OAuth metadata). If not set, defaults to protocol://api.baseDomain:port",
-          "required": [],
           "title": "serverBaseUrl",
           "type": "string"
         },
@@ -3776,7 +3484,6 @@
             "port": {
               "default": 8080,
               "description": "Service port",
-              "required": [],
               "title": "port",
               "type": "integer"
             },
@@ -3813,7 +3520,6 @@
             "name": {
               "default": "openchoreo-api",
               "description": "Service account name (always created when openchoreoApi.enabled is true)",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -3829,7 +3535,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         },
@@ -3839,7 +3544,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
         }
@@ -3855,7 +3559,6 @@
         "authServerBaseUrl": {
           "default": "",
           "description": "Base URL for the authorization server (used for OAuth metadata). If not set, defaults to protocol://thunder.baseDomain:port",
-          "required": [],
           "title": "authServerBaseUrl",
           "type": "string"
         },
@@ -3866,21 +3569,18 @@
             "databasePath": {
               "default": "/var/lib/openchoreo/data/casbin.db",
               "description": "Path to the Casbin database file",
-              "required": [],
               "title": "databasePath",
               "type": "string"
             },
             "defaultAuthzDataFilePath": {
               "default": "/etc/openchoreo/authz/default-roles-mappings.yaml",
               "description": "Path to custom authz data file (roles and mappings). If not set, embedded defaults are used. To use custom data, set this path and mount a ConfigMap",
-              "required": [],
               "title": "defaultAuthzDataFilePath",
               "type": "string"
             },
             "enabled": {
               "default": false,
               "description": "Enable authorization using Casbin",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3892,7 +3592,6 @@
         "enabled": {
           "default": true,
           "description": "Global security toggle - when disabled, authentication is turned off for all components",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -3903,7 +3602,6 @@
             "audience": {
               "default": "",
               "description": "Expected audience claim in JWT tokens",
-              "required": [],
               "title": "audience",
               "type": "string"
             }
@@ -3919,68 +3617,81 @@
             "authorizationUrl": {
               "default": "",
               "description": "OIDC authorization endpoint URL",
-              "required": [],
               "title": "authorizationUrl",
               "type": "string"
+            },
+            "externalClients": {
+              "description": "External client configurations for authentication",
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "client_id": {
+                        "default": "openchoreo-cli",
+                        "title": "client_id",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "cli",
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "scopes": {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "required": []
+                        },
+                        "title": "scopes",
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "client_id",
+                      "scopes"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "required": []
+              },
+              "title": "externalClients",
+              "type": "array"
             },
             "issuer": {
               "default": "",
               "description": "OIDC provider issuer URL",
-              "required": [],
               "title": "issuer",
               "type": "string"
             },
             "jwksUrl": {
               "default": "",
               "description": "OIDC JWKS URL for token validation",
-              "required": [],
               "title": "jwksUrl",
               "type": "string"
             },
             "tokenUrl": {
               "default": "",
               "description": "OIDC token endpoint URL",
-              "required": [],
               "title": "tokenUrl",
               "type": "string"
             },
             "wellKnownEndpoint": {
               "default": "",
               "description": "OIDC well-known configuration endpoint URL",
-              "required": [],
               "title": "wellKnownEndpoint",
               "type": "string"
-            },
-            "externalClients": {
-              "description": "External client configurations for authentication",
-              "items": {
-                "properties": {
-                  "name": {
-                    "description": "Name of the external client",
-                    "required": [],
-                    "type": "string"
-                  },
-                  "client_id": {
-                    "description": "OAuth2 client ID for this client type",
-                    "required": [],
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "description": "OAuth2 scopes for this client",
-                    "items": {
-                      "required": [],
-                      "type": "string"
-                    },
-                    "required": [],
-                    "type": "array"
-                  }
-                },
-                "required": [],
-                "type": "object"
-              },
-              "required": [],
-              "title": "externalClients",
-              "type": "array"
             }
           },
           "required": [],
@@ -4007,17 +3718,14 @@
                 "files": {
                   "description": "Bootstrap script files to run",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "files",
                   "type": "array"
                 },
                 "name": {
                   "default": "openchoreo-thunder-bootstrap",
                   "description": "ConfigMap name containing bootstrap scripts",
-                  "required": [],
                   "title": "name",
                   "type": "string"
                 }
@@ -4032,19 +3740,16 @@
                 "properties": {
                   "clientId": {
                     "description": "OAuth client ID",
-                    "required": [],
                     "type": "string"
                   },
                   "clientSecret": {
                     "description": "OAuth client secret",
-                    "required": [],
                     "type": "string"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "defaultApps",
               "type": "array"
             },
@@ -4054,45 +3759,37 @@
                 "properties": {
                   "familyName": {
                     "description": "User last name",
-                    "required": [],
                     "type": "string"
                   },
                   "givenName": {
                     "description": "User first name",
-                    "required": [],
                     "type": "string"
                   },
                   "groups": {
                     "description": "User group memberships",
                     "items": {
-                      "required": [],
                       "type": "string"
                     },
-                    "required": [],
                     "type": "array"
                   },
                   "password": {
                     "description": "User password",
-                    "required": [],
                     "type": "string"
                   },
                   "username": {
                     "description": "User email/username",
-                    "required": [],
                     "type": "string"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "defaultUsers",
               "type": "array"
             },
             "enabled": {
               "default": true,
               "description": "Enable bootstrap scripts",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -4102,13 +3799,11 @@
               "properties": {
                 "clientId": {
                   "default": "openchoreo-rca-agent",
-                  "required": [],
                   "title": "clientId",
                   "type": "string"
                 },
                 "clientSecret": {
                   "default": "openchoreo-rca-agent-secret",
-                  "required": [],
                   "title": "clientSecret",
                   "type": "string"
                 }
@@ -4138,14 +3833,12 @@
                 "cleanupInterval": {
                   "default": 300,
                   "description": "Cache cleanup interval in seconds",
-                  "required": [],
                   "title": "cleanupInterval",
                   "type": "integer"
                 },
                 "disabled": {
                   "default": false,
                   "description": "Disable caching",
-                  "required": [],
                   "title": "disabled",
                   "type": "boolean"
                 },
@@ -4162,14 +3855,12 @@
                 "size": {
                   "default": 1000,
                   "description": "Maximum cache size",
-                  "required": [],
                   "title": "size",
                   "type": "integer"
                 },
                 "ttl": {
                   "default": 3600,
                   "description": "Cache TTL in seconds",
-                  "required": [],
                   "title": "ttl",
                   "type": "integer"
                 },
@@ -4195,10 +3886,8 @@
                 "allowedOrigins": {
                   "description": "Allowed origins for CORS",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "allowedOrigins",
                   "type": "array"
                 }
@@ -4218,14 +3907,12 @@
                     "sqliteOptions": {
                       "default": "_journal_mode=WAL\u0026_busy_timeout=5000",
                       "description": "SQLite connection options",
-                      "required": [],
                       "title": "sqliteOptions",
                       "type": "string"
                     },
                     "sqlitePath": {
                       "default": "repository/database/thunderdb.db",
                       "description": "SQLite database file path",
-                      "required": [],
                       "title": "sqlitePath",
                       "type": "string"
                     },
@@ -4252,14 +3939,12 @@
                     "sqliteOptions": {
                       "default": "_journal_mode=WAL\u0026_busy_timeout=5000",
                       "description": "SQLite connection options",
-                      "required": [],
                       "title": "sqliteOptions",
                       "type": "string"
                     },
                     "sqlitePath": {
                       "default": "repository/database/runtimedb.db",
                       "description": "SQLite database file path",
-                      "required": [],
                       "title": "sqlitePath",
                       "type": "string"
                     },
@@ -4286,14 +3971,12 @@
                     "sqliteOptions": {
                       "default": "_journal_mode=WAL\u0026_busy_timeout=5000",
                       "description": "SQLite connection options",
-                      "required": [],
                       "title": "sqliteOptions",
                       "type": "string"
                     },
                     "sqlitePath": {
                       "default": "repository/database/userdb.db",
                       "description": "SQLite database file path",
-                      "required": [],
                       "title": "sqlitePath",
                       "type": "string"
                     },
@@ -4329,7 +4012,6 @@
                     "defaultFlow": {
                       "default": "auth_flow_config_basic",
                       "description": "Default authentication flow",
-                      "required": [],
                       "title": "defaultFlow",
                       "type": "string"
                     }
@@ -4341,7 +4023,6 @@
                 "graphDirectory": {
                   "default": "repository/resources/graphs/",
                   "description": "Directory containing flow graph definitions",
-                  "required": [],
                   "title": "graphDirectory",
                   "type": "string"
                 }
@@ -4357,28 +4038,24 @@
                 "errorPath": {
                   "default": "/gate/error",
                   "description": "Error path",
-                  "required": [],
                   "title": "errorPath",
                   "type": "string"
                 },
                 "hostname": {
                   "default": "",
                   "description": "Gate client hostname",
-                  "required": [],
                   "title": "hostname",
                   "type": "string"
                 },
                 "loginPath": {
                   "default": "/gate/signin",
                   "description": "Login path",
-                  "required": [],
                   "title": "loginPath",
                   "type": "string"
                 },
                 "port": {
                   "default": 8080,
                   "description": "Gate client port",
-                  "required": [],
                   "title": "port",
                   "type": "integer"
                 },
@@ -4404,21 +4081,18 @@
                 "audience": {
                   "default": "application",
                   "description": "Token audience",
-                  "required": [],
                   "title": "audience",
                   "type": "string"
                 },
                 "issuer": {
                   "default": "thunder",
                   "description": "JWT issuer name",
-                  "required": [],
                   "title": "issuer",
                   "type": "string"
                 },
                 "validityPeriod": {
                   "default": 3600,
                   "description": "Token validity period in seconds",
-                  "required": [],
                   "title": "validityPeriod",
                   "type": "integer"
                 }
@@ -4438,14 +4112,12 @@
                     "renewOnGrant": {
                       "default": false,
                       "description": "Renew refresh token on grant",
-                      "required": [],
                       "title": "renewOnGrant",
                       "type": "boolean"
                     },
                     "validityPeriod": {
                       "default": 86400,
                       "description": "Refresh token validity period in seconds",
-                      "required": [],
                       "title": "validityPeriod",
                       "type": "integer"
                     }
@@ -4466,21 +4138,18 @@
                 "certFile": {
                   "default": "repository/resources/security/server.cert",
                   "description": "Server certificate file path",
-                  "required": [],
                   "title": "certFile",
                   "type": "string"
                 },
                 "cryptoFile": {
                   "default": "repository/resources/security/crypto.key",
                   "description": "Crypto key file path",
-                  "required": [],
                   "title": "cryptoFile",
                   "type": "string"
                 },
                 "keyFile": {
                   "default": "repository/resources/security/server.key",
                   "description": "Server private key file path",
-                  "required": [],
                   "title": "keyFile",
                   "type": "string"
                 }
@@ -4496,21 +4165,18 @@
                 "httpOnly": {
                   "default": true,
                   "description": "HTTP-only mode (no HTTPS termination at Thunder)",
-                  "required": [],
                   "title": "httpOnly",
                   "type": "boolean"
                 },
                 "port": {
                   "default": 8090,
                   "description": "Server port",
-                  "required": [],
                   "title": "port",
                   "type": "integer"
                 },
                 "publicUrl": {
                   "default": "",
                   "description": "Public URL for Thunder. If empty, auto-derived from global.baseDomain",
-                  "required": [],
                   "title": "publicUrl",
                   "type": "string"
                 }
@@ -4535,7 +4201,6 @@
                 "port": {
                   "default": 8090,
                   "description": "Container port",
-                  "required": [],
                   "title": "port",
                   "type": "integer"
                 }
@@ -4562,21 +4227,18 @@
                 "registry": {
                   "default": "ghcr.io/asgardeo",
                   "description": "Image registry",
-                  "required": [],
                   "title": "registry",
                   "type": "string"
                 },
                 "repository": {
                   "default": "thunder",
                   "description": "Image repository",
-                  "required": [],
                   "title": "repository",
                   "type": "string"
                 },
                 "tag": {
                   "default": "0.15.0",
                   "description": "Image tag",
-                  "required": [],
                   "title": "tag",
                   "type": "string"
                 }
@@ -4589,7 +4251,6 @@
               "default": 1,
               "description": "Number of Thunder replicas",
               "minimum": 1,
-              "required": [],
               "title": "replicaCount",
               "type": "integer"
             },
@@ -4604,14 +4265,12 @@
                     "cpu": {
                       "default": "500m",
                       "description": "CPU limit",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "512Mi",
                       "description": "Memory limit",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -4627,14 +4286,12 @@
                     "cpu": {
                       "default": "100m",
                       "description": "CPU request",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "128Mi",
                       "description": "Memory request",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -4655,28 +4312,24 @@
                 "enableRunAsUser": {
                   "default": true,
                   "description": "Enable run as user",
-                  "required": [],
                   "title": "enableRunAsUser",
                   "type": "boolean"
                 },
                 "fsGroup": {
                   "default": 802,
                   "description": "Filesystem group",
-                  "required": [],
                   "title": "fsGroup",
                   "type": "integer"
                 },
                 "readOnlyRootFilesystem": {
                   "default": false,
                   "description": "Read-only root filesystem. Must be false for SQLite",
-                  "required": [],
                   "title": "readOnlyRootFilesystem",
                   "type": "boolean"
                 },
                 "runAsUser": {
                   "default": 802,
                   "description": "User ID",
-                  "required": [],
                   "title": "runAsUser",
                   "type": "integer"
                 },
@@ -4687,7 +4340,6 @@
                     "enabled": {
                       "default": true,
                       "description": "Enable seccomp profile",
-                      "required": [],
                       "title": "enabled",
                       "type": "boolean"
                     },
@@ -4723,14 +4375,12 @@
                     "maxSurge": {
                       "default": 1,
                       "description": "Maximum surge pods during update",
-                      "required": [],
                       "title": "maxSurge",
                       "type": "integer"
                     },
                     "maxUnavailable": {
                       "default": 0,
                       "description": "Maximum unavailable pods during update",
-                      "required": [],
                       "title": "maxUnavailable",
                       "type": "integer"
                     }
@@ -4747,7 +4397,6 @@
             "terminationGracePeriodSeconds": {
               "default": 10,
               "description": "Termination grace period in seconds",
-              "required": [],
               "title": "terminationGracePeriodSeconds",
               "type": "integer"
             }
@@ -4759,14 +4408,12 @@
         "enabled": {
           "default": true,
           "description": "Enable Thunder identity provider deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "thunder",
           "description": "Override the Thunder release name",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -4777,7 +4424,6 @@
             "enabled": {
               "default": false,
               "description": "Enable HPA",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -4801,7 +4447,6 @@
             "enabled": {
               "default": false,
               "description": "Enable standard ingress",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -4812,14 +4457,12 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "hosts",
               "type": "array"
             },
             "ingressClassName": {
               "default": "",
               "description": "Ingress class name",
-              "required": [],
               "title": "ingressClassName",
               "type": "string"
             },
@@ -4830,7 +4473,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "tls",
               "type": "array"
             }
@@ -4854,7 +4496,6 @@
             "enabled": {
               "default": true,
               "description": "Enable OpenChoreo ingress",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -4865,14 +4506,12 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "hosts",
               "type": "array"
             },
             "ingressClassName": {
               "default": "",
               "description": "Ingress class name. If empty, uses global.ingressClassName",
-              "required": [],
               "title": "ingressClassName",
               "type": "string"
             },
@@ -4883,7 +4522,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "tls",
               "type": "array"
             }
@@ -4899,7 +4537,6 @@
             "minAvailable": {
               "default": "50%",
               "description": "Minimum available pods (percentage or number)",
-              "required": [],
               "title": "minAvailable",
               "type": "string"
             }
@@ -4934,21 +4571,18 @@
             "enabled": {
               "default": true,
               "description": "Enable persistent storage",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "size": {
               "default": "1Gi",
               "description": "Size of the persistent volume",
-              "required": [],
               "title": "size",
               "type": "string"
             },
             "storageClass": {
               "default": "",
               "description": "Storage class name. If empty, uses default storage class",
-              "required": [],
               "title": "storageClass",
               "type": "string"
             }
@@ -4964,7 +4598,6 @@
             "port": {
               "default": 8090,
               "description": "Service port",
-              "required": [],
               "title": "port",
               "type": "integer"
             }
@@ -4980,14 +4613,12 @@
             "create": {
               "default": true,
               "description": "Create service account",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "thunder-service-account",
               "description": "Service account name",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -5003,28 +4634,24 @@
             "backoffLimit": {
               "default": 3,
               "description": "Job backoff limit (retry count)",
-              "required": [],
               "title": "backoffLimit",
               "type": "integer"
             },
             "debug": {
               "default": false,
               "description": "Enable debug mode for setup job",
-              "required": [],
               "title": "debug",
               "type": "boolean"
             },
             "enabled": {
               "default": true,
               "description": "Enable the setup job",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "preserveJob": {
               "default": true,
               "description": "Preserve job after completion",
-              "required": [],
               "title": "preserveJob",
               "type": "boolean"
             },
@@ -5039,14 +4666,12 @@
                     "cpu": {
                       "default": "500m",
                       "description": "CPU limit",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "256Mi",
                       "description": "Memory limit",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -5062,14 +4687,12 @@
                     "cpu": {
                       "default": "250m",
                       "description": "CPU request",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "128Mi",
                       "description": "Memory request",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -5086,7 +4709,6 @@
             "ttlSecondsAfterFinished": {
               "default": 86400,
               "description": "Job retention time in seconds after completion (24 hours)",
-              "required": [],
               "title": "ttlSecondsAfterFinished",
               "type": "integer"
             }
@@ -5107,7 +4729,6 @@
         "image": {
           "default": "bitnamilegacy/kubectl:1.32.4",
           "description": "Container image for wait jobs",
-          "required": [],
           "title": "image",
           "type": "string"
         }
@@ -5125,7 +4746,6 @@
           "items": {
             "properties": {
               "port": {
-                "required": [],
                 "type": "integer"
               },
               "protocol": {
@@ -5133,18 +4753,15 @@
                   "TCP",
                   "UDP"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               },
               "targetPort": {
-                "required": [],
                 "type": "integer"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "ports",
           "type": "array"
         },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -631,7 +631,6 @@ controllerManager:
         #   type: object
         #   properties:
         #     type:
-        #       type: string
         #       enum: [Percent, Pods]
         #     value:
         #       type: integer
@@ -660,7 +659,6 @@ controllerManager:
         #   type: object
         #   properties:
         #     type:
-        #       type: string
         #       enum: [Percent, Pods]
         #     value:
         #       type: integer
@@ -694,7 +692,6 @@ controllerManager:
   #       type: string
   #       description: Node label key for topology
   #     whenUnsatisfiable:
-  #       type: string
   #       enum: [DoNotSchedule, ScheduleAnyway]
   #     labelSelector:
   #       type: object
@@ -738,12 +735,10 @@ controllerManager:
   #     key:
   #       type: string
   #     operator:
-  #       type: string
   #       enum: [Exists, Equal]
   #     value:
   #       type: string
   #     effect:
-  #       type: string
   #       enum: [NoSchedule, PreferNoSchedule, NoExecute]
   # default: []
   # @schema
@@ -935,7 +930,6 @@ metricsService:
   #     port:
   #       type: integer
   #     protocol:
-  #       type: string
   #       enum: [TCP, UDP]
   #     targetPort:
   #       type: integer
@@ -966,7 +960,6 @@ webhookService:
   #     port:
   #       type: integer
   #     protocol:
-  #       type: string
   #       enum: [TCP, UDP]
   #     targetPort:
   #       type: integer

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -9,7 +9,6 @@
         "enabled": {
           "default": false,
           "description": "Enable WSO2 API Platform gateway operator",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -24,7 +23,6 @@
                 "chartName": {
                   "default": "oci://ghcr.io/wso2/api-platform/helm-charts/gateway",
                   "description": "OCI chart reference for the API Platform gateway",
-                  "required": [],
                   "title": "chartName",
                   "type": "string"
                 }
@@ -60,24 +58,20 @@
                                   ],
                                   "description": "Allowed JWT signing algorithms",
                                   "items": {
-                                    "required": [],
                                     "type": "string"
                                   },
-                                  "required": [],
                                   "title": "AllowedAlgorithms",
                                   "type": "array"
                                 },
                                 "AuthHeaderScheme": {
                                   "default": "Bearer",
                                   "description": "Authorization header scheme prefix",
-                                  "required": [],
                                   "title": "AuthHeaderScheme",
                                   "type": "string"
                                 },
                                 "ErrorMessage": {
                                   "default": "Authentication failed.",
                                   "description": "Error message returned on authentication failure",
-                                  "required": [],
                                   "title": "ErrorMessage",
                                   "type": "string"
                                 },
@@ -94,14 +88,12 @@
                                 "HeaderName": {
                                   "default": "Authorization",
                                   "description": "HTTP header name for JWT token",
-                                  "required": [],
                                   "title": "HeaderName",
                                   "type": "string"
                                 },
                                 "JwksCacheTtl": {
                                   "default": "5m",
                                   "description": "Cache TTL for JWKS keys",
-                                  "required": [],
                                   "title": "JwksCacheTtl",
                                   "type": "string"
                                 },
@@ -109,21 +101,18 @@
                                   "default": 3,
                                   "description": "Number of retry attempts for JWKS fetch",
                                   "minimum": 1,
-                                  "required": [],
                                   "title": "JwksFetchRetryCount",
                                   "type": "integer"
                                 },
                                 "JwksFetchRetryInterval": {
                                   "default": "2s",
                                   "description": "Interval between JWKS fetch retries",
-                                  "required": [],
                                   "title": "JwksFetchRetryInterval",
                                   "type": "string"
                                 },
                                 "JwksFetchTimeout": {
                                   "default": "5s",
                                   "description": "Timeout for fetching JWKS",
-                                  "required": [],
                                   "title": "JwksFetchTimeout",
                                   "type": "string"
                                 },
@@ -133,7 +122,6 @@
                                     "properties": {
                                       "issuer": {
                                         "description": "JWT issuer identifier",
-                                        "required": [],
                                         "type": "string"
                                       },
                                       "jwks": {
@@ -143,35 +131,30 @@
                                       },
                                       "name": {
                                         "description": "Key manager name",
-                                        "required": [],
                                         "type": "string"
                                       }
                                     },
                                     "required": [],
                                     "type": "object"
                                   },
-                                  "required": [],
                                   "title": "KeyManagers",
                                   "type": "array"
                                 },
                                 "Leeway": {
                                   "default": "30s",
                                   "description": "Clock skew tolerance for JWT validation",
-                                  "required": [],
                                   "title": "Leeway",
                                   "type": "string"
                                 },
                                 "OnFailureStatusCode": {
                                   "default": 401,
                                   "description": "HTTP status code returned on authentication failure",
-                                  "required": [],
                                   "title": "OnFailureStatusCode",
                                   "type": "integer"
                                 },
                                 "ValidateIssuer": {
                                   "default": true,
                                   "description": "Validate the JWT issuer claim",
-                                  "required": [],
                                   "title": "ValidateIssuer",
                                   "type": "boolean"
                                 }
@@ -229,7 +212,6 @@
             "enabled": {
               "default": false,
               "description": "Enable CoreDNS rewrite of *.openchoreo.localhost to host.k3d.internal",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -241,14 +223,12 @@
         "enabled": {
           "default": true,
           "description": "Enable the cluster agent deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "heartbeatInterval": {
           "default": "30s",
           "description": "Interval between heartbeat messages to control plane",
-          "required": [],
           "title": "heartbeatInterval",
           "type": "string"
         },
@@ -270,14 +250,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/cluster-agent",
               "description": "Cluster agent image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. Empty uses Chart.AppVersion.",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -302,7 +280,6 @@
         "name": {
           "default": "cluster-agent-dataplane",
           "description": "Name of the cluster agent deployment",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -319,7 +296,6 @@
         "planeID": {
           "default": "default-dataplane",
           "description": "Logical plane identifier shared across multiple CRs connecting to the same physical plane. Defaults to Helm release name if not specified.",
-          "required": [],
           "title": "planeID",
           "type": "string"
         },
@@ -351,21 +327,18 @@
             "fsGroup": {
               "default": 1000,
               "description": "Group ID for volume mounts",
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run container as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
             "runAsUser": {
               "default": 1000,
               "description": "User ID to run container as",
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -381,21 +354,18 @@
             "create": {
               "default": false,
               "description": "Create a PriorityClass for cluster agent",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-agent-dataplane",
               "description": "PriorityClass name",
-              "required": [],
               "title": "name",
               "type": "string"
             },
             "value": {
               "default": 900000,
               "description": "Priority value (higher = more important)",
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -411,7 +381,6 @@
             "create": {
               "default": true,
               "description": "Create RBAC resources (ClusterRole, ClusterRoleBinding)",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -423,7 +392,6 @@
         "reconnectDelay": {
           "default": "5s",
           "description": "Delay before attempting reconnection after disconnect",
-          "required": [],
           "title": "reconnectDelay",
           "type": "string"
         },
@@ -431,7 +399,6 @@
           "default": 1,
           "description": "Number of cluster agent replicas (typically 1 per data plane)",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -446,14 +413,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU limit for the agent",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit for the agent",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -469,14 +434,12 @@
                 "cpu": {
                   "default": "50m",
                   "description": "CPU request for the agent",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request for the agent",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -497,7 +460,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -511,10 +473,8 @@
                   ],
                   "description": "Capabilities to drop from container",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -526,7 +486,6 @@
             "readOnlyRootFilesystem": {
               "default": true,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             }
@@ -538,14 +497,12 @@
         "serverCANamespace": {
           "default": "openchoreo-control-plane",
           "description": "Namespace where cluster-gateway CA exists (control plane namespace)",
-          "required": [],
           "title": "serverCANamespace",
           "type": "string"
         },
         "serverUrl": {
           "default": "wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws",
           "description": "WebSocket URL of the cluster gateway in control plane",
-          "required": [],
           "title": "serverUrl",
           "type": "string"
         },
@@ -566,14 +523,12 @@
             "create": {
               "default": true,
               "description": "Create a service account for the cluster agent",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-agent-dataplane",
               "description": "Service account name",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -589,77 +544,66 @@
             "caSecretName": {
               "default": "cluster-gateway-ca",
               "description": "CA secret name for signing agent client certificates. If empty, self-signed certs will be generated (required for multi-cluster setup).",
-              "required": [],
               "title": "caSecretName",
               "type": "string"
             },
             "caSecretNamespace": {
               "default": "openchoreo-control-plane",
               "description": "Namespace where the CA secret exists. If empty, self-signed certs will be generated (required for multi-cluster setup).",
-              "required": [],
               "title": "caSecretNamespace",
               "type": "string"
             },
             "caValue": {
               "default": "",
               "description": "Inline CA certificate in PEM format (for multi-cluster setup). Takes precedence over caSecretName/caSecretNamespace.",
-              "required": [],
               "title": "caValue",
               "type": "string"
             },
             "clientSecretName": {
               "default": "cluster-agent-tls",
               "description": "Secret name for client certificate (typically same as secretName)",
-              "required": [],
               "title": "clientSecretName",
               "type": "string"
             },
             "duration": {
               "default": "2160h",
               "description": "Certificate validity duration",
-              "required": [],
               "title": "duration",
               "type": "string"
             },
             "enabled": {
               "default": true,
               "description": "Enable TLS for agent-gateway communication",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "generateCerts": {
               "default": false,
               "description": "Generate client certificates locally using cert-manager (for multi-cluster setups where data plane is in different cluster)",
-              "required": [],
               "title": "generateCerts",
               "type": "boolean"
             },
             "renewBefore": {
               "default": "360h",
               "description": "Time before expiry to renew certificate",
-              "required": [],
               "title": "renewBefore",
               "type": "string"
             },
             "secretName": {
               "default": "cluster-agent-tls",
               "description": "Secret name for client certificate and key",
-              "required": [],
               "title": "secretName",
               "type": "string"
             },
             "serverCAConfigMap": {
               "default": "cluster-gateway-ca",
               "description": "ConfigMap name containing server CA certificate for verifying gateway",
-              "required": [],
               "title": "serverCAConfigMap",
               "type": "string"
             },
             "serverCAValue": {
               "default": "",
               "description": "Inline server CA certificate in PEM format (for multi-cluster setup). Takes precedence over copying from control plane.",
-              "required": [],
               "title": "serverCAValue",
               "type": "string"
             }
@@ -679,11 +623,9 @@
                   "PreferNoSchedule",
                   "NoExecute"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               },
               "key": {
-                "required": [],
                 "type": "string"
               },
               "operator": {
@@ -691,18 +633,15 @@
                   "Exists",
                   "Equal"
                 ],
-                "required": [],
-                "type": "string"
+                "required": []
               },
               "value": {
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         }
@@ -718,21 +657,18 @@
         "enabled": {
           "default": false,
           "description": "Enable External Secrets Operator for production secret management",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "external-secrets",
           "description": "Override the full name of External Secrets resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
         "nameOverride": {
           "default": "external-secrets",
           "description": "Override the name of External Secrets resources",
-          "required": [],
           "title": "nameOverride",
           "type": "string"
         }
@@ -748,14 +684,12 @@
         "enabled": {
           "default": true,
           "description": "Enable the fake secret store (development only - disable in production)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "name": {
           "default": "default",
           "description": "Name of the fake ClusterSecretStore resource",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -765,19 +699,16 @@
             "properties": {
               "key": {
                 "description": "Secret key name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Secret value (for development only)",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "secrets",
           "type": "array"
         }
@@ -797,28 +728,24 @@
             "customParsers": {
               "default": "[PARSER]\n    Name docker_no_time\n    Format json\n    Time_Keep Off\n    Time_Key time\n    Time_Format %Y-%m-%dT%H:%M:%S.%L\n",
               "description": "Custom parser definitions in Fluent Bit configuration format",
-              "required": [],
               "title": "customParsers",
               "type": "string"
             },
             "filters": {
               "default": "[FILTER]\n    Name kubernetes\n    Buffer_Size 32MB\n    K8S-Logging.Parser On\n    K8S-Logging.Exclude On\n    Keep_Log On\n    Match kube.*\n    Merge_Log Off\n    tls.verify Off\n    Use_Kubelet true\n",
               "description": "Filter plugin configuration for log processing",
-              "required": [],
               "title": "filters",
               "type": "string"
             },
             "inputs": {
               "default": "[INPUT]\n    Name tail\n    Buffer_Chunk_Size 32KB\n    Buffer_Max_Size 2MB\n    DB /var/lib/fluent-bit/db/tail-container-logs.db\n    Exclude_Path /var/log/containers/fluent-bit-*_openchoreo-data-plane_*.log\n    Inotify_Watcher false\n    Mem_Buf_Limit 256MB\n    Path /var/log/containers/*.log\n    multiline.parser docker, cri\n    Read_from_Head On\n    Refresh_Interval 5\n    Skip_Long_Lines On\n    Tag kube.*\n",
               "description": "Input plugin configuration for log collection",
-              "required": [],
               "title": "inputs",
               "type": "string"
             },
             "outputs": {
               "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
               "description": "Output plugin configuration for log forwarding to OpenSearch",
-              "required": [],
               "title": "outputs",
               "type": "string"
             }
@@ -842,7 +769,6 @@
         "enabled": {
           "default": false,
           "description": "Enable Fluent Bit log collector deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -852,7 +778,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraVolumeMounts",
           "type": "array"
         },
@@ -862,21 +787,18 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraVolumes",
           "type": "array"
         },
         "fullnameOverride": {
           "default": "fluent-bit",
           "description": "Override the full name of Fluent Bit resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
         "hostNetwork": {
           "default": true,
           "description": "Use host network for Fluent Bit pods (required for node log access)",
-          "required": [],
           "title": "hostNetwork",
           "type": "boolean"
         },
@@ -886,7 +808,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "initContainers",
           "type": "array"
         },
@@ -895,7 +816,6 @@
           "description": "Port for Fluent Bit metrics endpoint",
           "maximum": 65535,
           "minimum": 1,
-          "required": [],
           "title": "metricsPort",
           "type": "integer"
         },
@@ -906,7 +826,6 @@
             "nodeAccess": {
               "default": true,
               "description": "Enable node-level access for reading container logs",
-              "required": [],
               "title": "nodeAccess",
               "type": "boolean"
             }
@@ -926,14 +845,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU limit for Fluent Bit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit for Fluent Bit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -949,14 +866,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request for Fluent Bit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request for Fluent Bit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -977,7 +892,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -988,10 +902,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -1003,14 +915,12 @@
             "readOnlyRootFilesystem": {
               "default": true,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run container as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
@@ -1018,7 +928,6 @@
               "default": 10000,
               "description": "User ID to run the container",
               "minimum": 0,
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -1036,7 +945,6 @@
               "description": "Service port for Fluent Bit metrics",
               "maximum": 65535,
               "minimum": 1,
-              "required": [],
               "title": "port",
               "type": "integer"
             }
@@ -1052,7 +960,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Fluent Bit test framework",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1077,7 +984,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Agent Gateway for AI agent connectivity",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1108,21 +1014,18 @@
                 "registry": {
                   "default": "",
                   "description": "Container registry for the controller image. Empty uses default registry.",
-                  "required": [],
                   "title": "registry",
                   "type": "string"
                 },
                 "repository": {
                   "default": "kgateway",
                   "description": "Image repository name for the gateway controller",
-                  "required": [],
                   "title": "repository",
                   "type": "string"
                 },
                 "tag": {
                   "default": "",
                   "description": "Image tag. Empty uses Chart.AppVersion.",
-                  "required": [],
                   "title": "tag",
                   "type": "string"
                 }
@@ -1148,7 +1051,6 @@
               "default": 1,
               "description": "Number of gateway controller replicas",
               "minimum": 1,
-              "required": [],
               "title": "replicaCount",
               "type": "integer"
             },
@@ -1163,14 +1065,12 @@
                     "cpu": {
                       "default": "200m",
                       "description": "CPU limit for the controller",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "256Mi",
                       "description": "Memory limit for the controller",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -1186,14 +1086,12 @@
                     "cpu": {
                       "default": "100m",
                       "description": "CPU request for the controller",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "128Mi",
                       "description": "Memory request for the controller",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -1218,28 +1116,24 @@
                     "agwGrpc": {
                       "default": 9978,
                       "description": "Agent gateway gRPC port",
-                      "required": [],
                       "title": "agwGrpc",
                       "type": "integer"
                     },
                     "grpc": {
                       "default": 9977,
                       "description": "gRPC port for xDS communication",
-                      "required": [],
                       "title": "grpc",
                       "type": "integer"
                     },
                     "health": {
                       "default": 9093,
                       "description": "Health check endpoint port",
-                      "required": [],
                       "title": "health",
                       "type": "integer"
                     },
                     "metrics": {
                       "default": 9092,
                       "description": "Metrics endpoint port",
-                      "required": [],
                       "title": "metrics",
                       "type": "integer"
                     }
@@ -1272,7 +1166,6 @@
         "enabled": {
           "default": true,
           "description": "Enable Gateway CR creation",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -1283,14 +1176,12 @@
             "enabled": {
               "default": true,
               "description": "Enable Envoy proxy for traffic routing",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "mountTmpVolume": {
               "default": false,
               "description": "Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues on macOS with Docker Desktop/Colima",
-              "required": [],
               "title": "mountTmpVolume",
               "type": "boolean"
             }
@@ -1304,7 +1195,6 @@
           "description": "Port for the HTTP listener on the gateway",
           "maximum": 65535,
           "minimum": 1,
-          "required": [],
           "title": "httpPort",
           "type": "integer"
         },
@@ -1313,7 +1203,6 @@
           "description": "Port for the HTTPS listener on the gateway",
           "maximum": 65535,
           "minimum": 1,
-          "required": [],
           "title": "httpsPort",
           "type": "integer"
         },
@@ -1335,14 +1224,12 @@
             "registry": {
               "default": "cr.kgateway.dev/kgateway-dev",
               "description": "Container registry for gateway images",
-              "required": [],
               "title": "registry",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Image tag. Empty uses Chart.AppVersion.",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -1358,7 +1245,6 @@
             "enabled": {
               "default": true,
               "description": "Create self-signed ClusterIssuer (set to false in single cluster mode)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1374,21 +1260,18 @@
             "certName": {
               "default": "openchoreo-gateway-tls",
               "description": "Kubernetes Secret name for storing the TLS certificate",
-              "required": [],
               "title": "certName",
               "type": "string"
             },
             "clusterIssuer": {
               "default": "",
               "description": "Cert-manager ClusterIssuer name for certificate generation. Defaults to openchoreo-selfsigned-issuer if empty.",
-              "required": [],
               "title": "clusterIssuer",
               "type": "string"
             },
             "hostname": {
               "default": "*.openchoreoapis.localhost",
               "description": "Hostname pattern for the HTTPS listener certificate",
-              "required": [],
               "title": "hostname",
               "type": "string"
             }
@@ -1409,7 +1292,6 @@
         "enabled": {
           "default": true,
           "description": "Enable kgateway controller installation (set to false in single cluster mode for data-plane)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         }
@@ -1455,7 +1337,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Alertmanager for alert management (not used by OpenChoreo)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1467,7 +1348,6 @@
         "cleanPrometheusOperatorObjectNames": {
           "default": true,
           "description": "Produce cleaner resource names without redundant prefixes",
-          "required": [],
           "title": "cleanPrometheusOperatorObjectNames",
           "type": "boolean"
         },
@@ -1478,7 +1358,6 @@
             "enabled": {
               "default": false,
               "description": "Enable CoreDNS metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1494,7 +1373,6 @@
             "enabled": {
               "default": true,
               "description": "Install Prometheus Operator CRDs (ServiceMonitor, PodMonitor, etc.)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1510,7 +1388,6 @@
             "create": {
               "default": false,
               "description": "Create default alerting rules (disabled - OpenChoreo uses custom rules)",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -1522,14 +1399,12 @@
         "enabled": {
           "default": false,
           "description": "Enable the Prometheus monitoring stack for metrics collection",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "openchoreo-observability",
           "description": "Override the full name of Prometheus stack resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -1540,7 +1415,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Grafana dashboards (not used by OpenChoreo - use observability plane instead)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1559,37 +1433,30 @@
               ],
               "description": "Kubernetes resource types to collect metrics from",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "collectors",
               "type": "array"
             },
             "fullnameOverride": {
               "default": "kube-state-metrics",
               "description": "Override the full name of kube-state-metrics resources",
-              "required": [],
               "title": "fullnameOverride",
               "type": "string"
             },
             "metricAllowlist": {
               "description": "Specific metrics to collect (allowlist filter)",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "metricAllowlist",
               "type": "array"
             },
             "metricLabelsAllowlist": {
               "description": "Pod labels to include in metrics for filtering by OpenChoreo resources",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "metricLabelsAllowlist",
               "type": "array"
             }
@@ -1605,7 +1472,6 @@
             "enabled": {
               "default": false,
               "description": "Enable API server metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1621,7 +1487,6 @@
             "enabled": {
               "default": false,
               "description": "Enable controller manager metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1637,7 +1502,6 @@
             "enabled": {
               "default": false,
               "description": "Enable etcd metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1653,7 +1517,6 @@
             "enabled": {
               "default": false,
               "description": "Enable kube-proxy metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1669,7 +1532,6 @@
             "enabled": {
               "default": false,
               "description": "Enable scheduler metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1685,7 +1547,6 @@
             "enabled": {
               "default": false,
               "description": "Enable node-level metrics collection",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1701,14 +1562,12 @@
             "agentMode": {
               "default": true,
               "description": "Run Prometheus in agent mode for lightweight remote-write only operation",
-              "required": [],
               "title": "agentMode",
               "type": "boolean"
             },
             "enabled": {
               "default": true,
               "description": "Deploy a Prometheus instance (requires Prometheus Operator)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1722,14 +1581,12 @@
                     "properties": {
                       "url": {
                         "description": "Remote write endpoint URL",
-                        "required": [],
                         "type": "string"
                       }
                     },
                     "required": [],
                     "type": "object"
                   },
-                  "required": [],
                   "title": "remoteWrite",
                   "type": "array"
                 }
@@ -1750,14 +1607,12 @@
             "enabled": {
               "default": true,
               "description": "Enable Prometheus Operator for managing Prometheus instances",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "fullnameOverride": {
               "default": "prometheus-operator",
               "description": "Override the full name of Prometheus Operator resources",
-              "required": [],
               "title": "fullnameOverride",
               "type": "string"
             },
@@ -1772,14 +1627,12 @@
                     "cpu": {
                       "default": "40m",
                       "description": "CPU limit for Prometheus Operator",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "50Mi",
                       "description": "Memory limit for Prometheus Operator",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -1795,14 +1648,12 @@
                     "cpu": {
                       "default": "20m",
                       "description": "CPU request for Prometheus Operator",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "30Mi",
                       "description": "Memory request for Prometheus Operator",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -1829,7 +1680,6 @@
     "kubernetesClusterDomain": {
       "default": "cluster.local",
       "description": "Kubernetes cluster DNS domain used for service discovery and certificate generation",
-      "required": [],
       "title": "kubernetesClusterDomain",
       "type": "string"
     },
@@ -1840,7 +1690,6 @@
         "enabled": {
           "default": true,
           "description": "Enable networking features (network policies, service mesh integration)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         }
@@ -1856,7 +1705,6 @@
         "enabled": {
           "default": true,
           "description": "Master switch for all observability features",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -1867,7 +1715,6 @@
             "enabled": {
               "default": false,
               "description": "Enable log collection. Set to true after observability plane is installed.",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -1882,7 +1729,6 @@
                     "enabled": {
                       "default": true,
                       "description": "Enable Fluent Bit as the log publisher",
-                      "required": [],
                       "title": "enabled",
                       "type": "boolean"
                     }
@@ -1908,7 +1754,6 @@
             "enabled": {
               "default": false,
               "description": "Enable metrics collection. Set to true after observability plane is installed.",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1920,7 +1765,6 @@
         "observabilityPlaneUrl": {
           "default": "",
           "description": "URL of the observability plane for sending telemetry data (OTLP endpoint)",
-          "required": [],
           "title": "observabilityPlaneUrl",
           "type": "string"
         }
@@ -1940,7 +1784,6 @@
             "create": {
               "default": true,
               "description": "Create ClusterRole for OpenTelemetry Collector",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
@@ -1950,33 +1793,26 @@
                 "properties": {
                   "apiGroups": {
                     "items": {
-                      "required": [],
                       "type": "string"
                     },
-                    "required": [],
                     "type": "array"
                   },
                   "resources": {
                     "items": {
-                      "required": [],
                       "type": "string"
                     },
-                    "required": [],
                     "type": "array"
                   },
                   "verbs": {
                     "items": {
-                      "required": [],
                       "type": "string"
                     },
-                    "required": [],
                     "type": "array"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "rules",
               "type": "array"
             }
@@ -1992,14 +1828,12 @@
             "create": {
               "default": false,
               "description": "Create a new ConfigMap (false to use existing)",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "existingName": {
               "default": "opentelemetry-collector-config",
               "description": "Name of existing ConfigMap containing collector configuration",
-              "required": [],
               "title": "existingName",
               "type": "string"
             }
@@ -2011,14 +1845,12 @@
         "enabled": {
           "default": false,
           "description": "Enable OpenTelemetry Collector deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "opentelemetry-collector",
           "description": "Override the full name of OpenTelemetry Collector resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -2029,7 +1861,6 @@
             "repository": {
               "default": "otel/opentelemetry-collector-contrib",
               "description": "OpenTelemetry Collector image repository (contrib version includes extra receivers/exporters)",
-              "required": [],
               "title": "repository",
               "type": "string"
             }
@@ -2061,14 +1892,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU limit for the collector",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "200Mi",
                   "description": "Memory limit for the collector",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2084,14 +1913,12 @@
                 "cpu": {
                   "default": "50m",
                   "description": "CPU request for the collector",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "100Mi",
                   "description": "Memory request for the collector",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2117,7 +1944,6 @@
         "enabled": {
           "default": false,
           "description": "[DEPRECATED] Enable the container registry. Use Build Plane registry instead.",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -2132,14 +1958,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU limit for the registry",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit for the registry",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2155,14 +1979,12 @@
                 "cpu": {
                   "default": "50m",
                   "description": "CPU request for the registry",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request for the registry",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2185,7 +2007,6 @@
               "description": "NodePort for external access to the registry",
               "maximum": 32767,
               "minimum": 30000,
-              "required": [],
               "title": "nodePort",
               "type": "integer"
             }
@@ -2201,7 +2022,6 @@
             "size": {
               "default": "2Gi",
               "description": "Size of the persistent volume for storing container images",
-              "required": [],
               "title": "size",
               "type": "string"
             }
@@ -2222,7 +2042,6 @@
         "enabled": {
           "default": true,
           "description": "Enable security features (certificate issuers, TLS configuration)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         }
@@ -2238,7 +2057,6 @@
         "image": {
           "default": "bitnamilegacy/kubectl:1.32.4",
           "description": "Container image for kubectl-based wait jobs used in Helm hooks",
-          "required": [],
           "title": "image",
           "type": "string"
         }

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -1723,12 +1723,10 @@ clusterAgent:
   #     key:
   #       type: string
   #     operator:
-  #       type: string
   #       enum: [Exists, Equal]
   #     value:
   #       type: string
   #     effect:
-  #       type: string
   #       enum: [NoSchedule, PreferNoSchedule, NoExecute]
   # default: []
   # @schema

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -21,7 +21,6 @@
             "enabled": {
               "default": false,
               "description": "Enable CoreDNS rewrite for *.openchoreo.localhost to host.k3d.internal",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -33,14 +32,12 @@
         "enabled": {
           "default": true,
           "description": "Enable cluster agent deployment for multi-cluster communication",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "heartbeatInterval": {
           "default": "30s",
           "description": "Interval between heartbeat messages to the control plane",
-          "required": [],
           "title": "heartbeatInterval",
           "type": "string"
         },
@@ -62,14 +59,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/cluster-agent",
               "description": "Container image repository for the cluster agent",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Container image tag (defaults to Chart.AppVersion if empty)",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -93,7 +88,6 @@
         "name": {
           "default": "cluster-agent-observabilityplane",
           "description": "Name of the cluster agent deployment and associated resources",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -110,7 +104,6 @@
         "planeID": {
           "default": "default-observabilityplane",
           "description": "Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.\nDefaults to Helm release name if not specified.\n",
-          "required": [],
           "title": "planeID",
           "type": "string"
         },
@@ -143,14 +136,12 @@
               "default": 1000,
               "description": "Filesystem group ID",
               "minimum": 0,
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
@@ -158,7 +149,6 @@
               "default": 1000,
               "description": "User ID to run as",
               "minimum": 0,
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -174,14 +164,12 @@
             "create": {
               "default": false,
               "description": "Create a priority class",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-agent-observabilityplane",
               "description": "Name of the priority class",
-              "required": [],
               "title": "name",
               "type": "string"
             },
@@ -189,7 +177,6 @@
               "default": 900000,
               "description": "Priority value",
               "minimum": 0,
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -205,7 +192,6 @@
             "create": {
               "default": true,
               "description": "Create ClusterRole and ClusterRoleBinding for the agent",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -217,7 +203,6 @@
         "reconnectDelay": {
           "default": "5s",
           "description": "Delay before reconnecting after connection loss",
-          "required": [],
           "title": "reconnectDelay",
           "type": "string"
         },
@@ -225,7 +210,6 @@
           "default": 1,
           "description": "Number of cluster agent pod replicas",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -240,14 +224,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU limit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -263,14 +245,12 @@
                 "cpu": {
                   "default": "50m",
                   "description": "CPU request",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -291,7 +271,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -302,10 +281,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -317,7 +294,6 @@
             "readOnlyRootFilesystem": {
               "default": true,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             }
@@ -329,14 +305,12 @@
         "serverCANamespace": {
           "default": "openchoreo-control-plane",
           "description": "Namespace where cluster-gateway CA ConfigMap exists",
-          "required": [],
           "title": "serverCANamespace",
           "type": "string"
         },
         "serverUrl": {
           "default": "wss://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443/ws",
           "description": "WebSocket URL of the cluster gateway in the control plane",
-          "required": [],
           "title": "serverUrl",
           "type": "string"
         },
@@ -357,14 +331,12 @@
             "create": {
               "default": true,
               "description": "Create a dedicated service account",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "cluster-agent-observabilityplane",
               "description": "Name of the service account",
-              "required": [],
               "title": "name",
               "type": "string"
             }
@@ -380,77 +352,66 @@
             "caSecretName": {
               "default": "cluster-gateway-ca",
               "description": "CA secret name for signing agent client certificates. If empty, self-signed certs will be generated (required for multi-cluster setup).",
-              "required": [],
               "title": "caSecretName",
               "type": "string"
             },
             "caSecretNamespace": {
               "default": "openchoreo-control-plane",
               "description": "Namespace where the CA secret exists. If empty, self-signed certs will be generated (required for multi-cluster setup).",
-              "required": [],
               "title": "caSecretNamespace",
               "type": "string"
             },
             "caValue": {
               "default": "",
               "description": "Inline CA certificate in PEM format (for multi-cluster, takes precedence)",
-              "required": [],
               "title": "caValue",
               "type": "string"
             },
             "clientSecretName": {
               "default": "cluster-agent-tls",
               "description": "Name of the client certificate Secret",
-              "required": [],
               "title": "clientSecretName",
               "type": "string"
             },
             "duration": {
               "default": "2160h",
               "description": "Certificate validity duration (e.g., 2160h = 90 days)",
-              "required": [],
               "title": "duration",
               "type": "string"
             },
             "enabled": {
               "default": true,
               "description": "Enable TLS for cluster agent communication",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "generateCerts": {
               "default": false,
               "description": "Generate client certificates using cert-manager (for multi-cluster setups)",
-              "required": [],
               "title": "generateCerts",
               "type": "boolean"
             },
             "renewBefore": {
               "default": "360h",
               "description": "Time before expiry to renew certificate (e.g., 360h = 15 days)",
-              "required": [],
               "title": "renewBefore",
               "type": "string"
             },
             "secretName": {
               "default": "cluster-agent-tls",
               "description": "Name of the Secret containing client certificate and key",
-              "required": [],
               "title": "secretName",
               "type": "string"
             },
             "serverCAConfigMap": {
               "default": "cluster-gateway-ca",
               "description": "Name of the ConfigMap containing server CA certificate",
-              "required": [],
               "title": "serverCAConfigMap",
               "type": "string"
             },
             "serverCAValue": {
               "default": "",
               "description": "Inline server CA certificate in PEM format (for multi-cluster setups)",
-              "required": [],
               "title": "serverCAValue",
               "type": "string"
             }
@@ -466,7 +427,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         }
@@ -494,7 +454,6 @@
             "enabled": {
               "default": false,
               "description": "Enable cluster gateway integration for multi-cluster setups",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -505,14 +464,12 @@
                 "caConfigMap": {
                   "default": "cluster-gateway-ca",
                   "description": "Name of the ConfigMap containing the gateway CA certificate",
-                  "required": [],
                   "title": "caConfigMap",
                   "type": "string"
                 },
                 "caPath": {
                   "default": "/etc/cluster-gateway/ca.crt",
                   "description": "Path to the CA certificate file for gateway verification",
-                  "required": [],
                   "title": "caPath",
                   "type": "string"
                 }
@@ -524,7 +481,6 @@
             "url": {
               "default": "https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443",
               "description": "URL of the cluster gateway service in the control plane",
-              "required": [],
               "title": "url",
               "type": "string"
             }
@@ -540,7 +496,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation within the container",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -554,10 +509,8 @@
                   ],
                   "description": "Capabilities to drop from the container",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -569,7 +522,6 @@
             "readOnlyRootFilesystem": {
               "default": false,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
@@ -601,14 +553,12 @@
         "deploymentPlane": {
           "default": "observabilityplane",
           "description": "Identifier for this deployment plane type",
-          "required": [],
           "title": "deploymentPlane",
           "type": "string"
         },
         "enabled": {
           "default": true,
           "description": "Enable or disable the controller manager deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -630,14 +580,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/controller",
               "description": "Container image repository for the controller manager",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Container image tag (defaults to Chart.AppVersion if empty)",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -653,10 +601,8 @@
             "args": {
               "description": "Command line arguments passed to the controller manager",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "args",
               "type": "array"
             },
@@ -667,7 +613,6 @@
                 "enableWebhooks": {
                   "default": "false",
                   "description": "Enable or disable admission webhooks",
-                  "required": [],
                   "title": "enableWebhooks",
                   "type": "string"
                 }
@@ -684,7 +629,6 @@
         "name": {
           "default": "controller-manager",
           "description": "Name of the controller manager deployment and associated resources",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -706,7 +650,6 @@
               "default": 1000,
               "description": "Group ID for filesystem access",
               "minimum": 0,
-              "required": [],
               "title": "fsGroup",
               "type": "integer"
             },
@@ -714,14 +657,12 @@
               "default": 1000,
               "description": "Group ID to run the container process",
               "minimum": 0,
-              "required": [],
               "title": "runAsGroup",
               "type": "integer"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Require the container to run as a non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
@@ -729,7 +670,6 @@
               "default": 1000,
               "description": "User ID to run the container process",
               "minimum": 0,
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -745,14 +685,12 @@
             "create": {
               "default": false,
               "description": "Create a priority class for the controller manager",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "observabilityplane-controller-manager",
               "description": "Name of the priority class",
-              "required": [],
               "title": "name",
               "type": "string"
             },
@@ -760,7 +698,6 @@
               "default": 900000,
               "description": "Priority value (higher values indicate higher priority)",
               "minimum": 0,
-              "required": [],
               "title": "value",
               "type": "integer"
             }
@@ -773,7 +710,6 @@
           "default": 1,
           "description": "Number of controller manager pod replicas",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -788,14 +724,12 @@
                 "cpu": {
                   "default": "500m",
                   "description": "CPU limit for the controller manager",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "512Mi",
                   "description": "Memory limit for the controller manager",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -811,14 +745,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request for the controller manager",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory request for the controller manager",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -849,7 +781,6 @@
             "create": {
               "default": true,
               "description": "Create a dedicated service account for the controller manager",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -865,7 +796,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "tolerations",
           "type": "array"
         },
@@ -876,7 +806,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
         }
@@ -892,14 +821,12 @@
         "enabled": {
           "default": false,
           "description": "Enable Data Prepper for trace pipeline processing",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "data-prepper",
           "description": "Override the full name of Data Prepper resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -922,13 +849,11 @@
                           "properties": {
                             "batch_size": {
                               "default": 200,
-                              "required": [],
                               "title": "batch_size",
                               "type": "integer"
                             },
                             "buffer_size": {
                               "default": 12800,
-                              "required": [],
                               "title": "buffer_size",
                               "type": "integer"
                             }
@@ -949,7 +874,6 @@
                     },
                     "delay": {
                       "default": "100",
-                      "required": [],
                       "title": "delay",
                       "type": "string"
                     },
@@ -966,37 +890,31 @@
                                     "items": {
                                       "anyOf": [
                                         {
-                                          "required": [],
                                           "type": "string"
                                         }
                                       ],
                                       "required": []
                                     },
-                                    "required": [],
                                     "title": "hosts",
                                     "type": "array"
                                   },
                                   "index": {
                                     "default": "otel-traces-%{yyyy-MM-dd}",
-                                    "required": [],
                                     "title": "index",
                                     "type": "string"
                                   },
                                   "insecure": {
                                     "default": true,
-                                    "required": [],
                                     "title": "insecure",
                                     "type": "boolean"
                                   },
                                   "password": {
                                     "default": "ThisIsTheOpenSearchPassword1",
-                                    "required": [],
                                     "title": "password",
                                     "type": "string"
                                   },
                                   "username": {
                                     "default": "admin",
-                                    "required": [],
                                     "title": "username",
                                     "type": "string"
                                   }
@@ -1020,7 +938,6 @@
                         ],
                         "required": []
                       },
-                      "required": [],
                       "title": "sink",
                       "type": "array"
                     },
@@ -1032,7 +949,6 @@
                           "properties": {
                             "ssl": {
                               "default": false,
-                              "required": [],
                               "title": "ssl",
                               "type": "boolean"
                             }
@@ -1070,7 +986,6 @@
             "enabled": {
               "default": true,
               "description": "Enable pipeline configuration",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1090,14 +1005,12 @@
                 "cpu": {
                   "default": "1000m",
                   "description": "CPU limit for Data Prepper",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "500Mi",
                   "description": "Memory limit for Data Prepper",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1113,14 +1026,12 @@
                 "cpu": {
                   "default": "700m",
                   "description": "CPU request for Data Prepper",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "500Mi",
                   "description": "Memory request for Data Prepper",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1146,21 +1057,18 @@
         "enabled": {
           "default": false,
           "description": "Enable External Secrets Operator installation in this chart",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "external-secrets",
           "description": "Override the full name of External Secrets Operator resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
         "nameOverride": {
           "default": "external-secrets",
           "description": "Override the name of External Secrets Operator resources",
-          "required": [],
           "title": "nameOverride",
           "type": "string"
         }
@@ -1176,14 +1084,12 @@
         "enabled": {
           "default": false,
           "description": "Enable fake secret store (requires external-secrets.enabled to be true)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "name": {
           "default": "default",
           "description": "Name of the ClusterSecretStore resource",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -1193,19 +1099,16 @@
             "properties": {
               "key": {
                 "description": "Secret key name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Secret value",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "secrets",
           "type": "array"
         }
@@ -1225,28 +1128,24 @@
             "customParsers": {
               "default": "[PARSER]\n    Name docker_no_time\n    Format json\n    Time_Keep Off\n    Time_Key time\n    Time_Format %Y-%m-%dT%H:%M:%S.%L\n",
               "description": "Custom parser definitions in Fluent Bit configuration format",
-              "required": [],
               "title": "customParsers",
               "type": "string"
             },
             "filters": {
               "default": "[FILTER]\n    Name kubernetes\n    Buffer_Size 32MB\n    K8S-Logging.Parser On\n    K8S-Logging.Exclude On\n    Keep_Log On\n    Match kube.*\n    Merge_Log Off\n    tls.verify Off\n    Use_Kubelet true\n",
               "description": "Filter plugin configuration for log processing",
-              "required": [],
               "title": "filters",
               "type": "string"
             },
             "inputs": {
               "default": "[INPUT]\n    Name tail\n    Buffer_Chunk_Size 32KB\n    Buffer_Max_Size 2MB\n    DB /var/lib/fluent-bit/db/tail-container-logs.db\n    Exclude_Path /var/log/containers/fluent-bit-*_openchoreo-observability-plane_*.log\n    Inotify_Watcher false\n    Mem_Buf_Limit 256MB\n    Path /var/log/containers/*.log\n    multiline.parser docker, cri\n    Read_from_Head On\n    Refresh_Interval 5\n    Skip_Long_Lines On\n    Tag kube.*\n",
               "description": "Input plugin configuration for log collection",
-              "required": [],
               "title": "inputs",
               "type": "string"
             },
             "outputs": {
               "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
               "description": "Output plugin configuration for log forwarding to OpenSearch",
-              "required": [],
               "title": "outputs",
               "type": "string"
             }
@@ -1270,7 +1169,6 @@
         "enabled": {
           "default": false,
           "description": "Enable Fluent Bit log collector deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -1280,7 +1178,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraVolumeMounts",
           "type": "array"
         },
@@ -1290,21 +1187,18 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraVolumes",
           "type": "array"
         },
         "fullnameOverride": {
           "default": "fluent-bit",
           "description": "Override the full name of Fluent Bit resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
         "hostNetwork": {
           "default": true,
           "description": "Use host network for Fluent Bit pods (required for node log access)",
-          "required": [],
           "title": "hostNetwork",
           "type": "boolean"
         },
@@ -1314,7 +1208,6 @@
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "initContainers",
           "type": "array"
         },
@@ -1323,7 +1216,6 @@
           "description": "Port for Fluent Bit metrics endpoint",
           "maximum": 65535,
           "minimum": 1,
-          "required": [],
           "title": "metricsPort",
           "type": "integer"
         },
@@ -1334,7 +1226,6 @@
             "nodeAccess": {
               "default": true,
               "description": "Enable node-level access for reading container logs",
-              "required": [],
               "title": "nodeAccess",
               "type": "boolean"
             }
@@ -1354,14 +1245,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU limit for Fluent Bit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "256Mi",
                   "description": "Memory limit for Fluent Bit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1377,14 +1266,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request for Fluent Bit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request for Fluent Bit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1405,7 +1292,6 @@
             "allowPrivilegeEscalation": {
               "default": false,
               "description": "Prevent privilege escalation",
-              "required": [],
               "title": "allowPrivilegeEscalation",
               "type": "boolean"
             },
@@ -1416,10 +1302,8 @@
                 "drop": {
                   "description": "Capabilities to drop",
                   "items": {
-                    "required": [],
                     "type": "string"
                   },
-                  "required": [],
                   "title": "drop",
                   "type": "array"
                 }
@@ -1431,14 +1315,12 @@
             "readOnlyRootFilesystem": {
               "default": true,
               "description": "Mount root filesystem as read-only",
-              "required": [],
               "title": "readOnlyRootFilesystem",
               "type": "boolean"
             },
             "runAsNonRoot": {
               "default": true,
               "description": "Run container as non-root user",
-              "required": [],
               "title": "runAsNonRoot",
               "type": "boolean"
             },
@@ -1446,7 +1328,6 @@
               "default": 10000,
               "description": "User ID to run the container",
               "minimum": 0,
-              "required": [],
               "title": "runAsUser",
               "type": "integer"
             }
@@ -1464,7 +1345,6 @@
               "description": "Service port for Fluent Bit metrics",
               "maximum": 65535,
               "minimum": 1,
-              "required": [],
               "title": "port",
               "type": "integer"
             }
@@ -1480,7 +1360,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Fluent Bit test framework",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -1501,7 +1380,6 @@
         "enabled": {
           "default": false,
           "description": "Enable gateway resource creation",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -1512,7 +1390,6 @@
             "mountTmpVolume": {
               "default": false,
               "description": "Mount /tmp as emptyDir volume to fix Envoy temporary file creation issues on macOS with Docker Desktop/Colima",
-              "required": [],
               "title": "mountTmpVolume",
               "type": "boolean"
             }
@@ -1533,7 +1410,6 @@
         "baseDomain": {
           "default": "",
           "description": "Base domain for the observability plane used in gateway routing and ingress configuration",
-          "required": [],
           "title": "baseDomain",
           "type": "string"
         },
@@ -1602,14 +1478,12 @@
                     "cpu": {
                       "default": "200m",
                       "description": "CPU limit for KGateway controller",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "256Mi",
                       "description": "Memory limit for KGateway controller",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -1625,14 +1499,12 @@
                     "cpu": {
                       "default": "100m",
                       "description": "CPU request for KGateway controller",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "128Mi",
                       "description": "Memory request for KGateway controller",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -1659,7 +1531,6 @@
                       "description": "gRPC port for the API gateway",
                       "maximum": 65535,
                       "minimum": 1,
-                      "required": [],
                       "title": "agwGrpc",
                       "type": "integer"
                     }
@@ -1692,14 +1563,12 @@
         "enabled": {
           "default": false,
           "description": "Enable KGateway API gateway",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "kgateway",
           "description": "Override the full name of KGateway resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         }
@@ -1711,7 +1580,6 @@
     "kubernetesClusterDomain": {
       "default": "cluster.local",
       "description": "Kubernetes cluster domain used for service discovery DNS resolution",
-      "required": [],
       "title": "kubernetesClusterDomain",
       "type": "string"
     },
@@ -1725,19 +1593,16 @@
             "properties": {
               "name": {
                 "description": "Environment variable name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Environment variable value",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraEnvs",
           "type": "array"
         },
@@ -1759,14 +1624,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/observer",
               "description": "Container image repository for the Observer",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Container image tag (defaults to Chart.AppVersion if empty)",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -1790,14 +1653,12 @@
         "openSearchPassword": {
           "default": "ThisIsTheOpenSearchPassword1",
           "description": "Password for OpenSearch authentication",
-          "required": [],
           "title": "openSearchPassword",
           "type": "string"
         },
         "openSearchUsername": {
           "default": "admin",
           "description": "Username for OpenSearch authentication",
-          "required": [],
           "title": "openSearchUsername",
           "type": "string"
         },
@@ -1808,14 +1669,12 @@
             "address": {
               "default": "",
               "description": "Prometheus server address (auto-constructed from release name if empty)",
-              "required": [],
               "title": "address",
               "type": "string"
             },
             "timeout": {
               "default": "30s",
               "description": "Timeout for Prometheus queries",
-              "required": [],
               "title": "timeout",
               "type": "string"
             }
@@ -1828,7 +1687,6 @@
           "default": 1,
           "description": "Number of Observer pod replicas",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -1843,14 +1701,12 @@
                 "cpu": {
                   "default": "200m",
                   "description": "CPU limit for the Observer",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "200Mi",
                   "description": "Memory limit for the Observer",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1866,14 +1722,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request for the Observer",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "128Mi",
                   "description": "Memory request for the Observer",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -1902,12 +1756,10 @@
                           "properties": {
                             "claim": {
                               "description": "JWT claim name for entitlement",
-                              "required": [],
                               "type": "string"
                             },
                             "display_name": {
                               "description": "Human-readable name for the claim",
-                              "required": [],
                               "type": "string"
                             }
                           },
@@ -1916,36 +1768,30 @@
                         },
                         "type": {
                           "description": "Authentication mechanism type (oauth2, etc.)",
-                          "required": [],
                           "type": "string"
                         }
                       },
                       "required": [],
                       "type": "object"
                     },
-                    "required": [],
                     "type": "array"
                   },
                   "display_name": {
                     "description": "Human-readable name for the user type",
-                    "required": [],
                     "type": "string"
                   },
                   "priority": {
                     "description": "Detection priority (lower = higher priority)",
-                    "required": [],
                     "type": "integer"
                   },
                   "type": {
                     "description": "User type identifier (user, service_account, etc.)",
-                    "required": [],
                     "type": "string"
                   }
                 },
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "userTypes",
               "type": "array"
             }
@@ -1963,7 +1809,6 @@
               "description": "Service port for the Observer API",
               "maximum": 65535,
               "minimum": 1,
-              "required": [],
               "title": "port",
               "type": "integer"
             },
@@ -1995,7 +1840,6 @@
         "enabled": {
           "default": false,
           "description": "Enable OpenSearch Helm chart deployment (alternative to operator-based openSearchCluster)",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -2005,19 +1849,16 @@
             "properties": {
               "name": {
                 "description": "Environment variable name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Environment variable value",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraEnvs",
           "type": "array"
         },
@@ -2028,7 +1869,6 @@
             "tag": {
               "default": "3.3.0",
               "description": "OpenSearch image tag version",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -2040,14 +1880,12 @@
         "masterService": {
           "default": "opensearch",
           "description": "Name of the master service for cluster discovery",
-          "required": [],
           "title": "masterService",
           "type": "string"
         },
         "nameOverride": {
           "default": "opensearch",
           "description": "Override the name of OpenSearch resources",
-          "required": [],
           "title": "nameOverride",
           "type": "string"
         },
@@ -2058,14 +1896,12 @@
             "create": {
               "default": true,
               "description": "Create RBAC resources for OpenSearch",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "serviceAccountName": {
               "default": "opensearch",
               "description": "Name of the service account for OpenSearch",
-              "required": [],
               "title": "serviceAccountName",
               "type": "string"
             }
@@ -2077,7 +1913,6 @@
         "singleNode": {
           "default": true,
           "description": "Run OpenSearch as a single node (for development/testing)",
-          "required": [],
           "title": "singleNode",
           "type": "boolean"
         }
@@ -2093,14 +1928,12 @@
         "adminUserPassword": {
           "default": "ThisIsTheOpenSearchPassword1",
           "description": "Admin password for OpenSearch cluster",
-          "required": [],
           "title": "adminUserPassword",
           "type": "string"
         },
         "adminUsername": {
           "default": "admin",
           "description": "Admin username for OpenSearch cluster",
-          "required": [],
           "title": "adminUsername",
           "type": "string"
         },
@@ -2119,14 +1952,12 @@
                     "cpu": {
                       "default": "1000m",
                       "description": "CPU limit",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "1000Mi",
                       "description": "Memory limit",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -2142,14 +1973,12 @@
                     "cpu": {
                       "default": "100m",
                       "description": "CPU request",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "1000Mi",
                       "description": "Memory request",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -2175,7 +2004,6 @@
             "enable": {
               "default": false,
               "description": "Enable OpenSearch Dashboards",
-              "required": [],
               "title": "enable",
               "type": "boolean"
             },
@@ -2183,14 +2011,12 @@
               "default": 1,
               "description": "Number of dashboard replicas",
               "minimum": 0,
-              "required": [],
               "title": "replicas",
               "type": "integer"
             },
             "version": {
               "default": "3.3.0",
               "description": "OpenSearch Dashboards version",
-              "required": [],
               "title": "version",
               "type": "string"
             }
@@ -2202,7 +2028,6 @@
         "enabled": {
           "default": true,
           "description": "Enable OpenSearch cluster deployment via OpenSearch Operator",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -2213,14 +2038,12 @@
             "setVMMaxMapCount": {
               "default": true,
               "description": "Set vm.max_map_count sysctl for OpenSearch (required for production)",
-              "required": [],
               "title": "setVMMaxMapCount",
               "type": "boolean"
             },
             "version": {
               "default": "3.3.0",
               "description": "OpenSearch version to deploy",
-              "required": [],
               "title": "version",
               "type": "string"
             }
@@ -2232,7 +2055,6 @@
         "internalUsers": {
           "default": "# This is the internal user database\n# The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh\n\n_meta:\n  type: \"internalusers\"\n  config_version: 2\n\nadmin:\n  hash: \"%s\"\n  reserved: true\n  backend_roles:\n  - \"admin\"\n  description: \"Admin user\"\n",
           "description": "Internal users configuration in YAML format (bcrypt hashed passwords)",
-          "required": [],
           "title": "internalUsers",
           "type": "string"
         },
@@ -2247,7 +2069,6 @@
                 "diskSize": {
                   "default": "5Gi",
                   "description": "Persistent volume size for data nodes",
-                  "required": [],
                   "title": "diskSize",
                   "type": "string"
                 },
@@ -2255,7 +2076,6 @@
                   "default": 2,
                   "description": "Number of data node replicas",
                   "minimum": 1,
-                  "required": [],
                   "title": "replicas",
                   "type": "integer"
                 },
@@ -2270,14 +2090,12 @@
                         "cpu": {
                           "default": "1000m",
                           "description": "CPU limit",
-                          "required": [],
                           "title": "cpu",
                           "type": "string"
                         },
                         "memory": {
                           "default": "1000Mi",
                           "description": "Memory limit",
-                          "required": [],
                           "title": "memory",
                           "type": "string"
                         }
@@ -2293,14 +2111,12 @@
                         "cpu": {
                           "default": "100m",
                           "description": "CPU request",
-                          "required": [],
                           "title": "cpu",
                           "type": "string"
                         },
                         "memory": {
                           "default": "1000Mi",
                           "description": "Memory request",
-                          "required": [],
                           "title": "memory",
                           "type": "string"
                         }
@@ -2326,7 +2142,6 @@
                 "diskSize": {
                   "default": "1Gi",
                   "description": "Persistent volume size for master nodes",
-                  "required": [],
                   "title": "diskSize",
                   "type": "string"
                 },
@@ -2334,7 +2149,6 @@
                   "default": 3,
                   "description": "Number of master node replicas (should be odd for quorum)",
                   "minimum": 1,
-                  "required": [],
                   "title": "replicas",
                   "type": "integer"
                 },
@@ -2349,14 +2163,12 @@
                         "cpu": {
                           "default": "1000m",
                           "description": "CPU limit",
-                          "required": [],
                           "title": "cpu",
                           "type": "string"
                         },
                         "memory": {
                           "default": "900Mi",
                           "description": "Memory limit",
-                          "required": [],
                           "title": "memory",
                           "type": "string"
                         }
@@ -2372,14 +2184,12 @@
                         "cpu": {
                           "default": "100m",
                           "description": "CPU request",
-                          "required": [],
                           "title": "cpu",
                           "type": "string"
                         },
                         "memory": {
                           "default": "900Mi",
                           "description": "Memory request",
-                          "required": [],
                           "title": "memory",
                           "type": "string"
                         }
@@ -2415,7 +2225,6 @@
         "alertingWebhookUrl": {
           "default": "http://observer.openchoreo-observability-plane:8080/api/alerting/webhook/opensearch",
           "description": "Alerting webhook URL for setup configuration",
-          "required": [],
           "title": "alertingWebhookUrl",
           "type": "string"
         },
@@ -2426,21 +2235,18 @@
             "containerLogs": {
               "default": "30d",
               "description": "Retention period for container logs",
-              "required": [],
               "title": "containerLogs",
               "type": "string"
             },
             "rcaReports": {
               "default": "90d",
               "description": "Retention period for RCA reports",
-              "required": [],
               "title": "rcaReports",
               "type": "string"
             },
             "traces": {
               "default": "30d",
               "description": "Retention period for traces",
-              "required": [],
               "title": "traces",
               "type": "string"
             }
@@ -2456,14 +2262,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/init-observability-opensearch",
               "description": "Container image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Container image tag (defaults to Chart.AppVersion if empty)",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -2488,7 +2292,6 @@
             "disableSecurity": {
               "default": "true",
               "description": "Disable security features in dashboards (for development)",
-              "required": [],
               "title": "disableSecurity",
               "type": "string"
             }
@@ -2500,7 +2303,6 @@
         "enabled": {
           "default": false,
           "description": "Enable OpenSearch Dashboards deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -2510,26 +2312,22 @@
             "properties": {
               "name": {
                 "description": "Environment variable name",
-                "required": [],
                 "type": "string"
               },
               "value": {
                 "description": "Environment variable value",
-                "required": [],
                 "type": "string"
               }
             },
             "required": [],
             "type": "object"
           },
-          "required": [],
           "title": "extraEnvs",
           "type": "array"
         },
         "fullnameOverride": {
           "default": "opensearch-dashboards",
           "description": "Override the full name of OpenSearch Dashboards resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -2540,7 +2338,6 @@
             "tag": {
               "default": "3.3.0",
               "description": "OpenSearch Dashboards image tag version",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -2552,14 +2349,12 @@
         "nameOverride": {
           "default": "opensearch-dashboards",
           "description": "Override the name of OpenSearch Dashboards resources",
-          "required": [],
           "title": "nameOverride",
           "type": "string"
         },
         "opensearchHosts": {
           "default": "http://opensearch:9200",
           "description": "URL of the OpenSearch cluster to connect to",
-          "required": [],
           "title": "opensearchHosts",
           "type": "string"
         },
@@ -2567,7 +2362,6 @@
           "default": 1,
           "description": "Number of OpenSearch Dashboards replicas",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         }
@@ -2587,7 +2381,6 @@
             "create": {
               "default": true,
               "description": "Create a ClusterRole for the collector",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
@@ -2597,7 +2390,6 @@
                 "required": [],
                 "type": "object"
               },
-              "required": [],
               "title": "rules",
               "type": "array"
             }
@@ -2613,14 +2405,12 @@
             "create": {
               "default": false,
               "description": "Create ConfigMap (set to false to use existing ConfigMap)",
-              "required": [],
               "title": "create",
               "type": "boolean"
             },
             "existingName": {
               "default": "opentelemetry-collector-config",
               "description": "Name of existing ConfigMap to use for collector configuration",
-              "required": [],
               "title": "existingName",
               "type": "string"
             }
@@ -2632,14 +2422,12 @@
         "enabled": {
           "default": true,
           "description": "Enable OpenTelemetry Collector deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "opentelemetry-collector",
           "description": "Override the full name of OpenTelemetry Collector resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -2650,7 +2438,6 @@
             "repository": {
               "default": "otel/opentelemetry-collector-contrib",
               "description": "Container image repository (uses contrib distribution for extended features)",
-              "required": [],
               "title": "repository",
               "type": "string"
             }
@@ -2682,14 +2469,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU limit for the collector",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "200Mi",
                   "description": "Memory limit for the collector",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2705,14 +2490,12 @@
                 "cpu": {
                   "default": "50m",
                   "description": "CPU request for the collector",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "100Mi",
                   "description": "Memory request for the collector",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -2743,7 +2526,6 @@
               "default": 5,
               "description": "Number of consumers processing the queue",
               "minimum": 1,
-              "required": [],
               "title": "numConsumers",
               "type": "integer"
             },
@@ -2751,7 +2533,6 @@
               "default": 1000,
               "description": "Maximum queue size for pending exports",
               "minimum": 1,
-              "required": [],
               "title": "queueSize",
               "type": "integer"
             },
@@ -2782,7 +2563,6 @@
                   "default": 1000,
                   "description": "Cache size for non-sampled trace decisions",
                   "minimum": 0,
-                  "required": [],
                   "title": "nonSampledCacheSize",
                   "type": "integer"
                 },
@@ -2790,7 +2570,6 @@
                   "default": 10000,
                   "description": "Cache size for sampled trace decisions",
                   "minimum": 0,
-                  "required": [],
                   "title": "sampledCacheSize",
                   "type": "integer"
                 }
@@ -2802,7 +2581,6 @@
             "decisionWait": {
               "default": "10s",
               "description": "Time to wait before making sampling decision",
-              "required": [],
               "title": "decisionWait",
               "type": "string"
             },
@@ -2810,7 +2588,6 @@
               "default": 10,
               "description": "Expected new traces per second (for cache sizing)",
               "minimum": 1,
-              "required": [],
               "title": "expectedNewTracesPerSec",
               "type": "integer"
             },
@@ -2818,7 +2595,6 @@
               "default": 100,
               "description": "Number of traces to keep in memory",
               "minimum": 1,
-              "required": [],
               "title": "numTraces",
               "type": "integer"
             },
@@ -2826,7 +2602,6 @@
               "default": 10,
               "description": "Maximum spans per second rate limit",
               "minimum": 1,
-              "required": [],
               "title": "spansPerSecond",
               "type": "integer"
             }
@@ -2846,7 +2621,7 @@
       "properties": {
         "alertmanager": {
           "additionalProperties": true,
-          "description": "Alertmanager configuration (disabled by default in OpenChoreo)",
+          "description": "Alertmanager configuration for metric-based alerts",
           "properties": {
             "alertmanagerSpec": {
               "additionalProperties": true,
@@ -2859,7 +2634,6 @@
                     "name": {
                       "default": "alertmanager",
                       "description": "Name for Alertmanager pod metadata",
-                      "required": [],
                       "title": "name",
                       "type": "string"
                     }
@@ -2867,16 +2641,247 @@
                   "required": [],
                   "title": "podMetadata",
                   "type": "object"
+                },
+                "resources": {
+                  "additionalProperties": true,
+                  "description": "Resource requests and limits for Alertmanager",
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "cpu": {
+                          "default": "100m",
+                          "title": "cpu",
+                          "type": "string"
+                        },
+                        "memory": {
+                          "default": "200Mi",
+                          "title": "memory",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "memory",
+                        "cpu"
+                      ],
+                      "title": "limits",
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "cpu": {
+                          "default": "50m",
+                          "title": "cpu",
+                          "type": "string"
+                        },
+                        "memory": {
+                          "default": "100Mi",
+                          "title": "memory",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "memory",
+                        "cpu"
+                      ],
+                      "title": "requests",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "requests",
+                    "limits"
+                  ],
+                  "title": "resources",
+                  "type": "object"
                 }
               },
               "required": [],
               "title": "alertmanagerSpec",
               "type": "object"
             },
+            "config": {
+              "additionalProperties": true,
+              "description": "Alertmanager routing and receiver configuration",
+              "properties": {
+                "global": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "resolve_timeout": {
+                      "default": "5m",
+                      "title": "resolve_timeout",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "resolve_timeout"
+                  ],
+                  "title": "global",
+                  "type": "object"
+                },
+                "receivers": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "default": "openchoreo-alerts",
+                            "title": "name",
+                            "type": "string"
+                          },
+                          "webhook_configs": {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "send_resolved": {
+                                      "default": false,
+                                      "title": "send_resolved",
+                                      "type": "boolean"
+                                    },
+                                    "url": {
+                                      "default": "http://observer.openchoreo-observability-plane.svc.cluster.local:8080/api/alerting/webhook/prometheus",
+                                      "title": "url",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "url",
+                                    "send_resolved"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "required": []
+                            },
+                            "title": "webhook_configs",
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "webhook_configs"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "default": "null",
+                            "title": "name",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "receivers",
+                  "type": "array"
+                },
+                "route": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "group_by": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "group_by",
+                      "type": "array"
+                    },
+                    "group_interval": {
+                      "default": "5m",
+                      "title": "group_interval",
+                      "type": "string"
+                    },
+                    "group_wait": {
+                      "default": "30s",
+                      "title": "group_wait",
+                      "type": "string"
+                    },
+                    "receiver": {
+                      "default": "null",
+                      "title": "receiver",
+                      "type": "string"
+                    },
+                    "repeat_interval": {
+                      "default": "12h",
+                      "title": "repeat_interval",
+                      "type": "string"
+                    },
+                    "routes": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "matchers": {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "required": []
+                                },
+                                "title": "matchers",
+                                "type": "array"
+                              },
+                              "receiver": {
+                                "default": "openchoreo-alerts",
+                                "title": "receiver",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "receiver",
+                              "matchers"
+                            ],
+                            "type": "object"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "routes",
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "group_by",
+                    "group_wait",
+                    "group_interval",
+                    "repeat_interval",
+                    "receiver",
+                    "routes"
+                  ],
+                  "title": "route",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "global",
+                "route",
+                "receivers"
+              ],
+              "title": "config",
+              "type": "object"
+            },
             "enabled": {
-              "default": false,
+              "default": true,
               "description": "Enable Alertmanager deployment",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -2888,7 +2893,6 @@
         "cleanPrometheusOperatorObjectNames": {
           "default": true,
           "description": "Produce cleaner resource names without redundant suffixes",
-          "required": [],
           "title": "cleanPrometheusOperatorObjectNames",
           "type": "boolean"
         },
@@ -2899,7 +2903,6 @@
             "enabled": {
               "default": false,
               "description": "Enable CoreDNS metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -2915,7 +2918,6 @@
             "enabled": {
               "default": true,
               "description": "Install Prometheus Operator CRDs (ServiceMonitor, PodMonitor, etc.)",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -2931,7 +2933,6 @@
             "create": {
               "default": false,
               "description": "Create default alerting rules",
-              "required": [],
               "title": "create",
               "type": "boolean"
             }
@@ -2943,14 +2944,12 @@
         "enabled": {
           "default": true,
           "description": "Enable Prometheus stack deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
           "default": "openchoreo-observability",
           "description": "Override the full name of Prometheus stack resources",
-          "required": [],
           "title": "fullnameOverride",
           "type": "string"
         },
@@ -2961,14 +2960,12 @@
             "adminPassword": {
               "default": "admin",
               "description": "Grafana admin password",
-              "required": [],
               "title": "adminPassword",
               "type": "string"
             },
             "adminUser": {
               "default": "admin",
               "description": "Grafana admin username",
-              "required": [],
               "title": "adminUser",
               "type": "string"
             },
@@ -2981,7 +2978,6 @@
                   "properties": {
                     "apiVersion": {
                       "default": 1,
-                      "required": [],
                       "title": "apiVersion",
                       "type": "integer"
                     },
@@ -2993,31 +2989,26 @@
                             "properties": {
                               "access": {
                                 "default": "proxy",
-                                "required": [],
                                 "title": "access",
                                 "type": "string"
                               },
                               "isDefault": {
                                 "default": true,
-                                "required": [],
                                 "title": "isDefault",
                                 "type": "boolean"
                               },
                               "name": {
                                 "default": "Prometheus",
-                                "required": [],
                                 "title": "name",
                                 "type": "string"
                               },
                               "type": {
                                 "default": "prometheus",
-                                "required": [],
                                 "title": "type",
                                 "type": "string"
                               },
                               "url": {
                                 "default": "http://openchoreo-observability-prometheus:9091",
-                                "required": [],
                                 "title": "url",
                                 "type": "string"
                               }
@@ -3034,7 +3025,6 @@
                         ],
                         "required": []
                       },
-                      "required": [],
                       "title": "datasources",
                       "type": "array"
                     }
@@ -3056,23 +3046,45 @@
             "defaultDashboardsEnabled": {
               "default": false,
               "description": "Enable default Grafana dashboards",
-              "required": [],
               "title": "defaultDashboardsEnabled",
               "type": "boolean"
             },
             "enabled": {
               "default": false,
               "description": "Enable Grafana deployment",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "fullnameOverride": {
               "default": "grafana",
               "description": "Override the full name of Grafana resources",
-              "required": [],
               "title": "fullnameOverride",
               "type": "string"
+            },
+            "grafana.ini": {
+              "additionalProperties": false,
+              "properties": {
+                "unified_alerting": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "default": true,
+                      "title": "enabled",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "title": "unified_alerting",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "unified_alerting"
+              ],
+              "title": "grafana.ini",
+              "type": "object"
             },
             "sidecar": {
               "additionalProperties": true,
@@ -3085,7 +3097,6 @@
                     "enabled": {
                       "default": false,
                       "description": "Enable dashboard sidecar",
-                      "required": [],
                       "title": "enabled",
                       "type": "boolean"
                     }
@@ -3101,7 +3112,6 @@
                     "enabled": {
                       "default": false,
                       "description": "Enable datasource sidecar",
-                      "required": [],
                       "title": "enabled",
                       "type": "boolean"
                     }
@@ -3116,7 +3126,9 @@
               "type": "object"
             }
           },
-          "required": [],
+          "required": [
+            "grafana.ini"
+          ],
           "title": "grafana",
           "type": "object"
         },
@@ -3127,37 +3139,30 @@
             "collectors": {
               "description": "List of Kubernetes resources to collect metrics from",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "collectors",
               "type": "array"
             },
             "fullnameOverride": {
               "default": "kube-state-metrics",
               "description": "Override the full name of kube-state-metrics resources",
-              "required": [],
               "title": "fullnameOverride",
               "type": "string"
             },
             "metricAllowlist": {
               "description": "Allowlist of specific metrics to collect (improves performance)",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "metricAllowlist",
               "type": "array"
             },
             "metricLabelsAllowlist": {
               "description": "Labels to include from Kubernetes resources (OpenChoreo-specific labels)",
               "items": {
-                "required": [],
                 "type": "string"
               },
-              "required": [],
               "title": "metricLabelsAllowlist",
               "type": "array"
             }
@@ -3173,7 +3178,6 @@
             "enabled": {
               "default": false,
               "description": "Enable API server metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3189,7 +3193,6 @@
             "enabled": {
               "default": false,
               "description": "Enable controller manager metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3205,7 +3208,6 @@
             "enabled": {
               "default": false,
               "description": "Enable etcd metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3221,7 +3223,6 @@
             "enabled": {
               "default": false,
               "description": "Enable kube-proxy metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3237,7 +3238,6 @@
             "enabled": {
               "default": false,
               "description": "Enable scheduler metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3253,7 +3253,6 @@
             "enabled": {
               "default": true,
               "description": "Enable kube-state-metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3269,7 +3268,6 @@
             "enabled": {
               "default": true,
               "description": "Enable kubelet metrics scraping",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3285,7 +3283,6 @@
             "enabled": {
               "default": true,
               "description": "Enable Kubernetes component ServiceMonitors",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3301,7 +3298,6 @@
             "enabled": {
               "default": false,
               "description": "Enable node exporter deployment",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3317,7 +3313,6 @@
             "enabled": {
               "default": true,
               "description": "Enable Prometheus server deployment",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
@@ -3325,6 +3320,28 @@
               "additionalProperties": true,
               "description": "Prometheus specification configuration",
               "properties": {
+                "ruleNamespaceSelector": {
+                  "additionalProperties": true,
+                  "default": {},
+                  "description": "Namespace selector for PrometheusRules (empty = all namespaces)",
+                  "required": [],
+                  "title": "ruleNamespaceSelector",
+                  "type": "object"
+                },
+                "ruleSelector": {
+                  "additionalProperties": true,
+                  "default": {},
+                  "description": "Label selector for PrometheusRules (empty = all PrometheusRules)",
+                  "required": [],
+                  "title": "ruleSelector",
+                  "type": "object"
+                },
+                "ruleSelectorNilUsesHelmValues": {
+                  "default": false,
+                  "description": "Use Helm values for PrometheusRule selection when selector is nil",
+                  "title": "ruleSelectorNilUsesHelmValues",
+                  "type": "boolean"
+                },
                 "serviceMonitorNamespaceSelector": {
                   "additionalProperties": true,
                   "default": {},
@@ -3344,7 +3361,6 @@
                 "serviceMonitorSelectorNilUsesHelmValues": {
                   "default": false,
                   "description": "Use Helm values for ServiceMonitor selection when selector is nil",
-                  "required": [],
                   "title": "serviceMonitorSelectorNilUsesHelmValues",
                   "type": "boolean"
                 }
@@ -3362,7 +3378,6 @@
                   "description": "Prometheus server port",
                   "maximum": 65535,
                   "minimum": 1,
-                  "required": [],
                   "title": "port",
                   "type": "integer"
                 },
@@ -3371,7 +3386,6 @@
                   "description": "Config reloader web port",
                   "maximum": 65535,
                   "minimum": 1,
-                  "required": [],
                   "title": "reloaderWebPort",
                   "type": "integer"
                 }
@@ -3392,14 +3406,12 @@
             "enabled": {
               "default": true,
               "description": "Enable Prometheus Operator deployment",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             },
             "fullnameOverride": {
               "default": "prometheus-operator",
               "description": "Override the full name of Prometheus Operator resources",
-              "required": [],
               "title": "fullnameOverride",
               "type": "string"
             },
@@ -3414,14 +3426,12 @@
                     "cpu": {
                       "default": "40m",
                       "description": "CPU limit",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "50Mi",
                       "description": "Memory limit",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -3437,14 +3447,12 @@
                     "cpu": {
                       "default": "20m",
                       "description": "CPU request",
-                      "required": [],
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
                       "default": "30Mi",
                       "description": "Memory request",
-                      "required": [],
                       "title": "memory",
                       "type": "string"
                     }
@@ -3470,7 +3478,6 @@
             "enabled": {
               "default": false,
               "description": "Enable Thanos Ruler for long-term alerting",
-              "required": [],
               "title": "enabled",
               "type": "boolean"
             }
@@ -3491,14 +3498,12 @@
         "controlPlaneNamespace": {
           "default": "openchoreo-control-plane",
           "description": "Control plane namespace for service auto-discovery",
-          "required": [],
           "title": "controlPlaneNamespace",
           "type": "string"
         },
         "enabled": {
           "default": false,
           "description": "Enable RCA agent deployment",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -3520,14 +3525,12 @@
             "repository": {
               "default": "ghcr.io/openchoreo/ai-rca-agent",
               "description": "Container image repository",
-              "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Container image tag (defaults to Chart.AppVersion if empty)",
-              "required": [],
               "title": "tag",
               "type": "string"
             }
@@ -3543,14 +3546,12 @@
             "apiKey": {
               "default": "",
               "description": "LLM API key (set via --set rca.llm.apiKey during install)",
-              "required": [],
               "title": "apiKey",
               "type": "string"
             },
             "modelName": {
               "default": "",
               "description": "LLM model name (e.g., claude-sonnet-4-5, gpt-5, gemini-2.0-flash-exp)",
-              "required": [],
               "title": "modelName",
               "type": "string"
             }
@@ -3562,14 +3563,12 @@
         "logLevel": {
           "default": "INFO",
           "description": "Log level for the RCA agent",
-          "required": [],
           "title": "logLevel",
           "type": "string"
         },
         "name": {
           "default": "ai-rca-agent",
           "description": "Name of the RCA agent deployment",
-          "required": [],
           "title": "name",
           "type": "string"
         },
@@ -3580,14 +3579,12 @@
             "clientId": {
               "default": "openchoreo-rca-agent",
               "description": "OAuth2 client ID registered with the IDP",
-              "required": [],
               "title": "clientId",
               "type": "string"
             },
             "clientSecret": {
               "default": "openchoreo-rca-agent-secret",
               "description": "OAuth2 client secret (override via --set rca.oauth.clientSecret)",
-              "required": [],
               "title": "clientSecret",
               "type": "string"
             }
@@ -3599,14 +3596,12 @@
         "observerMcpUrl": {
           "default": "",
           "description": "Observer MCP endpoint URL",
-          "required": [],
           "title": "observerMcpUrl",
           "type": "string"
         },
         "openchoreoMcpUrl": {
           "default": "",
           "description": "OpenChoreo API MCP endpoint URL",
-          "required": [],
           "title": "openchoreoMcpUrl",
           "type": "string"
         },
@@ -3617,7 +3612,6 @@
             "address": {
               "default": "https://opensearch:9200",
               "description": "OpenSearch cluster address",
-              "required": [],
               "title": "address",
               "type": "string"
             }
@@ -3630,7 +3624,6 @@
           "default": 1,
           "description": "Number of RCA agent replicas",
           "minimum": 0,
-          "required": [],
           "title": "replicas",
           "type": "integer"
         },
@@ -3645,14 +3638,12 @@
                 "cpu": {
                   "default": "250m",
                   "description": "CPU limit",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "1536Mi",
                   "description": "Memory limit",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -3668,14 +3659,12 @@
                 "cpu": {
                   "default": "100m",
                   "description": "CPU request",
-                  "required": [],
                   "title": "cpu",
                   "type": "string"
                 },
                 "memory": {
                   "default": "1024Mi",
                   "description": "Memory request",
-                  "required": [],
                   "title": "memory",
                   "type": "string"
                 }
@@ -3698,7 +3687,6 @@
               "description": "Service port",
               "maximum": 65535,
               "minimum": 1,
-              "required": [],
               "title": "port",
               "type": "integer"
             },
@@ -3730,7 +3718,6 @@
         "enabled": {
           "default": true,
           "description": "Global security toggle - when disabled, authentication is turned off for all components",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         },
@@ -3741,7 +3728,6 @@
             "audience": {
               "default": "",
               "description": "Expected audience claim in JWT tokens",
-              "required": [],
               "title": "audience",
               "type": "string"
             }
@@ -3757,28 +3743,24 @@
             "issuer": {
               "default": "",
               "description": "OIDC issuer URL",
-              "required": [],
               "title": "issuer",
               "type": "string"
             },
             "jwksUrl": {
               "default": "",
               "description": "JWKS URL for token verification",
-              "required": [],
               "title": "jwksUrl",
               "type": "string"
             },
             "jwksUrlTlsInsecureSkipVerify": {
               "default": "false",
               "description": "Skip TLS verification for JWKS URL",
-              "required": [],
               "title": "jwksUrlTlsInsecureSkipVerify",
               "type": "string"
             },
             "tokenUrl": {
               "default": "",
               "description": "OIDC token endpoint URL",
-              "required": [],
               "title": "tokenUrl",
               "type": "string"
             }
@@ -3799,7 +3781,6 @@
         "enabled": {
           "default": false,
           "description": "Enable TLS certificate generation for the observability plane",
-          "required": [],
           "title": "enabled",
           "type": "boolean"
         }
@@ -3815,7 +3796,6 @@
         "image": {
           "default": "bitnamilegacy/kubectl:1.32.4",
           "description": "Container image for kubectl-based wait jobs",
-          "required": [],
           "title": "image",
           "type": "string"
         }

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -22,7 +22,7 @@ OBSERVABILITY_PLANE_CRDS := \
 # Define the generation targets for the helm charts that are required for the helm package and push.
 # Ex: make helm-generate.cilium, make helm-generate.choreo
 .PHONY: helm-generate.%
-helm-generate.%: yq ## Generate helm chart for the specified chart name.
+helm-generate.%: yq helm-schema ## Generate helm chart for the specified chart name.
 	@if [ -z "$(filter $*,$(HELM_CHART_NAMES))" ]; then \
     		$(call log_error, Invalid helm generate target '$*'); \
     		exit 1; \
@@ -65,6 +65,8 @@ helm-generate.%: yq ## Generate helm chart for the specified chart name.
 	esac
 	helm dependency update $(CHART_PATH)
 	helm lint $(CHART_PATH)
+	@$(call log_info, Generating values.schema.json for '$(CHART_NAME)')
+	$(HELM_SCHEMA) -c $(CHART_PATH) --no-dependencies -a
 
 
 

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -32,6 +32,7 @@ GOLANGCI_LINT ?= $(TOOL_BIN)/golangci-lint
 HELMIFY ?= $(TOOL_BIN)/helmify
 YQ ?= $(TOOL_BIN)/yq
 OAPI_CODEGEN ?= $(TOOL_BIN)/oapi-codegen
+HELM_SCHEMA ?= $(TOOL_BIN)/helm-schema
 KUBEBUILDER_HELM_GEN ?= go run $(PROJECT_DIR)/tools/helm-gen
 
 ## Tool Versions
@@ -42,6 +43,7 @@ GOLANGCI_LINT_VERSION ?= v1.64.8
 HELMIFY_VERSION ?= v0.4.17
 YQ_VERSION ?= v4.45.1
 OAPI_CODEGEN_VERSION ?= v2.5.1
+HELM_SCHEMA_VERSION ?= 0.20.0-1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -77,4 +79,9 @@ $(YQ): $(TOOL_BIN)
 oapi-codegen: $(OAPI_CODEGEN) ## Download oapi-codegen locally if necessary.
 $(OAPI_CODEGEN): $(TOOL_BIN)
 	$(call go_install_tool,$(OAPI_CODEGEN),github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen,$(OAPI_CODEGEN_VERSION))
+
+.PHONY: helm-schema
+helm-schema: $(HELM_SCHEMA) ## Download helm-schema locally if necessary.
+$(HELM_SCHEMA): $(TOOL_BIN)
+	$(call go_install_tool,$(HELM_SCHEMA),github.com/dadav/helm-schema/cmd/helm-schema,$(HELM_SCHEMA_VERSION))
 


### PR DESCRIPTION
## Purpose
Add automated JSON schema generation for Helm chart values.yaml files using helm-schema tool.

## Approach
- Add helm-schema tool (v0.20.0-1) to make/tools.mk
- Integrate schema generation into helm-generate.% target in make/helm.mk
- Fix schema annotations where both 'type' and 'enum' were used together (not allowed by helm-schema)
- Regenerate values.schema.json for all helm charts

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> The schema files got smaller because helm-schema generates cleaner/more compact JSON schemas. Schema generation is now part of `make code.gen` and will be verified by `make code.gen-check` in CI.