### PR TITLE
feat(api): add workload validating webhook for one-per-component uniqueness

### DIFF
--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -203,6 +203,7 @@ type WorkloadOwner struct {
 }
 
 type WorkloadSpec struct {
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.owner is immutable"
 	Owner WorkloadOwner `json:"owner"`
 
 	// Inline *all* the template fields so they appear at top level.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,6 +65,7 @@ import (
 	projectwebhook "github.com/openchoreo/openchoreo/internal/webhook/project"
 	releasebindingwebhook "github.com/openchoreo/openchoreo/internal/webhook/releasebinding"
 	traitwebhook "github.com/openchoreo/openchoreo/internal/webhook/trait"
+	workloadwebhook "github.com/openchoreo/openchoreo/internal/webhook/workload"
 )
 
 const (
@@ -536,6 +537,13 @@ func main() {
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err := releasebindingwebhook.SetupReleaseBindingWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ReleaseBinding")
+			os.Exit(1)
+		}
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := workloadwebhook.SetupWorkloadWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Workload")
 			os.Exit(1)
 		}
 	}

--- a/config/crd/bases/openchoreo.dev_workloads.yaml
+++ b/config/crd/bases/openchoreo.dev_workloads.yaml
@@ -272,6 +272,9 @@ spec:
                 - componentName
                 - projectName
                 type: object
+                x-kubernetes-validations:
+                - message: spec.owner is immutable
+                  rule: self == oldSelf
             required:
             - owner
             type: object

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -210,3 +210,23 @@ webhooks:
     resources:
     - traits
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-openchoreo-dev-v1alpha1-workload
+  failurePolicy: Fail
+  name: vworkload-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workloads
+  sideEffects: None

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
@@ -271,6 +271,9 @@ spec:
                 - componentName
                 - projectName
                 type: object
+                x-kubernetes-validations:
+                - message: spec.owner is immutable
+                  rule: self == oldSelf
             required:
             - owner
             type: object

