### PR TITLE
feat: support pod distruption budget for cluster agent

### DIFF
--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/pdb.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.clusterAgent.enabled .Values.clusterAgent.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+spec:
+  {{- if .Values.clusterAgent.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.clusterAgent.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.clusterAgent.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.clusterAgent.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: cluster-agent
+      app.kubernetes.io/component: cluster-agent
+      {{- include "openchoreo-build-plane.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/install/helm/openchoreo-build-plane/values.schema.json
+++ b/install/helm/openchoreo-build-plane/values.schema.json
@@ -273,6 +273,39 @@
           "title": "podAnnotations",
           "type": "object"
         },
+        "podDisruptionBudget": {
+          "additionalProperties": false,
+          "description": "Pod Disruption Budget configuration for cluster agent",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable PodDisruptionBudget for cluster agent",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "default": "null",
+              "description": "Maximum number of pods that can be unavailable",
+              "minimum": 0,
+              "required": [],
+              "title": "maxUnavailable",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minAvailable": {
+              "default": 1,
+              "description": "Minimum number of pods that must be available",
+              "minimum": 0,
+              "title": "minAvailable",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "podDisruptionBudget",
+          "type": "object"
+        },
         "podSecurityContext": {
           "additionalProperties": true,
           "description": "Pod security context for cluster agent",

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -953,6 +953,31 @@ clusterAgent:
 
   # @schema
   # type: object
+  # description: Pod Disruption Budget configuration for cluster agent
+  # @schema
+  podDisruptionBudget:
+    # @schema
+    # type: boolean
+    # description: Enable PodDisruptionBudget for cluster agent
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: integer
+    # description: Minimum number of pods that must be available
+    # minimum: 0
+    # default: 1
+    # @schema
+    minAvailable: 1
+    # @schema
+    # type: [integer, "null"]
+    # description: Maximum number of pods that can be unavailable
+    # minimum: 0
+    # @schema
+    maxUnavailable: null
+
+  # @schema
+  # type: object
   # additionalProperties: false
   # description: Service account configuration for cluster agent
   # @schema

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/pdb.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.clusterAgent.enabled .Values.clusterAgent.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+spec:
+  {{- if .Values.clusterAgent.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.clusterAgent.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.clusterAgent.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.clusterAgent.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: cluster-agent
+      app.kubernetes.io/component: cluster-agent
+      {{- include "openchoreo-data-plane.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -189,6 +189,39 @@
           "title": "podAnnotations",
           "type": "object"
         },
+        "podDisruptionBudget": {
+          "additionalProperties": false,
+          "description": "Pod Disruption Budget configuration for cluster agent",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable PodDisruptionBudget for cluster agent",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "default": "null",
+              "description": "Maximum number of pods that can be unavailable",
+              "minimum": 0,
+              "required": [],
+              "title": "maxUnavailable",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minAvailable": {
+              "default": 1,
+              "description": "Minimum number of pods that must be available",
+              "minimum": 0,
+              "title": "minAvailable",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "podDisruptionBudget",
+          "type": "object"
+        },
         "podSecurityContext": {
           "additionalProperties": false,
           "description": "Pod-level security context",

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -1499,6 +1499,31 @@ clusterAgent:
 
   # @schema
   # type: object
+  # description: Pod Disruption Budget configuration for cluster agent
+  # @schema
+  podDisruptionBudget:
+    # @schema
+    # type: boolean
+    # description: Enable PodDisruptionBudget for cluster agent
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: integer
+    # description: Minimum number of pods that must be available
+    # minimum: 0
+    # default: 1
+    # @schema
+    minAvailable: 1
+    # @schema
+    # type: [integer, "null"]
+    # description: Maximum number of pods that can be unavailable
+    # minimum: 0
+    # @schema
+    maxUnavailable: null
+
+  # @schema
+  # type: object
   # description: Service account configuration for cluster agent
   # @schema
   serviceAccount:

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/pdb.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.clusterAgent.enabled .Values.clusterAgent.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+spec:
+  {{- if .Values.clusterAgent.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.clusterAgent.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.clusterAgent.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.clusterAgent.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: cluster-agent
+      app.kubernetes.io/component: cluster-agent
+      {{- include "openchoreo-observability-plane.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -143,6 +143,39 @@
           "title": "podAnnotations",
           "type": "object"
         },
+        "podDisruptionBudget": {
+          "additionalProperties": false,
+          "description": "Pod Disruption Budget configuration for cluster agent",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable PodDisruptionBudget for cluster agent",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "default": "null",
+              "description": "Maximum number of pods that can be unavailable",
+              "minimum": 0,
+              "required": [],
+              "title": "maxUnavailable",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minAvailable": {
+              "default": 1,
+              "description": "Minimum number of pods that must be available",
+              "minimum": 0,
+              "title": "minAvailable",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "podDisruptionBudget",
+          "type": "object"
+        },
         "podSecurityContext": {
           "additionalProperties": false,
           "description": "Pod-level security context",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -2163,6 +2163,31 @@ clusterAgent:
 
   # @schema
   # type: object
+  # description: Pod Disruption Budget configuration for cluster agent
+  # @schema
+  podDisruptionBudget:
+    # @schema
+    # type: boolean
+    # description: Enable PodDisruptionBudget for cluster agent
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: integer
+    # description: Minimum number of pods that must be available
+    # minimum: 0
+    # default: 1
+    # @schema
+    minAvailable: 1
+    # @schema
+    # type: [integer, "null"]
+    # description: Maximum number of pods that can be unavailable
+    # minimum: 0
+    # @schema
+    maxUnavailable: null
+
+  # @schema
+  # type: object
   # description: Service account configuration for the cluster agent
   # @schema
   serviceAccount:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

This pull request introduces Pod Disruption Budget (PDB) support for the `cluster-agent` across all three Helm charts: build-plane, data-plane, and observability-plane. The changes allow users to optionally enable a PDB for the cluster-agent, improving availability during voluntary disruptions (like node drains or upgrades) by specifying minimum available pods and maximum unavailable pods.

Pod Disruption Budget support for cluster-agent:

* Added a new `podDisruptionBudget` section to the `clusterAgent` configuration in `values.yaml` for build-plane, data-plane, and observability-plane charts, allowing users to enable PDB and set `minAvailable` and `maxUnavailable` values. [[1]](diffhunk://#diff-442bf9dde4241ceb55b74d638aa90b74f8fb084d0887a7b532d507cdfa6964c9R954-R978) [[2]](diffhunk://#diff-342c1aa422ad171ca7d2aa5cce28fe8b0ff13365fc7ea11116b99fc679cc876eR1500-R1524) [[3]](diffhunk://#diff-94d6c293793c60fc65baa0fcff151f7d1c0b5127349cc1b09a01d232e1d6ffefR2164-R2188)
* Updated the corresponding `values.schema.json` files to define the schema for the new `podDisruptionBudget` configuration, including descriptions and type validations for its fields. [[1]](diffhunk://#diff-7e255a2e039cd50d5bdba9ce5ae0889abac81546689cd5d0b8492845cef8e8a5R397-R428) [[2]](diffhunk://#diff-a1b50a38b97d8c07f88804aa9664c0dbc1ca0d4f09842ea3b39657e12380b459R310-R341) [[3]](diffhunk://#diff-bd387735a71f5cea83c08ae06006319e4b0b7a64ca0ca19f6de73c62a2bcb959R267-R298)

Helm chart template changes:

* Added new PDB templates (`pdb.yaml`) for the cluster-agent in each chart, which conditionally create a `PodDisruptionBudget` resource based on the new configuration. These templates use the provided `minAvailable` and `maxUnavailable` values and select cluster-agent pods via labels. [[1]](diffhunk://#diff-64da7318f2dba537d2439bc3d52aa0066ebf34839ec2420ffa21192994ac5fffR1-R22) [[2]](diffhunk://#diff-7a3f7d9c5b55f107a06f848824920bbd8812a16e7ef4d07415b5a1b802366889R1-R22) [[3]](diffhunk://#diff-e76ab5b3cdc42a2deb4ceb2aa00e0d3bd3d21b143d51846925299236e00cf691R1-R22)

## Approach

Add PDB for cluster agent helm installations.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1803

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
