### PR TITLE
fix: make secret ref optional in default component workflows

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -775,7 +775,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"
@@ -887,7 +887,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"
@@ -996,7 +996,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"
@@ -1102,7 +1102,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"

--- a/samples/getting-started/component-workflows/ballerina-buildpack.yaml
+++ b/samples/getting-started/component-workflows/ballerina-buildpack.yaml
@@ -11,7 +11,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"

--- a/samples/getting-started/component-workflows/docker.yaml
+++ b/samples/getting-started/component-workflows/docker.yaml
@@ -11,7 +11,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"

--- a/samples/getting-started/component-workflows/google-cloud-buildpacks.yaml
+++ b/samples/getting-started/component-workflows/google-cloud-buildpacks.yaml
@@ -11,7 +11,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"

--- a/samples/getting-started/component-workflows/react.yaml
+++ b/samples/getting-started/component-workflows/react.yaml
@@ -11,7 +11,7 @@ spec:
     systemParameters:
       repository:
         url: string | description="Git repository URL"
-        secretRef: string | description="Secret reference name for Git credentials"
+        secretRef: string | default="" description="Secret reference name for Git credentials"
         revision:
           branch: string | default=main description="Git branch to checkout"
           commit: string | description="Git commit SHA or reference (optional, defaults to latest)"


### PR DESCRIPTION
This pull request makes a small but important change to several sample workflow YAML files. The `secretRef` field in the repository configuration now has a default value of an empty string, making it optional and improving usability for workflows that do not require Git credentials.

* Updated the `secretRef` field in the `repository` section of multiple sample workflow YAML files (`all.yaml`, `ballerina-buildpack.yaml`, `docker.yaml`, `google-cloud-buildpacks.yaml`, `react.yaml`) to include a default value of `""`, making it optional. [[1]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L778-R778) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L890-R890) [[3]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L999-R999) [[4]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1105-R1105) [[5]](diffhunk://#diff-beb4f4f5a8e8a81adc35a19dbd134529cf185e7ca133ec64d21560531aa7c905L14-R14) [[6]](diffhunk://#diff-93bc678d2fca84338634d91a840b618c02572efd5200714bb3fbd9302d3e3742L14-R14) [[7]](diffhunk://#diff-5a6db831e13932f74c9b5bfce7c16c7f37e598d388732b9b309429c4fdb26db7L14-R14) [[8]](diffhunk://#diff-957bc6b3e2f76a92781a372fe59de73a07a25eda0e61a6967255b92224973d8fL14-R14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## File Changes Breakdown

**Changed Files by Directory:**
- `samples/`: 5 files (14 total lines changed: +4/-4 after accounting for all files)

## Summary

This PR makes the `secretRef` field optional in ComponentWorkflow sample YAML files by adding `default=""` to the `systemParameters.repository.secretRef` field schema across 5 sample workflow manifests (docker.yaml, react.yaml, ballerina-buildpack.yaml, google-cloud-buildpacks.yaml, and all.yaml).

The change improves usability for workflows that do not require Git credentials by explicitly allowing an empty default value. This complements existing pipeline logic that already handles empty or missing secretRef values gracefully.

## API/CRD Surface Changes

**Compatibility Risk: Low**

No changes to API types or CRD definitions. The modification is purely to sample workflow YAML schema definitions:
- Field: `spec.schema.systemParameters.repository.secretRef` in ComponentWorkflow samples
- Change: Added `default=""` to the schema field definition
- Impact: Schema-level only; no breaking changes to the CustomResourceDefinition itself

The runtime pipeline code in `internal/pipeline/componentworkflow/pipeline.go` already implements the necessary logic to handle empty or unset secretRef values, populating CEL context with empty `secretRef` fields when no GitSecret is provided.

## Tests

No test files were modified or added. Existing ComponentWorkflow tests remain unchanged and already cover scenarios with and without Git secrets through conditional resource evaluation via `includeWhen: ${has(systemParameters.repository.secretRef)}` expressions.

## Risk Assessment

**Overall Risk: Low**

- **Sample/Documentation Only**: Changes are confined to sample files with no impact to core functionality
- **Backward Compatible**: Existing workflows that provide secretRef values continue to work unchanged
- **Pre-existing Support**: The ComponentWorkflowRun controller and pipeline already handle empty secretRef through safe conditional checks and empty field initialization in the CEL context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->