### PR TITLE
Rename action organization:view to namespace:view

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/default-roles-mappings-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/default-roles-mappings-configmap.yaml
@@ -14,7 +14,7 @@ data:
     # roles:
     #   - name: custom-role
     #     actions:
-    #       - "organization:view"
+    #       - "namespace:view"
     #       - "project:view"
     #
     # mappings:
@@ -43,7 +43,7 @@ data:
         actions:
           - "component:view"
           - "componenttype:view"
-          - "organization:view"
+          - "namespace:view"
           - "project:view"
           - "dataplane:view"
           - "environment:view"
@@ -54,7 +54,7 @@ data:
         actions:
           - "component:view"
           - "project:view"
-          - "organization:view"
+          - "namespace:view"
           - "componentrelease:view"
           - "releasebinding:view"
           - "componentworkflowrun:view"

--- a/internal/authz/casbin/action_repository_test.go
+++ b/internal/authz/casbin/action_repository_test.go
@@ -37,9 +37,8 @@ func setupTestActionRepository(t *testing.T) *ActionRepository {
 		{Action: "project:create", IsInternal: false},
 		{Action: "*", IsInternal: false},
 		{Action: "internal:secret", IsInternal: true},
-		{Action: "internal:admin:*", IsInternal: true},
-		{Action: "organization:view", IsInternal: false},
-		{Action: "organization:manage", IsInternal: false},
+		{Action: "internal:*", IsInternal: true},
+		{Action: "namespace:view", IsInternal: false},
 	}
 
 	for _, action := range testActions {
@@ -61,7 +60,7 @@ func TestActionRepository_ListPublicActions(t *testing.T) {
 			t.Fatalf("ListPublicActions() error = %v", err)
 		}
 
-		if len(actions) != 10 {
+		if len(actions) != 9 {
 			t.Errorf("ListPublicActions() returned %d actions, want 10", len(actions))
 		}
 
@@ -84,13 +83,13 @@ func TestActionRepository_ListConcretePublicActions(t *testing.T) {
 			t.Fatalf("ListConcretePublicActions() error = %v", err)
 		}
 
-		if len(actions) != 8 {
+		if len(actions) != 7 {
 			t.Errorf("ListConcretePublicActions() returned %d actions, want 8", len(actions))
 		}
 
 		// Verify no wildcarded actions are included
 		for _, action := range actions {
-			if action.Action == "*" || action.Action == "component:*" || action.Action == "internal:admin:*" {
+			if action.Action == "*" || action.Action == "component:*" || action.Action == "internal:*" {
 				t.Errorf("ListConcretePublicActions() returned wildcarded action: %s", action.Action)
 			}
 		}

--- a/internal/authz/casbin/casbin_test.go
+++ b/internal/authz/casbin/casbin_test.go
@@ -58,7 +58,7 @@ func TestCasbinEnforcer_Evaluate_ClusterRoles_Focused(t *testing.T) {
 	// Setup: Create cluster role with multiple actions and wildcards
 	multiRole := &authzcore.Role{
 		Name:    "multi-role",
-		Actions: []string{"organization:view", "component:*", "project:view"},
+		Actions: []string{"namespace:view", "component:*", "project:view"},
 	}
 	if err := enforcer.AddRole(ctx, multiRole); err != nil {
 		t.Fatalf("failed to add multi-role: %v", err)
@@ -234,9 +234,9 @@ func TestCasbinEnforcer_Evaluate_ClusterRoles_Focused(t *testing.T) {
 			name:              "cluster role - basic authorization",
 			entitlementValues: []string{"test-group"},
 			resource:          authzcore.ResourceHierarchy{Namespace: "acme"},
-			action:            "organization:view",
+			action:            "namespace:view",
 			want:              true,
-			reason:            "organization:* should match organization:view",
+			reason:            "namespace:* should match namespace:view",
 		},
 		{
 			name:              "cluster role - hierarchical matching",
@@ -338,7 +338,7 @@ func TestCasbinEnforcer_Evaluate_ClusterRoles_Focused(t *testing.T) {
 			name:              "path matching - no false positive for similar names",
 			entitlementValues: []string{"test-group"},
 			resource:          authzcore.ResourceHierarchy{Namespace: "acme2"},
-			action:            "organization:view",
+			action:            "namespace:view",
 			want:              false,
 			reason:            "'acme' policy should not match 'acme2'",
 		},
@@ -1438,7 +1438,7 @@ func TestCasbinEnforcer_buildCapabilitiesFromPolicies(t *testing.T) {
 		{Action: "component:delete"},
 		{Action: "project:view"},
 		{Action: "project:create"},
-		{Action: "organization:view"},
+		{Action: "namespace:view"},
 	}
 	actionIdx := indexActions(testActions)
 
@@ -1492,13 +1492,13 @@ func TestCasbinEnforcer_buildCapabilitiesFromPolicies(t *testing.T) {
 				allowedCount int
 				deniedCount  int
 			}{
-				"component:view":    {allowedCount: 1, deniedCount: 0},
-				"component:create":  {allowedCount: 1, deniedCount: 0},
-				"component:update":  {allowedCount: 1, deniedCount: 0},
-				"component:delete":  {allowedCount: 1, deniedCount: 0},
-				"project:view":      {allowedCount: 1, deniedCount: 0},
-				"project:create":    {allowedCount: 1, deniedCount: 0},
-				"organization:view": {allowedCount: 1, deniedCount: 0},
+				"component:view":   {allowedCount: 1, deniedCount: 0},
+				"component:create": {allowedCount: 1, deniedCount: 0},
+				"component:update": {allowedCount: 1, deniedCount: 0},
+				"component:delete": {allowedCount: 1, deniedCount: 0},
+				"project:view":     {allowedCount: 1, deniedCount: 0},
+				"project:create":   {allowedCount: 1, deniedCount: 0},
+				"namespace:view":   {allowedCount: 1, deniedCount: 0},
 			},
 		},
 		{

--- a/internal/authz/casbin/helpers_test.go
+++ b/internal/authz/casbin/helpers_test.go
@@ -517,7 +517,7 @@ func TestExpandActionWildcard(t *testing.T) {
 		{Action: "component:delete"},
 		{Action: "project:view"},
 		{Action: "project:update"},
-		{Action: "organization:view"},
+		{Action: "namespace:view"},
 	}
 	actionIdx := indexActions(testActions)
 
@@ -539,7 +539,7 @@ func TestExpandActionWildcard(t *testing.T) {
 		{
 			name:          "full wildcard expands to all actions",
 			actionPattern: "*",
-			want:          []string{"component:create", "component:view", "component:delete", "project:view", "project:update", "organization:view"},
+			want:          []string{"component:create", "component:view", "component:delete", "project:view", "project:update", "namespace:view"},
 		},
 		{
 			name:          "wildcard for non-existent resource type returns empty",
@@ -777,7 +777,7 @@ func TestIndexActions(t *testing.T) {
 				{Action: "component:delete"},
 				{Action: "project:view"},
 				{Action: "project:create"},
-				{Action: "organization:view"},
+				{Action: "namespace:view"},
 			},
 			wantLen: 7,
 		},

--- a/internal/authz/data/default_authz_data.yaml
+++ b/internal/authz/data/default_authz_data.yaml
@@ -4,7 +4,7 @@
 #   - name: custom-role
 #     namespace: ""                 # Empty for cluster role, namespace name for namespace-scoped role
 #     actions:
-#       - "organization:view"
+#       - "namespace:view"
 #       - "project:view"
 #
 # mappings:
@@ -32,7 +32,7 @@ roles:
     actions:
       - "component:view"
       - "componenttype:view"
-      - "organization:view"
+      - "namespace:view"
       - "project:view"
       - "dataplane:view"
       - "environment:view"
@@ -42,7 +42,7 @@ roles:
     actions:
       - "component:view"
       - "project:view"
-      - "organization:view"
+      - "namespace:view"
       - "componentrelease:view"
       - "releasebinding:view"
       - "componentworkflowrun:view"

--- a/internal/authz/data/loader.go
+++ b/internal/authz/data/loader.go
@@ -31,8 +31,8 @@ type ActionData struct {
 // systemActions defines all available actions in the system
 // IsInternal indicates if the action is internal (not publicly visible)
 var systemActions = []ActionData{
-	// Organization
-	{Name: "organization:view", IsInternal: false},
+	// Namespace
+	{Name: "namespace:view", IsInternal: false},
 
 	// Project
 	{Name: "project:view", IsInternal: false},

--- a/internal/authz/data/loader_test.go
+++ b/internal/authz/data/loader_test.go
@@ -23,7 +23,7 @@ func TestLoadActions(t *testing.T) {
 
 	// Verify some expected actions exist
 	expectedActions := []string{
-		"organization:view",
+		"namespace:view",
 		"project:view",
 		"project:create",
 		"component:view",


### PR DESCRIPTION
## Purpose
This Pr is to rename the existing action `organization:view` to `namespace:view` and update the relevant test cases.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1273

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
