### PR TITLE
feat: add e2e testing infrastructure and platform health tests

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -3,6 +3,6 @@ description: Sets up Go environment
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v6.1.0
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version-file: go.mod

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,39 +1,76 @@
 name: E2E Tests
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      helm_chart_version:
+        description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<commit-sha>)"
+        required: false
+        default: "0.0.0-latest-dev"
+      with_build:
+        description: "Include build plane"
+        type: boolean
+        default: false
+      with_observability:
+        description: "Include observability plane"
+        type: boolean
+        default: false
+  schedule:
+    - cron: "0 1 * * *" # nightly at 01:00 UTC (06:30 IST)
 
 permissions:
   contents: read
 
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HELM_CHART_VERSION: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
+  E2E_WITH_BUILD: ${{ github.event.inputs.with_build || 'false' }}
+  E2E_WITH_OBSERVABILITY: ${{ github.event.inputs.with_observability || 'false' }}
+  K3D_VERSION: v5.8.3
+  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
+  YQ_VERSION: v4.45.4
+  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
+
 jobs:
-  test-e2e:
-    name: Run on Ubuntu
-    runs-on: ubuntu-latest
+  e2e:
+    name: E2E
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-# TODO: Enable me once the e2e tests are ready
-#      - name: Setup Go
-#        uses: actions/setup-go@v6.1.0
-#        with:
-#          go-version: '~1.23'
-#
-#      - name: Install the latest version of kind
-#        run: |
-#          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
-#          chmod +x ./kind
-#          sudo mv ./kind /usr/local/bin/kind
-#
-#      - name: Verify kind installation
-#        run: kind version
-#
-#      - name: Create kind cluster
-#        run: kind create cluster
-#
-#      - name: Running Test e2e
-#        run: |
-#          go mod tidy
-#          make test-e2e
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Run e2e tests
+        run: |
+          make e2e \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION=${{ env.HELM_CHART_VERSION }} \
+            E2E_WITH_BUILD=${{ env.E2E_WITH_BUILD }} \
+            E2E_WITH_OBSERVABILITY=${{ env.E2E_WITH_OBSERVABILITY }}
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: e2e-diagnostics
+          path: test/e2e/_diagnostics/
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,4 @@ include make/lint.mk
 include make/docker.mk
 include make/kube.mk
 include make/helm.mk
