### PR TITLE
chore: add opencode redirect uri to mcp user app

### DIFF
--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -574,7 +574,8 @@ bootstrap:
               "client_id": "user_mcp_client",
               "redirect_uris": [
                 "http://localhost:8075/callback",
-                "cursor://anysphere.cursor-mcp/oauth/callback"
+                "cursor://anysphere.cursor-mcp/oauth/callback",
+                "http://127.0.0.1:19876/mcp/oauth/callback"
               ],
               "grant_types": [
                 "authorization_code",


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Adds opencode redirect URI to the default MCP tryout application for quick start guide for MCPs.

## Related Issues
https://github.com/openchoreo/openchoreo/pull/1955

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes Breakdown
- Files changed: 1
  - install/k3d/common/values-thunder.yaml (+2/-1 lines)

Top-level folder distribution (file counts):
- api: 34
- config: 174
- internal: 606
- pkg: 76
- install: 231 (1 file modified)
- docs: 41
- openapi: 1
- rca-agent: 48
- make: 7
- cmd: 15
- samples: 94

## Changes Summary
- Added OAuth2 redirect URI http://127.0.0.1:19876/mcp/oauth/callback to the User MCP App `redirect_uris` in install/k3d/common/values-thunder.yaml. This is an additive change (appended to the existing array).

## API/CRD Surface Changes
- None. No API definitions or CRDs modified — configuration-only change for k3d development values.

## Test Coverage
- No tests added or updated in this PR.
- Install/bootstrap configuration (k3d values) remains untested by this change.

## Risk Assessment
- Compatibility: LOW — purely additive redirect URI; existing callbacks preserved.
- Authn/Authz Risk: LOW — expands allowed redirect destinations for the MCP User App to include a localhost callback; does not change auth flows, grant types, PKCE, or token settings.
- Installation/Upgrade Path: LOW — change affects k3d development Helm values only (no production deployment changes).
- Hotspots: auth redirect surface (allowed redirect URIs) — requires caution but low-risk here since it's a localhost test URI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->