### PR TITLE
chore: add default mcp tryout client role binding

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1163,6 +1163,15 @@ openchoreoApi:
                 claim: sub
                 value: openchoreo-rca-agent
               effect: allow
+
+            # MCP tryout client mapping - grants MCP tryout client full access
+            - name: mcp-tryout-client-binding
+              roleRef:
+                name: super-admin
+              entitlement:
+                claim: sub
+                value: service_mcp_client
+              effect: allow
     # identity.oidc and identity.clients come from security.oidc.* and security.oidc.externalClients
     # @schema
     # type: object


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This PR adds a role binding to the default MCP tryout client

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1963

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Files Changed**: 1 (100% in `install/`)
- `install/helm/openchoreo-control-plane/values.yaml` (+9/-0)

## Changes Breakdown

### Authorization Bootstrap Configuration
Adds a single authorization role binding mapping to the OpenChoreo API bootstrap configuration:
- **Binding**: `mcp-tryout-client-binding`
- **Role**: `super-admin` (grants all actions: `"*"`)
- **Subject**: Service account with JWT claim `sub: service_mcp_client`
- **Effect**: `allow`

This enables the MCP (Model Context Protocol) tryout client to perform all operations on the platform as a privileged user during installation.

## API/CRD Surface Changes
None. This is a pure configuration/values change to `openchoreoApi.config.security.authorization.bootstrap.mappings`. The change is compatible with existing `AuthzRoleBinding` and `AuthzClusterRoleBinding` CRD definitions (v1alpha1, no breaking changes).

## Tests
No tests added or updated. The PR explicitly marks both "tests updated" and "samples updated" as unchecked. Bootstrap authorization mappings are validated through existing authz integration tests (e.g., `internal/authz/casbin/pap_test.go`).

## Risk Hotspots

**AUTHZ/RBAC - MEDIUM RISK**: The MCP tryout client is granted the `super-admin` role with full platform access. While appropriate for a development/tryout client, this grants unrestricted permissions (`"*"` actions). This should be scoped appropriately in production configurations. Consider monitoring this client's usage patterns.

**Install/Upgrade - LOW RISK**: Helm values changes are additive and safe. This bootstrap mapping is only created during initial installation; upgrades will not re-create existing bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->