### PR TITLE
Rename authz checks of org resources from `organization:x` to `namespace:x`

### DIFF
--- a/internal/openchoreo-api/services/constants.go
+++ b/internal/openchoreo-api/services/constants.go
@@ -24,7 +24,7 @@ const (
 	SystemActionCreateWorkload systemAction = "workload:create"
 	SystemActionViewWorkload   systemAction = "workload:view"
 
-	SystemActionViewOrganization systemAction = "organization:view"
+	SystemActionViewNamespace systemAction = "namespace:view"
 
 	SystemActionCreateRole        systemAction = "role:create"
 	SystemActionViewRole          systemAction = "role:view"
@@ -65,7 +65,7 @@ const (
 	ResourceTypeComponentRelease     ResourceType = "componentRelease"
 	ResourceTypeReleaseBinding       ResourceType = "releaseBinding"
 	ResourceTypeWorkload             ResourceType = "workload"
-	ResourceTypeOrganization         ResourceType = "organization"
+	ResourceTypeNamespace            ResourceType = "namespace"
 	ResourceTypeRole                 ResourceType = "role"
 	ResourceTypeRoleMapping          ResourceType = "roleMapping"
 	ResourceTypeComponentType        ResourceType = "componentType"

--- a/internal/openchoreo-api/services/organization_service.go
+++ b/internal/openchoreo-api/services/organization_service.go
@@ -47,7 +47,7 @@ func (s *OrganizationService) ListOrganizations(ctx context.Context) ([]*models.
 	organizations := make([]*models.OrganizationResponse, 0, len(orgList.Items))
 	for _, item := range orgList.Items {
 		// Authorization check for each organization
-		if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewOrganization, ResourceTypeOrganization, item.Name,
+		if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewNamespace, ResourceTypeNamespace, item.Name,
 			authz.ResourceHierarchy{Namespace: item.Name}); err != nil {
 			if errors.Is(err, ErrForbidden) {
 				// Skip unauthorized organizations
@@ -69,7 +69,7 @@ func (s *OrganizationService) GetOrganization(ctx context.Context, orgName strin
 	s.logger.Debug("Getting organization", "org", orgName)
 
 	// Authorization check
-	if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewOrganization, ResourceTypeOrganization, orgName,
+	if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewNamespace, ResourceTypeNamespace, orgName,
 		authz.ResourceHierarchy{Namespace: orgName}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Purpose
This pull request updates the authorization model to use "namespace" instead of "organization" for viewing permissions and resource types. The main changes involve renaming constants and updating authorization checks to reflect this new terminology.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1273

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
