### PR TITLE
feat: expose agent connection status in plane API responses

### DIFF
--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -173,34 +173,46 @@ type EnvironmentResponse struct {
 	Status       string    `json:"status,omitempty"`
 }
 
+// AgentConnectionStatusResponse represents the agent connection status in API responses
+type AgentConnectionStatusResponse struct {
+	Connected            bool       `json:"connected"`
+	ConnectedAgents      int        `json:"connectedAgents"`
+	LastConnectedTime    *time.Time `json:"lastConnectedTime,omitempty"`
+	LastDisconnectedTime *time.Time `json:"lastDisconnectedTime,omitempty"`
+	LastHeartbeatTime    *time.Time `json:"lastHeartbeatTime,omitempty"`
+	Message              string     `json:"message,omitempty"`
+}
+
 // DataPlaneResponse represents a dataplane in API responses
 type DataPlaneResponse struct {
-	Name                    string    `json:"name"`
-	Namespace               string    `json:"namespace"`
-	DisplayName             string    `json:"displayName,omitempty"`
-	Description             string    `json:"description,omitempty"`
-	ImagePullSecretRefs     []string  `json:"imagePullSecretRefs,omitempty"`
-	SecretStoreRef          string    `json:"secretStoreRef,omitempty"`
-	PublicVirtualHost       string    `json:"publicVirtualHost"`
-	OrganizationVirtualHost string    `json:"organizationVirtualHost"`
-	PublicHTTPPort          int32     `json:"publicHTTPPort"`
-	PublicHTTPSPort         int32     `json:"publicHTTPSPort"`
-	OrganizationHTTPPort    int32     `json:"organizationHTTPPort"`
-	OrganizationHTTPSPort   int32     `json:"organizationHTTPSPort"`
-	ObservabilityPlaneRef   string    `json:"observabilityPlaneRef,omitempty"`
-	CreatedAt               time.Time `json:"createdAt"`
-	Status                  string    `json:"status,omitempty"`
+	Name                    string                         `json:"name"`
+	Namespace               string                         `json:"namespace"`
+	DisplayName             string                         `json:"displayName,omitempty"`
+	Description             string                         `json:"description,omitempty"`
+	ImagePullSecretRefs     []string                       `json:"imagePullSecretRefs,omitempty"`
+	SecretStoreRef          string                         `json:"secretStoreRef,omitempty"`
+	PublicVirtualHost       string                         `json:"publicVirtualHost"`
+	OrganizationVirtualHost string                         `json:"organizationVirtualHost"`
+	PublicHTTPPort          int32                          `json:"publicHTTPPort"`
+	PublicHTTPSPort         int32                          `json:"publicHTTPSPort"`
+	OrganizationHTTPPort    int32                          `json:"organizationHTTPPort"`
+	OrganizationHTTPSPort   int32                          `json:"organizationHTTPSPort"`
+	ObservabilityPlaneRef   string                         `json:"observabilityPlaneRef,omitempty"`
+	AgentConnection         *AgentConnectionStatusResponse `json:"agentConnection,omitempty"`
+	CreatedAt               time.Time                      `json:"createdAt"`
+	Status                  string                         `json:"status,omitempty"`
 }
 
 // BuildPlaneResponse represents a buildplane in API responses
 type BuildPlaneResponse struct {
-	Name                  string    `json:"name"`
-	Namespace             string    `json:"namespace"`
-	DisplayName           string    `json:"displayName,omitempty"`
-	Description           string    `json:"description,omitempty"`
-	ObservabilityPlaneRef string    `json:"observabilityPlaneRef,omitempty"`
-	CreatedAt             time.Time `json:"createdAt"`
-	Status                string    `json:"status,omitempty"`
+	Name                  string                         `json:"name"`
+	Namespace             string                         `json:"namespace"`
+	DisplayName           string                         `json:"displayName,omitempty"`
+	Description           string                         `json:"description,omitempty"`
+	ObservabilityPlaneRef string                         `json:"observabilityPlaneRef,omitempty"`
+	AgentConnection       *AgentConnectionStatusResponse `json:"agentConnection,omitempty"`
+	CreatedAt             time.Time                      `json:"createdAt"`
+	Status                string                         `json:"status,omitempty"`
 }
 
 // ComponentWorkflowResponse represents a component workflow run in API responses
