### PR TITLE
feat(api): enhance live obs check logic in ComponentWorkflowRunStatus

### DIFF
--- a/internal/openchoreo-api/handlers/component_workflows.go
+++ b/internal/openchoreo-api/handlers/component_workflows.go
@@ -268,7 +268,7 @@ func (h *Handler) GetComponentWorkflowRunStatus(w http.ResponseWriter, r *http.R
 
 	log = log.With("namespace", namespaceName, "project", projectName, "component", componentName, "run", runName)
 	// Call service to get component workflow run status
-	status, err := h.services.ComponentWorkflowService.GetComponentWorkflowRunStatus(ctx, namespaceName, projectName, componentName, runName)
+	status, err := h.services.ComponentWorkflowService.GetComponentWorkflowRunStatus(ctx, namespaceName, projectName, componentName, runName, h.config.ClusterGateway.URL)
 	if err != nil {
 		if errors.Is(err, services.ErrComponentWorkflowRunNotFound) {
 			log.Error("Component workflow run not found")


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Based on the discussion in https://github.com/openchoreo/openchoreo/pull/1883#discussion_r2796970132

This pull request updates how the system determines if a component workflow run has live observability, making the check more accurate and reliable. Instead of relying on the workflow's age and a fixed TTL, it now directly checks if the Argo Workflow resource still exists on the build plane. The changes also update the method signatures and add a new helper function to support this.

Improvements to workflow run status and observability logic:

* Changed the `GetComponentWorkflowRunStatus` method in `ComponentWorkflowService` to accept an additional `gatewayURL` parameter, enabling more precise resource checks.
* Updated the logic for determining `HasLiveObservability` in `GetComponentWorkflowRunStatus`: now checks for the existence of the Argo Workflow resource on the build plane instead of using workflow age and TTL.
* Added the new `checkArgoWorkflowExistsOnBuildPlane` helper function to encapsulate the resource existence check, improving code clarity and maintainability.

API handler updates:

* Modified the handler for `GetComponentWorkflowRunStatus` to pass the cluster gateway URL to the service, aligning with the updated method signature.

## Approach
- Updated GetComponentWorkflowRunStatus method to accept a gateway URL parameter for improved service interaction.
- Implemented a new checkArgoWorkflowExistsOnBuildPlane method to determine if the Argo Workflow resource exists, enabling live observability of workflow runs.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1474

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

**Changed files count by top-level folder:**
- internal/: 2 files
  - internal/openchoreo-api/services/component_workflow_service.go: +40/-8
  - internal/openchoreo-api/handlers/component_workflows.go: +1/-1

**Total PR delta:** 2 files changed, +41 / -9 lines (approx)

---

## API/CRD Surface Changes

- Method signature change (breaking within internal API):
  - GetComponentWorkflowRunStatus(...)
    - Old: GetComponentWorkflowRunStatus(ctx, namespaceName, projectName, componentName, runName string)
    - New: GetComponentWorkflowRunStatus(ctx, namespaceName, projectName, componentName, runName, gatewayURL string)
  - Location: internal/openchoreo-api/services/component_workflow_service.go
  - Compatibility risk: Medium (internal service API; handler updated but any other callers must be updated)

- Response model behavior change (non-breaking to external contract):
  - Field: HasLiveObservability in ComponentWorkflowRunStatusResponse
  - Change: Determination moved from TTL/age-based heuristic to checking Argo Workflow resource existence on the build plane.
  - Compatibility risk: Low for consumers (field still present); behavioral risk: Medium (different runtime semantics)

---

## Tests Added/Updated

- No tests added or modified in this PR.
- Critical paths lacking tests (quantified):
  - 1 new helper: checkArgoWorkflowExistsOnBuildPlane — no unit tests.
  - Live observability path that queries build plane client — no unit/integration tests.
  - Error/edge cases: build plane unreachable, transient client errors, RunReference nil/invalid — no tests.
  - Handler/service signature change — no compile-time test coverage beyond local build (no tests updated).

---

## Risk Hotspots (short reasons)

1. Build plane connectivity (Medium-High)
   - New dependency: buildPlaneService.GetBuildPlaneClient(ctx, namespaceName, gatewayURL)
   - If client retrieval fails or is transient, helper returns false → live observability suppressed.

2. Semantic change in observability logic (Medium)
   - Replaces TTL heuristic with resource-existence check; may alter UX/monitoring assumptions.

3. Error handling indistinction (Medium)
   - checkArgoWorkflowExistsOnBuildPlane returns false for both "not found" and client errors → cannot distinguish deleted vs transient failure.

4. Internal API breakage (Medium)
   - Service method signature changed; handler updated, but any other internal callers must be verified.

5. Missing test coverage (High)
   - No tests for helper, build plane integration, or new control paths; increases regression risk.

---

## Related Issue
- https://github.com/openchoreo/openchoreo/issues/1474
<!-- end of auto-generated comment: release notes by coderabbit.ai -->