### PR TITLE
fix: quote env variable in observer deployment

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           echo "OpenSearch is ready!"
         env:
         - name: EXPERIMENTAL_USE_LOGS_BACKEND
-          value: {{ if .Values.observer.experimental }}{{ .Values.observer.experimental.useLogsBackend | default "false" }}{{ else }}"false"{{ end }}
+          value: {{ if .Values.observer.experimental }}{{ .Values.observer.experimental.useLogsBackend | default "false" | quote }}{{ else }}"false"{{ end }}
         - name: OPENSEARCH_ADDRESS
           value: "https://opensearch:9200"
         - name: OPENSEARCH_USERNAME


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Fix helm chart deployment failure when the useLogsBackend helm value is set to true

## Approach
Quoted the helm values file when passing to the observer env variables section

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

### Changed Files Breakdown
- **install/**: 1 file modified
  - `install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml`
- All other top-level directories (api/, config/, internal/, pkg/, cmd/, docs/, etc.): No changes

**Total files changed: 1** (limited to Helm template)

### Changes Detail
The fix addresses a Helm chart deployment failure by ensuring proper quoting of the `EXPERIMENTAL_USE_LOGS_BACKEND` environment variable in the observer deployment initContainer. The environment variable value is now consistently quoted as a string ("true"/"false") when rendered, preventing shell script comparison failures in the `wait-for-opensearch` init container which uses string equality checks: `[ "$EXPERIMENTAL_USE_LOGS_BACKEND" = "true" ]`.

### API/CRD Surface Changes
**None** — This PR contains no API or CRD modifications. The sole change is in Helm templating logic for environment variable value rendering. **Compatibility risk: Low** (backward compatible fix that corrects template output format).

### Tests
**No tests added or modified.** The fix is purely template-based with no test coverage changes.

### Risk Hotspots
- **Install/Upgrade Path**: Medium risk — The fix corrects a runtime deployment failure when `observer.experimental.useLogsBackend` is set to `true`. This is a critical path fix for observability plane initialization, as the init container dependency check on OpenSearch may fail silently without proper value quoting.
- **Helm Template Rendering**: Low risk — Change is isolated to environment variable quoting and uses standard Helm `quote` filter function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->