### PR TITLE
fix: bypass user-level authz check for webhook-triggered workflow runs

### DIFF
--- a/internal/openchoreo-api/services/component_workflow_service.go
+++ b/internal/openchoreo-api/services/component_workflow_service.go
@@ -70,6 +70,12 @@ func (s *ComponentWorkflowService) TriggerWorkflow(ctx context.Context, namespac
 		return nil, err
 	}
 
+	return s.triggerWorkflowInternal(ctx, namespaceName, projectName, componentName, commit)
+}
+
+// triggerWorkflowInternal contains the core workflow triggering logic without authorization checks.
+// This is used by the webhook service which authenticates via HMAC signature validation instead of user-level auth.
+func (s *ComponentWorkflowService) triggerWorkflowInternal(ctx context.Context, namespaceName, projectName, componentName, commit string) (*models.ComponentWorkflowResponse, error) {
 	// Retrieve component and use that to create the workflow run
 	var component openchoreov1alpha1.Component
 	err := s.k8sClient.Get(ctx, client.ObjectKey{

--- a/internal/openchoreo-api/services/webhook_service.go
+++ b/internal/openchoreo-api/services/webhook_service.go
@@ -69,7 +69,7 @@ func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provid
 			"component", componentName,
 			"commit", event.Commit)
 
-		_, err := s.workflowService.TriggerWorkflow(
+		_, err := s.workflowService.triggerWorkflowInternal(
 			ctx,
 			namespaceName,
 			projectName,


### PR DESCRIPTION
## Purpose
- bypass user-level authz check for webhook-triggered workflow runs
- Fix https://github.com/openchoreo/openchoreo/issues/2014

## Description
Extracted the core workflow creation logic into an unexported `triggerWorkflowInternal` method that skips user-level authorization. The webhook service now calls this internal method
  directly, since webhook authentication is already handled via HMAC signature validation in the handler. The public `TriggerWorkflow` method retains full authorization checks for API
  callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**File Changes by Top-Level Folder:**
- `internal/`: 2 files modified
  - internal/openchoreo-api/services/component_workflow_service.go (+6 lines)
  - internal/openchoreo-api/services/webhook_service.go (+1/-1 line)
- Total: 2 files, 7 lines added / 1 line removed

**Core Changes:**

The PR refactors workflow triggering to bypass user-level authorization checks for webhook-triggered component workflows:

1. **ComponentWorkflowService** - Introduced internal method `triggerWorkflowInternal()`:
   - Extracted core workflow triggering logic (component retrieval, workflow validation, run creation, parameter extraction, K8s resource creation) into unexported method
   - Public `TriggerWorkflow()` retains existing `SystemActionCreateComponentWorkflow` authorization check via `checkAuthorization()` then delegates to internal method
   - Internal method bypasses all authz checks, intended for webhook flows that authenticate via HMAC signatures

2. **WebhookService** - Updated ProcessWebhook():
   - Changed workflow trigger call from `s.workflowService.TriggerWorkflow()` (public) to `s.workflowService.triggerWorkflowInternal()` (private)
   - No changes to component discovery, event processing, or error handling logic

**Authorization & Authentication Architecture:**
- **Risk Hotspot - Authn/Authz Bypass**: This change shifts workflow trigger authentication from user-level authorization (RBAC via PDP) to webhook signature validation. The security model now depends entirely on HMAC validation being performed at the HTTP handler layer before `ProcessWebhook()` is called. If HMAC validation is missing, misconfigured, or bypassed in webhook handlers, unauthorized workflow triggers are possible.
- User-triggered workflows maintain full authorization checks via TriggerWorkflow()
- Webhook-triggered workflows skip user-level authz entirely, relying on upstream HMAC signature validation
- HTTP handlers calling TriggerWorkflow() (e.g., component_workflows.go, mcphandlers/components.go) still enforce authorization

**Tests:**
- **Critical Gap**: No tests added for the new internal method path
- Only 1 test file exists for openchoreo-api services: `component_service_test.go` (no webhook or workflow service tests)
- Existing workflow tests found in `internal/controller/componentworkflow/`, `internal/controller/componentworkflowrun/`, and `internal/pipeline/componentworkflow/` but do not cover service-layer webhook bypass code path
- Missing test coverage for: triggerWorkflowInternal() path, webhook-triggered workflow execution, HMAC validation bypass scenarios

**API/CRD Surface:**
- No CRD or API schema changes
- No public method signature changes
- Internal refactoring only; component_workflow_service.go line count: 959

**Compatibility Risk: Medium**
- API surface risk: Low (internal method only)
- Operational risk: Medium (authorization bypass dependent on upstream HMAC validation strength)
- Test coverage risk: High (critical path lacks automated tests)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->