### PR TITLE
docs: enhance documentation for component-alerts sample

### DIFF
--- a/samples/component-alerts/README.md
+++ b/samples/component-alerts/README.md
@@ -11,104 +11,157 @@ This sample builds on top of the `gcp-microservices-demo` in `samples/gcp-micros
 - A running OpenChoreo control plane, data plane, and observability plane
 - `kubectl` configured to talk to the cluster where OpenChoreo is installed
 
+### Architecture Overview
+
+This sample uses a simple, role-based workflow:
+
+- **Platform Engineers (one-time setup)**:
+  - Deploy the `observability-alert-rule` trait once per OpenChoreo installation
+  - Configure notification channels once per environment (email, webhook, etc.)
+
+- **Developers (once per component)**:
+  - Attach `observability-alert-rule` traits to components
+  - The same alert rules are reused as components are promoted across environments
+
+- **Per-environment tuning (by Platform Engineers)**:
+  - Use `ReleaseBinding` `traitOverrides` to enable/disable alerts, toggle AI analysis, and choose notification channels per environment
+
 ### Files in this folder
 
-- `alert-rule-trait.yaml`: the `Trait` definition for `observability-alert-rule` that enables attaching alert rules to components. This trait is typically installed as part of the OpenChoreo control plane, but is included here for reference.
-- `alert-notification-channels.yaml`: two `ObservabilityAlertsNotificationChannel`s (one email, one webhook) plus their backing `Secret`s for the `development` environment.
-- `components-with-alert-rules.yaml`: `Component` definitions for `frontend`, `recommendation`, and `cart` microservices with alert rules attached as `observability-alert-rule` traits.
-- `failure-scenario-setup.yaml`: `ReleaseBinding`s that deliberately misconfigure the system (env var overrides, CPU / memory limit overrides) to cause alerts to fire.
-- `trigger-alerts.sh`: simple script that drives traffic to the `frontend` to trigger the configured alerts.
+- `alert-rule-trait.yaml`: The `Trait` definition for `observability-alert-rule` that enables attaching alert rules to components. This trait is typically installed as part of the OpenChoreo control plane, but is included here for reference. **One-time setup by Platform Engineers.**
+- `alert-notification-channels.yaml`: Two `ObservabilityAlertsNotificationChannel`s (one email, one webhook) plus their backing `Secret`s for the `development` environment. **One-time setup per environment by Platform Engineers.**
+- `components-with-alert-rules.yaml`: `Component` definitions for `frontend`, `recommendation`, and `cart` microservices with alert rules attached as `observability-alert-rule` traits. **Defined once by Developers - alert rules propagate through environments.**
+- `failure-scenario-setup.yaml`: `ReleaseBinding`s that deliberately misconfigure the system (env var overrides, CPU / memory limit overrides) to cause alerts to fire. Also demonstrates environment-specific alert customization via `traitOverrides`.
+- `trigger-alerts.sh`: Simple script that drives traffic to the `frontend` to trigger the configured alerts.
 
-### Order of execution
+---
 
-1. Deploy the `gcp-microservices-demo` sample to setup the project and components
-   - See `samples/gcp-microservices-demo/README.md` for exact commands.
+## One-Time Setup (Platform Engineers)
 
-2. Ensure the `observability-alert-rule` trait is available
-   - The trait is typically installed as part of the OpenChoreo control plane by default unless you have disabled the default resources.
-   - If it's not available, you can deploy it manually:
-     ```bash
-     kubectl apply -f samples/component-alerts/alert-rule-trait.yaml
-     ```
-   - Verify it exists:
-     ```bash
-     kubectl get trait observability-alert-rule -n default
-     ```
+### Step 1: Deploy Alert Rule Trait (One-Time Setup)
 
-3. Deploy the `alert-notification-channels` to setup the notification channels
-   - Edit `samples/component-alerts/alert-notification-channels.yaml` and replace the placeholder values:
-     - SMTP credentials (host, port, username, password, from/to email addresses)
-     - Webhook URL and custom headers (if required)
-     - **Webhook payload template** (optional): For webhooks that require specific JSON formats (like Slack), you can provide a `payloadTemplate` using CEL expressions. The sample includes a Slack-compatible template. If not provided, the raw alertDetails object will be sent.
-   - Then apply:
-     ```bash
-     kubectl apply -f samples/component-alerts/alert-notification-channels.yaml
-     ```
-   - Note: The notification channels are bounded to the environment. Channels in this sample are specified for the `development` environment. The first notitification channel created will be marked as the default notification channel for the environment by OpenChoreo.
+Platform Engineers deploy this trait once per OpenChoreo installation so developers can attach alert rules to any component.
 
-4. Deploy the `components-with-alert-rules` to setup the alert rules for frontend, recommendation and cart components
-   - This attaches alert-rule traits to the existing components:
-     - **Frontend**: Log-based alert that triggers when "rpc error: code = Unavailable" appears more than 5 times within 5 minutes
-     - **Recommendation**: Metric-based alert that triggers when CPU usage exceeds 80% for 5 minutes
-     - **Cart**: Metric-based alert that triggers when memory usage exceeds 70% for 2 minutes
-   - Apply:
-     ```bash
-     kubectl apply -f samples/component-alerts/components-with-alert-rules.yaml
-     ```
-   - **Note**: The alert rules defined here don't specify notification channels in the trait parameters. Notification channels are configured per environment via `ReleaseBinding` `traitOverrides`. If you want to connect these alert rules to specific notification channels, you can use the `ReleaseBinding` resources in step 5 with `traitOverrides` that reference the notification channel names (e.g., `email-notification-channel-development` or `webhook-notification-channel-development`). If not specified, the default notification channel for the environment will be used.
+The trait is typically installed as part of the OpenChoreo control plane by default unless you have disabled the default resources. If it's not available, you can deploy it manually:
 
-5. Deploy the `failure-scenario-setup` to setup the failure scenario for frontend, recommendation and cart components
-   - This creates `ReleaseBinding`s that:
-     - **Misconfigure resources** to trigger alerts:
-       - `frontend`: Override `PRODUCT_CATALOG_SERVICE_ADDR` to `http://localhost:8080` (invalid endpoint) via `workloadOverrides`
-       - `recommendation`: Lower CPU limits to `10m` (very restrictive) via `componentTypeEnvOverrides`
-       - `cart`: Lower memory requests to `100Mi` and limits to `150Mi` (restrictive) via `componentTypeEnvOverrides`
-     - **Configure alert rule behavior per environment** via `traitOverrides`:
-       - **Frontend alert** (`frontend-rpc-unavailable-error-log-alert`):
-         - `enabled: true` - Alert rule is enabled (default is `true`)
-         - `enableAiRootCauseAnalysis: false` - AI root cause analysis disabled (default is `false`)
-         - `notificationChannel: "email-notification-channel-development"` - Uses email notification channel
-       - **Recommendation alert** (`recommendation-high-cpu-alert`):
-         - `enabled: true` - Alert rule is enabled
-         - `enableAiRootCauseAnalysis: true` - AI root cause analysis enabled
-         - `notificationChannel: "webhook-notification-channel-development"` - Uses webhook notification channel
-       - **Cart alert** (`cartservice-high-memory-alert`):
-         - No `traitOverrides` specified - Uses default values (enabled, no AI analysis, default notification channel for environment)
-   - Apply:
-     ```bash
-     kubectl apply -f samples/component-alerts/failure-scenario-setup.yaml
-     ```
-   - **Note**: The `traitOverrides` allow you to customize alert rule behavior per environment. You can enable/disable alerts, toggle AI root cause analysis, and specify which notification channel to use. If `traitOverrides` are not specified for an alert rule, it will use the defaults (enabled, no AI analysis, default notification channel for the environment).
+```bash
+kubectl apply -f samples/component-alerts/alert-rule-trait.yaml
+kubectl get trait observability-alert-rule -n default
+```
 
