### PR TITLE
feat(controller): make workload creation optional

### DIFF
--- a/internal/controller/componentworkflowrun/controller.go
+++ b/internal/controller/componentworkflowrun/controller.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	}
 
 	if isWorkflowCompleted(componentWorkflowRun) {
-		if isWorkflowSucceeded(componentWorkflowRun) {
+		if isWorkflowSucceeded(componentWorkflowRun) && hasGenerateWorkloadTask(componentWorkflowRun) {
 			return r.handleWorkloadCreation(ctx, componentWorkflowRun, bpClient), nil
 		}
 		return ctrl.Result{}, nil
@@ -917,4 +917,15 @@ func extractArgoStepOrderFromNodeName(nodeName string) int {
 	}
 
 	return order
+}
+
+// hasGenerateWorkloadTask checks if the generate-workload-cr task exists in the workflow tasks.
+// This is used to determine if workload creation should be attempted.
+func hasGenerateWorkloadTask(componentWorkflowRun *openchoreodevv1alpha1.ComponentWorkflowRun) bool {
+	for _, task := range componentWorkflowRun.Status.Tasks {
+		if task.Name == "generate-workload-cr" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/componentworkflowrun/controller_unit_test.go
+++ b/internal/controller/componentworkflowrun/controller_unit_test.go
@@ -733,6 +733,96 @@ func TestConditionFunctions(t *testing.T) {
 	})
 }
 
+func TestHasGenerateWorkloadTask(t *testing.T) {
+	tests := []struct {
+		name string
+		cwfr *openchoreodevv1alpha1.ComponentWorkflowRun
+		want bool
+	}{
+		{
+			name: "should return true when generate-workload-cr task exists",
+			cwfr: &openchoreodevv1alpha1.ComponentWorkflowRun{
+				Status: openchoreodevv1alpha1.ComponentWorkflowRunStatus{
+					Tasks: []openchoreodevv1alpha1.WorkflowTask{
+						{
+							Name:  "build",
+							Phase: "Succeeded",
+						},
+						{
+							Name:  "generate-workload-cr",
+							Phase: "Succeeded",
+						},
+						{
+							Name:  "push",
+							Phase: "Succeeded",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should return false when generate-workload-cr task does not exist",
+			cwfr: &openchoreodevv1alpha1.ComponentWorkflowRun{
+				Status: openchoreodevv1alpha1.ComponentWorkflowRunStatus{
+					Tasks: []openchoreodevv1alpha1.WorkflowTask{
+						{
+							Name:  "build",
+							Phase: "Succeeded",
+						},
+						{
+							Name:  "push",
+							Phase: "Succeeded",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false when tasks list is empty",
+			cwfr: &openchoreodevv1alpha1.ComponentWorkflowRun{
+				Status: openchoreodevv1alpha1.ComponentWorkflowRunStatus{
+					Tasks: []openchoreodevv1alpha1.WorkflowTask{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false when tasks list is nil",
+			cwfr: &openchoreodevv1alpha1.ComponentWorkflowRun{
+				Status: openchoreodevv1alpha1.ComponentWorkflowRunStatus{
+					Tasks: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return true even when task phase is not succeeded",
+			cwfr: &openchoreodevv1alpha1.ComponentWorkflowRun{
+				Status: openchoreodevv1alpha1.ComponentWorkflowRunStatus{
+					Tasks: []openchoreodevv1alpha1.WorkflowTask{
+						{
+							Name:  "generate-workload-cr",
+							Phase: "Failed",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasGenerateWorkloadTask(tt.cwfr)
+			if result != tt.want {
+				t.Errorf("hasGenerateWorkloadTask() = %v, want %v", result, tt.want)
+			}
+		})
+	}
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && len(substr) > 0 && findSubstring(s, substr))


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
$subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1675

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary of Changes

**Changed files breakdown by top-level folder**
- internal/: 2 files
  - internal/controller/componentworkflowrun/controller.go
  - internal/controller/componentworkflowrun/controller_unit_test.go
- api/, config/, pkg/, install/, docs/, openapi/, rca-agent/, make/, cmd/, samples/: 0 files changed

**Lines changed**
- Net: +101 lines
  - Production: +12
  - Tests: +90
  - Deletions: -1

## Code Changes (evidence-based)
- internal/controller/componentworkflowrun/controller.go
  - Reconciliation change: workload creation now only triggered when both
    - isWorkflowSucceeded(componentWorkflowRun) is true AND
    - hasGenerateWorkloadTask(componentWorkflowRun) returns true
  - Added helper hasGenerateWorkloadTask(componentWorkflowRun) that inspects componentWorkflowRun.Status.Tasks for a task named "generate-workload-cr" (name-only check).
  - Behavior: workflows that succeed but do not contain a "generate-workload-cr" task will skip workload creation.

## Test Coverage Added / Updated
- internal/controller/componentworkflowrun/controller_unit_test.go
  - Added unit test(s) for hasGenerateWorkloadTask: multiple scenarios (task present, absent, empty/nil tasks, present but non-succeeded phase).
  - Note: a duplicate occurrence of TestHasGenerateWorkloadTask exists in the same file (duplicate test introduced).
- Missing/insufficient tests
  - No integration/e2e tests added to validate reconciliation behavior end-to-end (e.g., workflow succeeds without generate-workload-cr should skip workload creation and produce observable status/conditions).
  - No tests added to assert user-visible feedback (conditions/logging) when workload creation is skipped.

## API / CRD Impact
- None. No changes to API/CRD surface or exported types. Compatibility risk: Low.

## Risk Hotspots (with short reasons)
- Reconciliation gate (Medium risk)
  - Silent skip: when the generate-workload-cr task is missing, workload creation is silently skipped (no error/condition set). This can cause unexpected no-op behavior for users with custom workflows that omit the task.
  - Backward compatibility: low risk for standard templates—existing templates that include the task remain unaffected.
- Observability / UX (Low–Medium risk)
  - No explicit condition or user-facing message added to indicate workload creation was intentionally skipped; troubleshooting could be harder.
- Tests / Regression (Low–Medium risk)
  - Only unit tests added; lacking integration tests increases risk of regressions in the full reconciliation flow.
- RBAC / Secrets / Authn (Low risk)
  - No RBAC or secret-handling code changed in this PR.

## Recommendation / Notes for reviewers
- Consider adding:
  - An integration test that exercises a succeeded workflow without the generate-workload-cr task to assert expected controller behavior and any status/conditions.
  - A non-silent signal (condition or event) when workload creation is skipped to improve observability for users.
- Remove duplicate unit test entry in controller_unit_test.go.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->