### PR TITLE
fix: use wildcard query for log level filter to match OpenSearch fiel…

### DIFF
--- a/internal/observer/opensearch/queries.go
+++ b/internal/observer/opensearch/queries.go
@@ -80,10 +80,13 @@ func addLogLevelFilter(mustConditions []map[string]interface{}, logLevels []stri
 		shouldConditions := []map[string]interface{}{}
 
 		for _, logLevel := range logLevels {
-			// Use match query to find log level in the log content
+			// Use wildcard query since the log field is mapped as wildcard type in OpenSearch
 			shouldConditions = append(shouldConditions, map[string]interface{}{
-				"match": map[string]interface{}{
-					"log": strings.ToUpper(logLevel),
+				"wildcard": map[string]interface{}{
+					"log": map[string]interface{}{
+						"value":            "*" + strings.ToUpper(logLevel) + "*",
+						"case_insensitive": true,
+					},
 				},
 			})
 		}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
  - Fix log level filter (ERROR, WARN, etc.) returning no results in the logs UI

## Approach
  - The `log` field is mapped as `wildcard` type in OpenSearch, which doesn't support `match` queries. changed to `wildcard` query to match the field type

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes Summary
- internal/: 1 file (internal/observer/opensearch/queries.go)

## Code Changes
- Modified: internal/observer/opensearch/queries.go (+6 / -3)
  - Replaced log level filter from a `match` query to a `wildcard` query to match OpenSearch mapping.
  - Pattern used: "*" + strings.ToUpper(logLevel) + "*" with `case_insensitive: true`.
  - Preserves existing boolean wrapping (`should` clause with `minimum_should_match: 1`).

## API / CRD Surface Changes
- None. Internal observer module change only. Compatibility risk: Low.

## Tests
- No test updates included in this PR.
- Existing test coverage: internal/observer/opensearch/queries_test.go (large test file covering multiple query builders).
- Gap: No explicit unit test added for the log level filter change (no direct test asserting wildcard query generation or case-insensitive matching).

## Risk Assessment
- Risk level: Low.
- Reasoning: Read-only query-generation bug fix, localized to OpenSearch query construction. No changes to authN/authZ, RBAC, secrets, reconciliation loops, install/upgrade paths, or public APIs.

## Risk Hotspots
- None of the usual high-risk areas (authn/authz, secrets, reconciliation) affected. Primary hotspot is correctness of query for OpenSearch wildcard-mapped `log` field — addressed by switching to a `wildcard` query.

## Related Call Sites
- addLogLevelFilter() is used by multiple query builders (component/build/gateway logs), so the fix applies across those log queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->