### PR TITLE
fix: use http in openchoreo mcp connection in k3d multi cluster

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -216,8 +216,6 @@ spec:
         value: "dev-user"
       - key: password
         value: "dev-password"
-      - key: RCA_LLM_API_KEY
-        value: "fake-llm-api-key-for-development"
 EOF
 ```
 

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -79,7 +79,7 @@ prometheus:
       type: LoadBalancer
 
 rca:
-  controlPlaneUrl: "https://api.openchoreo.localhost:8443"
+  controlPlaneUrl: "http://api.openchoreo.localhost:8080"
   http:
     hostnames:
     - host.k3d.internal

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -186,8 +186,6 @@ spec:
         value: "dev-user"
       - key: password
         value: "dev-password"
-      - key: RCA_LLM_API_KEY
-        value: "fake-llm-api-key-for-development"
 EOF
 ```
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
$subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Changes

Files changed by top-level folder:
- install/: 3 files
  - install/k3d/multi-cluster/README.md (modified)
  - install/k3d/multi-cluster/values-op.yaml (modified)
  - install/k3d/single-cluster/README.md (modified)
- api/, config/, internal/, pkg/, docs/, openapi/, rca-agent/, make/, cmd/, samples/: 0 files changed

Summary of changes:
- Primary: install/k3d/multi-cluster/values-op.yaml
  - rca.controlPlaneUrl changed from "https://api.openchoreo.localhost:8443" to "http://api.openchoreo.localhost:8080"
  - Net diff: +1 / -1 lines
- Documentation: Removed RCA_LLM_API_KEY entries from External Secrets examples in:
  - install/k3d/multi-cluster/README.md (-2 lines)
  - install/k3d/single-cluster/README.md (-2 lines)

API / CRD surface changes:
- None. No API or CRD files modified. Compatibility risk: Low.

Tests:
- No tests added or updated. Critical paths lacking tests: none introduced by these config/docs-only changes.

Risk hotspots:
- Protocol / Security (Low→Medium): switching k3d MCP/control-plane connection to HTTP removes TLS for that local-dev config—acceptable for local k3d but should not be applied to production configs.
- Secrets (Low): only README/examples removed an example secret key (RCA_LLM_API_KEY); no runtime secret provisioning changes detected.
- Install/upgrade paths (Low): changes are limited to k3d local deploy values/README; production Helm charts and operator manifests unaffected.

Overall assessment:
- Scope: narrow, limited to k3d local development configs and README examples.
- Compatibility/impact: Low — no code, CRD, or test changes; reviewers should verify this HTTP usage is intentionally scoped to k3d and document any required warnings for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->