### PR TITLE
feat: set endpoint visibilty in samples

### DIFF
--- a/samples/component-types/component-http-service/http-service-component.yaml
+++ b/samples/component-types/component-http-service/http-service-component.yaml
@@ -32,6 +32,7 @@ spec:
     http:
       type: HTTP
       port: 9090
+      visibility: external
 
   containers:
     main:

--- a/samples/component-types/component-web-app/webapp-component.yaml
+++ b/samples/component-types/component-web-app/webapp-component.yaml
@@ -33,6 +33,7 @@ spec:
     http:
       type: HTTP
       port: 8080
+      visibility: external
 
   containers:
     main:

--- a/samples/component-types/component-with-api-management/component-with-api-management.yaml
+++ b/samples/component-types/component-with-api-management/component-with-api-management.yaml
@@ -122,6 +122,7 @@ spec:
     http:
       type: HTTP
       port: 9090
+      visibility: external
 
   containers:
     main:

--- a/samples/component-types/component-with-configs/component-with-configs.yaml
+++ b/samples/component-types/component-with-configs/component-with-configs.yaml
@@ -241,6 +241,7 @@ spec:
     http:
       type: HTTP
       port: 8080
+      visibility: external
 
   containers:
     main:

--- a/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+++ b/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
@@ -383,6 +383,7 @@ spec:
     http:
       type: HTTP
       port: 9090
+      visibility: external
 
   containers:
     main:

--- a/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
+++ b/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
@@ -11,7 +11,6 @@ spec:
   componentType: deployment/service
 
 ---
-
 # Defines a workload that specifies the developer contract which describes the source code including
 # what configuration is needed to run, what endpoints are exposed, and how it connects to other components or platform resources.
 apiVersion: openchoreo.dev/v1alpha1
@@ -27,6 +26,7 @@ spec:
     websocket:
       type: Websocket
       port: 8080
+      visibility: external
   containers:
     main:
       image: "jmalloc/echo-server:latest"

--- a/samples/from-image/go-greeter-service/greeter-service.yaml
+++ b/samples/from-image/go-greeter-service/greeter-service.yaml
@@ -27,6 +27,7 @@ spec:
     http:
       type: HTTP
       port: 9090
+      visibility: external
   containers:
     main:
       image: "ghcr.io/openchoreo/samples/greeter-service:latest"

--- a/samples/from-image/react-starter-web-app/react-starter.yaml
+++ b/samples/from-image/react-starter-web-app/react-starter.yaml
@@ -25,6 +25,7 @@ spec:
     http:
       type: HTTP
       port: 8080
+      visibility: external
   containers:
     main:
       image: choreoanonymouspullable.azurecr.io/react-spa:v0.9

--- a/samples/gcp-microservices-demo/components/ad-component.yaml
+++ b/samples/gcp-microservices-demo/components/ad-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 9555
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/cart-component.yaml
+++ b/samples/gcp-microservices-demo/components/cart-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 7070
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/checkout-component.yaml
+++ b/samples/gcp-microservices-demo/components/checkout-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 5050
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/currency-component.yaml
+++ b/samples/gcp-microservices-demo/components/currency-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 7000
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/email-component.yaml
+++ b/samples/gcp-microservices-demo/components/email-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 5000
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/frontend-component.yaml
+++ b/samples/gcp-microservices-demo/components/frontend-component.yaml
@@ -25,6 +25,7 @@ spec:
     http:
       type: HTTP
       port: 8080
+      visibility: external
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend:v0.10.3

--- a/samples/gcp-microservices-demo/components/payment-component.yaml
+++ b/samples/gcp-microservices-demo/components/payment-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 50051
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/productcatalog-component.yaml
+++ b/samples/gcp-microservices-demo/components/productcatalog-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 3550
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/recommendation-component.yaml
+++ b/samples/gcp-microservices-demo/components/recommendation-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 8080
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice:v0.10.3

--- a/samples/gcp-microservices-demo/components/redis-component.yaml
+++ b/samples/gcp-microservices-demo/components/redis-component.yaml
@@ -25,6 +25,7 @@ spec:
     redis:
       type: TCP
       port: 6379
+      visibility: project
   containers:
     main:
       image: redis:7.2-alpine

--- a/samples/gcp-microservices-demo/components/shipping-component.yaml
+++ b/samples/gcp-microservices-demo/components/shipping-component.yaml
@@ -25,6 +25,7 @@ spec:
     grpc:
       type: gRPC
       port: 50055
+      visibility: project
   containers:
     main:
       image: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice:v0.10.3


### PR DESCRIPTION
## Purpose
> https://github.com/openchoreo/openchoreo/issues/2000

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Changes Breakdown by Directory
- api/: 0
- config/: 0
- internal/: 0
- pkg/: 0
- install/: 0
- docs/: 0
- openapi/: 0
- rca-agent/: 0
- make/: 0
- cmd/: 0
- samples/: 19
  - samples/component-types/: 5
  - samples/from-image/: 3
  - samples/gcp-microservices-demo/: 11

Total changed files: 19 (all under samples/)

## Changes Summary (evidence-based, quant-heavy)
- Added a new endpoint field spec.endpoints.<type>.visibility in 19 sample manifests.
  - visibility: external applied to HTTP/WebSocket endpoints in 8 files (component-types: 5; from-image: 3; gcp demo: frontend-component).
  - visibility: project applied to gRPC/Redis endpoints in 11 files (gcp-microservices-demo components).
- One sample (echo-websocket-service.yaml) also added an environment variable PORT="8080".
- Approx. lines changed: +19 / -1 (mostly single-line additions per file).

## API / CRD Surface Changes
- What changed: sample Workload manifests now include spec.endpoints.<type>.visibility (values observed: external, project).
- Compatibility risk: Low — changes are confined to sample YAML files only; no CRD schema, API, or controller/source-code modifications detected in this PR.
- Impact on public API/CRDs: None in production code; no exported/public entity signatures altered.

## Tests Added / Updated
- Tests: None added or updated (checklist shows samples updated but tests unchecked).
- Coverage gaps: No tests introduced for visibility semantics. Critical runtime paths (controller reconciliation, RBAC/auth related to endpoint exposure) remain untested by this PR.

## Risk Assessment & Hotspots
- Overall risk: Low — documentation/sample-only changes.
- Notable hotspots (low probability):
  - AuthN/AuthZ & RBAC: visibility implies exposure semantics; sample changes may create expectations but do not modify policies or controllers—verify controllers interpret visibility as intended.
  - Secrets & env: echo-websocket-service added PORT env var — trivial; no secret exposure observed.
  - Reconciliation / install / upgrade: no code changes; samples do not affect upgrade paths.
- Recommendation: merge as sample updates. Consider a follow-up to add tests and documentation describing visibility semantics and expected runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->