### PR TITLE
fix: update single cluster setup value yamls

### DIFF
--- a/install/k3d/single-cluster/values-bp.yaml
+++ b/install/k3d/single-cluster/values-bp.yaml
@@ -19,10 +19,6 @@ global:
     buildpackCache:
       enabled: true
 
-# Disable External Secrets since it's already in the Data Plane (single cluster)
-external-secrets:
-  enabled: false
-
 # Disable Fluent Bit for Build Plane in single-cluster mode
 # Reason: Data Plane FluentBit (DaemonSet on all nodes) already collects logs from ALL namespaces,
 # including openchoreo-build-plane and openchoreo-ci-* (Argo Workflows build jobs).

--- a/install/k3d/single-cluster/values-dp.yaml
+++ b/install/k3d/single-cluster/values-dp.yaml
@@ -15,7 +15,3 @@ gateway:
 # Reuse the existing control plane's cluster gateway controller
 gatewayController:
   enabled: false
-
-# External Secrets Operator configuration
-external-secrets:
-  enabled: true

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -25,10 +25,6 @@ openSearchDashboards:
   service:
     type: LoadBalancer
 
-# Disable External Secrets since it's already in the Data Plane (single cluster)
-external-secrets:
-  enabled: false
-
 fakeSecretStore:
   enabled: false
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

This pull request removes configuration blocks related to the `external-secrets` operator from several values files in the single-cluster installation setup. The main focus is to clean up redundant or unnecessary `external-secrets` settings, as the operator is already managed in the Data Plane. This helps simplify the configuration and avoids confusion about where `external-secrets` should be enabled.

Configuration cleanup:

* Removed the `external-secrets` block from `install/k3d/single-cluster/values-bp.yaml`, clarifying that it is managed in the Data Plane.
* Removed the `external-secrets` block from `install/k3d/single-cluster/values-dp.yaml`, as it is not needed in the Gateway Controller configuration.
* Removed the `external-secrets` block from `install/k3d/single-cluster/values-op.yaml`, since it is already present in the Data Plane.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
