### PR TITLE
feat(cli): make release-config.yaml optional for bulk generate commands

### DIFF
--- a/internal/occ/cmd/componentrelease/resolver.go
+++ b/internal/occ/cmd/componentrelease/resolver.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package componentrelease
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode/output"
+)
+
+// buildOutputDirResolver creates an OutputDirResolverFunc that resolves output directories
+// for component releases using the filesystem index. This is used when no release-config.yaml
+// is present, allowing --all and --project operations to infer output directories.
+//
+// Resolution priority:
+//  1. If existing releases exist for the component in the index, use the same directory.
+//  2. If no existing releases, use a "releases/" directory alongside the component file.
+//  3. If "releases/" already exists at that location, use "releases-<componentName>/" to avoid conflicts.
+func buildOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.OutputDirResolverFunc {
+	return func(projectName, componentName string) string {
+		// Priority 1: Use directory of existing releases
+		releases := ocIndex.ListReleasesForComponent(projectName, componentName)
+		if len(releases) > 0 {
+			return filepath.Dir(releases[0].FilePath)
+		}
+
+		// Look up the component to find its file path
+		compEntry, ok := ocIndex.GetComponent(namespace, componentName)
+		if !ok {
+			return "" // fall through to hardcoded default
+		}
+
+		componentDir := filepath.Dir(compEntry.FilePath)
+		releasesDir := filepath.Join(componentDir, "releases")
+
+		// Priority 2: Use "releases/" next to the component file (if it doesn't already exist)
+		if _, err := os.Stat(releasesDir); os.IsNotExist(err) {
+			return releasesDir
+		}
+
+		// Priority 3: Use "releases-<componentName>/" to avoid conflicts
+		return filepath.Join(componentDir, "releases-"+componentName)
+	}
+}

