### PR TITLE
feat: add generic GET endpoint for any resource type

### DIFF
--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -102,6 +102,10 @@ func (h *Handler) Routes() http.Handler {
 	api.HandleFunc("POST "+v1+"/apply", h.ApplyResource)
 	api.HandleFunc("DELETE "+v1+"/delete", h.DeleteResource)
 
+	// TODO: Remove this generic resource GET endpoint after the API spec redesign
+	// Generic resource GET endpoint
+	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/resources/{kind}/{resourceName}", h.GetResource)
+
 	// DataPlane management
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/dataplanes", h.ListDataPlanes)
 	api.HandleFunc("POST "+v1+"/namespaces/{namespaceName}/dataplanes", h.CreateDataPlane)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Currently, there is no way to get the Kubernetes yaml files of oc resources. This is required for developing applications with oc API server. Until the API spec redesign, this endpoint will be added

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR Summary: Generic GET Endpoint for Any Resource Type

### File Changes by Directory
- **internal/**: 2 files modified (+38 lines net)
  - `internal/openchoreo-api/handlers/handlers.go`: +4 lines (route registration)
  - `internal/openchoreo-api/handlers/resource_crud.go`: +34 lines (new handler method)
- **Other directories**: No changes (api/, config/, pkg/, install/, docs/, openapi/, rca-agent/, make/, cmd/)

### API/CRD Surface Changes
**New Endpoint Added:**
- `GET /api/v1/namespaces/{namespaceName}/resources/{kind}/{resourceName}` → `Handler.GetResource()`
- Path parameters: `namespaceName`, `kind`, `resourceName` (all required)
- Returns: Raw unstructured Kubernetes resource object as JSON
- Status codes: 200 (success), 400 (missing params), 404 (not found), 500 (error)
- **Marked for removal**: TODO comment indicates endpoint should be deleted after API spec redesign

**Compatibility Risk: MEDIUM**
- Generic resource retrieval bypasses resource-type-specific endpoints
- Enables retrieval of any resource kind via kind string parameter
- Temporary API surface with planned redesign

### Authorization/RBAC Checks: **CRITICAL RISK - HIGH**
The new `GetResource()` handler has a significant authorization gap:
- **Missing ErbiddenError check**: Unlike all other GET handlers (DataPlane, Environment, Component, etc.), this endpoint does **NOT** check for `services.ErrForbidden` 
- **No RBAC enforcement**: Calls `h.getResourceByGVK()` which is a direct Kubernetes client wrapper with no authorization validation
- **Inconsistent pattern**: Every other handler in the codebase validates RBAC via service layer checks (e.g., `if errors.Is(err, services.ErrForbidden) { return 403 }`)
- **Exposure window**: Until removed per TODO, this endpoint could allow users with partial API access to retrieve arbitrary resources

### Test Coverage: **CRITICAL GAP**
- **No tests added** for the new `GetResource()` endpoint
- Handlers package has only 1 test file (`components_test.go`, 1208 lines) 
- No unit tests added for:
  - Path parameter validation
  - NotFound (404) vs Internal Error (500) differentiation
  - Authorization denial scenarios
  - Request/response serialization

### Risk Hotspots
1. **Authorization (HIGH)**: Generic endpoint bypasses service-layer RBAC checks present in all type-specific handlers
2. **Temporary API surface (MEDIUM)**: TODO comment indicates unfinished API design; could accumulate clients before removal
3. **Untested code paths (MEDIUM)**: New handler lacks test coverage for error conditions and edge cases
4. **Parameter validation (LOW)**: Endpoint validates required parameters but no test coverage for this validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->