### PR TITLE
fix: validate --mode flag and improve error messages

### DIFF
--- a/internal/occ/cmd/componentrelease/componentrelease.go
+++ b/internal/occ/cmd/componentrelease/componentrelease.go
@@ -65,12 +65,8 @@ func (c *ComponentReleaseImpl) GenerateComponentRelease(params api.GenerateCompo
 		mode = flags.ModeAPIServer
 	}
 
-	if mode == flags.ModeAPIServer {
-		return fmt.Errorf("component-release generate is not implemented for api-server mode")
-	}
-
 	if mode != flags.ModeFileSystem {
-		return fmt.Errorf("unsupported mode %q: must be %q or %q", mode, flags.ModeAPIServer, flags.ModeFileSystem)
+		return fmt.Errorf("componentrelease generate only supports file-system mode; use --mode file-system (got %q)", mode)
 	}
 
 	// 2. Load context for other defaults (namespace, etc.)

--- a/internal/occ/cmd/releasebinding/releasebinding.go
+++ b/internal/occ/cmd/releasebinding/releasebinding.go
@@ -66,12 +66,8 @@ func (r *ReleaseBindingImpl) GenerateReleaseBinding(params api.GenerateReleaseBi
 		mode = flags.ModeAPIServer
 	}
 
-	if mode == flags.ModeAPIServer {
-		return fmt.Errorf("release-binding generate is not implemented for api-server mode")
-	}
-
 	if mode != flags.ModeFileSystem {
-		return fmt.Errorf("unsupported mode %q: must be %q or %q", mode, flags.ModeAPIServer, flags.ModeFileSystem)
+		return fmt.Errorf("releasebinding generate only supports file-system mode; use --mode file-system (got %q)", mode)
 	}
 
 	// 2. Load context for other defaults (namespace, etc.)

--- a/internal/occ/cmd/workload/workload.go
+++ b/internal/occ/cmd/workload/workload.go
@@ -41,12 +41,14 @@ func (i *WorkloadImpl) CreateWorkload(params api.CreateWorkloadParams) error {
 	}
 
 	// Route to appropriate implementation based on mode
-	if mode == flags.ModeFileSystem {
+	switch mode {
+	case flags.ModeFileSystem:
 		return i.createWorkloadFileSystemMode(params)
+	case flags.ModeAPIServer:
+		return i.createWorkloadAPIServerMode(params)
+	default:
+		return fmt.Errorf("unsupported mode %q: must be %q or %q", mode, flags.ModeAPIServer, flags.ModeFileSystem)
 	}
-
-	// Default: API server mode (existing implementation)
-	return i.createWorkloadAPIServerMode(params)
 }
 
 // createWorkloadAPIServerMode handles the existing API server mode logic


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR consolidates `--mode` flag validation across three OpenChoreo CLI commands and improves error messaging to guide users toward the correct mode parameter.

## Changes by Directory

**internal/** (3 files modified)
- `internal/occ/cmd/componentrelease/componentrelease.go` (+1/-5 lines)
- `internal/occ/cmd/releasebinding/releasebinding.go` (+1/-5 lines)
- `internal/occ/cmd/workload/workload.go` (+6/-4 lines)

## Functional Changes

### Mode Validation Refinements

**componentrelease generate & releasebinding generate:**
- Removed early-exit logic that specifically handled `ModeAPIServer`
- Consolidated to single validation: only `file-system` mode is supported
- Improved error message format: `"<command> generate only supports file-system mode; use --mode file-system (got %q)"`
- Now explicitly rejects api-server mode (previously may have silently defaulted or fallen through)

**workload create:**
- Replaced implicit fallback logic with explicit `switch` statement
- Handles both `ModeFileSystem` and `ModeAPIServer` cases explicitly
- Added `default` case returning error: `"unsupported mode %q: must be %q or %q"`
- Maintains support for both modes with mode-specific implementations (`createWorkloadFileSystemMode` / `createWorkloadAPIServerMode`)

## Test Coverage Gap

**Critical finding:** No unit tests exist for `--mode` flag validation logic across all three commands.
- Existing test files (`resolver_test.go` in componentrelease and releasebinding) only cover helper functions for output directory resolution
- No test coverage for mode validation, error messages, or fallback defaults
- Workload mode dispatch logic is untested

## Risk Assessment

**Compatibility Risk: Medium**
- **Breaking change**: `componentrelease generate` and `releasebinding generate` now explicitly reject `--mode api-server` (previously behavior undefined)
- Users relying on implicit defaults or api-server mode with these commands will now receive error messages directing them to use `--mode file-system`
- Workload command maintains backward compatibility by supporting both modes

**Coverage Risk: High**
- Mode flag validation paths lack test coverage; regression risk is elevated without automated validation
- Error message strings are untested and subject to drift

No API/CRD surface changes or public signature modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->