### PR TITLE
fix: align k3d port mappings to 1:1 host-to-container

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-data-plane/templates/NOTES.txt
@@ -4,8 +4,8 @@ OpenChoreo Data Plane installed in namespace "{{ .Release.Namespace }}".
 {{- if .Values.gateway.enabled }}
 
 Gateway:
-{{- with .Values.gateway.tls.hostname }}
-  Domain: {{ . }}
+{{- if .Values.gateway.tls.enabled }}
+  Domain: {{ .Values.gateway.tls.hostname }}
 {{- end }}
   HTTP:   {{ .Values.gateway.httpPort }}
 {{- if .Values.gateway.tls.enabled }}

--- a/install/k3d/multi-cluster/config-bp.yaml
+++ b/install/k3d/multi-cluster/config-bp.yaml
@@ -10,11 +10,11 @@ kubeAPI:
 # Build Plane uses port range 10xxx
 ports:
   # Argo Workflows UI for development testing
-  - port: 10081:2746
+  - port: 10081:10081
     nodeFilters:
       - loadbalancer
   # Container Registry for storing built images
-  - port: 10082:5000
+  - port: 10082:10082
     nodeFilters:
       - loadbalancer
 options:

--- a/install/k3d/multi-cluster/config-cp.yaml
+++ b/install/k3d/multi-cluster/config-cp.yaml
@@ -9,12 +9,12 @@ kubeAPI:
   hostPort: "6550"
 # Control Plane uses port range 8xxx
 ports:
-  # HTTP traffic to OpenChoreo UI, API (Kgateway LoadBalancer on port 80)
-  - port: 8080:80
+  # HTTP traffic to OpenChoreo UI, API (Kgateway LoadBalancer)
+  - port: 8080:8080
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic to OpenChoreo UI, API, and Cluster Gateway (via ingress, Kgateway on port 443)
-  - port: 8443:443
+  # HTTPS traffic to OpenChoreo UI, API, and Cluster Gateway (Kgateway LoadBalancer)
+  - port: 8443:8443
     nodeFilters:
       - loadbalancer
 options:

--- a/install/k3d/multi-cluster/config-op.yaml
+++ b/install/k3d/multi-cluster/config-op.yaml
@@ -25,7 +25,7 @@ ports:
     nodeFilters:
       - loadbalancer
   # KGateway TLS
-  - port: 11085:11443
+  - port: 11085:11085
     nodeFilters:
       - loadbalancer
   # OpenTelemetry Collector
@@ -33,7 +33,7 @@ ports:
     nodeFilters:
       - loadbalancer
   # KGateway HTTP
-  - port: 11087:8075
+  - port: 11087:11087
     nodeFilters:
       - loadbalancer
     

--- a/install/k3d/multi-cluster/values-bp.yaml
+++ b/install/k3d/multi-cluster/values-bp.yaml
@@ -18,7 +18,7 @@ argo-workflows:
     # Disable this to save resources in development setups.
     enabled: true
     serviceType: LoadBalancer
-    servicePort: 2746
+    servicePort: 10081
     authModes:
       - server
 

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -46,5 +46,7 @@ thunder:
   host: thunder.openchoreo.localhost
 
 gateway:
+  httpPort: 8080
+  httpsPort: 8443
   tls:
     hostname: "*.openchoreo.localhost"

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -80,6 +80,8 @@ clusterAgent:
 
 gateway:
   enabled: true
+  httpPort: 11087
+  httpsPort: 11085
   tlsHostname: "opensearch.observability.openchoreo.localhost"
 
   envoy:

--- a/install/k3d/multi-cluster/values-registry.yaml
+++ b/install/k3d/multi-cluster/values-registry.yaml
@@ -5,3 +5,4 @@ persistence:
 
 service:
   type: LoadBalancer
+  port: 10082

--- a/install/k3d/single-cluster/config.yaml
+++ b/install/k3d/single-cluster/config.yaml
@@ -10,12 +10,12 @@ kubeAPI:
 # Single cluster mode exposes all plane port ranges for consistency with multi-cluster setup
 ports:
   # Control Plane uses port range 8xxx
-  # HTTP traffic to OpenChoreo UI and API (Kgateway LoadBalancer on port 80)
-  - port: 8080:80
+  # HTTP traffic to OpenChoreo UI and API (Kgateway LoadBalancer)
+  - port: 8080:8080
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic to OpenChoreo UI and API (Kgateway LoadBalancer on port 443)
-  - port: 8443:443
+  # HTTPS traffic to OpenChoreo UI and API (Kgateway LoadBalancer)
+  - port: 8443:8443
     nodeFilters:
       - loadbalancer
   # Data Plane uses port range 19xxx (matches kind and other cluster setups)
@@ -29,20 +29,20 @@ ports:
       - loadbalancer
   # Build Plane uses port range 10xxx
   # Argo Workflows UI for development testing
-  - port: 10081:2746
+  - port: 10081:10081
     nodeFilters:
       - loadbalancer
   # Container Registry for storing built images
-  - port: 10082:5000
+  - port: 10082:10082
     nodeFilters:
       - loadbalancer
   # Observability Plane uses port range 11xxx
-  # HTTP traffic to CLI and and API (Kgateway LoadBalancer on port 8075)
-  - port: 11080:8075
+  # HTTP traffic to CLI and API (Kgateway LoadBalancer)
+  - port: 11080:11080
     nodeFilters:
       - loadbalancer
-  # HTTPS traffic for OpenSearch access (Kgateway LoadBalancer on port 11443)
-  - port: 11085:11443
+  # HTTPS traffic for OpenSearch access (Kgateway LoadBalancer)
+  - port: 11085:11085
     nodeFilters:
       - loadbalancer
   # OpenSearch Dashboard

