### PR TITLE
fix: remove default port value from webapp

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
+++ b/install/helm/openchoreo-control-plane/templates/default-resources/component-types/webapp.yaml
@@ -28,7 +28,7 @@ spec:
     parameters:
       replicas: "integer | default=1"
       imagePullPolicy: "string | default=IfNotPresent"
-      port: "integer | default=80"
+      port: "integer"
 
     envOverrides:
       resources: "ResourceRequirements | default={}"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
> Remove the default=80 from the port parameter in the webapp ComponentType schema, requiring users to explicitly specify the port for their web applications.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
