### PR TITLE
feat: add mcp support for cluster planes

### DIFF
--- a/internal/openchoreo-api/mcphandlers/clusterbuildplanes.go
+++ b/internal/openchoreo-api/mcphandlers/clusterbuildplanes.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+type ListClusterBuildPlanesResponse struct {
+	ClusterBuildPlanes []models.ClusterBuildPlaneResponse `json:"cluster_build_planes"`
+}
+
+func (h *MCPHandler) ListClusterBuildPlanes(ctx context.Context) (any, error) {
+	clusterBuildPlanes, err := h.Services.ClusterBuildPlaneService.ListClusterBuildPlanes(ctx)
+	if err != nil {
+		return ListClusterBuildPlanesResponse{}, fmt.Errorf("list cluster build planes failed: %w", err)
+	}
+	return ListClusterBuildPlanesResponse{
+		ClusterBuildPlanes: clusterBuildPlanes,
+	}, nil
+}

--- a/internal/openchoreo-api/mcphandlers/clusterdataplanes.go
+++ b/internal/openchoreo-api/mcphandlers/clusterdataplanes.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+type ListClusterDataPlanesResponse struct {
+	ClusterDataPlanes []*models.ClusterDataPlaneResponse `json:"cluster_data_planes"`
+}
+
+func (h *MCPHandler) ListClusterDataPlanes(ctx context.Context) (any, error) {
+	clusterDataPlanes, err := h.Services.ClusterDataPlaneService.ListClusterDataPlanes(ctx)
+	if err != nil {
+		return ListClusterDataPlanesResponse{}, fmt.Errorf("list cluster dataplanes failed: %w", err)
+	}
+	return ListClusterDataPlanesResponse{
+		ClusterDataPlanes: clusterDataPlanes,
+	}, nil
+}
+
+func (h *MCPHandler) GetClusterDataPlane(ctx context.Context, cdpName string) (any, error) {
+	result, err := h.Services.ClusterDataPlaneService.GetClusterDataPlane(ctx, cdpName)
+	if err != nil {
+		return nil, fmt.Errorf("get cluster dataplane %q failed: %w", cdpName, err)
+	}
+	return result, nil
+}
+
+func (h *MCPHandler) CreateClusterDataPlane(ctx context.Context, req *models.CreateClusterDataPlaneRequest) (any, error) {
+	result, err := h.Services.ClusterDataPlaneService.CreateClusterDataPlane(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("create cluster dataplane failed: %w", err)
+	}
+	return result, nil
+}

--- a/internal/openchoreo-api/mcphandlers/clusterobservabilityplanes.go
+++ b/internal/openchoreo-api/mcphandlers/clusterobservabilityplanes.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+type ListClusterObservabilityPlanesResponse struct {
+	ClusterObservabilityPlanes []models.ClusterObservabilityPlaneResponse `json:"cluster_observability_planes"`
+}
+
+func (h *MCPHandler) ListClusterObservabilityPlanes(ctx context.Context) (any, error) {
+	clusterObservabilityPlanes, err := h.Services.ClusterObservabilityPlaneService.ListClusterObservabilityPlanes(ctx)
+	if err != nil {
+		return ListClusterObservabilityPlanesResponse{}, fmt.Errorf("list cluster observability planes failed: %w", err)
+	}
+	return ListClusterObservabilityPlanesResponse{
+		ClusterObservabilityPlanes: clusterObservabilityPlanes,
+	}, nil
+}

--- a/pkg/mcp/tools/infrastructure_specs_test.go
+++ b/pkg/mcp/tools/infrastructure_specs_test.go
@@ -271,5 +271,78 @@ func infrastructureToolSpecs() []toolTestSpec {
 				}
 			},
 		},
+		{
+			name:                "list_cluster_dataplanes",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "data", "plane"},
+			descriptionMinLen:   10,
+			testArgs:            map[string]any{},
+			expectedMethod:      "ListClusterDataPlanes",
+			validateCall: func(t *testing.T, args []interface{}) {
+				// No arguments to validate
+			},
+		},
+		{
+			name:                "get_cluster_dataplane",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "data", "plane"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"cdp_name"},
+			testArgs: map[string]any{
+				"cdp_name": "cdp1",
+			},
+			expectedMethod: "GetClusterDataPlane",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != "cdp1" {
+					t.Errorf("Expected cdp_name %q, got %v", "cdp1", args[0])
+				}
+			},
+		},
+		{
+			name:                "create_cluster_dataplane",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"create", "cluster", "data", "plane"},
+			descriptionMinLen:   10,
+			requiredParams: []string{
+				"name", "plane_id", "cluster_agent_client_ca", "public_virtual_host", "organization_virtual_host",
+			},
+			optionalParams: []string{
+				"display_name", "description", "public_http_port", "public_https_port",
+				"organization_http_port", "organization_https_port", "observability_plane_ref",
+			},
+			testArgs: map[string]any{
+				"name":                      "new-cdp",
+				"plane_id":                  "us-west-prod",
+				"cluster_agent_client_ca":   "-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----",
+				"public_virtual_host":       "public.example.com",
+				"organization_virtual_host": "org.example.com",
+			},
+			expectedMethod: "CreateClusterDataPlane",
+			validateCall: func(t *testing.T, args []interface{}) {
+				// args[0] is *models.CreateClusterDataPlaneRequest
+			},
+		},
+		{
+			name:                "list_cluster_buildplanes",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "build", "plane"},
+			descriptionMinLen:   10,
+			testArgs:            map[string]any{},
+			expectedMethod:      "ListClusterBuildPlanes",
+			validateCall: func(t *testing.T, args []interface{}) {
+				// No arguments to validate
+			},
+		},
+		{
+			name:                "list_cluster_observability_planes",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "observability", "plane"},
+			descriptionMinLen:   10,
+			testArgs:            map[string]any{},
+			expectedMethod:      "ListClusterObservabilityPlanes",
+			validateCall: func(t *testing.T, args []interface{}) {
+				// No arguments to validate
+			},
+		},
 	}
 }