+include make/e2e.mk

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -1,0 +1,369 @@
+# This makefile contains all the make targets related to e2e testing.
+
+# Cluster
+E2E_CLUSTER_NAME       ?= openchoreo-e2e
+E2E_KUBECONTEXT        := k3d-$(E2E_CLUSTER_NAME)
+
+# "local" uses chart dirs from install/helm/, "oci" pulls published charts from HELM_OCI_REGISTRY
+E2E_HELM_SOURCE        ?= local
+# Set to "true" to include build plane and observability plane in the e2e setup
+E2E_WITH_BUILD         ?= false
+E2E_WITH_OBSERVABILITY ?= false
+# Go duration for the test suite (go test -timeout)
+E2E_TEST_TIMEOUT       ?= 20m
+# Go duration for each individual helm install and kubectl wait (not the overall setup timeout)
+E2E_SETUP_TIMEOUT      ?= 5m
+
+# Directories
+E2E_DIR                := $(PROJECT_DIR)/test/e2e
+E2E_K3D_DIR            := $(E2E_DIR)/k3d
+E2E_DIAGNOSTICS_DIR    ?= $(E2E_DIR)/_diagnostics
+
+# Namespaces
+E2E_CP_NS              := openchoreo-control-plane
+E2E_DP_NS              := openchoreo-data-plane
+E2E_BP_NS              := openchoreo-build-plane
+E2E_OP_NS              := openchoreo-observability-plane
+
+# Dependency versions (keep in sync with install/k3d/single-cluster/README.md)
+GATEWAY_API_VERSION    ?= v1.4.1
+CERT_MANAGER_VERSION   ?= v1.19.2
+ESO_VERSION            ?= 1.3.2
+KGATEWAY_VERSION       ?= v2.1.1
+THUNDER_VERSION        ?= 0.21.0
+
+# Helm chart references: local chart dirs or OCI registry
+ifeq ($(E2E_HELM_SOURCE),oci)
+  E2E_HELM_DEP_UPDATE :=
+  E2E_CP_CHART := $(HELM_OCI_REGISTRY)/openchoreo-control-plane --version $(HELM_CHART_VERSION)
+  E2E_DP_CHART := $(HELM_OCI_REGISTRY)/openchoreo-data-plane --version $(HELM_CHART_VERSION)
+  E2E_BP_CHART := $(HELM_OCI_REGISTRY)/openchoreo-build-plane --version $(HELM_CHART_VERSION)
+  E2E_OP_CHART := $(HELM_OCI_REGISTRY)/openchoreo-observability-plane --version $(HELM_CHART_VERSION)
+else
+  E2E_HELM_DEP_UPDATE := --dependency-update
+  E2E_CP_CHART := $(HELM_CHARTS_DIR)/openchoreo-control-plane
+  E2E_DP_CHART := $(HELM_CHARTS_DIR)/openchoreo-data-plane
+  E2E_BP_CHART := $(HELM_CHARTS_DIR)/openchoreo-build-plane
+  E2E_OP_CHART := $(HELM_CHARTS_DIR)/openchoreo-observability-plane
+endif
+
+# Shorthand for kubectl/helm with e2e context
+E2E_KUBECTL := kubectl --context $(E2E_KUBECONTEXT)
+E2E_HELM    := helm --kube-context $(E2E_KUBECONTEXT)
+
+# ---------------------------------------------------------------------------
+# Helper: copy cluster-gateway certs from CP namespace to a target namespace.
+# The CP chart creates a CA cert (via cert-manager) and a Job that extracts it
+# into a ConfigMap. Both the ConfigMap and Secret must be copied to each plane
+# namespace for the cluster-agent mTLS handshake to work.
+# Usage: $(call e2e_copy_gateway_certs,<target-namespace>)
+# ---------------------------------------------------------------------------
+define e2e_copy_gateway_certs
+	@$(call log_info, Copying cluster-gateway certs to $(1))
+	@$(E2E_KUBECTL) create namespace $(1) --dry-run=client -o yaml | $(E2E_KUBECTL) apply -f -
+	@CA_CRT=$$($(E2E_KUBECTL) get configmap cluster-gateway-ca \
+		-n $(E2E_CP_NS) -o jsonpath='{.data.ca\.crt}') && \
+	$(E2E_KUBECTL) create configmap cluster-gateway-ca \
+		--from-literal=ca.crt="$$CA_CRT" \
+		-n $(1) --dry-run=client -o yaml | $(E2E_KUBECTL) apply -f -
+	@TLS_CRT=$$($(E2E_KUBECTL) get secret cluster-gateway-ca \
+		-n $(E2E_CP_NS) -o jsonpath='{.data.tls\.crt}' | base64 -d) && \
+	TLS_KEY=$$($(E2E_KUBECTL) get secret cluster-gateway-ca \
+		-n $(E2E_CP_NS) -o jsonpath='{.data.tls\.key}' | base64 -d) && \
+	CA_CRT=$$($(E2E_KUBECTL) get configmap cluster-gateway-ca \
+		-n $(E2E_CP_NS) -o jsonpath='{.data.ca\.crt}') && \
+	$(E2E_KUBECTL) create secret generic cluster-gateway-ca \
+		--from-literal=tls.crt="$$TLS_CRT" \
+		--from-literal=tls.key="$$TLS_KEY" \
+		--from-literal=ca.crt="$$CA_CRT" \
+		-n $(1) --dry-run=client -o yaml | $(E2E_KUBECTL) apply -f -
+endef
+
+# ---------------------------------------------------------------------------
+# Helper: patch gateway-default deployment with /tmp volume (kgateway#9800).
+# Usage: $(call e2e_patch_gateway,<namespace>)
+# ---------------------------------------------------------------------------
+define e2e_patch_gateway
+	@$(call log_info, Waiting for gateway-default deployment in $(1))
+	@for i in $$(seq 1 30); do \
+		$(E2E_KUBECTL) get deployment gateway-default -n $(1) >/dev/null 2>&1 && break; \
+		if [ $$i -eq 30 ]; then echo "gateway-default not found in $(1), skipping patch"; exit 0; fi; \
+		sleep 2; \
+	done
+	@$(call log_info, Patching gateway-default in $(1) with /tmp volume)
+	@$(E2E_KUBECTL) patch deployment gateway-default -n $(1) \
+		--type='json' \
+		-p='[{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"tmp","emptyDir":{}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"tmp","mountPath":"/tmp"}}]'
+endef
+
+# ---------------------------------------------------------------------------
+# Helper: register a plane CR by injecting the cluster-agent CA cert via yq.
+# Waits for the agent TLS secret, extracts CA, substitutes into template YAML.
+# Usage: $(call e2e_register_plane,<namespace>,<template-yaml>)
+# ---------------------------------------------------------------------------
+define e2e_register_plane
+	@$(call log_info, Waiting for cluster-agent TLS cert in $(1))
+	@for i in $$(seq 1 60); do \
+		$(E2E_KUBECTL) get secret cluster-agent-tls -n $(1) >/dev/null 2>&1 && break; \
+		if [ $$i -eq 60 ]; then echo "Timed out waiting for cluster-agent-tls in $(1)"; exit 1; fi; \
+		sleep 2; \
+	done
+	@export AGENT_CA=$$($(E2E_KUBECTL) get secret cluster-agent-tls \
+		-n $(1) -o jsonpath='{.data.ca\.crt}' | base64 -d) && \
+	yq '.spec.clusterAgent.clientCA.value = strenv(AGENT_CA)' $(2) | \
+	$(E2E_KUBECTL) apply -f -
+endef
+
+##@ E2E Testing
+
+# ---------------------------------------------------------------------------
+# Lifecycle target
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e
+e2e: ## Full e2e lifecycle: setup → test → down (collects diagnostics on failure)
+	@setup_ok=0; \
+	$(MAKE) e2e.setup && setup_ok=1; \
+	if [ $$setup_ok -eq 1 ]; then \
+		$(MAKE) e2e.test; test_exit=$$?; \
+		if [ $$test_exit -ne 0 ]; then $(MAKE) e2e.diagnostics || true; fi; \
+	else \
+		test_exit=1; \
+		$(MAKE) e2e.diagnostics || true; \
+	fi; \
+	$(MAKE) e2e.down || true; \
+	exit $$test_exit
+
+# ---------------------------------------------------------------------------
+# Setup targets
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e.setup
+e2e.setup: ## All setup: cluster + prerequisites + install + configure
+	@$(MAKE) e2e.setup-cluster
+	@$(MAKE) e2e.setup-prerequisites
+	@$(MAKE) e2e.setup-install
+	@$(MAKE) e2e.setup-configure
+	@$(call log_success, E2E setup complete)
+
+.PHONY: e2e.setup-cluster
+e2e.setup-cluster: ## Create k3d cluster
+	@$(call log_info, Creating k3d cluster '$(E2E_CLUSTER_NAME)')
+	k3d cluster create --config $(E2E_K3D_DIR)/config.yaml
+	@$(call log_info, Applying CoreDNS rewrite for e2e domains)
+	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/coredns-custom.yaml
+	@$(call log_success, k3d cluster '$(E2E_CLUSTER_NAME)' created)
+
+.PHONY: e2e.setup-prerequisites
+e2e.setup-prerequisites: ## Install Gateway API, cert-manager, ESO, kgateway
+	@$(call log_info, Installing Gateway API CRDs $(GATEWAY_API_VERSION))
+	$(E2E_KUBECTL) apply --server-side \
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+	@$(call log_info, Installing cert-manager $(CERT_MANAGER_VERSION))
+	$(E2E_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+		--namespace cert-manager --create-namespace \
+		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Installing External Secrets Operator $(ESO_VERSION))
+	$(E2E_HELM) upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets \
+		--namespace external-secrets --create-namespace \
+		--version $(ESO_VERSION) --set installCRDs=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Installing kgateway $(KGATEWAY_VERSION))
+	$(E2E_HELM) upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+		--version $(KGATEWAY_VERSION)
+	$(E2E_HELM) upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+		--namespace $(E2E_CP_NS) --create-namespace \
+		--version $(KGATEWAY_VERSION) \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Creating ClusterSecretStore)
+	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/secretstore.yaml
+	@$(call log_success, Prerequisites installed)
+
+.PHONY: e2e.setup-install
+e2e.setup-install: ## Install all planes via Helm
+	@$(MAKE) _e2e.install-thunder
+	@$(MAKE) _e2e.install-cp
+	@$(MAKE) _e2e.install-dp
+	@if [ "$(E2E_WITH_BUILD)" = "true" ]; then $(MAKE) _e2e.install-bp; fi
+	@if [ "$(E2E_WITH_OBSERVABILITY)" = "true" ]; then $(MAKE) _e2e.install-op; fi
+	@$(call log_success, All planes installed)
+
+.PHONY: e2e.setup-configure
+e2e.setup-configure: ## Apply default resources, register planes, and link observability
+	@$(call log_info, Applying default resources)
+	$(E2E_KUBECTL) label namespace default openchoreo.dev/controlplane-namespace=true --overwrite
+	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/all.yaml
+	@$(MAKE) _e2e.configure-dp
+	@if [ "$(E2E_WITH_BUILD)" = "true" ]; then $(MAKE) _e2e.configure-bp; fi
+	@if [ "$(E2E_WITH_OBSERVABILITY)" = "true" ]; then $(MAKE) _e2e.configure-op; fi
+	@if [ "$(E2E_WITH_OBSERVABILITY)" = "true" ]; then $(MAKE) _e2e.link-observability; fi
+	@$(call log_success, E2E configuration complete)
+
+# ---------------------------------------------------------------------------
+# Internal install targets
+# ---------------------------------------------------------------------------
+
+.PHONY: _e2e.install-thunder
+_e2e.install-thunder:
+	@# Thunder requires a valid /etc/machine-id on the node
+	docker exec k3d-$(E2E_CLUSTER_NAME)-server-0 sh -c \
+		"cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+	@$(call log_info, Installing Thunder $(THUNDER_VERSION))
+	$(E2E_HELM) upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
+		--namespace $(E2E_CP_NS) --create-namespace \
+		--version $(THUNDER_VERSION) \
+		--values $(PROJECT_DIR)/install/k3d/common/values-thunder.yaml \
+		--values $(E2E_K3D_DIR)/values-thunder.yaml \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+
+.PHONY: _e2e.install-cp
+_e2e.install-cp:
+	@$(call log_info, Installing Control Plane)
+	$(E2E_HELM) upgrade --install openchoreo-control-plane $(E2E_CP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_CP_NS) --create-namespace \
+		--values $(E2E_K3D_DIR)/values-cp.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(call e2e_patch_gateway,$(E2E_CP_NS))
+	$(E2E_KUBECTL) wait -n $(E2E_CP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+	@# Wait for the CA extractor job to create the cluster-gateway-ca configmap
+	@$(call log_info, Waiting for cluster-gateway CA)
+	@for i in $$(seq 1 60); do \
+		$(E2E_KUBECTL) get configmap cluster-gateway-ca -n $(E2E_CP_NS) >/dev/null 2>&1 && break; \
+		if [ $$i -eq 60 ]; then echo "Timed out waiting for cluster-gateway-ca configmap"; exit 1; fi; \
+		sleep 2; \
+	done
+
+.PHONY: _e2e.install-dp
+_e2e.install-dp:
+	$(call e2e_copy_gateway_certs,$(E2E_DP_NS))
+	@$(call log_info, Installing Data Plane)
+	$(E2E_HELM) upgrade --install openchoreo-data-plane $(E2E_DP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_DP_NS) --create-namespace \
+		--values $(E2E_K3D_DIR)/values-dp.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(call e2e_patch_gateway,$(E2E_DP_NS))
+	$(E2E_KUBECTL) wait -n $(E2E_DP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+.PHONY: _e2e.install-bp
+_e2e.install-bp:
+	$(call e2e_copy_gateway_certs,$(E2E_BP_NS))
+	@$(call log_info, Installing container registry)
+	helm repo add twuni https://twuni.github.io/docker-registry.helm 2>/dev/null || true
+	helm repo update twuni
+	$(E2E_HELM) upgrade --install registry twuni/docker-registry \
+		--namespace $(E2E_BP_NS) --create-namespace \
+		--values $(PROJECT_DIR)/install/k3d/single-cluster/values-registry.yaml
+	@$(call log_info, Installing Build Plane)
+	$(E2E_HELM) upgrade --install openchoreo-build-plane $(E2E_BP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_BP_NS) --create-namespace \
+		--values $(E2E_K3D_DIR)/values-bp.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_KUBECTL) wait -n $(E2E_BP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+.PHONY: _e2e.install-op
+_e2e.install-op:
+	$(call e2e_copy_gateway_certs,$(E2E_OP_NS))
+	@$(call log_info, Creating OpenSearch credentials)
+	@$(E2E_KUBECTL) create namespace $(E2E_OP_NS) --dry-run=client -o yaml | $(E2E_KUBECTL) apply -f -
+	@$(E2E_KUBECTL) create secret generic observer-opensearch-credentials \
+		-n $(E2E_OP_NS) \
+		--from-literal=username="admin" \
+		--from-literal=password="ThisIsTheOpenSearchPassword1" \
+		--dry-run=client -o yaml | $(E2E_KUBECTL) apply -f -
+	@$(call log_info, Installing Observability Plane)
+	$(E2E_HELM) upgrade --install openchoreo-observability-plane $(E2E_OP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_OP_NS) --create-namespace \
+		--values $(E2E_K3D_DIR)/values-op.yaml \
+		--set openSearch.enabled=true \
+		--set openSearchCluster.enabled=false \
+		--set fluent-bit.enabled=true \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(call e2e_patch_gateway,$(E2E_OP_NS))
+	$(E2E_KUBECTL) wait -n $(E2E_OP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+# ---------------------------------------------------------------------------
+# Internal configure targets
+# ---------------------------------------------------------------------------
+
+.PHONY: _e2e.configure-dp
+_e2e.configure-dp:
+	@$(call log_info, Registering DataPlane)
+	$(call e2e_register_plane,$(E2E_DP_NS),$(E2E_K3D_DIR)/dataplane.yaml)
+
+.PHONY: _e2e.configure-bp
+_e2e.configure-bp:
+	@$(call log_info, Registering BuildPlane)
+	$(call e2e_register_plane,$(E2E_BP_NS),$(E2E_K3D_DIR)/buildplane.yaml)
+
+.PHONY: _e2e.configure-op
+_e2e.configure-op:
+	@$(call log_info, Registering ObservabilityPlane)
+	$(call e2e_register_plane,$(E2E_OP_NS),$(E2E_K3D_DIR)/observabilityplane.yaml)
+
+.PHONY: _e2e.link-observability
+_e2e.link-observability:
+	@$(call log_info, Linking ObservabilityPlane to other planes)
+	$(E2E_KUBECTL) patch dataplane default -n default --type merge \
+		-p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
+	@if [ "$(E2E_WITH_BUILD)" = "true" ]; then \
+		$(E2E_KUBECTL) patch buildplane default -n default --type merge \
+			-p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'; \
+	fi
+
+# ---------------------------------------------------------------------------
+# Test target
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e.test
+e2e.test: ## Run e2e test suite
+	@$(call log_info, Running e2e tests)
+	go test $(E2E_DIR)/ -v -ginkgo.v -timeout $(E2E_TEST_TIMEOUT) \
+		--e2e.kubecontext=$(E2E_KUBECONTEXT)
+
+# ---------------------------------------------------------------------------
+# Utility targets
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e.status
+e2e.status: ## Check status of all planes and agent connections
+	@echo "=== Pods ==="
+	@$(E2E_KUBECTL) get pods -A
+	@echo ""
+	@echo "=== Plane Resources ==="
+	@$(E2E_KUBECTL) get dataplane,buildplane,observabilityplane -n default 2>/dev/null || true
+	@echo ""
+	@echo "=== Agent Connections ==="
+	@for ns in $(E2E_DP_NS) $(E2E_BP_NS) $(E2E_OP_NS); do \
+		echo "--- $$ns ---"; \
+		$(E2E_KUBECTL) logs -n $$ns -l app=cluster-agent --tail=3 2>/dev/null || echo "(no agent)"; \
+	done
+
+.PHONY: e2e.diagnostics
+e2e.diagnostics: ## Collect logs, events, and resource dumps from all namespaces
+	@$(call log_info, Collecting diagnostics to $(E2E_DIAGNOSTICS_DIR))
+	@mkdir -p $(E2E_DIAGNOSTICS_DIR)
+	@for ns in $(E2E_CP_NS) $(E2E_DP_NS) $(E2E_BP_NS) $(E2E_OP_NS) default; do \
+		$(E2E_KUBECTL) get pods -n $$ns -o wide > $(E2E_DIAGNOSTICS_DIR)/pods-$$ns.txt 2>&1 || true; \
+		$(E2E_KUBECTL) get events -n $$ns --sort-by=.lastTimestamp > $(E2E_DIAGNOSTICS_DIR)/events-$$ns.txt 2>&1 || true; \
+		for pod in $$($(E2E_KUBECTL) get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
+			$(E2E_KUBECTL) logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_DIAGNOSTICS_DIR)/logs-$$ns-$$pod.txt 2>&1 || true; \
+		done; \
+	done
+	@$(E2E_KUBECTL) get dataplane,buildplane,observabilityplane -n default -o yaml > $(E2E_DIAGNOSTICS_DIR)/plane-resources.yaml 2>&1 || true
+	@$(E2E_KUBECTL) get component,componentrelease,releasebinding,release -A -o yaml > $(E2E_DIAGNOSTICS_DIR)/release-chain.yaml 2>&1 || true
+	@$(call log_success, Diagnostics collected to $(E2E_DIAGNOSTICS_DIR))
+
+.PHONY: e2e.down
+e2e.down: ## Delete k3d cluster
+	@$(call log_info, Deleting k3d cluster '$(E2E_CLUSTER_NAME)')
+	k3d cluster delete $(E2E_CLUSTER_NAME)
+	@$(call log_success, k3d cluster '$(E2E_CLUSTER_NAME)' deleted)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,329 +4,110 @@
 package e2e
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
 
-	"github.com/openchoreo/openchoreo/test/utils"
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
-// namespace where the project is deployed in
-const namespace = "choreo-system"
+var _ = Describe("Platform Health", Ordered, func() {
+	const (
+		cpNamespace = "openchoreo-control-plane"
+		dpNamespace = "openchoreo-data-plane"
+		defaultNS   = "default"
+	)
 
-// serviceAccountName created for the project
-const serviceAccountName = "choreo-controller-manager"
+	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
+	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 
-// metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "choreo-controller-manager-metrics-service"
-
-// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "choreo-metrics-binding"
-
-var _ = Describe("Manager", Ordered, func() {
-	var controllerPodName string
-
-	// Before running the tests, set up the environment by creating the namespace,
-	// installing CRDs, and deploying the controller.
-	BeforeAll(func() {
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+	Context("Control Plane", func() {
+		It("should have all pods running", func() {
+			Eventually(func(g Gomega) {
+				framework.AssertAllPodsRunning(g, kubeContext, cpNamespace)
+			}).Should(Succeed())
+		})
 	})
 
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
-	AfterAll(func() {
-		By("cleaning up the curl pod for metrics")
-		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
+	Context("Data Plane", func() {
+		It("should have all pods running", func() {
+			Eventually(func(g Gomega) {
+				framework.AssertAllPodsRunning(g, kubeContext, dpNamespace)
+			}).Should(Succeed())
+		})
 	})
 
-	// After each test, check for failures and collect logs, events,
-	// and pod descriptions for debugging.
-	AfterEach(func() {
-		specReport := CurrentSpecReport()
-		if specReport.Failed() {
-			By("Fetching controller manager pod logs")
-			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-			controllerLogs, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s", err)
-			}
+	Context("CRDs", func() {
+		crds := []string{
+			"projects.openchoreo.dev",
+			"components.openchoreo.dev",
+			"componenttypes.openchoreo.dev",
+			"traits.openchoreo.dev",
+			"environments.openchoreo.dev",
+			"dataplanes.openchoreo.dev",
+			"deploymentpipelines.openchoreo.dev",
+			"componentreleases.openchoreo.dev",
+			"releasebindings.openchoreo.dev",
+			"releases.openchoreo.dev",
+			"workloads.openchoreo.dev",
+		}
 
-			By("Fetching Kubernetes events")
-			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
-			eventsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
-			}
-
-			By("Fetching curl-metrics logs")
-			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-			metricsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
-			}
-
-			By("Fetching controller manager pod description")
-			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
-			podDescription, err := utils.Run(cmd)
-			if err == nil {
-				fmt.Println("Pod description:\n", podDescription)
-			} else {
-				fmt.Println("Failed to describe controller pod")
-			}
+		for _, crd := range crds {
+			It("should have CRD "+crd, func() {
+				_, err := framework.Kubectl(kubeContext, "get", "crd", crd)
+				Expect(err).NotTo(HaveOccurred(), "CRD %s should be registered", crd)
+			})
 		}
 	})
 
-	SetDefaultEventuallyTimeout(2 * time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
-
-	Context("Manager", func() {
-		It("should run successfully", func() {
-			By("validating that the controller-manager pod is running as expected")
-			verifyControllerUp := func(g Gomega) {
-				// Get the name of the controller-manager pod
-				cmd := exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
-				)
-
-				podOutput, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to retrieve controller-manager pod information")
-				podNames := utils.GetNonEmptyLines(podOutput)
-				g.Expect(podNames).To(HaveLen(1), "expected 1 controller pod running")
-				controllerPodName = podNames[0]
-				g.Expect(controllerPodName).To(ContainSubstring("controller-manager"))
-
-				// Validate the pod's status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
-				)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Running"), "Incorrect controller-manager pod status")
-			}
-			Eventually(verifyControllerUp).Should(Succeed())
+	Context("Default Resources", func() {
+		It("should have Project 'default'", func() {
+			framework.AssertResourceExists(Default, kubeContext, defaultNS, "project", "default")
 		})
 
-		It("should ensure the metrics endpoint is serving metrics", func() {
-			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=choreo-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
-
-			By("validating that the metrics service is available")
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
-
-			By("validating that the ServiceMonitor for Prometheus is applied in the namespace")
-			cmd = exec.Command("kubectl", "get", "ServiceMonitor", "-n", namespace)
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "ServiceMonitor should exist")
-
-			By("getting the service account token")
-			token, err := serviceAccountToken()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(token).NotTo(BeEmpty())
-
-			By("waiting for the metrics endpoint to be ready")
-			verifyMetricsEndpointReady := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
-			}
-			Eventually(verifyMetricsEndpointReady).Should(Succeed())
-
-			By("verifying that the controller manager is serving the metrics server")
-			verifyMetricsServerStarted := func(g Gomega) {
-				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
-					"Metrics server not yet started")
-			}
-			Eventually(verifyMetricsServerStarted).Should(Succeed())
-
-			By("creating the curl-metrics pod to access the metrics endpoint")
-			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-				"--namespace", namespace,
-				"--image=curlimages/curl:7.78.0",
-				"--", "/bin/sh", "-c", fmt.Sprintf(
-					"curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics",
-					token, metricsServiceName, namespace))
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
-
-			By("waiting for the curl-metrics pod to complete.")
-			verifyCurlUp := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
-					"-o", "jsonpath={.status.phase}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
-			}
-			Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
-
-			By("getting the metrics by checking curl-metrics logs")
-			metricsOutput := getMetricsOutput()
-			Expect(metricsOutput).To(ContainSubstring(
-				"controller_runtime_reconcile_total",
-			))
+		It("should have DeploymentPipeline 'default'", func() {
+			framework.AssertResourceExists(Default, kubeContext, defaultNS, "deploymentpipeline", "default")
 		})
 
-		It("should provisioned cert-manager", func() {
-			By("validating that cert-manager has the certificate Secret")
-			verifyCertManager := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "secrets", "webhook-server-cert", "-n", namespace)
-				_, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-			}
-			Eventually(verifyCertManager).Should(Succeed())
+		environments := []string{"development", "staging", "production"}
+		for _, env := range environments {
+			It("should have Environment '"+env+"'", func() {
+				framework.AssertResourceExists(Default, kubeContext, defaultNS, "environment", env)
+			})
+		}
+
+		componentTypes := []string{"worker", "service", "web-application", "scheduled-task"}
+		for _, ct := range componentTypes {
+			It("should have ComponentType '"+ct+"'", func() {
+				framework.AssertResourceExists(Default, kubeContext, defaultNS, "componenttype", ct)
+			})
+		}
+
+		traits := []string{"api-configuration", "observability-alert-rule"}
+		for _, trait := range traits {
+			It("should have Trait '"+trait+"'", func() {
+				framework.AssertResourceExists(Default, kubeContext, defaultNS, "trait", trait)
+			})
+		}
+	})
+
+	Context("DataPlane Connectivity", func() {
+		It("should have DataPlane 'default' with agent connected", func() {
+			Eventually(func(g Gomega) {
+				framework.AssertJsonpathEquals(g, kubeContext, defaultNS,
+					"dataplane", "default",
+					"{.status.agentConnection.connected}", "true")
+			}, 5*time.Minute).Should(Succeed())
 		})
 
-		It("should have CA injection for mutating webhooks", func() {
-			By("checking CA injection for mutating webhooks")
-			verifyCAInjection := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get",
-					"mutatingwebhookconfigurations.admissionregistration.k8s.io",
-					"choreo-mutating-webhook-configuration",
-					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
-				mwhOutput, err := utils.Run(cmd)
+		It("should have cluster-agent logs showing connection", func() {
+			Eventually(func(g Gomega) {
+				output, err := framework.KubectlLogs(kubeContext, dpNamespace, "app=cluster-agent", 50)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(mwhOutput)).To(BeNumerically(">", 10))
-			}
-			Eventually(verifyCAInjection).Should(Succeed())
+				g.Expect(output).To(ContainSubstring("connected"),
+					"cluster-agent logs should indicate connection to control plane")
+			}).Should(Succeed())
 		})
-
-		It("should have CA injection for validating webhooks", func() {
-			By("checking CA injection for validating webhooks")
-			verifyCAInjection := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get",
-					"validatingwebhookconfigurations.admissionregistration.k8s.io",
-					"choreo-validating-webhook-configuration",
-					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
-				vwhOutput, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(vwhOutput)).To(BeNumerically(">", 10))
-			}
-			Eventually(verifyCAInjection).Should(Succeed())
-		})
-
-		// +kubebuilder:scaffold:e2e-webhooks-checks
-
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput := getMetricsOutput()
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
 	})
 })
-
-// serviceAccountToken returns a token for the specified service account in the given namespace.
-// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
-// and parsing the resulting token from the API response.
-func serviceAccountToken() (string, error) {
-	const tokenRequestRawString = `{
-		"apiVersion": "authentication.k8s.io/v1",
-		"kind": "TokenRequest"
-	}`
-
-	// Temporary file to store the token request
-	secretName := fmt.Sprintf("%s-token-request", serviceAccountName)
-	tokenRequestFile := filepath.Join("/tmp", secretName)
-	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
-	if err != nil {
-		return "", err
-	}
-
-	var out string
-	verifyTokenCreation := func(g Gomega) {
-		// Execute kubectl command to create the token
-		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
-			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
-			namespace,
-			serviceAccountName,
-		), "-f", tokenRequestFile)
-
-		output, err := cmd.CombinedOutput()
-		g.Expect(err).NotTo(HaveOccurred())
-
-		// Parse the JSON output to extract the token
-		var token tokenRequest
-		err = json.Unmarshal(output, &token)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		out = token.Status.Token
-	}
-	Eventually(verifyTokenCreation).Should(Succeed())
-
-	return out, err
-}
-
-// getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
-func getMetricsOutput() string {
-	By("getting the curl-metrics logs")
-	cmd := exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-	metricsOutput, err := utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-	Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
-	return metricsOutput
-}
-
-// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
-// containing only the token field that we need to extract.
-type tokenRequest struct {
-	Status struct {
-		Token string `json:"token"`
-	} `json:"status"`
-}

--- a/test/e2e/framework/kubectl.go
+++ b/test/e2e/framework/kubectl.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+)
+
+// Kubectl executes an arbitrary kubectl command with the given context.
+// Returns trimmed combined output (stdout+stderr) and any error.
+func Kubectl(kubeContext string, args ...string) (string, error) {
+	cmdArgs := append([]string{"--context", kubeContext}, args...)
+	cmd := exec.Command("kubectl", cmdArgs...)
+	fmt.Fprintf(GinkgoWriter, "running: kubectl %s\n", strings.Join(cmdArgs, " "))
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return output, fmt.Errorf("kubectl %s failed: %w\n%s", strings.Join(args, " "), err, output)
+	}
+	return output, nil
+}
+
+// KubectlGet runs: kubectl get <resource> -n <namespace> [extraArgs...]
+func KubectlGet(kubeContext, namespace, resource string, extraArgs ...string) (string, error) {
+	args := []string{"get", resource, "-n", namespace}
+	args = append(args, extraArgs...)
+	return Kubectl(kubeContext, args...)
+}
+
+// KubectlGetJsonpath runs: kubectl get <resource> <name> -n <namespace> -o jsonpath=<expr>
+func KubectlGetJsonpath(kubeContext, namespace, resource, name, jsonpath string) (string, error) {
+	return Kubectl(kubeContext, "get", resource, name, "-n", namespace,
+		"-o", fmt.Sprintf("jsonpath=%s", jsonpath))
+}
+
+// KubectlLogs runs: kubectl logs -n <namespace> -l <labelSelector> --tail=<tail>
+func KubectlLogs(kubeContext, namespace, labelSelector string, tail int) (string, error) {
+	return Kubectl(kubeContext, "logs", "-n", namespace, "-l", labelSelector,
+		"--tail", fmt.Sprintf("%d", tail))
+}

--- a/test/e2e/framework/wait.go
+++ b/test/e2e/framework/wait.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+const (
+	DefaultTimeout = 3 * time.Minute
+	DefaultPolling = 2 * time.Second
+)
+
+// PodStatus holds parsed pod information.
+type PodStatus struct {
+	Name     string
+	Phase    string
+	Restarts string
+}
+
+// GetPodStatuses returns the status of all non-completed pods in a namespace.
+// Completed pods (Succeeded/Failed) are filtered out via field-selector so
+// Job pods like the CA-extractor don't cause false failures.
+func GetPodStatuses(kubeContext, namespace string) ([]PodStatus, error) {
+	output, err := KubectlGet(kubeContext, namespace, "pods",
+		"--field-selector=status.phase!=Succeeded,status.phase!=Failed",
+		"-o", "custom-columns=NAME:.metadata.name,PHASE:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount",
+		"--no-headers")
+	if err != nil {
+		return nil, err
+	}
+
+	var pods []PodStatus
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		restarts := "<none>"
+		if len(fields) >= 3 {
+			restarts = fields[2]
+		}
+		pods = append(pods, PodStatus{
+			Name:     fields[0],
+			Phase:    fields[1],
+			Restarts: restarts,
+		})
+	}
+	return pods, nil
+}
+
+// AssertAllPodsRunning checks every non-completed pod in the namespace is Running.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertAllPodsRunning(g gomega.Gomega, kubeContext, namespace string) {
+	pods, err := GetPodStatuses(kubeContext, namespace)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get pods in %s", namespace)
+	g.Expect(pods).NotTo(gomega.BeEmpty(), "no pods found in %s", namespace)
+
+	for _, pod := range pods {
+		g.Expect(pod.Phase).To(gomega.Equal("Running"),
+			fmt.Sprintf("pod %s in %s is %s (restarts: %s)", pod.Name, namespace, pod.Phase, pod.Restarts))
+	}
+}
+
+// AssertResourceExists checks that a named resource exists in the namespace.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertResourceExists(g gomega.Gomega, kubeContext, namespace, resource, name string) {
+	_, err := KubectlGetJsonpath(kubeContext, namespace, resource, name, "{.metadata.name}")
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		fmt.Sprintf("%s/%s should exist in namespace %s", resource, name, namespace))
+}
+
+// AssertJsonpathEquals checks that a jsonpath value on a resource matches the expected string.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertJsonpathEquals(g gomega.Gomega, kubeContext, namespace, resource, name, jsonpath, expected string) {
+	output, err := KubectlGetJsonpath(kubeContext, namespace, resource, name, jsonpath)
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		fmt.Sprintf("failed to get %s on %s/%s in %s", jsonpath, resource, name, namespace))
+	g.Expect(output).To(gomega.Equal(expected),
+		fmt.Sprintf("%s/%s jsonpath %s: got %q, want %q", resource, name, jsonpath, output, expected))
+}

