### PR TITLE
feat: add component release cleanup logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,6 +94,7 @@ func setupControlPlaneControllers(
 	k8sClientMgr *kubernetesClient.KubeMultiClientManager,
 	clusterGatewayURL string,
 	enableLegacyCRDs bool,
+	revisionHistoryLimit int,
 ) error {
 	// Create gateway client for plane lifecycle notifications
 	var gwClient *gatewayClient.Client
@@ -174,8 +175,9 @@ func setupControlPlaneControllers(
 	}
 
 	if err := (&component.Reconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		RevisionHistoryLimit: revisionHistoryLimit,
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}
@@ -359,6 +361,9 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.BoolVar(&enableLegacyCRDs, "enable-legacy-crds", false, // TODO <-- remove me
 		"If set, legacy CRDs will be enabled. This is only for the POC and will be removed in the future.")
+	var revisionHistoryLimit int
+	flag.IntVar(&revisionHistoryLimit, "revision-history-limit", 10,
+		"Maximum number of old ComponentReleases to retain per component. Set to 0 to disable cleanup.")
 	flag.StringVar(&deploymentPlane, "deployment-plane", deploymentPlaneControlPlane,
 		"The deployment plane this manager should serve. Supported values: controlplane, observabilityplane")
 	opts := zap.Options{
@@ -371,6 +376,11 @@ func main() {
 
 	if deploymentPlane != deploymentPlaneControlPlane && deploymentPlane != deploymentPlaneObservabilityPlane {
 		setupLog.Error(nil, "invalid deployment plane", "deploymentPlane", deploymentPlane)
+		os.Exit(1)
+	}
+
+	if revisionHistoryLimit < 0 {
+		setupLog.Error(nil, "invalid revision-history-limit: must be >= 0", "revisionHistoryLimit", revisionHistoryLimit)
 		os.Exit(1)
 	}
 
@@ -474,7 +484,9 @@ func main() {
 	switch deploymentPlane {
 	// Control plane controllers
 	case deploymentPlaneControlPlane:
-		if err = setupControlPlaneControllers(mgr, k8sClientMgr, clusterGatewayURL, enableLegacyCRDs); err != nil {
+		if err = setupControlPlaneControllers(
+			mgr, k8sClientMgr, clusterGatewayURL, enableLegacyCRDs, revisionHistoryLimit,
+		); err != nil {
 			setupLog.Error(err, "unable to setup control plane controllers")
 			os.Exit(1)
 		}

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -702,6 +702,7 @@ controllerManager:
       - --metrics-bind-address=:8443
       - --leader-elect
       - --health-probe-bind-address=:8081
+      - --revision-history-limit=10
     # @schema
     # type: object
     # description: Environment variables for the controller-manager

--- a/internal/controller/component/controller_cleanup.go
+++ b/internal/controller/component/controller_cleanup.go
@@ -1,0 +1,105 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+const (
+	// cleanupListTimeout is the timeout for List calls during cleanup.
+	cleanupListTimeout = 30 * time.Second
+	// cleanupDeleteTimeout is the timeout for each Delete call during cleanup.
+	cleanupDeleteTimeout = 10 * time.Second
+)
+
+// cleanupComponentReleases deletes the oldest ComponentReleases that exceed the
+// RevisionHistoryLimit for the given component, while protecting releases that
+// are still in use (referenced by any ReleaseBinding or marked as LatestRelease).
+func (r *Reconciler) cleanupComponentReleases(ctx context.Context, comp *openchoreov1alpha1.Component) error {
+	logger := log.FromContext(ctx).WithValues("component", comp.Name)
+
+	// List all ComponentReleases owned by this component
+	listCtx, listCancel := context.WithTimeout(ctx, cleanupListTimeout)
+	defer listCancel()
+
+	releaseList := &openchoreov1alpha1.ComponentReleaseList{}
+	if err := r.List(listCtx, releaseList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{"spec.owner.componentName": comp.Name}); err != nil {
+		return fmt.Errorf("failed to list component releases: %w", err)
+	}
+
+	// Nothing to clean if within limit
+	if len(releaseList.Items) <= r.RevisionHistoryLimit {
+		return nil
+	}
+
+	// Build the in-use set from ReleaseBindings
+	inUse := make(map[string]bool)
+
+	bindingCtx, bindingCancel := context.WithTimeout(ctx, cleanupListTimeout)
+	defer bindingCancel()
+
+	bindingList := &openchoreov1alpha1.ReleaseBindingList{}
+	if err := r.List(bindingCtx, bindingList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{controller.IndexKeyReleaseBindingOwnerComponentName: comp.Name}); err != nil {
+		return fmt.Errorf("failed to list release bindings: %w", err)
+	}
+	for i := range bindingList.Items {
+		if bindingList.Items[i].Spec.ReleaseName != "" {
+			inUse[bindingList.Items[i].Spec.ReleaseName] = true
+		}
+	}
+
+	// Also protect the LatestRelease
+	if comp.Status.LatestRelease != nil && comp.Status.LatestRelease.Name != "" {
+		inUse[comp.Status.LatestRelease.Name] = true
+	}
+
+	// Sort releases by creation timestamp ascending (oldest first)
+	releases := releaseList.Items
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].CreationTimestamp.Before(&releases[j].CreationTimestamp)
+	})
+
+	// Calculate how many need to be deleted
+	excess := len(releases) - r.RevisionHistoryLimit
+	var errs []error
+
+	for i := range releases {
+		if excess <= 0 {
+			break
+		}
+		release := &releases[i]
+		if inUse[release.Name] {
+			continue
+		}
+		logger.Info("Deleting old ComponentRelease", "release", release.Name)
+
+		deleteCtx, deleteCancel := context.WithTimeout(ctx, cleanupDeleteTimeout)
+		if err := client.IgnoreNotFound(r.Delete(deleteCtx, release)); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete ComponentRelease %s: %w", release.Name, err))
+			deleteCancel()
+			continue
+		}
+		deleteCancel()
+		excess--
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors during ComponentRelease cleanup: %v", errs)
+	}
+	return nil
+}

--- a/internal/controller/component/controller_cleanup_test.go
+++ b/internal/controller/component/controller_cleanup_test.go
@@ -1,0 +1,518 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// deleteFailClient wraps a client.Client and returns predefined errors
+// for Delete calls on objects whose name is in the failFor map.
+type deleteFailClient struct {
+	client.Client
+	failFor map[string]error
+}
+
+func (c *deleteFailClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if err, ok := c.failFor[obj.GetName()]; ok {
+		return err
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+var _ = Describe("ComponentRelease Cleanup", func() {
+	const (
+		projectName = "cleanup-test-project"
+		namespace   = "default"
+		timeout     = time.Second * 10
+		interval    = time.Millisecond * 250
+	)
+
+	createRelease := func(ctx context.Context, name, compName string) {
+		release := &openchoreov1alpha1.ComponentRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: openchoreov1alpha1.ComponentReleaseSpec{
+				Owner: openchoreov1alpha1.ComponentReleaseOwner{
+					ProjectName:   projectName,
+					ComponentName: compName,
+				},
+				ComponentType: openchoreov1alpha1.ComponentTypeSpec{
+					WorkloadType: "deployment",
+					Resources: []openchoreov1alpha1.ResourceTemplate{
+						{
+							ID:       "deployment",
+							Template: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"apps/v1","kind":"Deployment"}`)},
+						},
+					},
+				},
+				Workload: openchoreov1alpha1.WorkloadTemplateSpec{
+					Containers: map[string]openchoreov1alpha1.Container{
+						"app": {Image: "nginx:latest"},
+					},
+				},
+			},
+		}
+		ExpectWithOffset(1, k8sClient.Create(ctx, release)).To(Succeed())
+	}
+
+	createBinding := func(ctx context.Context, name, compName, releaseName string) {
+		binding := &openchoreov1alpha1.ReleaseBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: openchoreov1alpha1.ReleaseBindingSpec{
+				Owner: openchoreov1alpha1.ReleaseBindingOwner{
+					ProjectName:   projectName,
+					ComponentName: compName,
+				},
+				ReleaseName: releaseName,
+				Environment: "development",
+			},
+		}
+		ExpectWithOffset(1, k8sClient.Create(ctx, binding)).To(Succeed())
+	}
+
+	countReleases := func(ctx context.Context, compName string) int {
+		list := &openchoreov1alpha1.ComponentReleaseList{}
+		err := k8sClient.List(ctx, list,
+			client.InNamespace(namespace),
+			client.MatchingFields{"spec.owner.componentName": compName})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		return len(list.Items)
+	}
+
+	// waitForReleases waits until the informer cache reflects the expected number of releases.
+	// This is necessary because creates go to the API server directly while the cleanup
+	// reads from the cached client; without waiting, the cache may not have synced yet.
+	waitForReleases := func(ctx context.Context, compName string, expected int) {
+		EventuallyWithOffset(1, func() int {
+			return countReleases(ctx, compName)
+		}, timeout, interval).Should(Equal(expected))
+	}
+
+	releaseExists := func(ctx context.Context, name string) bool {
+		r := &openchoreov1alpha1.ComponentRelease{}
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, r)
+		if err == nil {
+			return true
+		}
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "unexpected error checking ComponentRelease existence")
+		return false
+	}
+
+	deleteAllReleases := func(ctx context.Context, compName string, count int) {
+		for i := 1; i <= count; i++ {
+			rel := &openchoreov1alpha1.ComponentRelease{}
+			relName := fmt.Sprintf("%s-rel-%02d", compName, i)
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: relName, Namespace: namespace}, rel); err == nil {
+				_ = k8sClient.Delete(ctx, rel)
+			}
+		}
+	}
+
+	Context("Basic retention", func() {
+		It("should delete releases exceeding the limit", func() {
+			ctx := context.Background()
+			compName := "cleanup-basic"
+			limit := 10
+
+			By("Creating 15 ComponentReleases")
+			for i := 1; i <= 15; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Waiting for cache to sync all 15 releases")
+			waitForReleases(ctx, compName, 15)
+
+			By("Running cleanup with limit=10")
+			reconciler := &Reconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: limit,
+			}
+
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+				},
+			}
+
+			err := reconciler.cleanupComponentReleases(ctx, comp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying exactly 10 releases remain")
+			Eventually(func() int {
+				return countReleases(ctx, compName)
+			}, timeout, interval).Should(Equal(10))
+
+			By("Cleaning up")
+			deleteAllReleases(ctx, compName, 15)
+		})
+	})
+
+	Context("In-use protection via ReleaseBinding", func() {
+		It("should not delete a release referenced by a ReleaseBinding", func() {
+			ctx := context.Background()
+			compName := "cleanup-inuse"
+			limit := 10
+
+			By("Creating 15 ComponentReleases")
+			for i := 1; i <= 15; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Creating a ReleaseBinding referencing release #3")
+			protectedRelease := fmt.Sprintf("%s-rel-03", compName)
+			createBinding(ctx, compName+"-binding", compName, protectedRelease)
+
+			By("Waiting for cache to sync all 15 releases")
+			waitForReleases(ctx, compName, 15)
+
+			By("Running cleanup with limit=10")
+			reconciler := &Reconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: limit,
+			}
+
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+				},
+			}
+
+			err := reconciler.cleanupComponentReleases(ctx, comp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying protected release #3 survives")
+			Expect(releaseExists(ctx, protectedRelease)).To(BeTrue())
+
+			By("Verifying exactly 10 releases remain")
+			Eventually(func() int {
+				return countReleases(ctx, compName)
+			}, timeout, interval).Should(Equal(10))
+
+			By("Cleaning up")
+			binding := &openchoreov1alpha1.ReleaseBinding{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{
+				Name: compName + "-binding", Namespace: namespace,
+			}, binding); err == nil {
+				Expect(k8sClient.Delete(ctx, binding)).To(Succeed())
+			}
+			deleteAllReleases(ctx, compName, 15)
+		})
+	})
+
+	Context("LatestRelease protection", func() {
+		It("should not delete a release marked as LatestRelease", func() {
+			ctx := context.Background()
+			compName := "cleanup-latest"
+			limit := 10
+
+			By("Creating 15 ComponentReleases")
+			for i := 1; i <= 15; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Waiting for cache to sync all 15 releases")
+			waitForReleases(ctx, compName, 15)
+
+			By("Running cleanup with LatestRelease pointing to release #2")
+			protectedRelease := fmt.Sprintf("%s-rel-02", compName)
+			reconciler := &Reconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: limit,
+			}
+
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+				},
+				Status: openchoreov1alpha1.ComponentStatus{
+					LatestRelease: &openchoreov1alpha1.LatestRelease{
+						Name:        protectedRelease,
+						ReleaseHash: "fakehash",
+					},
+				},
+			}
+
+			err := reconciler.cleanupComponentReleases(ctx, comp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying protected release #2 survives")
+			Expect(releaseExists(ctx, protectedRelease)).To(BeTrue())
+
+			By("Verifying exactly 10 releases remain")
+			Eventually(func() int {
+				return countReleases(ctx, compName)
+			}, timeout, interval).Should(Equal(10))
+
+			By("Cleaning up")
+			deleteAllReleases(ctx, compName, 15)
+		})
+	})
+
+	Context("Under limit", func() {
+		It("should not delete anything when under the limit", func() {
+			ctx := context.Background()
+			compName := "cleanup-under"
+			limit := 10
+
+			By("Creating 5 ComponentReleases")
+			for i := 1; i <= 5; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Waiting for cache to sync all 5 releases")
+			waitForReleases(ctx, compName, 5)
+
+			By("Running cleanup with limit=10")
+			reconciler := &Reconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: limit,
+			}
+
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+				},
+			}
+
+			err := reconciler.cleanupComponentReleases(ctx, comp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying all 5 releases still exist")
+			Expect(countReleases(ctx, compName)).To(Equal(5))
+
+			By("Cleaning up")
+			deleteAllReleases(ctx, compName, 5)
+		})
+	})
+
+	Context("All protected", func() {
+		It("should not delete anything when all releases are in use", func() {
+			ctx := context.Background()
+			compName := "cleanup-allprot"
+			limit := 10
+
+			By("Creating 15 ComponentReleases")
+			for i := 1; i <= 15; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Creating a ReleaseBinding for each release")
+			for i := 1; i <= 15; i++ {
+				relName := fmt.Sprintf("%s-rel-%02d", compName, i)
+				bindingName := fmt.Sprintf("%s-bind-%02d", compName, i)
+				createBinding(ctx, bindingName, compName, relName)
+			}
+
+			By("Waiting for cache to sync all 15 releases")
+			waitForReleases(ctx, compName, 15)
+
+			By("Running cleanup with limit=10")
+			reconciler := &Reconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: limit,
+			}
+
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+				},
+			}
+
+			err := reconciler.cleanupComponentReleases(ctx, comp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying all 15 releases still exist")
+			Expect(countReleases(ctx, compName)).To(Equal(15))
+
+			By("Cleaning up")
+			for i := 1; i <= 15; i++ {
+				binding := &openchoreov1alpha1.ReleaseBinding{}
+				bindName := fmt.Sprintf("%s-bind-%02d", compName, i)
+				if err := k8sClient.Get(ctx, client.ObjectKey{
+					Name: bindName, Namespace: namespace,
+				}, binding); err == nil {
+					_ = k8sClient.Delete(ctx, binding)
+				}
+			}
+			deleteAllReleases(ctx, compName, 15)
+		})
+	})
+
+	Context("Limit=0 disables cleanup", func() {
+		It("should not call cleanup when limit is 0", func() {
+			ctx := context.Background()
+			compName := "cleanup-disabled"
+
+			By("Creating 15 ComponentReleases")
+			for i := 1; i <= 15; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Waiting for cache to sync all 15 releases")
+			waitForReleases(ctx, compName, 15)
+
+			By("Verifying the controller guard: RevisionHistoryLimit > 0")
+			reconciler := &Reconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: 0,
+			}
+			// When limit=0 the controller doesn't call cleanup at all.
+			// Verify the guard condition.
+			Expect(reconciler.RevisionHistoryLimit).To(Equal(0))
+
+			By("Verifying all 15 releases still exist (cleanup was never called)")
+			Expect(countReleases(ctx, compName)).To(Equal(15))
+
+			By("Cleaning up")
+			deleteAllReleases(ctx, compName, 15)
+		})
+	})
+
+	Context("Delete failure aggregation", func() {
+		It("should aggregate delete errors and return them", func() {
+			ctx := context.Background()
+			compName := "cleanup-delfail"
+			limit := 3
+
+			By("Creating 5 ComponentReleases")
+			for i := 1; i <= 5; i++ {
+				createRelease(ctx, fmt.Sprintf("%s-rel-%02d", compName, i), compName)
+			}
+
+			By("Creating a ReleaseBinding protecting release #4")
+			protectedByBinding := fmt.Sprintf("%s-rel-04", compName)
+			createBinding(ctx, compName+"-binding", compName, protectedByBinding)
+
+			By("Waiting for cache to sync all 5 releases")
+			waitForReleases(ctx, compName, 5)
+
+			// Make rel-01 and rel-02 fail to delete. With 5 releases, limit=3,
+			// excess=2, and two protected releases (#4 via binding, #5 via LatestRelease),
+			// the only deletable candidates are #1, #2, and #3. Both failing releases
+			// will always be attempted regardless of sort order because a single
+			// successful delete (#3) cannot bring excess to 0 on its own.
+			failRel01 := fmt.Sprintf("%s-rel-01", compName)
+			failRel02 := fmt.Sprintf("%s-rel-02", compName)
+			protectedByLatest := fmt.Sprintf("%s-rel-05", compName)
+
+			By("Creating a reconciler with a delete-failing client for rel-01 and rel-02")
+			failClient := &deleteFailClient{
+				Client: k8sClient,
+				failFor: map[string]error{
+					failRel01: fmt.Errorf("simulated delete failure for rel-01"),
+					failRel02: fmt.Errorf("simulated delete failure for rel-02"),
+				},
+			}
+			reconciler := &Reconciler{
+				Client:               failClient,
+				Scheme:               k8sClient.Scheme(),
+				RevisionHistoryLimit: limit,
+			}
+
+			comp := &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compName,
+					Namespace: namespace,
+				},
+				Spec: openchoreov1alpha1.ComponentSpec{
+					Owner: openchoreov1alpha1.ComponentOwner{
+						ProjectName: projectName,
+					},
+				},
+				Status: openchoreov1alpha1.ComponentStatus{
+					LatestRelease: &openchoreov1alpha1.LatestRelease{
+						Name:        protectedByLatest,
+						ReleaseHash: "fakehash",
+					},
+				},
+			}
+
+			err := reconciler.cleanupComponentReleases(ctx, comp)
+
+			By("Verifying the aggregated error is returned")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("errors during ComponentRelease cleanup"))
+			Expect(err.Error()).To(ContainSubstring("simulated delete failure for rel-01"))
+			Expect(err.Error()).To(ContainSubstring("simulated delete failure for rel-02"))
+
+			By("Verifying failed-to-delete releases still exist")
+			Expect(releaseExists(ctx, failRel01)).To(BeTrue())
+			Expect(releaseExists(ctx, failRel02)).To(BeTrue())
+
+			By("Verifying protected releases still exist")
+			Expect(releaseExists(ctx, protectedByBinding)).To(BeTrue())
+			Expect(releaseExists(ctx, protectedByLatest)).To(BeTrue())
+
+			By("Verifying the non-protected, non-failing release was deleted")
+			Eventually(func() bool {
+				return releaseExists(ctx, fmt.Sprintf("%s-rel-03", compName))
+			}, timeout, interval).Should(BeFalse())
+
+			By("Cleaning up")
+			binding := &openchoreov1alpha1.ReleaseBinding{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{
+				Name: compName + "-binding", Namespace: namespace,
+			}, binding); err == nil {
+				Expect(k8sClient.Delete(ctx, binding)).To(Succeed())
+			}
+			deleteAllReleases(ctx, compName, 5)
+		})
+	})
+})


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
ComponentReleases accumulate indefinitely — every config change (autoDeploy) or manual API call creates a new immutable ComponentRelease, but none are ever deleted (except when the parent Component is deleted via finalizer). This bloats etcd over time. This change adds a cleanup mechanism that deletes old ComponentReleases while protecting those still in use.

## Approach
  - Added a --revision-history-limit controller flag (default: 10, set to 0 to disable) that caps the number of ComponentReleases retained per component.
  - Cleanup runs as a non-fatal step at the end of reconcileWithComponentType — failures are logged but do not block the component from being marked as ready.
  - The cleanup logic lists all releases for the component, builds an in-use set (releases referenced by any ReleaseBinding + the LatestRelease in status), sorts by CreationTimestamp, and deletes the oldest unprotected releases until the count is within the limit.
  - Reuses existing field indexes (spec.owner.componentName and IndexKeyReleaseBindingOwnerComponentName) — no new indexes or CRD changes required.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
  - No CRD/type changes — the retention limit is a controller runtime flag, not a spec field.
  - No new field indexes — reuses the same indexes already used by the finalizer logic in controller_finalize.go.
  - In-use releases are never deleted, even if the total count exceeds the limit (e.g., if all releases are bound to environments, nothing gets deleted).
  - The cleanup is intentionally best-effort: if some deletions fail, remaining deletions still proceed and errors are aggregated and logged. The reconcile itself still succeeds.
  - Follows the existing code-split pattern (controller_finalize.go, controller_hash.go → controller_cleanup.go).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Mini breakdown — changed files by top-level folder
- cmd/: 1 file
- install/: 1 file
- internal/: 17 files
- openapi/: 1 file
- api/: 0 files
- pkg/: 0 files
- docs/: 0 files
- rca-agent/: 0 files
- make/: 0 files
- samples/: 0 files

Changed files (high-level)
- cmd/main.go — adds controller flag --revision-history-limit, validates it, and threads an int value into controller setup to pass into component.Reconciler.
- install/helm/openchoreo-control-plane/values.yaml — adds default controller arg --revision-history-limit=10.
- internal/controller/component/controller.go — adds RevisionHistoryLimit int to Reconciler and invokes best-effort cleanupComponentReleases at end of reconcileWithComponentType when limit > 0.
- internal/controller/component/controller_cleanup.go — implements cleanupComponentReleases: lists ComponentReleases owned by a Component, computes in-use set from ReleaseBindings + Component.status.LatestRelease, sorts by CreationTimestamp, deletes oldest unprotected releases until count ≤ limit; uses 30s list and 10s delete timeouts; aggregates deletion errors; never deletes releases known to be in-use.
- internal/controller/component/controller_cleanup_test.go — new Ginkgo/Gomega test suite covering multiple retention scenarios.
- internal/openchoreo-api/api/handlers/*.go & internal/openchoreo-api/handlers/*.go — add HTTP/OpenAPI handler methods for ClusterDataPlanes, ClusterBuildPlanes, ClusterObservabilityPlanes (list/create/get stubs where applicable).
- internal/openchoreo-api/models/*.go — add CreateClusterDataPlaneRequest (+ Validate/Sanitize) and cluster-scoped response types (ClusterDataPlaneResponse, ClusterBuildPlaneResponse, ClusterObservabilityPlaneResponse).
- internal/openchoreo-api/services/*.go — add ClusterDataPlaneService, ClusterBuildPlaneService, ClusterObservabilityPlaneService, related helpers, constructors, constants, and errors; wire into Services struct.
- openapi/openchoreo-api.yaml — adds cluster-scoped endpoints/schemas for ClusterDataPlane(s), ClusterBuildPlane(s), ClusterObservabilityPlane(s) and related request/response schemas and tags.

Size/LOC highlights (quant)
- internal/controller/component/controller_cleanup.go: +105 LOC.
- internal/controller/component/controller_cleanup_test.go: +513 LOC.
- openapi/openchoreo-api.yaml: +444 LOC.
- internal/openchoreo-api/services/clusterdataplane_service.go: +248 LOC.
- Multiple other service/handler files added (~50–100 LOC each).

API / CRD surface changes
- New public HTTP/OpenAPI endpoints and models added (openapi/ + internal/openchoreo-api/*):
  - /api/v1/clusterdataplanes (list, create), /api/v1/clusterdataplanes/{cdpName} (get)
  - /api/v1/clusterbuildplanes (list)
  - /api/v1/clusterobservabilityplanes (list)
  - New schemas: ClusterDataPlane, CreateClusterDataPlaneRequest, ClusterBuildPlane, ClusterObservabilityPlane, and list/response variants.
- Controller/CRD changes: none to CRD schemas/types. Internal controller config adds Reconciler.RevisionHistoryLimit (runtime flag).
- Compatibility risk: MEDIUM for API surface additions (new endpoints/models increase public API; clients may rely on OpenAPI). LOW for CRD compatibility (no CRD/type changes).

Tests added / updated
- New tests: internal/controller/component/controller_cleanup_test.go — covers:
  - Basic retention behavior (e.g., 15 → 10).
  - Protection via ReleaseBinding.
  - Protection via Component.status.LatestRelease.
  - Under-limit behavior (no deletions).
  - All-protected behavior (no deletions).
  - Limit=0 disables cleanup.
- Test gaps / missing coverage:
  - Failure modes: listing failures for ReleaseBindings or ComponentReleases.
  - Deletion failures / partial delete error handling and retries/backoff.
  - Concurrency/race scenarios (concurrent binding/latest-release updates during cleanup).
  - Operator-visible metrics/conditions for repeated cleanup failures.
  - Unit/integration tests for newly added cluster-scoped services and HTTP handlers (no tests provided in this PR).

Risk hotspots (short)
1. ReleaseBinding listing dependency (Severity: High) — incomplete/failed listing of ReleaseBindings can produce an incomplete in-use set; current behavior logs/returns listing errors but deletion logic assumes in-use set is accurate, raising risk of accidental deletion under partial failures.
2. Concurrency window (Severity: Medium) — race between building in-use set and concurrent updates to ReleaseBindings or Component.status.LatestRelease may allow unsafe deletions in edge cases.
3. Deletion error handling (Severity: Medium) — deletion errors are aggregated and logged; no retry/backoff, metrics, or operator-visible condition introduced to surface persistent failures.
4. Non-blocking semantics (Severity: Medium) — cleanup is best-effort and non-fatal; persistent failures will not block readiness and may allow accumulation unless operators monitor logs/metrics.
5. API surface expansion (Severity: Medium) — new cluster-scoped endpoints/models increase public API surface (requires documentation and reviewers to validate auth/validation).
6. RBAC & authz (Severity: Medium) — PR introduces server handlers and services requiring view/create/list/delete verbs and new system actions/constants; reviewers must verify RBAC manifests and PDP policies are updated accordingly during rollout.
7. Install/upgrade/ops surprise (Severity: Low) — default retention=10 may be unexpected for some operators; must be documented and exposed as a tunable flag (already provided).

Other notes / reviewer recommendations
- Strengths: Reuse of existing field indexes, no CRD/type schema changes, in-use protection via ReleaseBindings and LatestRelease, non-fatal cleanup to avoid blocking reconciliation.
- Recommended follow-ups: add tests for list/delete failure modes and concurrency; introduce metrics and an operator-visible condition for persistent cleanup failures; consider retry/backoff or safer abort-on-list-failure behavior; update RBAC docs/manifests and OpenAPI docs to reflect new endpoints and system actions; document default limit and tuning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->