### PR TITLE
fix(helm): fix jwt issuer configuration resolution issue

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.openchoreoApi.enabled }}
 {{- /* Computed defaults from helpers */ -}}
 {{- $publicUrl := printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.apiHost" .) (include "openchoreo.port" .) }}
-{{- $oidcIssuer := .Values.security.authServerBaseUrl | default (printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.thunderHost" .) (include "openchoreo.port" .)) }}
+{{- $oidcIssuer := .Values.security.oidc.issuer | default (printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.thunderHost" .) (include "openchoreo.port" .)) }}
 {{- $jwksUrl := .Values.security.oidc.jwksUrl | default (printf "%s/oauth2/jwks" (include "openchoreo.thunderInternalUrl" .)) }}
 {{- $authzUrl := .Values.security.oidc.authorizationUrl | default (printf "%s/oauth2/authorize" $oidcIssuer) }}
 {{- $tokenUrl := .Values.security.oidc.tokenUrl | default (printf "%s/oauth2/token" $oidcIssuer) }}
@@ -29,7 +29,7 @@ data:
       authentication:
         jwt:
           enabled: {{ .Values.security.enabled }}
-          issuer: {{ .Values.thunder.configuration.jwt.issuer | quote }}
+          issuer: {{ $oidcIssuer | quote }}
           audiences:
             {{- if .Values.security.jwt.audience }}
             - {{ .Values.security.jwt.audience | quote }}

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -232,7 +232,7 @@ security:
     # description: OIDC provider issuer URL
     # default: ""
     # @schema
-    issuer: ""
+    issuer: "thunder"
     # @schema
     # type: string
     # description: OIDC well-known configuration endpoint URL


### PR DESCRIPTION
This pull request updates the configuration for OIDC issuer handling in the OpenChoreo control plane Helm chart. The main change is to standardize how the OIDC issuer is set and referenced, ensuring consistency and simplifying configuration management.

**OIDC Issuer Configuration Updates:**

* Changed the OIDC issuer reference in `configmap.yaml` to use `.Values.security.oidc.issuer` instead of `.Values.security.authServerBaseUrl`, making the issuer source consistent across the chart.
* Updated the JWT issuer value in the `authentication` section of the ConfigMap to use the computed `$oidcIssuer` variable instead of `.Values.thunder.configuration.jwt.issuer`.
* Set the default value of `security.oidc.issuer` to `"thunder"` in `values.yaml`, establishing a clear default for the issuer URL.