--- a/test/e2e/k3d/buildplane.yaml
+++ b/test/e2e/k3d/buildplane.yaml
@@ -1,0 +1,14 @@
+# BuildPlane CR for e2e testing
+# The clusterAgent.clientCA.value is replaced at apply time by the Makefile
+apiVersion: openchoreo.dev/v1alpha1
+kind: BuildPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: openbao

--- a/test/e2e/k3d/config.yaml
+++ b/test/e2e/k3d/config.yaml
@@ -1,0 +1,66 @@
+# k3d cluster config for e2e testing
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: openchoreo-e2e
+image: rancher/k3s:v1.32.9-k3s1
+servers: 1
+agents: 0
+kubeAPI:
+  hostPort: "26550"
+ports:
+  # Control Plane — port range 28xxx
+  - port: 28080:8080
+    nodeFilters:
+      - loadbalancer
+  - port: 28443:8443
+    nodeFilters:
+      - loadbalancer
+  # Data Plane — port range 29xxx
+  - port: 29080:19080
+    nodeFilters:
+      - loadbalancer
+  - port: 29443:19443
+    nodeFilters:
+      - loadbalancer
+  # Build Plane — port range 20xxx (only used when E2E_WITH_BUILD=true)
+  - port: 20082:10082
+    nodeFilters:
+      - loadbalancer
+  # Observability Plane — port range 21xxx (only used when E2E_WITH_OBSERVABILITY=true)
+  - port: 21080:11080
+    nodeFilters:
+      - loadbalancer
+  - port: 21085:11085
+    nodeFilters:
+      - loadbalancer
+  - port: 21081:5601
+    nodeFilters:
+      - loadbalancer
+  - port: 21082:9200
+    nodeFilters:
+      - loadbalancer
+options:
+  k3s:
+    extraArgs:
+      # Add host.k3d.internal to API server TLS SANs so kubelet can pull images
+      # from the build plane registry at host.k3d.internal:20082 via HTTP proxy
+      - arg: "--tls-san=host.k3d.internal"
+        nodeFilters:
+          - server:*
+      # Lower eviction thresholds to prevent spurious pod evictions on CI runners
+      - arg: "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%"
+        nodeFilters:
+          - server:*
+      - arg: "--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%"
+        nodeFilters:
+          - server:*
+      - arg: "--disable=traefik"
+        nodeFilters:
+          - server:*
+registries:
+  config: |
+    mirrors:
+      "host.k3d.internal:20082":
+        endpoint:
+          - http://host.k3d.internal:20082