--- a/internal/webhook/workload/suite_test.go
+++ b/internal/webhook/workload/suite_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package workload
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = openchoreodevv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupWorkloadWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		//nolint:gosec // G402: Using self-signed cert in test environment
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/internal/webhook/workload/webhook.go
+++ b/internal/webhook/workload/webhook.go
@@ -1,0 +1,144 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package workload
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var workloadlog = logf.Log.WithName("workload-resource")
+
+// SetupWorkloadWebhookWithManager registers the webhook for Workload in the manager.
+func SetupWorkloadWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&openchoreodevv1alpha1.Workload{}).
+		WithValidator(&Validator{Client: mgr.GetClient()}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-openchoreo-dev-v1alpha1-workload,mutating=false,failurePolicy=fail,sideEffects=None,groups=openchoreo.dev,resources=workloads,verbs=create;update,versions=v1alpha1,name=vworkload-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// Validator struct is responsible for validating the Workload resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
+type Validator struct {
+	Client client.Client
+}
+
+var _ webhook.CustomValidator = &Validator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Workload.
+func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	workload, ok := obj.(*openchoreodevv1alpha1.Workload)
+	if !ok {
+		return nil, fmt.Errorf("expected a Workload object but got %T", obj)
+	}
+	workloadlog.Info("Validation for Workload upon creation", "name", workload.GetName())
+
+	allErrs := field.ErrorList{}
+
+	// Check that no other Workload exists for the same Component in this namespace
+	errs := v.validateUniqueWorkloadPerComponent(ctx, workload, "")
+	allErrs = append(allErrs, errs...)
+
+	if len(allErrs) > 0 {
+		return nil, allErrs.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Workload.
+func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	_, ok := oldObj.(*openchoreodevv1alpha1.Workload)
+	if !ok {
+		return nil, fmt.Errorf("expected a Workload object for the oldObj but got %T", oldObj)
+	}
+
+	newWorkload, ok := newObj.(*openchoreodevv1alpha1.Workload)
+	if !ok {
+		return nil, fmt.Errorf("expected a Workload object for the newObj but got %T", newObj)
+	}
+	workloadlog.Info("Validation for Workload upon update", "name", newWorkload.GetName())
+
+	allErrs := field.ErrorList{}
+
+	// Owner immutability is enforced by CEL, but also check uniqueness in case of reassignment
+	errs := v.validateUniqueWorkloadPerComponent(ctx, newWorkload, newWorkload.Name)
+	allErrs = append(allErrs, errs...)
+
+	if len(allErrs) > 0 {
+		return nil, allErrs.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Workload.
+func (v *Validator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	workload, ok := obj.(*openchoreodevv1alpha1.Workload)
+	if !ok {
+		return nil, fmt.Errorf("expected a Workload object but got %T", obj)
+	}
+	workloadlog.Info("Validation for Workload upon deletion", "name", workload.GetName())
+
+	// No special validation needed for deletion
+	return nil, nil
+}
+
+// validateUniqueWorkloadPerComponent checks that only one Workload exists per Component.
+// excludeName is the name of the current Workload to exclude from the check (used during updates).
+func (v *Validator) validateUniqueWorkloadPerComponent(
+	ctx context.Context,
+	workload *openchoreodevv1alpha1.Workload,
+	excludeName string,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	existingWorkloads := &openchoreodevv1alpha1.WorkloadList{}
+	if err := v.Client.List(ctx, existingWorkloads, client.InNamespace(workload.Namespace)); err != nil {
+		allErrs = append(allErrs, field.InternalError(
+			field.NewPath("spec", "owner"),
+			fmt.Errorf("failed to list existing workloads: %w", err),
+		))
+		return allErrs
+	}
+
+	for i := range existingWorkloads.Items {
+		existing := &existingWorkloads.Items[i]
+		if existing.Name == excludeName {
+			continue
+		}
+		if existing.Spec.Owner.ProjectName == workload.Spec.Owner.ProjectName &&
+			existing.Spec.Owner.ComponentName == workload.Spec.Owner.ComponentName {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "owner"),
+				fmt.Sprintf(
+					"a workload %q already exists for component %q in project %q",
+					existing.Name,
+					workload.Spec.Owner.ComponentName,
+					workload.Spec.Owner.ProjectName,
+				),
+			))
+			break
+		}
+	}
+
+	return allErrs
+}

