### PR TITLE
refactor: update pod selectors with comp/proj/env names

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -270,9 +270,13 @@ func (r *Reconciler) buildMetadataContext(
 
 	// Build pod selectors
 	podSelectors := map[string]string{
-		labels.LabelKeyComponentUID:   componentUID,
-		labels.LabelKeyEnvironmentUID: environmentUID,
-		labels.LabelKeyProjectUID:     projectUID,
+		labels.LabelKeyNamespaceName:   namespaceName,
+		labels.LabelKeyProjectName:     projectName,
+		labels.LabelKeyComponentName:   componentName,
+		labels.LabelKeyEnvironmentName: environmentName,
+		labels.LabelKeyComponentUID:    componentUID,
+		labels.LabelKeyEnvironmentUID:  environmentUID,
+		labels.LabelKeyProjectUID:      projectUID,
 	}
 
 	return pipelinecontext.MetadataContext{

--- a/internal/controller/releasebinding/controller_test.go
+++ b/internal/controller/releasebinding/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
 var _ = Describe("ReleaseBinding Controller", func() {
@@ -72,6 +73,107 @@ var _ = Describe("ReleaseBinding Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("buildMetadataContext", func() {
+		var reconciler *Reconciler
+
+		BeforeEach(func() {
+			reconciler = &Reconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+		})
+
+		It("should include all required fields in pod selectors", func() {
+			By("Creating test resources")
+			namespaceName := "test-namespace"
+			projectName := "test-project"
+			componentName := "test-component"
+			environmentName := "test-env"
+			componentUID := types.UID("component-uid-123")
+			projectUID := types.UID("project-uid-456")
+			environmentUID := types.UID("environment-uid-789")
+			dataPlaneUID := types.UID("dataplane-uid-abc")
+			dataPlaneName := "test-dataplane"
+
+			componentRelease := &openchoreodevv1alpha1.ComponentRelease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-release",
+					Namespace: namespaceName,
+				},
+				Spec: openchoreodevv1alpha1.ComponentReleaseSpec{
+					Owner: openchoreodevv1alpha1.ComponentReleaseOwner{
+						ProjectName:   projectName,
+						ComponentName: componentName,
+					},
+				},
+			}
+
+			component := &openchoreodevv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespaceName,
+					UID:       componentUID,
+				},
+			}
+
+			project := &openchoreodevv1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      projectName,
+					Namespace: namespaceName,
+					UID:       projectUID,
+				},
+			}
+
+			dataPlane := &openchoreodevv1alpha1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: dataPlaneName,
+					UID:  dataPlaneUID,
+				},
+			}
+
+			environment := &openchoreodevv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      environmentName,
+					Namespace: namespaceName,
+					UID:       environmentUID,
+				},
+			}
+
+			By("Building metadata context")
+			metadataContext := reconciler.buildMetadataContext(
+				componentRelease,
+				component,
+				project,
+				dataPlane,
+				environment,
+				environmentName,
+			)
+
+			By("Verifying pod selectors include all required fields")
+			Expect(metadataContext.PodSelectors).NotTo(BeNil())
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyNamespaceName, namespaceName))
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyProjectName, projectName))
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyComponentName, componentName))
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyEnvironmentName, environmentName))
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyComponentUID, string(componentUID)))
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyEnvironmentUID, string(environmentUID)))
+			Expect(metadataContext.PodSelectors).To(HaveKeyWithValue(labels.LabelKeyProjectUID, string(projectUID)))
+
+			By("Verifying pod selectors have exactly 7 entries")
+			Expect(metadataContext.PodSelectors).To(HaveLen(7))
+
+			By("Verifying standard labels also include all required fields")
+			Expect(metadataContext.Labels).NotTo(BeNil())
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyNamespaceName, namespaceName))
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyProjectName, projectName))
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyComponentName, componentName))
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyEnvironmentName, environmentName))
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyComponentUID, string(componentUID)))
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyEnvironmentUID, string(environmentUID)))
+			Expect(metadataContext.Labels).To(HaveKeyWithValue(labels.LabelKeyProjectUID, string(projectUID)))
 		})
 	})
 })

