### PR TITLE
Fix openchoreo-api JWT issuer validation mismatch

### DIFF
--- a/cmd/openchoreo-api/config.yaml
+++ b/cmd/openchoreo-api/config.yaml
@@ -55,6 +55,10 @@ security:
       # When disabled, all requests are treated as unauthenticated.
       enabled: false
 
+      # Expected "iss" claim value in JWT tokens.
+      # If empty, falls back to identity.oidc.issuer.
+      issuer: ""
+
       # List of acceptable audiences (aud) for the JWT.
       # Tokens must contain at least one of these audiences.
       audiences: [ ]

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -29,6 +29,7 @@ data:
       authentication:
         jwt:
           enabled: {{ .Values.security.enabled }}
+          issuer: {{ .Values.thunder.configuration.jwt.issuer | quote }}
           audiences:
             {{- if .Values.security.jwt.audience }}
             - {{ .Values.security.jwt.audience | quote }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2943,7 +2943,7 @@
                   "properties": {
                     "jwt": {
                       "additionalProperties": false,
-                      "description": "JWT authentication configuration. Enabled/audiences come from security.enabled and security.jwt.audience. Issuer/JWKS URL come from identity.oidc (computed from security.oidc.*).",
+                      "description": "JWT authentication configuration. Enabled/audiences come from security.enabled and security.jwt.audience. Issuer comes from thunder.configuration.jwt.issuer. JWKS URL comes from identity.oidc (computed from security.oidc.*).",
                       "properties": {
                         "clock_skew": {
                           "default": "0s",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1248,7 +1248,7 @@ openchoreoApi:
       authentication:
         # @schema
         # type: object
-        # description: JWT authentication configuration. Enabled/audiences come from security.enabled and security.jwt.audience. Issuer/JWKS URL come from identity.oidc (computed from security.oidc.*).
+        # description: JWT authentication configuration. Enabled/audiences come from security.enabled and security.jwt.audience. Issuer comes from thunder.configuration.jwt.issuer. JWKS URL comes from identity.oidc (computed from security.oidc.*).
         # @schema
         jwt:
           # @schema

--- a/internal/openchoreo-api/config/security.go
+++ b/internal/openchoreo-api/config/security.go
@@ -90,6 +90,9 @@ func (c *AuthenticationConfig) Validate(path *config.Path) config.ValidationErro
 type JWTConfig struct {
 	// Enabled enables JWT authentication.
 	Enabled bool `koanf:"enabled"`
+	// Issuer is the expected "iss" claim value in JWT tokens.
+	// If empty, falls back to identity.oidc.issuer.
+	Issuer string `koanf:"issuer"`
 	// Audiences is the list of acceptable token audiences (aud claim).
 	// Token must contain at least one of these audiences. Optional.
 	Audiences []string `koanf:"audiences"`
@@ -126,14 +129,19 @@ func (c *JWTConfig) Validate(path *config.Path) config.ValidationErrors {
 }
 
 // ToJWTMiddlewareConfig converts to the JWT middleware library config.
-// The oidc parameter provides issuer and JWKS URL from identity configuration.
+// The oidc parameter provides JWKS URL and fallback issuer from identity configuration.
 func (c *JWTConfig) ToJWTMiddlewareConfig(oidc *OIDCConfig, logger *slog.Logger, resolver *jwt.Resolver) jwt.Config {
+	issuer := c.Issuer
+	if issuer == "" {
+		issuer = oidc.Issuer
+	}
+
 	return jwt.Config{
 		Disabled:                     !c.Enabled,
 		JWKSURL:                      oidc.JWKSURL,
 		JWKSRefreshInterval:          c.JWKS.RefreshInterval,
 		JWKSURLTLSInsecureSkipVerify: c.JWKS.SkipTLSVerify,
-		ValidateIssuer:               oidc.Issuer,
+		ValidateIssuer:               issuer,
 		ValidateAudiences:            c.Audiences,
 		ClockSkew:                    c.ClockSkew,
 		Detector:                     resolver,


### PR DESCRIPTION
## Purpose
Fix 401 Unauthorized errors in openchoreo-api caused by JWT issuer mismatch between `identity.oidc.issuer` (URL) and Thunder's actual `iss` claim (`"thunder"`).

## Approach
- Add `issuer` field to `security.authentication.jwt` config, separate from the OIDC provider URL
- Falls back to `identity.oidc.issuer` when not set
- Wire `thunder.configuration.jwt.issuer` into the Helm configmap template

## Related Issues
Part of #275

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)