--- a/test/e2e/k3d/coredns-custom.yaml
+++ b/test/e2e/k3d/coredns-custom.yaml
@@ -1,0 +1,26 @@
+# CoreDNS custom config for e2e k3d cluster
+# Rewrites e2e plane domains to host.k3d.internal so pods can
+# reach services exposed via k3d load balancer
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  e2e.override: |
+    rewrite stop {
+      name regex (.+\.)?e2e-cp\.local host.k3d.internal
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-dp\.local host.k3d.internal
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-bp\.local host.k3d.internal
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-op\.local host.k3d.internal
+      answer auto
+    }

--- a/test/e2e/k3d/dataplane.yaml
+++ b/test/e2e/k3d/dataplane.yaml
@@ -1,0 +1,18 @@
+# DataPlane CR for e2e testing
+# The clusterAgent.clientCA.value is replaced at apply time by the Makefile
+apiVersion: openchoreo.dev/v1alpha1
+kind: DataPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: default
+  gateway:
+    publicVirtualHost: e2e-dp.local
+    publicHTTPPort: 29080
+    publicHTTPSPort: 29443

--- a/test/e2e/k3d/observabilityplane.yaml
+++ b/test/e2e/k3d/observabilityplane.yaml
@@ -1,0 +1,13 @@
+# ObservabilityPlane CR for e2e testing
+# The clusterAgent.clientCA.value is replaced at apply time by the Makefile
+apiVersion: openchoreo.dev/v1alpha1
+kind: ObservabilityPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  observerURL: http://observer.e2e-op.local:21080

