### PR TITLE
Fix Dependabot Python ecosystem to use uv instead of pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,8 +34,8 @@ updates:
     schedule:
       interval: "monthly"
 
-  # Python dependencies
-  - package-ecosystem: "pip"
+  # Python dependencies (uv)
+  - package-ecosystem: "uv"
     directory: "/rca-agent"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Purpose
Fix the Dependabot configuration to use `uv` package ecosystem instead of `pip` for the rca-agent Python project.

## Approach
- Change `package-ecosystem` from `pip` to `uv` for `/rca-agent` directory

## Related Issues
Related #1582

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)