### PR TITLE
fix: add gateway crd install step to quick start

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -544,6 +544,12 @@ install_eso() {
         "--set" "installCRDs=true"
 }
 
+install_gateway_crds() {
+    log_info "Installing Gateway CRDs...."
+    
+    kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+}
+
 # Install OpenChoreo Control Plane
 install_control_plane() {
     log_info "Installing OpenChoreo Control Plane..."

--- a/install/quick-start/install.sh
+++ b/install/quick-start/install.sh
@@ -106,6 +106,9 @@ install_cert_manager
 # Step 3.5: Install External Secrets Operator (prerequisite for secret management)
 install_eso
 
+# Step 3.6: Install Gateway CRDs
+install_gateway_crds
+
 # Step 4: Install OpenChoreo Control Plane
 install_control_plane
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request adds the installation of Gateway CRDs as part of the setup process for the quick start installation script. The most important changes are:

**Gateway CRDs Installation:**

* Added a new function `install_gateway_crds` in `.helpers.sh` to install Gateway CRDs using `kubectl` and the official Gateway API release.
* Updated `install.sh` to call `install_gateway_crds` as a new step (Step 3.6) in the installation sequence, immediately after installing the External Secrets Operator.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
