### PR TITLE
chore(deps): update thunder key manager issuer in api platform gateway

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/api-platform/configuration.yaml
+++ b/install/helm/openchoreo-data-plane/templates/api-platform/configuration.yaml
@@ -302,7 +302,7 @@ data:
           jwtauth_v010:
             keymanagers:
             - name: ThunderKeyManager
-              issuer: thunder
+              issuer: http://thunder.openchoreo.localhost:8080
               jwks:
                 remote:
                   uri: http://thunder-service.openchoreo-control-plane:8090/oauth2/jwks


### PR DESCRIPTION
## Purpose
This PR updates the WSO2 API platform gateway Thunder key manager issuer name. Previously Thunder used the issuer name as `thunder` and with the recent Thunder version upgrades, they have switched to `http://thunder.openchoreo.localhost:8080`.

## Approach
Update the issuer name in Thunder key manager.