-6. Deploy the `trigger-alerts` script to trigger the alerts
-   - From the repo root:
-     ```bash
-     chmod +x samples/component-alerts/trigger-alerts.sh
-     ./samples/component-alerts/trigger-alerts.sh
-     ```
-   - This continuously calls the frontend URL to generate load and surface the misconfigurations.
+### Step 2: Configure Notification Channels (One-Time Setup)
 
-7. Verify the alerts received to configured notification channels
-   - For the email channel, check the inbox configured in `alert-notification-channels.yaml`.
-   - For the webhook channel, check the target endpoint and/or the OpenChoreo observer logs.
+Platform Engineers configure notification channels once per environment (email/webhook) and reuse them across all alert rules in that environment.
 
-8. Cleanup the resources
-   - Stop the trigger script (Ctrl+C).
-   - Delete the sample resources in reverse order if desired:
-     ```bash
-     kubectl delete -f samples/component-alerts/failure-scenario-setup.yaml
-     kubectl delete -f samples/component-alerts/components-with-alert-rules.yaml
-     kubectl delete -f samples/component-alerts/alert-notification-channels.yaml
-     # Optionally delete the gcp-microservices-demo resources as well
-     ```
-   - Note: If you manually deployed the trait, you can remove it:
-     ```bash
-     kubectl delete -f samples/component-alerts/alert-rule-trait.yaml
-     ```
+1. Edit `samples/component-alerts/alert-notification-channels.yaml` and replace the placeholder values:
+   - SMTP credentials (host, port, username, password, from/to email addresses)
+   - Webhook URL and custom headers (if required)
+   - **Email template** (optional): For emails that require specific formatting, you can provide a `template` using CEL expressions. The sample includes a template. If not provided, the raw alertDetails object will be sent.
+   - **Webhook payload template** (optional): For webhooks that require specific JSON formats (like Slack), you can provide a `payloadTemplate` using CEL expressions. The sample includes a Slack-compatible template. If not provided, the raw alertDetails object will be sent.
 
