### PR TITLE
ci: add code coverage reporting with Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,18 @@
+# Codecov configuration for OpenChoreo
+# Validate: curl -X POST --data-binary @.github/codecov.yml https://codecov.io/validate
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "cmd"                                # Application entrypoints
+  - "test"                               # Test helpers and utilities
+  - "**/zz_generated.*.go"               # Generated deepcopy and register files
+  - "api/v1alpha1/groupversion_info.go"  # Generated CRD group/version boilerplate
+  - "internal/openchoreo-api/api/gen"    # Generated OpenAPI server, client, and models
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,6 +46,9 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # Required for Codecov OIDC
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,6 +59,13 @@ jobs:
       - name: Running Tests
         run: |
           make test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          files: ./cover.out
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
   build:
     name: Build


### PR DESCRIPTION
## Purpose

Add Codecov integration for code coverage reporting on PRs and main branch pushes.

## Approach

- Add `.github/codecov.yml` with informational-only coverage status (does not block PRs)
- Exclude generated files and entrypoints from coverage (deepcopy, oapi-codegen, cmd/)
- Add `codecov/codecov-action` (SHA-pinned) to the test job in `build-and-test.yml`
- Use OIDC authentication for non-fork PRs, unauthenticated fallback for fork PRs

## Related Issues

Closes #2012

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Coverage Reporting Integration via Codecov

### File Changes Breakdown
- Total modified/added files: 2 (both under .github/)
- Top-level folders (changed file counts):
  - api/: 0
  - config/: 0
  - internal/: 0
  - pkg/: 0
  - install/: 0
  - docs/: 0
  - openapi/: 0
  - rca-agent/: 0
  - make/: 0
  - cmd/: 0
  - samples/: 0
  - .github/: 2
- Net lines changed: +28 / -0
  - .github/codecov.yml: +18
  - .github/workflows/build-and-test.yml: +10

### Changes Overview (evidence)
- .github/codecov.yml (new, 18 lines)
  - Sets coverage.status.project.default.informational: true and coverage.status.patch.default.informational: true (informational-only checks).
  - ignore patterns added:
    - "cmd" (application entrypoints)
    - "test" (test helpers)
    - "**/zz_generated.*.go" (generated deepcopy/register files)
    - "api/v1alpha1/groupversion_info.go" (generated CRD group/version boilerplate)
    - "internal/openchoreo-api/api/gen" (generated OpenAPI server/client/models)
  - Includes validation curl example comment.

- .github/workflows/build-and-test.yml (modified, ~221 lines file; +10 lines)
  - test job permissions: adds id-token: write (in addition to contents: read) to support OIDC.
  - New step "Upload coverage to Codecov" using codecov/codecov-action pinned to commit 671740ac (v5.5.2).
    - with:
      - files: ./cover.out
      - fail_ci_if_error: ${{ github.event_name == 'push' }} (fail CI on push uploads)
      - use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }} (OIDC enabled for non-fork PRs; disabled for forked PRs => unauthenticated fallback)

### API / CRD Surface Changes
- None. No application code, CRDs, or generated API artifacts were modified. Compatibility risk: low.

### Tests
- No tests added or updated in this PR.
- CI change only: Codecov upload introduced; no coverage thresholds enforced (informational). Coverage plumbing will surface gaps but does not change test coverage requirements.

### Risk Hotspots (concise, with reason)
1. OIDC authentication logic (medium)
   - use_oidc conditional depends on github.event.pull_request.head.repo.fork; mis-detection could prevent authenticated uploads for eligible runs.
2. CI failure escalation (medium-high)
   - fail_ci_if_error: true on push means transient Codecov/network failures could fail the test job on main branch pushes.
3. Coverage exclusion scope (low-medium)
   - Broad ignores (cmd/, test/) may suppress coverage visibility for entrypoints/test helpers; review reports for unexpected omissions.
4. Fork PR behaviour (low)
   - Forked PRs fall back to unauthenticated uploads; verify Codecov accepts these and metadata is adequate.
5. Operational dependency (low)
   - Reliance on Codecov availability and GitHub OIDC provider for uploads.

### Related Issue
- Closes issue #2012: "Add code coverage reporting with Codecov"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->