### PR TITLE
fix(api): remove duplicate issuer config

### DIFF
--- a/cmd/openchoreo-api/config.yaml
+++ b/cmd/openchoreo-api/config.yaml
@@ -55,10 +55,6 @@ security:
       # When disabled, all requests are treated as unauthenticated.
       enabled: false
 
-      # Expected "iss" claim value in JWT tokens.
-      # If empty, falls back to identity.oidc.issuer.
-      issuer: ""
-
       # List of acceptable audiences (aud) for the JWT.
       # Tokens must contain at least one of these audiences.
       audiences: [ ]

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.openchoreoApi.enabled }}
 {{- /* Computed defaults from helpers */ -}}
 {{- $publicUrl := printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.apiHost" .) (include "openchoreo.port" .) }}
-{{- $oidcIssuer := .Values.security.oidc.issuer | default (printf "%s://%s%s" (include "openchoreo.protocol" .) (include "openchoreo.thunderHost" .) (include "openchoreo.port" .)) }}
+{{- $oidcIssuer := .Values.security.oidc.issuer }}
 {{- $jwksUrl := .Values.security.oidc.jwksUrl | default (printf "%s/oauth2/jwks" (include "openchoreo.thunderInternalUrl" .)) }}
 {{- $authzUrl := .Values.security.oidc.authorizationUrl | default (printf "%s/oauth2/authorize" $oidcIssuer) }}
 {{- $tokenUrl := .Values.security.oidc.tokenUrl | default (printf "%s/oauth2/token" $oidcIssuer) }}
@@ -29,7 +29,6 @@ data:
       authentication:
         jwt:
           enabled: {{ .Values.security.enabled }}
-          issuer: {{ $oidcIssuer | quote }}
           audiences:
             {{- if .Values.security.jwt.audience }}
             - {{ .Values.security.jwt.audience | quote }}

--- a/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
@@ -58,7 +58,6 @@ data:
             "pkce_required": false,
             "public_client": false,
             "token": {
-              "issuer": "thunder",
               "access_token": {
                 "validity_period": 86400,
                 "user_attributes": [
@@ -390,7 +389,6 @@ data:
             "pkce_required": true,
             "public_client": true,
             "token": {
-              "issuer": "thunder",
               "access_token": {
                 "validity_period": 3600,
                 "user_attributes": [

--- a/internal/openchoreo-api/config/security.go
+++ b/internal/openchoreo-api/config/security.go
@@ -90,9 +90,6 @@ func (c *AuthenticationConfig) Validate(path *config.Path) config.ValidationErro
 type JWTConfig struct {
 	// Enabled enables JWT authentication.
 	Enabled bool `koanf:"enabled"`
-	// Issuer is the expected "iss" claim value in JWT tokens.
-	// If empty, falls back to identity.oidc.issuer.
-	Issuer string `koanf:"issuer"`
 	// Audiences is the list of acceptable token audiences (aud claim).
 	// Token must contain at least one of these audiences. Optional.
 	Audiences []string `koanf:"audiences"`
@@ -129,19 +126,14 @@ func (c *JWTConfig) Validate(path *config.Path) config.ValidationErrors {
 }
 
 // ToJWTMiddlewareConfig converts to the JWT middleware library config.
-// The oidc parameter provides JWKS URL and fallback issuer from identity configuration.
+// The oidc parameter provides issuer and JWKS URL from identity configuration.
 func (c *JWTConfig) ToJWTMiddlewareConfig(oidc *OIDCConfig, logger *slog.Logger, resolver *jwt.Resolver) jwt.Config {
-	issuer := c.Issuer
-	if issuer == "" {
-		issuer = oidc.Issuer
-	}
-
 	return jwt.Config{
 		Disabled:                     !c.Enabled,
 		JWKSURL:                      oidc.JWKSURL,
 		JWKSRefreshInterval:          c.JWKS.RefreshInterval,
 		JWKSURLTLSInsecureSkipVerify: c.JWKS.SkipTLSVerify,
-		ValidateIssuer:               issuer,
+		ValidateIssuer:               oidc.Issuer,
 		ValidateAudiences:            c.Audiences,
 		ClockSkew:                    c.ClockSkew,
 		Detector:                     resolver,


### PR DESCRIPTION
This pull request simplifies and standardizes how the JWT issuer is configured across the OpenChoreo API and related Helm charts. The main change is the removal of the ability to override the JWT issuer in the API's configuration, ensuring that the issuer is always sourced from the OIDC configuration. This reduces potential misconfigurations and aligns the issuer handling throughout the deployment.

**Configuration simplification and standardization:**

* Removed the `issuer` field from the JWT configuration in `cmd/openchoreo-api/config.yaml` and `internal/openchoreo-api/config/security.go`, so the JWT issuer is now always sourced from the OIDC configuration. [[1]](diffhunk://#diff-2aaad409116ee7032f008605c1c6bff72617a53677b359083aff2538fb5758eeL58-L61) [[2]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4L93-L95)
* Updated the JWT middleware configuration logic to always use the OIDC issuer, removing fallback and override logic.
* Updated the Helm chart template for `openchoreo-api` to remove the `issuer` field from the generated configmap, ensuring the issuer is not set from chart values but always comes from OIDC. [[1]](diffhunk://#diff-bebe2f11ef7e2bf893c559a8de30e43911451e2b07da12e035a2add4f47c413cL4-R4) [[2]](diffhunk://#diff-bebe2f11ef7e2bf893c559a8de30e43911451e2b07da12e035a2add4f47c413cL32)

**Bootstrap and token configuration alignment:**

* Updated the Thunder bootstrap scripts to set the token `issuer` dynamically from the OIDC configuration, ensuring consistency with the rest of the system. [[1]](diffhunk://#diff-ac2d192cdee0606a272d6be38bc972c2885662d9c4121cfa5b3ec761fc4d429fL61) [[2]](diffhunk://#diff-ac2d192cdee0606a272d6be38bc972c2885662d9c4121cfa5b3ec761fc4d429fL393-R392)