-### Troubleshooting
+2. Apply the notification channels:
+   ```bash
+   kubectl apply -f samples/component-alerts/alert-notification-channels.yaml
+   ```
 
-#### Webhook returns 400 Bad Request (e.g., Slack)
+3. The notification channels are bounded to the environment. In this sample they are created for the `development` environment. The first notification channel created will be marked as the default notification channel for the environment by OpenChoreo.
+
+---
+
+## Developer Workflow
+
+### Step 3: Define Alert Rules for Components (One-Time per Component)
+
+Developers attach alert rules as traits to components once. These rules automatically propagate to all environments as the component is promoted. Platform Engineers can still customize behavior per environment via `ReleaseBinding` `traitOverrides` (enable/disable, AI analysis, notification channel selection).
+
+This step attaches alert-rule traits to the existing components:
+
+- **Frontend**: Log-based alert that triggers when "rpc error: code = Unavailable" appears more than 5 times within 5 minutes
+- **Recommendation**: Metric-based alert that triggers when CPU usage exceeds 80% for 5 minutes
+- **Cart**: Metric-based alert that triggers when memory usage exceeds 70% for 2 minutes
+
+Apply the components with alert rules:
+```bash
+kubectl apply -f samples/component-alerts/components-with-alert-rules.yaml
+```
+
+**Note**: The alert rules defined here don't specify notification channels in the trait parameters. Notification channels are configured per environment via `ReleaseBinding` `traitOverrides`. If you want to connect these alert rules to specific notification channels, you can use the `ReleaseBinding` resources in the next section with `traitOverrides` that reference the notification channel names (e.g., `email-notification-channel-development` or `webhook-notification-channel-development`). If not specified, the default notification channel for the environment will be used.
+
+---
+
+## Testing and Verification
+
+### Step 4: Deploy the gcp-microservices-demo Sample
+
+Deploy the `gcp-microservices-demo` sample to setup the project and components:
+- See `samples/gcp-microservices-demo/README.md` for exact commands.
+
+### Step 5: Configure Failure Scenarios (Optional - for Testing)
+
+This step creates `ReleaseBinding`s that:
+- **Misconfigure resources** to trigger alerts:
+  - `frontend`: Override `PRODUCT_CATALOG_SERVICE_ADDR` to `http://localhost:8080` (invalid endpoint) via `workloadOverrides`
+  - `recommendation`: Lower CPU limits to `10m` (very restrictive) via `componentTypeEnvOverrides`
+  - `cart`: Lower memory requests to `100Mi` and limits to `150Mi` (restrictive) via `componentTypeEnvOverrides`
+- **Configure alert rule behavior per environment** via `traitOverrides`:
+  - **Frontend alert** (`frontend-rpc-unavailable-error-log-alert`):
+    - `enabled: true` - Alert rule is enabled (default is `true`)
+    - `enableAiRootCauseAnalysis: false` - AI root cause analysis disabled (default is `false`)
+    - `notificationChannel: "email-notification-channel-development"` - Uses email notification channel
+  - **Recommendation alert** (`recommendation-high-cpu-alert`):
+    - `enabled: true` - Alert rule is enabled
+    - `enableAiRootCauseAnalysis: true` - AI root cause analysis enabled
+    - `notificationChannel: "webhook-notification-channel-development"` - Uses webhook notification channel
+  - **Cart alert** (`cartservice-high-memory-alert`):
+    - No `traitOverrides` specified - Uses default values (enabled, no AI analysis, default notification channel for environment)
+
+Apply the failure scenario setup:
+```bash
+kubectl apply -f samples/component-alerts/failure-scenario-setup.yaml
+```
+
+> **Note**: `traitOverrides` let Platform Engineers customize alert rule behavior per environment (enable/disable, AI analysis, notification channel) without changing the component definition. If `traitOverrides` are not specified for an alert rule, it uses the defaults (enabled, no AI analysis, default notification channel for the environment).
+
+### Step 6: Trigger Alerts
+
+Deploy the `trigger-alerts` script to trigger the alerts:
+- From the repo root:
+  ```bash
+  chmod +x samples/component-alerts/trigger-alerts.sh
+  ./samples/component-alerts/trigger-alerts.sh
+  ```
+- This continuously calls the frontend URL to generate load and surface the misconfigurations.
+
+### Step 7: Verify Alerts
+
+Verify the alerts received to configured notification channels:
+- For the email channel, check the inbox configured in `alert-notification-channels.yaml`.
+- For the webhook channel, check the target endpoint and/or the OpenChoreo observer logs.
+
+---
+
+## Cleanup
+
+Stop the trigger script (Ctrl+C).
+
+Delete the sample resources in reverse order if desired:
+```bash
+kubectl delete -f samples/component-alerts/failure-scenario-setup.yaml
+kubectl delete -f samples/component-alerts/components-with-alert-rules.yaml
+kubectl delete -f samples/component-alerts/alert-notification-channels.yaml
+# Optionally delete the gcp-microservices-demo resources as well
+```
+
+**Note**: If you manually deployed the trait, you can remove it:
+```bash
+kubectl delete -f samples/component-alerts/alert-rule-trait.yaml
+```
+
+---
+
+## Troubleshooting
+
+### Webhook returns 400 Bad Request (e.g., Slack)
 
 **Problem**: Some webhook endpoints (like Slack) require a specific JSON payload format, but OpenChoreo sends the raw alert details object by default.
 

