### PR TITLE
feat: add permissions to access cluster resources

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
@@ -19,6 +19,9 @@ rules:
   - apis
   - buildplanes
   - builds
+  - clusterbuildplanes
+  - clusterdataplanes
+  - clusterobservabilityplanes
   - componentreleases
   - components
   - componenttypes
@@ -79,6 +82,9 @@ rules:
   - apis/status
   - buildplanes/status
   - builds/status
+  - clusterbuildplanes/status
+  - clusterdataplanes/status
+  - clusterobservabilityplanes/status
   - componentreleases/status
   - components/status
   - componenttypes/status


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This has been added to acces cluster level resources

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds RBAC permissions for the OpenChoreo API server to access three new cluster-scoped resources.

### Files Changed by Directory
- **install/** (1 file): helm clusterrole.yaml template
- **Total change**: 1 file modified, +6 lines

### CRD/API Surface Changes
**High**: Three cluster-scoped resources granted broad permissions in the `openchoreo.dev` apiGroup:
- `clusterbuildplanes`
- `clusterdataplanes`
- `clusterobservabilityplanes`

**Verbs granted** (per resource):
- Base resources: `create`, `delete`, `get`, `list`, `patch`, `update`, `watch`
- Status subresources: `get`, `patch`, `update`

**Compatibility Risk: Medium-High**
- These are cluster-scoped resources (not namespaced), expanding the API server's permissions boundary
- Broad mutation verbs (`create`, `delete`, `update`, `patch`) on cluster resources increases blast radius
- Resources already have corresponding CRD definitions (verified in `config/crd/bases/`)
- API handlers and controllers already exist in codebase (verified in `internal/openchoreo-api/handlers/` and `internal/controller/`)

### Tests Added/Updated
**None**. The change includes no tests. This is a critical gap:
- No RBAC integration tests validating that these permissions are necessary and sufficient
- Existing test coverage is minimal: only 5 test files in the entire codebase mention ClusterRole/RBAC
- No tests specifically validating the permissions for clusterbuildplanes, clusterdataplanes, or clusterobservabilityplanes

### Risk Hotspots
1. **RBAC Authorization (Medium-High Risk)**: 
   - Broad mutation permissions on cluster-scoped resources without evidence of principle of least privilege
   - No validation that all granted verbs are actually used by API server handlers

2. **Missing Permission Tests (High Risk)**:
   - No tests validating that API server operations fail appropriately without these permissions
   - No e2e coverage of cluster resource access

3. **Cluster-Scoped Resource Boundary (Medium Risk)**:
   - Expansion from namespace-scoped to cluster-scoped resource access
   - Single API server instance can now create/delete/modify cluster infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->