### PR TITLE
refactor: update alert rule trait with enhanced descriptions

### DIFF
--- a/samples/component-alerts/alert-rule-trait.yaml
+++ b/samples/component-alerts/alert-rule-trait.yaml
@@ -9,23 +9,23 @@ spec:
   schema:
     parameters:
       # Developer-facing parameters - static across environments
-      description: "string"
-      severity: "string | default=warning"
+      description: "string | description=\"A human-readable description of what this alert rule monitors and when it triggers.\""
+      severity: "string | enum=info,warning,critical | default=warning | description=\"The severity level of alerts triggered by this rule. Determines alert priority and notification urgency.\""
       source:
-        type: "string"
-        query: "string | default="    # Required for log-based alerts
-        metric: "string | default="   # Required for metric-based alerts
+        type: "string | enum=log,metric | description=\"The data source type for the alert rule.\""
+        query: "string | default=\"\" | description=\"The query expression for log-based alerts. Required when source type is 'log'.\""
+        metric: "string | default=\"\" | description=\"The predefined metric to monitor for metric-based alerts. Must be one of: cpu_usage, memory_usage. Required when source type is 'metric'.\""
       condition:
-        window: "string | default=5m"
-        interval: "string | default=1m"
-        operator: "string | default=gt"
-        threshold: "integer | default=10"
+        window: "string | default=5m | description=\"The time window over which data is aggregated before evaluating the alert condition (e.g. 5m, 10m, 30m, 1h).\""
+        interval: "string | default=1m | description=\"The frequency at which the alert rule is evaluated (e.g. 1m, 5m, 15m, 30m).\""
+        operator: "string | enum=gt,lt,gte,lte,eq | default=gt | description=\"The comparison operator used to evaluate the condition against the threshold (gt: greater than, lt: less than, gte: greater than or equal, lte: less than or equal, eq: equal).\""
+        threshold: "integer | default=10 | description=\"The numeric threshold value used with the operator to determine when the alert triggers.\""
 
     envOverrides:
       # Platform engineers can override per environment
-      enabled: "boolean | default=true | description=\"Enable/Disable the alert rule\""
-      enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enable/Disable AI powered root cause analysis for alerts triggered by this rule\""
-      notificationChannel: "string | description=\"The notification channel to send alerts to\""
+      enabled: "boolean | default=true | description=\"Controls whether this alert rule is active. When disabled, the rule will not trigger alerts.\""
+      enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enables AI-powered root cause analysis for alerts triggered by this rule. When enabled, provides automated reports of root causes for alert conditions.\""
+      notificationChannel: "string | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers.\""
 
   creates:
     - targetPlane: observabilityplane

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -1273,23 +1273,23 @@ spec:
   schema:
     parameters:
       # Developer-facing parameters - static across environments
-      description: "string"
-      severity: "string | default=warning"
+      description: "string | description=\"A human-readable description of what this alert rule monitors and when it triggers.\""
+      severity: "string | enum=info,warning,critical | default=warning | description=\"The severity level of alerts triggered by this rule. Determines alert priority and notification urgency.\""
       source:
-        type: "string"
-        query: "string | default="    # Required for log-based alerts
-        metric: "string | default="   # Required for metric-based alerts
+        type: "string | enum=log,metric | description=\"The data source type for the alert rule.\""
+        query: "string | default=\"\" | description=\"The query expression for log-based alerts. Required when source type is 'log'.\""
+        metric: "string | default=\"\" | description=\"The predefined metric to monitor for metric-based alerts. Must be one of: cpu_usage, memory_usage. Required when source type is 'metric'.\""
       condition:
-        window: "string | default=5m"
-        interval: "string | default=1m"
-        operator: "string | default=gt"
-        threshold: "integer | default=10"
+        window: "string | default=5m | description=\"The time window over which data is aggregated before evaluating the alert condition (e.g. 5m, 10m, 30m, 1h).\""
+        interval: "string | default=1m | description=\"The frequency at which the alert rule is evaluated (e.g. 1m, 5m, 15m, 30m).\""
+        operator: "string | enum=gt,lt,gte,lte,eq | default=gt | description=\"The comparison operator used to evaluate the condition against the threshold (gt: greater than, lt: less than, gte: greater than or equal, lte: less than or equal, eq: equal).\""
+        threshold: "integer | default=10 | description=\"The numeric threshold value used with the operator to determine when the alert triggers.\""
 
     envOverrides:
       # Platform engineers can override per environment
-      enabled: "boolean | default=true | description=\"Enable/Disable the alert rule\""
-      enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enable/Disable AI powered root cause analysis for alerts triggered by this rule\""
-      notificationChannel: "string | description=\"The notification channel to send alerts to\""
+      enabled: "boolean | default=true | description=\"Controls whether this alert rule is active. When disabled, the rule will not trigger alerts.\""
+      enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enables AI-powered root cause analysis for alerts triggered by this rule. When enabled, provides automated reports of root causes for alert conditions.\""
+      notificationChannel: "string | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers.\""
 
   creates:
     - targetPlane: observabilityplane

