### PR TITLE
fix(helm): increase token expiry for backstage portal

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
@@ -60,7 +60,7 @@ data:
             "token": {
               "issuer": "thunder",
               "access_token": {
-                "validity_period": 3600,
+                "validity_period": 86400,
                 "user_attributes": [
                   "given_name",
                   "family_name",
@@ -69,7 +69,7 @@ data:
                 ]
               },
               "id_token": {
-                "validity_period": 3600,
+                "validity_period": 86400,
                 "user_attributes": [
                   "given_name",
                   "family_name",


### PR DESCRIPTION
This pull request updates the token configuration in the Thunder bootstrap scripts config map to extend the validity period for both access and ID tokens.

Token configuration updates:

* Increased the `validity_period` for `access_token` from 1 hour (3600 seconds) to 24 hours (86400 seconds) in `bootstrap-scripts-configmap.yaml`.
* Increased the `validity_period` for `id_token` from 1 hour (3600 seconds) to 24 hours (86400 seconds) in `bootstrap-scripts-configmap.yaml`.