### PR TITLE
chore: minor docs and sample updates

### DIFF
--- a/internal/pipeline/component/testdata/component-with-traits.yaml
+++ b/internal/pipeline/component/testdata/component-with-traits.yaml
@@ -282,11 +282,6 @@ spec:
     kind: DataPlane
     name: dev-dataplane
   isProduction: false
-  gateway:
-    dnsPrefix: dev
-    security:
-      remoteJwks:
-        uri: https://auth.example.com/.well-known/jwks.json
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: DataPlane

--- a/samples/component-types/component-with-api-management/README.md
+++ b/samples/component-types/component-with-api-management/README.md
@@ -302,6 +302,33 @@ The API Platform Gateway will:
 - Route the request to the backend service
 - Return the response from the greeter service
 
+## Cleanup
+
+### 1. Disable API Management for a Component
+
+To disable API management for a component, remove the trait:
+
+```bash
+kubectl patch component demo-app-http-service --type=json \
+  -p='[{"op": "remove", "path": "/spec/traits"}]'
+```
+
+### 2. Delete the API Platform Gateway Instance
+
+```bash
+kubectl delete gateway/api-platform-default -n openchoreo-data-plane
+```
+
+### 3. Uninstall the API Platform Module
+
+```bash
+helm upgrade openchoreo-data-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-plane \
+  --version 0.0.0-latest-dev \
+  --namespace openchoreo-data-plane \
+  --reuse-values \
+  --set api-platform.enabled=false
+```
+
 ## Notes
 
 - The Backend resource is created in the **component's namespace**, avoiding cross-namespace permission issues

--- a/samples/platform-config/new-environments/development-environment.yaml
+++ b/samples/platform-config/new-environments/development-environment.yaml
@@ -12,6 +12,4 @@ spec:
   dataPlaneRef:
     kind: DataPlane
     name: default
-  gateway:
-    dnsPrefix: dev
   isProduction: false

--- a/samples/platform-config/new-environments/pre-production-environment.yaml
+++ b/samples/platform-config/new-environments/pre-production-environment.yaml
@@ -12,6 +12,4 @@ spec:
   dataPlaneRef:
     kind: DataPlane
     name: default
-  gateway:
-    dnsPrefix: preprod
   isProduction: false

--- a/samples/platform-config/new-environments/production-environment.yaml
+++ b/samples/platform-config/new-environments/production-environment.yaml
@@ -12,6 +12,4 @@ spec:
   dataPlaneRef:
     kind: DataPlane
     name: default
-  gateway:
-    dnsPrefix: prod
   isProduction: true

--- a/samples/platform-config/new-environments/qa-environment.yaml
+++ b/samples/platform-config/new-environments/qa-environment.yaml
@@ -12,6 +12,4 @@ spec:
   dataPlaneRef:
     kind: DataPlane
     name: default
-  gateway:
-    dnsPrefix: qa
   isProduction: false


### PR DESCRIPTION
## Purpose
This PR adds minor docs changes and sample changes as follows.

- Remove stale gateway spec from Environment. Related to https://github.com/openchoreo/openchoreo/pull/1902
- Add API platform gateway clean up section for the component with API management guide



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## File Distribution by Folder
- **samples/**: 5 files (4 YAML configs, 1 README documentation)
- **internal/**: 1 file (component test data YAML)

**Total: 6 files changed, +27/-13 lines**

## Changes Summary
This PR removes gateway DNS prefix configuration (`spec.gateway.dnsPrefix`) from:
- 4 environment specification files (development, QA, pre-production, production)
- 1 component test data file (`component-with-traits.yaml`)

Adds cleanup documentation to `samples/component-types/component-with-api-management/README.md` with kubectl/helm commands for API management teardown (disabling API management, deleting API Platform Gateway, uninstalling the module).

## API/CRD Surface Changes
None. No changes to exported/public declarations or API surface areas. These are configuration value removals and documentation-only additions.

## Tests
No tests added or updated.

## Risk Assessment
**Medium Risk (Configuration Breaking Change)**
- Removal of gateway DNS prefix configuration alters the Environment resource spec structure
- Existing environment deployments may break if they relied on gateway configuration
- No authn/authz, RBAC, or secrets handling changes
- No reconciliation logic or install/upgrade path impacts detected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->