### PR TITLE
feat: skip OpenSearch health check when using the logs backend

### DIFF
--- a/internal/observer/service/service.go
+++ b/internal/observer/service/service.go
@@ -594,6 +594,15 @@ func (s *LoggingService) HealthCheck(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
+	// Skip OpenSearch health check if using experimental logs backend
+	if s.config.Experimental.UseLogsBackend {
+		if s.logsBackend == nil {
+			return fmt.Errorf("logs backend enabled but not configured")
+		}
+		s.logger.Debug("Health check passed (OpenSearch check skipped - using logs backend)")
+		return nil
+	}
+
 	if err := s.osClient.HealthCheck(ctx); err != nil {
 		s.logger.Error("Health check failed", "error", err)
 		return fmt.Errorf("opensearch health check failed: %w", err)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
When using Observability modules, OpenSearch is not mandatory. Hence the OpenSearch health check should be skipped. For now, this will be when only when the `EXPERIMENTAL_LOGS_BACKEND` is enabled

## Approach
Skips the OpenSearch health check when the EXPERIMENTAL_LOGS_BACKEND environment variable is enabled

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1930

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes by Directory
- internal/: 1 file (internal/observer/service/service.go)
- TOTAL: 1

Repository file counts (top-level folders)
- api: 34
- config: 174
- internal: 583
- pkg: 76
- install: 279
- docs: 41
- openapi: 1
- rca-agent: 47
- make: 8
- cmd: 15
- samples: 95
- TOTAL_FILES: 1403

Code change summary
- Files changed: 1 (internal/observer/service/service.go)
- Lines changed: +9 / -0 (approx.)
- Change: LoggingService.HealthCheck updated to skip OpenSearch.HealthCheck when config.Experimental.UseLogsBackend (EXPERIMENTAL_LOGS_BACKEND) is true:
  - If UseLogsBackend == true and logsBackend == nil → return error "logs backend enabled but not configured".
  - If UseLogsBackend == true and logsBackend != nil → log debug and return nil (skip osClient.HealthCheck).
  - When UseLogsBackend == false → existing OpenSearch health check remains unchanged.

API / CRD surface changes
- None. No exported/public signature changes detected. Compatibility risk: Low.

Tests added / updated
- No new tests added.
- Existing test file present: internal/observer/service/service_test.go (885 lines).
- Current tests do not cover the two new conditional branches introduced:
  - UseLogsBackend=true with logsBackend configured (skip OpenSearch health check).
  - UseLogsBackend=true with logsBackend == nil (configuration error path).
- Critical missing coverage: unit tests for both branches above.

Risk hotspots
- Observability dependency semantics (LOW–MED): skipping OpenSearch health checks when EXPERIMENTAL_LOGS_BACKEND is enabled changes startup/health behavior and may affect monitoring/alerts expecting OpenSearch.
- Configuration drift (LOW): enabling the flag without configuring a logs backend returns an explicit error — this prevents silent failures but requires documentation and tests.
- Install/upgrade paths (LOW): toggling the experimental flag changes runtime dependencies; deployments and health expectations should be documented.
- Not impacted: authn/authz, RBAC, secrets, reconciliation loops appear unchanged.

Related items
- Related issue: https://github.com/openchoreo/openchoreo/issues/1930

Recommendations
- Add unit tests for:
  - UseLogsBackend=true with logsBackend != nil (expect skip of OpenSearch HealthCheck).
  - UseLogsBackend=true with logsBackend == nil (expect configuration error).
- Add a short note in observability/upgrade/docs describing the effect of EXPERIMENTAL_LOGS_BACKEND on health checks and deployment expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->