### PR TITLE
fix(helm): add missing permissions to backstage-catalog-reader role

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1133,6 +1133,7 @@ openchoreoApi:
                 - "buildplane:view"
                 - "componentworkflow:view"
                 - "deploymentpipeline:view"
+                - "observabilityplane:view"
 
             # Root Cause Analysis (RCA) agent role for troubleshooting and debugging
             - name: rca-agent


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
fix(helm): add missing permissions to backstage-catalog-reader role

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes by Top-Level Directory

| Directory | Files Changed |
|-----------|---------------|
| `install/` | 1 |
| `api/` | 0 |
| `config/` | 0 |
| `internal/` | 0 |
| `pkg/` | 0 |
| `docs/` | 0 |
| `openapi/` | 0 |
| `rca-agent/` | 0 |
| `make/` | 0 |
| `cmd/` | 0 |
| `samples/` | 0 |
| **Total** | **1** |

Changed file: install/helm/openchoreo-control-plane/values.yaml

## API / CRD Surface Changes

- Modified RBAC-like configuration in Helm values (AuthzRole/AuthzRoleBinding via values):
  - Target: backstage-catalog-reader role (bootstrap.roles in values.yaml)
  - Added view permissions (additive):
    - trait:view
    - buildplane:view
    - componentworkflow:view
    - deploymentpipeline:view
    - observabilityplane:view
- Compatibility risk: Low — purely additive role permissions; no CRD schema or API surface change.

## Tests

- No tests added or updated.
- Missing automated coverage for:
  - Permission enforcement for backstage-catalog-reader.
  - Integration tests validating Backstage catalog reads for the newly allowed resource types.

## Risk Hotspots

- Authorization / RBAC — Medium
  - Expands Backstage catalog service account's read surface to additional resource types; requires least-privilege review to avoid unintended data exposure.
  - Changes take effect on Helm install/upgrade without extra gating.
- Install / Upgrade paths — Low
  - Helm upgrades will apply the new permissions immediately; recommend documenting rollout/opt-in if needed.
- Tests / Validation — Low/Medium
  - Lack of tests increases risk of accidental over-permissioning and no regression checks for intended access boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->