### PR TITLE
feat: add namespace name to image name

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -662,7 +662,7 @@ spec:
           - name: dockerfile-path
             value: ${parameters.docker.filePath}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}-image
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret
@@ -770,7 +770,7 @@ spec:
           - name: node-version
             value: ${parameters.nodeVersion}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret
@@ -875,7 +875,7 @@ spec:
           - name: app-path
             value: ${systemParameters.repository.appPath}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}-image
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret
@@ -980,7 +980,7 @@ spec:
           - name: app-path
             value: ${systemParameters.repository.appPath}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}-image
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret

--- a/samples/getting-started/component-workflows/ballerina-buildpack.yaml
+++ b/samples/getting-started/component-workflows/ballerina-buildpack.yaml
@@ -40,7 +40,7 @@ spec:
           - name: app-path
             value: ${systemParameters.repository.appPath}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}-image
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret

--- a/samples/getting-started/component-workflows/docker.yaml
+++ b/samples/getting-started/component-workflows/docker.yaml
@@ -47,7 +47,7 @@ spec:
           - name: dockerfile-path
             value: ${parameters.docker.filePath}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}-image
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret

--- a/samples/getting-started/component-workflows/google-cloud-buildpacks.yaml
+++ b/samples/getting-started/component-workflows/google-cloud-buildpacks.yaml
@@ -40,7 +40,7 @@ spec:
           - name: app-path
             value: ${systemParameters.repository.appPath}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}-image
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret

--- a/samples/getting-started/component-workflows/react.yaml
+++ b/samples/getting-started/component-workflows/react.yaml
@@ -43,7 +43,7 @@ spec:
           - name: node-version
             value: ${parameters.nodeVersion}
           - name: image-name
-            value: ${metadata.projectName}-${metadata.componentName}
+            value: ${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}
           - name: image-tag
             value: v1
           - name: git-secret


### PR DESCRIPTION
This pull request updates the way image names are generated in several sample workflow YAML files. The main change is to include the `namespaceName` as a prefix in the `image-name` values, making image names more unique and less likely to conflict across different namespaces.

**Image name generation changes:**

* Updated `image-name` to use the format `${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}` instead of omitting the namespace or using the `-image` suffix in the following files and locations:
  * `samples/getting-started/all.yaml` for Docker, React, and other build steps [[1]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L665-R665) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L773-R773) [[3]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L878-R878) [[4]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L983-R983)
  * `samples/getting-started/component-workflows/ballerina-buildpack.yaml`
  * `samples/getting-started/component-workflows/docker.yaml`
  * `samples/getting-started/component-workflows/google-cloud-buildpacks.yaml`
  * `samples/getting-started/component-workflows/react.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

### File Changes Breakdown by Directory
- **samples/**: 5 files modified (+8/-8 total lines)
  - samples/getting-started/all.yaml (4 changes)
  - samples/getting-started/component-workflows/: 4 files with 1 change each
    - ballerina-buildpack.yaml
    - docker.yaml
    - google-cloud-buildpacks.yaml
    - react.yaml
- **All other directories** (api/, cmd/, config/, internal/, pkg/, install/, docs/): No changes

### Changes Overview
Sample workflow YAML files updated to use namespace prefix in image name generation:
- **Old format**: `${metadata.projectName}-${metadata.componentName}-image`
- **New format**: `${metadata.namespaceName}-${metadata.projectName}-${metadata.componentName}`

Affected build workflows: Docker, React, Ballerina-buildpack, Google Cloud Buildpacks.

### API/CRD Surface Changes
**None** — The `metadata.namespaceName` variable is already documented in existing API types (`api/v1alpha1/componentworkflow_types.go`, `api/v1alpha1/workflow_types.go`). This PR only updates sample configurations to use this existing metadata variable. No type definitions or interfaces are modified.

### Tests
No tests added or updated. Note: Image name generation logic exists in production code at `internal/controller/build/engines/argo/workflow.go` (using `names.MakeImageName()`), but this backend implementation is not modified and therefore compatibility with the new naming convention should be verified.

### Risk Assessment
**Risk level: Low**
- Configuration-only changes in sample files; no production code modifications
- Leverages existing `metadata.namespaceName` variable already supported by API types
- No RBAC, authentication, authorization, or secret handling changes
- No reconciliation logic or system behavior changes
- **Gap**: No tests added to validate that backend image name generation logic (`internal/controller/build/engines/argo/workflow.go`) produces the same naming format as samples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->