### PR TITLE
Fix quick start build deploy script

### DIFF
--- a/install/quick-start/build-deploy-greeter.sh
+++ b/install/quick-start/build-deploy-greeter.sh
@@ -156,20 +156,20 @@ while true; do
         fi
     fi
 
-    WORKFLOW_COMPLETED=$(kubectl get workflowrun "$WORKFLOWRUN_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.conditions[]? | select(.type=="WorkflowCompleted") | .status' || echo "")
+    WORKFLOW_COMPLETED=$(kubectl get componentworkflowrun "$WORKFLOWRUN_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.conditions[]? | select(.type=="WorkflowCompleted") | .status' || echo "")
 
     if [[ "$WORKFLOW_COMPLETED" == "True" ]]; then
         log_success "Container image build completed successfully"
 
         # Get the built image reference
-        IMAGE_REF=$(kubectl get workflowrun "$WORKFLOWRUN_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.imageStatus.imageRef' || echo "")
+        IMAGE_REF=$(kubectl get componentworkflowrun "$WORKFLOWRUN_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.imageStatus.imageRef' || echo "")
         if [[ -n "$IMAGE_REF" ]] && [[ "$IMAGE_REF" != "null" ]]; then
             log_info "Built image: $IMAGE_REF"
         fi
         break
     elif [[ "$WORKFLOW_COMPLETED" == "False" ]]; then
         # Check if there's an error
-        WORKFLOW_ERROR=$(kubectl get workflowrun "$WORKFLOWRUN_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.conditions[]? | select(.type=="WorkflowCompleted" and .status=="False") | .message' || echo "")
+        WORKFLOW_ERROR=$(kubectl get componentworkflowrun "$WORKFLOWRUN_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.conditions[]? | select(.type=="WorkflowCompleted" and .status=="False") | .message' || echo "")
         if [[ -n "$WORKFLOW_ERROR" ]] && [[ "$WORKFLOW_ERROR" != "Workflow has not completed yet" ]]; then
             log_error "Build failed: $WORKFLOW_ERROR"
             exit 1


### PR DESCRIPTION
## Purpose

This pull request updates the resource type used in the build monitoring logic of the `install/quick-start/build-deploy-greeter.sh` script. The script now queries `componentworkflowrun` resources instead of `workflowrun` resources when checking the build status and retrieving the built image reference.

**Build monitoring logic update:**

* Changed all occurrences of `workflowrun` to `componentworkflowrun` in the `kubectl get` commands used to check workflow completion, retrieve the built image reference, and capture workflow errors in the build monitoring loop of `build-deploy-greeter.sh`.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
