### PR TITLE
fix(helm): backstage jenkins configuration missing issue

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/configmap-ci.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/configmap-ci.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.backstage.enabled }}
-{{- if .Values.backstage.externalCI.jenkins.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,5 +15,4 @@ data:
       baseUrl: ${JENKINS_BASE_URL}
       username: ${JENKINS_USERNAME}
       apiKey: ${JENKINS_API_KEY}
-{{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -47,13 +47,13 @@ spec:
       - name: backstage
         image: "{{ .Values.backstage.image.repository }}:{{ .Values.backstage.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.backstage.image.pullPolicy }}
-        {{- if .Values.backstage.externalCI.jenkins.enabled }}
         args:
         - "node"
         - "packages/backend"
         - "--config"
+        - "app-config.yaml"
+        - "--config"
         - "app-config.ci.yaml"
-        {{- end }}
         ports:
         - containerPort: 7007
           name: http
@@ -109,7 +109,6 @@ spec:
           value: {{ .Values.security.authz.enabled | quote }}
         # External CI Platform Integrations
         # Jenkins: requires jenkins.io/job-full-name annotation on entity
-        {{- if .Values.backstage.externalCI.jenkins.enabled }}
         - name: JENKINS_BASE_URL
           value: {{ .Values.backstage.externalCI.jenkins.baseUrl | quote }}
         - name: JENKINS_USERNAME
@@ -119,7 +118,6 @@ spec:
             secretKeyRef:
               name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-secrets
               key: jenkins-api-key
-        {{- end }}
         # Database configuration
         {{- if eq .Values.backstage.database.type "sqlite" }}
         - name: DATABASE_CLIENT
@@ -157,7 +155,7 @@ spec:
           httpGet:
             path: /healthcheck
             port: http
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
         resources:
           {{- toYaml .Values.backstage.resources | nindent 12 }}
@@ -170,12 +168,10 @@ spec:
         - name: backstage-db
           mountPath: {{ .Values.backstage.database.sqlite.mountPath }}
         {{- end }}
-        {{- if .Values.backstage.externalCI.jenkins.enabled }}
         - name: ci-config
           mountPath: /app/app-config.ci.yaml
           subPath: app-config.ci.yaml
           readOnly: true
-        {{- end }}
       volumes:
       {{- if eq .Values.backstage.database.type "sqlite" }}
       - name: backstage-db
@@ -186,9 +182,7 @@ spec:
         emptyDir: {}
         {{- end }}
       {{- end }}
-      {{- if .Values.backstage.externalCI.jenkins.enabled }}
       - name: ci-config
         configMap:
           name: {{ include "openchoreo-control-plane.fullname" . }}-backstage-ci-config
-      {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/secret.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/secret.yaml
@@ -18,7 +18,5 @@ data:
   postgres-password: {{ .Values.backstage.database.postgresql.password | b64enc | quote }}
   {{- end }}
   # External CI Platform Secrets
-  {{- if .Values.backstage.externalCI.jenkins.enabled }}
   jenkins-api-key: {{ .Values.backstage.externalCI.jenkins.apiKey | b64enc | quote }}
-  {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2091,19 +2091,19 @@ backstage:
       # description: Jenkins server base URL (e.g., https://jenkins.example.com)
       # default: ""
       # @schema
-      baseUrl: ""
+      baseUrl: "https://jenkins.example.com"
       # @schema
       # type: string
       # description: Jenkins username for API authentication
       # default: ""
       # @schema
-      username: ""
+      username: "jenkins-user"
       # @schema
       # type: string
       # description: Jenkins API key/token for authentication
       # default: ""
       # @schema
-      apiKey: ""
+      apiKey: "jenkins-api-key"
 
   # @schema
   # type: array


### PR DESCRIPTION
This pull request simplifies the Helm chart templates for the Backstage deployment by removing conditional blocks around Jenkins CI integration. Now, Jenkins-related configuration, secrets, and mounts are always included if present in values, regardless of the `.Values.backstage.externalCI.jenkins.enabled` flag. Additionally, default Jenkins values are set in `values.yaml`, making it easier to configure Jenkins integration.

Configuration simplification:

* Removed all `if .Values.backstage.externalCI.jenkins.enabled` conditionals from `configmap-ci.yaml`, `deployment.yaml`, and `secret.yaml`, so Jenkins-related configuration is always included if values are set. [[1]](diffhunk://#diff-8e9c06111130b2d9ba05712bd2c54b8840d606d19f056d3ea136bf34184e95a0L2) [[2]](diffhunk://#diff-8e9c06111130b2d9ba05712bd2c54b8840d606d19f056d3ea136bf34184e95a0L20) [[3]](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aL50-L56) [[4]](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aL112) [[5]](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aL122) [[6]](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aL173-L178) [[7]](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aL189-L194) [[8]](diffhunk://#diff-b15c989c1cb9ba1b38ac74db616d516a85445f08fd6c7b19a6561d0cec2e0f40L21-L24)

Default Jenkins values:

* Set default values for Jenkins `baseUrl`, `username`, and `apiKey` in `values.yaml` to provide example configuration and simplify setup.