### PR TITLE
fix: update auth mechanism from oauth2 to jwt in obs api

### DIFF
--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1002,7 +1002,7 @@ observer:
         display_name: "User"
         priority: 1
         auth_mechanisms:
-          - type: "oauth2"
+          - type: "jwt"
             entitlement:
               claim: "groups"
               display_name: "User Group"
@@ -1010,7 +1010,7 @@ observer:
         display_name: "Service Account"
         priority: 2
         auth_mechanisms:
-          - type: "oauth2"
+          - type: "jwt"
             entitlement:
               claim: "sub"
               display_name: "Client ID"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose                                                                                                                
                                                                                                                         
  The observer was failing to create the JWT subject resolver because the auth config specified type: oauth2 for auth    
  mechanisms, but the middleware expects type: jwt.                                                                      
                                                                                                                         
  Error: Failed to create JWT subject resolver                                                                           
                                                                                                                                                                                                           

## Approach
  Updated the observer-auth-config ConfigMap to use type: jwt instead of type: oauth2 for the auth mechanisms:   

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