--- a/install/k3d/single-cluster/values-bp.yaml
+++ b/install/k3d/single-cluster/values-bp.yaml
@@ -6,7 +6,7 @@ argo-workflows:
     # Argo Workflows UI is enabled for testing/development purposes
     enabled: true
     serviceType: LoadBalancer
-    servicePort: 2746
+    servicePort: 10081
     authModes:
       - server
 

--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -26,5 +26,7 @@ thunder:
   host: thunder.openchoreo.localhost
 
 gateway:
+  httpPort: 8080
+  httpsPort: 8443
   tls:
     enabled: false

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -13,8 +13,6 @@ openSearchCluster:
 # Observer API - REST API for querying logs and metrics
 observer:
   openSearchSecretName: observer-opensearch-credentials
-  service:
-    type: LoadBalancer
   http:
     hostnames:
     - observer.openchoreo.localhost
@@ -25,11 +23,12 @@ openSearchDashboards:
     type: LoadBalancer
 
 security:
-  enabled: false
   oidc:
     jwksUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
     tokenUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/token"
 
 gateway:
+  httpPort: 11080
+  httpsPort: 11085
   tls:
     enabled: false

--- a/install/k3d/single-cluster/values-registry.yaml
+++ b/install/k3d/single-cluster/values-registry.yaml
@@ -5,3 +5,4 @@ persistence:
 
 service:
   type: LoadBalancer
+  port: 10082

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -60,5 +60,7 @@ thunder:
   host: thunder.openchoreo.localhost
 
 gateway:
+  httpPort: 8080
+  httpsPort: 8443
   tls:
     enabled: false

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -37,6 +37,8 @@ observer:
 
 # Gateway configuration for quick-start
 gateway:
+  httpPort: 11080
+  httpsPort: 11085
   tls:
     enabled: false
 

--- a/install/quick-start/.values-registry.yaml
+++ b/install/quick-start/.values-registry.yaml
@@ -6,4 +6,4 @@ persistence:
 
 service:
   type: LoadBalancer
-  port: 5000
+  port: 10082


### PR DESCRIPTION
## Summary
- aligned all k3d port mappings so host and container ports match (no more `8080:80`, `10082:5000`, etc.)
- inlined the gateway tmp volume patch JSON directly in READMEs instead of referencing a separate file
- restructured single-cluster README for clarity, added collapsible sections
- added explicit `httpPort`/`httpsPort` to values files for cp, op, and quick-start

## Test plan
- [ ] create single-cluster setup with updated config and verify all services reachable on expected ports
- [ ] create multi-cluster setup and verify port mappings
- [ ] verify quick-start flow still works

relates to https://github.com/openchoreo/openchoreo/issues/1859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes Breakdown

- Top-level folders touched:
  - install: 18 files changed
  - api: 0
  - config: 0
  - internal: 0
  - pkg: 0
  - docs: 0
  - openapi: 0
  - rca-agent: 0
  - make: 0
  - cmd: 0
  - samples: 0

Net lines (from raw summary): approx +283 / -445 (net -162), with README restructuring accounting for most deletions.

## API/CRD Surface Changes

- None. No API definitions or CRDs were added/changed. Compatibility risk: Low.

## Tests

- No tests added or updated in this PR.
- Critical gaps: no automated tests added for upgrade/migration of k3d clusters or end-to-end reachability verification on the new ports.

## Key Changes (quantitative)

- Port mapping alignment to 1:1 host:container:
  - single-cluster config.yaml: 6 asymmetric mappings made symmetric (8080, 8443, 10081, 10082, 11080, 11085).
  - multi-cluster:
    - config-cp.yaml: 8080:80 → 8080:8080; 8443:443 → 8443:8443.
    - config-bp.yaml: 10081:2746 → 10081:10081.
    - config-op.yaml: 11085:11443 → 11085:11085; 11087:8075 → 11087:11087.
  - values files:
    - Added gateway.httpPort and gateway.httpsPort in cp, op, and quick-start values.
    - Argo workflows port updated (2746 → 10081) in bp values.
    - Registry service port set to 10082 in registry values.

- Documentation and patching:
  - multi-cluster README: inlined kubectl patch JSON payloads (removed external gateway-tmp-volume-patch.json).
  - single-cluster README: major restructuring and condensation (large net deletions; content reorganized, collapsible sections added).

- Helm template:
  - NOTES.txt: TLS Domain line now rendered only when .Values.gateway.tls.enabled is true and uses explicit .Values.gateway.tls.hostname.

## Risk Hotspots (short reasons)

1. Deployment/Upgrade compatibility — Medium  
   - Changing host:container mappings may break existing k3d clusters or operator scripts expecting previous ports; clusters likely need recreation or reconfiguration.

2. Gateway configuration surface — Medium  
   - New explicit httpPort/httpsPort fields increase config surface and may cause mismatches with prior defaults (80/443).

3. Install/quick-start regressions — Medium  
   - README simplifications removed explicit steps/waits; users following older guides may miss necessary actions. No tests added to cover these flows.

4. Observability & Registry exposure — Low–Medium  
   - Ports moved into 1008x/1108x ranges; external tooling, firewall rules, or CI expectations may need updates.

5. Inline patch maintenance — Low  
   - Moving patch payloads into READMEs reduces single-source patch file reuse and may increase duplication when patches change.

## Suggested follow-ups

- Provide upgrade/migration guidance or scripts for existing k3d deployments.
- Add E2E tests validating service reachability on updated ports for single- and multi-cluster flows.
- Document new gateway.httpPort/httpsPort fields in the values schema and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->