### PR TITLE
refactor: make all controller struct consistent

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -228,7 +228,7 @@ func setupControlPlaneControllers(
 		return err
 	}
 
-	if err := (&buildplane.BuildPlaneReconciler{
+	if err := (&buildplane.Reconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		ClientMgr:     k8sClientMgr,
@@ -245,7 +245,7 @@ func setupControlPlaneControllers(
 		return err
 	}
 
-	if err := (&componentworkflowrun.ComponentWorkflowRunReconciler{
+	if err := (&componentworkflowrun.Reconciler{
 		Client:       mgr.GetClient(),
 		K8sClientMgr: k8sClientMgr,
 		Scheme:       mgr.GetScheme(),

--- a/internal/controller/buildplane/controller.go
+++ b/internal/controller/buildplane/controller.go
@@ -28,8 +28,8 @@ const (
 	BuildPlaneCleanupFinalizer = "openchoreo.dev/buildplane-cleanup"
 )
 
-// BuildPlaneReconciler reconciles a BuildPlane object
-type BuildPlaneReconciler struct {
+// Reconciler reconciles a BuildPlane object
+type Reconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
 	Recorder      record.EventRecorder
@@ -44,7 +44,7 @@ type BuildPlaneReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *BuildPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Fetch the BuildPlane instance
@@ -135,13 +135,13 @@ func (r *BuildPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{RequeueAfter: controller.StatusUpdateInterval}, nil
 }
 
-func (r *BuildPlaneReconciler) shouldIgnoreReconcile(buildPlane *openchoreov1alpha1.BuildPlane) bool {
+func (r *Reconciler) shouldIgnoreReconcile(buildPlane *openchoreov1alpha1.BuildPlane) bool {
 	return meta.FindStatusCondition(buildPlane.Status.Conditions, string(controller.TypeCreated)) != nil
 }
 
 // ensureFinalizer ensures that the finalizer is added to the buildplane.
 // The first return value indicates whether the finalizer was added to the buildplane.
-func (r *BuildPlaneReconciler) ensureFinalizer(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane) (bool, error) {
+func (r *Reconciler) ensureFinalizer(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane) (bool, error) {
 	if !buildPlane.DeletionTimestamp.IsZero() {
 		return false, nil
 	}
@@ -153,7 +153,7 @@ func (r *BuildPlaneReconciler) ensureFinalizer(ctx context.Context, buildPlane *
 	return false, nil
 }
 
-func (r *BuildPlaneReconciler) finalize(ctx context.Context, _, buildPlane *openchoreov1alpha1.BuildPlane) (ctrl.Result, error) {
+func (r *Reconciler) finalize(ctx context.Context, _, buildPlane *openchoreov1alpha1.BuildPlane) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("buildplane", buildPlane.Name)
 
 	if !controllerutil.ContainsFinalizer(buildPlane, BuildPlaneCleanupFinalizer) {
@@ -186,7 +186,7 @@ func (r *BuildPlaneReconciler) finalize(ctx context.Context, _, buildPlane *open
 }
 
 // invalidateCache invalidates the cached Kubernetes client for this BuildPlane
-func (r *BuildPlaneReconciler) invalidateCache(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane) {
+func (r *Reconciler) invalidateCache(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane) {
 	logger := log.FromContext(ctx).WithValues("buildplane", buildPlane.Name)
 
 	effectivePlaneID := buildPlane.Spec.PlaneID
@@ -210,7 +210,7 @@ func (r *BuildPlaneReconciler) invalidateCache(ctx context.Context, buildPlane *
 }
 
 // notifyGateway notifies the cluster gateway about BuildPlane lifecycle events
-func (r *BuildPlaneReconciler) notifyGateway(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane, event string) error {
+func (r *Reconciler) notifyGateway(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane, event string) error {
 	logger := log.FromContext(ctx).WithValues("buildplane", buildPlane.Name)
 
 	effectivePlaneID := buildPlane.Spec.PlaneID
@@ -247,7 +247,7 @@ func (r *BuildPlaneReconciler) notifyGateway(ctx context.Context, buildPlane *op
 
 // populateAgentConnectionStatus queries the cluster-gateway for agent connection status
 // and populates the BuildPlane status fields (without persisting to API server)
-func (r *BuildPlaneReconciler) populateAgentConnectionStatus(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane) error {
+func (r *Reconciler) populateAgentConnectionStatus(ctx context.Context, buildPlane *openchoreov1alpha1.BuildPlane) error {
 	logger := log.FromContext(ctx).WithValues("buildplane", buildPlane.Name)
 
 	// Skip if gateway client not configured
@@ -324,7 +324,7 @@ func NewBuildPlaneCreatedCondition(generation int64) metav1.Condition {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *BuildPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorderFor("buildplane-controller")
 	}

--- a/internal/controller/buildplane/controller_test.go
+++ b/internal/controller/buildplane/controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("BuildPlane Controller", func() {
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			controllerReconciler := &BuildPlaneReconciler{
+			controllerReconciler := &Reconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}

--- a/internal/controller/componentworkflow/controller.go
+++ b/internal/controller/componentworkflow/controller.go
@@ -14,8 +14,8 @@ import (
 	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 )
 
-// ComponentWorkflowReconciler reconciles a ComponentWorkflow object
-type ComponentWorkflowReconciler struct {
+// Reconciler reconciles a ComponentWorkflow object
+type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
@@ -33,7 +33,7 @@ type ComponentWorkflowReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.22.1/pkg/reconcile
-func (r *ComponentWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = logf.FromContext(ctx)
 
 	// TODO(user): your logic here
@@ -42,7 +42,7 @@ func (r *ComponentWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ComponentWorkflowReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openchoreodevv1alpha1.ComponentWorkflow{}).
 		Named("componentworkflow").

--- a/internal/controller/componentworkflowrun/controller.go
+++ b/internal/controller/componentworkflowrun/controller.go
@@ -28,8 +28,8 @@ import (
 	componentworkflowpipeline "github.com/openchoreo/openchoreo/internal/pipeline/componentworkflow"
 )
 
-// ComponentWorkflowRunReconciler reconciles a ComponentWorkflowRun object
-type ComponentWorkflowRunReconciler struct {
+// Reconciler reconciles a ComponentWorkflowRun object
+type Reconciler struct {
 	client.Client
 	Scheme       *runtime.Scheme
 	K8sClientMgr *kubernetesClient.KubeMultiClientManager
@@ -51,7 +51,7 @@ type ComponentWorkflowRunReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *ComponentWorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, rErr error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, rErr error) {
 	logger := log.FromContext(ctx).WithValues("componentworkflowrun", req.NamespacedName)
 
 	componentWorkflowRun := &openchoreodevv1alpha1.ComponentWorkflowRun{}
@@ -177,7 +177,7 @@ func (r *ComponentWorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl
 	return r.ensureRunResource(ctx, componentWorkflowRun, output, runResNamespace, bpClient), nil
 }
 
-func (r *ComponentWorkflowRunReconciler) handleWorkloadCreation(
+func (r *Reconciler) handleWorkloadCreation(
 	ctx context.Context,
 	componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun,
 	bpClient client.Client) ctrl.Result {
@@ -199,7 +199,7 @@ func (r *ComponentWorkflowRunReconciler) handleWorkloadCreation(
 	return ctrl.Result{}
 }
 
-func (r *ComponentWorkflowRunReconciler) ensureRunResource(
+func (r *Reconciler) ensureRunResource(
 	ctx context.Context,
 	componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun,
 	output *componentworkflowpipeline.RenderOutput,
@@ -242,7 +242,7 @@ func (r *ComponentWorkflowRunReconciler) ensureRunResource(
 	return ctrl.Result{Requeue: true}
 }
 
-func (r *ComponentWorkflowRunReconciler) syncWorkflowRunStatus(
+func (r *Reconciler) syncWorkflowRunStatus(
 	componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun,
 	runResource *argoproj.Workflow,
 ) ctrl.Result {
@@ -270,7 +270,7 @@ func (r *ComponentWorkflowRunReconciler) syncWorkflowRunStatus(
 	}
 }
 
-func (r *ComponentWorkflowRunReconciler) applyRenderedRunResource(
+func (r *Reconciler) applyRenderedRunResource(
 	ctx context.Context,
 	componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun,
 	resource map[string]any,
@@ -336,7 +336,7 @@ func (r *ComponentWorkflowRunReconciler) applyRenderedRunResource(
 }
 
 // applyRenderedResources applies additional rendered resources (e.g., secrets, configmaps) to the build plane.
-func (r *ComponentWorkflowRunReconciler) applyRenderedResources(
+func (r *Reconciler) applyRenderedResources(
 	ctx context.Context,
 	componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun,
 	resources []componentworkflowpipeline.RenderedResource,
@@ -405,7 +405,7 @@ func (r *ComponentWorkflowRunReconciler) applyRenderedResources(
 	return &appliedResources, nil
 }
 
-func (r *ComponentWorkflowRunReconciler) createWorkloadFromComponentWorkflowRun(
+func (r *Reconciler) createWorkloadFromComponentWorkflowRun(
 	ctx context.Context,
 	componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun,
 	bpClient client.Client,
@@ -458,7 +458,7 @@ func (r *ComponentWorkflowRunReconciler) createWorkloadFromComponentWorkflowRun(
 	return false, nil
 }
 
-func (r *ComponentWorkflowRunReconciler) getBuildPlaneClient(buildPlane *openchoreodevv1alpha1.BuildPlane) (client.Client, error) {
+func (r *Reconciler) getBuildPlaneClient(buildPlane *openchoreodevv1alpha1.BuildPlane) (client.Client, error) {
 	bpClient, err := kubernetesClient.GetK8sClientFromBuildPlane(r.K8sClientMgr, buildPlane, r.GatewayURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get build plane client: %w", err)
@@ -467,7 +467,7 @@ func (r *ComponentWorkflowRunReconciler) getBuildPlaneClient(buildPlane *opencho
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ComponentWorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.K8sClientMgr == nil {
 		r.K8sClientMgr = kubernetesClient.NewManager()
 	}

--- a/internal/controller/componentworkflowrun/controller_finalize.go
+++ b/internal/controller/componentworkflowrun/controller_finalize.go
@@ -27,7 +27,7 @@ const (
 
 // ensureFinalizer ensures that the finalizer is added to the ComponentWorkflowRun.
 // Returns true if the finalizer was added (indicating the caller should return early).
-func (r *ComponentWorkflowRunReconciler) ensureFinalizer(ctx context.Context, cwRun *openchoreodevv1alpha1.ComponentWorkflowRun) (bool, error) {
+func (r *Reconciler) ensureFinalizer(ctx context.Context, cwRun *openchoreodevv1alpha1.ComponentWorkflowRun) (bool, error) {
 	// If already being deleted, no need to add finalizer
 	if !cwRun.DeletionTimestamp.IsZero() {
 		return false, nil
@@ -41,7 +41,7 @@ func (r *ComponentWorkflowRunReconciler) ensureFinalizer(ctx context.Context, cw
 }
 
 // finalize cleans up the build plane resources associated with the ComponentWorkflowRun.
-func (r *ComponentWorkflowRunReconciler) finalize(ctx context.Context, cwRun *openchoreodevv1alpha1.ComponentWorkflowRun) (ctrl.Result, error) {
+func (r *Reconciler) finalize(ctx context.Context, cwRun *openchoreodevv1alpha1.ComponentWorkflowRun) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if !controllerutil.ContainsFinalizer(cwRun, ComponentWorkflowRunCleanupFinalizer) {
@@ -93,7 +93,7 @@ func (r *ComponentWorkflowRunReconciler) finalize(ctx context.Context, cwRun *op
 }
 
 // deleteResource deletes a single resource from the build plane using the ResourceReference.
-func (r *ComponentWorkflowRunReconciler) deleteResource(ctx context.Context, bpClient client.Client, ref openchoreodevv1alpha1.ResourceReference) error {
+func (r *Reconciler) deleteResource(ctx context.Context, bpClient client.Client, ref openchoreodevv1alpha1.ResourceReference) error {
 	gv, err := schema.ParseGroupVersion(ref.APIVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse API version %q: %w", ref.APIVersion, err)
@@ -117,7 +117,7 @@ func (r *ComponentWorkflowRunReconciler) deleteResource(ctx context.Context, bpC
 }
 
 // removeFinalizer removes the finalizer from the ComponentWorkflowRun.
-func (r *ComponentWorkflowRunReconciler) removeFinalizer(ctx context.Context, cwRun *openchoreodevv1alpha1.ComponentWorkflowRun) (ctrl.Result, error) {
+func (r *Reconciler) removeFinalizer(ctx context.Context, cwRun *openchoreodevv1alpha1.ComponentWorkflowRun) (ctrl.Result, error) {
 	if controllerutil.RemoveFinalizer(cwRun, ComponentWorkflowRunCleanupFinalizer) {
 		if err := r.Update(ctx, cwRun); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/componentworkflowrun/controller_test.go
+++ b/internal/controller/componentworkflowrun/controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("ComponentWorkflowRun Controller", func() {
 
 		It("should handle reconciliation when resource not found", func() {
 			By("Reconciling a non-existent resource")
-			reconciler := &ComponentWorkflowRunReconciler{
+			reconciler := &Reconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}

--- a/internal/controller/componentworkflowrun/run_engine.go
+++ b/internal/controller/componentworkflowrun/run_engine.go
@@ -23,7 +23,7 @@ const (
 
 // ensurePrerequisites creates prerequisite resources in the build plane
 // before creating the component workflow run: create namespace, service account, role, and role binding.
-func (r *ComponentWorkflowRunReconciler) ensurePrerequisites(ctx context.Context, namespace, serviceAccountName string, bpClient client.Client) error {
+func (r *Reconciler) ensurePrerequisites(ctx context.Context, namespace, serviceAccountName string, bpClient client.Client) error {
 	logger := log.FromContext(ctx).WithValues("namespace", namespace, "serviceAccount", serviceAccountName)
 
 	roleName := fmt.Sprintf("%s-%s", serviceAccountName, workflowRoleNameSuffix)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

This pull request refactors the controller codebase by standardizing the reconciler struct names across several controllers. Specifically, it renames the controller structs from specific names like `BuildPlaneReconciler`, `ComponentWorkflowReconciler`, and `ComponentWorkflowRunReconciler` to a generic `Reconciler`. This change improves code consistency and maintainability throughout the project.

**Controller struct renaming and method updates:**

* Renamed `BuildPlaneReconciler` to `Reconciler` in `internal/controller/buildplane/controller.go` and updated all associated method receivers and references accordingly. [[1]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L31-R32) [[2]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L47-R47) [[3]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L138-R144) [[4]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L156-R156) [[5]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L189-R189) [[6]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L213-R213) [[7]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L250-R250) [[8]](diffhunk://#diff-aed11c3c5da4198d009a3feb2c031fb77606358e0d12dab18ea7ec4635b15990L327-R327)
* Renamed `ComponentWorkflowReconciler` to `Reconciler` in `internal/controller/componentworkflow/controller.go` and updated all associated method receivers and references. [[1]](diffhunk://#diff-3034b797be81a980bb4ffff87fb01c9133377d882953cc13de0c0ae1531f6f4cL17-R18) [[2]](diffhunk://#diff-3034b797be81a980bb4ffff87fb01c9133377d882953cc13de0c0ae1531f6f4cL36-R36) [[3]](diffhunk://#diff-3034b797be81a980bb4ffff87fb01c9133377d882953cc13de0c0ae1531f6f4cL45-R45)
* Renamed `ComponentWorkflowRunReconciler` to `Reconciler` in `internal/controller/componentworkflowrun/controller.go`, `internal/controller/componentworkflowrun/controller_finalize.go`, and `internal/controller/componentworkflowrun/run_engine.go`, updating all method receivers and references. [[1]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L31-R32) [[2]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L54-R54) [[3]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L180-R180) [[4]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L202-R202) [[5]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L245-R245) [[6]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L273-R273) [[7]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L339-R339) [[8]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L408-R408) [[9]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L461-R461) [[10]](diffhunk://#diff-85c25166c225a5ab91308247fb53fdd87b1c0ecd1b8023f228cbab08a7730d40L470-R470) [[11]](diffhunk://#diff-bad8ef9d60548b84319910c4b0c0a0fd8f19f5e3ee30e884bd972de343e28e9cL30-R30) [[12]](diffhunk://#diff-bad8ef9d60548b84319910c4b0c0a0fd8f19f5e3ee30e884bd972de343e28e9cL44-R44) [[13]](diffhunk://#diff-bad8ef9d60548b84319910c4b0c0a0fd8f19f5e3ee30e884bd972de343e28e9cL96-R96) [[14]](diffhunk://#diff-bad8ef9d60548b84319910c4b0c0a0fd8f19f5e3ee30e884bd972de343e28e9cL120-R120) [[15]](diffhunk://#diff-089949522895704126f7ee6bff87c74ce8cb8d4b86411c8312a9afedb40295d0L26-R26)

**Test updates:**

* Updated controller instantiations in test files to use the new `Reconciler` struct name. [[1]](diffhunk://#diff-ce5a62b74f3bf936bbc98944eb4459520157a28acc5d0bc5dd5ac54d7d46cb87L57-R57) [[2]](diffhunk://#diff-2d4be09578cc478e4e15cad8db0cbd6739dd7412ece8097a71e2d1da75bf5352L85-R85)

**Main controller setup updates:**

* Updated controller setup calls in `cmd/main.go` to use the new `Reconciler` struct names for build plane and component workflow run controllers. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L231-R231) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L248-R248)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