--- a/test/e2e/k3d/secretstore.yaml
+++ b/test/e2e/k3d/secretstore.yaml
@@ -1,0 +1,22 @@
+# Fake ClusterSecretStore for e2e testing
+# Provides dummy secrets for ESO SecretStore references in DataPlane/BuildPlane
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: default
+spec:
+  provider:
+    fake:
+      data:
+      - key: npm-token
+        value: "fake-npm-token"
+      - key: docker-username
+        value: "e2e-user"
+      - key: docker-password
+        value: "e2e-password"
+      - key: github-pat
+        value: "fake-github-token"
+      - key: username
+        value: "e2e-user"
+      - key: password
+        value: "e2e-password"

--- a/test/e2e/k3d/values-bp.yaml
+++ b/test/e2e/k3d/values-bp.yaml
@@ -1,0 +1,19 @@
+# Helm values for OpenChoreo Build Plane in e2e testing setup
+# Only used when E2E_WITH_BUILD=true
+
+argo-workflows:
+  server:
+    enabled: false
+
+defaultResources:
+  enabled: true
+  registry:
+    # Port 20082 is the host-side port mapped to container port 10082 in k3d config.
+    # Inside the cluster, host.k3d.internal resolves to the k3d load balancer which
+    # routes 20082 → 10082, so pods can push/pull images through the LB.
+    host: "host.k3d.internal:20082"
+
+openbao:
+  server:
+    dev:
+      enabled: true

