### PR TITLE
fix(cli): preserve workload fields when updating container image

### DIFF
--- a/internal/occ/fsmode/index.go
+++ b/internal/occ/fsmode/index.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	typed2 "github.com/openchoreo/openchoreo/internal/occ/fsmode/typed"
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode/typed"
 	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
 )
 
@@ -216,39 +216,39 @@ func (idx *Index) ListReleases() []*index.ResourceEntry {
 }
 
 // GetTypedComponent retrieves a component by namespace and name and returns a typed wrapper
-func (idx *Index) GetTypedComponent(namespace, name string) (*typed2.Component, error) {
+func (idx *Index) GetTypedComponent(namespace, name string) (*typed.Component, error) {
 	entry, ok := idx.GetComponent(namespace, name)
 	if !ok {
 		return nil, fmt.Errorf("component %q not found in namespace %q", name, namespace)
 	}
-	return typed2.NewComponent(entry)
+	return typed.NewComponent(entry)
 }
 
 // GetTypedComponentType retrieves a component type by name and returns a typed wrapper
-func (idx *Index) GetTypedComponentType(name string) (*typed2.ComponentType, error) {
+func (idx *Index) GetTypedComponentType(name string) (*typed.ComponentType, error) {
 	entry, ok := idx.GetComponentType(name)
 	if !ok {
 		return nil, fmt.Errorf("component type %q not found", name)
 	}
-	return typed2.NewComponentType(entry)
+	return typed.NewComponentType(entry)
 }
 
 // GetTypedTrait retrieves a trait by name and returns a typed wrapper
-func (idx *Index) GetTypedTrait(name string) (*typed2.Trait, error) {
+func (idx *Index) GetTypedTrait(name string) (*typed.Trait, error) {
 	entry, ok := idx.GetTrait(name)
 	if !ok {
 		return nil, fmt.Errorf("trait %q not found", name)
 	}
-	return typed2.NewTrait(entry)
+	return typed.NewTrait(entry)
 }
 
 // GetTypedWorkloadForComponent retrieves the workload for a specific component and returns a typed wrapper
-func (idx *Index) GetTypedWorkloadForComponent(projectName, componentName string) (*typed2.Workload, error) {
+func (idx *Index) GetTypedWorkloadForComponent(projectName, componentName string) (*typed.Workload, error) {
 	entry, ok := idx.GetWorkloadForComponent(projectName, componentName)
 	if !ok {
 		return nil, fmt.Errorf("workload for component %q (project: %q) not found", componentName, projectName)
 	}
-	return typed2.NewWorkload(entry)
+	return typed.NewWorkload(entry)
 }
 
 // ListReleasesForComponent returns all component releases for a specific component


### PR DESCRIPTION
## Purpose
When running `occ workload create` in file-system mode without a --descriptor flag, the command was replacing the entire existing workload.yaml with a minimal workload containing only the image and owner fields. This caused env vars, endpoints, connections, and other configuration to be lost.
                                                                                                                                
Now, if a workload already exists for the component and no descriptor is provided, the command reads the existing workload and updates only the container image, preserving all other fields.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

### Overview
This PR adds file-system mode support to the `occ workload create` command to preserve existing workload configuration when updating container images, preventing loss of environment variables, endpoints, connections, and other fields.

### Changed Files Breakdown by Top-Level Folder
| Folder | Files | Changes |
|--------|-------|---------|
| internal/ | 2 | +469 lines |
| **Total** | **2** | **+469 lines** |

**Specifics:**
- `internal/occ/cmd/workload/workload.go` - NEW file (158 lines, +36/-8 functional)
- `internal/occ/fsmode/index.go` - NEW file (311 lines)

### Key Implementation Changes

**1. Workload Creation Logic (`internal/occ/cmd/workload/workload.go`)**
- Introduces conditional routing between API server mode and file-system mode based on stored configuration
- **File-system mode behavior (core fix):**
  - When no descriptor provided (`FilePath == ""`): Checks if workload already exists for the component
  - If exists: **Reads existing workload and updates only the `main` container image**, preserving all other fields (env vars, endpoints, connections, configured traits)
  - If not exists: Generates new minimal workload CR from scratch
- API server mode remains unchanged (delegates to `kinds.NewWorkloadResource`)

**2. Index Wrapper (`internal/occ/fsmode/index.go`)**
- New `Index` type wraps generic filesystem index with OpenChoreo-specific functionality
- Maintains specialized in-memory maps: `workloadsByComponent`, `componentsByProject`, `componentTypes`, `traits`, `releasesByComponent`, `releaseBindingsByEnv`, `deploymentPipelines`
- Provides `GetWorkloadForComponent()` method used by workload creation to detect existing workloads
- Thread-safe with mutex locks for concurrent access

### API/CRD Surface Changes
**Status: NONE** - No changes to OpenChoreo API types or Workload CRD structure
- Workload CRD schema remains unchanged
- Changes are purely CLI implementation layer
- **Compatibility Risk: LOW** - Purely internal CLI enhancement, no API/RBAC surface impact

### Tests Added/Updated
**Critical Gap Identified:**
- ✗ **No new tests added** for the file-system mode workload creation logic
- ✗ **No tests for the index wrapper** functionality
- Only existing test file touched: None (but `internal/occ/fsmode/config/release_config_test.go` exists)
- **Missing test coverage:** 
  - File-system mode creation with existing workload
  - File-system mode creation with new workload
  - Container image update on existing workload
  - Preservation of env vars/endpoints/connections
  - Error case: workload with no "main" container

### Risk Hotspots

| Risk Area | Severity | Details |
|-----------|----------|---------|
| **Container assumption** | MEDIUM | Code hardcodes "main" container lookup; fails if not present. No validation that containers map is non-empty before access. |
| **Test coverage gap** | HIGH | Core logic paths lack automated tests, increasing regression risk for file-system mode users. |
| **Unvalidated config load** | LOW | `config.LoadStoredConfig()` errors silently fall back to API mode; unclear if this is intended behavior. |
| **Reconciliation safety** | LOW | Existing workload read/update logic assumes file consistency; no transactional guarantees or conflict detection. |

### Verification
- ✓ No RBAC/AuthZ changes required
- ✓ No secrets or credential handling
- ✓ No install/upgrade path modifications
- ✓ Backward compatible (API server mode unchanged)
- ✗ Sample files unchanged (no demonstration of new functionality)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->