--- a/internal/occ/cmd/componentrelease/resolver_test.go
+++ b/internal/occ/cmd/componentrelease/resolver_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package componentrelease
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
+)
+
+func TestBuildOutputDirResolver(t *testing.T) {
+	const namespace = "test-ns"
+
+	t.Run("priority 1: existing releases directory", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// Add a component
+		addComponent(t, idx, namespace, "my-comp", "my-proj", "/repo/projects/my-proj/components/my-comp/component.yaml")
+
+		// Add an existing release for the component
+		addRelease(t, idx, namespace, "my-comp-20250101-001", "my-proj", "my-comp", "/repo/projects/my-proj/components/my-comp/releases/my-comp-20250101-001.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("my-proj", "my-comp")
+		want := "/repo/projects/my-proj/components/my-comp/releases"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("priority 2: releases dir next to component (does not exist on disk)", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// Use a temp directory for the component so os.Stat works
+		tmpDir := t.TempDir()
+		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
+		if err := os.MkdirAll(compDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		compFile := filepath.Join(compDir, "component.yaml")
+		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("my-proj", "my-comp")
+		want := filepath.Join(compDir, "releases")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("priority 3: releases dir already exists, use releases-<name>", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// Use a temp directory and create the releases/ dir to simulate conflict
+		tmpDir := t.TempDir()
+		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
+		releasesDir := filepath.Join(compDir, "releases")
+		if err := os.MkdirAll(releasesDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		compFile := filepath.Join(compDir, "component.yaml")
+		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("my-proj", "my-comp")
+		want := filepath.Join(compDir, "releases-my-comp")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("component not found: returns empty string", func(t *testing.T) {
+		idx := index.New("/repo")
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("nonexistent-proj", "nonexistent-comp")
+		if got != "" {
+			t.Errorf("expected empty string for unknown component, got %q", got)
+		}
+	})
+}
+
+// addComponent adds a Component resource entry to the index.
+func addComponent(t *testing.T, idx *index.Index, namespace, name, project, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName": project,
+					},
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// addRelease adds a ComponentRelease resource entry to the index.
+func addRelease(t *testing.T, idx *index.Index, namespace, name, project, component, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentRelease",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   project,
+						"componentName": component,
+					},
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/occ/cmd/releasebinding/resolver.go
+++ b/internal/occ/cmd/releasebinding/resolver.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode/output"
+)
+
+// buildBindingOutputDirResolver creates an OutputDirResolverFunc that resolves output directories
+// for release bindings using the filesystem index. This is used when no release-config.yaml
+// is present, allowing --all and --project operations to infer output directories.
+//
+// Resolution priority:
+//  1. If existing bindings exist for the component in the index, use the same directory.
+//  2. If no existing bindings, use a "bindings/" directory alongside the component file.
+//  3. If "bindings/" already exists at that location, use "bindings-<componentName>/" to avoid conflicts.
+func buildBindingOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.OutputDirResolverFunc {
+	return func(projectName, componentName string) string {
+		// Priority 1: Use directory of existing bindings
+		allBindings := ocIndex.ListReleaseBindings()
+		for _, entry := range allBindings {
+			owner := fsmode.ExtractOwnerRef(entry)
+			if owner != nil && owner.ProjectName == projectName && owner.ComponentName == componentName {
+				return filepath.Dir(entry.FilePath)
+			}
+		}
+
+		// Look up the component to find its file path
+		compEntry, ok := ocIndex.GetComponent(namespace, componentName)
+		if !ok {
+			return "" // fall through to hardcoded default
+		}
+
+		componentDir := filepath.Dir(compEntry.FilePath)
+		bindingsDir := filepath.Join(componentDir, "bindings")
+
+		// Priority 2: Use "bindings/" next to the component file (if it doesn't already exist)
+		if _, err := os.Stat(bindingsDir); os.IsNotExist(err) {
+			return bindingsDir
+		}
+
+		// Priority 3: Use "bindings-<componentName>/" to avoid conflicts
+		return filepath.Join(componentDir, "bindings-"+componentName)
+	}
+}

--- a/internal/occ/cmd/releasebinding/resolver_test.go
+++ b/internal/occ/cmd/releasebinding/resolver_test.go
@@ -1,0 +1,154 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
+)
+
+func TestBuildBindingOutputDirResolver(t *testing.T) {
+	const namespace = "test-ns"
+
+	t.Run("priority 1: existing bindings directory", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// Add a component
+		addComponent(t, idx, namespace, "my-comp", "my-proj", "/repo/projects/my-proj/components/my-comp/component.yaml")
+
+		// Add an existing binding for the component
+		addBinding(t, idx, namespace, "my-comp-dev", "my-proj", "my-comp", "dev", "/repo/projects/my-proj/components/my-comp/bindings/my-comp-dev.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("my-proj", "my-comp")
+		want := "/repo/projects/my-proj/components/my-comp/bindings"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("priority 2: bindings dir next to component (does not exist on disk)", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		tmpDir := t.TempDir()
+		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
+		if err := os.MkdirAll(compDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		compFile := filepath.Join(compDir, "component.yaml")
+		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("my-proj", "my-comp")
+		want := filepath.Join(compDir, "bindings")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("priority 3: bindings dir already exists, use bindings-<name>", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		tmpDir := t.TempDir()
+		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
+		bindingsDir := filepath.Join(compDir, "bindings")
+		if err := os.MkdirAll(bindingsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		compFile := filepath.Join(compDir, "component.yaml")
+		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("my-proj", "my-comp")
+		want := filepath.Join(compDir, "bindings-my-comp")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("component not found: returns empty string", func(t *testing.T) {
+		idx := index.New("/repo")
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
+
+		got := resolver("nonexistent-proj", "nonexistent-comp")
+		if got != "" {
+			t.Errorf("expected empty string for unknown component, got %q", got)
+		}
+	})
+}
+
+// addComponent adds a Component resource entry to the index.
+func addComponent(t *testing.T, idx *index.Index, namespace, name, project, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName": project,
+					},
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// addBinding adds a ReleaseBinding resource entry to the index.
+func addBinding(t *testing.T, idx *index.Index, namespace, name, project, component, env, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ReleaseBinding",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   project,
+						"componentName": component,
+					},
+					"environment": env,
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Purpose

- Make `release-config.yaml` optional for `componentrelease generate --all/--project` and `releasebinding generate --all/--project` by inferring output directories from the filesystem index
- Add `OutputDirResolverFunc` to the bulk write options, enabling pluggable directory resolution between config-based and index-based approaches
- When no config exists, output directories resolve per-component using:
  1. Existing resource directory (from index)
  2. `releases/` or `bindings/` next to the component file
  3. `releases-<name>/` or `bindings-<name>/` if the above already exists (conflict avoidance)

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR Summary: Make release-config.yaml Optional for Bulk Generate Commands

### Changed files by top-level folder
- internal/: 7 (internal/occ/cmd/componentrelease/componentrelease.go; internal/occ/cmd/componentrelease/resolver.go; internal/occ/cmd/componentrelease/resolver_test.go; internal/occ/cmd/releasebinding/releasebinding.go; internal/occ/cmd/releasebinding/resolver.go; internal/occ/cmd/releasebinding/resolver_test.go; internal/occ/fsmode/output/writer.go)
- api/: 0
- config/: 0
- pkg/: 0
- install/: 0
- docs/: 0
- openapi/: 0
- rca-agent/: 0
- make/: 0
- cmd/: 0
- samples/: 0

### Core behavioral changes (concise)
- Bulk generation commands (occ componentrelease generate --all/--project and occ releasebinding generate --all/--project) no longer require release-config.yaml; loader called with requireForBulk=false so releaseConfig may be nil.
- Introduces pluggable OutputDirResolverFunc and wires it through bulk flows so output directories can be inferred from a filesystem index when config is absent.
- New resolver factories:
  - componentrelease: buildOutputDirResolver(ocIndex, namespace)
  - releasebinding: buildBindingOutputDirResolver(ocIndex, namespace)
- Directory resolution priority used by resolvers (per component/project):
  1) Use directory of an existing release/binding from the index (if present).
  2) Use releases/ (componentrelease) or bindings/ (releasebinding) adjacent to the component file.
  3) If that would conflict, use releases-<name>/ or bindings-<name>/ to avoid clashes.
- Existing behavior unchanged when release-config.yaml is present (config continues to take priority).
- Bulk writer options extended to accept Resolver so writer honors resolver-provided paths when non-empty.

### API / CRD surface changes and compatibility risk
- Public API / CRD surface: none changed. Modified functions are internal implementation plumbing (methods on ComponentReleaseImpl / ReleaseBindingImpl and internal writer options). Public CLI entry points remain unchanged.
- Compatibility risk: Low (no exported or CRD changes; behavior change limited to how bulk commands infer output paths when config is absent).

### Tests added / updated
- Added: internal/occ/cmd/componentrelease/resolver_test.go (~155 lines) — 4 subtests covering resolver priority cases for component releases.
- Added: internal/occ/cmd/releasebinding/resolver_test.go (~154 lines) — 4 subtests covering resolver priority cases for bindings.
- Tests use in-memory index helpers (addComponent/addRelease/addBinding) and temporary dirs.
- Missing / still-needed tests:
  - Integration / E2E tests for bulk commands (--all / --project) exercising resolver + writer end-to-end.
  - Tests validating resolver is ignored when release-config.yaml is present (config precedence).
  - Tests for concurrent/edge cases where index is stale or multiple components lead to directory conflicts.
  - Samples and docs updates to show optional release-config.yaml behavior.

### Risk hotspots (short reasons)
- Directory resolution / index reliance (Medium): new code path depends on filesystem index accuracy; stale or incomplete indexes may cause writes to unexpected locations.
- Write path conflicts (Medium): conflict-avoidance naming (releases-<name>/, bindings-<name>/) mitigates but could still surprise users or break CI that expects fixed locations.
- Install/upgrade paths (Low): no installer or CRD changes, but output-location changes could affect downstream tooling that assumes prior layout.
- Authn/Authz, RBAC, secrets, reconciliation loops: No changes to these areas (Low).

### Lines / size indicators (from diffs)
- Significant additions: resolver implementations and unit tests (~+155 and +154 lines for tests); writer changes small (~+28/-2); componentrelease and releasebinding function signature changes (+14/-11 each).
- Overall change is concentrated in internal/occ cmd code and unit tests.

### Checklist items noted in PR
- Tests: resolver unit tests added; integration/E2E tests not added.
- Samples/docs: not updated (checklist items left incomplete in PR description).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->