### PR TITLE
fix: add namespace to embedded traits sample hostname

### DIFF
--- a/samples/component-types/component-with-embedded-traits/README.md
+++ b/samples/component-types/component-with-embedded-traits/README.md
@@ -104,7 +104,7 @@ kubectl get releasebinding demo-app-with-embedded-traits-development -o yaml | g
 Once deployed, test the greeter service:
 
 ```bash
-curl http://development.openchoreoapis.localhost:19080/demo-app-with-embedded-traits-development-<hash>/greeter/greet
+curl http://default.development.openchoreoapis.localhost:19080/demo-app-with-embedded-traits-development-d47a92df/greeter/greet
 ```
 
 Output:
@@ -114,18 +114,13 @@ Hello, Stranger!
 
 With a name parameter:
 ```bash
-curl "http://development.openchoreoapis.localhost:19080/demo-app-with-embedded-traits-development-<hash>/greeter/greet?name=Alice"
+curl "curl http://default.development.openchoreoapis.localhost:19080/demo-app-with-embedded-traits-development-d47a92df/greeter/greet?name=Alice"
 ```
 
 Output:
 ```text
 Hello, Alice!
 ```
-
-> **Note**: Replace `<hash>` with the actual hash from your deployment. You can find it by running:
-> ```bash
-> kubectl get releasebinding demo-app-with-embedded-traits-development -o jsonpath='{.status.release.name}'
-> ```
 
 ## Key Features Demonstrated
 

--- a/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+++ b/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
@@ -241,7 +241,7 @@ spec:
             - name: gateway-default
               namespace: openchoreo-data-plane
           hostnames:
-            - ${metadata.environmentName}.${dataplane.publicVirtualHost}
+            - ${metadata.componentNamespace}.${metadata.environmentName}.${dataplane.publicVirtualHost}
           rules:
           - matches:
             - path:
@@ -342,5 +342,5 @@ spec:
   traitOverrides:
     # Override persistent volume size for dev
     data-storage:
-      size: "1Gi"
+      size: "10Mi"
       storageClass: "local-path"


### PR DESCRIPTION
This pull request updates the sample for the "component with embedded traits" to improve accuracy and usability in both the YAML configuration and the documentation. The changes include correcting hostnames in the gateway definition, adjusting storage size for development, and updating example commands and instructions in the README for clarity.

**YAML configuration improvements:**

* Updated the `hostnames` field in the `component-with-embedded-traits.yaml` file to include the component namespace, ensuring the generated hostname is more specific and accurate.
* Reduced the persistent volume size in the development override from `1Gi` to `10Mi` to make local testing more lightweight and resource-efficient.

**Documentation updates:**

* Updated example `curl` commands in `README.md` to use a concrete hash and the correct fully qualified hostname, making the examples copy-paste ready and reducing confusion for users. [[1]](diffhunk://#diff-6ce1fc9971c7a096522527b0b4862f4f882d80e34fe917953325a544c5d50cd7L107-R107) [[2]](diffhunk://#diff-6ce1fc9971c7a096522527b0b4862f4f882d80e34fe917953325a544c5d50cd7L117-L129)
* Removed outdated instructions about replacing the hash in the example commands, since the examples now use a specific value.