### PR TITLE
feat: add 'namespace:create' permission

### DIFF
--- a/internal/authz/core/actions.go
+++ b/internal/authz/core/actions.go
@@ -19,6 +19,7 @@ type Action struct {
 var systemActions = []Action{
 	// Namespace
 	{Name: "namespace:view", IsInternal: false},
+	{Name: "namespace:create", IsInternal: false},
 
 	// Project
 	{Name: "project:view", IsInternal: false},

--- a/internal/authz/core/actions_test.go
+++ b/internal/authz/core/actions_test.go
@@ -19,7 +19,7 @@ func TestAllActions(t *testing.T) {
 	})
 
 	t.Run("returns expected action count", func(t *testing.T) {
-		expectedCount := 53 // Update this when intentionally adding/removing actions
+		expectedCount := 54 // Update this when intentionally adding/removing actions
 		if len(actions) != expectedCount {
 			t.Errorf("Expected %d actions, got %d. Update expected count if intentional.", expectedCount, len(actions))
 		}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

feat: add 'namespace:create' permission

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1852

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changed Files by Folder
- **internal/** (2 files): `authz/core/actions.go`, `authz/core/actions_test.go`

## API/CRD Surface Changes
**No API or CRD modifications.** This is a pure permission definition change. The `namespace:create` action was already wired into the system (referenced in namespace_service.go for authorization checks and in multiple RBAC test fixtures), and this PR formalizes it by adding it to the core actions registry.

## Tests
- **Updated**: `TestAllActions` - hardcoded expected action count incremented from 53 to 54
- **Already Tested**: The `namespace:create` permission is already exercised in `internal/authz/casbin/k8s_watcher_test.go` (10+ references in test fixtures for role/action bindings), indicating the permission was already in active use before this PR

## Risk Hotspots
**Risk Level: Medium** (Authorization/RBAC change)
- **Rationale**: Adds a new permission to the authorization system. While the permission appears to already be functional in the codebase (usage in namespace_service.go exists), this PR makes it an officially registered action. Review should verify:
  1. All existing role bindings that grant `namespace:create` remain compatible with the new registration
  2. Default roles and cluster roles that should include namespace creation capability are updated accordingly
  3. The permission is properly scoped (appears cluster-scoped based on `role_ns: "*"` patterns in test data)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->