### PR TITLE
docs: update set-control-plane command examples to use --url flag

### DIFF
--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -719,11 +719,11 @@ This command allows you to:
 		Use:   "set-control-plane",
 		Short: "Configure OpenChoreo API server connection",
 		Long:  "Set the OpenChoreo API server endpoint and authentication details for remote connections.",
-		Example: fmt.Sprintf(`  # Set remote control plane endpoint
-  %[1]s config set-control-plane --endpoint https://api.choreo.example.com --token <your-token>
+		Example: fmt.Sprintf(`  # Set remote control plane url
+  %[1]s config set-control-plane --url https://api.choreo.example.com --token <your-token>
 
   # Set local control plane (for development)
-  %[1]s config set-control-plane --endpoint http://localhost:8080`, messages.DefaultCLIName),
+  %[1]s config set-control-plane --url http://localhost:8080`, messages.DefaultCLIName),
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Update the command examples in the set-control-plane command definition to use the correct --url flag instead of --endpoint, aligning with the actual flag implementation.

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
