### PR TITLE
docs: update multi-cluster setup guide with observability plane fixes

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -420,6 +420,16 @@ helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgatew
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --version v2.1.1
+
+# OpenSearch Operator (for HA OpenSearch cluster)
+helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
+helm repo update
+
+helm install opensearch-operator opensearch-operator/opensearch-operator \
+  --kube-context k3d-openchoreo-op \
+  --namespace openchoreo-observability-plane \
+  --create-namespace \
+  --version 2.8.0
 ```
 
 ### CoreDNS Rewrite and Certificates

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -1,14 +1,12 @@
 # Helm values for OpenChoreo Observability Plane in k3d multi-cluster setup
 
-# Use standalone OpenSearch (not operator-managed cluster)
 openSearch:
-  enabled: true
-  service:
-    type: LoadBalancer
-
-# Disable OpenSearch operator cluster (using standalone instead)
-openSearchCluster:
   enabled: false
+
+openSearchCluster:
+  enabled: true
+  credentialsSecretName: observer-opensearch-credentials
+  adminPassword: "ThisIsTheOpenSearchPassword1"
 
 observer:
   openSearchSecretName: observer-opensearch-credentials
@@ -59,6 +57,12 @@ clusterAgent:
   tls:
     generateCerts: true
     caSecretName: ""
+
+tls:
+  enabled: true
+  dnsNames:
+    - "observability.openchoreo.localhost"
+    - "*.observability.openchoreo.localhost"
 
 fluent-bit:
   enabled: true


### PR DESCRIPTION
rewrites the multi-cluster setup guide and fixes a bunch of missing config in observability plane values

changes:
- rewrite README with clearer structure and observability plane setup
- add missing rca agent, jwksUrlTlsInsecureSkipVerify, hostname configs
- switch to operator-managed opensearch cluster with tls
- add fluent-bit tls.vhost and gateway passthrough for opensearch
- fix quoting on env variable in observer deployment
- opensearch operator helm install step in docs

also bundles some unrelated stuff that was on the branch already (codecov, sample fixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Summary

**Files changed by folder (top-level):**
- `internal/`: 605 files
- `install/`: 191 files  
- `config/`: 174 files
- `samples/`: 93 files
- `pkg/`: 76 files
- `api/`: 34 files
- `docs/`: 30 files
- `cmd/`: 10 files
- `rca-agent/`: 2 files
- `openapi/`: 1 file

**Note:** This PR includes 1,378 added files and 1 deletion, predominantly representing initial repository setup/structure alongside targeted observability plane changes.

## API/CRD Surface Changes

**Observability Plane Configuration Changes:**
- `openSearch.enabled`: `true` → `false` (disables standalone deployment)
- `openSearchCluster.enabled`: `false` → `true` (enables operator-managed cluster)
- New fields: `openSearchCluster.credentialsSecretName`, `openSearchCluster.adminPassword`
- New top-level `tls` block: enables TLS for observability plane with DNS names `observability.openchoreo.localhost` and `*.observability.openchoreo.localhost`
- Gateway `tlsPassthrough`: enabled for OpenSearch on hostname `opensearch.observability.openchoreo.localhost` port 11085

**Configuration additions** (no breaking changes to existing CRDs):
- Observer deployment now includes `JWKS_URL_TLS_INSECURE_SKIP_VERIFY` environment variable (default: `false`)
- RCA agent configuration block available in values (currently disabled by default)
- FluentBit TLS and gateway passthrough support documented

**Compatibility risk: LOW** - Changes are additive/configuration-only; no CRD schema modifications for existing resource types.

## Tests

No new tests were added in this PR. Existing test coverage includes:
- `internal/observer/config/config_test.go` - OpenSearch configuration defaults and environment variable handling
- `internal/observer/service/service_test.go` - Mock OpenSearch client testing
- Cluster observability plane controller tests (pre-existing)

**Critical path gaps:** No tests added for operator-managed OpenSearch cluster initialization, TLS certificate generation for observability plane, or RCA agent configuration validation.

## Risk Hotspots

**HIGH:**
- **Hardcoded credentials** in `values-op.yaml`: `openSearchCluster.adminPassword: "ThisIsTheOpenSearchPassword1"` - credentials exposed in version control for multi-cluster k3d setup
- **TLS insecurity flag** `jwksUrlTlsInsecureSkipVerify: "true"` in observer deployment - bypasses certificate verification for OIDC JWKS endpoint

**MEDIUM:**
- **Operator-managed OpenSearch migration:** Switching from standalone to operator-managed introduces reconciliation loop dependency; no documented upgrade path or data migration guidance
- **Secret management:** OpenSearch operator expects credentials via `credentialsSecretName` reference; setup job must complete before observer deployment initializes (mitigated with init containers checking readiness)
- **TLS certificate generation:** New TLS issuer/certificate resources added; potential for cert provisioning race conditions during cluster bootstrap

**LOW:**
- **RBAC:** Cluster agents and observer service accounts have predefined RBAC roles; no new permissions introduced
- **Configuration sprawl:** New `rca` block configuration available but disabled by default, reducing immediate impact

## Installation/Upgrade Considerations

- OpenSearch Operator Helm chart installation documented in README but not automated in installation flow
- Observability plane setup now requires operator to be pre-installed; manual prerequisite step required before Helm chart deployment
- Multi-cluster setup guide rewritten with clearer structure and updated observability plane section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->