### PR TITLE
fix(cli): omit empty componentProfile in generated ComponentRelease

### DIFF
--- a/api/v1alpha1/componentrelease_types.go
+++ b/api/v1alpha1/componentrelease_types.go
@@ -29,9 +29,9 @@ type ComponentReleaseSpec struct {
 
 	// ComponentProfile contains the immutable snapshot of parameter values and trait configs
 	// specified for this component at release time
-	// +kubebuilder:validation:Required
+	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.componentProfile is immutable"
-	ComponentProfile ComponentProfile `json:"componentProfile"`
+	ComponentProfile *ComponentProfile `json:"componentProfile,omitempty"`
 
 	// Workload is a full embedded copy of the Workload
 	// This preserves the workload spec with the built image

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -524,7 +524,11 @@ func (in *ComponentReleaseSpec) DeepCopyInto(out *ComponentReleaseSpec) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	in.ComponentProfile.DeepCopyInto(&out.ComponentProfile)
+	if in.ComponentProfile != nil {
+		in, out := &in.ComponentProfile, &out.ComponentProfile
+		*out = new(ComponentProfile)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Workload.DeepCopyInto(&out.Workload)
 }
 

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -641,7 +641,6 @@ spec:
                 - message: spec.workload is immutable
                   rule: self == oldSelf
             required:
-            - componentProfile
             - componentType
             - owner
             - workload

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -640,7 +640,6 @@ spec:
                 - message: spec.workload is immutable
                   rule: self == oldSelf
             required:
-            - componentProfile
             - componentType
             - owner
             - workload

--- a/internal/controller/component/controller.go
+++ b/internal/controller/component/controller.go
@@ -616,9 +616,13 @@ func buildTraitsMap(traits []openchoreov1alpha1.Trait) map[string]openchoreov1al
 	return traitsMap
 }
 