--- a/internal/pipeline/component/benchmark_test.go
+++ b/internal/pipeline/component/benchmark_test.go
@@ -158,6 +158,10 @@ func buildRenderInputFromSample(tb testing.TB, samplePath string) *RenderInput {
 			},
 			Annotations: map[string]string{},
 			PodSelectors: map[string]string{
+				"openchoreo.dev/namespace":       "dp-demo-project-development-x1y2z3w4",
+				"openchoreo.dev/project":         "demo-project",
+				"openchoreo.dev/component":       "demo-app",
+				"openchoreo.dev/environment":     "development",
 				"openchoreo.dev/component-uid":   "a1b2c3d4-5678-90ab-cdef-1234567890ab",
 				"openchoreo.dev/environment-uid": "d4e5f6a7-8901-23de-f012-4567890abcde",
 				"openchoreo.dev/project-uid":     "b2c3d4e5-6789-01bc-def0-234567890abc",
@@ -597,6 +601,10 @@ spec:
 			},
 			Annotations: map[string]string{},
 			PodSelectors: map[string]string{
+				"openchoreo.dev/namespace":       "test-namespace",
+				"openchoreo.dev/project":         "test-project",
+				"openchoreo.dev/component":       "test-app",
+				"openchoreo.dev/environment":     "dev",
 				"openchoreo.dev/component-uid":   "a1b2c3d4-5678-90ab-cdef-1234567890ab",
 				"openchoreo.dev/environment-uid": "d4e5f6a7-8901-23de-f012-4567890abcde",
 				"openchoreo.dev/project-uid":     "b2c3d4e5-6789-01bc-def0-234567890abc",

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -66,6 +66,10 @@ type MetadataContext struct {
 	// PodSelectors are platform-injected selectors for pod identity.
 	// Used in Deployment selectors, Service selectors, etc.
 	// Example: {
+	//   "openchoreo.dev/namespace": "dp-acme-corp-payment-dev-x1y2z3w4",
+	//   "openchoreo.dev/project": "acme-corp",
+	//   "openchoreo.dev/component": "payment",
+	//   "openchoreo.dev/environment": "dev",
 	//   "openchoreo.dev/component-uid": "abc123",
 	//   "openchoreo.dev/environment-uid": "dev",
 	//   "openchoreo.dev/project-uid": "xyz789",

--- a/internal/pipeline/component/pipeline_test.go
+++ b/internal/pipeline/component/pipeline_test.go
@@ -870,6 +870,10 @@ spec:
 					},
 					Annotations: map[string]string{},
 					PodSelectors: map[string]string{
+						"openchoreo.dev/namespace":       "test-namespace",
+						"openchoreo.dev/project":         "test-project",
+						"openchoreo.dev/component":       "test-app",
+						"openchoreo.dev/environment":     "dev",
 						"openchoreo.dev/component-uid":   "a1b2c3d4-5678-90ab-cdef-1234567890ab",
 						"openchoreo.dev/environment-uid": "d4e5f6a7-8901-23de-f012-4567890abcde",
 						"openchoreo.dev/project-uid":     "b2c3d4e5-6789-01bc-def0-234567890abc",


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
This pull request expands the set of pod selectors used for pod identity throughout the codebase, adding new fields for namespace, project, component, and environment names. These additions improve the granularity and traceability of pod metadata, which will be useful for deployment, service selection, and testing.

Enhancements to pod selector metadata:

* Added `openchoreo.dev/namespace`, `openchoreo.dev/project`, `openchoreo.dev/component`, and `openchoreo.dev/environment` to the `podSelectors` map in the `buildMetadataContext` method in `controller.go`, increasing metadata coverage for pods.
* Updated the `MetadataContext` struct documentation in `types.go` to reflect the new pod selector fields, providing clearer examples for developers.

Test improvements:

* Updated test cases in `benchmark_test.go` and `pipeline_test.go` to include the new pod selector fields, ensuring tests validate the expanded metadata. [[1]](diffhunk://#diff-cd5903edcb0e17dcdfa3f27b4a6430e93b8ea9b497851860b7b3863837291348R161-R164) [[2]](diffhunk://#diff-cd5903edcb0e17dcdfa3f27b4a6430e93b8ea9b497851860b7b3863837291348R604-R607) [[3]](diffhunk://#diff-749a44af0c1cb51ca9f9d17f3408e8c32e2fd23da09be37ff33e98ab3f4c53adR873-R876)

component/project/environment UIDs was added as labels to all k8s resources generated in the release via PR https://github.com/openchoreo/openchoreo/pull/1891. This is a follow up PR on that

## Approach
- Modified pod selectors in the releasebinding controller to include new keys for namespace, project, component, and environment names.
- Updated test files to reflect changes in pod selectors with corresponding values for different environments.
- Enhanced documentation in the MetadataContext type to illustrate the new pod selector structure.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/1816

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