--- a/test/e2e/k3d/values-cp.yaml
+++ b/test/e2e/k3d/values-cp.yaml
@@ -1,0 +1,34 @@
+# Helm values for OpenChoreo Control Plane in e2e testing setup
+# Uses *.e2e-cp.local domain, HTTP only
+# Backstage UI is not needed — e2e tests use kubectl/Go client
+
+openchoreoApi:
+  http:
+    hostnames:
+    - api.e2e-cp.local
+  config:
+    server:
+      publicUrl: "http://api.e2e-cp.local:28080"
+
+backstage:
+  enabled: false
+  baseUrl: "http://openchoreo.e2e-cp.local:28080"
+  http:
+    hostnames:
+      - openchoreo.e2e-cp.local
+
+security:
+  oidc:
+    issuer: "http://thunder.e2e-cp.local:28080"
+    jwksUrl: "http://thunder.e2e-cp.local:28080/oauth2/jwks"
+    authorizationUrl: "http://thunder.e2e-cp.local:28080/oauth2/authorize"
+    tokenUrl: "http://thunder.e2e-cp.local:28080/oauth2/token"
+
+thunder:
+  host: thunder.e2e-cp.local
+
+gateway:
+  httpPort: 8080
+  httpsPort: 8443
+  tls:
+    enabled: false

