### PR TITLE
fix: replace containerName parameter with hardcoded 'main' in compone…

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/scheduled-task.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/scheduled-task.yaml
@@ -34,7 +34,6 @@ spec:
       activeDeadlineSeconds: "integer | default=300"
       restartPolicy: "string | default=OnFailure"
       imagePullPolicy: "string | default=IfNotPresent"
-      containerName: "string | default=main"
 
     envOverrides:
       schedule: 'string | default="0 0 31 2 *"' # will never execute
@@ -66,13 +65,13 @@ spec:
                 spec:
                   restartPolicy: ${parameters.restartPolicy}
                   containers:
-                    - name: ${parameters.containerName}
-                      image: ${workload.containers[parameters.containerName].image}
+                    - name: main
+                      image: ${workload.containers["main"].image}
                       imagePullPolicy: ${parameters.imagePullPolicy}
                       command: |
-                        ${has(workload.containers[parameters.containerName].command) ? workload.containers[parameters.containerName].command : oc_omit()}
+                        ${has(workload.containers["main"].command) ? workload.containers["main"].command : oc_omit()}
                       args: |
-                        ${has(workload.containers[parameters.containerName].args) ? workload.containers[parameters.containerName].args : oc_omit()}
+                        ${has(workload.containers["main"].args) ? workload.containers["main"].args : oc_omit()}
                       resources:
                         requests:
                           cpu: ${envOverrides.resources.requests.cpu}
@@ -80,8 +79,8 @@ spec:
                         limits:
                           cpu: ${envOverrides.resources.limits.cpu}
                           memory: ${envOverrides.resources.limits.memory}
-                      envFrom: ${configurations.toContainerEnvFrom(parameters.containerName)}
-                      volumeMounts: ${configurations.toContainerVolumeMounts(parameters.containerName)}
+                      envFrom: ${configurations.toContainerEnvFrom("main")}
+                      volumeMounts: ${configurations.toContainerVolumeMounts("main")}
                   volumes: ${configurations.toVolumes()}
 
     - id: env-config

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/service.yaml
@@ -32,7 +32,6 @@ spec:
       imagePullPolicy: "string | default=IfNotPresent"
       port: "integer | default=80"
       exposed: "boolean | default=false"
-      containerName: "string | default=main"
 
     envOverrides:
       resources: "ResourceRequirements | default={}"
@@ -55,13 +54,13 @@ spec:
               labels: ${metadata.podSelectors}
             spec:
               containers:
-                - name: ${parameters.containerName}
-                  image: ${workload.containers[parameters.containerName].image}
+                - name: main
+                  image: ${workload.containers["main"].image}
                   imagePullPolicy: ${parameters.imagePullPolicy}
                   command: |
-                    ${has(workload.containers[parameters.containerName].command) ? workload.containers[parameters.containerName].command : oc_omit()}
+                    ${has(workload.containers["main"].command) ? workload.containers["main"].command : oc_omit()}
                   args: |
-                    ${has(workload.containers[parameters.containerName].args) ? workload.containers[parameters.containerName].args : oc_omit()}
+                    ${has(workload.containers["main"].args) ? workload.containers["main"].args : oc_omit()}
                   ports:
                     - name: http
                       containerPort: ${parameters.port}
@@ -73,8 +72,8 @@ spec:
                     limits:
                       cpu: ${envOverrides.resources.limits.cpu}
                       memory: ${envOverrides.resources.limits.memory}
-                  envFrom: ${configurations.toContainerEnvFrom(parameters.containerName)}
-                  volumeMounts: ${configurations.toContainerVolumeMounts(parameters.containerName)}
+                  envFrom: ${configurations.toContainerEnvFrom("main")}
+                  volumeMounts: ${configurations.toContainerVolumeMounts("main")}
               volumes: ${configurations.toVolumes()}   
 
     - id: service

--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
@@ -29,7 +29,6 @@ spec:
       replicas: "integer | default=1"
       imagePullPolicy: "string | default=IfNotPresent"
       port: "integer | default=80"
