### PR TITLE
fix(controller): remove unwanted embedded trait param validation against releasebinding

### DIFF
--- a/internal/pipeline/component/context/embedded_trait.go
+++ b/internal/pipeline/component/context/embedded_trait.go
@@ -21,18 +21,18 @@ type EmbeddedTraitContextInput struct {
 	// Trait is the trait definition.
 	Trait *v1alpha1.Trait `validate:"required"`
 
-	// Instance contains the synthetic trait instance with resolved parameters.
-	Instance v1alpha1.ComponentTrait `validate:"required"`
+	// InstanceName is the unique instance name for this embedded trait.
+	InstanceName string `validate:"required"`
+
+	// ResolvedParameters contains the CEL-resolved parameters from the embedded binding.
+	// These are already concrete values (CEL expressions have been evaluated).
+	ResolvedParameters map[string]any
 
 	// ResolvedEnvOverrides contains the CEL-resolved envOverride defaults from the embedded binding.
-	// These serve as defaults that can be overridden by ReleaseBinding.traitOverrides[instanceName].
-	ResolvedEnvOverrides *runtime.RawExtension
+	ResolvedEnvOverrides map[string]any
 
 	// Component is the component this trait is being applied to.
 	Component *v1alpha1.Component `validate:"required"`
-
-	// ReleaseBinding contains release reference and environment-specific overrides.
-	ReleaseBinding *v1alpha1.ReleaseBinding
 
 	// WorkloadData is the pre-computed workload data.
 	WorkloadData WorkloadData
@@ -60,12 +60,12 @@ type EmbeddedTraitContextInput struct {
 //   - Concrete values (locked by PE): passed through as-is
 //   - CEL expressions like "${parameters.storage.mountPath}": evaluated against the component context
 //
-// Returns the resolved parameters and envOverrides as RawExtension.
+// Returns the resolved parameters and envOverrides as maps.
 func ResolveEmbeddedTraitBindings(
 	engine *template.Engine,
 	embeddedTrait v1alpha1.ComponentTypeTrait,
 	componentContextMap map[string]any,
-) (resolvedParams *runtime.RawExtension, resolvedEnvOverrides *runtime.RawExtension, err error) {
+) (resolvedParams map[string]any, resolvedEnvOverrides map[string]any, err error) {
 	resolvedParams, err = resolveBindings(engine, embeddedTrait.Parameters, componentContextMap)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve embedded trait %s/%s parameters: %w",
@@ -82,13 +82,13 @@ func ResolveEmbeddedTraitBindings(
 }
 
 // resolveBindings takes a RawExtension containing mixed concrete values and CEL expressions,
-// evaluates all CEL expressions against the given context, and returns a new RawExtension
-// with all values resolved to concrete types.
+// evaluates all CEL expressions against the given context, and returns a map with all values
+// resolved to concrete types.
 func resolveBindings(
 	engine *template.Engine,
 	raw *runtime.RawExtension,
 	contextMap map[string]any,
-) (*runtime.RawExtension, error) {
+) (map[string]any, error) {
 	if raw == nil || raw.Raw == nil {
 		return nil, nil
 	}
@@ -103,26 +103,21 @@ func resolveBindings(
 		return nil, fmt.Errorf("failed to evaluate CEL bindings: %w", err)
 	}
 
-	resolvedBytes, err := json.Marshal(resolved)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal resolved bindings: %w", err)
+	resolvedMap, ok := resolved.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("resolved bindings is not a map, got type %T", resolved)
 	}
 
-	return &runtime.RawExtension{Raw: resolvedBytes}, nil
+	return resolvedMap, nil
 }
 
 // BuildEmbeddedTraitContext builds a CEL evaluation context for rendering an embedded trait's resources.
 //
 // Unlike BuildTraitContext, this function:
 //   - Uses pre-resolved parameters (already evaluated from CEL bindings)
-//   - Merges resolved envOverride defaults with ReleaseBinding traitOverrides (ReleaseBinding wins)
 func BuildEmbeddedTraitContext(input *EmbeddedTraitContextInput) (*TraitContext, error) {
 	if err := validate.Struct(input); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)
-	}
-
-	if input.Instance.InstanceName == "" {
-		return nil, fmt.Errorf("trait instance name is required")
 	}
 
 	parameters, envOverrides, err := processEmbeddedTraitParameters(input)
@@ -147,7 +142,7 @@ func BuildEmbeddedTraitContext(input *EmbeddedTraitContextInput) (*TraitContext,
 		Metadata:     metadata,
 		Trait: TraitMetadata{
 			Name:         input.Trait.Name,
-			InstanceName: input.Instance.InstanceName,
+			InstanceName: input.InstanceName,
 		},
 	}
 
@@ -162,8 +157,7 @@ func BuildEmbeddedTraitContext(input *EmbeddedTraitContextInput) (*TraitContext,
 // processEmbeddedTraitParameters processes parameters and envOverrides for an embedded trait.
 //
 // Parameters: Come from the resolved bindings (already concrete values from CEL evaluation).
-// EnvOverrides: Start with resolved binding defaults, then merge with ReleaseBinding.traitOverrides
-// (ReleaseBinding values take precedence).
+// EnvOverrides: Come from the resolved bindings (already concrete values from CEL evaluation).
 func processEmbeddedTraitParameters(input *EmbeddedTraitContextInput) (map[string]any, map[string]any, error) {
 	traitName := input.Trait.Name
 
@@ -185,17 +179,11 @@ func processEmbeddedTraitParameters(input *EmbeddedTraitContextInput) (map[strin
 		setCachedSchemaBundle(input.SchemaCache, traitName+":envOverrides", envOverridesBundle)
 	}
 
-	// Extract resolved parameters (already concrete from CEL evaluation)
-	instanceParams, err := extractParameters(input.Instance.Parameters)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to extract resolved trait parameters: %w", err)
-	}
-
 	// Process parameters: prune, apply defaults, validate
 	var parameters map[string]any
 	if parametersBundle != nil {
-		parameters = make(map[string]any, len(instanceParams))
-		maps.Copy(parameters, instanceParams)
+		parameters = make(map[string]any, len(input.ResolvedParameters))
+		maps.Copy(parameters, input.ResolvedParameters)
 		pruning.Prune(parameters, parametersBundle.Structural, false)
 		parameters = schema.ApplyDefaults(parameters, parametersBundle.Structural)
 		if err := schema.ValidateWithJSONSchema(parameters, parametersBundle.JSONSchema); err != nil {
@@ -205,30 +193,11 @@ func processEmbeddedTraitParameters(input *EmbeddedTraitContextInput) (map[strin
 		parameters = make(map[string]any)
 	}
 
-	// Process envOverrides: merge resolved defaults with ReleaseBinding overrides
-	resolvedDefaults, err := extractParameters(input.ResolvedEnvOverrides)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to extract resolved trait envOverrides: %w", err)
-	}
-
-	// Start with resolved defaults from embedded binding
-	envOverrides := make(map[string]any, len(resolvedDefaults))
-	maps.Copy(envOverrides, resolvedDefaults)
-
-	// Merge ReleaseBinding traitOverrides on top (ReleaseBinding wins)
-	instanceName := input.Instance.InstanceName
-	if input.ReleaseBinding != nil && input.ReleaseBinding.Spec.TraitOverrides != nil {
-		if instanceOverride, ok := input.ReleaseBinding.Spec.TraitOverrides[instanceName]; ok {
-			releaseOverrides, err := extractParameters(&instanceOverride)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to extract trait environment overrides: %w", err)
-			}
-			maps.Copy(envOverrides, releaseOverrides)
-		}
-	}
-
-	// Prune against schema, apply defaults, and validate
+	// Process envOverrides: prune, apply defaults, validate
+	var envOverrides map[string]any
 	if envOverridesBundle != nil {
+		envOverrides = make(map[string]any, len(input.ResolvedEnvOverrides))
+		maps.Copy(envOverrides, input.ResolvedEnvOverrides)
 		pruning.Prune(envOverrides, envOverridesBundle.Structural, false)
 		envOverrides = schema.ApplyDefaults(envOverrides, envOverridesBundle.Structural)
 		if err := schema.ValidateWithJSONSchema(envOverrides, envOverridesBundle.JSONSchema); err != nil {

--- a/internal/pipeline/component/pipeline.go
+++ b/internal/pipeline/component/pipeline.go
@@ -156,20 +156,13 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 				embeddedTrait.Name, embeddedTrait.InstanceName, err)
 		}
 
-		// Build a synthetic ComponentTrait with resolved parameters
-		syntheticInstance := v1alpha1.ComponentTrait{
-			Name:         embeddedTrait.Name,
-			InstanceName: embeddedTrait.InstanceName,
-			Parameters:   resolvedParams,
-		}
-
 		// Build embedded trait context
 		traitContext, err := context.BuildEmbeddedTraitContext(&context.EmbeddedTraitContextInput{
 			Trait:                t,
-			Instance:             syntheticInstance,
+			InstanceName:         embeddedTrait.InstanceName,
+			ResolvedParameters:   resolvedParams,
 			ResolvedEnvOverrides: resolvedEnvOverrides,
 			Component:            input.Component,
-			ReleaseBinding:       input.ReleaseBinding,
 			WorkloadData:         workloadData,
 			Configurations:       configurations,
 			Metadata:             input.Metadata,


### PR DESCRIPTION
This pull request refactors how embedded trait parameters and environment overrides are handled in the pipeline, moving away from using `RawExtension` and synthetic `ComponentTrait` instances to directly passing resolved maps. This simplifies the code, improves type safety, and eliminates unnecessary conversions. The changes also update the tests to match the new approach.

**Embedded trait parameter and envOverrides refactor:**

* The `EmbeddedTraitContextInput` struct now takes `InstanceName`, `ResolvedParameters`, and `ResolvedEnvOverrides` as direct fields, removing the need for a synthetic `ComponentTrait` and `RawExtension` usage.
* The `ResolveEmbeddedTraitBindings` and `resolveBindings` functions now return plain maps instead of `RawExtension`, simplifying parameter and envOverride resolution. [[1]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L63-R68) [[2]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L85-R91) [[3]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L106-R111)
* The `processEmbeddedTraitParameters` function is updated to use the resolved maps directly and no longer merges with `ReleaseBinding` trait overrides. [[1]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L165-R161) [[2]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L188-R187) [[3]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L208-R201)
* The pipeline's `Render` method is updated to pass resolved maps to `BuildEmbeddedTraitContext` instead of constructing a synthetic `ComponentTrait`.

**Test updates and cleanup:**

* Unit tests are updated to use resolved parameter and envOverride maps directly, and test cases are adjusted to reflect the new logic (e.g., no more merging with `ReleaseBinding`). Helper functions for marshaling/unmarshaling `RawExtension` are removed as they're no longer needed. [[1]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L164-R164) [[2]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L176-R175) [[3]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L226-L234) [[4]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L250-R243) [[5]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L267-L285) [[6]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L296-R279) [[7]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L314-R299) [[8]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L339-L341) [[9]](diffhunk://#diff-addf77c8b32c3bd396ab0f4d21a0d4644bfebf8f76717607a22d9127cbd71aa5L401-L412)

**Minor improvements and validation:**

* The instance name is now validated directly as a required field in `EmbeddedTraitContextInput`, and related code is simplified. [[1]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L124-L127) [[2]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L150-R146)

These changes streamline the handling of embedded trait data, making the codebase easier to maintain and less error-prone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Files Changed by Folder
- **internal/**: 3 files changed
  - internal/pipeline/component/context/embedded_trait.go (API surface: EmbeddedTraitContextInput and several functions changed; net +/- lines in PR summary)
  - internal/pipeline/component/context/embedded_trait_test.go (tests updated/expanded)
  - internal/pipeline/component/pipeline.go (pipeline uses new input fields)
- No changes in: api/, config/, docs/, install/, openapi/, pkg/, cmd/, samples/, rca-agent/, make/.

Total files changed: 3 (all under internal/). Net change: internal refactor concentrated in pipeline/component context and pipeline rendering.

## API / CRD Surface Changes
- Public API/CRDs: None changed. No modifications under api/ or CRD types.
- Compatibility risk: Low — this is an internal refactor; exported production types unaffected. Callers of internal pipeline APIs must adapt to changed internal types/signatures where used.

## Key Code Changes (evidence-based / quant)
- EmbeddedTraitContextInput restructured:
  - Removed: Instance (v1alpha1.ComponentTrait) and ReleaseBinding.
  - Added: InstanceName string (`validate:"required"`), ResolvedParameters map[string]any, ResolvedEnvOverrides map[string]any.
- Binding resolution return types changed from runtime.RawExtension pointers to concrete maps:
  - ResolveEmbeddedTraitBindings(...) now returns (resolvedParams map[string]any, resolvedEnvOverrides map[string]any, err error).
  - resolveBindings(...) now returns (map[string]any, error).
- Data flow:
  - Pipeline render no longer constructs synthetic ComponentTrait with RawExtension parameters; it passes InstanceName and ResolvedParameters directly to BuildEmbeddedTraitContext.
  - processEmbeddedTraitParameters consumes resolved maps directly; removed merging of ReleaseBinding overrides into embedded trait params/envOverrides.
- Tests:
  - Tests updated to compare concrete resolved maps directly and to assert schema-default population when ResolvedParameters is empty.
  - RawExtension marshal/unmarshal test helpers removed.

## Tests Added / Updated
- Updated tests (internal/pipeline/component/context/embedded_trait_test.go):
  - Switched assertions from RawExtension unmarshalling to direct map comparisons.
  - Added/adjusted cases to validate schema-default population when ResolvedParameters is empty.
  - Removed RawExtension helper functions.
- Tests not added:
  - No new integration or e2e tests added to validate end-to-end ReleaseBinding → pipeline resolution → embedded trait final values.

## Risk Hotspots (short reasons)
1. Trait parameter resolution/behavior change — Medium
   - Removal of ReleaseBinding merging in this code path may change final trait values if upstream callers previously relied on implicit merging here. Callers must supply fully resolved maps including overrides.

2. EnvOverrides semantics — Low–Medium
   - EnvOverrides are now taken solely from ResolvedEnvOverrides map; differences in merge order or missing ReleaseBinding merges may alter environment variables delivered to traits.

3. Internal API call sites — Low
   - Code that previously relied on synthetic ComponentTrait/RawExtension shape should be audited to ensure it now provides InstanceName + resolved maps.

4. Testing / integration coverage — Low
   - Lack of end-to-end tests covering ReleaseBinding → resolution → embedded trait increases regression risk.

## Recommendations / Next Steps
- Audit and update callers that produce resolved parameter/env maps so ReleaseBinding-derived overrides (if required) are applied before invoking the new map-based paths.
- Add an integration/e2e test that covers ReleaseBinding → ResolveEmbeddedTraitBindings → pipeline.Render → BuildEmbeddedTraitContext to validate final trait parameter/env values end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->