### PR TITLE
Add deletion timestamp to ProjectResponse

### DIFF
--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -27,14 +27,15 @@ type ListResponse[T any] struct {
 
 // ProjectResponse represents a project in API responses
 type ProjectResponse struct {
-	UID                string    `json:"uid"`
-	Name               string    `json:"name"`
-	OrgName            string    `json:"orgName"`
-	DisplayName        string    `json:"displayName,omitempty"`
-	Description        string    `json:"description,omitempty"`
-	DeploymentPipeline string    `json:"deploymentPipeline,omitempty"`
-	CreatedAt          time.Time `json:"createdAt"`
-	Status             string    `json:"status,omitempty"`
+	UID                string     `json:"uid"`
+	Name               string     `json:"name"`
+	OrgName            string     `json:"orgName"`
+	DisplayName        string     `json:"displayName,omitempty"`
+	Description        string     `json:"description,omitempty"`
+	DeploymentPipeline string     `json:"deploymentPipeline,omitempty"`
+	CreatedAt          time.Time  `json:"createdAt"`
+	Status             string     `json:"status,omitempty"`
+	DeletionTimestamp  *time.Time `json:"deletionTimestamp,omitempty"`
 }
 
 // ComponentResponse represents a component in API responses

--- a/internal/openchoreo-api/services/project_service.go
+++ b/internal/openchoreo-api/services/project_service.go
@@ -239,7 +239,7 @@ func (s *ProjectService) toProjectResponse(project *openchoreov1alpha1.Project) 
 		}
 	}
 
-	return &models.ProjectResponse{
+	response := &models.ProjectResponse{
 		UID:                string(project.UID),
 		Name:               project.Name,
 		OrgName:            project.Namespace,
@@ -249,4 +249,11 @@ func (s *ProjectService) toProjectResponse(project *openchoreov1alpha1.Project) 
 		CreatedAt:          project.CreationTimestamp.Time,
 		Status:             status,
 	}
+
+	// Include deletion timestamp if the project is marked for deletion
+	if project.DeletionTimestamp != nil {
+		response.DeletionTimestamp = &project.DeletionTimestamp.Time
+	}
+
+	return response
 }


### PR DESCRIPTION
## Purpose

Add deletion timestamp to ProjectResponse

- Enhanced ProjectResponse struct to include a DeletionTimestamp field.
- Modified toProjectResponse method to set DeletionTimestamp if the project is marked for deletion.

Related PRs

Frontend PR: https://github.com/openchoreo/backstage-plugins/pull/194
https://github.com/openchoreo/openchoreo/pull/1482

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1470

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
