### PR TITLE
refactor: switch to using Observability modules in the Observability plane

### DIFF
--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -474,7 +474,7 @@ opentelemetry-collector:
   # description: Enable OpenTelemetry Collector deployment
   # default: true
   # @schema
-  enabled: true
+  enabled: false
 
   # @schema
   # type: object
@@ -1317,7 +1317,7 @@ prometheus:
   # description: Enable Prometheus stack deployment
   # default: true
   # @schema
-  enabled: true
+  enabled: false
 
   # @schema
   # type: string
@@ -2355,7 +2355,7 @@ openSearchCluster:
   # description: Enable OpenSearch cluster deployment via OpenSearch Operator
   # default: true
   # @schema
-  enabled: true
+  enabled: false
 
   # @schema
   # type: object

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -418,16 +418,6 @@ helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgatew
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --version v2.1.1
-
-# OpenSearch Operator (for HA OpenSearch cluster)
-helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
-helm repo update
-
-helm install opensearch-operator opensearch-operator/opensearch-operator \
-  --kube-context k3d-openchoreo-op \
-  --namespace openchoreo-observability-plane \
-  --create-namespace \
-  --version 2.8.0
 ```
 
 ### CoreDNS Rewrite and Certificates
@@ -452,6 +442,13 @@ kubectl --context k3d-openchoreo-op create configmap cluster-gateway-ca \
 ### OpenSearch Credentials
 
 ```bash
+kubectl --context k3d-openchoreo-op create secret generic opensearch-admin-credentials \
+  -n openchoreo-observability-plane \
+  --from-literal=username="admin" \
+  --from-literal=password="ThisIsTheOpenSearchPassword1"
+```
+
+```bash
 kubectl --context k3d-openchoreo-op create secret generic observer-opensearch-credentials \
   -n openchoreo-observability-plane \
   --from-literal=username="admin" \
@@ -469,6 +466,10 @@ helm upgrade --install openchoreo-observability-plane install/helm/openchoreo-ob
   --values install/k3d/multi-cluster/values-op.yaml \
   --timeout 10m
 ```
+
+#### Install Observability Modules
+
+Install the required logs, metrics and tracing modules. Refer https://openchoreo.dev/modules for more details
 
 ```bash
 kubectl --context k3d-openchoreo-op wait -n openchoreo-observability-plane \

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -4,7 +4,7 @@ openSearch:
   enabled: false
 
 openSearchCluster:
-  enabled: true
+  enabled: false
   credentialsSecretName: observer-opensearch-credentials
   adminPassword: "ThisIsTheOpenSearchPassword1"
 
@@ -61,7 +61,7 @@ tls:
     - "*.observability.openchoreo.localhost"
 
 fluent-bit:
-  enabled: true
+  enabled: false
 
 opentelemetry-collector:
   service:

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -332,6 +332,11 @@ kubectl create secret generic cluster-gateway-ca \
 ### OpenSearch Credentials
 
 ```bash
+kubectl create secret generic opensearch-admin-credentials \
+  -n openchoreo-observability-plane \
+  --from-literal=username="admin" \
+  --from-literal=password="ThisIsTheOpenSearchPassword1" 
+
 kubectl create secret generic observer-opensearch-credentials \
   -n openchoreo-observability-plane \
   --from-literal=username="admin" \
@@ -340,39 +345,18 @@ kubectl create secret generic observer-opensearch-credentials \
 
 ### Install Observability Plane
 
-Non-HA mode (standalone OpenSearch, no operator):
-
 ```bash
 helm upgrade --install openchoreo-observability-plane install/helm/openchoreo-observability-plane \
   --dependency-update \
   --namespace openchoreo-observability-plane \
   --values install/k3d/single-cluster/values-op.yaml \
-  --set openSearch.enabled=true \
-  --set openSearchCluster.enabled=false \
-  --set fluent-bit.enabled=true \
   --timeout 10m
 ```
 
-<details>
-<summary>HA mode (OpenSearch operator)</summary>
+#### Install Observability Modules
 
-```bash
-helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
-helm repo update
+Install the required logs, metrics and tracing modules. Refer https://openchoreo.dev/modules for more details
 
-helm install opensearch-operator opensearch-operator/opensearch-operator \
-  --create-namespace \
-  --namespace openchoreo-observability-plane \
-  --version 2.8.0
-
-helm install openchoreo-observability-plane install/helm/openchoreo-observability-plane \
-  --dependency-update \
-  --namespace openchoreo-observability-plane \
-  --create-namespace \
-  --values install/k3d/single-cluster/values-op.yaml
-```
-
-</details>
 
 ### Gateway Patch
 

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -2,7 +2,7 @@
 
 # Use standalone OpenSearch (not operator-managed cluster)
 openSearch:
-  enabled: true
+  enabled: false
   service:
     type: LoadBalancer
 

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -966,6 +966,16 @@ install_observability_plane() {
     install_helm_chart "openchoreo-observability-plane" "openchoreo-observability-plane" "$OBSERVABILITY_NS" "true" "true" "true" "1800" \
         "--values" "$HOME/.values-op.yaml" \
         "--set" "observer.image.tag=$OPENCHOREO_VERSION"
+
+    # Install logs and metrics observability modules
+    # See https://github.com/openchoreo/community-modules for more details
+    local modules_repo="oci://ghcr.io/openchoreo/charts"
+
+    log_info "Installing observability modules..."
+
+    install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600"
+
+    install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600"
 }
 
 # Install default OpenChoreo resources (Project, Environments, ComponentTypes, etc.)

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -5,13 +5,13 @@ global:
   installationMode: quickStart
 
 fluent-bit:
-  enabled: true
+  enabled: false
 
 opentelemetry-collector:
   enabled: false
 
 openSearch:
-  enabled: true
+  enabled: false
 
 # OpenSearch cluster configuration
 openSearchCluster:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
Currently OpenChoreo installs the backend tools required for Observability (E.g. Fluent Bit, Prometheus, OpenTelemetry collector) from the openchoreo-observability-plane helm charts. Stop doing that by default and install them through observability modules

## Approach
Disabled these tools from the openchoreo-observability-plane chart and added instructions to install them from modules

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1958
https://github.com/openchoreo/openchoreo/issues/1960
https://github.com/openchoreo/openchoreo/issues/1957

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
