### PR TITLE
feat: add observability plane actions and authorization checks

### DIFF
--- a/internal/authz/core/actions.go
+++ b/internal/authz/core/actions.go
@@ -69,6 +69,9 @@ var systemActions = []Action{
 	// BuildPlane
 	{Name: "buildplane:view", IsInternal: false},
 
+	// ObservabilityPlane
+	{Name: "observabilityplane:view", IsInternal: false},
+
 	// DeploymentPipeline
 	{Name: "deploymentpipeline:view", IsInternal: false},
 

--- a/internal/authz/core/actions_test.go
+++ b/internal/authz/core/actions_test.go
@@ -19,7 +19,7 @@ func TestAllActions(t *testing.T) {
 	})
 
 	t.Run("returns expected action count", func(t *testing.T) {
-		expectedCount := 48 // Update this when intentionally adding/removing actions
+		expectedCount := 49 // Update this when intentionally adding/removing actions
 		if len(actions) != expectedCount {
 			t.Errorf("Expected %d actions, got %d. Update expected count if intentional.", expectedCount, len(actions))
 		}

--- a/internal/openchoreo-api/services/constants.go
+++ b/internal/openchoreo-api/services/constants.go
@@ -46,6 +46,8 @@ const (
 
 	SystemActionViewBuildPlane systemAction = "buildplane:view"
 
+	SystemActionViewObservabilityPlane systemAction = "observabilityplane:view"
+
 	SystemActionCreateEnvironment systemAction = "environment:create"
 	SystemActionViewEnvironment   systemAction = "environment:view"
 
@@ -80,6 +82,7 @@ const (
 	ResourceTypeTrait                ResourceType = "trait"
 	ResourceTypeDataPlane            ResourceType = "dataPlane"
 	ResourceTypeBuildPlane           ResourceType = "buildPlane"
+	ResourceTypeObservabilityPlane   ResourceType = "observabilityPlane"
 	ResourceTypeEnvironment          ResourceType = "environment"
 	ResourceTypeDeploymentPipeline   ResourceType = "deploymentPipeline"
 	ResourceTypeWorkflow             ResourceType = "workflow"

--- a/internal/openchoreo-api/services/services.go
+++ b/internal/openchoreo-api/services/services.go
@@ -89,7 +89,7 @@ func NewServices(k8sClient client.Client, k8sClientMgr *kubernetesClient.KubeMul
 	authzService := NewAuthzService(authzPAP, authzPDP, logger.With("service", "authz"))
 
 	// Create ObservabilityPlane service
-	observabilityPlaneService := NewObservabilityPlaneService(k8sClient, logger.With("service", "observabilityplane"))
+	observabilityPlaneService := NewObservabilityPlaneService(k8sClient, logger.With("service", "observabilityplane"), authzPDP)
 
 	return &Services{
 		ProjectService:            projectService,


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request introduces authorization checks for the ObservabilityPlane resource and updates related constants and service constructors to support this functionality. The main focus is to ensure that only authorized users can view ObservabilityPlane resources, aligning the ObservabilityPlane service with the existing authorization framework.

**Authorization and Access Control:**

* Added a new system action constant `observabilityplane:view` and resource type constant `observabilityPlane` to support fine-grained access control for ObservabilityPlane resources (`internal/openchoreo-api/services/constants.go`). [[1]](diffhunk://#diff-bd6b5ce786efb1468b379cc368f35d1a3f472ff57503245b893c18716df0a700R49-R50) [[2]](diffhunk://#diff-bd6b5ce786efb1468b379cc368f35d1a3f472ff57503245b893c18716df0a700R85) [[3]](diffhunk://#diff-264f336899ce0e5dd8a92ac2cbb4afeb0df49f4f42e5aecd24ff4e9aa2dce8d8R72-R74)
* Integrated authorization checks into the `ListObservabilityPlanes` method, so only users with the appropriate permissions can view each ObservabilityPlane (`internal/openchoreo-api/services/observabilityplane_service.go`).
* Updated the `ObservabilityPlaneService` to accept an `authz.PDP` (Policy Decision Point) and passed it through the service initialization to enable authorization checks (`internal/openchoreo-api/services/observabilityplane_service.go`, `internal/openchoreo-api/services/services.go`). [[1]](diffhunk://#diff-5432c5fef5d57af06fd97fb5ad41cb31a51f5d65c68adf6469e453c5e0571b87R25-R33) [[2]](diffhunk://#diff-0a185371af5fbe721cea2d00bd362630840dd21c28929893b30fa6afb29bc36bL92-R92)

**Testing and Maintenance:**

* Updated the expected action count in the authorization tests to reflect the addition of the new action (`internal/authz/core/actions_test.go`).

## Approach
- Introduced new action for observability plane: `observabilityplane:view`.
- Updated expected action count in tests to reflect the addition of the new action.
- Enhanced the ObservabilityPlaneService to include authorization checks for listing observability planes.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1872

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