--- a/samples/getting-started/component-traits/alert-rule-trait.yaml
+++ b/samples/getting-started/component-traits/alert-rule-trait.yaml
@@ -9,23 +9,23 @@ spec:
   schema:
     parameters:
       # Developer-facing parameters - static across environments
-      description: "string"
-      severity: "string | default=warning"
+      description: "string | description=\"A human-readable description of what this alert rule monitors and when it triggers.\""
+      severity: "string | enum=info,warning,critical | default=warning | description=\"The severity level of alerts triggered by this rule. Determines alert priority and notification urgency.\""
       source:
-        type: "string"
-        query: "string | default="    # Required for log-based alerts
-        metric: "string | default="   # Required for metric-based alerts
+        type: "string | enum=log,metric | description=\"The data source type for the alert rule.\""
+        query: "string | default=\"\" | description=\"The query expression for log-based alerts. Required when source type is 'log'.\""
+        metric: "string | default=\"\" | description=\"The predefined metric to monitor for metric-based alerts. Must be one of: cpu_usage, memory_usage. Required when source type is 'metric'.\""
       condition:
-        window: "string | default=5m"
-        interval: "string | default=1m"
-        operator: "string | default=gt"
-        threshold: "integer | default=10"
+        window: "string | default=5m | description=\"The time window over which data is aggregated before evaluating the alert condition (e.g. 5m, 10m, 30m, 1h).\""
+        interval: "string | default=1m | description=\"The frequency at which the alert rule is evaluated (e.g. 1m, 5m, 15m, 30m).\""
+        operator: "string | enum=gt,lt,gte,lte,eq | default=gt | description=\"The comparison operator used to evaluate the condition against the threshold (gt: greater than, lt: less than, gte: greater than or equal, lte: less than or equal, eq: equal).\""
+        threshold: "integer | default=10 | description=\"The numeric threshold value used with the operator to determine when the alert triggers.\""
 
     envOverrides:
       # Platform engineers can override per environment
-      enabled: "boolean | default=true | description=\"Enable/Disable the alert rule\""
-      enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enable/Disable AI powered root cause analysis for alerts triggered by this rule\""
-      notificationChannel: "string | description=\"The notification channel to send alerts to\""
+      enabled: "boolean | default=true | description=\"Controls whether this alert rule is active. When disabled, the rule will not trigger alerts.\""
+      enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enables AI-powered root cause analysis for alerts triggered by this rule. When enabled, provides automated reports of root causes for alert conditions.\""
+      notificationChannel: "string | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers.\""
 
   creates:
     - targetPlane: observabilityplane


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request enhances the schema definitions for alert rule traits across multiple sample YAML files. The main focus is on improving parameter documentation, adding value constraints, and clarifying the intended usage for each field. These changes make the alert rule configuration more robust, self-explanatory, and easier to use for both developers and platform engineers.

Key improvements include:

**Schema Documentation and Constraints:**

* Added detailed descriptions to all parameters in the `parameters` and `envOverrides` sections, clarifying their purpose and expected usage. [[1]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L12-R28) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1276-R1292) [[3]](diffhunk://#diff-daed52d64156c6673de934271d3a1671368cdc592f4b7cd72f326c5d3977aa03L12-R28)
* Introduced `enum` constraints for fields like `severity`, `source.type`, `source.metric`, and `condition.operator` to restrict values and prevent misconfiguration. [[1]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L12-R28) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1276-R1292) [[3]](diffhunk://#diff-daed52d64156c6673de934271d3a1671368cdc592f4b7cd72f326c5d3977aa03L12-R28)
* Provided explicit default values and improved descriptions for fields such as `condition.window`, `condition.interval`, `condition.threshold`, and `envOverrides.enabled`. [[1]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L12-R28) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1276-R1292) [[3]](diffhunk://#diff-daed52d64156c6673de934271d3a1671368cdc592f4b7cd72f326c5d3977aa03L12-R28)

**Field-Specific Enhancements:**

* Clarified the distinction and requirements for log-based versus metric-based alert rules by specifying when `query` or `metric` fields are required and what values are allowed. [[1]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L12-R28) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1276-R1292) [[3]](diffhunk://#diff-daed52d64156c6673de934271d3a1671368cdc592f4b7cd72f326c5d3977aa03L12-R28)
* Improved the descriptions and configuration guidance for environment-specific overrides, such as enabling AI-powered root cause analysis and setting notification channels. [[1]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L12-R28) [[2]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1276-R1292) [[3]](diffhunk://#diff-daed52d64156c6673de934271d3a1671368cdc592f4b7cd72f326c5d3977aa03L12-R28)

These descriptions will appear in the backstage portal improving the developer experience when adding an alert rule trait
<img width="1512" height="802" alt="image" src="https://github.com/user-attachments/assets/f9ad5fff-d890-4e70-a6e4-cf976885c1e0" />



## Approach
- Updated alert-rule-trait.yaml and related files to include detailed descriptions for parameters, improving clarity on usage and expected values.
- Adjusted source types and conditions to provide better guidance for developers on alert configurations.


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
