### PR TITLE
fix: set controlplane mcp timeout traffic policy as a post install hook

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/traffic-policy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/traffic-policy.yaml
@@ -4,6 +4,9 @@ kind: TrafficPolicy
 metadata:
   name: {{ include "openchoreo-control-plane.openchoreoApi.name" . }}-mcp-timeout
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: hook-failed
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: api-server


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Currently, `install/helm/openchoreo-control-plane/templates/openchoreo-api/traffic-policy.yaml` installation fails since the helm doesn't ensure the CRD availability at the time of this file applying.

Therefore, this PR updates this file applying as a helm post-install hook.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1638

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
