### PR TITLE
feat(helm): support external secrets for backstage and postgresql ssl

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -123,6 +123,14 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
+Backstage secrets name.
+Uses existingSecret when provided, otherwise falls back to the chart-generated secret.
+*/}}
+{{- define "openchoreo-control-plane.backstage.secretName" -}}
+{{- .Values.backstage.existingSecret | default (printf "%s-backstage-secrets" (include "openchoreo-control-plane.fullname" .)) }}
+{{- end }}
+
+{{/*
 Backstage service account name
 Always returns openchoreo-backstage (or custom name from values).
 Service account is always created when backstage is enabled for security.

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - name: BACKEND_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-secrets
+              name: {{ include "openchoreo-control-plane.backstage.secretName" . }}
               key: backend-secret
         {{- if .Values.thunder.enabled }}
         # Thunder-specific configuration
@@ -89,7 +89,7 @@ spec:
         - name: OPENCHOREO_AUTH_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-secrets
+              name: {{ include "openchoreo-control-plane.backstage.secretName" . }}
               key: client-secret
         # Feature flags for OpenChoreo functionality
         - name: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED
@@ -118,10 +118,14 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-secrets
+              name: {{ include "openchoreo-control-plane.backstage.secretName" . }}
               key: postgres-password
         - name: POSTGRES_DB
           value: {{ .Values.backstage.database.postgresql.database | quote }}
+        {{- if .Values.backstage.database.postgresql.ssl }}
+        - name: PGSSLMODE
+          value: "require"
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/install/helm/openchoreo-control-plane/templates/backstage/secret.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backstage.enabled }}
+{{- if and .Values.backstage.enabled (not .Values.backstage.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,6 +12,9 @@ data:
   backend-secret: {{ (.Values.backstage.backendSecret | default (randAlphaNum 32)) | b64enc | quote }}
   client-secret: {{ .Values.backstage.auth.clientSecret | b64enc | quote }}
   {{- if eq .Values.backstage.database.type "postgresql" }}
+  {{- if not .Values.backstage.database.postgresql.password }}
+  {{- fail "backstage.database.postgresql.password is required when database type is postgresql and backstage.existingSecret is not set" }}
+  {{- end }}
   postgres-password: {{ .Values.backstage.database.postgresql.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/thunder/update-backstage-hook.yaml
+++ b/install/helm/openchoreo-control-plane/templates/thunder/update-backstage-hook.yaml
@@ -142,7 +142,7 @@ spec:
         - name: BACKSTAGE_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-secrets
+              name: {{ include "openchoreo-control-plane.backstage.secretName" . }}
               key: client-secret
         command:
         - /bin/sh

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -279,6 +279,12 @@
                   "title": "port",
                   "type": "integer"
                 },
+                "ssl": {
+                  "default": false,
+                  "description": "Enable SSL for the PostgreSQL connection (sets PGSSLMODE=require)",
+                  "title": "ssl",
+                  "type": "boolean"
+                },
                 "user": {
                   "default": "backstage",
                   "description": "PostgreSQL username",
@@ -381,6 +387,12 @@
           },
           "title": "env",
           "type": "array"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret containing backstage secrets (backend-secret, client-secret, postgres-password). When set, the chart does not create its own Secret.",
+          "title": "existingSecret",
+          "type": "string"
         },
         "features": {
           "additionalProperties": false,

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1878,6 +1878,13 @@ backstage:
   enabled: true
 
   # @schema
+  # type: string
+  # description: Name of an existing Secret containing backstage secrets (backend-secret, client-secret, postgres-password). When set, the chart does not create its own Secret.
+  # default: ""
+  # @schema
+  existingSecret: ""
+
+  # @schema
   # type: integer
   # description: Number of Backstage replicas
   # minimum: 1
@@ -2600,6 +2607,12 @@ backstage:
       # default: ""
       # @schema
       password: ""
+      # @schema
+      # type: boolean
+      # description: Enable SSL for the PostgreSQL connection (sets PGSSLMODE=require)
+      # default: false
+      # @schema
+      ssl: false
       # @schema
       # type: string
       # description: PostgreSQL database name

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -2465,6 +2465,7 @@ gateway:
 # type: object
 # description: OpenSearch Operator-based cluster configuration (preferred over openSearch Helm chart)
 # @schema
+# Requires OpenSearch Operator (https://github.com/opensearch-project/opensearch-k8s-operator) to be pre-installed
 openSearchCluster:
   # @schema
   # type: boolean


### PR DESCRIPTION
came out of the aws deployment work in #1794. the charts assume secrets are always chart-managed, which doesn't work when you're pulling credentials from Secrets Manager via ESO or similar.

changes:
- new `backstage.existingSecret` value. when set, chart skips creating its Secret and all secretKeyRef point to the external one. expected keys: `backend-secret`, `client-secret`, `postgres-password`
- helper template `backstage.secretName` centralizes the secret name resolution
- `backstage.database.postgresql.ssl` adds `PGSSLMODE=require` env var when true (RDS 17 enforces ssl by default)
- fail validation when postgresql is used without a password and no existingSecret
- opensearch operator prerequisite comment in observability-plane values

for quick start / local dev, leave `existingSecret` empty and everything works as before. for prod, set `existingSecret` to your externally-managed Secret name.

tested with `helm template` for default values, existingSecret override, and ssl=true.

relates to #1794