### PR TITLE
chore: add nilushancosta as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Please refer https://help.github.com/articles/about-codeowners for the CODEOWNERS documentation
 
-*  @binoyPeries @chalindukodikara @chathuranga95 @ChathurangaKCD @JanakaSandaruwan @mevan-karu @Mirage20 @NomadXD @sameerajayasoma @VajiraPrabuddhaka @yashodgayashan
+*  @binoyPeries @chalindukodikara @chathuranga95 @ChathurangaKCD @JanakaSandaruwan @mevan-karu @Mirage20 @nilushancosta @NomadXD @sameerajayasoma @VajiraPrabuddhaka @yashodgayashan


### PR DESCRIPTION
## Purpose
chore: add nilushancosta as code owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Scope:** 1 file changed (`.github/CODEOWNERS`)

**File Breakdown by Top-Level Folder:**
- `.github/`: 1 file

**Changes:**
- Added `@nilushancosta` to the CODEOWNERS list for all files (`*` pattern)
- Note: The change introduces a formatting anomaly with an isolated `@` separator appearing in the owners list (`@Mirage20 @ @nilushancosta`)

**API/CRD Surface Changes:** None

**Tests Added/Updated:** None

**Risk Assessment:** Low
- This is a purely administrative change to code ownership metadata
- No code changes, no functional impact
- Formatting issue in CODEOWNERS (isolated `@`) may require attention for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->