### PR TITLE
perf: improve per plane CR validation improving per physical plane validations

### DIFF
--- a/api/v1alpha1/buildplane_types.go
+++ b/api/v1alpha1/buildplane_types.go
@@ -36,6 +36,7 @@ type BuildPlaneSpec struct {
 	SecretStoreRef *SecretStoreRef `json:"secretStoreRef,omitempty"`
 
 	// ObservabilityPlaneRef specifies the name of the ObservabilityPlane for this BuildPlane.
+	// If not specified, defaults to an ObservabilityPlane named "default" in the same namespace.
 	// +optional
 	ObservabilityPlaneRef string `json:"observabilityPlaneRef,omitempty"`
 }

--- a/api/v1alpha1/dataplane_types.go
+++ b/api/v1alpha1/dataplane_types.go
@@ -101,6 +101,7 @@ type DataPlaneSpec struct {
 	SecretStoreRef *SecretStoreRef `json:"secretStoreRef,omitempty"`
 
 	// ObservabilityPlaneRef specifies the name of the ObservabilityPlane for this DataPlane.
+	// If not specified, defaults to an ObservabilityPlane named "default" in the same namespace.
 	// +optional
 	ObservabilityPlaneRef string `json:"observabilityPlaneRef,omitempty"`
 }

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -13,7 +13,9 @@ import (
 // EnvironmentSpec defines the desired state of Environment.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.dataPlaneRef) || size(oldSelf.dataPlaneRef) == 0 || oldSelf.dataPlaneRef == self.dataPlaneRef",message="dataPlaneRef is immutable once set"
 type EnvironmentSpec struct {
-	// DataPlaneRef references the DataPlane for this environment. Immutable once set.
+	// DataPlaneRef references the DataPlane for this environment.
+	// If not specified, defaults to a DataPlane named "default" in the same namespace.
+	// Immutable once set.
 	DataPlaneRef string        `json:"dataPlaneRef,omitempty"`
 	IsProduction bool          `json:"isProduction,omitempty"`
 	Gateway      GatewayConfig `json:"gateway,omitempty"`

--- a/config/crd/bases/openchoreo.dev_buildplanes.yaml
+++ b/config/crd/bases/openchoreo.dev_buildplanes.yaml
@@ -76,8 +76,9 @@ spec:
                 - clientCA
                 type: object
               observabilityPlaneRef:
-                description: ObservabilityPlaneRef specifies the name of the ObservabilityPlane
-                  for this BuildPlane.
+                description: |-
+                  ObservabilityPlaneRef specifies the name of the ObservabilityPlane for this BuildPlane.
+                  If not specified, defaults to an ObservabilityPlane named "default" in the same namespace.
                 type: string
               planeID:
                 description: |-

--- a/config/crd/bases/openchoreo.dev_dataplanes.yaml
+++ b/config/crd/bases/openchoreo.dev_dataplanes.yaml
@@ -120,8 +120,9 @@ spec:
                   type: string
                 type: array
               observabilityPlaneRef:
-                description: ObservabilityPlaneRef specifies the name of the ObservabilityPlane
-                  for this DataPlane.
+                description: |-
+                  ObservabilityPlaneRef specifies the name of the ObservabilityPlane for this DataPlane.
+                  If not specified, defaults to an ObservabilityPlane named "default" in the same namespace.
                 type: string
               planeID:
                 description: |-

--- a/config/crd/bases/openchoreo.dev_environments.yaml
+++ b/config/crd/bases/openchoreo.dev_environments.yaml
@@ -43,7 +43,9 @@ spec:
             description: EnvironmentSpec defines the desired state of Environment.
             properties:
               dataPlaneRef:
-                description: DataPlaneRef references the DataPlane for this environment.
+                description: |-
+                  DataPlaneRef references the DataPlane for this environment.
+                  If not specified, defaults to a DataPlane named "default" in the same namespace.
                   Immutable once set.
                 type: string
               gateway:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_buildplanes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_buildplanes.yaml
@@ -75,8 +75,9 @@ spec:
                 - clientCA
                 type: object
               observabilityPlaneRef:
-                description: ObservabilityPlaneRef specifies the name of the ObservabilityPlane
-                  for this BuildPlane.
+                description: |-
+                  ObservabilityPlaneRef specifies the name of the ObservabilityPlane for this BuildPlane.
+                  If not specified, defaults to an ObservabilityPlane named "default" in the same namespace.
                 type: string
               planeID:
                 description: |-

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_dataplanes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_dataplanes.yaml
@@ -119,8 +119,9 @@ spec:
                   type: string
                 type: array
               observabilityPlaneRef:
-                description: ObservabilityPlaneRef specifies the name of the ObservabilityPlane
-                  for this DataPlane.
+                description: |-
+                  ObservabilityPlaneRef specifies the name of the ObservabilityPlane for this DataPlane.
+                  If not specified, defaults to an ObservabilityPlane named "default" in the same namespace.
                 type: string
               planeID:
                 description: |-

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_environments.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_environments.yaml
@@ -42,7 +42,9 @@ spec:
             description: EnvironmentSpec defines the desired state of Environment.
             properties:
               dataPlaneRef:
-                description: DataPlaneRef references the DataPlane for this environment.
+                description: |-
+                  DataPlaneRef references the DataPlane for this environment.
+                  If not specified, defaults to a DataPlane named "default" in the same namespace.
                   Immutable once set.
                 type: string
               gateway:

--- a/internal/clients/gateway/client.go
+++ b/internal/clients/gateway/client.go
@@ -310,8 +310,16 @@ func (c *Client) ForceReconnect(ctx context.Context, planeType, planeID string) 
 
 // GetPlaneStatus retrieves the connection status for a specific plane from the gateway
 // This is used by controllers to query agent connection status and update CR status fields
-func (c *Client) GetPlaneStatus(ctx context.Context, planeType, planeID string) (*PlaneConnectionStatus, error) {
+// If namespace and name are provided, it returns CR-specific authorization status
+// If they are empty, it returns plane-level connection status
+func (c *Client) GetPlaneStatus(ctx context.Context, planeType, planeID, namespace, name string) (*PlaneConnectionStatus, error) {
 	url := fmt.Sprintf("%s/api/v1/planes/%s/%s/status", c.baseURL, planeType, planeID)
+
+	// Add query parameters for CR-specific status if provided
+	if namespace != "" && name != "" {
+		url = fmt.Sprintf("%s?namespace=%s&name=%s", url, namespace, name)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/internal/cluster-gateway/connection_manager.go
+++ b/internal/cluster-gateway/connection_manager.go
@@ -4,9 +4,11 @@
 package clustergateway
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -27,7 +29,103 @@ type AgentConnection struct {
 	PlaneIdentifier string // Simplified identifier: {planeType}/{planeID}
 	ConnectedAt     time.Time
 	LastSeen        time.Time
+	ValidCRs        []string          // List of CRs (namespace/name) this connection is authorized for
+	clientCert      *x509.Certificate // Client certificate for re-validation on CR updates
 	mu              sync.Mutex
+}
+
+// IsValidForCR checks if this connection is authorized for the specified CR
+func (ac *AgentConnection) IsValidForCR(crKey string) bool {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	return slices.Contains(ac.ValidCRs, crKey)
+}
+
+// SetValidCRs replaces the ValidCRs list (used during re-validation)
+func (ac *AgentConnection) SetValidCRs(validCRs []string) {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	ac.ValidCRs = validCRs
+}
+
+// GetValidCRs returns a copy of the ValidCRs list
+func (ac *AgentConnection) GetValidCRs() []string {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	result := make([]string, len(ac.ValidCRs))
+	copy(result, ac.ValidCRs)
+	return result
+}
+
+// AddValidCR adds a CR to the ValidCRs list if not already present
+func (ac *AgentConnection) AddValidCR(crKey string) {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	if slices.Contains(ac.ValidCRs, crKey) {
+		return
+	}
+	ac.ValidCRs = append(ac.ValidCRs, crKey)
+}
+
+// RemoveValidCR removes a CR from the ValidCRs list
+func (ac *AgentConnection) RemoveValidCR(crKey string) {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	newValidCRs := []string{}
+	for _, validCR := range ac.ValidCRs {
+		if validCR != crKey {
+			newValidCRs = append(newValidCRs, validCR)
+		}
+	}
+	ac.ValidCRs = newValidCRs
+}
+
+// removeValidCRUnsafe removes a CR from the ValidCRs list
+// Must be called with ac.mu lock held
+func (ac *AgentConnection) removeValidCRUnsafe(crKey string) {
+	newValidCRs := []string{}
+	for _, validCR := range ac.ValidCRs {
+		if validCR != crKey {
+			newValidCRs = append(newValidCRs, validCR)
+		}
+	}
+	ac.ValidCRs = newValidCRs
+}
+
+// UpdateCRValidity validates the connection's client certificate against the given CA pool
+// and updates the CR's authorization status accordingly.
+// Returns (granted=true) if authorization was newly granted, (revoked=true) if authorization was revoked.
+// Returns error if certificate verification fails and authorization is revoked.
+func (ac *AgentConnection) UpdateCRValidity(crKey string, certPool *x509.CertPool) (granted bool, revoked bool, err error) {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	wasValid := slices.Contains(ac.ValidCRs, crKey)
+
+	// Verify connection's client cert against CA pool
+	opts := x509.VerifyOptions{
+		Roots:     certPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	_, verifyErr := ac.clientCert.Verify(opts)
+	isValid := (verifyErr == nil)
+
+	if isValid && !wasValid {
+		// Authorization granted
+		ac.ValidCRs = append(ac.ValidCRs, crKey)
+		return true, false, nil
+	} else if !isValid && wasValid {
+		// Authorization revoked
+		ac.removeValidCRUnsafe(crKey)
+		return false, true, verifyErr
+	}
+
+	// Status unchanged (still valid or still invalid)
+	return false, false, nil
 }
 
 // ConnectionManager manages active agent connections
@@ -52,11 +150,18 @@ func NewConnectionManager(logger *slog.Logger) *ConnectionManager {
 	}
 }
 
-// Register registers a new agent connection
+// Register registers a new agent connection with per-CR authorization
 // planeIdentifier format: {planeType}/{planeID}
 // Multiple agent replicas (for HA) for the same plane share the same planeIdentifier
+// validCRs contains the list of CRs (namespace/name) this connection is authorized for
+// clientCert is stored for re-validation when CRs are updated
 // Returns the connection ID which should be used for unregistration
-func (cm *ConnectionManager) Register(planeType, planeID string, conn *websocket.Conn) (string, error) {
+func (cm *ConnectionManager) Register(
+	planeType, planeID string,
+	conn *websocket.Conn,
+	validCRs []string,
+	clientCert *x509.Certificate,
+) (string, error) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
@@ -72,6 +177,8 @@ func (cm *ConnectionManager) Register(planeType, planeID string, conn *websocket
 		PlaneIdentifier: planeIdentifier,
 		ConnectedAt:     now,
 		LastSeen:        now,
+		ValidCRs:        validCRs,
+		clientCert:      clientCert,
 	}
 
 	// Store by planeIdentifier (supports HA - multiple replicas)
@@ -85,6 +192,8 @@ func (cm *ConnectionManager) Register(planeType, planeID string, conn *websocket
 		"planeType", planeType,
 		"planeID", planeID,
 		"connectionID", connID,
+		"validCRs", validCRs,
+		"validCRCount", len(validCRs),
 		"connectionsForPlane", totalForPlane,
 		"totalConnections", totalConnections,
 	)
@@ -114,13 +223,21 @@ func (cm *ConnectionManager) Unregister(planeIdentifier, connID string) {
 
 	for i, conn := range conns {
 		if conn.ID == connID {
+			// Capture CRs from the connection being removed for cleanup
+			validCRs := conn.GetValidCRs()
+
 			conn.Conn.Close()
 			cm.connections[planeIdentifier] = append(conns[:i], conns[i+1:]...)
 
-			// Clean up index if no connections remain for this plane
+			// Clean up indices if no connections remain for this plane
 			if len(cm.connections[planeIdentifier]) == 0 {
 				delete(cm.connections, planeIdentifier)
 				delete(cm.roundRobin, planeIdentifier)
+				// Clean up all per-CR round-robin keys for this plane
+				cm.cleanupPerCRRoundRobinKeys(planeIdentifier)
+			} else {
+				// Clean up per-CR round-robin keys for CRs that no longer have any authorized connections
+				cm.cleanupOrphanedCRKeys(planeIdentifier, validCRs)
 			}
 
 			totalAll := cm.countAllConnections()
@@ -155,6 +272,54 @@ func (cm *ConnectionManager) Get(planeIdentifier string) (*AgentConnection, erro
 	cm.roundRobin[planeIdentifier] = (idx + 1) % len(conns)
 
 	return conns[idx], nil
+}
+
+// GetForCR retrieves an agent connection authorized for the specified CR using round-robin selection
+// Only connections where the agent's certificate is valid for the requested CR are considered
+// This enforces per-CR security boundaries in multi-tenant scenarios
+// Returns error if no authorized connections are found
+func (cm *ConnectionManager) GetForCR(planeIdentifier, crKey string) (*AgentConnection, error) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	conns, exists := cm.connections[planeIdentifier]
+	if !exists || len(conns) == 0 {
+		return nil, fmt.Errorf("no agents found for plane %s", planeIdentifier)
+	}
+
+	var validConns []*AgentConnection
+	for _, conn := range conns {
+		if conn.IsValidForCR(crKey) {
+			validConns = append(validConns, conn)
+		}
+	}
+
+	if len(validConns) == 0 {
+		cm.logger.Warn("no agents authorized for CR",
+			"planeIdentifier", planeIdentifier,
+			"requestedCR", crKey,
+			"totalAgents", len(conns),
+		)
+		return nil, fmt.Errorf("no agents authorized for CR %s", crKey)
+	}
+
+	// Round-robin among valid connections only
+	// Use CR-specific round-robin key to ensure fair distribution per CR
+	rrKey := fmt.Sprintf("%s/%s", planeIdentifier, crKey)
+	idx := cm.roundRobin[rrKey] % len(validConns)
+	cm.roundRobin[rrKey] = (idx + 1) % len(validConns)
+
+	selectedConn := validConns[idx]
+
+	cm.logger.Debug("selected agent for CR",
+		"planeIdentifier", planeIdentifier,
+		"cr", crKey,
+		"connectionID", selectedConn.ID,
+		"validAgents", len(validConns),
+		"totalAgents", len(conns),
+	)
+
+	return selectedConn, nil
 }
 
 func (cm *ConnectionManager) GetAll() []*AgentConnection {
@@ -232,6 +397,8 @@ func (cm *ConnectionManager) DisconnectAllForPlane(planeType, planeID string) in
 
 	delete(cm.connections, planeIdentifier)
 	delete(cm.roundRobin, planeIdentifier)
+	// Clean up all per-CR round-robin keys for this plane
+	cm.cleanupPerCRRoundRobinKeys(planeIdentifier)
 
 	cm.logger.Info("disconnected all agents for plane",
 		"planeType", planeType,
@@ -310,6 +477,60 @@ func (cm *ConnectionManager) GetPlaneStatus(planeType, planeID string) *PlaneCon
 	return status
 }
 
+// GetCRAuthorizationStatus returns authorization status for a specific CR within a plane
+// This is different from GetPlaneStatus which only checks if agents are connected to the plane
+// This method checks if the connected agents are actually authorized for the specific CR (namespace/name)
+func (cm *ConnectionManager) GetCRAuthorizationStatus(planeType, planeID, namespace, name string) *PlaneConnectionStatus {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
+	conns, exists := cm.connections[planeIdentifier]
+
+	crIdentifier := fmt.Sprintf("%s/%s", namespace, name)
+
+	status := &PlaneConnectionStatus{
+		PlaneType:       planeType,
+		PlaneID:         planeID,
+		Connected:       false, // Will be set to true only if at least one agent is authorized for this CR
+		ConnectedAgents: 0,     // Will count only agents authorized for this CR
+	}
+
+	if !exists || len(conns) == 0 {
+		return status
+	}
+
+	var authorizedConnCount int
+	var mostRecentLastSeen time.Time
+
+	for _, conn := range conns {
+		conn.mu.Lock()
+		isAuthorized := false
+		for _, validCR := range conn.ValidCRs {
+			if validCR == crIdentifier {
+				isAuthorized = true
+				break
+			}
+		}
+
+		if isAuthorized {
+			authorizedConnCount++
+			if conn.LastSeen.After(mostRecentLastSeen) {
+				mostRecentLastSeen = conn.LastSeen
+			}
+		}
+		conn.mu.Unlock()
+	}
+
+	if authorizedConnCount > 0 {
+		status.Connected = true
+		status.ConnectedAgents = authorizedConnCount
+		status.LastSeen = mostRecentLastSeen
+	}
+
+	return status
+}
+
 // GetAllPlaneStatuses returns connection status for all planes
 func (cm *ConnectionManager) GetAllPlaneStatuses() []PlaneConnectionStatus {
 	cm.mu.RLock()
@@ -363,4 +584,170 @@ func splitPlaneIdentifier(identifier string) []string {
 		}
 	}
 	return []string{identifier}
+}
+
+// RevalidateCR re-validates all connections for a specific CR without disconnecting
+// This is called when a CR is updated (e.g., certificate rotation) to enforce new security policy
+// without causing service disruption. Returns counts of authorizations granted and revoked.
+func (cm *ConnectionManager) RevalidateCR(
+	planeType, planeID, crNamespace, crName string,
+	newCAData []byte,
+) (updated int, removed int, err error) {
+	cm.mu.RLock()
+	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
+	conns, exists := cm.connections[planeIdentifier]
+	// Make a copy of the connections slice to safely iterate without holding the lock
+	// This prevents race conditions if another goroutine modifies the slice during iteration
+	connsCopy := make([]*AgentConnection, len(conns))
+	copy(connsCopy, conns)
+	cm.mu.RUnlock()
+
+	if !exists || len(connsCopy) == 0 {
+		cm.logger.Debug("no connections to revalidate",
+			"planeType", planeType,
+			"planeID", planeID,
+			"cr", fmt.Sprintf("%s/%s", crNamespace, crName),
+		)
+		return 0, 0, nil
+	}
+
+	crKey := fmt.Sprintf("%s/%s", crNamespace, crName)
+
+	// Parse new CA certificate
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(newCAData) {
+		return 0, 0, fmt.Errorf("failed to parse new CA certificate")
+	}
+
+	cm.logger.Info("revalidating connections for CR",
+		"planeType", planeType,
+		"planeID", planeID,
+		"cr", crKey,
+		"totalConnections", len(connsCopy),
+	)
+
+	// Re-validate each connection using the extracted UpdateCRValidity method
+	for _, conn := range connsCopy {
+		granted, revoked, verifyErr := conn.UpdateCRValidity(crKey, certPool)
+
+		if granted {
+			updated++
+			cm.logger.Info("CR authorization granted to connection",
+				"connectionID", conn.ID,
+				"cr", crKey,
+				"clientCN", conn.clientCert.Subject.CommonName,
+			)
+		} else if revoked {
+			removed++
+			cm.logger.Warn("CR authorization revoked from connection",
+				"connectionID", conn.ID,
+				"cr", crKey,
+				"clientCN", conn.clientCert.Subject.CommonName,
+				"reason", verifyErr,
+			)
+		}
+		// else: status unchanged (still valid or still invalid)
+	}
+
+	cm.logger.Info("CR re-validation completed",
+		"planeType", planeType,
+		"planeID", planeID,
+		"cr", crKey,
+		"totalConnections", len(connsCopy),
+		"authorizationsGranted", updated,
+		"authorizationsRevoked", removed,
+	)
+
+	// If authorizations were revoked, clean up per-CR round-robin key if no connections remain authorized
+	if removed > 0 {
+		cm.mu.Lock()
+		defer cm.mu.Unlock()
+
+		hasAuthorizedConn := false
+		if conns, exists := cm.connections[planeIdentifier]; exists {
+			for _, conn := range conns {
+				if conn.IsValidForCR(crKey) {
+					hasAuthorizedConn = true
+					break
+				}
+			}
+		}
+
+		if !hasAuthorizedConn {
+			rrKey := fmt.Sprintf("%s/%s", planeIdentifier, crKey)
+			if _, exists := cm.roundRobin[rrKey]; exists {
+				delete(cm.roundRobin, rrKey)
+				cm.logger.Debug("cleaned up per-CR round-robin key after revocation",
+					"planeIdentifier", planeIdentifier,
+					"cr", crKey,
+				)
+			}
+		}
+	}
+
+	return updated, removed, nil
+}
+
+// cleanupPerCRRoundRobinKeys removes all per-CR round-robin keys for a given plane identifier
+// This should be called when all connections for a plane are removed
+// Must be called with cm.mu lock held
+func (cm *ConnectionManager) cleanupPerCRRoundRobinKeys(planeIdentifier string) {
+	prefix := planeIdentifier + "/"
+	keysToDelete := []string{}
+
+	for key := range cm.roundRobin {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			keysToDelete = append(keysToDelete, key)
+		}
+	}
+
+	for _, key := range keysToDelete {
+		delete(cm.roundRobin, key)
+	}
+
+	if len(keysToDelete) > 0 {
+		cm.logger.Debug("cleaned up per-CR round-robin keys",
+			"planeIdentifier", planeIdentifier,
+			"keysRemoved", len(keysToDelete),
+		)
+	}
+}
+
+// cleanupOrphanedCRKeys removes per-CR round-robin keys for CRs that no longer have any authorized connections
+// This should be called when a connection is removed but other connections remain for the plane
+// Must be called with cm.mu lock held
+func (cm *ConnectionManager) cleanupOrphanedCRKeys(planeIdentifier string, removedCRs []string) {
+	if len(removedCRs) == 0 {
+		return
+	}
+
+	remainingConns := cm.connections[planeIdentifier]
+	keysToDelete := []string{}
+
+	// For each CR that was on the removed connection, check if any remaining connections have it
+	for _, crKey := range removedCRs {
+		hasAuthorizedConn := false
+		for _, conn := range remainingConns {
+			if conn.IsValidForCR(crKey) {
+				hasAuthorizedConn = true
+				break
+			}
+		}
+
+		// If no remaining connections are authorized for this CR, clean up its round-robin key
+		if !hasAuthorizedConn {
+			rrKey := fmt.Sprintf("%s/%s", planeIdentifier, crKey)
+			if _, exists := cm.roundRobin[rrKey]; exists {
+				keysToDelete = append(keysToDelete, rrKey)
+				delete(cm.roundRobin, rrKey)
+			}
+		}
+	}
+
+	if len(keysToDelete) > 0 {
+		cm.logger.Debug("cleaned up orphaned per-CR round-robin keys",
+			"planeIdentifier", planeIdentifier,
+			"keysRemoved", len(keysToDelete),
+		)
+	}
 }

--- a/internal/cluster-gateway/plane_api.go
+++ b/internal/cluster-gateway/plane_api.go
@@ -12,6 +12,7 @@ import (
 
 type PlaneAPI struct {
 	connMgr *ConnectionManager
+	server  *Server // For accessing k8sClient to fetch CR CAs
 	logger  *slog.Logger
 }
 
@@ -23,9 +24,32 @@ type PlaneNotification struct {
 	Name      string `json:"name"`
 }
 
-func NewPlaneAPI(connMgr *ConnectionManager, logger *slog.Logger) *PlaneAPI {
+// PlaneNotificationResponse represents the response to a plane notification
+type PlaneNotificationResponse struct {
+	Success               bool   `json:"success"`
+	Action                string `json:"action"` // "disconnect", "disconnect_fallback", "revalidate"
+	DisconnectedAgents    *int   `json:"disconnectedAgents,omitempty"`
+	AuthorizationsGranted *int   `json:"authorizationsGranted,omitempty"`
+	AuthorizationsRevoked *int   `json:"authorizationsRevoked,omitempty"`
+	Error                 string `json:"error,omitempty"`
+}
+
+// PlaneReconnectResponse represents the response to a manual reconnect request
+type PlaneReconnectResponse struct {
+	Success            bool `json:"success"`
+	DisconnectedAgents int  `json:"disconnectedAgents"`
+}
+
+// AllPlaneStatusResponse represents the response for all plane statuses
+type AllPlaneStatusResponse struct {
+	Planes []PlaneConnectionStatus `json:"planes"`
+	Total  int                     `json:"total"`
+}
+
+func NewPlaneAPI(connMgr *ConnectionManager, server *Server, logger *slog.Logger) *PlaneAPI {
 	return &PlaneAPI{
 		connMgr: connMgr,
+		server:  server,
 		logger:  logger.With("component", "plane-api"),
 	}
 }
@@ -62,17 +86,69 @@ func (api *PlaneAPI) handlePlaneNotification(w http.ResponseWriter, r *http.Requ
 		"cr", fmt.Sprintf("%s/%s", notification.Namespace, notification.Name),
 	)
 
-	var disconnectedCount int
+	var result PlaneNotificationResponse
+	result.Success = true
 
 	switch notification.Event {
-	case "created", "updated", "deleted":
-		disconnectedCount = api.connMgr.DisconnectAllForPlane(notification.PlaneType, notification.PlaneID)
-		api.logger.Info("disconnected agents for reconnection",
+	case "created":
+		// New CR: Disconnect agents to pick up new CA
+		disconnectedCount := api.connMgr.DisconnectAllForPlane(notification.PlaneType, notification.PlaneID)
+		api.logger.Info("disconnected agents for new CR",
 			"planeType", notification.PlaneType,
 			"planeID", notification.PlaneID,
-			"event", notification.Event,
 			"disconnectedAgents", disconnectedCount,
 		)
+		result.Action = "disconnect"
+		result.DisconnectedAgents = &disconnectedCount
+
+	case "updated":
+		caData, err := api.fetchCRClientCA(notification)
+		if err != nil {
+			api.logger.Error("failed to fetch CR CA for re-validation", "error", err)
+			// Fall back to disconnect on error
+			disconnectedCount := api.connMgr.DisconnectAllForPlane(notification.PlaneType, notification.PlaneID)
+			api.logger.Warn("falling back to disconnect due to CA fetch error",
+				"planeType", notification.PlaneType,
+				"planeID", notification.PlaneID,
+				"disconnectedAgents", disconnectedCount,
+			)
+			result.Action = "disconnect_fallback"
+			result.DisconnectedAgents = &disconnectedCount
+			result.Error = err.Error()
+		} else {
+			updated, removed, err := api.connMgr.RevalidateCR(
+				notification.PlaneType,
+				notification.PlaneID,
+				notification.Namespace,
+				notification.Name,
+				caData,
+			)
+			if err != nil {
+				api.logger.Error("CR re-validation failed", "error", err)
+				http.Error(w, fmt.Sprintf("re-validation failed: %v", err), http.StatusInternalServerError)
+				return
+			}
+			api.logger.Info("CR re-validation completed",
+				"planeType", notification.PlaneType,
+				"planeID", notification.PlaneID,
+				"cr", fmt.Sprintf("%s/%s", notification.Namespace, notification.Name),
+				"authorizationsGranted", updated,
+				"authorizationsRevoked", removed,
+			)
+			result.Action = "revalidate"
+			result.AuthorizationsGranted = &updated
+			result.AuthorizationsRevoked = &removed
+		}
+
+	case "deleted":
+		disconnectedCount := api.connMgr.DisconnectAllForPlane(notification.PlaneType, notification.PlaneID)
+		api.logger.Info("disconnected agents for CR deletion",
+			"planeType", notification.PlaneType,
+			"planeID", notification.PlaneID,
+			"disconnectedAgents", disconnectedCount,
+		)
+		result.Action = "disconnect"
+		result.DisconnectedAgents = &disconnectedCount
 
 	default:
 		api.logger.Warn("unknown event type", "event", notification.Event)
@@ -82,10 +158,7 @@ func (api *PlaneAPI) handlePlaneNotification(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"disconnectedAgents": disconnectedCount,
-		"success":            true,
-	}); err != nil {
+	if err := json.NewEncoder(w).Encode(result); err != nil {
 		api.logger.Error("failed to encode response", "error", err)
 	}
 }
@@ -112,18 +185,23 @@ func (api *PlaneAPI) handleReconnect(w http.ResponseWriter, r *http.Request) {
 		"disconnectedAgents", disconnectedCount,
 	)
 
+	response := PlaneReconnectResponse{
+		Success:            true,
+		DisconnectedAgents: disconnectedCount,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"disconnectedAgents": disconnectedCount,
-		"success":            true,
-	}); err != nil {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		api.logger.Error("failed to encode response", "error", err)
 	}
 }
 
 // handleGetPlaneStatus returns connection status for a specific plane
 // This endpoint is called by the controller to update DataPlane CR status
+// If namespace and name query parameters are provided, it returns CR-specific authorization status
+// GET /api/v1/planes/{type}/{id}/status -> plane-level status (all agents connected to plane)
+// GET /api/v1/planes/{type}/{id}/status?namespace=X&name=Y -> CR-specific authorization status
 func (api *PlaneAPI) handleGetPlaneStatus(w http.ResponseWriter, r *http.Request) {
 	planeType := r.PathValue("type")
 	planeID := r.PathValue("id")
@@ -133,7 +211,16 @@ func (api *PlaneAPI) handleGetPlaneStatus(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	status := api.connMgr.GetPlaneStatus(planeType, planeID)
+	// Check for CR-specific query parameters
+	namespace := r.URL.Query().Get("namespace")
+	name := r.URL.Query().Get("name")
+
+	var status *PlaneConnectionStatus
+	if namespace != "" && name != "" {
+		status = api.connMgr.GetCRAuthorizationStatus(planeType, planeID, namespace, name)
+	} else {
+		status = api.connMgr.GetPlaneStatus(planeType, planeID)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -147,12 +234,41 @@ func (api *PlaneAPI) handleGetPlaneStatus(w http.ResponseWriter, r *http.Request
 func (api *PlaneAPI) handleGetAllPlaneStatus(w http.ResponseWriter, r *http.Request) {
 	statuses := api.connMgr.GetAllPlaneStatuses()
 
+	response := AllPlaneStatusResponse{
+		Planes: statuses,
+		Total:  len(statuses),
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"planes": statuses,
-		"total":  len(statuses),
-	}); err != nil {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		api.logger.Error("failed to encode response", "error", err)
 	}
+}
+
+// fetchCRClientCA fetches the client CA certificate for a specific CR
+// Uses the server's getAllPlaneClientCAs() method to query Kubernetes API
+func (api *PlaneAPI) fetchCRClientCA(notification PlaneNotification) ([]byte, error) {
+	// Use server's method to get CA data for all CRs with matching planeType/planeID
+	allCRs, err := api.server.getAllPlaneClientCAs(notification.PlaneType, notification.PlaneID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CRs: %w", err)
+	}
+
+	crKey := fmt.Sprintf("%s/%s", notification.Namespace, notification.Name)
+	caData, exists := allCRs[crKey]
+	if !exists {
+		return nil, fmt.Errorf("CR %s not found", crKey)
+	}
+
+	if caData == nil {
+		return nil, fmt.Errorf("CR %s has no CA configured", crKey)
+	}
+
+	api.logger.Debug("fetched CA for CR",
+		"cr", crKey,
+		"caSize", len(caData),
+	)
+
+	return caData, nil
 }

--- a/internal/controller/buildplane/controller.go
+++ b/internal/controller/buildplane/controller.go
@@ -83,6 +83,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Ignore reconcile if the BuildPlane is already available since this is a one-time create
 	// However, we still want to update agent connection status periodically
 	if r.shouldIgnoreReconcile(buildPlane) {
+		// Check if spec has changed (generation > observedGeneration)
+		// If so, notify gateway to re-validate agent certificates with updated CA
+		specChanged := buildPlane.Status.ObservedGeneration < buildPlane.Generation
+		if specChanged && r.GatewayClient != nil {
+			logger.Info("detected spec change, notifying gateway for certificate re-validation",
+				"generation", buildPlane.Generation,
+				"observedGeneration", buildPlane.Status.ObservedGeneration,
+			)
+			if err := r.notifyGateway(ctx, buildPlane, "updated"); err != nil {
+				if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "BuildPlane spec update"); shouldRetry {
+					return result, retryErr
+				}
+			}
+			// Update observedGeneration to track that we processed this change
+			buildPlane.Status.ObservedGeneration = buildPlane.Generation
+		}
+
 		if err := r.populateAgentConnectionStatus(ctx, buildPlane); err != nil {
 			logger.Error(err, "failed to get agent connection status")
 			// Don't fail reconciliation for status query errors
@@ -260,8 +277,9 @@ func (r *Reconciler) populateAgentConnectionStatus(ctx context.Context, buildPla
 		effectivePlaneID = buildPlane.Name
 	}
 
-	// Query gateway for connection status
-	status, err := r.GatewayClient.GetPlaneStatus(ctx, "buildplane", effectivePlaneID)
+	// Query gateway for CR-specific authorization status
+	// Pass namespace and name to get authorization status for this specific CR
+	status, err := r.GatewayClient.GetPlaneStatus(ctx, "buildplane", effectivePlaneID, buildPlane.Namespace, buildPlane.Name)
 	if err != nil {
 		// Log error but don't fail reconciliation
 		// If gateway is unreachable, we'll try again on next requeue

--- a/internal/controller/dataplane/controller.go
+++ b/internal/controller/dataplane/controller.go
@@ -84,6 +84,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Ignore reconcile if the Dataplane is already available since this is a one-time create
 	// However, we still want to update agent connection status periodically
 	if r.shouldIgnoreReconcile(dataPlane) {
+		// Check if spec has changed (generation > observedGeneration)
+		// If so, notify gateway to re-validate agent certificates with updated CA
+		specChanged := dataPlane.Status.ObservedGeneration < dataPlane.Generation
+		if specChanged && r.GatewayClient != nil {
+			logger.Info("detected spec change, notifying gateway for certificate re-validation",
+				"generation", dataPlane.Generation,
+				"observedGeneration", dataPlane.Status.ObservedGeneration,
+			)
+			if err := r.notifyGateway(ctx, dataPlane, "updated"); err != nil {
+				if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "DataPlane spec update"); shouldRetry {
+					return result, retryErr
+				}
+			}
+			// Update observedGeneration to track that we processed this change
+			dataPlane.Status.ObservedGeneration = dataPlane.Generation
+		}
+
 		if err := r.populateAgentConnectionStatus(ctx, dataPlane); err != nil {
 			logger.Error(err, "failed to get agent connection status")
 			// Don't fail reconciliation for status query errors
@@ -210,8 +227,9 @@ func (r *Reconciler) populateAgentConnectionStatus(ctx context.Context, dataPlan
 		effectivePlaneID = dataPlane.Name
 	}
 
-	// Query gateway for connection status
-	status, err := r.GatewayClient.GetPlaneStatus(ctx, "dataplane", effectivePlaneID)
+	// Query gateway for CR-specific authorization status
+	// Pass namespace and name to get authorization status for this specific CR
+	status, err := r.GatewayClient.GetPlaneStatus(ctx, "dataplane", effectivePlaneID, dataPlane.Namespace, dataPlane.Name)
 	if err != nil {
 		// Log error but don't fail reconciliation
 		// If gateway is unreachable, we'll try again on next requeue

--- a/internal/controller/reference.go
+++ b/internal/controller/reference.go
@@ -7,29 +7,85 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
-	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+const (
+	// DefaultPlaneName is the default name for plane resources when no explicit reference is provided
+	DefaultPlaneName = "default"
 )
 
 func GetDataplaneOfEnv(ctx context.Context, c client.Client, env *openchoreov1alpha1.Environment) (*openchoreov1alpha1.DataPlane, error) {
-	dataplaneList := &openchoreov1alpha1.DataPlaneList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(env.GetNamespace()),
-		client.MatchingLabels{
-			labels.LabelKeyNamespaceName: GetNamespaceName(env),
-			labels.LabelKeyName:          env.Spec.DataPlaneRef,
-		},
+	// Determine the plane name to look for
+	planeName := env.Spec.DataPlaneRef
+	if planeName == "" {
+		planeName = DefaultPlaneName
 	}
 
-	if err := c.List(ctx, dataplaneList, listOpts...); err != nil {
-		return nil, fmt.Errorf("failed to list dataplanes: %w", err)
+	// Try to find the DataPlane in the same namespace
+	dataPlane := &openchoreov1alpha1.DataPlane{}
+	key := client.ObjectKey{Namespace: env.Namespace, Name: planeName}
+
+	if err := c.Get(ctx, key, dataPlane); err != nil {
+		if apierrors.IsNotFound(err) {
+			if env.Spec.DataPlaneRef == "" {
+				return nil, fmt.Errorf("no dataPlaneRef specified and default DataPlane '%s' not found in namespace '%s'. Error is: %w", DefaultPlaneName, env.Namespace, err)
+			}
+			return nil, fmt.Errorf("dataPlane '%s' not found in namespace '%s'. Error is: %w", planeName, env.Namespace, err)
+		}
+		return nil, fmt.Errorf("failed to get dataPlane. Error is: %w", err)
 	}
 
-	if len(dataplaneList.Items) > 0 {
-		return &dataplaneList.Items[0], nil
+	return dataPlane, nil
+}
+
+func GetObservabilityPlaneOfBuildPlane(ctx context.Context, c client.Client, buildPlane *openchoreov1alpha1.BuildPlane) (*openchoreov1alpha1.ObservabilityPlane, error) {
+	// Determine the plane name to look for
+	planeName := buildPlane.Spec.ObservabilityPlaneRef
+	if planeName == "" {
+		planeName = DefaultPlaneName
 	}
 
-	return nil, fmt.Errorf("failed to find dataplane for environment: %s", env.Spec.DataPlaneRef)
+	// Try to find the ObservabilityPlane in the same namespace
+	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{}
+	key := client.ObjectKey{Namespace: buildPlane.Namespace, Name: planeName}
+
+	if err := c.Get(ctx, key, observabilityPlane); err != nil {
+		if apierrors.IsNotFound(err) {
+			if buildPlane.Spec.ObservabilityPlaneRef == "" {
+				return nil, fmt.Errorf("no observabilityPlaneRef specified and default ObservabilityPlane '%s' not found in namespace '%s'. Error is: %w", DefaultPlaneName, buildPlane.Namespace, err)
+			}
+			return nil, fmt.Errorf("observabilityPlane '%s' not found in namespace '%s'. Error is: %w", planeName, buildPlane.Namespace, err)
+		}
+		return nil, fmt.Errorf("failed to get observabilityPlane. Error is: %w", err)
+	}
+
+	return observabilityPlane, nil
+}
+
+func GetObservabilityPlaneOfDataPlane(ctx context.Context, c client.Client, dataPlane *openchoreov1alpha1.DataPlane) (*openchoreov1alpha1.ObservabilityPlane, error) {
+	// Determine the plane name to look for
+	planeName := dataPlane.Spec.ObservabilityPlaneRef
+	if planeName == "" {
+		planeName = DefaultPlaneName
+	}
+
+	// Try to find the ObservabilityPlane in the same namespace
+	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{}
+	key := client.ObjectKey{Namespace: dataPlane.Namespace, Name: planeName}
+
+	if err := c.Get(ctx, key, observabilityPlane); err != nil {
+		if apierrors.IsNotFound(err) {
+			if dataPlane.Spec.ObservabilityPlaneRef == "" {
+				return nil, fmt.Errorf("no observabilityPlaneRef specified and default ObservabilityPlane '%s' not found in namespace '%s'", DefaultPlaneName, dataPlane.Namespace)
+			}
+			return nil, fmt.Errorf("observabilityPlane '%s' not found in namespace '%s'", planeName, dataPlane.Namespace)
+		}
+		return nil, fmt.Errorf("failed to get observabilityPlane: %w", err)
+	}
+
+	return observabilityPlane, nil
 }

--- a/internal/controller/reference_test.go
+++ b/internal/controller/reference_test.go
@@ -1,0 +1,393 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+func TestGetDataplaneOfEnv_WithExplicitRef(t *testing.T) {
+	// Create a scheme with our API types
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create test DataPlane
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-dataplane",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create test Environment with explicit dataPlaneRef
+	environment := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-env",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: "my-dataplane",
+		},
+	}
+
+	// Create fake client with objects
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dataPlane, environment).
+		Build()
+
+	// Test the function
+	result, err := GetDataplaneOfEnv(context.Background(), fakeClient, environment)
+
+	// Assertions
+	require.NoError(t, err)
+	assert.Equal(t, "my-dataplane", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+}
+
+func TestGetDataplaneOfEnv_WithEmptyRef_DefaultExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create default DataPlane
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create Environment without dataPlaneRef
+	environment := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-env",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: "", // Empty ref - should fallback to "default"
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dataPlane, environment).
+		Build()
+
+	result, err := GetDataplaneOfEnv(context.Background(), fakeClient, environment)
+
+	require.NoError(t, err)
+	assert.Equal(t, "default", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+}
+
+func TestGetDataplaneOfEnv_WithEmptyRef_DefaultNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create Environment without dataPlaneRef, but no "default" DataPlane exists
+	environment := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-env",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: "",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(environment).
+		Build()
+
+	result, err := GetDataplaneOfEnv(context.Background(), fakeClient, environment)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no dataPlaneRef specified and default DataPlane 'default' not found in namespace 'test-namespace'")
+}
+
+func TestGetDataplaneOfEnv_WithExplicitRef_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create Environment with explicit ref that doesn't exist
+	environment := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-env",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: "nonexistent-dataplane",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(environment).
+		Build()
+
+	result, err := GetDataplaneOfEnv(context.Background(), fakeClient, environment)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "dataPlane 'nonexistent-dataplane' not found in namespace 'test-namespace'")
+}
+
+func TestGetObservabilityPlaneOfBuildPlane_WithExplicitRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create test ObservabilityPlane
+	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-observability",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create test BuildPlane with explicit observabilityPlaneRef
+	buildPlane := &openchoreov1alpha1.BuildPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-buildplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.BuildPlaneSpec{
+			ObservabilityPlaneRef: "my-observability",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(observabilityPlane, buildPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfBuildPlane(context.Background(), fakeClient, buildPlane)
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-observability", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+}
+
+func TestGetObservabilityPlaneOfBuildPlane_WithEmptyRef_DefaultExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create default ObservabilityPlane
+	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create BuildPlane without observabilityPlaneRef
+	buildPlane := &openchoreov1alpha1.BuildPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-buildplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.BuildPlaneSpec{
+			ObservabilityPlaneRef: "",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(observabilityPlane, buildPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfBuildPlane(context.Background(), fakeClient, buildPlane)
+
+	require.NoError(t, err)
+	assert.Equal(t, "default", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+}
+
+func TestGetObservabilityPlaneOfBuildPlane_WithEmptyRef_DefaultNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create BuildPlane without observabilityPlaneRef, but no "default" ObservabilityPlane exists
+	buildPlane := &openchoreov1alpha1.BuildPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-buildplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.BuildPlaneSpec{
+			ObservabilityPlaneRef: "",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(buildPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfBuildPlane(context.Background(), fakeClient, buildPlane)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no observabilityPlaneRef specified and default ObservabilityPlane 'default' not found in namespace 'test-namespace'")
+}
+
+func TestGetObservabilityPlaneOfBuildPlane_WithExplicitRef_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create BuildPlane with explicit ref that doesn't exist
+	buildPlane := &openchoreov1alpha1.BuildPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-buildplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.BuildPlaneSpec{
+			ObservabilityPlaneRef: "nonexistent-observability",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(buildPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfBuildPlane(context.Background(), fakeClient, buildPlane)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "observabilityPlane 'nonexistent-observability' not found in namespace 'test-namespace'")
+}
+
+func TestGetObservabilityPlaneOfDataPlane_WithExplicitRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create test ObservabilityPlane
+	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-observability",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create test DataPlane with explicit observabilityPlaneRef
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			ObservabilityPlaneRef: "my-observability",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(observabilityPlane, dataPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfDataPlane(context.Background(), fakeClient, dataPlane)
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-observability", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+}
+
+func TestGetObservabilityPlaneOfDataPlane_WithEmptyRef_DefaultExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create default ObservabilityPlane
+	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create DataPlane without observabilityPlaneRef
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			ObservabilityPlaneRef: "",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(observabilityPlane, dataPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfDataPlane(context.Background(), fakeClient, dataPlane)
+
+	require.NoError(t, err)
+	assert.Equal(t, "default", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+}
+
+func TestGetObservabilityPlaneOfDataPlane_WithEmptyRef_DefaultNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create DataPlane without observabilityPlaneRef, but no "default" ObservabilityPlane exists
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			ObservabilityPlaneRef: "",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dataPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfDataPlane(context.Background(), fakeClient, dataPlane)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no observabilityPlaneRef specified and default ObservabilityPlane 'default' not found in namespace 'test-namespace'")
+}
+
+func TestGetObservabilityPlaneOfDataPlane_WithExplicitRef_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+
+	// Create DataPlane with explicit ref that doesn't exist
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataplane",
+			Namespace: "test-namespace",
+		},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			ObservabilityPlaneRef: "nonexistent-observability",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dataPlane).
+		Build()
+
+	result, err := GetObservabilityPlaneOfDataPlane(context.Background(), fakeClient, dataPlane)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "observabilityPlane 'nonexistent-observability' not found in namespace 'test-namespace'")
+}

--- a/internal/controller/release/controller.go
+++ b/internal/controller/release/controller.go
@@ -21,6 +21,7 @@ import (
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
@@ -176,9 +177,10 @@ func (r *Reconciler) getDPClient(ctx context.Context, namespaceName string, envi
 		return nil, fmt.Errorf("failed to get environment %s: %w", environmentName, err)
 	}
 
-	dataplane := &openchoreov1alpha1.DataPlane{}
-	if err := r.Get(ctx, client.ObjectKey{Name: env.Spec.DataPlaneRef, Namespace: namespaceName}, dataplane); err != nil {
-		return nil, fmt.Errorf("failed to get dataplane %s for environment %s: %w", env.Spec.DataPlaneRef, environmentName, err)
+	// Use the resolution function to get the DataPlane (with default fallback)
+	dataplane, err := controller.GetDataplaneOfEnv(ctx, r.Client, env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve dataplane for environment %s: %w", environmentName, err)
 	}
 
 	// Get Kubernetes client - supports both agent mode (via HTTP proxy) and direct access mode
@@ -198,32 +200,16 @@ func (r *Reconciler) getOPClient(ctx context.Context, namespaceName string, envi
 		return nil, fmt.Errorf("failed to get environment %s: %w", environmentName, err)
 	}
 
-	// Check if DataPlaneRef is configured
-	if env.Spec.DataPlaneRef == "" {
-		return nil, fmt.Errorf("environment %s has no DataPlaneRef configured", environmentName)
+	// Use the resolution function to get the DataPlane (with default fallback)
+	dataPlane, err := controller.GetDataplaneOfEnv(ctx, r.Client, env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve dataplane for environment %s: %w", environmentName, err)
 	}
 
-	// Get the DataPlane
-	dataPlane := &openchoreov1alpha1.DataPlane{}
-	if err := r.Get(ctx, client.ObjectKey{Name: env.Spec.DataPlaneRef, Namespace: namespaceName}, dataPlane); err != nil {
-		return nil, fmt.Errorf("failed to get dataplane %s for environment %s: %w", env.Spec.DataPlaneRef, environmentName, err)
-	}
-
-	// Check if ObservabilityPlaneRef is configured
-	if dataPlane.Spec.ObservabilityPlaneRef == "" {
-		return nil, fmt.Errorf("dataplane %s has no ObservabilityPlaneRef configured", dataPlane.Name)
-	}
-
-	// Get the ObservabilityPlane
-	observabilityPlane := &openchoreov1alpha1.ObservabilityPlane{}
-	if err := r.Get(ctx, client.ObjectKey{
-		Name:      dataPlane.Spec.ObservabilityPlaneRef,
-		Namespace: namespaceName,
-	}, observabilityPlane); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("observability plane %s not found", dataPlane.Spec.ObservabilityPlaneRef)
-		}
-		return nil, fmt.Errorf("failed to get observability plane %s: %w", dataPlane.Spec.ObservabilityPlaneRef, err)
+	// Use the resolution function to get the ObservabilityPlane (with default fallback)
+	observabilityPlane, err := controller.GetObservabilityPlaneOfDataPlane(ctx, r.Client, dataPlane)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve observability plane for dataplane %s: %w", dataPlane.Name, err)
 	}
 
 	// Get Kubernetes client - supports agent mode (via HTTP proxy) through cluster gateway


### PR DESCRIPTION
## Purpose

Previously, for the Cluster Agent and Gateway connection, we validated only the CA certificates present in the relevant CRs. With this PR, we have strengthened security by validating all CA certificates defined in the relevant plane CRs.

This pull request implements per-CR (Custom Resource) authorization for agent connections in the cluster gateway, enforcing stronger multi-tenancy and security boundaries. Now, each agent connection is explicitly authorized for specific CRs, and certificate validation is performed per CR. The connection manager and API are updated to support dynamic revalidation when CRs are updated, and proxy routing ensures requests are only sent to agents authorized for the relevant CR.

**Per-CR Authorization and Validation:**

* Added `ValidCRs` and `clientCert` fields to `AgentConnection`, with new methods for managing authorized CRs and checking authorization.
* Modified the `Register` method in `ConnectionManager` to accept a list of authorized CRs and the client certificate for each connection. [[1]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aL55-R125) [[2]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aR141-R142)
* Added `GetForCR` method to select an agent connection authorized for a specific CR, enforcing per-CR security boundaries.
* Implemented `RevalidateCR` to update connection authorizations when a CR's CA changes, without disconnecting agents.

**API and Proxy Routing Updates:**

* Updated `PlaneAPI` to handle CR lifecycle events more intelligently: on CR update, agent authorizations are revalidated using the latest CA; on create/delete, agents are disconnected as before. Added helper to fetch CA data for a CR. [[1]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcR15) [[2]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcL26-R30) [[3]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcL65-R147) [[4]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcR218-R244)
* Modified WebSocket connection handling to validate the client certificate per CR and register the connection with its authorized CR list. [[1]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L228-R244) [[2]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L248-L273)
* Changed HTTP proxy and streaming proxy logic to route requests only to agents authorized for the specific CR, returning a 403 if no agent is authorized. [[1]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L415-R426) [[2]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L437-R441) [[3]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L454-R473) [[4]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L504-R526) [[5]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L520-R542)

These changes significantly improve security and multi-tenancy by ensuring agents cannot access resources for which they are not explicitly authorized.

**References:**  
[[1]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aR31-R91) [[2]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aL55-R125) [[3]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aR141-R142) [[4]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aR230-R277) [[5]](diffhunk://#diff-90431c8509156e9123b3d7f3cfa6681b43f10cfa775d8c4175884251c9b7865aR485-R575) [[6]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcR15) [[7]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcL26-R30) [[8]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcL65-R147) [[9]](diffhunk://#diff-33c4ec998139782b8bc40b8c2c567a3b1afd938b6746271f7fe146ee393859bcR218-R244) [[10]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L228-R244) [[11]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L248-L273) [[12]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L415-R426) [[13]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L437-R441) [[14]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L454-R473) [[15]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L504-R526) [[16]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83L520-R542)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
