### PR TITLE
fix: add default values in workflow sample

### DIFF
--- a/samples/workflows/workflow-docker-build.yaml
+++ b/samples/workflows/workflow-docker-build.yaml
@@ -15,14 +15,14 @@ spec:
   schema:
     parameters:
       repository:
-        url: string | description="Git repository URL"
+        url: string | default="https://github.com/openchoreo/sample-workloads" description="Git repository URL"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | default="" description="Git commit SHA or reference (optional, defaults to latest)"
-        appPath: string | default=. description="Path to the application directory within the repository"
+        appPath: string | default="/service-go-greeter" description="Path to the application directory within the repository"
       docker:
-        context: string | default=. description="Docker build context path relative to the repository root"
-        filePath: string | default=./Dockerfile description="Path to the Dockerfile relative to the repository root"
+        context: string | default="/service-go-greeter" description="Docker build context path relative to the repository root"
+        filePath: string | default="/service-go-greeter/Dockerfile" description="Path to the Dockerfile relative to the repository root"
 
   # Rendered workflow resource for WorkflowRun executions
   runTemplate:


### PR DESCRIPTION
## Purpose
Add default values in workflow sample

## Related Issues
- Fix https://github.com/openchoreo/openchoreo/issues/1934


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Breakdown by Folder

**samples/** — 1 file modified
- `samples/workflows/workflow-docker-build.yaml` — Default values added to workflow parameter schema

## Changes Summary

Updated the generic workflow sample (`workflow-docker-build.yaml`) to include default values for four parameters, making it pre-populated and immediately usable in the Backstage UI without requiring manual input:

- `repository.url`: Added default `"https://github.com/openchoreo/sample-workloads"`
- `repository.appPath`: Changed default from `.` → `/service-go-greeter`
- `docker.context`: Changed default from `.` → `/service-go-greeter`
- `docker.filePath`: Changed default from `./Dockerfile` → `/service-go-greeter/Dockerfile`

**Lines changed:** +4/-4

## API/CRD Surface Changes

None — this PR modifies only a sample/example workflow configuration file, not core API or CRD definitions. Compatibility risk: **Low**.

## Tests

No test files added or modified.

## Risk Assessment

**Low risk overall**. This change is isolated to a sample workflow file intended to demonstrate functionality.

**Minor hotspot**: The hardcoded default paths are specific to the `service-go-greeter` application. If the repository structure or application paths change, these defaults would need manual updates to remain functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->