### PR TITLE
chore: add validation for AuthzClusterRoleBinding to reference only AuthzClusterRole

### DIFF
--- a/api/v1alpha1/authzclusterrolebinding_types.go
+++ b/api/v1alpha1/authzclusterrolebinding_types.go
@@ -8,6 +8,7 @@ import (
 )
 
 // AuthzClusterRoleBindingSpec defines the desired state of AuthzClusterRoleBinding
+// +kubebuilder:validation:XValidation:rule="self.roleRef.kind == 'AuthzClusterRole'",message="AuthzClusterRoleBinding can only reference AuthzClusterRole"
 type AuthzClusterRoleBindingSpec struct {
 	// Entitlement defines the subject (from JWT claims) to grant the role to
 	// +required

--- a/config/crd/bases/openchoreo.dev_authzclusterrolebindings.yaml
+++ b/config/crd/bases/openchoreo.dev_authzclusterrolebindings.yaml
@@ -92,6 +92,9 @@ spec:
             - entitlement
             - roleRef
             type: object
+            x-kubernetes-validations:
+            - message: AuthzClusterRoleBinding can only reference AuthzClusterRole
+              rule: self.roleRef.kind == 'AuthzClusterRole'
         type: object
     served: true
     storage: true

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_authzclusterrolebindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_authzclusterrolebindings.yaml
@@ -91,6 +91,9 @@ spec:
             - entitlement
             - roleRef
             type: object
+            x-kubernetes-validations:
+            - message: AuthzClusterRoleBinding can only reference AuthzClusterRole
+              rule: self.roleRef.kind == 'AuthzClusterRole'
         type: object
     served: true
     storage: true


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This is to improve the authz binding creation flow by adding a vakidation to ensure that AuthzClusterRoleBinding can only refer AuthzClusterRoles.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1855
## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Files Changed by Folder
- api/: 1 file (api/v1alpha1/authzclusterrolebinding_types.go) — +1 line
- config/: 1 file (config/crd/bases/openchoreo.dev_authzclusterrolebindings.yaml) — +3 lines
- install/: 1 file (install/helm/openchoreo-control-plane/crds/openchoreo.dev_authzclusterrolebindings.yaml) — +3 lines
- Total: 3 files affected, +7 lines added

## API/CRD Surface Changes
- What changed:
  - Added a kubebuilder XValidation on AuthzClusterRoleBindingSpec in api/v1alpha1/authzclusterrolebinding_types.go:
    - rule: self.roleRef.kind == 'AuthzClusterRole'
    - message: "AuthzClusterRoleBinding can only reference AuthzClusterRole"
  - Corresponding x-kubernetes-validations entry added to generated CRDs in config/crd/bases and the Helm chart CRD under spec. The validation enforces that spec.roleRef.kind must equal "AuthzClusterRole".
- Scope: Cluster-scoped CRD (AuthzClusterRoleBinding).
- Compatibility risk: Medium — server-side CRD validation will reject existing or incoming AuthzClusterRoleBinding resources whose roleRef.kind is not "AuthzClusterRole", which may break upgrades or deployments that contain misconfigured bindings.

## Tests
- Tests added/updated: None in this PR.
- Coverage gaps / critical missing tests:
  - No unit/integration tests validating the CEL/XValidation rule (positive and negative cases for creating/updating CRs).
  - No upgrade/install tests ensuring existing non-compliant resources are handled (migration/validation failure scenarios).

## Risk Hotspots
1. Authorization/RBAC — validation directly affects authz configuration; incorrect rule or enum mismatches could block intended bindings.
2. Install/Upgrade path — clusters with existing non-compliant AuthzClusterRoleBinding objects may fail CRD installs or upgrades until resources are corrected.
3. CRD validation correctness & Kubernetes versions — CEL/XValidation behavior can vary across Kubernetes versions; lack of tests increases risk.
4. Automation/CI — CI pipelines or operators that create AuthzClusterRoleBinding must be updated to set roleRef.kind correctly or will start failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->