### PR TITLE
chore: handle additional authorization errors in the new handlers path

### DIFF
--- a/internal/openchoreo-api/api/handlers/authz.go
+++ b/internal/openchoreo-api/api/handlers/authz.go
@@ -34,6 +34,9 @@ func (h *Handler) ListActions(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListActions403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.ListActions403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		return gen.ListActions500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
@@ -70,6 +73,9 @@ func (h *Handler) Evaluate(
 	decision, err := h.services.AuthzService.Evaluate(ctx, evalReq)
 	if err != nil {
 		h.logger.Error("Failed to evaluate", "error", err)
+		if errors.Is(err, authz.ErrInvalidRequest) {
+			return gen.Evaluate400JSONResponse{BadRequestJSONResponse: badRequest(err.Error())}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.Evaluate400JSONResponse{BadRequestJSONResponse: badRequest(services.ErrForbidden.Error())}, nil
 		}
@@ -128,6 +134,9 @@ func (h *Handler) BatchEvaluate(
 	batchResp, err := h.services.AuthzService.BatchEvaluate(ctx, batchReq)
 	if err != nil {
 		h.logger.Error("Failed to batch evaluate", "error", err)
+		if errors.Is(err, authz.ErrInvalidRequest) {
+			return gen.BatchEvaluate400JSONResponse{BadRequestJSONResponse: badRequest(err.Error())}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.BatchEvaluate400JSONResponse{BadRequestJSONResponse: badRequest(services.ErrForbidden.Error())}, nil
 		}
@@ -179,6 +188,9 @@ func (h *Handler) GetSubjectProfile(
 	profile, err := h.services.AuthzService.GetSubjectProfile(ctx, profileReq)
 	if err != nil {
 		h.logger.Error("Failed to get subject profile", "error", err)
+		if errors.Is(err, authz.ErrInvalidRequest) {
+			return gen.GetSubjectProfile400JSONResponse{BadRequestJSONResponse: badRequest(err.Error())}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.GetSubjectProfile403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
@@ -301,6 +313,9 @@ func (h *Handler) ListClusterRoles(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListClusterRoles403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.ListClusterRoles403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		return gen.ListClusterRoles500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
@@ -344,6 +359,9 @@ func (h *Handler) CreateClusterRole(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.CreateClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.CreateClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrRoleAlreadyExists) {
 			return gen.CreateClusterRole409JSONResponse{ConflictJSONResponse: conflict("Cluster role already exists")}, nil
 		}
@@ -370,6 +388,9 @@ func (h *Handler) GetClusterRole(
 	if err != nil {
 		h.logger.Error("Failed to get cluster role", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.GetClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.GetClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		if errors.Is(err, services.ErrRoleNotFound) {
@@ -409,6 +430,9 @@ func (h *Handler) UpdateClusterRole(
 	err := h.services.AuthzService.UpdateRole(ctx, role)
 	if err != nil {
 		h.logger.Error("Failed to update cluster role", "error", err)
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.UpdateClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.UpdateClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
@@ -439,6 +463,9 @@ func (h *Handler) DeleteClusterRole(
 	if err != nil {
 		h.logger.Error("Failed to delete cluster role", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.DeleteClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.DeleteClusterRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		if errors.Is(err, services.ErrRoleNotFound) {
@@ -473,6 +500,9 @@ func (h *Handler) ListClusterRoleBindings(
 	if err != nil {
 		h.logger.Error("Failed to list cluster role bindings", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.ListClusterRoleBindings403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.ListClusterRoleBindings403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.ListClusterRoleBindings500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
@@ -536,6 +566,9 @@ func (h *Handler) CreateClusterRoleBinding(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.CreateClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.CreateClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrRoleBindingAlreadyExists) {
 			return gen.CreateClusterRoleBinding409JSONResponse{ConflictJSONResponse: conflict("Cluster role binding already exists")}, nil
 		}
@@ -580,6 +613,9 @@ func (h *Handler) GetClusterRoleBinding(
 		}
 		if errors.Is(err, services.ErrRoleBindingNotFound) {
 			return gen.GetClusterRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Cluster role binding")}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.GetClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.GetClusterRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
@@ -628,11 +664,17 @@ func (h *Handler) UpdateClusterRoleBinding(
 	err := h.services.AuthzService.UpdateRoleMapping(ctx, mapping)
 	if err != nil {
 		h.logger.Error("Failed to update cluster role binding", "error", err)
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.UpdateClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.UpdateClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		if errors.Is(err, services.ErrRoleBindingNotFound) {
 			return gen.UpdateClusterRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Cluster role binding")}, nil
+		}
+		if errors.Is(err, authz.ErrCannotModifySystemMapping) {
+			return gen.UpdateClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.UpdateClusterRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
@@ -670,8 +712,14 @@ func (h *Handler) DeleteClusterRoleBinding(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.DeleteClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.DeleteClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrRoleBindingNotFound) {
 			return gen.DeleteClusterRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Cluster role binding")}, nil
+		}
+		if errors.Is(err, authz.ErrCannotDeleteSystemMapping) {
+			return gen.DeleteClusterRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.DeleteClusterRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
@@ -691,6 +739,9 @@ func (h *Handler) ListNamespaceRoles(
 	if err != nil {
 		h.logger.Error("Failed to list namespace roles", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.ListNamespaceRoles403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.ListNamespaceRoles403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.ListNamespaceRoles500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
@@ -737,6 +788,9 @@ func (h *Handler) CreateNamespaceRole(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.CreateNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.CreateNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrRoleAlreadyExists) {
 			return gen.CreateNamespaceRole409JSONResponse{ConflictJSONResponse: conflict("Namespace role already exists")}, nil
 		}
@@ -764,6 +818,9 @@ func (h *Handler) GetNamespaceRole(
 	if err != nil {
 		h.logger.Error("Failed to get namespace role", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.GetNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.GetNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		if errors.Is(err, services.ErrRoleNotFound) {
@@ -804,6 +861,9 @@ func (h *Handler) UpdateNamespaceRole(
 	err := h.services.AuthzService.UpdateRole(ctx, role)
 	if err != nil {
 		h.logger.Error("Failed to update namespace role", "error", err)
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.UpdateNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.UpdateNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
@@ -835,6 +895,9 @@ func (h *Handler) DeleteNamespaceRole(
 	if err != nil {
 		h.logger.Error("Failed to delete namespace role", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.DeleteNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.DeleteNamespaceRole403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		if errors.Is(err, services.ErrRoleNotFound) {
@@ -875,6 +938,9 @@ func (h *Handler) ListNamespaceRoleBindings(
 	if err != nil {
 		h.logger.Error("Failed to list namespace role bindings", "error", err)
 		if errors.Is(err, services.ErrForbidden) {
+			return gen.ListNamespaceRoleBindings403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
 			return gen.ListNamespaceRoleBindings403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.ListNamespaceRoleBindings500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
@@ -971,6 +1037,9 @@ func (h *Handler) CreateNamespaceRoleBinding(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.CreateNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.CreateNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrRoleBindingAlreadyExists) {
 			return gen.CreateNamespaceRoleBinding409JSONResponse{ConflictJSONResponse: conflict("Namespace role binding already exists")}, nil
 		}
@@ -1016,6 +1085,9 @@ func (h *Handler) GetNamespaceRoleBinding(
 		}
 		if errors.Is(err, services.ErrRoleBindingNotFound) {
 			return gen.GetNamespaceRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Namespace role binding")}, nil
+		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.GetNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		return gen.GetNamespaceRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
@@ -1079,6 +1151,9 @@ func (h *Handler) UpdateNamespaceRoleBinding(
 
 	err := h.services.AuthzService.UpdateRoleMapping(ctx, mapping)
 	if err != nil {
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.UpdateNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrForbidden) {
 			h.logger.Warn("Unauthorized to update namespace role binding", "binding", request.Name)
 			return gen.UpdateNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
@@ -1086,6 +1161,9 @@ func (h *Handler) UpdateNamespaceRoleBinding(
 		if errors.Is(err, services.ErrRoleBindingNotFound) {
 			h.logger.Warn("Namespace role binding not found", "binding", request.Name)
 			return gen.UpdateNamespaceRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Namespace role binding")}, nil
+		}
+		if errors.Is(err, authz.ErrCannotModifySystemMapping) {
+			return gen.UpdateNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		h.logger.Error("Failed to update namespace role binding", "error", err)
 		return gen.UpdateNamespaceRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
@@ -1125,9 +1203,15 @@ func (h *Handler) DeleteNamespaceRoleBinding(
 			h.logger.Warn("Unauthorized to delete namespace role binding", "binding", request.Name)
 			return gen.DeleteNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
+		if errors.Is(err, authz.ErrAuthzDisabled) {
+			return gen.DeleteNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
 		if errors.Is(err, services.ErrRoleBindingNotFound) {
 			h.logger.Warn("Namespace role binding not found", "binding", request.Name)
 			return gen.DeleteNamespaceRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Namespace role binding")}, nil
+		}
+		if errors.Is(err, authz.ErrCannotDeleteSystemMapping) {
+			return gen.DeleteNamespaceRoleBinding403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
 		h.logger.Error("Failed to delete namespace role binding", "error", err)
 		return gen.DeleteNamespaceRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request enhances error handling in the `internal/openchoreo-api/api/handlers/authz.go` file by adding checks for new authorization-related error types and ensuring appropriate HTTP responses are returned. 

Error handling improvements for authorization:

* Added checks for `authz.ErrAuthzDisabled` across all role and role binding handlers to return a 403 Forbidden response when authorization is disabled. [[1]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R37-R39) [[2]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R316-R318) [[3]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R362-R364) [[4]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R393-R395) [[5]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R433-R435) [[6]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R468-R470) [[7]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R505-R507) [[8]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R569-R571) [[9]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R617-R619) [[10]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R667-R678) [[11]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R715-R723) [[12]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R744-R746) [[13]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R791-R793) [[14]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R823-R825) [[15]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R864-R866) [[16]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R900-R902) [[17]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R943-R945) [[18]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R1040-R1042) [[19]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R1089-R1091) [[20]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R1154-R1156) [[21]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R1206-R1215)
* Added handling for `authz.ErrInvalidRequest` in `Evaluate`, `BatchEvaluate`, and `GetSubjectProfile` to return a 400 Bad Request response when the request is invalid. [[1]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R76-R78) [[2]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R137-R139) [[3]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R191-R193)

System mapping protection enhancements:

* Added checks for `authz.ErrCannotModifySystemMapping` and `authz.ErrCannotDeleteSystemMapping` in update and delete role binding handlers to return a 403 Forbidden response when attempting to modify or delete protected system mappings. [[1]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R667-R678) [[2]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R715-R723) [[3]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R1165-R1167) [[4]](diffhunk://#diff-662ddd89d2da8b4ae37a964ecfcd1b6f20700040c9787dd2eb1984b3f8be47c1R1206-R1215)

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1855

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## File Changes Breakdown
- **1 file changed**: `internal/openchoreo-api/api/handlers/authz.go` (1,222 lines added)
- **Directory distribution**: All changes in `internal/openchoreo-api/api/handlers/` (API layer, new path distinct from legacy handlers)

## API/CRD Surface Changes
- **Zero breaking changes**: Error handling additions only; no API contract modifications
- **HTTP Status Codes added**:
  - `403 Forbidden` for `authz.ErrAuthzDisabled` (20 endpoints)
  - `400 Bad Request` for `authz.ErrInvalidRequest` (4 endpoints)
  - `403 Forbidden` for `authz.ErrCannotModifySystemMapping` and `authz.ErrCannotDeleteSystemMapping` (2 endpoints)
- **Compatibility risk**: Low—purely defensive error handling for existing authorization service errors

## Scope of Error Handling Coverage
**28 error check additions** across 25 authorization handler functions:
- **Evaluation endpoints**: Evaluate, BatchEvaluate, GetSubjectProfile (invalid request checks)
- **Action/User Type endpoints**: ListActions, ListUserTypes (authz disabled checks)
- **Cluster-level RBAC** (5 role + 5 role-binding handlers): Protection against disabled authz and system mapping modifications
- **Namespace-level RBAC** (5 role + 5 role-binding handlers): Identical protection pattern

## Tests: Coverage Gap
- **Tests added**: 0
- **Critical path gaps**: All new error paths lack test coverage
  - No unit tests for `ErrAuthzDisabled` 403 responses
  - No unit tests for `ErrInvalidRequest` 400 responses
  - No unit tests for system mapping protection (`ErrCannotModify`/`ErrCannotDelete`)
  - Existing test file (`internal/openchoreo-api/config/security_test.go`) covers configuration validation only, not handler behavior

## Risk Hotspots
1. **Authorization/RBAC (HIGH)**: 28 new error checks introduce authorization state transitions; relies on underlying `authz.ErrAuthzDisabled`, `ErrInvalidRequest` error types being correctly raised by `AuthzService`—untested in this PR
2. **System Mapping Protection (HIGH)**: Two new checks (`ErrCannotModifySystemMapping`, `ErrCannotDeleteSystemMapping`) prevent mutations of system-managed role bindings; no integration tests validating protection behavior
3. **New Handler Path (MEDIUM)**: `internal/openchoreo-api/api/handlers/` is separate from legacy handlers (`internal/openchoreo-api/handlers/`)—potential for divergent error handling if legacy path not synchronized
4. **Implicit Error Mapping**: Evaluate handlers return `400 Bad Request` for both `ErrInvalidRequest` and `ErrForbidden`; could mask authorization failures as client errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->