--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -363,6 +363,33 @@ func (m *MockCoreToolsetHandler) ListObservabilityPlanes(ctx context.Context, na
 	return `[{"name":"observability-plane-1"}]`, nil
 }
 
+func (m *MockCoreToolsetHandler) ListClusterDataPlanes(ctx context.Context) (any, error) {
+	m.recordCall("ListClusterDataPlanes")
+	return `[{"name":"cdp1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterDataPlane(ctx context.Context, cdpName string) (any, error) {
+	m.recordCall("GetClusterDataPlane", cdpName)
+	return `{"name":"cdp1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateClusterDataPlane(
+	ctx context.Context, req *models.CreateClusterDataPlaneRequest,
+) (any, error) {
+	m.recordCall("CreateClusterDataPlane", req)
+	return `{"name":"new-cdp"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) ListClusterBuildPlanes(ctx context.Context) (any, error) {
+	m.recordCall("ListClusterBuildPlanes")
+	return `[{"name":"cbp1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) ListClusterObservabilityPlanes(ctx context.Context) (any, error) {
+	m.recordCall("ListClusterObservabilityPlanes")
+	return `[{"name":"cop1"}]`, nil
+}
+
 func (m *MockCoreToolsetHandler) ApplyResource(ctx context.Context, resource map[string]interface{}) (any, error) {
 	m.recordCall("ApplyResource", resource)
 	return `{"operation":"created"}`, nil

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -93,6 +93,11 @@ func (t *Toolsets) infrastructureToolRegistrations() []RegisterFunc {
 		t.RegisterListObservabilityPlanes,
 		t.RegisterListComponentWorkflowsOrgLevel,
 		t.RegisterGetComponentWorkflowSchemaOrgLevel,
+		t.RegisterListClusterDataPlanes,
+		t.RegisterGetClusterDataPlane,
+		t.RegisterCreateClusterDataPlane,
+		t.RegisterListClusterBuildPlanes,
+		t.RegisterListClusterObservabilityPlanes,
 	}
 }
 

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -167,6 +167,24 @@ type InfrastructureToolsetHandler interface {
 	GetComponentWorkflowSchema(ctx context.Context, namespaceName, cwName string) (any, error)
 }
 
+// ClusterPlaneHandler is an optional extension of InfrastructureToolsetHandler
+// for cluster-scoped plane operations. Handlers that implement this interface
+// alongside InfrastructureToolsetHandler will have cluster-plane MCP tools
+// registered automatically. If the InfrastructureToolset does not implement
+// ClusterPlaneHandler, the cluster-plane tools are silently skipped.
+type ClusterPlaneHandler interface {
+	// ClusterDataPlane operations
+	ListClusterDataPlanes(ctx context.Context) (any, error)
+	GetClusterDataPlane(ctx context.Context, cdpName string) (any, error)
+	CreateClusterDataPlane(ctx context.Context, req *models.CreateClusterDataPlaneRequest) (any, error)
+
+	// ClusterBuildPlane operations
+	ListClusterBuildPlanes(ctx context.Context) (any, error)
+
+	// ClusterObservabilityPlane operations
+	ListClusterObservabilityPlanes(ctx context.Context) (any, error)
+}
+
 // SchemaToolsetHandler handles schema and resource explanation operations
 type SchemaToolsetHandler interface {
 	ExplainSchema(ctx context.Context, kind, path string) (any, error)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

Add MCP (Model Context Protocol) tool support for cluster-scoped plane resources — ClusterDataPlane, ClusterBuildPlane, and ClusterObservabilityPlane. These resources already have REST API endpoints and services but were not accessible via MCP, meaning MCP clients (e.g., AI assistants, IDE integrations) couldn't manage or inspect shared platform infrastructure.  

## Approach

Mirrored the existing namespace-scoped MCP tool pattern (e.g., list_dataplanes, get_dataplane) but without the namespace_name parameter since cluster-scoped resources aren't namespaced.                                                    
                                                                                  
**5 new MCP tools added to the InfrastructureToolset:**                             

1. Tool: list_cluster_dataplanes                                                   
    Description: List all cluster-scoped data planes                                                                  
2. Tool: get_cluster_dataplane                                                     
  Description: Get details of a specific cluster data plane by name
3. Tool: create_cluster_dataplane
  Description: Create a new cluster data plane (with full gateway/port/observability config)
4. Tool: list_cluster_buildplanes
  Description: List all cluster-scoped build planes
5. Tool: list_cluster_observability_planes
  Description: List all cluster-scoped observability planes

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
- The create_cluster_dataplane tool hardcodes observabilityPlaneRef.kind to ClusterObservabilityPlane since cluster-scoped planes can only reference cluster-scoped observability planes (enforced by CEL validation on the CRD).
- No changes to services, handlers, or wiring — the MCP handlers delegate to existing service methods (ClusterDataPlaneService, ClusterBuildPlaneService, ClusterObservabilityPlaneService) that were already wired into the MCPHandler.
- Port fields (e.g., public_http_port) use inline map[string]any{"type": "integer", ...} since no intProperty helper exists in the tools package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR Summary: Add MCP Support for Cluster Planes

Scope: Add MCP (Model Context Protocol) tool support for cluster-scoped plane resources so MCP clients can manage/inspect cluster-scoped infrastructure (ClusterDataPlane, ClusterBuildPlane, ClusterObservabilityPlane). MCP handlers are added and tools registered; handlers delegate to existing Cluster*Service implementations.

Mini breakdown — changed files by top-level folder
- internal/: 3 files
  - internal/openchoreo-api/mcphandlers/clusterbuildplanes.go (+25)
  - internal/openchoreo-api/mcphandlers/clusterdataplanes.go (+41)
  - internal/openchoreo-api/mcphandlers/clusterobservabilityplanes.go (+25)
- pkg/: 5 files
  - pkg/mcp/tools/infrastructure.go (+173)
  - pkg/mcp/tools/infrastructure_specs_test.go (+73)
  - pkg/mcp/tools/mock_test.go (+27)
  - pkg/mcp/tools/register.go (+5)
  - pkg/mcp/tools/types.go (+18)

Total: 8 files changed, +387 lines added.

API / CRD surface changes (explicit)
- New MCP tools (cluster-scoped) added (additive):
  1. list_cluster_dataplanes — ListClusterDataPlanes (no args)
  2. get_cluster_dataplane — GetClusterDataPlane (requires cdp_name)
  3. create_cluster_dataplane — CreateClusterDataPlane (create ClusterDataPlane). Input surface includes: name, plane_id, cluster_agent_client_ca, public_virtual_host, organization_virtual_host (required); optional display_name, description, public_http_port, public_https_port, organization_http_port, organization_https_port, observability_plane_ref. Implementation forcibly sets observabilityPlaneRef.kind = "ClusterObservabilityPlane".
  4. list_cluster_buildplanes — ListClusterBuildPlanes (no args)
  5. list_cluster_observability_planes — ListClusterObservabilityPlanes (no args)
- New interface: ClusterPlaneHandler with five methods; infrastructure tool registration updated to register these tools only when implemented.
Compatibility risk: LOW — purely additive MCP tool registrations and interface additions; no changes to CRD schemas, REST APIs, or services. Handlers delegate to existing services.

Tests added / updated
- pkg/mcp/tools/infrastructure_specs_test.go — added 5 new tool specs for the cluster-scoped tools (+73 lines). Note: the new specs are duplicated twice in the file (potential accidental duplication).
- pkg/mcp/tools/mock_test.go — added mock implementations for the 5 new methods (+27 lines).

Tests still missing / critical paths lacking coverage
- No unit tests added for new MCP handler implementations under internal/openchoreo-api/mcphandlers (List/Get/Create handlers).
- No unit tests for CreateClusterDataPlane validation logic (observability_plane_ref.kind enforcement, port typing).
- No integration/e2e tests for end-to-end MCP tool invocation or service interaction.
- Samples and documentation not updated; checklist items remain unchecked.

Risk hotspots (short reasons)
1. Handler unit tests missing — High: MCP handler behavior (response shape, error wrapping) is untested and could regress MCP clients.
2. Hardcoded observabilityPlaneRef.kind — Medium: relies on CRD CEL validation for cluster-scoped refs; missing tests may hide edge cases or user errors.
3. Port schema/type handling — Medium: ports modeled via inline map[string]any with integer-type schema (no intProperty helper); risks type-safety or client parsing issues.
4. AuthN/AuthZ assumptions — Low/Medium: handlers call existing services (assumed to enforce authz); MCP-layer authorization behavior not validated here.
5. Test duplication in specs — Low/Medium: duplicated specs increase maintenance burden and may mask true test coverage.

Notes / recommendations
- Add unit tests for mcphandlers (List/Get/Create) and for CreateClusterDataPlane validation (observability ref and ports).
- Deduplicate specs in infrastructure_specs_test.go.
- Add integration/e2e tests and update samples/docs to validate MCP tool end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->