### PR TITLE
feat: update installations to cater new observabilityplaneref

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -428,13 +428,13 @@ kubectl --context k3d-openchoreo-cp create secret generic observabilityplane-def
 </details>
 
 ### 10. Configure DataPlane to use default ObservabilityPlane (Optional)
-```
-kubectl --context k3d-openchoreo-cp patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+```bash
+kubectl --context k3d-openchoreo-cp patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
 ```
 
 ### 11. Configure BuildPlane (if installed) to use default ObservabilityPlane
-```
-kubectl --context k3d-openchoreo-cp patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+```bash
+kubectl --context k3d-openchoreo-cp patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
 ```
 
 ## Port Mappings

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -242,13 +242,13 @@ Create a ObservabilityPlane resource to enable observability in data plane and b
 The agent establishes an outbound WebSocket connection to the cluster gateway, providing secure communication without exposing the Kubernetes API server.
 
 Configure DataPlane to use default ObservabilityPlane
-```
-kubectl patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+```bash
+kubectl patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
 ```
 
 Configure BuildPlane (if installed) to use default ObservabilityPlane
-```
-kubectl patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+```bash
+kubectl patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
 ```
 
 Enable logs collection by upgrading the observability plane with Fluent Bit enabled:

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -648,10 +648,10 @@ EOF
 # Configure the dataplane and buildplane with observabilityplane reference
 configure_observabilityplane_reference() {
     log_info "Configuring OpenChoreo Data Plane with observabilityplane reference..."
-    kubectl patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+    kubectl patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
     if [[ "$ENABLE_BUILD_PLANE" == "true" ]]; then
         log_info "Configuring OpenChoreo Build Plane with observabilityplane reference..."
-        kubectl patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+        kubectl patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
     fi
 }
 

--- a/internal/pipeline/component/testdata/component-with-traits.yaml
+++ b/internal/pipeline/component/testdata/component-with-traits.yaml
@@ -308,4 +308,6 @@ spec:
   gateway:
     publicVirtualHost: api.example.com
     organizationVirtualHost: internal.example.com
-  observabilityPlaneRef: dev-observability
+  observabilityPlaneRef:
+    kind: ObservabilityPlane
+    name: dev-observability


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This PR updates the observabilityPlaneRef field in DataPlane, BuildPlane, ClusterDataPlane, and ClusterBuildPlane resources from a string format to an object format with kind and name fields. This enables referencing both namespace-scoped ObservabilityPlane and cluster-scoped ClusterObservabilityPlane resources. 

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Summary

File distribution (mentions of observabilityPlaneRef in this PR):
- internal: 7 files
- install: 7 files
- config: 4 files
- api: 4 files
- samples: 3 files
- openapi: 1 file
- docs: 1 file

Key changed files (examples):
- api/v1alpha1/{dataplane_types.go,buildplane_types.go,clusterdataplane_types.go,clusterbuildplane_types.go}
- config/crd/bases/openchoreo.dev_*.yaml (CRD schema updates)
- install/helm/openchoreo-control-plane/crds/*.yaml (CRD docs/schema)
- install/quick-start/.helpers.sh, install/k3d/*/README.md (install/patch commands)
- internal/controller/reference.go, internal/controller/reference_test.go (reference resolution logic + tests)
- internal/pipeline/component/testdata/component-with-traits.yaml, docs/templating/context.md, openapi/openchoreo-api.yaml, internal/openchoreo-api models

API / CRD surface changes (explicit)
- Affected resources: DataPlane, BuildPlane, ClusterDataPlane, ClusterBuildPlane.
- Field changed: spec.observabilityPlaneRef
  - Old: string (e.g., "default")
  - New: object with { kind: "ObservabilityPlane" | "ClusterObservabilityPlane", name: "<name>" }
- New/changed types: ObservabilityPlaneRef (namespace-scoped), ClusterObservabilityPlaneRef (cluster-scoped). Validation enforces allowed kind for cluster-scoped CRs.
- Compatibility risk: HIGH for manifests (breaking change). Existing string-valued references will fail schema validation until converted. CRD/schema updates and operator/controller changes are present, but users must migrate manifests.

Tests added/updated
- internal/controller/reference_test.go — tests for:
  - explicit observabilityPlaneRef resolution (both kinds)
  - fallback to default ObservabilityPlane in namespace
  - error paths when default is missing
- Internal OpenChoreo API model validations updated (internal/openchoreo-api models & request validation).
- Samples/testdata updated: internal/pipeline/component/testdata/component-with-traits.yaml and sample templates reference new object shape.
- Coverage gaps / missing critical tests:
  - No explicit upgrade/migration tests for in-cluster manifests or operator upgrade path.
  - No end-to-end reconciliation tests demonstrating operator behavior across mixed-version clusters (old manifests vs new CRD).
  - No explicit RBAC/permission regression tests for controllers resolving cluster-scoped resources.

Risk hotspots (short)
- Installation / Upgrade path (HIGH)
  - Install scripts and README patch commands were updated to new object format; clusters that apply new resources before CRDs are updated or that run older operator versions will break.
- Breaking API change (CRITICAL)
  - Manifest/CRD incompatibility requires manual migration; no automated migration tooling included.
- Controller reconciliation (MEDIUM)
  - Reference resolution logic updated (internal/controller/reference.go); controllers must handle both ObservabilityPlane and ClusterObservabilityPlane. Potential for reconcile errors or loops if defaults are missing.
- Validation & Webhooks (MEDIUM)
  - New validation for kind/name adds rejection paths; cluster-scoped CRs restricted to cluster observability refs.
- RBAC / Secrets (LOW-MEDIUM)
  - Resolving cluster-scoped ObservabilityPlane may require broader permissions; no RBAC changes/tests shown.
- Templating / Samples (LOW)
  - Templates and samples updated to use has(dataplane.observabilityPlaneRef) and object fields; documentation updated but migration guide is absent.

Other notes (quant metrics)
- openapi/openchoreo-api.yaml updated (observabilityPlaneRef now $ref -> ObservabilityPlaneRef).
- Internal API model validation enforces:
  - observabilityPlaneRef.kind required and must be one of the two allowed kinds
  - observabilityPlaneRef.name required and DNS-1123 validated
- Evidenced test files: internal/controller/reference_test.go (multiple cases covering success/failure and defaults).

Overall impact: schema-level breaking change that is implemented across CRDs, API models, controller helper logic, install scripts, docs and samples. Immediate attention required on upgrade/migration guidance and reconciliation end-to-end tests before rolling to production clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->