### PR TITLE
ci: add stale issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    # Run daily at 00:30 UTC
+    - cron: "30 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    name: Mark Stale Issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Mark and close stale issues
+        uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had
+            no activity for 90 days. It will be closed in 30 days if no further
+            activity occurs. Comment to keep it open or add the `keep-open` label
+            to prevent it from being marked as stale.
+          close-issue-message: >
+            This issue has been automatically closed because it has been stale
+            for 30 days with no activity. If this issue is still relevant,
+            please reopen it with additional context.
+          stale-issue-label: stale
+
+          exempt-issue-labels: "keep-open,good first issue,help wanted"
+
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+
+          # Disable PR handling
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          operations-per-run: 200


### PR DESCRIPTION
## Purpose
Add GitHub Actions workflow to automatically mark and close stale issues after inactivity.

## Approach
- Use `actions/stale` action (SHA-pinned) to run daily at 00:30 UTC
- Issues with no activity for 90 days are marked as `stale`
- Stale issues with no further activity for 30 days are automatically closed
- Issues labeled `keep-open`, `good first issue`, or `help wanted` are exempt
- PRs are excluded from stale handling

## Related Issues
Closes #1707

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)