### PR TITLE
feat(helm): add gateway infrastructure config for cloud LB annotations

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
@@ -8,6 +8,10 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.gateway.tls.clusterIssuer | default "openchoreo-selfsigned-issuer" }}
 spec:
   gatewayClassName: kgateway
+  {{- with .Values.gateway.infrastructure }}
+  infrastructure:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2384,6 +2384,13 @@
           "title": "image",
           "type": "object"
         },
+        "infrastructure": {
+          "additionalProperties": true,
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"",
+          "required": [],
+          "title": "infrastructure",
+          "type": "object"
+        },
         "selfSignedIssuer": {
           "additionalProperties": false,
           "description": "Self-signed ClusterIssuer configuration",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -4445,6 +4445,22 @@ gateway:
 
   # @schema
   # type: object
+  # additionalProperties: true
+  # description: |
+  #   Gateway infrastructure configuration passed to the generated Service.
+  #   Used to configure cloud provider load balancer settings via annotations.
+  #   Example for AWS with Elastic IP:
+  #     infrastructure:
+  #       annotations:
+  #         service.beta.kubernetes.io/aws-load-balancer-type: "external"
+  #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+  #         service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+  #         service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-xxx"
+  # @schema
+  infrastructure: {}
+
+  # @schema
+  # type: object
   # description: Self-signed ClusterIssuer configuration
   # @schema
   selfSignedIssuer:

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -12,6 +12,10 @@ metadata:
   {{- end }}
 spec:
   gatewayClassName: kgateway
+  {{- with .Values.gateway.infrastructure }}
+  infrastructure:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -1092,6 +1092,13 @@
           "title": "image",
           "type": "object"
         },
+        "infrastructure": {
+          "additionalProperties": true,
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"",
+          "required": [],
+          "title": "infrastructure",
+          "type": "object"
+        },
         "selfSignedIssuer": {
           "additionalProperties": false,
           "description": "Self-signed ClusterIssuer configuration",

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -477,6 +477,22 @@ gateway:
 
   # @schema
   # type: object
+  # additionalProperties: true
+  # description: |
+  #   Gateway infrastructure configuration passed to the generated Service.
+  #   Used to configure cloud provider load balancer settings via annotations.
+  #   Example for AWS with Elastic IP:
+  #     infrastructure:
+  #       annotations:
+  #         service.beta.kubernetes.io/aws-load-balancer-type: "external"
+  #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+  #         service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+  #         service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-xxx"
+  # @schema
+  infrastructure: {}
+
+  # @schema
+  # type: object
   # description: Self-signed ClusterIssuer configuration
   # @schema
   selfSignedIssuer:


### PR DESCRIPTION
adds `gateway.infrastructure` field to both control-plane and data-plane helm charts

needed this for AWS deployments where we want to use Elastic IPs with the NLB instead of pre-provisioning load balancers via CloudFormation. the Gateway API `infrastructure` field passes annotations through to the generated Service.

changes:
- control-plane: added `gateway.infrastructure` to values.yaml and templated it in gateway.yaml
- data-plane: same changes

example usage for AWS:
```yaml
gateway:
  infrastructure:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: "external"
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-xxx"
```

should work for other cloud providers too (GCP, Azure) since it just passes through whatever annotations you set.

tested by templating the charts locally. kgateway should pick up the infrastructure field since its standard Gateway API.