### PR TITLE
refactor: add multiple endpoint definition support for service component type

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
@@ -30,7 +30,6 @@ spec:
     parameters:
       replicas: "integer | default=1"
       imagePullPolicy: "string | default=IfNotPresent"
-      port: "integer | default=80"
       exposed: "boolean | default=false | description='Expose the service externally' | title='Expose Service'"
 
     envOverrides:
@@ -87,20 +86,25 @@ spec:
         spec:
           type: ClusterIP
           selector: ${metadata.podSelectors}
-          ports:
-            - name: http
-              port: 80
-              targetPort: ${parameters.port}
-              protocol: TCP
-    - id: httproute
+          ports: |
+            ${workload.endpoints.transformList(name, endpoint, {
+              "name": name,
+              "port": endpoint.port,
+              "targetPort": endpoint.port,
+              "protocol": has(endpoint.protocol) ? endpoint.protocol : "TCP"
+            })}
+
+    - forEach: ${workload.endpoints}
+      var: endpoint
+      id: httproute
       includeWhen: ${parameters.exposed == true}
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: ${metadata.name}
-          namespace: ${metadata.namespace}
           labels: ${metadata.labels}
+          name: ${metadata.name}-${endpoint.key}
+          namespace: ${metadata.namespace}
         spec:
           parentRefs:
             - name: gateway-default
@@ -120,7 +124,7 @@ spec:
                     replacePrefixMatch: /
             backendRefs:
             - name: ${metadata.componentName}
-              port: 80
+              port: ${endpoint.value.port}
     - id: env-config
       forEach: ${configurations.toConfigEnvsByContainer()}
       var: envConfig


### PR DESCRIPTION
## Purpose
Add multiple endpoint definition support for default service component type. Currently the endpoints are hardcoded and not read from the workload crd. This PR checks the workload CR and populates the httpRoutes accordingly.

## Approach
Iterate the array definition of endpoints in workload CR and create HTTPRoutes per each endpoint definition.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
