### PR TITLE
refactor: move mode and root-dir from context to command flags

### DIFF
--- a/internal/occ/cmd/config/config.go
+++ b/internal/occ/cmd/config/config.go
@@ -285,16 +285,14 @@ func printContextDetails(cfg *configContext.StoredConfig, ctx *configContext.Con
 		{"Namespace", formatValueOrPlaceholder(ctx.Namespace)},
 		{"Project", formatValueOrPlaceholder(ctx.Project)},
 		{"Component", formatValueOrPlaceholder(ctx.Component)},
-		{"Mode", formatValueOrPlaceholder(ctx.Mode)},
-		{"Root Directory Path", formatValueOrPlaceholder(ctx.RootDirectoryPath)},
 	}
 
 	if err := printTable(headers, rows); err != nil {
 		return err
 	}
 
-	// Print control plane info if available and not in file-system mode
-	if ctx.ControlPlane != "" && ctx.Mode != configContext.ModeFileSystem {
+	// Print control plane info if available
+	if ctx.ControlPlane != "" {
 		for _, cp := range cfg.ControlPlanes {
 			if cp.Name == ctx.ControlPlane {
 				fmt.Println("\nControl Plane:")

--- a/pkg/cli/cmd/componentrelease/generate.go
+++ b/pkg/cli/cmd/componentrelease/generate.go
@@ -43,6 +43,8 @@ func newGenerateCmd(impl api.CommandImplementationInterface) *cobra.Command {
 			flags.Name,
 			flags.OutputPath,
 			flags.DryRun,
+			flags.Mode,
+			flags.RootDir,
 		},
 		RunE: func(fg *builder.FlagGetter) error {
 			// Check which flags were explicitly provided by the user on the command line
@@ -96,6 +98,8 @@ func newGenerateCmd(impl api.CommandImplementationInterface) *cobra.Command {
 			params := api.GenerateComponentReleaseParams{
 				OutputPath: fg.GetString(flags.OutputPath),
 				DryRun:     fg.GetBool(flags.DryRun),
+				Mode:       fg.GetString(flags.Mode),
+				RootDir:    fg.GetString(flags.RootDir),
 			}
 
 			// Only set the values that were explicitly provided

--- a/pkg/cli/cmd/config/types.go
+++ b/pkg/cli/cmd/config/types.go
@@ -29,17 +29,10 @@ type Credential struct {
 
 // Context represents a single named configuration context.
 type Context struct {
-	Name              string `yaml:"name"`
-	ControlPlane      string `yaml:"controlplane"`          // Reference to controlplanes[].name
-	Credentials       string `yaml:"credentials,omitempty"` // Reference to credentials[].name
-	Namespace         string `yaml:"namespace,omitempty"`
-	Project           string `yaml:"project,omitempty"`
-	Component         string `yaml:"component,omitempty"`
-	Mode              string `yaml:"mode,omitempty"`              // "api-server" or "file-system"
-	RootDirectoryPath string `yaml:"rootDirectoryPath,omitempty"` // Path for file-system mode
+	Name         string `yaml:"name"`
+	ControlPlane string `yaml:"controlplane"`          // Reference to controlplanes[].name
+	Credentials  string `yaml:"credentials,omitempty"` // Reference to credentials[].name
+	Namespace    string `yaml:"namespace,omitempty"`
+	Project      string `yaml:"project,omitempty"`
+	Component    string `yaml:"component,omitempty"`
 }
-
-const (
-	ModeAPIServer  = "api-server"
-	ModeFileSystem = "file-system"
-)

--- a/pkg/cli/cmd/releasebinding/generate.go
+++ b/pkg/cli/cmd/releasebinding/generate.go
@@ -45,6 +45,8 @@ func newGenerateCmd(impl api.CommandImplementationInterface) *cobra.Command {
 			flags.ComponentRelease,
 			flags.OutputPath,
 			flags.DryRun,
+			flags.Mode,
+			flags.RootDir,
 		},
 		RunE: func(fg *builder.FlagGetter) error {
 			// Validate required flags
@@ -87,6 +89,8 @@ func newGenerateCmd(impl api.CommandImplementationInterface) *cobra.Command {
 				UsePipeline: usePipeline,
 				OutputPath:  fg.GetString(flags.OutputPath),
 				DryRun:      fg.GetBool(flags.DryRun),
+				Mode:        fg.GetString(flags.Mode),
+				RootDir:     fg.GetString(flags.RootDir),
 			}
 
 			if allSet {

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -37,6 +37,8 @@ func newCreateWorkloadCmd(impl api.CommandImplementationInterface) *cobra.Comman
 		flags.Output,
 		flags.WorkloadDescriptor,
 		flags.DryRun,
+		flags.Mode,
+		flags.RootDir,
 	}
 
 	return (&builder.CommandBuilder{
@@ -51,6 +53,8 @@ func newCreateWorkloadCmd(impl api.CommandImplementationInterface) *cobra.Comman
 				ImageURL:      fg.GetString(flags.Image),
 				OutputPath:    fg.GetString(flags.Output),
 				DryRun:        fg.GetBool(flags.DryRun),
+				Mode:          fg.GetString(flags.Mode),
+				RootDir:       fg.GetString(flags.RootDir),
 			})
 		},
 	}).Build()

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -17,6 +17,12 @@ type Flag struct {
 	Type      string
 }
 
+// Mode constants for --mode flag
+const (
+	ModeAPIServer  = "api-server"
+	ModeFileSystem = "file-system"
+)
+
 var (
 	Kubeconfig = Flag{
 		Name:  "kubeconfig",
@@ -329,15 +335,15 @@ var (
 		Usage:     "Write output to specified file instead of stdout",
 	}
 
-	// Mode (context) flags
+	// Mode flags
 
 	Mode = Flag{
 		Name:  "mode",
-		Usage: "Context mode: 'api-server' (default) or 'file-system'",
+		Usage: "Operational mode: 'api-server' (default) or 'file-system'",
 	}
 
-	RootDirectoryPath = Flag{
-		Name:  "root-directory-path",
+	RootDir = Flag{
+		Name:  "root-dir",
 		Usage: "Root directory path for file-system mode (defaults to current directory)",
 	}
 

--- a/pkg/cli/types/api/params.go
+++ b/pkg/cli/types/api/params.go
@@ -352,6 +352,8 @@ type CreateWorkloadParams struct {
 	ImageURL      string
 	OutputPath    string
 	DryRun        bool
+	Mode          string // Operational mode: "api-server" or "file-system"
+	RootDir       string // Root directory path for file-system mode
 }
 
 // ScaffoldComponentParams defines parameters for scaffolding a component
@@ -375,6 +377,8 @@ type GenerateComponentReleaseParams struct {
 	ReleaseName   string // Optional: custom release name (only valid with --component)
 	OutputPath    string // Optional: custom output directory
 	DryRun        bool   // Preview without writing files
+	Mode          string // Operational mode: "api-server" or "file-system"
+	RootDir       string // Root directory path for file-system mode
 }
 
 // GenerateReleaseBindingParams defines parameters for generating release bindings
@@ -387,6 +391,8 @@ type GenerateReleaseBindingParams struct {
 	UsePipeline      string // Required: deployment pipeline name
 	OutputPath       string // Optional: custom output directory
 	DryRun           bool   // Preview without writing files
+	Mode             string // Operational mode: "api-server" or "file-system"
+	RootDir          string // Root directory path for file-system mode
 }
 
 // ListNamespacesParams defines parameters for listing namespaces

--- a/samples/gitops-workflows/component-workflows/build-and-release/docker/docker-gitops-release-template.yaml
+++ b/samples/gitops-workflows/component-workflows/build-and-release/docker/docker-gitops-release-template.yaml
@@ -345,11 +345,9 @@ spec:
             BINDING_NAME="${TARGET_ENV}-${COMPONENT_NAME}"
 
             echo "===== Initializing OCC Context ====="
-            # Initialize occ context for file-system mode (only once)
-            occ config set-context gitops-context \
-              --mode file-system \
-              --root-directory-path /mnt/vol/gitops \
-              --namespace "${NAMESPACE_NAME}"
+            # Initialize occ context
+            occ config context add gitops-context \
+              --namespace "${NAMESPACE_NAME}" --controlplane default --credentials default
 
             # Use the gitops-context
             occ config use-context gitops-context
@@ -374,6 +372,7 @@ spec:
                   --project "$PROJECT_NAME" \
                   --component "$COMPONENT_NAME" \
                   --image "$CONTAINER_IMAGE" \
+                  --mode file-system --root-dir /mnt/vol/gitops \
                   --descriptor /tmp/workload-descriptor.yaml
             else
                 echo "No workload descriptor provided, generating basic workload"
@@ -381,7 +380,8 @@ spec:
                 occ workload create \
                   --project "$PROJECT_NAME" \
                   --component "$COMPONENT_NAME" \
-                  --image "$CONTAINER_IMAGE"
+                  --image "$CONTAINER_IMAGE" \
+                  --mode file-system --root-dir /mnt/vol/gitops
             fi
             echo "Workload generated successfully"
 
@@ -393,11 +393,12 @@ spec:
             OUTPUT_PATH="projects/$PROJECT_NAME/components/$COMPONENT_NAME/releases"
             echo " - output-path: $OUTPUT_PATH"
             
-            occ component-release generate \
+            occ componentrelease generate \
               --name "$RELEASE_NAME" \
               --component "$COMPONENT_NAME" \
               --project "$PROJECT_NAME" \
-              --output-path "$OUTPUT_PATH"
+              --output-path "$OUTPUT_PATH" \
+              --mode file-system --root-dir /mnt/vol/gitops
 
             echo "ComponentRelease generated successfully"
 
@@ -409,12 +410,13 @@ spec:
             echo "Project: $PROJECT_NAME"
             echo "Use pipeline: $USE_PIPELINE"
 
-            occ release-binding generate \
+            occ releasebinding generate \
               --component "$COMPONENT_NAME" \
               --component-release "$RELEASE_NAME" \
               --target-env "$TARGET_ENV" \
               --project "$PROJECT_NAME" \
-              --use-pipeline "$USE_PIPELINE"
+              --use-pipeline "$USE_PIPELINE" \
+              --mode file-system --root-dir /mnt/vol/gitops
 
             echo "ReleaseBinding generated successfully"
             echo "===== All GitOps resources generated successfully ====="

--- a/samples/gitops-workflows/component-workflows/build-and-release/google-cloud-buildpacks/google-cloud-buildpacks-gitops-release-template.yaml
+++ b/samples/gitops-workflows/component-workflows/build-and-release/google-cloud-buildpacks/google-cloud-buildpacks-gitops-release-template.yaml
@@ -363,11 +363,9 @@ spec:
             BINDING_NAME="${TARGET_ENV}-${COMPONENT_NAME}"
 
             echo "===== Initializing OCC Context ====="
-            # Initialize occ context for file-system mode (only once)
-            occ config set-context gitops-context \
-              --mode file-system \
-              --root-directory-path /mnt/vol/gitops \
-              --namespace "${NAMESPACE_NAME}"
+            # Initialize occ context
+            occ config context add gitops-context \
+              --namespace "${NAMESPACE_NAME}" --controlplane default --credentials default
 
             # Use the gitops-context
             occ config use-context gitops-context
@@ -392,6 +390,7 @@ spec:
                   --project "$PROJECT_NAME" \
                   --component "$COMPONENT_NAME" \
                   --image "$CONTAINER_IMAGE" \
+                  --mode file-system --root-dir /mnt/vol/gitops \
                   --descriptor /tmp/workload-descriptor.yaml
             else
                 echo "No workload descriptor provided, generating basic workload"
@@ -399,7 +398,8 @@ spec:
                 occ workload create \
                   --project "$PROJECT_NAME" \
                   --component "$COMPONENT_NAME" \
-                  --image "$CONTAINER_IMAGE"
+                  --image "$CONTAINER_IMAGE" \
+                  --mode file-system --root-dir /mnt/vol/gitops
             fi
             echo "Workload generated successfully"
 
@@ -411,11 +411,12 @@ spec:
             OUTPUT_PATH="projects/$PROJECT_NAME/components/$COMPONENT_NAME/releases"
             echo " - output-path: $OUTPUT_PATH"
 
-            occ component-release generate \
+            occ componentrelease generate \
               --name "$RELEASE_NAME" \
               --component "$COMPONENT_NAME" \
               --project "$PROJECT_NAME" \
-              --output-path "$OUTPUT_PATH"
+              --output-path "$OUTPUT_PATH" \
+              --mode file-system --root-dir /mnt/vol/gitops
 
             echo "ComponentRelease generated successfully"
 
@@ -427,12 +428,13 @@ spec:
             echo "Project: $PROJECT_NAME"
             echo "Use pipeline: $USE_PIPELINE"
 
-            occ release-binding generate \
+            occ releasebinding generate \
               --component "$COMPONENT_NAME" \
               --component-release "$RELEASE_NAME" \
               --target-env "$TARGET_ENV" \
               --project "$PROJECT_NAME" \
-              --use-pipeline "$USE_PIPELINE"
+              --use-pipeline "$USE_PIPELINE" \
+              --mode file-system --root-dir /mnt/vol/gitops
 
             echo "ReleaseBinding generated successfully"
             echo "===== All GitOps resources generated successfully ====="

--- a/samples/gitops-workflows/component-workflows/build-and-release/react/react-gitops-release-template.yaml
+++ b/samples/gitops-workflows/component-workflows/build-and-release/react/react-gitops-release-template.yaml
@@ -440,11 +440,9 @@ spec:
             BINDING_NAME="${TARGET_ENV}-${COMPONENT_NAME}"
 
             echo "===== Initializing OCC Context ====="
-            # Initialize occ context for file-system mode (only once)
-            occ config set-context gitops-context \
-              --mode file-system \
-              --root-directory-path /mnt/vol/gitops \
-              --namespace "${NAMESPACE_NAME}"
+            # Initialize occ context
+            occ config context add gitops-context \
+              --namespace "${NAMESPACE_NAME}" --controlplane default --credentials default
 
             # Use the gitops-context
             occ config use-context gitops-context
@@ -469,6 +467,7 @@ spec:
                   --project "$PROJECT_NAME" \
                   --component "$COMPONENT_NAME" \
                   --image "$CONTAINER_IMAGE" \
+                  --mode file-system --root-dir /mnt/vol/gitops \
                   --descriptor /tmp/workload-descriptor.yaml
             else
                 echo "No workload descriptor provided, generating basic workload"
@@ -476,7 +475,8 @@ spec:
                 occ workload create \
                   --project "$PROJECT_NAME" \
                   --component "$COMPONENT_NAME" \
-                  --image "$CONTAINER_IMAGE"
+                  --image "$CONTAINER_IMAGE" \
+                  --mode file-system --root-dir /mnt/vol/gitops
             fi
             echo "Workload generated successfully"
 
@@ -488,11 +488,12 @@ spec:
             OUTPUT_PATH="projects/$PROJECT_NAME/components/$COMPONENT_NAME/releases"
             echo " - output-path: $OUTPUT_PATH"
 
-            occ component-release generate \
+            occ componentrelease generate \
               --name "$RELEASE_NAME" \
               --component "$COMPONENT_NAME" \
               --project "$PROJECT_NAME" \
-              --output-path "$OUTPUT_PATH"
+              --output-path "$OUTPUT_PATH" \
+              --mode file-system --root-dir /mnt/vol/gitops
 
             echo "ComponentRelease generated successfully"
 
@@ -504,12 +505,13 @@ spec:
             echo "Project: $PROJECT_NAME"
             echo "Use pipeline: $USE_PIPELINE"
 
-            occ release-binding generate \
+            occ releasebinding generate \
               --component "$COMPONENT_NAME" \
               --component-release "$RELEASE_NAME" \
               --target-env "$TARGET_ENV" \
               --project "$PROJECT_NAME" \
-              --use-pipeline "$USE_PIPELINE"
+              --use-pipeline "$USE_PIPELINE" \
+              --mode file-system --root-dir /mnt/vol/gitops
 
             echo "ReleaseBinding generated successfully"
             echo "===== All GitOps resources generated successfully ====="

--- a/samples/gitops-workflows/workflows/bulk-release/README.md
+++ b/samples/gitops-workflows/workflows/bulk-release/README.md
@@ -168,7 +168,7 @@ kubectl logs -n openchoreo-ci-default -l workflows.argoproj.io/workflow=<workflo
 |------|-------------|--------|
 | 1. `clone-gitops` | Clones the GitOps repository | GitOps workspace |
 | 2. `create-feature-branch` | Creates a release branch (`bulk-release/all-*` or `bulk-release/<project>-*`) | Branch name |
-| 3. `generate-bulk-bindings` | Generates ReleaseBindings for all components using `occ release-binding generate` | ReleaseBinding manifests |
+| 3. `generate-bulk-bindings` | Generates ReleaseBindings for all components using `occ releasebinding generate` | ReleaseBinding manifests |
 | 4. `git-commit-push-pr` | Commits changes, pushes to remote, and creates PR using GitHub CLI | PR URL |
 
 ## CLI Commands Used
@@ -177,10 +177,10 @@ The workflow internally uses the following `occ` CLI commands:
 
 ```bash
 # For all components across all projects
-occ release-binding generate --all --target-env <env> --use-pipeline <pipeline>
+occ releasebinding generate --all --target-env <env> --use-pipeline <pipeline>
 
 # For a specific project
-occ release-binding generate --project <project> --target-env <env> --use-pipeline <pipeline>
+occ releasebinding generate --project <project> --target-env <env> --use-pipeline <pipeline>
 ```
 
 ## Workflow Outputs

--- a/samples/gitops-workflows/workflows/bulk-release/bulk-gitops-release-template.yaml
+++ b/samples/gitops-workflows/workflows/bulk-release/bulk-gitops-release-template.yaml
@@ -112,11 +112,9 @@ spec:
             USE_PIPELINE={{workflow.parameters.gitops-deployment-pipeline}}
 
             echo "===== Initializing OCC Context ====="
-            # Initialize occ context for file-system mode
-            occ config set-context gitops-context \
-              --mode file-system \
-              --root-directory-path /mnt/vol/gitops \
-              --namespace "${NAMESPACE_NAME}"
+            # Initialize occ context
+            occ config context add gitops-context \
+              --namespace "${NAMESPACE_NAME}" --controlplane default --credentials default
 
             # Use the gitops-context
             occ config use-context gitops-context
@@ -127,10 +125,10 @@ spec:
 
             if [ "$SCOPE_ALL" = "true" ]; then
                 echo "Generating bindings for ALL components across all projects"
-                occ release-binding generate --all --target-env "$TARGET_ENV" --use-pipeline "$USE_PIPELINE"
+                occ releasebinding generate --all --target-env "$TARGET_ENV" --use-pipeline "$USE_PIPELINE" --mode file-system --root-dir /mnt/vol/gitops
             elif [ -n "$PROJECT_NAME" ]; then
                 echo "Generating bindings for project: $PROJECT_NAME"
-                occ release-binding generate --project "$PROJECT_NAME" --target-env "$TARGET_ENV" --use-pipeline "$USE_PIPELINE"
+                occ releasebinding generate --project "$PROJECT_NAME" --target-env "$TARGET_ENV" --use-pipeline "$USE_PIPELINE" --mode file-system --root-dir /mnt/vol/gitops
             else
                 echo "Error: scope-project-name is required when scope-all is false"
                 exit 1


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes by Top-Level Folder (counts)
- internal/: 4 files changed
- pkg/: 6 files changed
- samples/: 5 files changed
- api/: 0 files changed
- config/: 0 files changed
- install/: 0 files changed
- docs/: 0 files changed
- openapi/: 0 files changed
- rca-agent/: 0 files changed
- make/: 0 files changed
- cmd/: 0 files changed

Total files enumerated in summary: 15

---

## API / Public surface changes (explicit) — what changed and compatibility risk
- Additive parameter fields (low-to-medium risk — additive):
  - pkg/cli/types/api/params.go
    - CreateWorkloadParams: +Mode string, +RootDir string
    - GenerateComponentReleaseParams: +Mode string, +RootDir string
    - GenerateReleaseBindingParams: +Mode string, +RootDir string
  - CLI command handlers now accept flags --mode and --root-dir and populate the above params.

- Removed public struct fields (HIGH compatibility risk — breaking):
  - pkg/cli/cmd/config/types.go: Context struct no longer exposes Mode and RootDirectoryPath (and their YAML tags). Persisted config or downstream code depending on these fields will break without migration.

- New public constants / flag rename (medium risk):
  - pkg/cli/flags/flags.go: added ModeAPIServer and ModeFileSystem constants.
  - Flag renamed/identifier changed: RootDirectoryPath → RootDir (flag name changed from root-directory-path to root-dir).
  - Command name normalizations in samples: component-release → componentrelease, release-binding → releasebinding (breaking for scripts/automation).

Compatibility risk summary:
- Additive param fields: Low–Medium (backwards-compatible for callers ignoring new fields).
- Removal of Context fields: HIGH (breaking change for persisted config and consumers).
- CLI flag and command renames: Medium (breaks scripts/automation unless migrated).

---

## Tests added / updated
- No test files added or updated in the provided diffs.
- Critical untested paths to cover:
  - Mode validation and rejection behavior for api-server vs file-system (componentrelease, releasebinding, workload).
  - File-system mode flows using params.RootDir and fallback to current working directory, including error handling when Getwd fails.
  - Migration/compatibility for existing Context YAML where Mode/RootDirectoryPath were removed (loading/saving config).
  - Workload create behavior when descriptor is omitted and an existing workload exists (partial update of main container image).
  - CLI parsing and wiring of new flags (--mode, --root-dir) across commands.

---

## Risk Hotspots (short reasons)
1. HIGH — Context struct removal
   - Breaks persisted config and any code reading/writing Context.Mode or Context.RootDirectoryPath. No migration path in diff.

2. MEDIUM — CLI command renames & flag rename
   - Renamed commands (component-release → componentrelease, release-binding → releasebinding) and root-dir flag will break existing scripts/CI unless communicated/migrated.

3. MEDIUM — Mode enforcement changes
   - Several internal commands now read mode from flags and explicitly reject api-server in some flows; changes runtime behavior and could block previously valid runs.

4. MEDIUM — Config/context initialization changes in samples
   - Samples switch from set-context (with explicit mode/root path) to context add + use-context — may confuse users and affect upgrade scripts.

5. LOW–MEDIUM — RootDir fallback to CWD
   - Falling back to current working directory when RootDir unset can silently target wrong repo in CI; consider stricter validation or clear warnings.

---

## Suggested reviewer focus (priority)
- Confirm and document migration strategy for removed Context fields and any required changes to persisted YAML/config consumers.
- Add unit/integration tests for mode parsing/validation, RootDir fallback and error paths, and the workload partial-update behavior.
- Validate CLI rename/flag changes and update release notes, samples, and automation guidance to avoid breakage.
- Review samples to ensure they reflect intended new UX and include upgrade notes for operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->