### PR TITLE
fix: cluster plane component deployment not working

### DIFF
--- a/internal/clients/kubernetes/proxy_client.go
+++ b/internal/clients/kubernetes/proxy_client.go
@@ -46,9 +46,6 @@ func NewProxyClient(gatewayURL, planeIdentifier string, crNamespace, crName stri
 	if planeIdentifier == "" {
 		return nil, fmt.Errorf("planeIdentifier is required")
 	}
-	if crNamespace == "" {
-		return nil, fmt.Errorf("crNamespace is required")
-	}
 	if crName == "" {
 		return nil, fmt.Errorf("crName is required")
 	}

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -420,6 +420,11 @@ func (s *Server) handleHTTPProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Construct identifiers for CR-aware routing
 	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
+	// Handle cluster-scoped CR namespace placeholder: "_cluster" maps to empty namespace
+	// to match the key format "/name" used by getAllPlaneClientCAs for cluster-scoped resources
+	if crNamespace == "_cluster" {
+		crNamespace = ""
+	}
 	crKey := fmt.Sprintf("%s/%s", crNamespace, crName)
 
 	isStreaming := s.isStreamingRequest(r, targetPath)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose

The ReleaseBinding and Release controllers used GetDataplaneOfEnv() which only returns namespace-scoped *DataPlane. When an Environment references a ClusterDataPlane, this function errored out.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes Breakdown by Directory

| Directory | Changed Files |
|-----------|---|
| internal/ | 7 files |
| **Total** | **7 files** |

All changes are in `internal/`:
- internal/clients/kubernetes/client.go (+70/-0)
- internal/clients/kubernetes/proxy_client.go (+0/-3)
- internal/cluster-gateway/server.go (+5/-0)
- internal/controller/reference.go (+48/-0)
- internal/controller/release/controller.go (+23/-11)
- internal/controller/releasebinding/controller.go (+13/-7)
- internal/controller/reference_test.go (+225/-0)

Total diff: +384/-21 lines

## API/CRD Surface Changes

- No CRD or API (types) changes. Changes are internal implementation only.
- New exported helper functions/methods inside internal packages:
  - GetK8sClientFromClusterDataPlane(...)
  - GetK8sClientFromClusterObservabilityPlane(...)
  - DataPlaneResult.ToDataPlane()
  - DataPlaneResult.GetObservabilityPlane(...)
Compatibility risk: Low (no schema/CRD changes; behavior surface of controllers extended to support cluster-scoped planes).

## RBAC Changes

- Added read permissions for cluster-scoped resources:
  - controllers now request get/list/watch for `clusterdataplanes` and `clusterobservabilityplanes` (read-only).

## Tests Added / Updated

- Tests added in internal/controller/reference_test.go covering:
  - DataPlaneResult.ToDataPlane() for DataPlane and ClusterDataPlane cases (object meta and spec materialization, ObservabilityPlaneRef handling).
  - DataPlaneResult.GetObservabilityPlane() resolving both ObservabilityPlane and ClusterObservabilityPlane paths, default selection, and error cases (missing refs / not-found).
- Note: No explicit unit tests shown for:
  - GetK8sClientFromClusterDataPlane() / GetK8sClientFromClusterObservabilityPlane() proxy client creation and caching behavior.
  - Proxy URL construction and the "_cluster" namespace remapping behavior in the gateway server.
  - End-to-end reconciliation paths in Release/ReleaseBinding that use DataPlaneResult branching to cluster-scoped planes.

## Key Changes (concise)

- Controllers (Release, ReleaseBinding) now resolve an environment's plane via a unified DataPlaneResult that can represent either namespace-scoped DataPlane or cluster-scoped ClusterDataPlane. Reconciler code was updated to accept/propagate DataPlaneResult and materialize a facade DataPlane where needed.
- New client helpers to create proxied Kubernetes clients for cluster-scoped data/observability planes and cache them keyed by plane identifiers.
- Proxy/client behavior: New allowance for empty CR namespace in ProxyClient and server-side remapping of the "_cluster" placeholder to an empty namespace string for routing.

## Risk Hotspots

1. Proxy URL Construction (Medium)
   - New behavior permits empty crNamespace and maps "_cluster" → "". This may produce proxy URLs with empty namespace segments; no unit tests for URL composition or routing shown.

2. Reconciliation Logic Changes (High)
   - Switching controllers to a DataPlaneResult wrapper and materializing DataPlane via ToDataPlane() alters where and how metadata/spec fields are sourced. Mistmapped fields or missing observability refs could change reconciliation decisions; broader controller paths now exercise cluster-scoped code paths that previously were unreachable.

3. Client Caching & Gateway Dependency (Medium)
   - Cluster client creation requires gatewayURL and uses new cache keys/plane identifiers. Failures (missing gateway, malformed URL, or incorrect cache key) could lead to incorrect client reuse or failed remote calls; no tests cover connectivity/caching semantics.

4. RBAC Surface (Low–Medium)
   - Added read permissions for cluster-scoped planes. Ensure controllers running with cluster roles actually receive these bindings in cluster RBAC manifests during install/upgrade.

5. Observability Resolution Asymmetry (Medium)
   - Observability plane resolution now has dual paths (namespace vs cluster); subtle differences in defaults and error handling could lead to silent skips or different failure modes for observability-related reconciliations.

## Recommendations / Notes

- Add unit tests for:
  - Proxy URL construction and the "_cluster" remapping
  - GetK8sClientFromClusterDataPlane / GetK8sClientFromClusterObservabilityPlane (gateway URL validation, cache key behavior)
  - Reconcile paths that exercise ClusterDataPlane/ClusterObservabilityPlane branches (to prevent regressions)
- Verify RBAC manifests in install/upgrade pipelines include the new cluster-scoped permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->