### PR TITLE
fix: update Thunder URL in occ-login script

### DIFF
--- a/install/quick-start/occ-login.sh
+++ b/install/quick-start/occ-login.sh
@@ -28,7 +28,13 @@ fi
 CHOREO_API_ENDPOINT="http://${API_URL}:8080"
 
 # Discover Thunder URL from HTTPRoute
-THUNDER_URL=$(kubectl get httproute -n openchoreo-control-plane thunder-openchoreo -o jsonpath='{.spec.hostnames[0]}' 2>/dev/null || echo "")
+THUNDER_URL=$(kubectl get httproute -n openchoreo-control-plane thunder-service -o jsonpath='{.spec.hostnames[0]}' 2>/dev/null || echo "")
+
+if [ -z "$THUNDER_URL" ]; then
+  log_error "Failed to discover Thunder URL from HTTPRoute"
+  exit 1
+fi
+
 THUNDER_ENDPOINT="http://${THUNDER_URL}:8080"
 
 # Step 1: Get token using system app with scope=system


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Changed Files by Directory:** 1 file in `install/` directory
- `install/quick-start/occ-login.sh` (new file, 126 lines)

## Change Details

The PR introduces a new shell script `occ-login.sh` that configures OpenChoreo CLI login credentials. The script performs Thunder OAuth2 authentication by:

1. Discovering the API server URL from the `openchoreo-api` HTTPRoute
2. **Discovering Thunder URL from the `thunder-setup` HTTPRoute** (key change)
3. Obtaining a system token via OAuth2 client credentials flow
4. Creating or updating a CLI application in Thunder for quickstart authentication

**Critical Discovery Mechanism:** The script queries `kubectl get httproute -n openchoreo-control-plane thunder-setup` to discover the Thunder identity provider endpoint, replacing what was previously `thunder-openchoreo`. This HTTPRoute discovery pattern requires a `thunder-setup` HTTPRoute resource to exist in the control plane namespace for successful authentication bootstrap.

## API/CRD Surface Changes

No API/CRD signature changes. No surface compatibility impact. The change is purely operational (service discovery pattern update).

## Tests & Coverage

No new tests added. This script lacks automated test coverage:
- No shell script tests in `test/` directory
- E2E test suite (`test/e2e/`) contains Go-based tests only
- The authentication bootstrap and Thunder integration flow has no dedicated test coverage

**Coverage gap:** Manual authentication flow during quickstart installation and Thunder HTTPRoute discovery mechanism are untested.

## Risk Analysis

**Authn/Authz Risk: MEDIUM**
- Script performs OAuth2 token acquisition with system app credentials
- Depends on Thunder's OAuth2 setup endpoint being discoverable via HTTPRoute `thunder-setup`
- HTTPRoute discovery will silently fail if `thunder-setup` resource missing, causing `THUNDER_URL` to be empty and subsequent API calls to fail (line 31-35)
- Sensitive credentials (`SYSTEM_APP_CLIENT_ID`, `SYSTEM_APP_CLIENT_SECRET`) are used in clear text without validation
- No error handling for malformed Thunder responses (e.g., missing `access_token` field checking is basic)

**Install/Upgrade Path Risk: MEDIUM**
- Introduces dependency on specific HTTPRoute naming convention (`thunder-setup`) that must be coordinated with Thunder Helm chart configuration
- The `thunder-setup` HTTPRoute resource must be created before this script runs; unclear if it's provisioned by Thunder chart or control plane chart
- No pre-flight checks for HTTPRoute availability beyond empty string check (line 23-26)

**Configuration Discovery Risk: HIGH**
- HTTPRoute-based service discovery is fragile; if Thunder is deployed with different HTTPRoute naming or in different namespace, script will fail silently
- No validation that discovered URL is actually accessible before attempting OAuth2 calls
- No retry logic for transient discovery failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->