-// buildComponentProfile extracts the ComponentProfile from the Component
-func buildComponentProfile(comp *openchoreov1alpha1.Component) openchoreov1alpha1.ComponentProfile {
-	return openchoreov1alpha1.ComponentProfile{
+// buildComponentProfile extracts the ComponentProfile from the Component.
+// Returns nil if the component has no parameters and no traits.
+func buildComponentProfile(comp *openchoreov1alpha1.Component) *openchoreov1alpha1.ComponentProfile {
+	if comp.Spec.Parameters == nil && len(comp.Spec.Traits) == 0 {
+		return nil
+	}
+	return &openchoreov1alpha1.ComponentProfile{
 		Parameters: comp.Spec.Parameters,
 		Traits:     comp.Spec.Traits,
 	}

--- a/internal/controller/component/controller_hash.go
+++ b/internal/controller/component/controller_hash.go
@@ -21,7 +21,7 @@ type ReleaseSpec struct {
 	Traits map[string]openchoreov1alpha1.TraitSpec `json:"traits,omitempty"`
 
 	// ComponentProfile contains parameter values and trait configurations
-	ComponentProfile openchoreov1alpha1.ComponentProfile `json:"componentProfile"`
+	ComponentProfile *openchoreov1alpha1.ComponentProfile `json:"componentProfile,omitempty"`
 
 	// Workload is the embedded Workload template specification
 	Workload openchoreov1alpha1.WorkloadTemplateSpec `json:"workload"`
@@ -79,10 +79,13 @@ func BuildReleaseSpec(
 		}
 	}
 
-	// Build component profile
-	componentProfile := openchoreov1alpha1.ComponentProfile{
-		Parameters: comp.Spec.Parameters,
-		Traits:     comp.Spec.Traits,
+	// Build component profile (only if there's content)
+	var componentProfile *openchoreov1alpha1.ComponentProfile
+	if comp.Spec.Parameters != nil || len(comp.Spec.Traits) > 0 {
+		componentProfile = &openchoreov1alpha1.ComponentProfile{
+			Parameters: comp.Spec.Parameters,
+			Traits:     comp.Spec.Traits,
+		}
 	}
 
 	// Construct ReleaseSpec

--- a/internal/controller/component/controller_hash_test.go
+++ b/internal/controller/component/controller_hash_test.go
@@ -26,7 +26,7 @@ func TestComputeReleaseHash(t *testing.T) {
 				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
 					WorkloadType: "deployment",
 				},
-				ComponentProfile: openchoreov1alpha1.ComponentProfile{
+				ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 					Parameters: &runtime.RawExtension{Raw: []byte(`{"replicas": 3}`)},
 				},
 				Workload: openchoreov1alpha1.WorkloadTemplateSpec{
@@ -44,7 +44,7 @@ func TestComputeReleaseHash(t *testing.T) {
 				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
 					WorkloadType: "deployment",
 				},
-				ComponentProfile: openchoreov1alpha1.ComponentProfile{
+				ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 					Parameters: &runtime.RawExtension{Raw: []byte(`{"replicas": 3}`)},
 				},
 				Workload: openchoreov1alpha1.WorkloadTemplateSpec{
@@ -59,7 +59,7 @@ func TestComputeReleaseHash(t *testing.T) {
 				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
 					WorkloadType: "deployment",
 				},
-				ComponentProfile: openchoreov1alpha1.ComponentProfile{
+				ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 					Parameters: &runtime.RawExtension{Raw: []byte(`{"replicas": 3}`)},
 				},
 				Workload: openchoreov1alpha1.WorkloadTemplateSpec{
@@ -77,7 +77,7 @@ func TestComputeReleaseHash(t *testing.T) {
 				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
 					WorkloadType: "deployment",
 				},
-				ComponentProfile: openchoreov1alpha1.ComponentProfile{
+				ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 					Parameters: &runtime.RawExtension{Raw: []byte(`{"replicas": 3}`)},
 				},
 				Workload: openchoreov1alpha1.WorkloadTemplateSpec{
@@ -92,7 +92,7 @@ func TestComputeReleaseHash(t *testing.T) {
 				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
 					WorkloadType: "deployment",
 				},
-				ComponentProfile: openchoreov1alpha1.ComponentProfile{
+				ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 					Parameters: &runtime.RawExtension{Raw: []byte(`{"replicas": 3}`)},
 				},
 				Workload: openchoreov1alpha1.WorkloadTemplateSpec{
@@ -311,7 +311,7 @@ func TestHashOutputExamples(t *testing.T) {
 				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
 					WorkloadType: "deployment",
 				},
-				ComponentProfile: openchoreov1alpha1.ComponentProfile{
+				ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 					Parameters: &runtime.RawExtension{Raw: []byte(`{"replicas": 3, "port": 8080}`)},
 				},
 				Workload: openchoreov1alpha1.WorkloadTemplateSpec{

--- a/internal/controller/component/controller_test.go
+++ b/internal/controller/component/controller_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Component Controller Finalization", func() {
 							},
 						},
 					},
-					ComponentProfile: openchoreov1alpha1.ComponentProfile{},
+					ComponentProfile: nil,
 					Workload: openchoreov1alpha1.WorkloadTemplateSpec{
 						Containers: map[string]openchoreov1alpha1.Container{
 							"app": {Image: "nginx:latest"},
@@ -409,7 +409,7 @@ var _ = Describe("Component Controller Finalization", func() {
 							},
 						},
 					},
-					ComponentProfile: openchoreov1alpha1.ComponentProfile{},
+					ComponentProfile: nil,
 					Workload: openchoreov1alpha1.WorkloadTemplateSpec{
 						Containers: map[string]openchoreov1alpha1.Container{
 							"app": {Image: "nginx:latest"},

--- a/internal/controller/componentrelease/controller_test.go
+++ b/internal/controller/componentrelease/controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ComponentRelease Controller", func() {
 								},
 							},
 						},
-						ComponentProfile: openchoreov1alpha1.ComponentProfile{
+						ComponentProfile: &openchoreov1alpha1.ComponentProfile{
 							Parameters: &runtime.RawExtension{
 								Raw: []byte(`{"replicas":1,"image":"nginx:latest"}`),
 							},

--- a/internal/occ/fsmode/generator/release.go
+++ b/internal/occ/fsmode/generator/release.go
@@ -144,9 +144,6 @@ func (g *ReleaseGenerator) buildRelease(
 			"componentName": comp.Name,
 			"projectName":   comp.ProjectName(),
 		},
-		"componentProfile": map[string]interface{}{
-			"parameters": comp.GetParameters(),
-		},
 		"componentType": map[string]interface{}{
 			"workloadType": ct.WorkloadType(),
 			"schema":       ct.GetSchema(),
@@ -157,10 +154,17 @@ func (g *ReleaseGenerator) buildRelease(
 		},
 	}
 
-	// Add traits to componentProfile if present
+	// Build componentProfile only if there's content to add
+	componentProfile := make(map[string]interface{})
+	if params := comp.GetParameters(); len(params) > 0 {
+		componentProfile["parameters"] = params
+	}
 	if len(profileTraits) > 0 {
-		componentProfile := spec["componentProfile"].(map[string]interface{})
 		componentProfile["traits"] = profileTraits
+	}
+	// Only add componentProfile to spec if it has content
+	if len(componentProfile) > 0 {
+		spec["componentProfile"] = componentProfile
 	}
 
 	// Add traits map if present

--- a/internal/openchoreo-api/services/component_service.go
+++ b/internal/openchoreo-api/services/component_service.go
@@ -222,14 +222,16 @@ func (s *ComponentService) CreateComponentRelease(ctx context.Context, namespace
 		traits[componentTrait.Name] = trait.Spec
 	}
 
-	// Build ComponentProfile from Component parameters
-	componentProfile := openchoreov1alpha1.ComponentProfile{}
-	if component.Spec.Parameters != nil {
-		componentProfile.Parameters = component.Spec.Parameters
-	}
-
-	if component.Spec.Traits != nil {
-		componentProfile.Traits = component.Spec.Traits
+	// Build ComponentProfile from Component parameters (only if there's content)
+	var componentProfile *openchoreov1alpha1.ComponentProfile
+	if component.Spec.Parameters != nil || len(component.Spec.Traits) > 0 {
+		componentProfile = &openchoreov1alpha1.ComponentProfile{}
+		if component.Spec.Parameters != nil {
+			componentProfile.Parameters = component.Spec.Parameters
+		}
+		if component.Spec.Traits != nil {
+			componentProfile.Traits = component.Spec.Traits
+		}
 	}
 
 	// Build workload template spec from workload spec

--- a/internal/webhook/componentrelease/webhook_test.go
+++ b/internal/webhook/componentrelease/webhook_test.go
@@ -67,7 +67,7 @@ var _ = Describe("ComponentRelease Webhook", func() {
 						},
 					},
 				},
-				ComponentProfile: openchoreodevv1alpha1.ComponentProfile{},
+				ComponentProfile: &openchoreodevv1alpha1.ComponentProfile{},
 				Workload: openchoreodevv1alpha1.WorkloadTemplateSpec{
 					Containers: map[string]openchoreodevv1alpha1.Container{
 						"app": {


### PR DESCRIPTION
## Purpose
Change ComponentProfile from a required field to optional in ComponentReleaseSpec. When a component has no parameters or traits, the componentProfile section is now omitted entirely instead of generating 
```yaml
componentProfile: 
  parameters: null
```
(This makes issues in GitOps setups as when applied this the CR takes it as `componentProfile: {}` and next time flux reconcile fails with the following error as this is an immutable field)

```
ComponentRelease/default/greeter-service-gitops-a9b44f18 dry-run failed (Invalid): ComponentRelease.openchoreo.dev "greeter-service-gitops-a9b44f18" is invalid: spec.componentProfile: Invalid value: "object": spec.componentProfile is immutable
```


Changes:
- Make ComponentProfile an optional pointer type in the API
- Update release generator to only include componentProfile when there is actual content (parameters or traits)
- Update controllers and tests to use pointer semantics

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
