### PR TITLE
feat: update clusterobservabilityplaneref description with more details

### DIFF
--- a/api/v1alpha1/clusterbuildplane_types.go
+++ b/api/v1alpha1/clusterbuildplane_types.go
@@ -33,6 +33,13 @@ type ClusterBuildPlaneSpec struct {
 
 	// ObservabilityPlaneRef specifies the ClusterObservabilityPlane for this ClusterBuildPlane.
 	// Since this is a cluster-scoped resource, it can only reference cluster-scoped ClusterObservabilityPlane.
+	// Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
+	//
+	// Default behavior:
+	// - If not specified, the controller defaults to a ClusterObservabilityPlane named "default"
+	// - If the "default" ClusterObservabilityPlane does not exist, reconciliation fails with an error
+	//
+	// The kind field must be "ClusterObservabilityPlane".
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="!has(self.kind) || self.kind == 'ClusterObservabilityPlane'",message="ClusterBuildPlane can only reference ClusterObservabilityPlane"
 	ObservabilityPlaneRef *ClusterObservabilityPlaneRef `json:"observabilityPlaneRef,omitempty"`

--- a/api/v1alpha1/clusterdataplane_types.go
+++ b/api/v1alpha1/clusterdataplane_types.go
@@ -41,6 +41,13 @@ type ClusterDataPlaneSpec struct {
 
 	// ObservabilityPlaneRef specifies the ClusterObservabilityPlane for this ClusterDataPlane.
 	// Since this is a cluster-scoped resource, it can only reference cluster-scoped ClusterObservabilityPlane.
+	// Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
+	//
+	// Default behavior:
+	// - If not specified, the system looks for a ClusterObservabilityPlane named "default"
+	// - If "default" ClusterObservabilityPlane doesn't exist, observability features are disabled
+	//
+	// The kind field must be "ClusterObservabilityPlane".
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="!has(self.kind) || self.kind == 'ClusterObservabilityPlane'",message="ClusterDataPlane can only reference ClusterObservabilityPlane"
 	ObservabilityPlaneRef *ClusterObservabilityPlaneRef `json:"observabilityPlaneRef,omitempty"`

--- a/config/crd/bases/openchoreo.dev_clusterbuildplanes.yaml
+++ b/config/crd/bases/openchoreo.dev_clusterbuildplanes.yaml
@@ -88,6 +88,13 @@ spec:
                 description: |-
                   ObservabilityPlaneRef specifies the ClusterObservabilityPlane for this ClusterBuildPlane.
                   Since this is a cluster-scoped resource, it can only reference cluster-scoped ClusterObservabilityPlane.
+                  Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
+
+                  Default behavior:
+                  - If not specified, the controller defaults to a ClusterObservabilityPlane named "default"
+                  - If the "default" ClusterObservabilityPlane does not exist, reconciliation fails with an error
+
+                  The kind field must be "ClusterObservabilityPlane".
                 properties:
                   kind:
                     description: Kind is the kind of observability plane. Must be

--- a/config/crd/bases/openchoreo.dev_clusterdataplanes.yaml
+++ b/config/crd/bases/openchoreo.dev_clusterdataplanes.yaml
@@ -129,6 +129,13 @@ spec:
                 description: |-
                   ObservabilityPlaneRef specifies the ClusterObservabilityPlane for this ClusterDataPlane.
                   Since this is a cluster-scoped resource, it can only reference cluster-scoped ClusterObservabilityPlane.
+                  Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
+
+                  Default behavior:
+                  - If not specified, the system looks for a ClusterObservabilityPlane named "default"
+                  - If "default" ClusterObservabilityPlane doesn't exist, observability features are disabled
+
+                  The kind field must be "ClusterObservabilityPlane".
                 properties:
                   kind:
                     description: Kind is the kind of observability plane. Must be

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clusterbuildplanes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clusterbuildplanes.yaml
@@ -87,6 +87,13 @@ spec:
                 description: |-
                   ObservabilityPlaneRef specifies the ClusterObservabilityPlane for this ClusterBuildPlane.
                   Since this is a cluster-scoped resource, it can only reference cluster-scoped ClusterObservabilityPlane.
+                  Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
+
+                  Default behavior:
+                  - If not specified, the controller defaults to a ClusterObservabilityPlane named "default"
+                  - If the "default" ClusterObservabilityPlane does not exist, reconciliation fails with an error
+
+                  The kind field must be "ClusterObservabilityPlane".
                 properties:
                   kind:
                     description: Kind is the kind of observability plane. Must be

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clusterdataplanes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clusterdataplanes.yaml
@@ -128,6 +128,13 @@ spec:
                 description: |-
                   ObservabilityPlaneRef specifies the ClusterObservabilityPlane for this ClusterDataPlane.
                   Since this is a cluster-scoped resource, it can only reference cluster-scoped ClusterObservabilityPlane.
+                  Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
+
+                  Default behavior:
+                  - If not specified, the system looks for a ClusterObservabilityPlane named "default"
+                  - If "default" ClusterObservabilityPlane doesn't exist, observability features are disabled
+
+                  The kind field must be "ClusterObservabilityPlane".
                 properties:
                   kind:
                     description: Kind is the kind of observability plane. Must be


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request improves the documentation for the `ObservabilityPlaneRef` field in both the ClusterBuildPlane and ClusterDataPlane resources, clarifying how references to observability planes work for cluster-scoped resources. The changes ensure users understand the restrictions and default behaviors when configuring observability for these resources.

**Documentation improvements for ObservabilityPlaneRef:**

* Added clarification that namespace-scoped ObservabilityPlane references are not supported for cluster-scoped resources in both `ClusterBuildPlaneSpec` and `ClusterDataPlaneSpec` in the Go API files. [[1]](diffhunk://#diff-4e4e1e7bede95bdfbd44a0e1a827f55979d6d533fd1caf411f03bd86c6401d05R36-R42) [[2]](diffhunk://#diff-5330251e2ae24072b546b1192761d1f7586fc606528f598cba54b6b089f2996eR44-R50)
* Updated the CRD YAML files (`openchoreo.dev_clusterbuildplanes.yaml` and `openchoreo.dev_clusterdataplanes.yaml`) in both `config/crd/bases` and `install/helm/openchoreo-control-plane/crds` to include:
  - The restriction on namespace-scoped references,
  - The default behavior (using a "default" ClusterObservabilityPlane if not specified, and disabling observability if it doesn't exist),
  - The requirement for the `kind` field to be "ClusterObservabilityPlane" or omitted. [[1]](diffhunk://#diff-7c827ec0dabd12d3c08062c988745ef2ffc2c04aac7c1d4e17f7ee7502288bf3R91-R97) [[2]](diffhunk://#diff-5e120ae0576ee923f84c75d59ee719f9bc66e75fce18bf2b161055279859a638R132-R138) [[3]](diffhunk://#diff-059c9ff7c25706dfe1f24cc69a5f182c197e3ed96fe06330d9aaa78add2ec769R90-R96) [[4]](diffhunk://#diff-2ef9680672d853612a7d77e02985a7db01655b9d77405bd458626029abebd8a6R131-R137)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

**Changed Files by Directory (counts)**
- api/: 2 files
  - api/v1alpha1/clusterbuildplane_types.go (100 lines)
  - api/v1alpha1/clusterdataplane_types.go (108 lines)
- config/: 2 files
  - config/crd/bases/openchoreo.dev_clusterbuildplanes.yaml (253 lines)
  - config/crd/bases/openchoreo.dev_clusterdataplanes.yaml (295 lines)
- install/: 2 files
  - install/helm/openchoreo-control-plane/crds/openchoreo.dev_clusterbuildplanes.yaml (252 lines)
  - install/helm/openchoreo-control-plane/crds/openchoreo.dev_clusterdataplanes.yaml (294 lines)

Total: 6 files changed (documentation/comment and CRD schema text/enum additions only).

---

## API / CRD Surface Changes (explicit) — Compatibility risk: LOW

- Go API (api/v1alpha1):
  - ClusterBuildPlaneSpec.ObservabilityPlaneRef and ClusterDataPlaneSpec.ObservabilityPlaneRef: expanded doc comments clarifying:
    - Namespace-scoped ObservabilityPlane references are NOT supported for cluster-scoped resources.
    - Defaulting behavior: if omitted, the controller looks for a ClusterObservabilityPlane named "default"; if not found, reconciliation fails or observability is disabled (as documented).
    - The kind field must be "ClusterObservabilityPlane" (may be omitted).
  - No struct signature/type changes — comments only.

- CRD OpenAPI schemas (config/ and install/helm/):
  - observabilityPlaneRef.description expanded in ClusterBuildPlane and ClusterDataPlane CRDs to document scope restriction and defaulting/error behavior.
  - observabilityPlaneRef.kind: enum constraint added with allowed value "ClusterObservabilityPlane" and updated descriptions.
  - Effect: CRD validation will enforce kind == ClusterObservabilityPlane for these cluster-scoped resources.

Backward-compatibility note: risk is low — the PR codifies current controller behavior. Breakage only possible for existing manifests that used a different kind for observabilityPlaneRef on cluster-scoped resources (those manifests may be rejected by CRD validation).

---

## Tests

- Tests added/updated in this PR: none.
- Existing coverage relevant to these semantics (outside this PR):
  - internal/controller/reference_test.go contains tests covering:
    - explicit ClusterObservabilityPlane refs for ClusterBuildPlane/ClusterDataPlane.
    - default behavior when ClusterObservabilityPlane named "default" exists.
  - Controller logic (internal/controller/reference.go) already enforces kind validation and default lookup; tests exercise those functions.
- Missing test coverage introduced by this PR:
  - No CRD-level validation tests added to assert the new OpenAPI enum for observabilityPlaneRef.kind.
  - No integration/upgrade test to validate install/upgrade paths where manifests might previously have used other kind values.

---

## Risk Hotspots (brief reasons)

1. Default fallback semantics — operational surprise: observability will be disabled or reconciliation will fail if the "default" ClusterObservabilityPlane is absent; operators need to ensure a default exists or explicitly reference one.
2. CRD enum enforcement on kind — manifests using ObservabilityPlane (namespace-scoped) or other kind for cluster-scoped resources will be rejected at admission; could block upgrades or automated installs if such manifests are present.
3. Install/upgrade path — Helm/CRD changes add stricter schema text/enum; cluster operators should verify CRD compatibility during upgrades.
4. Documentation-only PR without runbook changes — operators may lack procedural guidance to create/verify the "default" ClusterObservabilityPlane and detect disabled observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->