--- a/test/e2e/k3d/values-dp.yaml
+++ b/test/e2e/k3d/values-dp.yaml
@@ -1,0 +1,11 @@
+# Helm values for OpenChoreo Data Plane in e2e testing setup
+# Uses *.e2e-dp.local domain, HTTP only
+
+gateway:
+  httpPort: 19080
+  httpsPort: 19443
+  tls:
+    enabled: false
+
+fluent-bit:
+  enabled: false

--- a/test/e2e/k3d/values-op.yaml
+++ b/test/e2e/k3d/values-op.yaml
@@ -1,0 +1,32 @@
+# Helm values for OpenChoreo Observability Plane in e2e testing setup
+# Only used when E2E_WITH_OBSERVABILITY=true
+# Uses external OIDC URLs (not svc.cluster.local) to test production-like paths
+
+openSearch:
+  enabled: true
+  service:
+    type: LoadBalancer
+
+openSearchCluster:
+  enabled: false
+
+observer:
+  openSearchSecretName: observer-opensearch-credentials
+  http:
+    hostnames:
+    - observer.e2e-op.local
+
+openSearchDashboards:
+  service:
+    type: LoadBalancer
+
+security:
+  oidc:
+    jwksUrl: "http://thunder.e2e-cp.local:28080/oauth2/jwks"
+    tokenUrl: "http://thunder.e2e-cp.local:28080/oauth2/token"
+
+gateway:
+  httpPort: 11080
+  httpsPort: 11085
+  tls:
+    enabled: false

