### PR TITLE
fix: add backstage.extraEnv for custom env vars

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -59,8 +59,8 @@ spec:
           name: http
           protocol: TCP
         env:
-        {{- if .Values.backstage.env }}
-        {{- toYaml .Values.backstage.env | nindent 8 }}
+        {{- with (concat (.Values.backstage.env | default list) (.Values.backstage.extraEnv | default list)) }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: OPENCHOREO_API_URL
           value: {{ .Values.backstage.openchoreoApi.url | default (printf "http://%s-api.%s.svc.cluster.local:8080/api/v1" (include "openchoreo-control-plane.fullname" .) .Release.Namespace) }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -436,6 +436,25 @@
           "title": "externalCI",
           "type": "object"
         },
+        "extraEnv": {
+          "description": "Additional environment variables to merge with the default env array. Use this instead of overriding backstage.env to avoid sparse array issues with --set.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Environment variable name",
+                "type": "string"
+              },
+              "value": {
+                "description": "Environment variable value",
+                "type": "string"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "title": "extraEnv",
+          "type": "array"
+        },
         "features": {
           "additionalProperties": false,
           "description": "Feature flags for enabling/disabling OpenChoreo features in Backstage",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2127,6 +2127,21 @@ backstage:
       value: "7007"
 
   # @schema
+  # type: array
+  # description: Additional environment variables to merge with the default env array. Use this instead of overriding backstage.env to avoid sparse array issues with --set.
+  # items:
+  #   type: object
+  #   properties:
+  #     name:
+  #       type: string
+  #       description: Environment variable name
+  #     value:
+  #       type: string
+  #       description: Environment variable value
+  # @schema
+  extraEnv: []
+
+  # @schema
   # type: string
   # description: Backstage public base URL. If empty, auto-derived from global.baseDomain
   # default: ""


### PR DESCRIPTION
fixes sparse array problem when adding env vars via `--set`

when users do `--set 'backstage.env[3].name=FOO'`, helm creates `[null, null, null, {name: FOO}]` which fails schema validation. instead of making users track the default array length, added `backstage.extraEnv` that gets concatenated with `backstage.env` in the deployment template.

changes:
- added `backstage.extraEnv` field (default `[]`) to values.yaml
- deployment template now uses `concat` to merge both arrays
- removed the NODE_TLS_REJECT_UNAUTHORIZED default (was wrong approach)
- regenerated values.schema.json

usage: `--set 'backstage.extraEnv[0].name=NODE_TLS_REJECT_UNAUTHORIZED' --set 'backstage.extraEnv[0].value=0'`