--- a/internal/webhook/workload/webhook_test.go
+++ b/internal/webhook/workload/webhook_test.go
@@ -1,0 +1,173 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package workload
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+var _ = Describe("Workload Webhook", func() {
+	const testNamespace = "default"
+
+	var (
+		validator Validator
+	)
+
+	BeforeEach(func() {
+		validator = Validator{Client: k8sClient}
+	})
+
+	Context("When creating a Workload", func() {
+		It("Should admit creation when no other Workload exists for the Component", func() {
+			workload := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload-create-admit",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-create-admit",
+						ComponentName: "component-create-admit",
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should reject creation when a Workload already exists for the same Component", func() {
+			// Create the first workload in the cluster
+			existing := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-workload-dup",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-dup",
+						ComponentName: "component-dup",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			// Try to create a second workload for the same component
+			duplicate := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicate-workload-dup",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-dup",
+						ComponentName: "component-dup",
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, duplicate)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("a workload"))
+			Expect(err.Error()).To(ContainSubstring("already exists for component"))
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, existing)).To(Succeed())
+		})
+
+		It("Should admit creation for a different Component in the same Project", func() {
+			// Create the first workload
+			existing := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-workload-diff",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-diff",
+						ComponentName: "component-a",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			// Create a workload for a different component in the same project
+			different := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "different-workload-diff",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-diff",
+						ComponentName: "component-b",
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, different)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, existing)).To(Succeed())
+		})
+	})
+
+	Context("When updating a Workload", func() {
+		It("Should admit update of non-owner fields", func() {
+			// Create the workload
+			existing := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-workload-update",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-update",
+						ComponentName: "component-update",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			// Update the workload (non-owner fields)
+			updated := existing.DeepCopy()
+			updated.Spec.Containers = map[string]openchoreodevv1alpha1.Container{
+				"main": {Image: "nginx:latest"},
+			}
+
+			_, err := validator.ValidateUpdate(context.Background(), existing, updated)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, existing)).To(Succeed())
+		})
+	})
+
+	Context("When deleting a Workload", func() {
+		It("Should admit deletion", func() {
+			workload := &openchoreodevv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload-delete",
+					Namespace: testNamespace,
+				},
+				Spec: openchoreodevv1alpha1.WorkloadSpec{
+					Owner: openchoreodevv1alpha1.WorkloadOwner{
+						ProjectName:   "project-delete",
+						ComponentName: "component-delete",
+					},
+				},
+			}
+
+			_, err := validator.ValidateDelete(context.Background(), workload)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Purpose
$subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## File Changes by Directory
- **api/v1alpha1/**: 1 file (+1 line)
- **cmd/**: 1 file (+8 lines)
- **config/crd/bases/ & config/webhook/**: 2 files (+23 lines)
- **install/helm/**: 1 file (+3 lines)
- **internal/webhook/workload/**: 3 files (+445 lines)
- **Total: 8 files, 480 lines added**

## API & CRD Surface Changes
**Compatibility Risk: Low**

- **WorkloadSpec.Owner immutability**: Added x-kubernetes-validations rule (`self == oldSelf`) to prevent owner field modification after creation. Reflected in both `config/crd/bases/openchoreo.dev_workloads.yaml` and `install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml`.
- **Workload ValidatingWebhook**: New webhook configuration registered at path `/validate-openchoreo-dev-v1alpha1-workload` with `failurePolicy: Fail` for CREATE and UPDATE operations on workloads in openchoreo.dev group v1alpha1.
- No changes to public API signatures beyond new webhook registration in `cmd/main.go`.

## Webhook Implementation Details
The new validating webhook enforces **one-per-component uniqueness** within a namespace:

- **ValidateCreate**: Calls `validateUniqueWorkloadPerComponent()` to verify no other workload exists with matching `spec.owner.ProjectName` and `spec.owner.ComponentName` in the same namespace.
- **ValidateUpdate**: Re-validates uniqueness excluding the current workload by name (since owner immutability is enforced by CEL rule).
- **ValidateDelete**: No-op (logs only).
- **Validation Logic**: Lists all workloads in the namespace and compares owner fields; returns `field.Forbidden` error if duplicate detected.

## Tests Added
**Test Coverage: 5 scenarios, 301 lines of test code**

- **suite_test.go** (128 lines): Integration test setup using Ginkgo/Gomega with controller-runtime envtest, webhook server over TLS, and custom resource registration.
- **webhook_test.go** (173 lines):
  1. ✅ Admit creation when no workload exists for component
  2. ✅ Reject creation when duplicate workload for same component exists
  3. ✅ Admit creation for different component in same project
  4. ✅ Admit update of non-owner fields
  5. ✅ Admit deletion

**Critical paths lacking tests:**
- Cross-namespace scenarios (uniqueness validation behavior across namespaces)
- Immutability violation attempts (spec.owner change rejection)
- Webhook error handling (client.List failures, internal errors)
- Multiple projects with identical component names

## Risk Hotspots

1. **Webhook Failure Mode (failurePolicy: Fail)**: Blocks workload CREATE/UPDATE if webhook service is unavailable or misconfigured. High operational impact during outages.

2. **Unbounded List Operation**: Each create/update performs namespace-wide `client.List()` of all workloads without pagination. Performance risk scales with workload count per namespace.

3. **Namespace-Scoped Uniqueness Only**: Validation does not prevent same component identity (ProjectName + ComponentName) across different namespaces—may be intentional but could mask configuration errors in multi-tenant or multi-environment clusters.

4. **Dual Validation Mechanisms**: Both CEL rule (`x-kubernetes-validations`) and webhook validator enforce owner immutability. Adds redundancy but increases maintenance burden and potential for inconsistencies.

5. **Missing Cross-Namespace RBAC Consideration**: Webhook performs operations across all workloads in a namespace; verify service account has appropriate RBAC permissions configured in `config/rbac/role.yaml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->