### PR TITLE
docs: document CEL `in` operator and `exists()` map behavior with tests

### DIFF
--- a/docs/templating/templating.md
+++ b/docs/templating/templating.md
@@ -106,6 +106,28 @@ Bracket notation is **required** for:
 - **Keys with special characters**: `${resource.metadata.labels["app.kubernetes.io/name"]}`
 - **Optional dynamic keys**: `${configurations[?containerName].?configs.orValue({})}`
 
+### Membership and Existence Checks
+
+The `in` operator checks membership in maps and lists:
+
+```
+# Check if a key exists in a map
+parameters.endpointName in workload.endpoints
+
+# Check if a value exists in a list (primitives only — strings, ints, bools)
+"HTTP" in parameters.allowedTypes
+```
+
+For maps, `exists()` and `all()` iterate over **keys** — use bracket notation to access values:
+
+```
+# Check if any endpoint is of type HTTP
+workload.endpoints.exists(name, workload.endpoints[name].type == 'HTTP')
+
+# Check all endpoints have a port > 0
+workload.endpoints.all(name, workload.endpoints[name].port > 0)
+```
+
 ### Conditional Logic
 
 ```yaml

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -615,6 +615,61 @@ decoded: ${string(base64.decode(parameters.encoded))}
 decoded: hello world
 `,
 		},
+		{
+			name: "in operator for map key existence",
+			template: `
+endpointNameFound: ${parameters.endpointName in workload.endpoints}
+missingNameFound: ${parameters.missingName in workload.endpoints}
+`,
+			inputs: `{
+  "parameters": {
+    "endpointName": "web",
+    "missingName": "nonexistent"
+  },
+  "workload": {
+    "endpoints": {
+      "web": {"type": "HTTP", "port": 8080},
+      "grpc": {"type": "gRPC", "port": 9090}
+    }
+  }
+}`,
+			want: `endpointNameFound: true
+missingNameFound: false
+`,
+		},
+		{
+			name: "in operator for list membership",
+			template: `
+found: ${"a" in parameters.items}
+missingItemFound: ${"z" in parameters.items}
+`,
+			inputs: `{
+  "parameters": {
+    "items": ["a", "b", "c"]
+  }
+}`,
+			want: `found: true
+missingItemFound: false
+`,
+		},
+		{
+			name: "exists macro on map iterates over keys",
+			template: `
+hasHTTP: ${workload.endpoints.exists(name, workload.endpoints[name].type == 'HTTP')}
+hasUDP: ${workload.endpoints.exists(name, workload.endpoints[name].type == 'UDP')}
+`,
+			inputs: `{
+  "workload": {
+    "endpoints": {
+      "web": {"type": "HTTP", "port": 8080},
+      "grpc": {"type": "gRPC", "port": 9090}
+    }
+  }
+}`,
+			want: `hasHTTP: true
+hasUDP: false
+`,
+		},
 	}
 
 	engine := NewEngine()


### PR DESCRIPTION
## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR documents CEL `in` operator and `exists()` map behavior and adds tests to cover those cases.

### Files Changed (by top-level folder)
- docs/: 1 file changed, +22 lines
- internal/: 1 file changed, +55 lines
- Total: 2 files changed, +77 lines, 0 deletions

### Changes Summary
- docs/templating/templating.md (+22)
  - Added "Membership and Existence Checks" under CEL Capabilities > Map Access Notation.
  - Documents `in` operator for:
    - Map key membership (e.g., `"key" in map`)
    - Primitive list membership (e.g., `"item" in list`)
  - Documents `exists()` and `all()` behavior when iterating map keys and recommends bracket notation for value access with examples.
- internal/template/engine_test.go (+55)
  - Added 3 tests to TestEngineRender:
    1. `in` operator for map key existence
    2. `in` operator for list membership
    3. `exists()` macro iterating over map keys with conditional checks
  - Each test includes template, JSON inputs, and expected YAML output.
  - Extends test coverage of CEL/templating behavior (now ~109+ tests in TestEngineRender as noted in repo context).

### API / CRD Surface Changes
- None. No API types, CRD definitions, exported/public signatures modified.
- Compatibility risk: Low (documentation and tests only)

### Tests Added / Updated
- Added: 3 new unit tests targeting templating/CEL expressions (`in`, `exists()`).
- Coverage: Core operator behaviors (`in`, `exists()`) for maps and lists are now covered.
- Remaining gaps: No tests documenting error/edge cases for unsupported operand types or type-mismatch behavior of `in`/`exists()`.

### Risk Hotspots
- AuthN/AuthZ, RBAC, secrets, reconciliation loops, install/upgrade paths: No changes → Low risk.
- Change type: Documentation + tests only — no runtime/behavioral changes.

Summary: Low-risk documentation enhancement with focused unit tests improving CEL templating docs and behavioral coverage for membership/exists operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->