### PR TITLE
fix: add cluster level plane resource access to cluster gateway role

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrole.yaml
@@ -11,13 +11,25 @@ rules:
 - apiGroups: ["openchoreo.dev"]
   resources: ["dataplanes"]
   verbs: ["get", "list", "watch"]
+# Allow reading ClusterDataPlane CRs to get client CA configuration
+- apiGroups: ["openchoreo.dev"]
+  resources: ["clusterdataplanes"]
+  verbs: ["get", "list", "watch"]
 # Allow reading BuildPlane CRs to get client CA configuration
 - apiGroups: ["openchoreo.dev"]
   resources: ["buildplanes"]
   verbs: ["get", "list", "watch"]
+# Allow reading ClusterBuildPlane CRs to get client CA configuration
+- apiGroups: ["openchoreo.dev"]
+  resources: ["clusterbuildplanes"]
+  verbs: ["get", "list", "watch"]
 # Allow reading ObservabilityPlane CRs to get client CA configuration
 - apiGroups: ["openchoreo.dev"]
   resources: ["observabilityplanes"]
+  verbs: ["get", "list", "watch"]
+# Allow reading ClusterObservabilityPlane CRs to get client CA configuration
+- apiGroups: ["openchoreo.dev"]
+  resources: ["clusterobservabilityplanes"]
   verbs: ["get", "list", "watch"]
 # Allow reading Secrets for client CA certificates
 - apiGroups: [""]


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request updates the Kubernetes `ClusterRole` configuration for the cluster-gateway component to grant read access to additional custom resources. This ensures the control plane can retrieve client CA configuration from both namespaced and cluster-scoped resources.

Access control enhancements:

* Added permissions to `clusterdataplanes`, `clusterbuildplanes`, and `clusterobservabilityplanes` resources in the `openchoreo.dev` API group, allowing `get`, `list`, and `watch` operations for each.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

**Files Changed by Directory:**
- `install/`: 1 file modified
  - `install/helm/openchoreo-control-plane/templates/cluster-gateway/clusterrole.yaml`

**Line Changes:** +12 lines / 0 deletions

---

## API/CRD Surface Changes

**Resource Access Expansion:** Additive RBAC permissions for cluster-scoped plane resources (v1alpha1 openchoreo.dev API group)

| Resource | New Verbs | Impact |
|----------|-----------|--------|
| `clusterdataplanes` | get, list, watch | Cluster-scoped CA configuration access |
| `clusterbuildplanes` | get, list, watch | Cluster-scoped CA configuration access |
| `clusterobservabilityplanes` | get, list, watch | Cluster-scoped CA configuration access |

**Compatibility Risk:** **LOW** — These cluster-scoped resources (ClusterDataPlane, ClusterBuildPlane, ClusterObservabilityPlane) already exist in the codebase (`api/v1alpha1/*_types.go`, `config/crd/bases/`). The change is purely additive—grants read-only permissions alongside existing namespaced plane resource rules, with no modification to existing secret access patterns or cluster-gateway control flow.

---

## Tests

**Tests Added/Updated:** None

**Critical Path Gap:** RBAC authorization changes lack test coverage. No tests validate that cluster-gateway can read cluster-scoped plane resources or that permissions correctly distinguish between namespaced vs. cluster-scoped variants.

---

## Risk Hotspots

1. **RBAC/AuthZ (Medium Risk):** Expands cluster-gateway privileges to access cluster-scoped resources for client CA certificate configuration. Minimal blast radius (read-only on plane CRs + existing secret access), but no test coverage to validate proper function.

2. **Install/Upgrade Path (Low Risk):** Helm template change only; existing deployments will automatically gain permissions on next upgrade. No migration or validation hooks required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->