### PR TITLE
feat: add endpoint visibility field to workload cr

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -53,20 +53,6 @@ type EndpointAccess struct {
 	// TODO: Add TLS and other details if needed
 }
 
-// EndpointExposeLevel defines the visibility scope for endpoint access
-type EndpointExposeLevel string
-
-const (
-	// EndpointExposeLevelProject restricts endpoint access to components within the same project
-	EndpointExposeLevelProject EndpointExposeLevel = "Project"
-
-	// EndpointExposeLevelOrganization allows endpoint access across all projects within the same organization
-	EndpointExposeLevelOrganization EndpointExposeLevel = "Organization"
-
-	// EndpointExposeLevelPublic exposes the endpoint publicly, accessible from outside the organization
-	EndpointExposeLevelPublic EndpointExposeLevel = "Public"
-)
-
 // ReleaseState defines the desired state of the Release created by a binding
 type ReleaseState string
 

--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -115,8 +115,32 @@ func (e EndpointType) String() string {
 	return string(e)
 }
 
+// EndpointVisibility defines the visibility scope for an endpoint.
+// It determines which components can access the endpoint and how that access is enforced at runtime.
+// +kubebuilder:validation:Enum=project;namespace;internal;external
+type EndpointVisibility string
+
+const (
+	// EndpointVisibilityProject makes the endpoint accessible only within the same project and environment.
+	EndpointVisibilityProject EndpointVisibility = "project"
+
+	// EndpointVisibilityNamespace makes the endpoint accessible across all projects in the same namespace and environment.
+	EndpointVisibilityNamespace EndpointVisibility = "namespace"
+
+	// EndpointVisibilityInternal makes the endpoint accessible across all namespaces in the deployment (intranet).
+	EndpointVisibilityInternal EndpointVisibility = "internal"
+
+	// EndpointVisibilityExternal makes the endpoint accessible from outside the deployment, including public internet.
+	EndpointVisibilityExternal EndpointVisibility = "external"
+)
+
 // WorkloadEndpoint represents a simple network endpoint for basic exposure.
 type WorkloadEndpoint struct {
+	// Visibility defines the access scope for the endpoint.
+	// +optional
+	// +kubebuilder:default=project
+	Visibility EndpointVisibility `json:"visibility,omitempty"`
+
 	// Type indicates the protocol/technology of the endpoint (HTTP, REST, gRPC, GraphQL, Websocket, TCP, UDP).
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=HTTP;REST;gRPC;GraphQL;Websocket;TCP;UDP

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -846,6 +846,16 @@ spec:
                           - TCP
                           - UDP
                           type: string
+                        visibility:
+                          default: project
+                          description: Visibility defines the access scope for the
+                            endpoint.
+                          enum:
+                          - project
+                          - namespace
+                          - internal
+                          - external
+                          type: string
                       required:
                       - port
                       - type

--- a/config/crd/bases/openchoreo.dev_workloads.yaml
+++ b/config/crd/bases/openchoreo.dev_workloads.yaml
@@ -372,6 +372,15 @@ spec:
                       - TCP
                       - UDP
                       type: string
+                    visibility:
+                      default: project
+                      description: Visibility defines the access scope for the endpoint.
+                      enum:
+                      - project
+                      - namespace
+                      - internal
+                      - external
+                      type: string
                   required:
                   - port
                   - type

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -845,6 +845,16 @@ spec:
                           - TCP
                           - UDP
                           type: string
+                        visibility:
+                          default: project
+                          description: Visibility defines the access scope for the
+                            endpoint.
+                          enum:
+                          - project
+                          - namespace
+                          - internal
+                          - external
+                          type: string
                       required:
                       - port
                       - type

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
@@ -371,6 +371,15 @@ spec:
                       - TCP
                       - UDP
                       type: string
+                    visibility:
+                      default: project
+                      description: Visibility defines the access scope for the endpoint.
+                      enum:
+                      - project
+                      - namespace
+                      - internal
+                      - external
+                      type: string
                   required:
                   - port
                   - type

--- a/internal/occ/resources/workload/converter.go
+++ b/internal/occ/resources/workload/converter.go
@@ -32,6 +32,7 @@ type WorkloadDescriptorMetadata struct {
 
 type WorkloadDescriptorEndpoint struct {
 	Name       string `yaml:"name"`
+	Visibility string `yaml:"visibility,omitempty"`
 	Port       int32  `yaml:"port"`
 	Type       string `yaml:"type"`
 	SchemaFile string `yaml:"schemaFile,omitempty"`
@@ -228,8 +229,9 @@ func addEndpointsFromDescriptor(workload *openchoreov1alpha1.Workload, descripto
 	workload.Spec.Endpoints = make(map[string]openchoreov1alpha1.WorkloadEndpoint)
 	for _, descriptorEndpoint := range descriptor.Endpoints {
 		endpoint := openchoreov1alpha1.WorkloadEndpoint{
-			Type: openchoreov1alpha1.EndpointType(descriptorEndpoint.Type),
-			Port: descriptorEndpoint.Port,
+			Visibility: openchoreov1alpha1.EndpointVisibility(descriptorEndpoint.Visibility),
+			Type:       openchoreov1alpha1.EndpointType(descriptorEndpoint.Type),
+			Port:       descriptorEndpoint.Port,
 		}
 
 		// Set schema if provided

--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -228,9 +228,15 @@ func ExtractWorkloadData(workload *v1alpha1.Workload) WorkloadData {
 	}
 
 	for name, endpoint := range workload.Spec.Endpoints {
+		visibility := string(endpoint.Visibility)
+		if visibility == "" {
+			visibility = string(v1alpha1.EndpointVisibilityProject)
+		}
+
 		epData := EndpointData{
-			Type: string(endpoint.Type),
-			Port: endpoint.Port,
+			Visibility: visibility,
+			Type:       string(endpoint.Type),
+			Port:       endpoint.Port,
 		}
 		if endpoint.Schema != nil {
 			epData.Schema = &SchemaData{

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -231,9 +231,10 @@ type ContainerData struct {
 
 // EndpointData contains endpoint information.
 type EndpointData struct {
-	Type   string      `json:"type"`
-	Port   int32       `json:"port"`
-	Schema *SchemaData `json:"schema,omitempty"`
+	Visibility string      `json:"visibility"`
+	Type       string      `json:"type"`
+	Port       int32       `json:"port"`
+	Schema     *SchemaData `json:"schema,omitempty"`
 }
 
 // SchemaData contains API schema information for an endpoint.


### PR DESCRIPTION
## Purpose

This PR adds endpoint-level visibility support to the Workload CR and propagates those fields through conversion and pipeline logic.

## Approach

  - Added visibility to WorkloadEndpoint in the API.
  - Introduced EndpointVisibility enum values:
      - project
      - internal
      - external
  - Updated workload descriptor conversion to map:
      - visibility into endpoint visibility
  - Added/defaulted behavior:
      - visibility defaults to project when not set
  - Regenerated CRD and Helm CRD manifests to include new schema fields.
 
## Related Issues
> closes https://github.com/openchoreo/openchoreo/issues/2000

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pull Request Summary

### File Changes Breakdown (9 files total)
- api/: 2 files (api/v1alpha1/types.go, api/v1alpha1/workload_types.go)
- config/: 2 files (config/crd/bases/openchoreo.dev_workloads.yaml, config/crd/bases/openchoreo.dev_componentreleases.yaml)
- install/: 2 files (install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml, install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml)
- internal/: 3 files (internal/occ/resources/workload/converter.go, internal/pipeline/component/context/component.go, internal/pipeline/component/context/types.go)
- Total delta (per provided summaries): approx +78 / -21 lines

### API / CRD Surface Changes (what changed; compatibility risk)
- Added EndpointVisibility string enum and constants:
  - Values: "project" (default), "namespace", "internal", "external"
  - New type: EndpointVisibility
  - Compatibility risk: Low — additive enum and default preserve existing behavior
- Removed legacy type/consts:
  - Removed EndpointExposeLevel and its constants (Project, Organization, Public)
  - Compatibility risk: Medium — removal of exported constants could break external code using them; no migration/aliases provided
- Workload API changes:
  - WorkloadEndpoint: added Visibility field (`visibility,omitempty`) with kubebuilder default "project"
  - WorkloadDescriptorEndpoint (internal descriptor): added Visibility yaml field
  - CRD schema (Workload and ComponentRelease CRDs): added spec.endpoints.*.visibility with enum and default "project"
  - Compatibility risk: Low for CRD semantics (optional field + default); Medium for API consumers who referenced removed constants

### Tests Added / Updated
- No tests added or updated for visibility in the provided change summaries.
- PR description checklist indicates tests and samples remain unchecked.
- Critical test gaps:
  - No unit/integration tests for visibility behavior (creation/update/round-trip)
  - No tests verifying conversion mapping from descriptor visibility → Workload CR → pipeline context
  - No tests validating enforcement/consumption of visibility in downstream controllers (service/ingress generation, network policy)

### Implementation & Data Flow Changes
- converter.go: WorkloadDescriptorEndpoint now includes Visibility; conversion maps descriptor.Visibility → openchoreov1alpha1.EndpointVisibility
- pipeline/component/context:
  - EndpointData struct gained Visibility string (reordered before Type)
  - ExtractWorkloadData assigns endpoint visibility, defaulting to "project" when unset
- CRD and Helm manifests regenerated to include new visibility schema

### Risk Hotspots (short reasons)
- Deprecation / API break:
  - Removed EndpointExposeLevel type/constants without migration or deprecation notice — potential breaks for external code/tools referencing them.
- Enforcement ambiguity:
  - No controller/reconciler changes shown to act on visibility (service/ingress selection, network policy, RBAC). It's unclear how "internal"/"external"/"namespace"/"project" are enforced.
- Install / upgrade:
  - CRD additions are additive with defaults (upgrade safe), but consumers expecting old constants may need code changes.
- Reconciliation / runtime behavior:
  - No evidence visibility is used by reconciliation logic; risk that field is inert unless other PRs consume it.
- Security / authz:
  - If visibility is intended to restrict access, no RBAC or network policy integration is present — risk of misleading schema without enforcement.

### Summary of Gaps / Action Items
- Add migration/deprecation guidance or aliases for removed EndpointExposeLevel constants.
- Add unit and integration tests:
  - conversion tests (descriptor → CR)
  - pipeline/context extraction tests
  - controller tests to validate visibility-driven behavior (service/ingress/network policy)
- Implement/enforce visibility in reconciliation code paths (or document intended consumer responsibilities).
- Add sample workloads demonstrating each visibility value and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->