### PR TITLE
feat: add experimental feature to enable an external logs backend

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -28,6 +28,12 @@ spec:
         - /bin/sh
         - -c
         - |
+          # Skip OpenSearch check if using logs backend
+          if [ -n "$EXPERIMENTAL_USE_LOGS_BACKEND" ] && [ "$EXPERIMENTAL_USE_LOGS_BACKEND" = "true" ]; then
+            echo "Logs backend enabled, skipping OpenSearch check"
+            exit 0
+          fi
+          
           echo "Waiting for OpenSearch to be ready..."
           AUTH_TOKEN=$(echo -n "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" | base64)
           echo "Checking OpenSearch at: $OPENSEARCH_ADDRESS"
@@ -37,6 +43,8 @@ spec:
           done
           echo "OpenSearch is ready!"
         env:
+        - name: EXPERIMENTAL_USE_LOGS_BACKEND
+          value: {{ if .Values.observer.experimental }}{{ .Values.observer.experimental.useLogsBackend | default "false" }}{{ else }}"false"{{ end }}
         - name: OPENSEARCH_ADDRESS
           value: "https://opensearch:9200"
         - name: OPENSEARCH_USERNAME

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1587,6 +1587,14 @@
       "additionalProperties": true,
       "description": "OpenChoreo Observer service configuration - REST API that abstracts OpenSearch for logging, metrics, and tracing",
       "properties": {
+        "experimental": {
+          "additionalProperties": true,
+          "default": true,
+          "description": "Control experimental features in the Observer service",
+          "required": [],
+          "title": "experimental",
+          "type": "object"
+        },
         "extraEnvs": {
           "description": "Extra environment variables for the Observer container",
           "items": {

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -952,6 +952,14 @@ openSearchDashboards:
 # @schema
 observer:
   # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Control experimental features in the Observer service
+  # default: true
+  # @schema
+  experimental: {}
+  
+  # @schema
   # type: integer
   # description: Number of Observer pod replicas
   # minimum: 0

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -18,14 +18,22 @@ import (
 
 // Config holds all configuration for the logging service
 type Config struct {
-	Server     ServerConfig     `koanf:"server"`
-	OpenSearch OpenSearchConfig `koanf:"opensearch"`
-	Prometheus PrometheusConfig `koanf:"prometheus"`
-	Auth       AuthConfig       `koanf:"auth"`
-	Authz      AuthzConfig      `koanf:"authz"`
-	Logging    LoggingConfig    `koanf:"logging"`
-	Alerting   AlertingConfig   `koanf:"alerting"`
-	LogLevel   string           `koanf:"loglevel"`
+	Server       ServerConfig       `koanf:"server"`
+	OpenSearch   OpenSearchConfig   `koanf:"opensearch"`
+	Prometheus   PrometheusConfig   `koanf:"prometheus"`
+	Auth         AuthConfig         `koanf:"auth"`
+	Authz        AuthzConfig        `koanf:"authz"`
+	Logging      LoggingConfig      `koanf:"logging"`
+	Alerting     AlertingConfig     `koanf:"alerting"`
+	Experimental ExperimentalConfig `koanf:"experimental"`
+	LogLevel     string             `koanf:"loglevel"`
+}
+
+// ExperimentalConfig holds experimental feature flags
+type ExperimentalConfig struct {
+	UseLogsBackend     bool          `koanf:"use.logs.backend"`
+	LogsBackendURL     string        `koanf:"logs.backend.url"`
+	LogsBackendTimeout time.Duration `koanf:"logs.backend.timeout"`
 }
 
 // ServerConfig holds HTTP server configuration
@@ -122,37 +130,40 @@ func Load() (*Config, error) {
 
 	// Define environment variable mappings
 	envMappings := map[string]string{
-		"SERVER_PORT":                     "server.port",
-		"SERVER_READ_TIMEOUT":             "server.read.timeout",
-		"SERVER_WRITE_TIMEOUT":            "server.write.timeout",
-		"SERVER_SHUTDOWN_TIMEOUT":         "server.shutdown.timeout",
-		"OPENSEARCH_ADDRESS":              "opensearch.address",
-		"OPENSEARCH_USERNAME":             "opensearch.username",
-		"OPENSEARCH_PASSWORD":             "opensearch.password",
-		"OPENSEARCH_TIMEOUT":              "opensearch.timeout",
-		"OPENSEARCH_MAX_RETRIES":          "opensearch.max.retries",
-		"OPENSEARCH_INDEX_PREFIX":         "opensearch.index.prefix",
-		"OPENSEARCH_INDEX_PATTERN":        "opensearch.index.pattern",
-		"OPENSEARCH_LEGACY_PATTERN":       "opensearch.legacy.pattern",
-		"PROMETHEUS_ADDRESS":              "prometheus.address",
-		"PROMETHEUS_TIMEOUT":              "prometheus.timeout",
-		"AUTH_JWT_SECRET":                 "auth.jwt.secret",
-		"AUTH_ENABLE_AUTH":                "auth.enable.auth",
-		"AUTH_REQUIRED_ROLE":              "auth.required.role",
-		"AUTHZ_ENABLED":                   "authz.enabled",
-		"AUTHZ_SERVICE_URL":               "authz.service.url",
-		"AUTHZ_TIMEOUT":                   "authz.timeout",
-		"LOGGING_MAX_LOG_LIMIT":           "logging.max.log.limit",
-		"LOGGING_DEFAULT_LOG_LIMIT":       "logging.default.log.limit",
-		"LOGGING_DEFAULT_BUILD_LOG_LIMIT": "logging.default.build.log.limit",
-		"LOGGING_MAX_LOG_LINES_PER_FILE":  "logging.max.log.lines.per.file",
-		"RCA_SERVICE_URL":                 "alerting.rca.service.url",
-		"OBSERVABILITY_NAMESPACE":         "alerting.observability.namespace",
-		"LOG_LEVEL":                       "loglevel",
-		"PORT":                            "server.port",           // Common alias
-		"JWT_SECRET":                      "auth.jwt.secret",       // Common alias
-		"ENABLE_AUTH":                     "auth.enable.auth",      // Common alias
-		"MAX_LOG_LIMIT":                   "logging.max.log.limit", // Common alias
+		"SERVER_PORT":                       "server.port",
+		"SERVER_READ_TIMEOUT":               "server.read.timeout",
+		"SERVER_WRITE_TIMEOUT":              "server.write.timeout",
+		"SERVER_SHUTDOWN_TIMEOUT":           "server.shutdown.timeout",
+		"OPENSEARCH_ADDRESS":                "opensearch.address",
+		"OPENSEARCH_USERNAME":               "opensearch.username",
+		"OPENSEARCH_PASSWORD":               "opensearch.password",
+		"OPENSEARCH_TIMEOUT":                "opensearch.timeout",
+		"OPENSEARCH_MAX_RETRIES":            "opensearch.max.retries",
+		"OPENSEARCH_INDEX_PREFIX":           "opensearch.index.prefix",
+		"OPENSEARCH_INDEX_PATTERN":          "opensearch.index.pattern",
+		"OPENSEARCH_LEGACY_PATTERN":         "opensearch.legacy.pattern",
+		"PROMETHEUS_ADDRESS":                "prometheus.address",
+		"PROMETHEUS_TIMEOUT":                "prometheus.timeout",
+		"AUTH_JWT_SECRET":                   "auth.jwt.secret",
+		"AUTH_ENABLE_AUTH":                  "auth.enable.auth",
+		"AUTH_REQUIRED_ROLE":                "auth.required.role",
+		"AUTHZ_ENABLED":                     "authz.enabled",
+		"AUTHZ_SERVICE_URL":                 "authz.service.url",
+		"AUTHZ_TIMEOUT":                     "authz.timeout",
+		"LOGGING_MAX_LOG_LIMIT":             "logging.max.log.limit",
+		"LOGGING_DEFAULT_LOG_LIMIT":         "logging.default.log.limit",
+		"LOGGING_DEFAULT_BUILD_LOG_LIMIT":   "logging.default.build.log.limit",
+		"LOGGING_MAX_LOG_LINES_PER_FILE":    "logging.max.log.lines.per.file",
+		"RCA_SERVICE_URL":                   "alerting.rca.service.url",
+		"OBSERVABILITY_NAMESPACE":           "alerting.observability.namespace",
+		"LOG_LEVEL":                         "loglevel",
+		"PORT":                              "server.port",           // Common alias
+		"JWT_SECRET":                        "auth.jwt.secret",       // Common alias
+		"ENABLE_AUTH":                       "auth.enable.auth",      // Common alias
+		"MAX_LOG_LIMIT":                     "logging.max.log.limit", // Common alias
+		"EXPERIMENTAL_USE_LOGS_BACKEND":     "experimental.use.logs.backend",
+		"EXPERIMENTAL_LOGS_BACKEND_URL":     "experimental.logs.backend.url",
+		"EXPERIMENTAL_LOGS_BACKEND_TIMEOUT": "experimental.logs.backend.timeout",
 	}
 
 	// Check for environment variables and map them to nested structure
@@ -256,6 +267,11 @@ func getDefaults() map[string]interface{} {
 		"alerting": map[string]interface{}{
 			"rca.service.url":         "http://ai-rca-agent:8080",
 			"observability.namespace": "openchoreo-observability-plane",
+		},
+		"experimental": map[string]interface{}{
+			"use.logs.backend":     false,
+			"logs.backend.url":     "",
+			"logs.backend.timeout": "30s",
 		},
 		"loglevel": "info",
 	}

--- a/internal/observer/service/logs_backend.go
+++ b/internal/observer/service/logs_backend.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/openchoreo/openchoreo/pkg/observability"
+)
+
+type LogsBackend struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type LogsBackendConfig struct {
+	BaseURL string
+	Timeout time.Duration
+}
+
+func NewLogsBackend(config LogsBackendConfig) *LogsBackend {
+	if config.Timeout == 0 {
+		config.Timeout = 30 * time.Second
+	}
+
+	return &LogsBackend{
+		baseURL: config.BaseURL,
+		httpClient: &http.Client{
+			Timeout: config.Timeout,
+		},
+	}
+}
+
+// GetComponentApplicationLogs implements observability.LogsBackend interface
+// It makes an HTTP POST request to the logs API with component application logs parameters
+func (p *LogsBackend) GetComponentApplicationLogs(ctx context.Context, params observability.ComponentApplicationLogsParams) (*observability.ComponentApplicationLogsResult, error) {
+	url := fmt.Sprintf("%s/api/v1/component-application-logs", p.baseURL)
+
+	requestBody, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create HTTP request for component logs to logs backend: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result observability.ComponentApplicationLogsResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/pkg/observability/logs.go
+++ b/pkg/observability/logs.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package observability provides public interfaces for component observability.
+// External Go modules can implement these interfaces to provide custom
+// logging backends while the Observer handles authentication, authorization,
+// and HTTP request handling.
+package observability
+
+import (
+	"context"
+	"time"
+)
+
+// ComponentApplicationLogsParams holds parameters for component application log queries
+type ComponentApplicationLogsParams struct {
+	ComponentID   string    `json:"componentId"`
+	EnvironmentID string    `json:"environmentId"`
+	ProjectID     string    `json:"projectId"`
+	Namespace     string    `json:"namespace"`
+	StartTime     time.Time `json:"startTime"`
+	EndTime       time.Time `json:"endTime"`
+	SearchPhrase  string    `json:"searchPhrase"`
+	LogLevels     []string  `json:"logLevels"`
+	Versions      []string  `json:"versions"`
+	VersionIDs    []string  `json:"versionIds"`
+	Limit         int       `json:"limit"`
+	SortOrder     string    `json:"sortOrder"`
+}
+
+// LogEntry represents a parsed log entry
+type LogEntry struct {
+	Timestamp     time.Time         `json:"timestamp"`
+	Log           string            `json:"log"`
+	LogLevel      string            `json:"logLevel"`
+	ComponentID   string            `json:"componentId"`
+	EnvironmentID string            `json:"environmentId"`
+	ProjectID     string            `json:"projectId"`
+	Version       string            `json:"version"`
+	VersionID     string            `json:"versionId"`
+	Namespace     string            `json:"namespace"`
+	PodID         string            `json:"podId"`
+	ContainerName string            `json:"containerName"`
+	Labels        map[string]string `json:"labels"`
+}
+
+// ComponentApplicationLogsResult represents the result of a component log query
+type ComponentApplicationLogsResult struct {
+	Logs       []LogEntry `json:"logs"`
+	TotalCount int        `json:"totalCount"`
+	Took       int        `json:"took"`
+}
+
+type LogsBackend interface {
+	GetComponentApplicationLogs(ctx context.Context,
+		params ComponentApplicationLogsParams) (*ComponentApplicationLogsResult, error)
+}


### PR DESCRIPTION
## Purpose
As part of the OpenChoreo modularization effort, a new OpenObserve module is being developed. To make it work, Observer needs to offload the actual log fetching part from the backend to an external service. This PR does that change and enables it with the following experimental flags that are passed as environment variables.
```
EXPERIMENTAL_USE_LOGS_BACKEND=true
EXPERIMENTAL_LOGS_BACKEND_URL=<URL>
```

## Approach
1. Adds a public observability package which defines the interface for the logs backend. OpenChoreo Observability modules should implement this
2. Offloads the component application log fetching part to the module's backend

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1641

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
As the first step, this PR only adds the change for fetching component application logs. Other functions will be added later
