### PR TITLE
feat: remove observer's opensearch-init container and remove opensearh health check

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -21,49 +21,6 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         fsGroup: 65532
-      initContainers:
-      - name: wait-for-opensearch
-        image: curlimages/curl:latest
-        command:
-        - /bin/sh
-        - -c
-        - |
-          # Skip OpenSearch check if using logs backend
-          if [ -n "$EXPERIMENTAL_USE_LOGS_BACKEND" ] && [ "$EXPERIMENTAL_USE_LOGS_BACKEND" = "true" ]; then
-            echo "Logs backend enabled, skipping OpenSearch check"
-            exit 0
-          fi
-          
-          echo "Waiting for OpenSearch to be ready..."
-          AUTH_TOKEN=$(echo -n "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" | base64)
-          echo "Checking OpenSearch at: $OPENSEARCH_ADDRESS"
-          until curl -s -H "Authorization: Basic $AUTH_TOKEN" "$OPENSEARCH_ADDRESS/_cluster/health" --insecure | grep -q '"status":"green\|yellow"'; do
-            echo "OpenSearch not ready, waiting 10 seconds..."
-            sleep 10
-          done
-          echo "OpenSearch is ready!"
-        env:
-        - name: EXPERIMENTAL_USE_LOGS_BACKEND
-          value: {{ if .Values.observer.experimental }}{{ .Values.observer.experimental.useLogsBackend | default "false" | quote }}{{ else }}"false"{{ end }}
-        - name: OPENSEARCH_ADDRESS
-          value: "https://opensearch:9200"
-        - name: OPENSEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.observer.openSearchSecretName }}
-              key: username
-        - name: OPENSEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.observer.openSearchSecretName }}
-              key: password
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 65532
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
       containers:
       - name: observer
         image: "{{ if .Values.observer.image }}{{ .Values.observer.image.repository | default "ghcr.io/openchoreo/observer" }}:{{ .Values.observer.image.tag | default .Chart.AppVersion }}{{ else }}ghcr.io/openchoreo/observer:{{ .Chart.AppVersion }}{{ end }}"

--- a/install/helm/openchoreo-observability-plane/templates/opentelemetry-collector/configMap.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/opentelemetry-collector/configMap.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values "opentelemetry-collector").enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -91,3 +92,4 @@ data:
           processors: [{{ join ", " $processors }}]
           {{- end }}
           exporters: [opensearch]
+{{- end }}

--- a/internal/observer/opensearch/client.go
+++ b/internal/observer/opensearch/client.go
@@ -137,15 +137,6 @@ func (c *Client) GetIndexMapping(ctx context.Context, index string) (*MappingRes
 	return mapping, nil
 }
 
-// HealthCheck performs a basic health check on the OpenSearch cluster
-func (c *Client) HealthCheck(ctx context.Context) error {
-	_, err := c.client.Info()
-	if err != nil {
-		return fmt.Errorf("health check failed: %w", err)
-	}
-	return nil
-}
-
 // SearchMonitorByName searches alerting monitors by name using the Alerting plugin API.
 func (c *Client) SearchMonitorByName(ctx context.Context, name string) (string, bool, error) {
 	path := "/_plugins/_alerting/monitors/_search"

--- a/internal/observer/service/service.go
+++ b/internal/observer/service/service.go
@@ -50,7 +50,6 @@ type OpenSearchClient interface {
 	UpdateMonitor(ctx context.Context, monitorID string, monitor map[string]interface{}) (lastUpdateTime int64, err error)
 	DeleteMonitor(ctx context.Context, monitorID string) error
 	WriteAlertEntry(ctx context.Context, entry map[string]interface{}) (string, error)
-	HealthCheck(ctx context.Context) error
 }
 
 // LoggingService provides logging and metrics functionality
@@ -589,25 +588,8 @@ func (s *LoggingService) GetTraces(ctx context.Context, params opensearch.Traces
 	}, nil
 }
 
-// HealthCheck performs a health check on the service
+// HealthCheck performs a health check on observer service
 func (s *LoggingService) HealthCheck(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	// Skip OpenSearch health check if using experimental logs backend
-	if s.config.Experimental.UseLogsBackend {
-		if s.logsBackend == nil {
-			return fmt.Errorf("logs backend enabled but not configured")
-		}
-		s.logger.Debug("Health check passed (OpenSearch check skipped - using logs backend)")
-		return nil
-	}
-
-	if err := s.osClient.HealthCheck(ctx); err != nil {
-		s.logger.Error("Health check failed", "error", err)
-		return fmt.Errorf("opensearch health check failed: %w", err)
-	}
-
 	s.logger.Debug("Health check passed")
 	return nil
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
1. Remove OpenSearch dependencies in Observer
2. Stop adding otel collector config when otel collector is disabled

## Approach
1. Wrapped otel-collector configMap is a helm if check
2. Removed wait-for-opensearch init container in observer deployment
3. Stopped checking OpenSearch heath from Observer

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1960

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