--- a/test/e2e/k3d/values-thunder.yaml
+++ b/test/e2e/k3d/values-thunder.yaml
@@ -1,0 +1,19 @@
+# Thunder IdP overrides for e2e testing
+# Applied on top of install/k3d/common/values-thunder.yaml:
+#   helm install thunder ... -f install/k3d/common/values-thunder.yaml -f test/e2e/k3d/values-thunder.yaml
+
+configuration:
+  server:
+    publicUrl: "http://thunder.e2e-cp.local:28080"
+
+  gateClient:
+    hostname: "thunder.e2e-cp.local"
+    port: 28080
+
+  cors:
+    allowedOrigins:
+      - "http://openchoreo.e2e-cp.local:28080"
+
+  passkey:
+    allowedOrigins:
+      - "http://openchoreo.e2e-cp.local:28080"


### PR DESCRIPTION
## Purpose

Add foundational e2e testing infrastructure that automates the manual release regression: k3d cluster creation → platform installation → health verification. Replaces the old disabled kubebuilder e2e scaffolding.

## Approach

- Add k3d cluster config with dedicated ports (28xxx/29xxx) and domains (`*.e2e.local`) to avoid collision with dev setup
- Add Helm values for all 4 planes (CP, DP, BP, OP) with external routing to simulate real multi-cluster communication paths
- Add `make/e2e.mk` with lifecycle targets: `make e2e` (setup → test → down), `make e2e.setup`, `make e2e.test`, `make e2e.diagnostics`, `make e2e.down`
- Support both local charts (`E2E_HELM_SOURCE=local`) and OCI registry (`E2E_HELM_SOURCE=oci`)
- Add Ginkgo v2 test framework with kubectl helpers and assertion utilities
- Add Platform Health test scenario: CP/DP pods running, core CRDs registered, default resources exist, DataPlane agent connected
- Add CI workflow with manual dispatch (`workflow_dispatch`) and nightly schedule
- Pin `setup-go` action to SHA and k3d install script to version tag

CI `workflow_dispatch` run: https://github.com/openchoreo/openchoreo/actions/runs/22129355279

## Related Issues

Closes #2060
Related #26

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)