### PR TITLE
feat: add Replace_Dots On in OpenSearch output plugin for Fluent Bit

### DIFF
--- a/install/helm/openchoreo-build-plane/values.schema.json
+++ b/install/helm/openchoreo-build-plane/values.schema.json
@@ -673,7 +673,7 @@
               "type": "string"
             },
             "outputs": {
-              "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
+              "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Replace_Dots On\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
               "description": "Output plugin configuration for log forwarding to OpenSearch",
               "title": "outputs",
               "type": "string"

--- a/install/helm/openchoreo-build-plane/values.yaml
+++ b/install/helm/openchoreo-build-plane/values.yaml
@@ -392,6 +392,7 @@ fluent-bit:
           Logstash_Prefix container-logs
           Match kube.*
           Port 9200
+          Replace_Dots On
           Suppress_Type_Name On
           tls On
           tls.verify Off

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -610,7 +610,7 @@
               "type": "string"
             },
             "outputs": {
-              "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
+              "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Replace_Dots On\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
               "description": "Output plugin configuration for log forwarding to OpenSearch",
               "title": "outputs",
               "type": "string"

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -976,6 +976,7 @@ fluent-bit:
           Logstash_Prefix container-logs
           Match kube.*
           Port 9200
+          Replace_Dots On
           Suppress_Type_Name On
           tls On
           tls.verify Off

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1150,7 +1150,7 @@
               "type": "string"
             },
             "outputs": {
-              "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
+              "default": "[OUTPUT]\n    Name opensearch\n    Host opensearch\n    Generate_ID On\n    HTTP_Passwd ThisIsTheOpenSearchPassword1\n    HTTP_User admin\n    Logstash_Format On\n    Logstash_DateFormat %Y-%m-%d\n    Logstash_Prefix container-logs\n    Match kube.*\n    Port 9200\n    Replace_Dots On\n    Suppress_Type_Name On\n    tls On\n    tls.verify Off\n",
               "description": "Output plugin configuration for log forwarding to OpenSearch",
               "title": "outputs",
               "type": "string"

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1253,6 +1253,7 @@ fluent-bit:
           Logstash_Prefix container-logs
           Match kube.*
           Port 9200
+          Replace_Dots On
           Suppress_Type_Name On
           tls On
           tls.verify Off

--- a/install/k3d/multi-cluster/values-bp.yaml
+++ b/install/k3d/multi-cluster/values-bp.yaml
@@ -59,6 +59,7 @@ fluent-bit:
           Logstash_Prefix container-logs
           Match kube.*
           Port 11085
+          Replace_Dots On
           Suppress_Type_Name On
           tls On
           tls.verify Off

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -42,6 +42,7 @@ fluent-bit:
           Logstash_Prefix container-logs
           Match kube.*
           Port 11085
+          Replace_Dots On
           Suppress_Type_Name On
           tls On
           tls.verify Off

--- a/internal/observer/labels/constants.go
+++ b/internal/observer/labels/constants.go
@@ -5,6 +5,14 @@
 // This centralizes label definitions to eliminate magic strings and improve maintainability.
 package labels
 
+import "strings"
+
+// ReplaceDots replaces dots with underscores in a string
+// This is used to match Fluent-Bit's Replace_Dots behavior in the OpenSearch output plugin.
+func ReplaceDots(s string) string {
+	return strings.ReplaceAll(s, ".", "_")
+}
+
 // Kubernetes label keys used for log filtering and identification across all logging components.
 // These labels are applied to Kubernetes resources and used by:
 // - OpenSearch queries for log filtering
@@ -77,20 +85,22 @@ const (
 	KubernetesLabelsPrefix  = KubernetesPrefix + ".labels"
 	KubernetesPodName       = KubernetesPrefix + ".pod_name"
 	KubernetesContainerName = KubernetesPrefix + ".container_name"
+)
 
-	// Full field paths for OpenSearch queries
-	OSComponentID   = KubernetesLabelsPrefix + "." + ComponentID
-	OSEnvironmentID = KubernetesLabelsPrefix + "." + EnvironmentID
-	OSProjectID     = KubernetesLabelsPrefix + "." + ProjectID
-	OSVersion       = KubernetesLabelsPrefix + "." + Version
-	OSVersionID     = KubernetesLabelsPrefix + "." + VersionID
-	OSNamespaceName = KubernetesLabelsPrefix + "." + NamespaceName
-	OSPipelineID    = KubernetesLabelsPrefix + "." + PipelineID
-	OSRunID         = KubernetesLabelsPrefix + "." + RunID
-	OSWorkflowName  = KubernetesLabelsPrefix + "." + WorkflowName
-	OSBuildID       = KubernetesLabelsPrefix + "." + BuildID
-	OSBuildUUID     = KubernetesLabelsPrefix + "." + BuildUUID
-	OSTarget        = KubernetesLabelsPrefix + "." + Target
+// OpenSearch field paths with dots replaced by underscores in label keys
+var (
+	OSComponentID   = KubernetesLabelsPrefix + "." + ReplaceDots(ComponentID)
+	OSEnvironmentID = KubernetesLabelsPrefix + "." + ReplaceDots(EnvironmentID)
+	OSProjectID     = KubernetesLabelsPrefix + "." + ReplaceDots(ProjectID)
+	OSVersion       = KubernetesLabelsPrefix + "." + ReplaceDots(Version)
+	OSVersionID     = KubernetesLabelsPrefix + "." + ReplaceDots(VersionID)
+	OSNamespaceName = KubernetesLabelsPrefix + "." + ReplaceDots(NamespaceName)
+	OSPipelineID    = KubernetesLabelsPrefix + "." + ReplaceDots(PipelineID)
+	OSRunID         = KubernetesLabelsPrefix + "." + ReplaceDots(RunID)
+	OSWorkflowName  = KubernetesLabelsPrefix + "." + ReplaceDots(WorkflowName)
+	OSBuildID       = KubernetesLabelsPrefix + "." + ReplaceDots(BuildID)
+	OSBuildUUID     = KubernetesLabelsPrefix + "." + ReplaceDots(BuildUUID)
+	OSTarget        = KubernetesLabelsPrefix + "." + ReplaceDots(Target)
 )
 
 // RequiredLabels are the required labels that must be present on all Choreo components for proper log filtering

--- a/internal/observer/opensearch/queries.go
+++ b/internal/observer/opensearch/queries.go
@@ -600,7 +600,7 @@ func (qb *QueryBuilder) BuildNamespaceLogsQuery(params QueryParams, podLabels ma
 	for key, value := range podLabels {
 		labelFilter := map[string]interface{}{
 			"term": map[string]interface{}{
-				fmt.Sprintf("kubernetes.labels.%s.keyword", key): value,
+				fmt.Sprintf("kubernetes.labels.%s.keyword", labels.ReplaceDots(key)): value,
 			},
 		}
 		mustConditions = append(mustConditions, labelFilter)

--- a/internal/observer/opensearch/types.go
+++ b/internal/observer/opensearch/types.go
@@ -202,11 +202,11 @@ func ParseLogEntry(hit Hit) LogEntry {
 	if k8s, ok := source["kubernetes"].(map[string]interface{}); ok {
 		// Parse labels
 		if labelMap, ok := k8s["labels"].(map[string]interface{}); ok {
-			entry.ComponentID = getStringValue(labelMap, labels.ComponentID)
-			entry.EnvironmentID = getStringValue(labelMap, labels.EnvironmentID)
-			entry.ProjectID = getStringValue(labelMap, labels.ProjectID)
-			entry.Version = getStringValue(labelMap, labels.Version)
-			entry.VersionID = getStringValue(labelMap, labels.VersionID)
+			entry.ComponentID = getStringValue(labelMap, labels.ReplaceDots(labels.ComponentID))
+			entry.EnvironmentID = getStringValue(labelMap, labels.ReplaceDots(labels.EnvironmentID))
+			entry.ProjectID = getStringValue(labelMap, labels.ReplaceDots(labels.ProjectID))
+			entry.Version = getStringValue(labelMap, labels.ReplaceDots(labels.Version))
+			entry.VersionID = getStringValue(labelMap, labels.ReplaceDots(labels.VersionID))
 
 			// Convert all labels to string map
 			for k, v := range labelMap {

--- a/internal/observer/service/service_test.go
+++ b/internal/observer/service/service_test.go
@@ -143,8 +143,8 @@ func TestLoggingService_GetComponentLogs(t *testing.T) {
 						"log":        "INFO: Application started",
 						"kubernetes": map[string]interface{}{
 							"labels": map[string]interface{}{
-								"openchoreo.dev/component-uid":   "8a4c5e2f-9d3b-4a7e-b1f6-2c8d4e9f3a7b",
-								"openchoreo.dev/environment-uid": "6c2d3e4f-7a1b-3d8c-9e5f-2c6d4e8f1a9b",
+								"openchoreo_dev/component-uid":   "8a4c5e2f-9d3b-4a7e-b1f6-2c8d4e9f3a7b",
+								"openchoreo_dev/environment-uid": "6c2d3e4f-7a1b-3d8c-9e5f-2c6d4e8f1a9b",
 							},
 							"namespace_name": "default",
 						},
@@ -156,8 +156,8 @@ func TestLoggingService_GetComponentLogs(t *testing.T) {
 						"log":        "ERROR: Something went wrong",
 						"kubernetes": map[string]interface{}{
 							"labels": map[string]interface{}{
-								"openchoreo.dev/component-uid":   "comp-123",
-								"openchoreo.dev/environment-uid": "env-456",
+								"openchoreo_dev/component-uid":   "comp-123",
+								"openchoreo_dev/environment-uid": "env-456",
 							},
 							"namespace_name": "default",
 						},
@@ -257,9 +257,9 @@ func TestLoggingService_GetProjectLogs(t *testing.T) {
 						"log":        "Project log entry",
 						"kubernetes": map[string]interface{}{
 							"labels": map[string]interface{}{
-								"openchoreo.dev/project-uid":     "proj-123",
-								"openchoreo.dev/component-uid":   "comp-456",
-								"openchoreo.dev/environment-uid": "env-789",
+								"openchoreo_dev/project-uid":     "proj-123",
+								"openchoreo_dev/component-uid":   "comp-456",
+								"openchoreo_dev/environment-uid": "env-789",
 							},
 						},
 					},
@@ -363,8 +363,8 @@ func TestParseLogEntry(t *testing.T) {
 			"log":        "ERROR: Database connection failed",
 			"kubernetes": map[string]interface{}{
 				"labels": map[string]interface{}{
-					"openchoreo.dev/component-uid":   "api-service",
-					"openchoreo.dev/environment-uid": "production",
+					"openchoreo_dev/component-uid":   "api-service",
+					"openchoreo_dev/environment-uid": "production",
 					"version":                        "v1.2.3",
 					"version_id":                     "ver-456",
 				},
@@ -427,8 +427,8 @@ func TestParseLogEntry(t *testing.T) {
 		t.Errorf("Expected 4 labels, got %d", len(entry.Labels))
 	}
 
-	if entry.Labels["openchoreo.dev/component-uid"] != "api-service" {
-		t.Errorf("Expected label component UID 'api-service', got '%s'", entry.Labels["openchoreo.dev/component-uid"])
+	if entry.Labels["openchoreo_dev/component-uid"] != "api-service" {
+		t.Errorf("Expected label component UID 'api-service', got '%s'", entry.Labels["openchoreo_dev/component-uid"])
 	}
 }
 
@@ -810,8 +810,8 @@ func TestLoggingService_GetBuildLogs(t *testing.T) {
 						"log":        "Build finished successfully",
 						"kubernetes": map[string]interface{}{
 							"labels": map[string]interface{}{
-								"openchoreo.dev/component-uid":   "8a4c5e2f-9d3b-4a7e-b1f6-2c8d4e9f3a7b",
-								"openchoreo.dev/environment-uid": "6c2d3e4f-7a1b-3d8c-9e5f-2c6d4e8f1a9b",
+								"openchoreo_dev/component-uid":   "8a4c5e2f-9d3b-4a7e-b1f6-2c8d4e9f3a7b",
+								"openchoreo_dev/environment-uid": "6c2d3e4f-7a1b-3d8c-9e5f-2c6d4e8f1a9b",
 							},
 							"namespace_name": "build-system",
 							"pod_name":       "build-123-job",


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
default for Replace_Dots config is Off in OpenSearch output plugin for Fluent Bit. Which makes the fluent-bit pods in current help charts to go to not ready state with following errors repeatedly.

```
{"took":2,"errors":true,"items":[{"create":{"_index":"container-logs-2026-02-13","_id":"EA0E8D6F-D94B-A936-187E-D9E57AA8EAC4","status":400,"error":{"type":"mapper_parsing_exception","reason":"object mapping for [kubernetes.labels.app] tried to parse field [app] as object, but found a concrete value"}}}]}

[2026/02/13 00:23:23.812649261] [ warn] [engine] failed to flush chunk '1-1770942203.460585002.flb', retry in 11 seconds: task_id=0, input=tail.0 > output=opensearch.0 (out_id=0)

[2026/02/13 00:23:23.824553555] [error] [output:opensearch:opensearch.0] error: Output

{"took":3,"errors":true,"items":[{"create":{"_index":"container-logs-2026-02-13","_id":"51909AB8-AE6D-BD4D-8729-5BBEB49641AA","status":400,"error":{"type":"mapper_parsing_exception","reason":"object mapping for [kubernetes.labels.app] tried to parse field [app] as object, but found a concrete value"}}},{"create":{"_index":"container-logs-2026-02-13","_id":"F18C8FF3-A2DE-9873-87FE-151677499882","status":400,"error" {"type":"mapper_parsing_exception","reason":"object mapping for [kubernetes.labels.app] tried to parse field [app] as object, but found a concrete value"}}},{"create":{"_index":"container-logs-2026-02-13","_id":"0B28DBF7-1D1F-4486-FCDB-018DC9922A6A","status":400,"error":{"type":"mapper_parsing_exception","reason":"object mapping for [kubernetes.labels.app] tried to parse field [app] as object, but found a concrete value"}}},{"create":{"_index":"container-logs-2026-02-13","_id":"D1D9A0FE-B78C-8D5F-2A07-176AE3BD8E12","status":400,"error":{"type":"mapper_parsing_exception","reason":"object mapping for [kubernetes.labels.app] tried to parse field [app] as object, but found a concrete value"}}}]}
```

Changes from this PR fixes the issue by setting the Replace Dots config On, and modifying the logs fetching queries accordingly.



## Approach
- Added 'Replace_Dots On' to the OpenSearch output configuration across multiple Helm charts to ensure proper handling of dots in log labels.
- Updated relevant schema and values files for the OpenChoreo build, data, and observability planes.
- Introduced a utility function to replace dots with underscores in label keys for consistency in log processing.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/1938

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Distribution by Folder

| Folder | Files Changed | Purpose |
|--------|---------------|---------|
| `install/` | ~10 files | Helm chart values and schema updates across 4 deployment planes (build, data, observability, k3d) |
| `internal/observer/` | ~5 files | Label transformation utility, OpenSearch query/parsing logic, and test updates |
| **Total** | **~15 files** | Configuration and code implementation for dot-to-underscore label key transformation |

## Core Changes Summary

**Purpose:** Prevent OpenSearch mapper_parsing_exception errors when Kubernetes label keys contain dots (e.g., `kubernetes.labels.openchoreo.dev/component-uid`). Fluent Bit's `Replace_Dots On` replaces dots with underscores in field names during indexing.

**Implementation:**
1. **Configuration (`install/` folder):** Added `Replace_Dots On` to Fluent Bit OpenSearch output plugin across 8 Helm values files and 6 schema files covering build-plane, data-plane, observability-plane, and k3d deployments
2. **Code Logic (`internal/observer/labels/constants.go`):** 
   - Added `ReplaceDots(s string) string` utility function (replaces "." with "_")
   - Converted 12 OpenSearch field path definitions from constants to vars, applying `ReplaceDots()` to label keys before building full field paths
3. **Query Construction (`internal/observer/opensearch/queries.go`):** Updated `BuildNamespaceLogsQuery()` to apply `ReplaceDots()` when constructing per-pod-label filter paths
4. **Log Parsing (`internal/observer/opensearch/types.go`):** Applied `ReplaceDots()` when extracting 5 label values (ComponentID, EnvironmentID, ProjectID, Version, VersionID) from OpenSearch hit results

## API/CRD Surface Changes

**Compatibility Risk: Low**
- No API or CRD definitions modified
- Single new public utility function: `labels.ReplaceDots(string) string` — non-breaking addition
- No breaking changes to existing public function signatures
- Changes are internal to observer module and transparent to external consumers

## Tests Added/Updated

**Coverage:** 
- `internal/observer/service/service_test.go`: 13 lines updated across multiple test cases
- 6 test functions updated: `GetComponentLogs`, `GetProjectLogs`, `ParseLogEntry`, `GetBuildLogs`, `GetTraces`, and supporting fixtures
- Test fixtures now use `openchoreo_dev/...` (underscore) instead of `openchoreo.dev/...` (dot), reflecting the label key transformation behavior
- Example: `"openchoreo_dev/component-uid"` in mock OpenSearch responses and assertions

**Gaps:** No new unit tests for the `ReplaceDots()` utility function itself; transformation logic relies on integration-level test fixture updates.

## Risk Hotspots

1. **Multi-plane Configuration Consistency (Medium):** Fluent Bit `Replace_Dots On` deployed across 4 independent deployment planes (build, data, observability, k3d/multi-cluster, k3d/single-cluster). Risk of inconsistent rollout or missed deployments if coordination fails.

2. **Label Key Transformation in Runtime Queries (Medium):** Three interconnected code paths (`queries.go`, `types.go`, and `constants.go` var block) must all apply `ReplaceDots()` consistently. Misalignment between Fluent Bit field name transformation and code-side label lookups would cause log filtering failures or silent data loss.

3. **Test Fixture Coverage (Medium):** Test updates focus on label key format assertions but don't explicitly verify the dot-to-underscore transformation logic. If Fluent Bit behavior deviates from test expectations, failures may go undetected until production.

4. **Backward Compatibility (Low):** Existing OpenSearch indices with dot-containing field names won't automatically re-index under new underscore-based names; split-brain state possible if configuration rollback occurs mid-deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->