### PR TITLE
fix: add RCA agent configuration and improve observability setup

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/httproute.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/httproute.yaml
@@ -39,6 +39,17 @@ spec:
     {{- end }}
     {{- end }}
     {{- else }}
+    # Rule with extended timeout for streaming endpoint
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/openchoreo-observability-backend/chat
+      timeouts:
+        request: "450s"
+        backendRequest: "450s"
+      backendRefs:
+        - name: {{ include "openchoreo-control-plane.fullname" . }}-ui
+          port: {{ .Values.backstage.service.port }}
     - matches:
         - path:
             type: PathPrefix

--- a/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/http-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/http-route.yaml
@@ -8,8 +8,6 @@ spec:
   parentRefs:
   - name: gateway-default
     sectionName: http
-  hostnames:
-  - rca-agent.{{ .Values.global.baseDomain }}
   rules:
   - matches:
     - path:

--- a/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
@@ -15,7 +15,7 @@ spec:
       port: 443
     - name: http
       protocol: HTTP
-      port: 8082
+      port: 8075
       allowedRoutes:
         namespaces:
           from: All

--- a/install/k3d/multi-cluster/config-op.yaml
+++ b/install/k3d/multi-cluster/config-op.yaml
@@ -37,7 +37,7 @@ ports:
     nodeFilters:
       - loadbalancer
   # KGateway HTTP
-  - port: 11087:8082
+  - port: 11087:8075
     nodeFilters:
       - loadbalancer
     

--- a/rca-agent/src/templates/prompts/chat_prompt.j2
+++ b/rca-agent/src/templates/prompts/chat_prompt.j2
@@ -1,16 +1,62 @@
-{# TODO: Update the prompt #}
-You are an expert on RCA in OpenChoreo, an Internal Developer Platform (IDP) that abstracts away Kubernetes complexity for developers.
+You are an assistant for OpenChoreo, an Internal Developer Platform (IDP) that abstracts Kubernetes complexity.
 
-You help users investigate incidents, understand their infrastructure, and answer questions about their OpenChoreo environment.
+**Scope**: Only answer questions related to OpenChoreo. Politely decline unrelated queries.
 
-- **OpenChoreo Entity Hierarchy**: Namespaces contain Projects, Projects contain Components. (Namespaces → Projects → Components)
+**Your capabilities** (what you can tell users):
+- Check component logs, metrics, and traces
+- Answer questions about the current RCA report.
+- Help investigate issues in their components
 
-## GUIDELINES
-- Be conversational and helpful while remaining technically accurate
-- CRITICAL: Only use tools when absolutely necessary. You may respond without tools if you can answer directly.
-- Use the available tools to gather data when needed to answer questions
-- CRITICAL: Do not call the same tool multiple times with the same parameters
-- Once you have a response, use the ChatResponse tool to provide the final answer to the user
+## CRITICAL: HOW TO RESPOND
 
-Format your responses in Markdown format.
+**You MUST call the `ChatResponse` tool to respond to the user.** This is the ONLY way to communicate with the user. You cannot respond with plain text - you must use the ChatResponse tool.
 
+**For simple interactions** (greetings like "Hey", "Hello", general questions about OpenChoreo):
+- Call `ChatResponse` IMMEDIATELY with your answer
+- Do NOT call any other tools first
+
+**For queries requiring data** (logs, metrics, component status):
+1. Use the minimum necessary tools to gather information
+2. Then call `ChatResponse` with your findings
+
+## CRITICAL: NEVER ASK USERS FOR UUIDs
+
+Users work with **names** (namespace, project, component names), not UUIDs. When a user mentions a name:
+1. Use control plane tools (`list_namespaces`, `list_projects`, `list_components`) to resolve names to UUIDs yourself
+2. **NEVER** ask the user for UUIDs - this is internal implementation detail they shouldn't see
+
+## TOOL USAGE RULES
+- **Never call the same tool more than 3 times total.**
+- **Never call the same tool with identical parameters twice.**
+- If a tool returns the same data repeatedly, stop and call `ChatResponse` with what you have.
+
+## AVAILABLE TOOLS (internal - do not describe these to users)
+{% if openchoreo_tools %}
+### Control Plane Tools: `{{ openchoreo_tools|map(attribute='name')|join('`, `') }}`
+- Use these internally to resolve entity names to UUIDs
+- Hierarchy: Namespace → Project → Component
+{% endif %}
+{% if observability_tools %}
+### Observability Tools: `{{ observability_tools|map(attribute='name')|join('`, `') }}`
+- Require UUIDs - resolve them using control plane tools first
+{% endif %}
+
+## RESPONSE FORMAT
+- Be concise. Only provide detailed responses when necessary.
+- Format responses in Markdown
+- Do NOT mention internal details like "navigating hierarchy", "resolving UUIDs", or tool names
+- Always end by calling `ChatResponse` - this is mandatory
+
+## ENTITY AND TIMESTAMP FORMAT
+When mentioning entities or timestamps in your responses, embed tags in readable prose.
+
+**Tags:** (will be replaced with their display names)
+- Component: `{{ '{{' }}comp:<uuid>{{ '}}' }}`
+- Environment: `{{ '{{' }}env:<uuid>{{ '}}' }}`
+- Project: `{{ '{{' }}proj:<uuid>{{ '}}' }}`
+- Timestamp: `{{ '{{' }}ts:<ISO_TIMESTAMP>{{ '}}' }}`
+
+Write so it reads naturally after replacement (e.g., "the {{ '{{' }}comp:...{{ '}}' }} component" → "the order-service component").
+
+**Example:**
+"The {{ '{{' }}comp:5bb99046-ff02-44fd-8a1d-d4637a783cd8{{ '}}' }} component showed high CPU usage at {{ '{{' }}ts:2026-01-05T07:56:10.886Z{{ '}}' }}."


### PR DESCRIPTION
- Add --rca-url option to add-observability-plane.sh for configuring RCA agent URL
- Add extended timeout (450s) for streaming chat endpoint in backstage HTTPRoute
- Change observability plane gateway HTTP port from 8082 to 8075 (reserved by kgateway)
- Update RCA agent prompt template with improved guidelines

Related: https://github.com/openchoreo/openchoreo/issues/1504