### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: OpenSSF Scorecard
+
+on:
+  # For Branch-Protection check. Only the default branch is supported.
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated.
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    # Run weekly on Sunday 20:00 UTC (Monday 01:30 IST)
+    - cron: "0 20 * * 0"
+  push:
+    branches:
+      - "main"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload results to code-scanning dashboard
+      security-events: write
+      # Required to publish results and get a badge
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Purpose
Add OpenSSF Scorecard workflow to assess and track the project's security posture.

## Approach
- Add `scorecard.yml` workflow that runs on push to main, branch protection changes, and weekly schedule (Sunday 20:00 UTC)
- Publish results to GitHub Security tab (Code Scanning) via SARIF upload
- Enable OpenSSF Scorecard badge with `publish_results: true`
- Check security best practices (branch protection, dependency pinning, signed releases, etc.)

## Related Issues
Closes #1646

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)