@@ -377,12 +389,14 @@ type WebhookEventResponse struct {
 
 // ObservabilityPlaneResponse represents an observability plane in API responses
 type ObservabilityPlaneResponse struct {
-	Name        string    `json:"name"`
-	Namespace   string    `json:"namespace"`
-	DisplayName string    `json:"displayName,omitempty"`
-	Description string    `json:"description,omitempty"`
-	CreatedAt   time.Time `json:"createdAt"`
-	Status      string    `json:"status,omitempty"`
+	Name            string                         `json:"name"`
+	Namespace       string                         `json:"namespace"`
+	DisplayName     string                         `json:"displayName,omitempty"`
+	Description     string                         `json:"description,omitempty"`
+	ObserverURL     string                         `json:"observerURL,omitempty"`
+	AgentConnection *AgentConnectionStatusResponse `json:"agentConnection,omitempty"`
+	CreatedAt       time.Time                      `json:"createdAt"`
+	Status          string                         `json:"status,omitempty"`
 }
 
 // VersionResponse represents the server version information in API responses.

--- a/internal/openchoreo-api/services/dataplane_service.go
+++ b/internal/openchoreo-api/services/dataplane_service.go
@@ -258,5 +258,10 @@ func (s *DataPlaneService) toDataPlaneResponse(dp *openchoreov1alpha1.DataPlane)
 		response.ObservabilityPlaneRef = dp.Spec.ObservabilityPlaneRef
 	}
 
+	// Map agent connection status
+	if dp.Status.AgentConnection != nil {
+		response.AgentConnection = toAgentConnectionStatusResponse(dp.Status.AgentConnection)
+	}
+
 	return response
 }

--- a/internal/openchoreo-api/services/helpers.go
+++ b/internal/openchoreo-api/services/helpers.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"log/slog"
 
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
 
@@ -52,4 +54,29 @@ func checkAuthorization(ctx context.Context, logger *slog.Logger, pdp authz.PDP,
 	}
 
 	return nil
+}
+
+// toAgentConnectionStatusResponse converts a CRD AgentConnectionStatus to an API response
+func toAgentConnectionStatusResponse(ac *openchoreov1alpha1.AgentConnectionStatus) *models.AgentConnectionStatusResponse {
+	if ac == nil {
+		return nil
+	}
+	resp := &models.AgentConnectionStatusResponse{
+		Connected:       ac.Connected,
+		ConnectedAgents: ac.ConnectedAgents,
+		Message:         ac.Message,
+	}
+	if ac.LastConnectedTime != nil {
+		t := ac.LastConnectedTime.Time
+		resp.LastConnectedTime = &t
+	}
+	if ac.LastDisconnectedTime != nil {
+		t := ac.LastDisconnectedTime.Time
+		resp.LastDisconnectedTime = &t
+	}
+	if ac.LastHeartbeatTime != nil {
+		t := ac.LastHeartbeatTime.Time
+		resp.LastHeartbeatTime = &t
+	}
+	return resp
 }


### PR DESCRIPTION
  Add AgentConnectionStatusResponse to DataPlane, BuildPlane, and
  ObservabilityPlane API responses. Extract shared helper to map
  CRD AgentConnectionStatus to the response model. Add dedicated
  toBuildPlaneResponse and toObservabilityPlaneResponse helpers with
  conditions-based status derivation and agent connection mapping.
  Also expose ObserverURL in ObservabilityPlane responses

Related to: https://github.com/openchoreo/openchoreo/issues/1635