### PR TITLE
feat(helm): enable authorization by default in oc cp

### DIFF
--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -3994,7 +3994,7 @@
           "description": "Authorization (authz) configuration using Casbin",
           "properties": {
             "enabled": {
-              "default": false,
+              "default": true,
               "description": "Enable authorization using Casbin. Policies are loaded from AuthzClusterRole, AuthzRole, AuthzClusterRoleBinding, and AuthzRoleBinding CRDs.",
               "title": "enabled",
               "type": "boolean"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -158,9 +158,9 @@ security:
     # @schema
     # type: boolean
     # description: Enable authorization using Casbin. Policies are loaded from AuthzClusterRole, AuthzRole, AuthzClusterRoleBinding, and AuthzRoleBinding CRDs.
-    # default: false
+    # default: true
     # @schema
-    enabled: false
+    enabled: true
   # @schema
   # type: string
   # description: Base URL for the authorization server (used for OAuth metadata). If not set, defaults to protocol://thunder.baseDomain:port


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
$subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

**Scope**: Enable Casbin-based authorization (Authz) by default in OpenChoreo Control Plane Helm chart, shifting from opt-in to opt-out model.

## File Changes by Directory

| Directory | Count | Key Changes |
|-----------|-------|------------|
| `config/rbac/` | 12 | RBAC role/binding manifests for 4 new AuthZ CRD types (admin/editor/viewer variants) |
| `config/crd/bases/` | 4 | New CRDs: AuthzClusterRole, AuthzClusterRoleBinding, AuthzRole, AuthzRoleBinding |
| `api/v1alpha1/` | 4 | Type definitions for 4 new Authz CRDs + deepcopy generation (~5.2K LOC) |
| `internal/authz/` | 5 | Casbin enforcer, PDP, PAP, K8s watcher implementations + 4 test files |
| `install/helm/openchoreo-control-plane/` | 5 | values.yaml, values.schema.json, new bootstrap-authz.yaml template |
| `config/samples/` | 4 | AuthZ CRD samples (AuthzClusterRole, AuthzClusterRoleBinding, AuthzRole, AuthzRoleBinding) |

## API/CRD Surface Changes

**New CRDs Added** (4 total):
- `AuthzClusterRole` - Cluster-scoped Casbin roles defining actionable permissions
- `AuthzClusterRoleBinding` - Cluster-scoped role-to-subject bindings  
- `AuthzRole` - Namespace-scoped Casbin roles
- `AuthzRoleBinding` - Namespace-scoped role-to-subject bindings

**Config Changes**:
- `security.authz.enabled`: `false` → `true` (default, affects install/helm values + values.schema.json)
- New environment variable: `OPENCHOREO_FEATURES_AUTHZ_ENABLED` passed to openchoreo-api deployment
- New helm template: `authz/bootstrap-authz.yaml` (gated on `security.authz.enabled` flag)

**Compatibility Risk**: **MEDIUM-HIGH**
- Existing deployments upgrading will have authorization **enforced by default**; requests without matching policies will be denied
- Mitigation: Bootstrap template auto-injects default role/binding policies from helm values (`openchoreoApi.config.security.authorization.bootstrap.roles/mappings`)
- No explicit deprecation period; change is immediate upon chart upgrade

## Tests Added

**Total**: 151 test files added (comprehensive coverage)

**Authz-specific test coverage** (8 files):
- `internal/authz/casbin/helpers_test.go` - Helper function unit tests
- `internal/authz/casbin/k8s_watcher_test.go` - K8s resource watcher tests (847 LOC)
- `internal/authz/casbin/pap_test.go` - Policy Administration Point tests (970 LOC)
- `internal/authz/casbin/pdp_test.go` - Policy Decision Point tests (1294 LOC) 
- `internal/authz/disabled_authorizer_test.go` - Fallback mode tests (220 LOC)
- `internal/openchoreo-api/config/security_test.go`
- `internal/server/middleware/auth/jwt/middleware_test.go`
- `pkg/fsindex/cache/benchmark_test.go`

**Coverage Gaps**:
- No explicit helm chart integration tests for bootstrap-authz template rendering
- No e2e tests covering deny-by-default authorization policy enforcement
- No upgrade/migration scenario tests

## Risk Hotspots

| Risk | Severity | Mitigation |
|------|----------|-----------|
| **Authorization enforcement by default** | HIGH | Bootstrap template injects default policies; helm value `security.authz.enabled` can be set `false` if needed, but this reverses the feature intent |
| **Casbin policy loading from CRDs** | MEDIUM | K8s watcher monitors AuthZ* CRD changes; policy sync relies on controller-manager webhook/reconciliation; watch failures could leave stale policies cached |
| **Reconciliation loop for policy changes** | MEDIUM | PDP caches policies; updates require k8s_watcher event → cache invalidation; no explicit cache TTL visible; slow propagation risk |
| **Helm template condition complexity** | MEDIUM | Bootstrap template has 3 nested conditionals (`security.authz.enabled`, `bootstrap.roles`, `bootstrap.mappings`); silent no-op if conditions unmet |
| **Installation/upgrade path** | MEDIUM-HIGH | First deployment: authz enabled, bootstrap roles injected. Upgrade from v<X: authz suddenly enforced; existing traffic not matching policies will fail unless policies pre-exist in cluster |

## Deployment Impact

- **First install**: Authorization active immediately via bootstrap policies
- **Upgrade scenario**: Requires pre-existing AuthZ* CRDs or helm bootstrap config to avoid access denial
- **Rollback risk**: Disabling authz requires helm `security.authz.enabled=false` + redeployment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->