### PR TITLE
refactor: enhance ComponentWorkflowRunStatusResponse with live obs flag

### DIFF
--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -438,9 +438,9 @@ type GitSecretResponse struct {
 
 // ComponentWorkflowRunStatusResponse represents the status of a component workflow run
 type ComponentWorkflowRunStatusResponse struct {
-	Status string               `json:"status"` // Overall workflow status (Pending/Running/Completed/Failed)
-	Steps  []WorkflowStepStatus `json:"steps"`  // Array of step-level statuses
-	LogURL string               `json:"logURL"` // Log URL for the workflow run (obs plane url, OC API url, or empty)
+	Status               string               `json:"status"`               // Overall workflow status (Pending/Running/Completed/Failed)
+	Steps                []WorkflowStepStatus `json:"steps"`                // Array of step-level statuses
+	HasLiveObservability bool                 `json:"hasLiveObservability"` // Whether the workflow run has live observability (logs/events from build plane)
 }
 
 // WorkflowStepStatus represents the status of an individual workflow step


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Refactor the previous `logUrl` field to now have `hasLiveObservability` field to be more extensible. This flag is then used to initialize openchoreoApiCLient or observabiliyApiClient to fetch logs/events accordingly instead of blindly using a provided logUrl.

## Approach
- Updated the ComponentWorkflowRunStatusResponse model to include HasLiveObservability field, indicating if the workflow run has live observability based on its age.
- Refactored GetComponentWorkflowRunStatus method to determine live observability without relying on a separate URL calculation.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pull Request Summary

### Changed Files Breakdown by Folder
- **internal/**: 2 files changed
  - `openchoreo-api/models/`: 1 file (response.go)
  - `openchoreo-api/services/`: 1 file (component_workflow_service.go)

Lines changed: +11 / -53 (net -42)

---

### API / CRD Surface Changes
- ComponentWorkflowRunStatusResponse (JSON response for the workflow-run status endpoint)
  - Removed: `logUrl` (LogURL string)
  - Added: `hasLiveObservability` (HasLiveObservability bool)
- Affected endpoint: GET status for component workflow runs (service/handler).
- Compatibility risk: HIGH — this is a breaking change to a public API response schema with no backward compatibility layer or deprecation path.

---

### Implementation Details
- Removed construction/return of an observability LogURL.
- Added HasLiveObservability flag computed as age < TTL (TTL hardcoded to 1 hour).
- Service now decides whether a run has "live observability" based on run age; Status and Steps mapping preserved.

---

### Tests & Coverage
- Tests added/updated: none identified in this PR.
- Coverage gaps: no unit tests for the new HasLiveObservability logic; no handler/integration tests validating the changed JSON response; no edge-case tests around the TTL boundary (exactly 1 hour).

---

### Risk Hotspots
1. Breaking API change (High) — clients expecting `logUrl` will fail to deserialize or lose functionality; no versioning/deprecation.
2. Hardcoded TTL (Medium) — 1-hour magic number (TODO noted to source from cluster/workflow template).
3. Observability flow coupling (Medium) — flag introduced but downstream client switching behavior not visible here; potential integration gaps.
4. Tests missing (Medium) — lack of unit/integration coverage for behavior and schema change increases regression risk.

---

### Summary Statistics
- Files changed: 2 (internal/)
- Tests changed: 0
- API endpoints affected: 1 (component workflow run status)
- Field removals: 1 (LogURL)
- Field additions: 1 (HasLiveObservability)
- Lines added/removed: +11 / -53
<!-- end of auto-generated comment: release notes by coderabbit.ai -->