--- a/samples/component-alerts/failure-scenario-setup.yaml
+++ b/samples/component-alerts/failure-scenario-setup.yaml
@@ -17,6 +17,12 @@ spec:
         env:
           - key: PRODUCT_CATALOG_SERVICE_ADDR
             value: "http://localhost:8080"
+  componentTypeEnvOverrides:                                       # Added to rollout restart the frontend service (Due to https://github.com/openchoreo/openchoreo/issues/1634)
+    resources:
+      requests:
+        cpu: "60m"
+      limits:
+        cpu: "250m"
   traitOverrides:
     frontend-rpc-unavailable-error-log-alert:
       enabled: true                                                 # Alert rules can be enabled/disabled per environment. Default is true.


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Improve the README to explain the clear separation of concerns for each role (PE and Dev) in observability alerts story.

## Approach
- Added detailed comments in `alert-notification-channels.yaml` to clarify the setup process for notification channels in the development environment.
- Updated `alert-rule-trait.yaml` with explanations on the one-time setup required by Platform Engineers and how developers can utilize the trait for alert rules.
- Expanded `components-with-alert-rules.yaml` to include guidance on defining alert rules and their propagation across environments.
- Improved `README.md` to outline the architecture overview, developer workflow, and steps for setting up and testing alert rules and notification channels.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1651

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
