### PR TITLE
feat: add get_resource mcp tool

### DIFF
--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -372,3 +372,10 @@ func (m *MockCoreToolsetHandler) DeleteResource(ctx context.Context, resource ma
 	m.recordCall("DeleteResource", resource)
 	return `{"operation":"deleted"}`, nil
 }
+
+func (m *MockCoreToolsetHandler) GetResource(
+	ctx context.Context, namespaceName, kind, resourceName string,
+) (any, error) {
+	m.recordCall("GetResource", namespaceName, kind, resourceName)
+	return `{"kind":"Component","metadata":{"name":"test-component"}}`, nil
+}

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -108,6 +108,7 @@ func (t *Toolsets) resourceToolRegistrations() []RegisterFunc {
 	return []RegisterFunc{
 		t.RegisterApplyResource,
 		t.RegisterDeleteResource,
+		t.RegisterGetResource,
 	}
 }
 

--- a/pkg/mcp/tools/resource.go
+++ b/pkg/mcp/tools/resource.go
@@ -28,6 +28,33 @@ func (t *Toolsets) RegisterApplyResource(s *mcp.Server) {
 	})
 }
 
+// RegisterGetResource registers the get_resource MCP tool.
+// TODO: cleanup when the upstream endpoint is deprecated.
+func (t *Toolsets) RegisterGetResource(s *mcp.Server) {
+	kindDesc := "The kind of the resource " +
+		"(e.g. Component, Project, Environment, DataPlane, ComponentType, Trait, Workflow)."
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_resource",
+		Description: "Get a Kubernetes resource by kind and name from the cluster. " +
+			"Only supports resources with 'openchoreo.dev' API group. " +
+			"Use explain_schema to discover valid kinds.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": stringProperty(
+				"The namespace of the resource. Required for namespaced resources, " +
+					"omit for cluster-scoped resources (e.g. ClusterDataPlane)."),
+			"kind":          stringProperty(kindDesc),
+			"resource_name": stringProperty("The name of the resource to retrieve."),
+		}, []string{"kind", "resource_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Kind          string `json:"kind"`
+		ResourceName  string `json:"resource_name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.ResourceToolset.GetResource(ctx, args.NamespaceName, args.Kind, args.ResourceName)
+		return handleToolResult(result, err)
+	})
+}
+
 func (t *Toolsets) RegisterDeleteResource(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: "delete_resource",

--- a/pkg/mcp/tools/resource_specs_test.go
+++ b/pkg/mcp/tools/resource_specs_test.go
@@ -34,6 +34,31 @@ func resourceToolSpecs() []toolTestSpec {
 			},
 		},
 		{
+			name:                "get_resource",
+			toolset:             "resource",
+			descriptionKeywords: []string{"get", "resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"kind", "resource_name"},
+			optionalParams:      []string{"namespace_name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"kind":           resourceKindComponent,
+				"resource_name":  testComponentName,
+			},
+			expectedMethod: "GetResource",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+				if args[1] != resourceKindComponent {
+					t.Errorf("Expected kind %q, got %v", resourceKindComponent, args[1])
+				}
+				if args[2] != testComponentName {
+					t.Errorf("Expected resource name %q, got %v", testComponentName, args[2])
+				}
+			},
+		},
+		{
 			name:                "delete_resource",
 			toolset:             "resource",
 			descriptionKeywords: []string{"delete", "resource"},

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -172,10 +172,11 @@ type SchemaToolsetHandler interface {
 	ExplainSchema(ctx context.Context, kind, path string) (any, error)
 }
 
-// ResourceToolsetHandler handles kubectl-like resource operations (apply/delete)
+// ResourceToolsetHandler handles kubectl-like resource operations (apply/delete/get)
 type ResourceToolsetHandler interface {
 	ApplyResource(ctx context.Context, resource map[string]interface{}) (any, error)
 	DeleteResource(ctx context.Context, resource map[string]interface{}) (any, error)
+	GetResource(ctx context.Context, namespaceName, kind, resourceName string) (any, error)
 }
 
 // RegisterFunc is a function type for registering MCP tools


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
$subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary of Changes

### File Changes by Top-Level Folder
- api/: 0  
- config/: 0  
- internal/: 1
  - internal/openchoreo-api/mcphandlers/resources.go — adds MCPHandler.GetResource (+36/-0)
- pkg/: 5
  - pkg/mcp/tools/register.go — registers get_resource (+1/-0)
  - pkg/mcp/tools/resource.go — adds RegisterGetResource / MCP tool "get_resource" (+27/-0)
  - pkg/mcp/tools/types.go — extends ResourceToolsetHandler with GetResource (+2/-1)
  - pkg/mcp/tools/mock_test.go — adds MockCoreToolsetHandler.GetResource (+7/-0)
  - pkg/mcp/tools/resource_specs_test.go — adds get_resource tool spec (+31/-0)
- install/: 0  
- docs/: 0  
- openapi/: 0  
- rca-agent/: 0  
- make/: 0  
- cmd/: 0  
- samples/: 0  

Total: 6 files changed
Estimated net lines changed: approx +103/-1

## Changes Overview (concise)
- Adds a new MCP tool "get_resource" to retrieve a Kubernetes resource by namespace, kind, and name.
  - Core handler: MCPHandler.GetResource(ctx, namespaceName, kind, resourceName) implemented in internal/openchoreo-api/mcphandlers/resources.go — validates inputs, builds a GroupVersionKind (group=openchoreo.dev, version=v1alpha1) for the provided kind, enforces namespace vs cluster-scoped rules, performs a controller-runtime client Get into an Unstructured and maps NotFound to a resource-not-found error.
  - Tool registration: RegisterGetResource added in pkg/mcp/tools/resource.go and wired in pkg/mcp/tools/register.go.
  - Toolset API: ResourceToolsetHandler interface extended with GetResource(ctx, namespaceName, kind, resourceName) (any, error) in pkg/mcp/tools/types.go.
  - Tests & mocks: MockCoreToolsetHandler.GetResource added (pkg/mcp/tools/mock_test.go) and a tool-spec test for "get_resource" added (pkg/mcp/tools/resource_specs_test.go).

## API / CRD Surface Changes
- New exported interface method: ResourceToolsetHandler.GetResource(ctx, namespaceName, kind, resourceName) (any, error).
- New MCP tool endpoint: "get_resource".
Compatibility risk: Low for the API (additive). Notable implementation constraint: the handler constructs a fixed Group=openchoreo.dev and Version=v1alpha1 for the requested Kind — this limits retrieval to that API group/version. Compatibility risk for cross-group or future CRD-version changes: Medium.

## Tests Added / Updated
- Added tool-spec test entry: pkg/mcp/tools/resource_specs_test.go — validates the "get_resource" tool wiring and expected call args.
- Added mock implementation: pkg/mcp/tools/mock_test.go — MockCoreToolsetHandler.GetResource returns a static Component JSON for test usage.
Critical missing tests:
- No unit tests for internal/openchoreo-api/mcphandlers/GetResource covering validation error paths, NotFound vs other error mapping, or correct GVK construction.
- No integration/e2e tests exercising actual Kubernetes client interactions, RBAC/permission-denied behavior, or retrieval across API groups/versions.
- No tests validating redaction/filtering of sensitive fields in returned unstructured objects.

## Risk Hotspots
1. Hardcoded GVK (Medium) — Handler always uses group=openchoreo.dev, version=v1alpha1; will not retrieve resources from other groups/versions or future CRD versions without change.
2. RBAC / AuthN-AZ (Medium) — Reading resources depends on service account/cluster RBAC; PR adds no explicit permission checks or tests for permission-denied scenarios.
3. Sensitive data exposure (Low–Medium) — The handler returns full unstructured objects; potential to expose secrets or sensitive fields unless callers redact.
4. Handler test coverage (Medium) — Lack of unit tests for validation and error branches increases regression risk.
5. Upgrade/deprecation note (Low) — A TODO in resource registration references upstream endpoint deprecation; no migration guidance included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->