### PR TITLE
fix: update role mapping functions to include proper ns authz checks

### DIFF
--- a/internal/authz/core/actions.go
+++ b/internal/authz/core/actions.go
@@ -84,6 +84,7 @@ var systemActions = []Action{
 	{Name: "role:create", IsInternal: false},
 	{Name: "role:delete", IsInternal: false},
 	{Name: "role:update", IsInternal: false},
+	{Name: "action:view", IsInternal: false},
 
 	// role mapping
 	{Name: "rolemapping:view", IsInternal: false},

--- a/internal/authz/core/actions_test.go
+++ b/internal/authz/core/actions_test.go
@@ -19,7 +19,7 @@ func TestAllActions(t *testing.T) {
 	})
 
 	t.Run("returns expected action count", func(t *testing.T) {
-		expectedCount := 45 // Update this when intentionally adding/removing actions
+		expectedCount := 46 // Update this when intentionally adding/removing actions
 		if len(actions) != expectedCount {
 			t.Errorf("Expected %d actions, got %d. Update expected count if intentional.", expectedCount, len(actions))
 		}

--- a/internal/openchoreo-api/services/authz_service.go
+++ b/internal/openchoreo-api/services/authz_service.go
@@ -237,7 +237,7 @@ func (s *AuthzService) ListNamespacedRoleMappings(ctx context.Context, namespace
 
 	if err := checkAuthorization(ctx, s.logger, s.pdp, SystemActionViewRoleMapping, ResourceTypeRoleMapping, "*",
 		authz.ResourceHierarchy{
-			Namespace: roleRef.Namespace,
+			Namespace: namespace,
 		}); err != nil {
 		return nil, err
 	}
@@ -280,7 +280,9 @@ func (s *AuthzService) GetRoleMapping(ctx context.Context, mappingRef *authz.Map
 	s.logger.Debug("Getting authorization role mapping", "mapping_name", mappingRef.Name, "mapping_namespace", mappingRef.Namespace)
 
 	if err := checkAuthorization(ctx, s.logger, s.pdp, SystemActionViewRoleMapping, ResourceTypeRoleMapping, mappingRef.Name,
-		authz.ResourceHierarchy{}); err != nil {
+		authz.ResourceHierarchy{
+			Namespace: mappingRef.Namespace,
+		}); err != nil {
 		return nil, err
 	}
 	mapping, err := s.pap.GetRoleEntitlementMapping(ctx, mappingRef)
@@ -301,7 +303,9 @@ func (s *AuthzService) AddRoleMapping(ctx context.Context, mapping *authz.RoleEn
 		"hierarchy", mapping.Hierarchy)
 
 	if err := checkAuthorization(ctx, s.logger, s.pdp, SystemActionCreateRoleMapping, ResourceTypeRoleMapping, mapping.RoleRef.Name,
-		authz.ResourceHierarchy{}); err != nil {
+		authz.ResourceHierarchy{
+			Namespace: mapping.Hierarchy.Namespace,
+		}); err != nil {
 		return err
 	}
 
@@ -321,7 +325,9 @@ func (s *AuthzService) UpdateRoleMapping(ctx context.Context, mapping *authz.Rol
 		"hierarchy", mapping.Hierarchy)
 
 	if err := checkAuthorization(ctx, s.logger, s.pdp, SystemActionUpdateRoleMapping, ResourceTypeRoleMapping, mapping.Name,
-		authz.ResourceHierarchy{}); err != nil {
+		authz.ResourceHierarchy{
+			Namespace: mapping.Hierarchy.Namespace,
+		}); err != nil {
 		return err
 	}
 
@@ -337,7 +343,9 @@ func (s *AuthzService) RemoveRoleMapping(ctx context.Context, mappingRef *authz.
 	s.logger.Debug("Removing authorization role mapping", "mapping_name", mappingRef.Name, "mapping_namespace", mappingRef.Namespace)
 
 	if err := checkAuthorization(ctx, s.logger, s.pdp, SystemActionDeleteRoleMapping, ResourceTypeRoleMapping, mappingRef.Name,
-		authz.ResourceHierarchy{}); err != nil {
+		authz.ResourceHierarchy{
+			Namespace: mappingRef.Namespace,
+		}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request introduces improvements to the authorization logic for role mappings and adds a new action to the system. The main changes ensure that the correct namespace is passed during authorization checks for role mapping operations, enhancing security and correctness. Additionally, a new `action:view` permission is introduced, and related tests are updated.

**Authorization logic improvements for role mappings:**

* Updated all role mapping authorization checks in `authz_service.go` to include the relevant `Namespace` in the `ResourceHierarchy`, ensuring that permissions are evaluated in the correct context. [[1]](diffhunk://#diff-6cdf781783ae1e1ffdd5793d314d70e6b85a7771652f77f547ab85128876a9d6L240-R240) [[2]](diffhunk://#diff-6cdf781783ae1e1ffdd5793d314d70e6b85a7771652f77f547ab85128876a9d6L283-R285) [[3]](diffhunk://#diff-6cdf781783ae1e1ffdd5793d314d70e6b85a7771652f77f547ab85128876a9d6L304-R308) [[4]](diffhunk://#diff-6cdf781783ae1e1ffdd5793d314d70e6b85a7771652f77f547ab85128876a9d6L324-R330) [[5]](diffhunk://#diff-6cdf781783ae1e1ffdd5793d314d70e6b85a7771652f77f547ab85128876a9d6L340-R348)

**System actions and tests:**

* Added a new `action:view` action to the list of system actions in `actions.go`.
* Updated the expected action count in `actions_test.go` to reflect the addition of the new action.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1520
## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
