### PR TITLE
feat: make the gatewayclass configurable for API gateway module

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/api-platform/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/api-platform/gateway.yaml
@@ -23,5 +23,5 @@ spec:
     type: sqlite
 
   configRef:
-    name: api-platform-default-gateway-values
+    name: {{ index .Values "api-platform" "gateway" "configRefName" }}
 {{- end }}

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -11,7 +11,7 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.gateway.tls.clusterIssuer }}
   {{- end }}
 spec:
-  gatewayClassName: kgateway
+  gatewayClassName: {{ .Values.gateway.gatewayClassName | default "kgateway" }}
   {{- with .Values.gateway.infrastructure }}
   infrastructure:
     {{- toYaml . | nindent 4 }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -16,6 +16,12 @@
           "additionalProperties": true,
           "description": "Gateway configuration for API Platform",
           "properties": {
+            "configRefName": {
+              "default": "api-platform-default-gateway-values",
+              "description": "Name of the ConfigMap referenced by the Gateway configRef",
+              "title": "configRefName",
+              "type": "string"
+            },
             "helm": {
               "additionalProperties": true,
               "description": "Helm chart reference for gateway sub-chart",
@@ -1049,6 +1055,12 @@
           "required": [],
           "title": "envoy",
           "type": "object"
+        },
+        "gatewayClassName": {
+          "default": "kgateway",
+          "description": "GatewayClass name to reference in the Gateway CR",
+          "title": "gatewayClassName",
+          "type": "string"
         },
         "httpPort": {
           "default": 9080,

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -476,6 +476,13 @@ gateway:
   enabled: true
 
   # @schema
+  # type: string
+  # description: GatewayClass name to reference in the Gateway CR
+  # default: "kgateway"
+  # @schema
+  gatewayClassName: "kgateway"
+
+  # @schema
   # type: object
   # additionalProperties: true
   # description: |
@@ -1797,3 +1804,10 @@ api-platform:
       # default: "0.3.0"
       # @schema
       chartVersion: "0.3.0"
+
+    # @schema
+    # type: string
+    # description: Name of the ConfigMap referenced by the Gateway configRef
+    # default: "api-platform-default-gateway-values"
+    # @schema
+    configRefName: "api-platform-default-gateway-values"


### PR DESCRIPTION
## Purpose
This PR makes the OpenChoreo Dataplane gatewayclass configurable via the dataplane helm installation and makes the default configmap of WSO2 API platform gateway configurable via the dataplane helm installation.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1797


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Make GatewayClass Configurable for API Gateway Module

## Mini breakdown — changed files by top-level folder
- install/: 4 files changed (all under install/helm/openchoreo-data-plane/)
  - install/helm/openchoreo-data-plane/templates/api-platform/gateway.yaml (modified)
  - install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml (modified)
  - install/helm/openchoreo-data-plane/values.schema.json (modified)
  - install/helm/openchoreo-data-plane/values.yaml (modified)
- api/: 0
- config/: 0
- internal/: 0
- pkg/: 0
- docs/: 0
- openapi/: 0
- rca-agent/: 0
- make/: 0
- cmd/: 0
- samples/: 0

## API / CRD surface changes (explicit)
- gateway.api-platform.wso2.com/v1alpha1
  - Field: configRef.name
  - Change: hardcoded "api-platform-default-gateway-values" → templated via values.api-platform.gateway.configRefName
  - Compatibility risk: LOW (default preserved)
- gateway.networking.k8s.io/v1 (Gateway)
  - Field: spec.gatewayClassName
  - Change: hardcoded "kgateway" → templated via values.gateway.gatewayClassName (default "kgateway")
  - Compatibility risk: LOW (default preserved)
- Values schema additions (install/helm/openchoreo-data-plane/values.schema.json)
  - api-platform.gateway.configRefName (string, default "api-platform-default-gateway-values")
  - gateway.gatewayClassName (string, default "kgateway")
  - Compatibility risk: LOW (schema additions only; defaults match previous behavior)

## Tests
- No test files added or modified in this PR.
- Coverage gaps: no unit/integration/helm-render tests added for:
  - Helm template rendering with overridden values (gatewayClassName, configRefName)
  - Upgrade/rollback Helm scenarios involving these new values

## Risk hotspots (short)
- Install/Upgrade path — Low risk: defaults preserve prior hardcoded values; upgrades should be transparent unless users override values.
- RBAC / Authn / Authz — None: no RBAC or auth changes.
- Secrets — None: only ConfigMap reference name made configurable (no secret handling changed).
- Reconciliation loops / controllers — None: operator/control-plane code unchanged.
- Misconfiguration risk — Medium: if users supply incorrect GatewayClass or ConfigMap names, Gateway resources may fail to bind or load configuration; recommend documenting values and validating overrides during upgrade.

## Summary assessment
- Change scope: small, configuration/Helm-only (4 files under install/helm/openchoreo-data-plane).
- Compatibility: low risk due to preserved defaults.
- Action items (recommended): add minimal Helm rendering tests and document the new values in chart/README to reduce misconfiguration risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->