### PR TITLE
feat(deps): bump thunder version to 0.21.0

### DIFF
--- a/install/helm/openchoreo-control-plane/Chart.lock
+++ b/install/helm/openchoreo-control-plane/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: v2.1.1
 - name: thunder
   repository: oci://ghcr.io/asgardeo/helm-charts
-  version: 0.20.0
-digest: sha256:32ec57ecd67999370c910f8fa1b631abb72a0d849793b006e2f3894aaa9e392e
-generated: "2026-02-04T02:00:13.40181+05:30"
+  version: 0.21.0
+digest: sha256:34673b9592429a400089c079ee2d757b416a3a110237cf5478d4759c46a00a2e
+generated: "2026-02-07T08:31:30.066886+05:30"

--- a/install/helm/openchoreo-control-plane/Chart.yaml
+++ b/install/helm/openchoreo-control-plane/Chart.yaml
@@ -36,4 +36,4 @@ dependencies:
   - name: thunder
     condition: thunder.enabled
     repository: oci://ghcr.io/asgardeo/helm-charts
-    version: "0.20.0"
+    version: "0.21.0"

--- a/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/thunder/bootstrap-scripts-configmap.yaml
@@ -181,14 +181,8 @@ data:
       "name": "Backstage",
       "description": "OpenChoreo Backstage Portal",
       "allowed_user_types": ["engineer"],
-      "token": {
-        "validity_period": 3600,
-        "user_attributes": [
-            "given_name",
-            "family_name",
-            "username",
-            "groups"
-        ]
+      "assertion": {
+        "validity_period": 3600
       },
       "inbound_auth_config": [
         {
@@ -422,14 +416,8 @@ data:
       "name": "OpenChoreo CLI",
       "description": "OpenChoreo CLI Default Application",
       "allowed_user_types": ["engineer"],
-      "token": {
-        "validity_period": 3600,
-        "user_attributes": [
-            "given_name",
-            "family_name",
-            "username",
-            "groups"
-        ]
+      "assertion": {
+        "validity_period": 3600
       },
       "inbound_auth_config": [
         {

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -4755,7 +4755,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "0.20.0",
+                  "default": "0.21.0",
                   "description": "Image tag",
                   "title": "tag",
                   "type": "string"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2893,13 +2893,13 @@ thunder:
       repository: thunder
       # type: string
       # description: Image tag
-      # default: "0.20.0"
+      # default: "0.21.0"
       # @schema
       # type: string
       # description: Image tag
-      # default: "0.20.0"
+      # default: "0.21.0"
       # @schema
-      tag: "0.20.0"
+      tag: "0.21.0"
       # description: Image pull policy
       # enum: [Always, IfNotPresent, Never]
       # default: IfNotPresent


### PR DESCRIPTION
This pull request updates the `thunder` dependency and configuration in the OpenChoreo control plane Helm chart, primarily to upgrade to version 0.21.0 and adjust related bootstrap script authentication structures. The most important changes are grouped below by theme.

Dependency and version updates:

* Upgraded the `thunder` Helm chart dependency version from 0.20.0 to 0.21.0 in `Chart.yaml`, and updated the default image tag to 0.21.0 in both `values.yaml` and `values.schema.json`. [[1]](diffhunk://#diff-abdfd953259713210d8ec5da4c15cfd2fb888bc46280972d8a4568e488edbeb2L39-R39) [[2]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L2896-R2902) [[3]](diffhunk://#diff-5c7308e4dd394e2a981e27c2748ac12e889689b0bf906e3a4e87402b34b535e8L4758-R4758)

Authentication structure changes:

* Replaced the `token` field with an `assertion` field in the bootstrap scripts config map for the Backstage portal and OpenChoreo CLI applications, removing the `user_attributes` subfield and retaining only the `validity_period`. [[1]](diffhunk://#diff-ac2d192cdee0606a272d6be38bc972c2885662d9c4121cfa5b3ec761fc4d429fL184-R185) [[2]](diffhunk://#diff-ac2d192cdee0606a272d6be38bc972c2885662d9c4121cfa5b3ec761fc4d429fL425-R420)