### PR TITLE
fix: cluster gateway pre commit hook stucked issue

### DIFF
--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/copy-ca-secret.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/copy-ca-secret.yaml
@@ -13,14 +13,7 @@ metadata:
   labels:
     {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 spec:
-  {{- if .Values.clusterAgent.copyCAJob.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ .Values.clusterAgent.copyCAJob.ttlSecondsAfterFinished }}
-  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/openchoreo-build-plane/values.schema.json
+++ b/install/helm/openchoreo-build-plane/values.schema.json
@@ -150,21 +150,6 @@
           "title": "affinity",
           "type": "object"
         },
-        "copyCAJob": {
-          "additionalProperties": false,
-          "description": "Copy CA job configuration",
-          "properties": {
-            "ttlSecondsAfterFinished": {
-              "default": 600,
-              "description": "Time in seconds after job completion before automatic cleanup (0 disables cleanup)",
-              "title": "ttlSecondsAfterFinished",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "copyCAJob",
-          "type": "object"
-        },
         "dnsRewrite": {
           "additionalProperties": false,
           "description": "DNS rewrite configuration for multi-cluster k3d setups. Configures CoreDNS to rewrite *.openchoreo.localhost to host.k3d.internal.",

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -1125,18 +1125,6 @@ clusterAgent:
     renewBefore: 360h
 
   # @schema
-  # type: object
-  # description: Copy CA job configuration
-  # @schema
-  copyCAJob:
-    # @schema
-    # type: integer
-    # description: Time in seconds after job completion before automatic cleanup (0 disables cleanup)
-    # default: 600
-    # @schema
-    ttlSecondsAfterFinished: 600
-
-  # @schema
   # type: string
   # description: Namespace where cluster-gateway CA exists
   # default: openchoreo-control-plane

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-extractor-job.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/ca-extractor-job.yaml
@@ -11,14 +11,7 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-gateway
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 spec:
-  {{- if .Values.clusterGateway.caExtractorJob.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ .Values.clusterGateway.caExtractorJob.ttlSecondsAfterFinished }}
-  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -918,21 +918,6 @@
           "title": "affinity",
           "type": "object"
         },
-        "caExtractorJob": {
-          "additionalProperties": false,
-          "description": "CA extractor job configuration",
-          "properties": {
-            "ttlSecondsAfterFinished": {
-              "default": 600,
-              "description": "Time in seconds after job completion before automatic cleanup (0 disables cleanup)",
-              "title": "ttlSecondsAfterFinished",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "caExtractorJob",
-          "type": "object"
-        },
         "enabled": {
           "default": true,
           "description": "Enable the cluster gateway",
@@ -5085,12 +5070,6 @@
               "required": [],
               "title": "resources",
               "type": "object"
-            },
-            "ttlSecondsAfterFinished": {
-              "default": 86400,
-              "description": "Job retention time in seconds after completion (24 hours)",
-              "title": "ttlSecondsAfterFinished",
-              "type": "integer"
             }
           },
           "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3662,15 +3662,6 @@ thunder:
     # default: 3
     # @schema
     backoffLimit: 3
-    # type: integer
-    # description: Job retention time in seconds after completion (24 hours)
-    # default: 86400
-    # @schema
-    # type: integer
-    # description: Job retention time in seconds after completion (24 hours)
-    # default: 86400
-    # @schema
-    ttlSecondsAfterFinished: 86400
     # type: boolean
     # description: Preserve job after completion
     # default: true
@@ -4294,18 +4285,6 @@ clusterGateway:
     # default: 360h
     # @schema
     renewBefore: 360h
-
-  # @schema
-  # type: object
-  # description: CA extractor job configuration
-  # @schema
-  caExtractorJob:
-    # @schema
-    # type: integer
-    # description: Time in seconds after job completion before automatic cleanup (0 disables cleanup)
-    # default: 600
-    # @schema
-    ttlSecondsAfterFinished: 600
 
   # type: object
   # description: Pod security context

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/copy-ca-secret.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/copy-ca-secret.yaml
@@ -13,14 +13,7 @@ metadata:
   labels:
     {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 spec:
-  {{- if .Values.clusterAgent.copyCAJob.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ .Values.clusterAgent.copyCAJob.ttlSecondsAfterFinished }}
-  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -59,21 +59,6 @@
           "title": "affinity",
           "type": "object"
         },
-        "copyCAJob": {
-          "additionalProperties": false,
-          "description": "Copy CA job configuration",
-          "properties": {
-            "ttlSecondsAfterFinished": {
-              "default": 600,
-              "description": "Time in seconds after job completion before automatic cleanup (0 disables cleanup)",
-              "title": "ttlSecondsAfterFinished",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "copyCAJob",
-          "type": "object"
-        },
         "dnsRewrite": {
           "additionalProperties": false,
           "description": "DNS rewrite configuration for multi-cluster k3d setups",

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -1671,18 +1671,6 @@ clusterAgent:
     renewBefore: 360h
 
   # @schema
-  # type: object
-  # description: Copy CA job configuration
-  # @schema
-  copyCAJob:
-    # @schema
-    # type: integer
-    # description: Time in seconds after job completion before automatic cleanup (0 disables cleanup)
-    # default: 600
-    # @schema
-    ttlSecondsAfterFinished: 600
-
-  # @schema
   # type: string
   # description: Namespace where cluster-gateway CA exists (control plane namespace)
   # default: openchoreo-control-plane

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/copy-ca-secret.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/copy-ca-secret.yaml
@@ -13,14 +13,7 @@ metadata:
   labels:
     {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 spec:
-  {{- if .Values.clusterAgent.copyCAJob.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ .Values.clusterAgent.copyCAJob.ttlSecondsAfterFinished }}
-  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -14,21 +14,6 @@
           "title": "affinity",
           "type": "object"
         },
-        "copyCAJob": {
-          "additionalProperties": false,
-          "description": "Copy CA job configuration",
-          "properties": {
-            "ttlSecondsAfterFinished": {
-              "default": 600,
-              "description": "Time in seconds after job completion before automatic cleanup (0 disables cleanup)",
-              "title": "ttlSecondsAfterFinished",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "copyCAJob",
-          "type": "object"
-        },
         "dnsRewrite": {
           "additionalProperties": false,
           "description": "DNS rewrite configuration for multi-cluster k3d setups",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -2338,18 +2338,6 @@ clusterAgent:
     renewBefore: 360h
 
   # @schema
-  # type: object
-  # description: Copy CA job configuration
-  # @schema
-  copyCAJob:
-    # @schema
-    # type: integer
-    # description: Time in seconds after job completion before automatic cleanup (0 disables cleanup)
-    # default: 600
-    # @schema
-    ttlSecondsAfterFinished: 600
-
-  # @schema
   # type: string
   # description: Namespace where cluster-gateway CA ConfigMap exists
   # default: openchoreo-control-plane


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request removes the configuration and support for automatic cleanup of CA copy and extractor jobs across multiple Helm charts in the OpenChoreo project. The changes eliminate the `ttlSecondsAfterFinished` setting and related Helm hook annotations, simplifying job lifecycle management and reducing complexity in values and schema files.

Removal of CA job cleanup configuration:

* Deleted the `copyCAJob` and `caExtractorJob` sections, including the `ttlSecondsAfterFinished` field, from the values files for `openchoreo-build-plane`, `openchoreo-data-plane`, and `openchoreo-observability-plane`, as well as from `openchoreo-control-plane`. [[1]](diffhunk://#diff-442bf9dde4241ceb55b74d638aa90b74f8fb084d0887a7b532d507cdfa6964c9L1127-L1138) [[2]](diffhunk://#diff-342c1aa422ad171ca7d2aa5cce28fe8b0ff13365fc7ea11116b99fc679cc876eL1673-L1684) [[3]](diffhunk://#diff-94d6c293793c60fc65baa0fcff151f7d1c0b5127349cc1b09a01d232e1d6ffefL2324-L2335) [[4]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L4298-L4309)
* Removed the corresponding schema definitions for `copyCAJob` and `caExtractorJob` from the `values.schema.json` files in all affected charts. [[1]](diffhunk://#diff-7e255a2e039cd50d5bdba9ce5ae0889abac81546689cd5d0b8492845cef8e8a5L153-L167) [[2]](diffhunk://#diff-a1b50a38b97d8c07f88804aa9664c0dbc1ca0d4f09842ea3b39657e12380b459L62-L76) [[3]](diffhunk://#diff-bd387735a71f5cea83c08ae06006319e4b0b7a64ca0ca19f6de73c62a2bcb959L17-L31) [[4]](diffhunk://#diff-5c7308e4dd394e2a981e27c2748ac12e889689b0bf906e3a4e87402b34b535e8L921-L935)

Simplification of job templates:

* Eliminated Helm hook annotations and the conditional `ttlSecondsAfterFinished` specification from the CA copy and extractor job templates in all affected charts. [[1]](diffhunk://#diff-982b9de8514b178b68a2cd3c9e1aa6732738f44104f587353c55718525daf0c3L16-L23) [[2]](diffhunk://#diff-22f4af2d6062b35ed55a949d0274489e91188c7804d186a8eeb66a1613c47265L16-L23) [[3]](diffhunk://#diff-ed16df668fc79350f27bf097dbcccb339fade1e76e1a20c3dcc61fa5cb14094bL16-L23) [[4]](diffhunk://#diff-04861ff9885f750f41e821f8c8936994b61c39069a97e7138d24d78de1ce9eb7L14-L21)

Other related cleanup:

* Removed the `ttlSecondsAfterFinished` field from the `thunder` job configuration in `openchoreo-control-plane` values and schema files. [[1]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L3665-L3673) [[2]](diffhunk://#diff-5c7308e4dd394e2a981e27c2748ac12e889689b0bf906e3a4e87402b34b535e8L5088-L5093)
## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