-      containerName: "string | default=main"
 
     envOverrides:
       resources: "ResourceRequirements | default={}"
@@ -52,13 +51,13 @@ spec:
               labels: ${metadata.podSelectors}
             spec:
               containers:
-                - name: ${parameters.containerName}
-                  image: ${workload.containers[parameters.containerName].image}
+                - name: main
+                  image: ${workload.containers["main"].image}
                   imagePullPolicy: ${parameters.imagePullPolicy}
                   command: |
-                    ${has(workload.containers[parameters.containerName].command) ? workload.containers[parameters.containerName].command : oc_omit()}
+                    ${has(workload.containers["main"].command) ? workload.containers["main"].command : oc_omit()}
                   args: |
-                    ${has(workload.containers[parameters.containerName].args) ? workload.containers[parameters.containerName].args : oc_omit()}
+                    ${has(workload.containers["main"].args) ? workload.containers["main"].args : oc_omit()}
                   ports:
                     - name: http
                       containerPort: ${parameters.port}
@@ -70,8 +69,8 @@ spec:
                     limits:
                       cpu: ${envOverrides.resources.limits.cpu}
                       memory: ${envOverrides.resources.limits.memory}
-                  envFrom: ${configurations.toContainerEnvFrom(parameters.containerName)}
-                  volumeMounts: ${configurations.toContainerVolumeMounts(parameters.containerName)}
+                  envFrom: ${configurations.toContainerEnvFrom("main")}
+                  volumeMounts: ${configurations.toContainerVolumeMounts("main")}
               volumes: ${configurations.toVolumes()}           
 
     - id: service


### PR DESCRIPTION


<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

Currently, containerName is a parameter of the component. It is shown when creating components through Backstage and causes unnecessary cognitive load for initial users by exposing an unnecessary parameter.


[
This pull request simplifies the Helm templates for the OpenChoreo control plane by removing the configurable `containerName` parameter from the `scheduled-task`, `service`, and `webapp` component types. Instead, all references are now hardcoded to use the `main` container. This change reduces complexity and enforces a consistent container naming convention across these components.

**Parameter removal and template simplification:**

* Removed the `containerName` parameter from the specifications in `scheduled-task.yaml`, `service.yaml`, and `webapp.yaml`, and updated all references to use `"main"` as the container name. [[1]](diffhunk://#diff-02c8b78d9ef6a5c139e0cf95973bbf1be653964d57752c820a16d306ec35614fL37) [[2]](diffhunk://#diff-bf6a01d2433ee9d037fd818549ca41b30b13140afad8cc6f12d9014f7c899fa6L35) [[3]](diffhunk://#diff-72fd9c2352a239c6baa3edcce1bb94c3b5499ad732b8e1092a5461d134563c73L32)
* Updated container definitions in all three templates to reference `workload.containers["main"]` directly for image, command, args, environment variables, and volume mounts, instead of using a parameterized container name. [[1]](diffhunk://#diff-02c8b78d9ef6a5c139e0cf95973bbf1be653964d57752c820a16d306ec35614fL69-R83) [[2]](diffhunk://#diff-bf6a01d2433ee9d037fd818549ca41b30b13140afad8cc6f12d9014f7c899fa6L58-R63) [[3]](diffhunk://#diff-72fd9c2352a239c6baa3edcce1bb94c3b5499ad732b8e1092a5461d134563c73L55-R60)
* Adjusted calls to helper functions like `toContainerEnvFrom` and `toContainerVolumeMounts` to use `"main"` explicitly. [[1]](diffhunk://#diff-02c8b78d9ef6a5c139e0cf95973bbf1be653964d57752c820a16d306ec35614fL69-R83) [[2]](diffhunk://#diff-bf6a01d2433ee9d037fd818549ca41b30b13140afad8cc6f12d9014f7c899fa6L76-R76) [[3]](diffhunk://#diff-72fd9c2352a239c6baa3edcce1bb94c3b5499ad732b8e1092a5461d134563c73L73-R73)

These changes make the templates easier to maintain and reduce the chance of misconfiguration by standardizing on a single container name.](url)


## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
