### PR TITLE
feat(controller): validate allowed workflows

### DIFF
--- a/internal/controller/component/controller_conditions.go
+++ b/internal/controller/component/controller_conditions.go
@@ -48,6 +48,10 @@ const (
 	ReasonDeploymentPipelineNotFound controller.ConditionReason = "DeploymentPipelineNotFound"
 	// ReasonInvalidConfiguration indicates the Component configuration is invalid
 	ReasonInvalidConfiguration controller.ConditionReason = "InvalidConfiguration"
+	// ReasonComponentWorkflowNotAllowed indicates the referenced ComponentWorkflow is not in allowedWorkflows
+	ReasonComponentWorkflowNotAllowed controller.ConditionReason = "ComponentWorkflowNotAllowed"
+	// ReasonComponentWorkflowNotFound indicates the referenced ComponentWorkflow doesn't exist
+	ReasonComponentWorkflowNotFound controller.ConditionReason = "ComponentWorkflowNotFound"
 
 	// AutoDeploy issues (Status=False)
 

--- a/internal/controller/componentworkflowrun/controller_conditions.go
+++ b/internal/controller/componentworkflowrun/controller_conditions.go
@@ -20,13 +20,17 @@ const (
 )
 
 const (
-	ReasonWorkflowPending       controller.ConditionReason = "WorkflowPending"
-	ReasonWorkflowRunning       controller.ConditionReason = "WorkflowRunning"
-	ReasonWorkflowSucceeded     controller.ConditionReason = "WorkflowSucceeded"
-	ReasonWorkflowFailed        controller.ConditionReason = "WorkflowFailed"
-	ReasonWorkloadUpdated       controller.ConditionReason = "WorkloadUpdated"
-	ReasonWorkloadUpdateFailed  controller.ConditionReason = "WorkloadUpdateFailed"
-	ReasonSecretResolutionError controller.ConditionReason = "SecretResolutionError"
+	ReasonWorkflowPending           controller.ConditionReason = "WorkflowPending"
+	ReasonWorkflowRunning           controller.ConditionReason = "WorkflowRunning"
+	ReasonWorkflowSucceeded         controller.ConditionReason = "WorkflowSucceeded"
+	ReasonWorkflowFailed            controller.ConditionReason = "WorkflowFailed"
+	ReasonWorkloadUpdated           controller.ConditionReason = "WorkloadUpdated"
+	ReasonWorkloadUpdateFailed      controller.ConditionReason = "WorkloadUpdateFailed"
+	ReasonSecretResolutionError     controller.ConditionReason = "SecretResolutionError"
+	ReasonWorkflowNotAllowed        controller.ConditionReason = "WorkflowNotAllowed"
+	ReasonComponentWorkflowNotFound controller.ConditionReason = "ComponentWorkflowNotFound"
+	ReasonComponentTypeNotFound     controller.ConditionReason = "ComponentTypeNotFound"
+	ReasonComponentNotFound         controller.ConditionReason = "ComponentNotFound"
 )
 
 func setWorkflowPendingCondition(componentWorkflowRun *openchoreov1alpha1.ComponentWorkflowRun) {
@@ -147,6 +151,23 @@ func setSecretResolutionFailedCondition(componentWorkflowRun *openchoreov1alpha1
 		Status:             metav1.ConditionTrue,
 		Reason:             string(ReasonSecretResolutionError),
 		Message:            "Failed to resolve git secret",
+		ObservedGeneration: componentWorkflowRun.Generation,
+	})
+}
+
+func setWorkflowNotAllowedCondition(componentWorkflowRun *openchoreov1alpha1.ComponentWorkflowRun, message string) {
+	meta.SetStatusCondition(&componentWorkflowRun.Status.Conditions, metav1.Condition{
+		Type:               string(ConditionWorkflowFailed),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(ReasonWorkflowNotAllowed),
+		Message:            message,
+		ObservedGeneration: componentWorkflowRun.Generation,
+	})
+	meta.SetStatusCondition(&componentWorkflowRun.Status.Conditions, metav1.Condition{
+		Type:               string(ConditionWorkflowCompleted),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(ReasonWorkflowNotAllowed),
+		Message:            "Workflow is not allowed by ComponentType",
 		ObservedGeneration: componentWorkflowRun.Generation,
 	})
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
$subject

## Approach
Both Component controller and Component Workflow Run controller validates whether workflow is in the allowed workflows list and whether the workflow exists.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds validation to ensure ComponentWorkflows referenced by Components and ComponentWorkflowRuns are allowed by the ComponentType and exist.

File changes by top-level folder
- internal/: 5 files changed (all under internal/controller/)
  - internal/controller/component/: 3 files modified — +120 / -0 (controller.go +77, controller_conditions.go +4, controller_watch.go +39)
  - internal/controller/componentworkflowrun/: 2 files modified — +137 / -15 (controller.go +109/-8 in go.mod combined with +28/-7 in controller_conditions.go — see below)
- repo root: go.mod — +109 / -8 (module deps updated)
- Total reported in diffs: 5 files, +257 lines / -15 lines

API / CRD surface changes
- No CRD schema changes to manifests or API types.
- Added/new condition reason constants (status reporting only):
  - Component controller: ReasonComponentWorkflowNotAllowed, ReasonComponentWorkflowNotFound
  - ComponentWorkflowRun controller: ReasonWorkflowNotAllowed, ReasonComponentWorkflowNotFound, ReasonComponentTypeNotFound, ReasonComponentNotFound
- Compatibility risk: Low — only condition/observability additions and internal controller behavior changes; no API or spec-breaking changes.

Tests added / updated
- No tests added or updated in this PR (checklist items indicate tests and samples not completed).
- Critical test gaps to cover:
  - AllowedWorkflows enforcement: workflows that are allowed vs disallowed.
  - Missing ComponentWorkflow resource handling (not-found vs transient errors).
  - Component ↔ ComponentWorkflowRun interaction (ensures consistent enforcement across controllers).
  - Index/watch behavior for ComponentWorkflow → Component reconciliation (ensure correct namespace scoping and expected reconcile fan-out).

Implementation highlights
- Component controller
  - New unexported helper validateComponentWorkflow(ctx, comp, ct) that:
    - Checks ComponentType.AllowedWorkflows (if present) for the referenced workflow name and sets ReasonComponentWorkflowNotAllowed when violated.
    - Attempts to fetch the referenced ComponentWorkflow and sets ReasonComponentWorkflowNotFound when missing.
    - Returns the ComponentWorkflow on success or nil with no error when validation fails (avoids requeue on disallowed/missing workflow).
  - Adds field index setup: setupWorkflowRefIndex registers an index on components by spec.workflow.name.
  - Adds a watch on ComponentWorkflow resources and listComponentsForComponentWorkflow to enqueue affected Components when a ComponentWorkflow changes.

- ComponentWorkflowRun controller
  - Replaces direct Get with validation flow:
    - New validateComponentWorkflow that locates the owning Component, parses its ComponentType (parseComponentType: expect workloadType/componentTypeName), fetches ComponentType, checks AllowedWorkflows, and fetches the ComponentWorkflow.
    - On disallowed/missing workflow, sets ConditionWorkflowFailed and ConditionWorkflowCompleted with ReasonWorkflowNotAllowed / ReasonComponentWorkflowNotFound and returns nil, nil (no error/requeue).
    - Transient fetch errors are propagated for requeue.
  - Adds helper setWorkflowNotAllowedCondition to set the two status conditions when validation fails.

Risk hotspots (concise)
1) Reconciliation fan-out and loops (Medium)
   - New watch indexing ComponentWorkflow → Component can increase reconciliations; verify namespace-scoped lookups and potential duplicate reconciles.
2) Inconsistent enforcement (Medium)
   - Two controller-local validateComponentWorkflow implementations risk behavioral divergence; shared logic extraction or integration tests recommended.
3) Condition semantics (Low)
   - Setting both ConditionWorkflowFailed and ConditionWorkflowCompleted to true on a validation failure may be confusing to consumers — check downstream consumers/readers.
4) parseComponentType brittleness (Low)
   - parseComponentType expects "workloadType/componentTypeName" and may be brittle if format varies; edge-case validation appears limited.
5) Dependency / build impact (Low)
   - go.mod updated (+109/-8); ensure dependency bump is intended and CI builds pass.

Samples & docs
- No samples or documentation updates included; behavior changes (validation/rejection) should be documented and added to samples and upgrade notes.

Recommendation summary
- Add unit and integration tests for AllowedWorkflows enforcement and ComponentWorkflow → Component index/watch behavior.
- Consider consolidating shared validation logic used in both controllers to avoid divergence.
- Add doc/sample updates explaining the allowedWorkflows enforcement and observable condition reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->