### PR TITLE
fix: add ingress host for observer service

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/http-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/http-route.yaml
@@ -9,7 +9,13 @@ spec:
   - name: gateway-default
     namespace: {{ .Release.Namespace }}
   hostnames:
-  - observer.{{ .Values.global.baseDomain }}
+    {{- if .Values.observer.ingress.hosts }}
+    {{- range .Values.observer.ingress.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+    {{- else }}
+    - observer.{{ .Values.global.baseDomain | quote }}
+    {{- end }}
   rules:
   - matches:
     - path:

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1694,6 +1694,29 @@
           "title": "image",
           "type": "object"
         },
+        "ingress": {
+          "additionalProperties": false,
+          "description": "Ingress configuration for the Observer service",
+          "properties": {
+            "hosts": {
+              "description": "Ingress hosts",
+              "items": {
+                "properties": {
+                  "host": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "title": "hosts",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "ingress",
+          "type": "object"
+        },
         "logLevel": {
           "default": "info",
           "description": "Log level for the Observer service",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -958,7 +958,7 @@ observer:
   # default: true
   # @schema
   experimental: {}
-  
+
   # @schema
   # type: integer
   # description: Number of Observer pod replicas
@@ -1176,6 +1176,22 @@ observer:
   # default: ThisIsTheOpenSearchPassword1
   # @schema
   openSearchPassword: ThisIsTheOpenSearchPassword1
+
+  # @schema
+  # type: object
+  # description: Ingress configuration for the Observer service
+  # @schema
+  ingress:
+    # @schema
+    # type: array
+    # description: Ingress hosts
+    # items:
+    #   type: object
+    #   properties:
+    #     host:
+    #       type: string
+    # @schema
+    hosts: []
 
 # @schema
 # type: object

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -54,7 +54,7 @@ helm install openchoreo-control-plane install/helm/openchoreo-control-plane \
   --values install/k3d/multi-cluster/values-cp.yaml
 
 # Create TLS Certificate for Control Plane Gateway
-kubectl apply -f - <<EOF                                            
+kubectl apply -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -368,7 +368,7 @@ kubectl --context k3d-openchoreo-cp create secret generic observabilityplane-def
   --control-plane-context k3d-openchoreo-cp \
   --agent-ca-secret observabilityplane-default-ca \
   --name default \
-  --observer-url http://host.k3d.internal:11080
+  --observer-url http://host.k3d.internal:11087
 ```
 </details>
 
@@ -415,7 +415,7 @@ kubectl --context k3d-openchoreo-cp patch buildplane default -n default --type m
 
 ### Observability Plane (if installed)
 
-- Observer API: http://localhost:11080
+- Observer API: http://localhost:11087
 - OpenSearch API: http://localhost:11082 (for Fluent Bit and direct API access)
 - Prometheus: http://localhost:11083 (for metrics)
 

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -45,6 +45,10 @@ observer:
     value: "http://api.openchoreo.localhost:8080"
   - name: AUTHZ_TIMEOUT
     value: "30s"
+  ingress:
+    hosts:
+    - host: host.k3d.internal
+    - host: observer.observability.openchoreo.localhost
 
 openSearchDashboards:
   service:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Add helm config to provide custom ingress hosts for observer service when running on k3d multi-cluster setup.
Related PR: https://github.com/openchoreo/openchoreo/pull/1749

## Approach
- Introduced a new ingress property in values.yaml to configure ingress hosts for the Observer service.
- Updated values.schema.json to define the schema for the new ingress configuration.
- Modified http-route.yaml to dynamically set hostnames based on the ingress configuration.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
TODO: Update RCA HTTPRoute 
