### PR TITLE
fix: nil pointer dereference in GetComponentReleaseSchema for releases without ComponentProfile

### DIFF
--- a/internal/openchoreo-api/services/component_service.go
+++ b/internal/openchoreo-api/services/component_service.go
@@ -534,21 +534,23 @@ func (s *ComponentService) GetComponentReleaseSchema(ctx context.Context, namesp
 
 	// Process trait overrides from ComponentRelease (trait instances with instance names)
 	traitSchemas := make(map[string]extv1.JSONSchemaProps)
-	for _, componentTrait := range release.Spec.ComponentProfile.Traits {
-		traitSpec, found := release.Spec.Traits[componentTrait.Name]
-		if !found {
-			s.logger.Warn("Trait definition not found in release", "trait", componentTrait.Name, "instanceName", componentTrait.InstanceName)
-			continue
-		}
+	if release.Spec.ComponentProfile != nil {
+		for _, componentTrait := range release.Spec.ComponentProfile.Traits {
+			traitSpec, found := release.Spec.Traits[componentTrait.Name]
+			if !found {
+				s.logger.Warn("Trait definition not found in release", "trait", componentTrait.Name, "instanceName", componentTrait.InstanceName)
+				continue
+			}
 
-		traitJSONSchema, err := s.buildTraitEnvOverridesSchema(traitSpec, componentTrait.Name)
-		if err != nil {
-			return nil, err
-		}
+			traitJSONSchema, err := s.buildTraitEnvOverridesSchema(traitSpec, componentTrait.Name)
+			if err != nil {
+				return nil, err
+			}
 
-		// Use instance name as the key (not trait name)
-		if traitJSONSchema != nil {
-			traitSchemas[componentTrait.InstanceName] = *traitJSONSchema
+			// Use instance name as the key (not trait name)
+			if traitJSONSchema != nil {
+				traitSchemas[componentTrait.InstanceName] = *traitJSONSchema
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Changed files: 1 (internal: 1)
Total lines changed: +15 / -13
Files changed:
- internal/openchoreo-api/services/component_service.go (+15/-13)

Change summary (evidence-based)
- Fix: Add defensive nil-check in GetComponentReleaseSchema to avoid nil pointer dereference when ComponentRelease.Spec.ComponentProfile is nil.
  - Guard added around trait iteration: if release.Spec.ComponentProfile != nil (around line ~537).
  - Only insert trait JSON schema when conversion produced a non-nil schema (conditional insert, ~line 549).
- Impact: logic now skips trait processing for releases without a ComponentProfile and avoids inserting nil trait schema entries.

API / CRD surface changes
- No API or CRD field definitions changed.
- Behavior change: internal handling of optional ComponentProfile is now defensive; no contract/CRD modification.
- Compatibility risk: Low

Tests
- No tests added or updated in this PR.
- Coverage gap: GetComponentReleaseSchema behavior for ComponentRelease.Spec.ComponentProfile == nil (and trait schema conversion failure paths) are not covered by tests in this PR.

Risk hotspots
- Nil pointer dereference (fixed): prior code iterated traits unguarded → crash for releases without ComponentProfile.
- Missing test coverage: regression risk remains until unit tests cover nil ComponentProfile and trait schema failure scenarios.
- Partial trait processing: code continues on per-trait errors (missing trait definitions / conversion errors); validate expected UX when some trait schemas fail to build.

Notes / Metrics
- Single-file fix isolated to internal/; small diff (+15/-13) focused on defensive checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->