### PR TITLE
fix: add allowedTraits to sample component types

### DIFF
--- a/samples/component-types/component-with-api-management/component-with-api-management.yaml
+++ b/samples/component-types/component-with-api-management/component-with-api-management.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   workloadType: deployment
 
+  allowedTraits:
+    - api-configuration
+
   schema:
     parameters:
       replicas: "integer | default=1"

--- a/samples/component-types/component-with-traits/component-with-traits.yaml
+++ b/samples/component-types/component-with-traits/component-with-traits.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   workloadType: deployment
 
+  allowedTraits:
+    - persistent-volume
+    - emptydir-volume
+
   schema:
     parameters:
       replicas: "integer | default=1"


### PR DESCRIPTION
This pull request updates the component type YAML files to explicitly specify which traits are allowed for each component. This helps clarify trait usage and enforces trait restrictions at the component definition level.

Trait configuration updates:

* [`component-with-api-management.yaml`](diffhunk://#diff-7d26d0d1db6f3789785294b51a6cf26f886463d86da63acd0361037bd67ade7cR10-R12): Added `allowedTraits` section with the `api-configuration` trait to indicate that only this trait is permitted for this component.
* [`component-with-traits.yaml`](diffhunk://#diff-739a40957d09d8664a635799d1cfbdc05860ce71e1442e3a347383e6497c6ccaR9-R12): Added `allowedTraits` section with `persistent-volume` and `emptydir-volume` traits to restrict this component to these storage-related traits.