### PR TITLE
fix: remove incorrect config in k3d dp multi cluster

### DIFF
--- a/install/k3d/multi-cluster/config-dp.yaml
+++ b/install/k3d/multi-cluster/config-dp.yaml
@@ -38,6 +38,3 @@ registries:
       "host.k3d.internal:10082":
         endpoint:
           - http://host.k3d.internal:10082
-
-opentelemetry-collector:
-  enabled: true

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -50,3 +50,6 @@ kube-prometheus-stack:
 
 observability:
   observabilityPlaneUrl: "http://host.k3d.internal:11086"
+
+opentelemetry-collector:
+  enabled: true


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Fix the incorrect configuration of otel collector in k3d multi cluster

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

**File breakdown by top-level folder:**
- `install/`: 2 files modified (k3d/multi-cluster/)
  - `config-dp.yaml`: -3 lines
  - `values-dp.yaml`: +3 lines

**Change details:**
The PR relocates the OpenTelemetry collector configuration from an incorrect location in the k3d cluster configuration to the proper Helm values file for the data plane:

1. **Removed from `config-dp.yaml`**: Deleted `opentelemetry-collector: enabled: true` from the registries section of the k3d cluster configuration. This was an incorrect placement since the k3d registries config is intended for container registry mirror settings, not Helm chart enablement.

2. **Added to `values-dp.yaml`**: Added `opentelemetry-collector: enabled: true` to the Helm values file, which is the correct location for controlling the deployment of the opentelemetry-collector Helm chart dependency (version 0.140.0, per the data plane Chart.yaml).

**API/CRD surface changes:**
None. This is a configuration relocation with no impact to API surfaces or CRD definitions.

**Tests:**
No tests added or updated (per PR checklist).

**Risk Assessment:**
Low risk. The change corrects a configuration misplacement without altering functionality. The opentelemetry-collector remains enabled in the data plane setup via the correct configuration mechanism (Helm values).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->