### PR TITLE
fix: allow cluster-agents and cluster-gateway to skip TLS using configs

### DIFF
--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -28,6 +28,7 @@ func main() {
 		serverURL         string
 		planeType         string
 		planeID           string
+		tlsEnabled        bool
 		clientCertPath    string
 		clientKeyPath     string
 		serverCAPath      string
@@ -46,6 +47,8 @@ func main() {
 		"Plane type: dataplane, buildplane, or observabilityplane")
 	flag.StringVar(&planeID, "plane-id", cmdutil.GetEnv("PLANE_ID", ""),
 		"Logical plane identifier (shared across multiple CRs with same physical plane)")
+	flag.BoolVar(&tlsEnabled, "tls-enabled", cmdutil.GetEnvBool("TLS_ENABLED", true),
+		"Enable mTLS for cluster gateway connection (disable for single-cluster setups)")
 	flag.StringVar(&clientCertPath, "client-cert",
 		cmdutil.GetEnv("CLIENT_CERT_PATH", "/certs/tls.crt"),
 		"Path to client certificate")
@@ -108,6 +111,7 @@ func main() {
 		ServerURL:         serverURL,
 		PlaneType:         planeType,
 		PlaneID:           planeID,
+		TLSEnabled:        tlsEnabled,
 		ClientCertPath:    clientCertPath,
 		ClientKeyPath:     clientKeyPath,
 		ServerCAPath:      serverCAPath,

--- a/cmd/cluster-gateway/main.go
+++ b/cmd/cluster-gateway/main.go
@@ -40,16 +40,17 @@ func init() {
 
 func main() {
 	var (
-		port              int
-		serverCertPath    string
-		serverKeyPath     string
-		readTimeout       time.Duration
-		writeTimeout      time.Duration
-		idleTimeout       time.Duration
-		shutdownTimeout   time.Duration
-		heartbeatInterval time.Duration
-		heartbeatTimeout  time.Duration
-		logLevel          string
+		port                 int
+		serverCertPath       string
+		serverKeyPath        string
+		skipClientCertVerify bool
+		readTimeout          time.Duration
+		writeTimeout         time.Duration
+		idleTimeout          time.Duration
+		shutdownTimeout      time.Duration
+		heartbeatInterval    time.Duration
+		heartbeatTimeout     time.Duration
+		logLevel             string
 	)
 
 	flag.IntVar(&port, "port", cmdutil.GetEnvInt("AGENT_SERVER_PORT", defaultPort), "Server port")
@@ -59,6 +60,9 @@ func main() {
 	flag.StringVar(&serverKeyPath, "server-key",
 		cmdutil.GetEnv("SERVER_KEY_PATH", "/certs/tls.key"),
 		"Path to server private key")
+	flag.BoolVar(&skipClientCertVerify, "skip-client-cert-verify",
+		cmdutil.GetEnvBool("SKIP_CLIENT_CERT_VERIFY", false),
+		"Skip client certificate verification (for single-cluster setups without mTLS)")
 	flag.DurationVar(&readTimeout, "read-timeout", defaultReadTimeout, "HTTP read timeout")
 	flag.DurationVar(&writeTimeout, "write-timeout", defaultWriteTimeout, "HTTP write timeout")
 	flag.DurationVar(&idleTimeout, "idle-timeout", defaultIdleTimeout, "HTTP idle timeout")
@@ -95,15 +99,16 @@ func main() {
 	logger.Info("Kubernetes client created successfully")
 
 	config := &clustergateway.Config{
-		Port:              port,
-		ServerCertPath:    serverCertPath,
-		ServerKeyPath:     serverKeyPath,
-		ReadTimeout:       readTimeout,
-		WriteTimeout:      writeTimeout,
-		IdleTimeout:       idleTimeout,
-		ShutdownTimeout:   shutdownTimeout,
-		HeartbeatInterval: heartbeatInterval,
-		HeartbeatTimeout:  heartbeatTimeout,
+		Port:                 port,
+		ServerCertPath:       serverCertPath,
+		ServerKeyPath:        serverKeyPath,
+		SkipClientCertVerify: skipClientCertVerify,
+		ReadTimeout:          readTimeout,
+		WriteTimeout:         writeTimeout,
+		IdleTimeout:          idleTimeout,
+		ShutdownTimeout:      shutdownTimeout,
+		HeartbeatInterval:    heartbeatInterval,
+		HeartbeatTimeout:     heartbeatTimeout,
 	}
 
 	srv := clustergateway.New(config, k8sClient, logger)

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/deployment.yaml
@@ -54,6 +54,7 @@ spec:
         - --server-url={{ .Values.clusterAgent.serverUrl }}
         - --plane-type={{ .Values.clusterAgent.planeType }}
         - --plane-id={{ .Values.clusterAgent.planeID | default .Release.Name }}
+        - --tls-enabled={{ .Values.clusterAgent.tls.enabled }}
         {{- if .Values.clusterAgent.tls.enabled }}
         - --client-cert=/certs/tls.crt
         - --client-key=/certs/tls.key

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --server-key=/certs/tls.key
         - --heartbeat-interval={{ .Values.clusterGateway.heartbeatInterval }}
         - --heartbeat-timeout={{ .Values.clusterGateway.heartbeatTimeout }}
+        - --skip-client-cert-verify={{ .Values.clusterGateway.tls.skipClientCertVerify }}
         - --log-level={{ .Values.clusterGateway.logLevel }}
         ports:
         - name: websocket

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1299,6 +1299,12 @@
               "description": "TLS secret name",
               "title": "secretName",
               "type": "string"
+            },
+            "skipClientCertVerify": {
+              "default": false,
+              "description": "Skip client certificate verification for agent connections (for single-cluster setups without mTLS)",
+              "title": "skipClientCertVerify",
+              "type": "boolean"
             }
           },
           "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -4211,6 +4211,12 @@ clusterGateway:
     # default: cluster-gateway-tls
     # @schema
     secretName: cluster-gateway-tls
+    # @schema
+    # type: boolean
+    # description: Skip client certificate verification for agent connections (for single-cluster setups without mTLS)
+    # default: false
+    # @schema
+    skipClientCertVerify: false
     # type: object
     # description: cert-manager issuer reference
     # @schema

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -54,6 +54,7 @@ spec:
         - --server-url={{ .Values.clusterAgent.serverUrl }}
         - --plane-type={{ .Values.clusterAgent.planeType }}
         - --plane-id={{ .Values.clusterAgent.planeID | default .Release.Name }}
+        - --tls-enabled={{ .Values.clusterAgent.tls.enabled }}
         {{- if .Values.clusterAgent.tls.enabled }}
         - --client-cert=/certs/tls.crt
         - --client-key=/certs/tls.key

--- a/internal/cluster-agent/config.go
+++ b/internal/cluster-agent/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	ServerURL         string
 	PlaneType         string // "dataplane" or "buildplane" or "observabilityplane"
 	PlaneID           string // Logical plane identifier (shared across multiple CRs with same physical plane)
+	TLSEnabled        bool
 	ClientCertPath    string
 	ClientKeyPath     string
 	ServerCAPath      string

--- a/internal/cluster-gateway/config.go
+++ b/internal/cluster-gateway/config.go
@@ -7,15 +7,16 @@ import "time"
 
 // Config holds configuration for the agent server
 type Config struct {
-	Port              int
-	ServerCertPath    string
-	ServerKeyPath     string
-	ReadTimeout       time.Duration
-	WriteTimeout      time.Duration
-	IdleTimeout       time.Duration
-	ShutdownTimeout   time.Duration
-	HeartbeatInterval time.Duration
-	HeartbeatTimeout  time.Duration
+	Port                 int
+	ServerCertPath       string
+	ServerKeyPath        string
+	SkipClientCertVerify bool
+	ReadTimeout          time.Duration
+	WriteTimeout         time.Duration
+	IdleTimeout          time.Duration
+	ShutdownTimeout      time.Duration
+	HeartbeatInterval    time.Duration
+	HeartbeatTimeout     time.Duration
 }
 
 // RemoteServerClientConfig holds configuration for RemoteServerClient

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -227,7 +227,9 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Certificate verification checks against ALL CRs with matching planeType and planeID
 	// This supports multiple CRs sharing the same physical plane with different CA certificates
-	if err := s.verifyClientCertificate(r, planeType, planeID); err != nil {
+	if s.config.SkipClientCertVerify {
+		s.logger.Debug("skipping client certificate verification", "planeType", planeType, "planeID", planeID)
+	} else if err := s.verifyClientCertificate(r, planeType, planeID); err != nil {
 		s.logger.Warn("client certificate verification failed",
 			"planeType", planeType,
 			"planeID", planeID,

--- a/internal/cmdutil/env.go
+++ b/internal/cmdutil/env.go
@@ -16,6 +16,15 @@ func GetEnv(key, defaultValue string) string {
 	return defaultValue
 }
 
+// GetEnvBool gets a boolean environment variable or returns a default value.
+// Recognizes "true", "1" as true and "false", "0" as false.
+func GetEnvBool(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		return value == "true" || value == "1"
+	}
+	return defaultValue
+}
+
 // GetEnvInt gets an integer environment variable or returns a default value
 func GetEnvInt(key string, defaultValue int) int {
 	if value := os.Getenv(key); value != "" {


### PR DESCRIPTION
## Purpose
The existing tls.enabled flag in cluster-agent Helm values did not fully disable mTLS. Volume mounts and cert args were rendered. The cluster-agent failed when cert files were absent, and the cluster gateway still rejected connections without client certificates. 

## Approach
This fix adds a --tls-enabled flag to the agent to skip certificate loading, a --skip-client-cert-verify flag to the gateway to bypass client cert verification, and makes Helm templates conditional on the TLS setting.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
