### PR TITLE
feat: add cluster component type and component trait endpoints to api server

### DIFF
--- a/internal/occ/cmd/list/list.go
+++ b/internal/occ/cmd/list/list.go
@@ -157,7 +157,7 @@ func (l *ListImpl) ListComponentTypes(params api.ListComponentTypesParams) error
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	result, err := c.ListComponentTypes(ctx, params.Namespace, &gen.ListComponentTypesParams{})
+	result, err := c.ListComponentTypes(ctx, params.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to list component types: %w", err)
 	}
@@ -178,7 +178,7 @@ func (l *ListImpl) ListTraits(params api.ListTraitsParams) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	result, err := c.ListTraits(ctx, params.Namespace, &gen.ListTraitsParams{})
+	result, err := c.ListTraits(ctx, params.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to list traits: %w", err)
 	}

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -170,8 +170,8 @@ func (c *Client) ListObservabilityPlanes(ctx context.Context, namespaceName stri
 }
 
 // ListComponentTypes retrieves all component types for a namespace
-func (c *Client) ListComponentTypes(ctx context.Context, namespaceName string, params *gen.ListComponentTypesParams) (*gen.ComponentTypeList, error) {
-	resp, err := c.client.ListComponentTypesWithResponse(ctx, namespaceName, params)
+func (c *Client) ListComponentTypes(ctx context.Context, namespaceName string) (*gen.ComponentTypeList, error) {
+	resp, err := c.client.ListComponentTypesWithResponse(ctx, namespaceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list component types: %w", err)
 	}
@@ -182,8 +182,8 @@ func (c *Client) ListComponentTypes(ctx context.Context, namespaceName string, p
 }
 
 // ListTraits retrieves all traits for a namespace
-func (c *Client) ListTraits(ctx context.Context, namespaceName string, params *gen.ListTraitsParams) (*gen.TraitList, error) {
-	resp, err := c.client.ListTraitsWithResponse(ctx, namespaceName, params)
+func (c *Client) ListTraits(ctx context.Context, namespaceName string) (*gen.TraitList, error) {
+	resp, err := c.client.ListTraitsWithResponse(ctx, namespaceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list traits: %w", err)
 	}

--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -119,6 +119,12 @@ type ClientInterface interface {
 	// ListClusterBuildPlanes request
 	ListClusterBuildPlanes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListClusterComponentTypes request
+	ListClusterComponentTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetClusterComponentTypeSchema request
+	GetClusterComponentTypeSchema(ctx context.Context, cctName ClusterComponentTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListClusterDataPlanes request
 	ListClusterDataPlanes(ctx context.Context, params *ListClusterDataPlanesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -171,6 +177,12 @@ type ClientInterface interface {
 
 	UpdateClusterRole(ctx context.Context, name string, body UpdateClusterRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListClusterTraits request
+	ListClusterTraits(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetClusterTraitSchema request
+	GetClusterTraitSchema(ctx context.Context, clusterTraitName ClusterTraitNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DeleteResourceWithBody request with any body
 	DeleteResourceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -191,7 +203,7 @@ type ClientInterface interface {
 	ListBuildPlanes(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListComponentTypes request
-	ListComponentTypes(ctx context.Context, namespaceName NamespaceNameParam, params *ListComponentTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListComponentTypes(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetComponentTypeSchema request
 	GetComponentTypeSchema(ctx context.Context, namespaceName NamespaceNameParam, ctName ComponentTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -398,7 +410,7 @@ type ClientInterface interface {
 	ListSecretReferences(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTraits request
-	ListTraits(ctx context.Context, namespaceName NamespaceNameParam, params *ListTraitsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListTraits(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTraitSchema request
 	GetTraitSchema(ctx context.Context, namespaceName NamespaceNameParam, traitName TraitNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -576,6 +588,30 @@ func (c *Client) GetSubjectProfile(ctx context.Context, params *GetSubjectProfil
 
 func (c *Client) ListClusterBuildPlanes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListClusterBuildPlanesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListClusterComponentTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListClusterComponentTypesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetClusterComponentTypeSchema(ctx context.Context, cctName ClusterComponentTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClusterComponentTypeSchemaRequest(c.Server, cctName)
 	if err != nil {
 		return nil, err
 	}
@@ -814,6 +850,30 @@ func (c *Client) UpdateClusterRole(ctx context.Context, name string, body Update
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListClusterTraits(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListClusterTraitsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetClusterTraitSchema(ctx context.Context, clusterTraitName ClusterTraitNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClusterTraitSchemaRequest(c.Server, clusterTraitName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) DeleteResourceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteResourceRequestWithBody(c.Server, contentType, body)
 	if err != nil {
@@ -898,8 +958,8 @@ func (c *Client) ListBuildPlanes(ctx context.Context, namespaceName NamespaceNam
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListComponentTypes(ctx context.Context, namespaceName NamespaceNameParam, params *ListComponentTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListComponentTypesRequest(c.Server, namespaceName, params)
+func (c *Client) ListComponentTypes(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListComponentTypesRequest(c.Server, namespaceName)
 	if err != nil {
 		return nil, err
 	}
@@ -1798,8 +1858,8 @@ func (c *Client) ListSecretReferences(ctx context.Context, namespaceName Namespa
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListTraits(ctx context.Context, namespaceName NamespaceNameParam, params *ListTraitsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListTraitsRequest(c.Server, namespaceName, params)
+func (c *Client) ListTraits(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListTraitsRequest(c.Server, namespaceName)
 	if err != nil {
 		return nil, err
 	}
@@ -2347,6 +2407,67 @@ func NewListClusterBuildPlanesRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewListClusterComponentTypesRequest generates requests for ListClusterComponentTypes
+func NewListClusterComponentTypesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clustercomponenttypes")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetClusterComponentTypeSchemaRequest generates requests for GetClusterComponentTypeSchema
+func NewGetClusterComponentTypeSchemaRequest(server string, cctName ClusterComponentTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "cctName", runtime.ParamLocationPath, cctName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clustercomponenttypes/%s/schema", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListClusterDataPlanesRequest generates requests for ListClusterDataPlanes
 func NewListClusterDataPlanesRequest(server string, params *ListClusterDataPlanesParams) (*http.Request, error) {
 	var err error
@@ -2877,6 +2998,67 @@ func NewUpdateClusterRoleRequestWithBody(server string, name string, contentType
 	return req, nil
 }
 
+// NewListClusterTraitsRequest generates requests for ListClusterTraits
+func NewListClusterTraitsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clustertraits")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetClusterTraitSchemaRequest generates requests for GetClusterTraitSchema
+func NewGetClusterTraitSchemaRequest(server string, clusterTraitName ClusterTraitNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterTraitName", runtime.ParamLocationPath, clusterTraitName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clustertraits/%s/schema", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewDeleteResourceRequest calls the generic DeleteResource builder with application/json body
 func NewDeleteResourceRequest(server string, body DeleteResourceJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -3091,7 +3273,7 @@ func NewListBuildPlanesRequest(server string, namespaceName NamespaceNameParam) 
 }
 
 // NewListComponentTypesRequest generates requests for ListComponentTypes
-func NewListComponentTypesRequest(server string, namespaceName NamespaceNameParam, params *ListComponentTypesParams) (*http.Request, error) {
+func NewListComponentTypesRequest(server string, namespaceName NamespaceNameParam) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3114,44 +3296,6 @@ func NewListComponentTypesRequest(server string, namespaceName NamespaceNamePara
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Limit != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Cursor != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -6139,7 +6283,7 @@ func NewListSecretReferencesRequest(server string, namespaceName NamespaceNamePa
 }
 
 // NewListTraitsRequest generates requests for ListTraits
-func NewListTraitsRequest(server string, namespaceName NamespaceNameParam, params *ListTraitsParams) (*http.Request, error) {
+func NewListTraitsRequest(server string, namespaceName NamespaceNameParam) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6162,44 +6306,6 @@ func NewListTraitsRequest(server string, namespaceName NamespaceNameParam, param
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Limit != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Cursor != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -6893,6 +6999,12 @@ type ClientWithResponsesInterface interface {
 	// ListClusterBuildPlanesWithResponse request
 	ListClusterBuildPlanesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClusterBuildPlanesResp, error)
 
+	// ListClusterComponentTypesWithResponse request
+	ListClusterComponentTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClusterComponentTypesResp, error)
+
+	// GetClusterComponentTypeSchemaWithResponse request
+	GetClusterComponentTypeSchemaWithResponse(ctx context.Context, cctName ClusterComponentTypeNameParam, reqEditors ...RequestEditorFn) (*GetClusterComponentTypeSchemaResp, error)
+
 	// ListClusterDataPlanesWithResponse request
 	ListClusterDataPlanesWithResponse(ctx context.Context, params *ListClusterDataPlanesParams, reqEditors ...RequestEditorFn) (*ListClusterDataPlanesResp, error)
 
@@ -6945,6 +7057,12 @@ type ClientWithResponsesInterface interface {
 
 	UpdateClusterRoleWithResponse(ctx context.Context, name string, body UpdateClusterRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateClusterRoleResp, error)
 
+	// ListClusterTraitsWithResponse request
+	ListClusterTraitsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClusterTraitsResp, error)
+
+	// GetClusterTraitSchemaWithResponse request
+	GetClusterTraitSchemaWithResponse(ctx context.Context, clusterTraitName ClusterTraitNameParam, reqEditors ...RequestEditorFn) (*GetClusterTraitSchemaResp, error)
+
 	// DeleteResourceWithBodyWithResponse request with any body
 	DeleteResourceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteResourceResp, error)
 
@@ -6965,7 +7083,7 @@ type ClientWithResponsesInterface interface {
 	ListBuildPlanesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*ListBuildPlanesResp, error)
 
 	// ListComponentTypesWithResponse request
-	ListComponentTypesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListComponentTypesParams, reqEditors ...RequestEditorFn) (*ListComponentTypesResp, error)
+	ListComponentTypesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*ListComponentTypesResp, error)
 
 	// GetComponentTypeSchemaWithResponse request
 	GetComponentTypeSchemaWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ctName ComponentTypeNameParam, reqEditors ...RequestEditorFn) (*GetComponentTypeSchemaResp, error)
@@ -7172,7 +7290,7 @@ type ClientWithResponsesInterface interface {
 	ListSecretReferencesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*ListSecretReferencesResp, error)
 
 	// ListTraitsWithResponse request
-	ListTraitsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListTraitsParams, reqEditors ...RequestEditorFn) (*ListTraitsResp, error)
+	ListTraitsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*ListTraitsResp, error)
 
 	// GetTraitSchemaWithResponse request
 	GetTraitSchemaWithResponse(ctx context.Context, namespaceName NamespaceNameParam, traitName TraitNameParam, reqEditors ...RequestEditorFn) (*GetTraitSchemaResp, error)
@@ -7418,6 +7536,57 @@ func (r ListClusterBuildPlanesResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListClusterBuildPlanesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListClusterComponentTypesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ClusterComponentTypeList
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListClusterComponentTypesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListClusterComponentTypesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetClusterComponentTypeSchemaResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchemaResponse
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetClusterComponentTypeSchemaResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetClusterComponentTypeSchemaResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -7784,6 +7953,57 @@ func (r UpdateClusterRoleResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateClusterRoleResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListClusterTraitsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ClusterTraitList
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListClusterTraitsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListClusterTraitsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetClusterTraitSchemaResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchemaResponse
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetClusterTraitSchemaResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetClusterTraitSchemaResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -9905,6 +10125,24 @@ func (c *ClientWithResponses) ListClusterBuildPlanesWithResponse(ctx context.Con
 	return ParseListClusterBuildPlanesResp(rsp)
 }
 
+// ListClusterComponentTypesWithResponse request returning *ListClusterComponentTypesResp
+func (c *ClientWithResponses) ListClusterComponentTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClusterComponentTypesResp, error) {
+	rsp, err := c.ListClusterComponentTypes(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListClusterComponentTypesResp(rsp)
+}
+
+// GetClusterComponentTypeSchemaWithResponse request returning *GetClusterComponentTypeSchemaResp
+func (c *ClientWithResponses) GetClusterComponentTypeSchemaWithResponse(ctx context.Context, cctName ClusterComponentTypeNameParam, reqEditors ...RequestEditorFn) (*GetClusterComponentTypeSchemaResp, error) {
+	rsp, err := c.GetClusterComponentTypeSchema(ctx, cctName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetClusterComponentTypeSchemaResp(rsp)
+}
+
 // ListClusterDataPlanesWithResponse request returning *ListClusterDataPlanesResp
 func (c *ClientWithResponses) ListClusterDataPlanesWithResponse(ctx context.Context, params *ListClusterDataPlanesParams, reqEditors ...RequestEditorFn) (*ListClusterDataPlanesResp, error) {
 	rsp, err := c.ListClusterDataPlanes(ctx, params, reqEditors...)
@@ -10071,6 +10309,24 @@ func (c *ClientWithResponses) UpdateClusterRoleWithResponse(ctx context.Context,
 	return ParseUpdateClusterRoleResp(rsp)
 }
 
+// ListClusterTraitsWithResponse request returning *ListClusterTraitsResp
+func (c *ClientWithResponses) ListClusterTraitsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClusterTraitsResp, error) {
+	rsp, err := c.ListClusterTraits(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListClusterTraitsResp(rsp)
+}
+
+// GetClusterTraitSchemaWithResponse request returning *GetClusterTraitSchemaResp
+func (c *ClientWithResponses) GetClusterTraitSchemaWithResponse(ctx context.Context, clusterTraitName ClusterTraitNameParam, reqEditors ...RequestEditorFn) (*GetClusterTraitSchemaResp, error) {
+	rsp, err := c.GetClusterTraitSchema(ctx, clusterTraitName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetClusterTraitSchemaResp(rsp)
+}
+
 // DeleteResourceWithBodyWithResponse request with arbitrary body returning *DeleteResourceResp
 func (c *ClientWithResponses) DeleteResourceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteResourceResp, error) {
 	rsp, err := c.DeleteResourceWithBody(ctx, contentType, body, reqEditors...)
@@ -10133,8 +10389,8 @@ func (c *ClientWithResponses) ListBuildPlanesWithResponse(ctx context.Context, n
 }
 
 // ListComponentTypesWithResponse request returning *ListComponentTypesResp
-func (c *ClientWithResponses) ListComponentTypesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListComponentTypesParams, reqEditors ...RequestEditorFn) (*ListComponentTypesResp, error) {
-	rsp, err := c.ListComponentTypes(ctx, namespaceName, params, reqEditors...)
+func (c *ClientWithResponses) ListComponentTypesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*ListComponentTypesResp, error) {
+	rsp, err := c.ListComponentTypes(ctx, namespaceName, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -10790,8 +11046,8 @@ func (c *ClientWithResponses) ListSecretReferencesWithResponse(ctx context.Conte
 }
 
 // ListTraitsWithResponse request returning *ListTraitsResp
-func (c *ClientWithResponses) ListTraitsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListTraitsParams, reqEditors ...RequestEditorFn) (*ListTraitsResp, error) {
-	rsp, err := c.ListTraits(ctx, namespaceName, params, reqEditors...)
+func (c *ClientWithResponses) ListTraitsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, reqEditors ...RequestEditorFn) (*ListTraitsResp, error) {
+	rsp, err := c.ListTraits(ctx, namespaceName, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -11300,6 +11556,107 @@ func ParseListClusterBuildPlanesResp(rsp *http.Response) (*ListClusterBuildPlane
 			return nil, err
 		}
 		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListClusterComponentTypesResp parses an HTTP response from a ListClusterComponentTypesWithResponse call
+func ParseListClusterComponentTypesResp(rsp *http.Response) (*ListClusterComponentTypesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListClusterComponentTypesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ClusterComponentTypeList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetClusterComponentTypeSchemaResp parses an HTTP response from a GetClusterComponentTypeSchemaWithResponse call
+func ParseGetClusterComponentTypeSchemaResp(rsp *http.Response) (*GetClusterComponentTypeSchemaResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetClusterComponentTypeSchemaResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchemaResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -12049,6 +12406,107 @@ func ParseUpdateClusterRoleResp(rsp *http.Response) (*UpdateClusterRoleResp, err
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListClusterTraitsResp parses an HTTP response from a ListClusterTraitsWithResponse call
+func ParseListClusterTraitsResp(rsp *http.Response) (*ListClusterTraitsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListClusterTraitsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ClusterTraitList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetClusterTraitSchemaResp parses an HTTP response from a GetClusterTraitSchemaWithResponse call
+func ParseGetClusterTraitSchemaResp(rsp *http.Response) (*GetClusterTraitSchemaResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetClusterTraitSchemaResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchemaResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -559,6 +559,39 @@ type ClusterBuildPlaneList struct {
 	Pagination Pagination `json:"pagination"`
 }
 
+// ClusterComponentType Cluster-scoped ComponentType resource defining a workload template
+type ClusterComponentType struct {
+	// AllowedTraits List of allowed trait references that developers can attach to components of this type (format "name" for Trait kind, "ClusterTrait:name" for ClusterTrait kind). If empty or omitted, no additional component-level traits are allowed; only traits embedded in the component type's spec.traits are permitted.
+	AllowedTraits *[]string `json:"allowedTraits,omitempty"`
+
+	// AllowedWorkflows List of allowed workflow names for this component type
+	AllowedWorkflows *[]string `json:"allowedWorkflows,omitempty"`
+
+	// CreatedAt Creation timestamp
+	CreatedAt time.Time `json:"createdAt"`
+
+	// Description ComponentType description
+	Description *string `json:"description,omitempty"`
+
+	// DisplayName Human-readable display name
+	DisplayName *string `json:"displayName,omitempty"`
+
+	// Name ClusterComponentType name (unique across the cluster)
+	Name string `json:"name"`
+
+	// WorkloadType Type of workload (service, web-application, scheduled-task)
+	WorkloadType string `json:"workloadType"`
+}
+
+// ClusterComponentTypeList Paginated list of cluster-scoped component types
+type ClusterComponentTypeList struct {
+	Items []ClusterComponentType `json:"items"`
+
+	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
+	// for efficient pagination through large result sets.
+	Pagination Pagination `json:"pagination"`
+}
+
 // ClusterDataPlane Cluster-scoped DataPlane resource for workload deployment
 type ClusterDataPlane struct {
 	// CreatedAt Creation timestamp
@@ -668,6 +701,30 @@ type ClusterObservabilityPlaneRefKind string
 type ClusterRoleRef struct {
 	// Name Cluster role name
 	Name string `json:"name"`
+}
+
+// ClusterTrait Cluster-scoped Trait resource for composable cross-cutting concerns
+type ClusterTrait struct {
+	// CreatedAt Creation timestamp
+	CreatedAt time.Time `json:"createdAt"`
+
+	// Description Trait description
+	Description *string `json:"description,omitempty"`
+
+	// DisplayName Human-readable display name
+	DisplayName *string `json:"displayName,omitempty"`
+
+	// Name ClusterTrait name (unique across the cluster)
+	Name string `json:"name"`
+}
+
+// ClusterTraitList Paginated list of cluster-scoped traits
+type ClusterTraitList struct {
+	Items []ClusterTrait `json:"items"`
+
+	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
+	// for efficient pagination through large result sets.
+	Pagination Pagination `json:"pagination"`
 }
 
 // Component Component resource (Kubernetes object without kind/apiVersion).
@@ -818,7 +875,7 @@ type ComponentTraitList struct {
 
 // ComponentType ComponentType resource defining a workload template
 type ComponentType struct {
-	// AllowedTraits List of allowed trait references for this component type (format "name" for Trait kind, "ClusterTrait:name" for ClusterTrait kind)
+	// AllowedTraits List of allowed trait references that developers can attach to components of this type (format "name" for Trait kind, "ClusterTrait:name" for ClusterTrait kind). If empty or omitted, no additional component-level traits are allowed; only traits embedded in the component type's spec.traits are permitted.
 	AllowedTraits *[]string `json:"allowedTraits,omitempty"`
 
 	// AllowedWorkflows List of allowed workflow names for this component type
@@ -2393,8 +2450,14 @@ type WorkloadSpec map[string]interface{}
 // BindingNameParam defines model for BindingNameParam.
 type BindingNameParam = string
 
+// ClusterComponentTypeNameParam defines model for ClusterComponentTypeNameParam.
+type ClusterComponentTypeNameParam = string
+
 // ClusterDataPlaneNameParam defines model for ClusterDataPlaneNameParam.
 type ClusterDataPlaneNameParam = string
+
+// ClusterTraitNameParam defines model for ClusterTraitNameParam.
+type ClusterTraitNameParam = string
 
 // ComponentEnvironmentNameParam defines model for ComponentEnvironmentNameParam.
 type ComponentEnvironmentNameParam = string
@@ -2497,16 +2560,6 @@ type ListNamespacesParams struct {
 	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
-// ListComponentTypesParams defines parameters for ListComponentTypes.
-type ListComponentTypesParams struct {
-	// Limit Maximum number of items to return per page
-	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
-
-	// Cursor Opaque pagination cursor from a previous response.
-	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
-	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
-}
-
 // ListComponentWorkflowsParams defines parameters for ListComponentWorkflows.
 type ListComponentWorkflowsParams struct {
 	// Limit Maximum number of items to return per page
@@ -2596,16 +2649,6 @@ type ListComponentWorkflowRunsParams struct {
 type CreateComponentWorkflowRunParams struct {
 	// Commit Specific git commit SHA to build (optional)
 	Commit *string `form:"commit,omitempty" json:"commit,omitempty"`
-}
-
-// ListTraitsParams defines parameters for ListTraits.
-type ListTraitsParams struct {
-	// Limit Maximum number of items to return per page
-	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
-
-	// Cursor Opaque pagination cursor from a previous response.
-	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
-	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
 // ListWorkflowRunsParams defines parameters for ListWorkflowRuns.

--- a/internal/openchoreo-api/api/gen/server.gen.go
+++ b/internal/openchoreo-api/api/gen/server.gen.go
@@ -48,6 +48,12 @@ type ServerInterface interface {
 	// List cluster build planes
 	// (GET /api/v1/clusterbuildplanes)
 	ListClusterBuildPlanes(w http.ResponseWriter, r *http.Request)
+	// List cluster component types
+	// (GET /api/v1/clustercomponenttypes)
+	ListClusterComponentTypes(w http.ResponseWriter, r *http.Request)
+	// Get cluster component type schema
+	// (GET /api/v1/clustercomponenttypes/{cctName}/schema)
+	GetClusterComponentTypeSchema(w http.ResponseWriter, r *http.Request, cctName ClusterComponentTypeNameParam)
 	// List cluster data planes
 	// (GET /api/v1/clusterdataplanes)
 	ListClusterDataPlanes(w http.ResponseWriter, r *http.Request, params ListClusterDataPlanesParams)
@@ -90,6 +96,12 @@ type ServerInterface interface {
 	// Update cluster role
 	// (PUT /api/v1/clusterroles/{name})
 	UpdateClusterRole(w http.ResponseWriter, r *http.Request, name string)
+	// List cluster traits
+	// (GET /api/v1/clustertraits)
+	ListClusterTraits(w http.ResponseWriter, r *http.Request)
+	// Get cluster trait schema
+	// (GET /api/v1/clustertraits/{clusterTraitName}/schema)
+	GetClusterTraitSchema(w http.ResponseWriter, r *http.Request, clusterTraitName ClusterTraitNameParam)
 	// Delete resource
 	// (DELETE /api/v1/delete)
 	DeleteResource(w http.ResponseWriter, r *http.Request)
@@ -107,7 +119,7 @@ type ServerInterface interface {
 	ListBuildPlanes(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// List component types
 	// (GET /api/v1/namespaces/{namespaceName}/component-types)
-	ListComponentTypes(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListComponentTypesParams)
+	ListComponentTypes(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// Get component type schema
 	// (GET /api/v1/namespaces/{namespaceName}/component-types/{ctName}/schema)
 	GetComponentTypeSchema(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, ctName ComponentTypeNameParam)
@@ -278,7 +290,7 @@ type ServerInterface interface {
 	ListSecretReferences(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// List traits
 	// (GET /api/v1/namespaces/{namespaceName}/traits)
-	ListTraits(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListTraitsParams)
+	ListTraits(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// Get trait schema
 	// (GET /api/v1/namespaces/{namespaceName}/traits/{traitName}/schema)
 	GetTraitSchema(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, traitName TraitNameParam)
@@ -503,6 +515,57 @@ func (siw *ServerInterfaceWrapper) ListClusterBuildPlanes(w http.ResponseWriter,
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListClusterBuildPlanes(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListClusterComponentTypes operation middleware
+func (siw *ServerInterfaceWrapper) ListClusterComponentTypes(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListClusterComponentTypes(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetClusterComponentTypeSchema operation middleware
+func (siw *ServerInterfaceWrapper) GetClusterComponentTypeSchema(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "cctName" -------------
+	var cctName ClusterComponentTypeNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "cctName", r.PathValue("cctName"), &cctName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cctName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetClusterComponentTypeSchema(w, r, cctName)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -890,6 +953,57 @@ func (siw *ServerInterfaceWrapper) UpdateClusterRole(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// ListClusterTraits operation middleware
+func (siw *ServerInterfaceWrapper) ListClusterTraits(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListClusterTraits(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetClusterTraitSchema operation middleware
+func (siw *ServerInterfaceWrapper) GetClusterTraitSchema(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "clusterTraitName" -------------
+	var clusterTraitName ClusterTraitNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "clusterTraitName", r.PathValue("clusterTraitName"), &clusterTraitName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "clusterTraitName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetClusterTraitSchema(w, r, clusterTraitName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // DeleteResource operation middleware
 func (siw *ServerInterfaceWrapper) DeleteResource(w http.ResponseWriter, r *http.Request) {
 
@@ -1053,27 +1167,8 @@ func (siw *ServerInterfaceWrapper) ListComponentTypes(w http.ResponseWriter, r *
 
 	r = r.WithContext(ctx)
 
-	// Parameter object where we will unmarshal all parameters from the context
-	var params ListComponentTypesParams
-
-	// ------------- Optional query parameter "limit" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "limit", r.URL.Query(), &params.Limit)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
-		return
-	}
-
-	// ------------- Optional query parameter "cursor" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "cursor", r.URL.Query(), &params.Cursor)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
-		return
-	}
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListComponentTypes(w, r, namespaceName, params)
+		siw.Handler.ListComponentTypes(w, r, namespaceName)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3643,27 +3738,8 @@ func (siw *ServerInterfaceWrapper) ListTraits(w http.ResponseWriter, r *http.Req
 
 	r = r.WithContext(ctx)
 
-	// Parameter object where we will unmarshal all parameters from the context
-	var params ListTraitsParams
-
-	// ------------- Optional query parameter "limit" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "limit", r.URL.Query(), &params.Limit)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
-		return
-	}
-
-	// ------------- Optional query parameter "cursor" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "cursor", r.URL.Query(), &params.Cursor)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
-		return
-	}
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListTraits(w, r, namespaceName, params)
+		siw.Handler.ListTraits(w, r, namespaceName)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4210,6 +4286,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/authz/evaluate", wrapper.Evaluate)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/authz/profile", wrapper.GetSubjectProfile)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clusterbuildplanes", wrapper.ListClusterBuildPlanes)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clustercomponenttypes", wrapper.ListClusterComponentTypes)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clustercomponenttypes/{cctName}/schema", wrapper.GetClusterComponentTypeSchema)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clusterdataplanes", wrapper.ListClusterDataPlanes)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/clusterdataplanes", wrapper.CreateClusterDataPlane)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clusterdataplanes/{cdpName}", wrapper.GetClusterDataPlane)
@@ -4224,6 +4302,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/clusterroles/{name}", wrapper.DeleteClusterRole)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clusterroles/{name}", wrapper.GetClusterRole)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/clusterroles/{name}", wrapper.UpdateClusterRole)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clustertraits", wrapper.ListClusterTraits)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/clustertraits/{clusterTraitName}/schema", wrapper.GetClusterTraitSchema)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/delete", wrapper.DeleteResource)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces", wrapper.ListNamespaces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces", wrapper.CreateNamespace)
@@ -4624,6 +4704,102 @@ func (response ListClusterBuildPlanes403JSONResponse) VisitListClusterBuildPlane
 type ListClusterBuildPlanes500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response ListClusterBuildPlanes500JSONResponse) VisitListClusterBuildPlanesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterComponentTypesRequestObject struct {
+}
+
+type ListClusterComponentTypesResponseObject interface {
+	VisitListClusterComponentTypesResponse(w http.ResponseWriter) error
+}
+
+type ListClusterComponentTypes200JSONResponse ClusterComponentTypeList
+
+func (response ListClusterComponentTypes200JSONResponse) VisitListClusterComponentTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterComponentTypes401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response ListClusterComponentTypes401JSONResponse) VisitListClusterComponentTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterComponentTypes403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response ListClusterComponentTypes403JSONResponse) VisitListClusterComponentTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterComponentTypes500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response ListClusterComponentTypes500JSONResponse) VisitListClusterComponentTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterComponentTypeSchemaRequestObject struct {
+	CctName ClusterComponentTypeNameParam `json:"cctName"`
+}
+
+type GetClusterComponentTypeSchemaResponseObject interface {
+	VisitGetClusterComponentTypeSchemaResponse(w http.ResponseWriter) error
+}
+
+type GetClusterComponentTypeSchema200JSONResponse SchemaResponse
+
+func (response GetClusterComponentTypeSchema200JSONResponse) VisitGetClusterComponentTypeSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterComponentTypeSchema401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetClusterComponentTypeSchema401JSONResponse) VisitGetClusterComponentTypeSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterComponentTypeSchema403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetClusterComponentTypeSchema403JSONResponse) VisitGetClusterComponentTypeSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterComponentTypeSchema404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetClusterComponentTypeSchema404JSONResponse) VisitGetClusterComponentTypeSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterComponentTypeSchema500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetClusterComponentTypeSchema500JSONResponse) VisitGetClusterComponentTypeSchemaResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -5405,6 +5581,102 @@ func (response UpdateClusterRole500JSONResponse) VisitUpdateClusterRoleResponse(
 	return json.NewEncoder(w).Encode(response)
 }
 
+type ListClusterTraitsRequestObject struct {
+}
+
+type ListClusterTraitsResponseObject interface {
+	VisitListClusterTraitsResponse(w http.ResponseWriter) error
+}
+
+type ListClusterTraits200JSONResponse ClusterTraitList
+
+func (response ListClusterTraits200JSONResponse) VisitListClusterTraitsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterTraits401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response ListClusterTraits401JSONResponse) VisitListClusterTraitsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterTraits403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response ListClusterTraits403JSONResponse) VisitListClusterTraitsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListClusterTraits500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response ListClusterTraits500JSONResponse) VisitListClusterTraitsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterTraitSchemaRequestObject struct {
+	ClusterTraitName ClusterTraitNameParam `json:"clusterTraitName"`
+}
+
+type GetClusterTraitSchemaResponseObject interface {
+	VisitGetClusterTraitSchemaResponse(w http.ResponseWriter) error
+}
+
+type GetClusterTraitSchema200JSONResponse SchemaResponse
+
+func (response GetClusterTraitSchema200JSONResponse) VisitGetClusterTraitSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterTraitSchema401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetClusterTraitSchema401JSONResponse) VisitGetClusterTraitSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterTraitSchema403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetClusterTraitSchema403JSONResponse) VisitGetClusterTraitSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterTraitSchema404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetClusterTraitSchema404JSONResponse) VisitGetClusterTraitSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClusterTraitSchema500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetClusterTraitSchema500JSONResponse) VisitGetClusterTraitSchemaResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type DeleteResourceRequestObject struct {
 	Body *DeleteResourceJSONRequestBody
 }
@@ -5663,7 +5935,6 @@ func (response ListBuildPlanes500JSONResponse) VisitListBuildPlanesResponse(w ht
 
 type ListComponentTypesRequestObject struct {
 	NamespaceName NamespaceNameParam `json:"namespaceName"`
-	Params        ListComponentTypesParams
 }
 
 type ListComponentTypesResponseObject interface {
@@ -8977,7 +9248,6 @@ func (response ListSecretReferences500JSONResponse) VisitListSecretReferencesRes
 
 type ListTraitsRequestObject struct {
 	NamespaceName NamespaceNameParam `json:"namespaceName"`
-	Params        ListTraitsParams
 }
 
 type ListTraitsResponseObject interface {
@@ -9638,6 +9908,12 @@ type StrictServerInterface interface {
 	// List cluster build planes
 	// (GET /api/v1/clusterbuildplanes)
 	ListClusterBuildPlanes(ctx context.Context, request ListClusterBuildPlanesRequestObject) (ListClusterBuildPlanesResponseObject, error)
+	// List cluster component types
+	// (GET /api/v1/clustercomponenttypes)
+	ListClusterComponentTypes(ctx context.Context, request ListClusterComponentTypesRequestObject) (ListClusterComponentTypesResponseObject, error)
+	// Get cluster component type schema
+	// (GET /api/v1/clustercomponenttypes/{cctName}/schema)
+	GetClusterComponentTypeSchema(ctx context.Context, request GetClusterComponentTypeSchemaRequestObject) (GetClusterComponentTypeSchemaResponseObject, error)
 	// List cluster data planes
 	// (GET /api/v1/clusterdataplanes)
 	ListClusterDataPlanes(ctx context.Context, request ListClusterDataPlanesRequestObject) (ListClusterDataPlanesResponseObject, error)
@@ -9680,6 +9956,12 @@ type StrictServerInterface interface {
 	// Update cluster role
 	// (PUT /api/v1/clusterroles/{name})
 	UpdateClusterRole(ctx context.Context, request UpdateClusterRoleRequestObject) (UpdateClusterRoleResponseObject, error)
+	// List cluster traits
+	// (GET /api/v1/clustertraits)
+	ListClusterTraits(ctx context.Context, request ListClusterTraitsRequestObject) (ListClusterTraitsResponseObject, error)
+	// Get cluster trait schema
+	// (GET /api/v1/clustertraits/{clusterTraitName}/schema)
+	GetClusterTraitSchema(ctx context.Context, request GetClusterTraitSchemaRequestObject) (GetClusterTraitSchemaResponseObject, error)
 	// Delete resource
 	// (DELETE /api/v1/delete)
 	DeleteResource(ctx context.Context, request DeleteResourceRequestObject) (DeleteResourceResponseObject, error)
@@ -10160,6 +10442,56 @@ func (sh *strictHandler) ListClusterBuildPlanes(w http.ResponseWriter, r *http.R
 	}
 }
 
+// ListClusterComponentTypes operation middleware
+func (sh *strictHandler) ListClusterComponentTypes(w http.ResponseWriter, r *http.Request) {
+	var request ListClusterComponentTypesRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListClusterComponentTypes(ctx, request.(ListClusterComponentTypesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListClusterComponentTypes")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListClusterComponentTypesResponseObject); ok {
+		if err := validResponse.VisitListClusterComponentTypesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetClusterComponentTypeSchema operation middleware
+func (sh *strictHandler) GetClusterComponentTypeSchema(w http.ResponseWriter, r *http.Request, cctName ClusterComponentTypeNameParam) {
+	var request GetClusterComponentTypeSchemaRequestObject
+
+	request.CctName = cctName
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetClusterComponentTypeSchema(ctx, request.(GetClusterComponentTypeSchemaRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetClusterComponentTypeSchema")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetClusterComponentTypeSchemaResponseObject); ok {
+		if err := validResponse.VisitGetClusterComponentTypeSchemaResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListClusterDataPlanes operation middleware
 func (sh *strictHandler) ListClusterDataPlanes(w http.ResponseWriter, r *http.Request, params ListClusterDataPlanesParams) {
 	var request ListClusterDataPlanesRequestObject
@@ -10547,6 +10879,56 @@ func (sh *strictHandler) UpdateClusterRole(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+// ListClusterTraits operation middleware
+func (sh *strictHandler) ListClusterTraits(w http.ResponseWriter, r *http.Request) {
+	var request ListClusterTraitsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListClusterTraits(ctx, request.(ListClusterTraitsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListClusterTraits")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListClusterTraitsResponseObject); ok {
+		if err := validResponse.VisitListClusterTraitsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetClusterTraitSchema operation middleware
+func (sh *strictHandler) GetClusterTraitSchema(w http.ResponseWriter, r *http.Request, clusterTraitName ClusterTraitNameParam) {
+	var request GetClusterTraitSchemaRequestObject
+
+	request.ClusterTraitName = clusterTraitName
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetClusterTraitSchema(ctx, request.(GetClusterTraitSchemaRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetClusterTraitSchema")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetClusterTraitSchemaResponseObject); ok {
+		if err := validResponse.VisitGetClusterTraitSchemaResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // DeleteResource operation middleware
 func (sh *strictHandler) DeleteResource(w http.ResponseWriter, r *http.Request) {
 	var request DeleteResourceRequestObject
@@ -10688,11 +11070,10 @@ func (sh *strictHandler) ListBuildPlanes(w http.ResponseWriter, r *http.Request,
 }
 
 // ListComponentTypes operation middleware
-func (sh *strictHandler) ListComponentTypes(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListComponentTypesParams) {
+func (sh *strictHandler) ListComponentTypes(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam) {
 	var request ListComponentTypesRequestObject
 
 	request.NamespaceName = namespaceName
-	request.Params = params
 
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.ListComponentTypes(ctx, request.(ListComponentTypesRequestObject))
@@ -12377,11 +12758,10 @@ func (sh *strictHandler) ListSecretReferences(w http.ResponseWriter, r *http.Req
 }
 
 // ListTraits operation middleware
-func (sh *strictHandler) ListTraits(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListTraitsParams) {
+func (sh *strictHandler) ListTraits(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam) {
 	var request ListTraitsRequestObject
 
 	request.NamespaceName = namespaceName
-	request.Params = params
 
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.ListTraits(ctx, request.(ListTraitsRequestObject))
@@ -12814,314 +13194,321 @@ func (sh *strictHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y9DVPbSNYw+le6fN+qhXttDCSZZ5aqrVsEyAyzCbAGJvU+Q26mLTV2T2RJ290y8ebJ",
-	"/e1v9ZfULbWklrENBLZ2a4nVn6dPnz7f51svSGZpEqOY0d7Bt14KCZwhhoj411schzienMEZuuAf+G8h",
-	"ogHBKcNJ3DvQLUAMZ6jX72H+WwrZtNfviZ8OeuNijF6/R9C/M0xQ2DtgJEP9Hg2maAb5uOgrnKUR7wFT",
-	"PKCIzHGABiGa9/o9tkj5B8oIjie979/7vaMoowyRY8jgRQRj1LDEctOGtQZh2mGddAoJCgchZDDlA7sX",
-	"qsF7Es8xSeIZilnDYo1WYp3gNiEgP6IBDZIUhSBJEYG8B3XvA9lzee6nFtZ6+iYg6zZN0DXH6Y4LzWu7",
-	"WqTIZ328XdMauyxukvit7WNCvtxGyZ3P+nTbpjXedTnUJPiCyGCc4Sh0rzIjNCE1yzpP4b8zBFI4wbFA",
-	"OBCI5uCWJDMAQUrQHCcZBQTRNIkp2rmJLyClgE0R+DNGX5kc/k8wh1GGZDdjtBlikN8fwBJwi1gwFR15",
-	"P96Kj6ZB8O8MkYUBAzFsz9xzdWs+1MGHLHSiCiG6hVnEWsjCctSg9rav4Ja/xzPMatbxAX7Fs2wG4mw2",
-	"RgQktwAzNKP81AhiGYlBiog4sZrjivjg1mkpMPUO9nf7vZkcv3ewt8v/hWP1r3ydOGZogohY6AeYpjie",
-	"nIY1ix0lEQIz2QicHrthNtOD+EFtb/9Vv3ebkBlkcjU/ve45F8cPgqYwaEK5vE3DmcbmOJ4nO1sM8m7O",
-	"I74gyV8oaEI41aJhYWkxhv+yVKemRf2LI0zNqt7hiCHCaUySkQBRMF6A1LHSEtIVsy6xrBGKEKRNx6ha",
-	"NMCKFGN4wmq+t7O7s+teUBI1roZjfcNSVG/fZzec4di5jCsCcRMGie8NC2G6v+9KMpbQAEaIOJfj8bR6",
-	"vKh3xii+ZBQyOIYUDWZ4InmxxvWNsthniSSLmw5RDrIEG02yeLC3/+q1Y43f+Wjy8ZY8PwxH6N8Zooz/",
-	"K0hihmLxJ0zTCAdiq8O/KF+3MRtvGfJx3x4efx6d/Ov65PKq1++FiEEc0d7BH996txhFoSJtvX5vhijl",
-	"D8ZBD3P2Qe3n+6d+DxGSkN5B7zSewwiH4iOi7EAyxFZrc+f/i6Db3kHv/xoWEs1QfqXDEz7kSG1Tbto+",
-	"gdJcwJCDBCcX30Y4WA4iR+dn796fHnFw6J1pMvu3ggj9DcCIIBguAPqKKaMr3NtI0U3HDO8SMsZhiOKl",
-	"dvbufPT29Pj45MzY2v9OMhAmIE4YmMI54ozBDFPKmT2WABgESHCH4hTlslZ6ijS7vcUB5gxTMTO1pkbW",
-	"zKcxQySG0Ylc/xJQOD27OhmdHb7/fDIanY96Jv7KoQG/hYgA+fsqd1sz/lnC3iVZHC61nbPzq8/vzq/P",
-	"jtvwlR/xrZhmDahqDX4dw4xNE4L/g5bb0/XZ4fXVr+ej0/8+Mbd1mLEpipnqvw6yUjMDSAhgyRcUAyzp",
-	"jngr1Kh80sOAtz+CKRzjCLOFQ2DU3zCiQkkAAU1RgG9xAGCg3qOUJCkivImAVRQldxKCbqhTcDdFBKn+",
-	"nNLqLv2eYPjb4FEseGRcMfXiQELgoidAFONuy1A9VriK4odkLHjA7/3eYZpGeZf8VF3LFF+UDMw7cUkD",
-	"FmSlAvgU/44IxRI9SxjCERiFeWdweHEK5qp133jOkxTFwTQhKNkJ0Xw434NROoV71Re93/uC49BjJtHM",
-	"nCJXQrgGlTxI66Dqdbf47KBtXCmy+A2uxRtfuaffy7VlLv2G+sRfCy7fCSxDMZc+/+gFBEEmfsnSUP8V",
-	"B1MYT1DY+2SuoWha5QELZu0PExXUOfU1Q1Qs85MLOTM2/YD43JjOOD+CJy4tEv89U1sSVCEG0KZBMz1I",
-	"BU15IxahmSKtjYSvaKrWkl+ob80kMJ8e8OZgC+1MdvrgpvfXHbvp8T8Svt59+TdM8ecvaHHT27YO/K87",
-	"1gpo8bVv7akOrP9RGmIuQtWqj7XqVb9EiqBzqWvrn9kYkRgxRMHR6Hh75yY+Rrc4RpQTZcRAcqtoGWc/",
-	"IAMBjMEYAUgpnsQo5NwJzcSSKJhjKEdVenMqdWD2SWm1WdsxnYtBPyAGxZuWoqCtRxkel7xPGbb59D4Q",
-	"VRaCVsCam3aBlI/DARrIbrI95+s07AAO+WnfcooxXnDMNw4fBBHEs4eFpYLEykD6HksZzQYr/5VjXFAP",
-	"XloBQv6uej2wdUfsemXNTcrBO+zwUkHZ3uGl4nMMKte02yqdu71FAbOUkJI36pXZt4skwsECyA5gSzTi",
-	"vFuI4sW28VAUveOF/S7oL5VHqQOxFcAxKS5HZT4G3+WI9/PoP1Jty2dirqMY0eeMOqFflWyuGglXiH1L",
-	"o111l1VeUD4E9YArXgouI3M8FoIso+YT+IdWbh5IxkNOI36YY3Rn/DNEEWKIbzuHagUXqwy6sbDyOn/N",
-	"ZjAeEARDOI4QMD7y1QvxWu67uATvsijK6bZQLWLKFJMixfJ2vkmBrf74uEz4VcqEYYh5axhdGKCXirIS",
-	"b5K3BIHsL8/VPMZe3YyVG+kw35Ten4G0gqUQEzFR+eUKoFNwC9zD//bxSg5bZbonJMlS6qI7YgXNS5VN",
-	"+mV18EAM2npScrF6otrzcjNbuWnkwdgtcIfZFMcAFsLGA3AN92C9GnmuCnx9ua5luK3HA8r7cV7eLFfc",
-	"BN2VvHcr5LaWYrMad/jCaFmMVr/HIJkgdgHZ1KvnVdH8nlxaO3sWtxPalSHsKjBVQb+sibtFBMWBpEwx",
-	"yFtz1Knwh+XduLVk/8RxyAEkn5rGEU3ELDbr0ClYiOpYl6eujRPvWh6r3mJrQtrUODXC+x4kYYNMcI51",
-	"BRtc/CQY4Qfle4/RHEV839r4pB7EZi+NTmzvlUViSqZ48a3QnqaQTR1vMthSskJxiYE4yu0qI5orctsd",
-	"AD19+HJJpdUZxdt1owKpt5AF0xPOkEKGDON2yZWVtyphL5KdtO2G9yvDRP3egMzVQaivKaO86DZKmo//",
-	"qR0MdfaNVjiojmVAhCjAtPla503AFo4BFfSMhPx+0Bw0276wOVaDtQKlWJgTKnW88jFKo2Qh2FnNICuh",
-	"P0d1fpE445t76dXfmDMnSb+ARLDLS18ec+46AoCqXoQt7oB1L1DJ27uDy3a/5NFWB4m47Bvnb+YxPdPq",
-	"hk+XISnSMhtmEQqvIP1iIEwTel66+vCxJJh8R7Fb8/4Msqz1cmjOXjauNc7oA9XWksK3vR7l7tD4sLC6",
-	"e+7jo7NT+aaqY1GrKfuL266HZQ9J+xYqKDVceDd/fCF9k1EIIkWzViS+1Upt/V7hD902yEXR0s1DW4M1",
-	"bP4yR6ISgyd+FxxYrVQXQcquCIypUJ25DPnvIWVAngBgeUvAcOnS7e/uvxns7g12f7ra2z3Y5f/9757h",
-	"ZxtChgaqVwUNc/+xFkZNrUM3t1jxKAIECaykABIEhHuUazKCIPVgCtVcqrXNCuaPCT9XoZN1EZrmc8mN",
-	"mlLoOI0vSDIhUn96GDA851/fQRwJS/RlRlMUh2VTdd7Qh3PKcBQK93gH7ci/FSwmfyCPTodHx0AEHAAc",
-	"3xJIGckClpEqy6Cs5ocufpJ/0lhDGZylq0OdRj7f2Jb5wZz8guAZJAu1R+Hkb+xcO5M61a8hpmkEF+5H",
-	"qixiyLbVx+pYalOAWCq4cAcZ1L7hxf6EP+VWFuN/Z6gim2yX2AQZ1SC2nDbNWOPLYagWizeeA41LTgYg",
-	"u3l2jPk7pZx9xJ48tDTnzk4Nl8+AmGpirnHkphnul83cTYH8nxpvnvdDVQDx3o9Vce0f+r3KV+KhAQLG",
-	"SfHrKJUsxma6qYBKWKmIrjVcdQqL1Fptl9DymATG8C6rXMt7630cLnO17nmCUph+vdrJuyr7xJQRiFVo",
-	"6VJmORxTBuMADSI0R/y15hsMdOhjZR+pUxEi7I+WGsQCYn4phzCYoaHWhqRwMXP6rLkeyqMI575Q7gt7",
-	"nqL49BgcJXHMJZDActWqFaotMfwzisM0wS5R7/wwY9P9stSumoPr0Xtrx1PGUnowHPLmOyXHwtzV1ilu",
-	"fpUux58DsV8HsTzkVEJoPVRTIJvaG/ZXgKhRJHxd1AhTmiHigMjp8RGQH7vs38mVoSAjmC0+o5g/zA6S",
-	"8XGK2BSRsq8dpkB1AZyTmSLlqm0uRl4ANec4SSIEpUoj+YI8Tly6ES910tLTbihGaPens5fTr8NMB444",
-	"AOikQRVa2uYy9oNyoBVA1DKilyIC/cH4UDX9UmxodZMWN6oda+5wWOJEVdR9MyO6FGOollTLH4rZTo8d",
-	"8m4ywQGM1AnkhnGS87fpdEFFC7Uta0MBHhQ/e0uEVfjdlzfV22vjTCszd3IEWyGXWiUYD8ysljNNtBKw",
-	"Ivjcol/85kYJDEGYaw2eEuEqdtVCt0Tkf0G2UpKEmYz50BBYO+3ia60nXXgGJ+gii6JLFBDERuiWNsgg",
-	"IsxMdAEp5zip6FQyWap8DARNMGVkMZCNutkpGymqndDAn6A25CtYEz1NyATGioH49erq4iIhLj7HaAV4",
-	"M5DydsYOft79edeOzn+174jOr0546TnjZXXK169fdZ7yd0xYBqNfE9o26Vy2BNOESo9ErEP9GIG3tziw",
-	"DlB/3FE/7QTJzGkgWc/7ldHBHaJswK9v00uWZuMIB/UHfSG+1x2xF7SLKS5b56gequ+ZylkaT1PNUznH",
-	"XChynSNMU9p2hpJcXLKEeChEpMDBOwDKe9hLcJCn3lwo+eSXgeizBE9SUKDVsSRVmNffrQqqVRGjhvjU",
-	"kQhPlijfuK/KrsQbFe/hilijghN5HJxR9SloZZGqXWxeaZbEmCVERGDGIYiSycRltHrE7JJjh3V80xGK",
-	"GYERsJ5jg4OKkgkVYJghRnCwdu7JWvqSEqBj+90YFwsY9cwLItej9y5vF4rA9ei9Vrmeq8bg8OK0okk5",
-	"GA71YDvWtANxBjt0HghuZIOvb4H/TW8vCeDhBMXMCwSjo0MgWtfBgARwAHmDzkBoeTkcuLBhqba6gk7S",
-	"reNiroiUO0jnY6XpPpaa+gPfKoM0jhbbHS03Lvq4xQdqmFelOjCdeutBb1l56pstZfSpX2KLCWgGv75H",
-	"8YRNewc/vRJp1PQ/94RlhPN9vYPe//cHHPxnd/D3T1t/DNRf/7f+afv//V/3tyUVvs0+mGDF847lWyMO",
-	"HWxFaAIDx+E3vidyoKqHmpd/dP2mfDxfc8bEDKSRYwijWZIxkXRhWGQB2N65ifMBKBAhVkCNEiQhEq95",
-	"aDqPmGaj3JlX2aw2G16Tr1vG1ZjUHUbR+a3I+uQ3gHJT+yQ8bcLzOFpIw0inYJ18OG/2u0h9e08anWPH",
-	"emly465VPrrqxk9ns4wJfk4lpAM0himdJqzs0Lpx99UHYsvdBKSU0K89K98Td2qt4cU0GO7LeXVz32zh",
-	"zkpI3vmGa9Rf2U3Xt+2hmTCLBjt82KnIN8XPEkm3zqPayw4zlghjSr19m7/YGUtmkHGBJFoARvBkgog0",
-	"61CQxPLVSjNq+Vjcwog6rdx8NOkbaYUJqvaei5DvI/9dDWC5vN9NUQyK/DythvfATBXtoWGzU0sXfkfW",
-	"7w0MrI6MLLd3s7YFRsv8OV6zW0xtaRrnaj/5S/H2ekgOHSwCxGaQHYBv2pzDx/4+/BaUk3Z/L3G0mt0Z",
-	"Whm2DRZ2q2jzPwK3b7OIIvY/AUniv5Lx//D/pST5utge3pPbreUIk7vY6XbCf6ZTnAIcy/3rUDmOK/Uv",
-	"bSOhN8UDTe1FaFyBDWMUJfGEApZ0CZUyd2qu4JPTt8osDeDvzWVjaD6KTDNAwZYkhvzq4lgGk8scjQqR",
-	"QlBB5crSRFJZWpeMVvuQUQAZg8FUpgAoH0c38i9GdhF/7XXhPZLO/arzaJVORaJZmSo1PwU1D7tSbXm+",
-	"BkESyxN2qWsyIjgPOVDRMhdhu8NVDeECaQQZog3srXHP4JjLWHwJshMov9f6IVA30rxCnmKmeRfrJnEK",
-	"6mYivAEcB3v7r9yhBmKMXyF1eDLyX9smF6JbSU+6/+ang7opXe6MSssZ/oLi2tx5xTe9ollCOaMVoJhF",
-	"C6DHsLDBJ4d6PWbLW1dzzc3L3STTaHLgJrWn6mtRfUNgCTOmUP4Y1sk2panuOx57uZO6R17OVqgT5Ab5",
-	"YsrR1n393hdNbP2Z+fTrSc0utipLt/B8/OWkDM1SjowO6a8RKss+KHJWo3cFZdwCiXXwn1rx7DROM9b2",
-	"pghkE1hxP7S7lsYObGGfUu+UXypbun7OmFefdXQjmKdYmDXhX4vhoeC7JfOzIrm2hrHpro5yS082M5if",
-	"n2D+ZBbd3PlNk5W6PMZXNUxfnkNCNstROvfSqj79SpaSjxO4EQd20xMN5ZHza9QHNxb+HhitrKvAG2/b",
-	"Xl8WOlqDRAmXn7v5f6mdfcwdfFthcGfWQKiFgNNTTVcOkg63MPiifum04kdpfrdQsc7kfqUfNw6zX5LB",
-	"GFIUghkOSKIk0/VZ2X9JwGW97rRFHs8LXXlG+DUVs5JijZbgHdRY6B5ui7u7pYbqgzs0HhhJ2vsgj6Uf",
-	"MEi/bPtFnbsJqrUobxUib91df8jHWx2R5Yt7LJrDkgDaoOHJqYhlhfKUm8plWHxLlC3/Wl9TRAZarZCv",
-	"vYlv7PfogjI0u7BmLIViixaDGYzhBIXGcGCLoDShmCVkIZQ/245cMbqBUvlYSeJTdxof/qtgLotbpK+y",
-	"MZ4J0J2hJk1DmGK3kDnHOh+9vYwxgXHgWMUvmAH1zRJ9oMuqKtQVM5eoxoeR38Dlr4c2yybk09d+AmpG",
-	"IvfgxhnUxUJNMJtm450gmQ0TMhnyHjsT7BXo5/OL42rViBIfnffJLvkoFRb+16xaSLCeSX6KF8+8cDgO",
-	"okzkLzFOvZk2/RA3kK9FxtHcEuEmvPx91BndjEsJtpJUnvO29/003x+1/k8PeGvN5fA5DXD382P+1Ca2",
-	"GWf7yVPEq2Cx18s7ymKvZ5dkMdiSB4++oiDjLZ1J2jxILxgjfnH4aMx1zCG6ffPTf/1cg0s/olOAiNxx",
-	"Z38QfjcM4hgRGeBjzapjeUzf/aFp2B8aGz6ovUb9NsbJKA7XtcrbD+qpkMVOL4UsjqUPeGWkLMNhvfIt",
-	"d721hnvzZhf9/Hp3d4D2/z4evN4LXw/gf+39NHj9+qef3rx5/Xp3d3e3TmRapSVonW4VBiXqLhqZ9Gll",
-	"IpJJGx+bpKR1Al5EO9eO15aHetTKkZz61ClI3krPjxKBpCCj/H05Fizm+jIhieFlBPoSOhJLJvXNhNRW",
-	"UNt1Z7vdQo1f97iKGutWfh9z3H/wS6ktxg2ppgaULSLDQN2Sy+4Ku7BFZLPjl0gZYtRYRmY726/IcSvf",
-	"rD6tnSufnU6YK4pr1mSy62rZ1UZc4UWldMYaAneQAoq8zLr1KfQ+wGCKY1TsTDY0XGaKwzM9EYMkDlSi",
-	"u65p9JS52ho5N1RlModeJJLxXMdf4uQuLpuqMufRsUbdaAE2VfNMOFNuL+FfqVT1OefjQOIc3DVXR5Lq",
-	"8zkiBIdOCqmaqLxLiWpJHUXj5t7E5CSe/w6Ji3Lc4gj5E6V3OELOgZzKGEF7ywGRtVmg1QcuYkuqDSCI",
-	"0V19qKajWotoKSKoVFqoQweED0HA+4hs6sg0nwIRWqXTJpUyCm1dnHxQfnU26gz4f96e/HJ6Bo5ORlen",
-	"706PDq9OxK838c7Ozk0s/j45O658fyR5Hozwlb3d/debTPxgTL3/5qeuEYzljAuzjDIwRmCZzAvriuF5",
-	"hCkcwJZyShB5M37e/Xl3+wGyOpRW8fr1q+2XRA+dEj2sD2W7ZowoY9T2RlJI2LOWEejxJ5VojZt1vWfd",
-	"MjJ8anuXjWJEnV7moKmGaF344FMrS2RUJKp/i66tx8aGhDsYclAk+K5aJ5pK4d4/wrLvKGjkhyT3xo5a",
-	"rFhVTRrOgfT6vTuCmYzieJr1F7vgWQUVNOA7oURTrRuFByVX527IUA4Fc9gGxe9u9vJc2cTyGErJ68GM",
-	"JYOJlJdRCPAtiBOh557jENleYLVhhN99NtxVXGmM8lpvxNUKgqxqo4q2/GOKnK5Fw2Y3Jz+daK288wHi",
-	"GIxOLq9EFf9ing2JNnzSS9eknYQay25XkWaUclRZHbYb7Hpr5AvvG4kksarZIcE3pshyAF9BUJH0FXG8",
-	"CoV6KSUoENGMzl0en1yMTrhwf3wArqmxHqGJ4gtHMNwB78U7WPaBvcUoCneWuDlLW7vUfr0TMQgqt7we",
-	"51krbto1NsePSVVzUcy+CnVNi56m2exTQOIx62teFDVPS1HzouB4MAXHWtUaJwU33PmFaionGBbvnk/y",
-	"z4LiFTEqxW++qaabc20Zyv2txvlMhUmRmNKRNftT+UG6RzItY3VrLaDS+Owa2NBQUwoNjNeWMjjB8aSE",
-	"DJsykajJT+omd7+6YUwvCLrFXx1P79klSMU3eaGLgQdUe6CSJGNSHWXwnnIlTnc9WrAHHSTZKaYAU5ky",
-	"SwO7RnatTVriRruTUpnNjgxGsdUN5XFrYbHP9DJbCdg4CReSDxbeSiKKT+ogYkYSbW0wnQfLhWMb7k6+",
-	"jNqbc2aVEwtlzWVxCgzBmQ3PN7u767o0HxbgzNiidVV3O9GuwgEzd0kqTDV9oLEKgjmMcAicldX4X9tN",
-	"/puPDcmWNABUqo+/mAAKJGg2AoS6OrmPIaBpcTrT4/d+j1nlyJs6GYXLV2EisBBpBRi0WTPBU6tS3w0D",
-	"6zFvdaYBw124M8Nt+i9X8zKtLwYqB4jk68eQos8iQqaXJpRNCKL/jg6GwygJYMRloYM3r1/tD2eLcMzp",
-	"N55IC87nucwk2jvozfd39nZ2ey57gl5Be36pwoU0UVEmpcNTSx3kK2g9RWtyS33rOtCG8jmOejkEpQRR",
-	"TisE32E8hlor95Qr6rQr7HQt2oespaPr0f5AxXRqquj4FcltLKWzbI1cS3H9UCVyX0r2OHn1x6EdfCmY",
-	"89QK5qyuUo4lXT/qWjmdi+SsrirOoymHc4yCPPi7VD7XKuAb6naO5IwMfXWAzyidrDsD3bjq7+KOyBjZ",
-	"ARjGIgrk5OwtmEIq3Ym0UOHh2BJ6bp0gylmKLc5bg39Y1RmafUtKJ5LP5z6HCDGkC1uPdBFmV+lr8UXE",
-	"2wPh0iXZzdqYviLDvyspM581LHjYw4tToLl4E8iler3zPRilU7jXnOetcSalxjZqVxjOCr5m1PKgrmje",
-	"oG3cGhbIObgmbB24nrQ2uOlcf1IoZuhwpK+e0PMn7PNtksWhrcopGjQTZeP0+5bpwFyZGyG5eNLBvU05",
-	"YsHlnNqOyj5xktvNx/V1X7OzJhQT1m+RS2AXOEURdsp5RcGLVDV6WuGzemv1kTEMxiEkVm2PfKuiwH6I",
-	"5n1tBuqLMiBcplu7DJcfijc9yPfq0PNIeShtGXPdeQlmCR/tArKpgwe70N9ByhuAMWJ3CFlGIe9q9Rfm",
-	"XC4mo44RzGG4Mj7QK/7/RFVtv2yNl4QxQF/ThKIQGKXefRIS6TmqJzdlLG19Hhq14nJFegYjC8UyPQXb",
-	"u0RHd9hnvu1yYsWabX93Ho9lIChPkH+UBCOIIJ4JQiHSkjrc2yCeVcf57eOV6lo5IFGNyHVCcoLGJek1",
-	"lIMOasYsYbNcq57oUzNs6hPXlbNqoa+MwIBJw3qxVjEblcwdS74gRxaLGuAd5YBTxkeGpNKNH4M5hYr5",
-	"vZEwpTc9/rcwONCb3nYV6vdW1hnpqxHQ4DRSS9ZMUnMO5szu0xCRvY028TkkmC+t6l+CFtWev6vW4Ata",
-	"DKuv1eHV4dvDy5PPMluUL4Lmg1axU6vcqwp3oW53z/COJDO/oOff8+YVzxK0aADp7+Y05c1EGQK5Glyp",
-	"MSrQpVrb6iDvUtVR39d5MqoX/+bNI6g+6hyXSLPXN1GpGc/qTAMGpyXNlI+Gk1y1U5cwPTa5kb14dG3A",
-	"o+vY8EQx6xGJE0KU1VjcV8TN53P3NuOpFaK5n5fWg3tleZpy5qs03tTspVV4qZMXzF35iwz9nl/6M6t+",
-	"5fXp8XbXfGj7Ju0TOddaszRiQ0digsRCoHZ5JgeLr3a5JObdR71svlAPrGA+ISQh9frMXPuAeDtOR5V6",
-	"U55ZVdvsyhFTSdwjBxONi3fh7eHx59HJv65PLq96/d712eH11a/no9P/Pjnu9XvvzkdvT4+PT856/d7Z",
-	"+dXnd+fXZ/z3o/Ozd+9Pj3iP07Ork9HZ4fvPJ6PR+ch+ScwuDv0MgziijSpyuWLVUvPowqtOPvbiO902",
-	"xX8bMiJcqjrFO/4zYFPIQAAzLjQLIsBHs66Smx9qSAIlzlXnfireerkMi7BoJ0EGIgQpA3sgmEIu/NR4",
-	"3VTj30roK1ff9iIhc4HO5FR/K3I9/k0Ey0o9axuB0MAT6OVEec6RQ1avNb3E8SRCIi6rMDMg2Uuqg2VH",
-	"t8eXA4/kM8USPUg5KygM3dlTc9NNEw04zNj0P0eqrYCF4nXanPF0O/56ZAI6nz2nvJTN80krit2c24Ka",
-	"HJdncB5MSWVSReqSYklfyMpJjCFF7gzNooR9yj+ZRzCEKR7OnfaSqdMKnStt+GdXqtVWk73TiJ4P6zSg",
-	"V+3l4kBc7nWj90B9q2RIdr72BDtoUxZF4Hp06kyyXNoiX2AtEJ1CmrKVy4Aa11ErW7oKkmxO1i0bfXbx",
-	"LOf8fuzrYU6PjZIm8qeK2q0wpg2CCC8neyB7+aWcB85BpY6ndgPyc3n1tpcTX7lgj1KS3GLpvTmDOOri",
-	"51QXA6UBnC/UdYN1vjXHOxchMEuyztod0dGp2ZEYsbOAs8j5MvLJ3DTgg1gHJwIAx0U+0jJFSIdyig5q",
-	"I7FaQeLc4tRKdUHmHl2HUbDmI+NJqJVFcm2I0BGfpyg+EpdAGJ21Mtbfdm2Yqov4lho79fZqjdmj5YzY",
-	"Zv17f/fdfLK8u5+1Y7QOo7hLtOwgRvqGZOia/0tASasGSv7ANcnyXebxxsr+HyQ/2SDQYA6JnDHWAk3l",
-	"0GoZ69zDw8W6Fi4D/ASlgwLNhLP8bRZF7cY5Pahrb2f15144GNboNGPzQteEW+3cxEfuLxRMk6hwtaAg",
-	"wl8QUHw67Rd1O6m0PxvyLd25ia+miFqjQWIoEfJCvhEcowj8Wbr+arFiRQXu/oMj2Z87N/GTMPK3h6aJ",
-	"fDBmRFqjsmcdYWirCjvb7qS2WlZNtpyzT52SrNjUfa3qzVqnfB5fnVNxZ+6pcSpO+oH1TYKbvSAJQwFD",
-	"oX4WPhhPr4P7Bfs7uyDVnQoap58CAGleFRzHYPTuCPz9v/Z/dmW0KiT6zyJfNWkK0LIUALI5uB69L8UW",
-	"5CJRxqY7NvXqFmAwRpAg8nmG2DQJ6WeapVwMRA4O51J/ArKPNEYD1bO0PATDrnUjSS3DyCXLor586UBq",
-	"JcUSTZ8FqbvSkRzmc+xtt/ZbivH2fTi6EJmv3KUGpGjjB3mJmUoYWlq+svfct3QnTmxtQBPH+p1XUPzF",
-	"r1yDvtegvrJncdm2uICQZLJ86bBg0bZ3buIPkAVTRKV/PCNZwDIiTon3nu/tFHPnpFyoJGnuNDTHUPx8",
-	"eHHqet5hHCcM5pGVbg70W8v73PsAU74o+ZmLl7Rwh5EyNmWJ+AazrzjCOm7Klf5Ll127ypmKjTIegmta",
-	"LyyU+74sn6ZYQBck2tUiRbloL9tac7Gf9clBGzN/7S4vg1UjrxyPZ6VNcQL8YGdJjDWexyGIkonI5oHj",
-	"WwLz2/skOGzHTutY7SMUMwIjYMW7GQGRUTKRN2CGGMHB+oMhrbWDjg4Pjo0vEYdowWKVfLoDyCvh2B3b",
-	"XmVgVDMbX53cl593gOO+nL2DDjw0i18XSNrgrgRj4DjSwpPIscturkqu277VcUrTi8m5oPrFWtZoZ98l",
-	"jAyuPWn6vgM+lLK/HJ9dDvb29l9JPctOjSvUhrK9tPlUSRAhcj16X6/L0424TGa5Jqj8FPwtc1BzT0Wf",
-	"Yf3HsXyiRHIMoiiNWwFoLglTAOcQR8raUVdhiVy7ip3yAZQfn26n8wTXPVNV2Uv3tApOdjHTXVh0o/TY",
-	"Z4QmRNW5L2hCLijsgGuKqCFJDHiDuTSQ4FgZ06Ub9U0sfMhub3EgjHLGcGxKkmwyBREkUmHL30yKhGax",
-	"qmtHX5lclyueC4qE5OKzgOEtYsGUY4lQKaGvYl60Ay4gVWlZBBcMoBBobuI/Zd8/wb8zRBZFjg6A42II",
-	"5R2wAw7HVLjcy3pYiKCbGBIE4gTMEoKAoKZyD8XBocVv+6d/JXj88ffd/335hpz/+iGDH3+eh3+d4PdH",
-	"vy1CfPrTh//8a/fs1e4/3CL0DOIYx5OjJHOZVQ/TlCRf8QwyBOJsNkaEExOxFJD3BfCWaV87AZCb+Er7",
-	"3cUAUSb769zlYLwwxUWBk5zfSQT5QV9hwHZu4mt1Na9PwRTHTOmQb3r//5tdAx43vR3wAS4E3ZLgu03I",
-	"TXyLI4YICgXgMSqD7fW+R2ExN3qzYNopd3rKe5hJ4lvTpperZZEkoiJJ+sD0M146P/q9U1xftWW4rgWc",
-	"ij7skI1LQ08HERb5pCqViYvFncTz87yqWKc9nrh8Uu2Nm/XKKrtcf0ikyh6+yv2JAZv3pRO9WNM2MYUf",
-	"Kx3cWFHEVFVC54QOqZD/q/qlBq2StjRJM3Rx9/IMVEZyLkF/ijIA0BU36Xo5TOtvM7+da88MS2hLrB/v",
-	"csmbWiINjKLz297BH37dZbfvn0TFvvA8jhYSKaomxAb7qBrMV15R2pf7yigaL9YrmDTs91IdUzl4mPIR",
-	"BD8nmGqobZpVh7IMR6FvUpy3VmOhuihHMnsGcFT6SVdRaeugZYdxehNz5DcRniQTwjlhFdZm3BysinSq",
-	"Iy4zIk3BEbVQbhTW/QCdF7+kToaTaD92oyhnXqazGNOzmoKu6unAy67VT+UKZgnlRC5AMYsWRUnUYmHL",
-	"cSkiWLhbjRcZzGyXs6kJWC5FgQkCfSKLdZaMA5J2o1KghE84hIyjco4q8zs2j1qb3bdECIrFm1N+qoWp",
-	"DsBuifXuCLkioffteoBoTEB9AEp1pje5J98LcuWYr9Wg5YRC3dpdJzM6OhSp1htF/9HRoSqiUZH9D08H",
-	"aXInpAWSJMqvHsAYRguK1y3/2+tqUwCQAMqttigAilFNDUDrRqv6ABLAgRioNQ9+9VhU2pCaFBzC9CrZ",
-	"YOE/6HAsdNwY57OsZqq4ipXTlehRfZwai/euSH+S34Emhrsl2sEFKYPB6+Afp/asldgeMpgtfjWGfhkR",
-	"eb6SV2OWjcAq/dRQ2skR1PAoJLsHsmGhptBkn4ewIdrQEetQW9WxOKNBW/ziGrOt8MNoHF61cQ7eYBhu",
-	"FNstJttV6s9HaK8zS2mId4m0fMIKAJcDnEU/7GOuJp2xdV3NVjeb3PlKsCV6d19JtkRzH9jSNkKcx88x",
-	"2oXsQgigS6Vv+CdaaMV2KbMl0Pkr7apXQ53xeZhCSu8SEtZcfD7zwsl0iy9aq1Mk2bSnahh8XheOoPJK",
-	"OJLn7bXaqmrybtRHVYxMJ4u6MMLKIUwxIpAE04Vv5N6veYfv/R5uCoQQ5Zm932h3nqJ8sErAVEO0QgmU",
-	"qmux0ya4/mrCo2Yt+UjSEa+enWkrX9kFPrGPI/6yD2K98rTTK+hkGJ21mkvZNJNIcfCyGAGnpbpQwbOt",
-	"iGxWQp6jZSshdyqG7YllnMA461LQPkCzlC2sspPiwz3jgZprLHAUMxJufYBp6pRN1AepCxSAkU4gqJSr",
-	"TOj2xbbqsW/JOOknXtnlfq9FI6LO1OEsXw3eqwiMG7v0DbRquhSbzc+tDvs8fI1UuRvpkifsRYUcU4tl",
-	"NVF8XcuWPNp77YLnZTBFYRah8ArSL7V6hrwVYJB+KeQQXU/IGRQpCja4DeQiGFdWdCjlSZDFGyxnFnOj",
-	"w4Ak8eCvZHxQL7kpeeCSQYYaVE+snKThMOCk3++dvRSYbiov/SW63y7Pz4AcwFZr2uWXaV+KebQPVNGS",
-	"2yi5K9WKKdWnyTMOKGonSytUkwoQlEY4gNRqvOdnqqjCQvDdx5DByxpmWXHmIrRAcXWGvtWh91MyTzvd",
-	"s4WjPMX/P1uEHUN96JA+8qo29WJIWSOez9o3Vv+pFlgN8lw5D9/jy3XsDOKqHrF3otwK/nTl+Sogaypo",
-	"zQ8WBAQJD38Y0XUGX15q3HKEdFCOBATR6RV2zfIeCjOjaAHUUbgPcK/rATZmZSyA6JJFaO2G1hmpocBw",
-	"GjNE5jByvv0CTli1kOE9So+xiO1CIXvTltIgtBY4sg5IDqKOGK7rjhTEyjcjdOVsNucIX6JXvjq5sjrq",
-	"vkq5Mtl8YK2c80DbWNKSYs3Htd3Cu0qqC2MVne+5HLJyx1UJm6Yha255ZdxVZKZQGSHcRyCUN/UsqzJ+",
-	"+PGqOt0Ubc9I5X3rSwnVHSi7Fg7Z0Gw9NJNs5xBzqqX4KxxAmURDOgnWVagxxMXPNRm4T8p5vDukMTeH",
-	"l4GRHjnNS8otO6t5iObq707qLbdqVsEy18wqfURGhQSqzvszDALhFG5pJlQbL7VtFchOyLgupNOVxMcC",
-	"WjxrQikJ05Qkc2GIYMxtz6EfYJzB6FC1HOX7qMspOxPti6GFk4Dq5OGA7aak9/JqyqFP9S7qV5979ehF",
-	"03wnHslwfTUBV1a5XudWc99e4THlcMzdUsrqghyCJI4W202avTVo79evZ7/ikrkDTsIuawXgig1SISoE",
-	"JKF0EGQCrTmdCxBxlRd4hMG3cmN1ctVJzPdHgTAy8McrAmkSiggIGsBoncmtDzOWgMsARvWauLrddAii",
-	"1Tvxr1LczFWLBfjy0lILdE8GWiLsA7PN1ynHwA7BJJnoAGCtL1MzG6O9v0mZnVGvZ87MXGY0RYK7vo5V",
-	"aMcnT67HUe5KrqYeACqGtGOZ+xwWpkr4h69uT5wGzSMTBL72tnIS4WpJ+UbLQ+Xslj+0Z1RQXkItzPff",
-	"UiLSygzYYIRUh5F7AwoS2eFADFW7m7qqn33Jq72S0zjNWKsbtZrCY3t5QftlNuiuN7+xwvZV39kFZWh2",
-	"Yc1YknVEC2MYgOMgykKZnSZNKGYJWbTkCy4aVu0kME1rYgI4X8sSzl5HyitZcwbGeCZ+7wwVH0q54O3m",
-	"8+d5kdNSxBGBceBYxS+YAfXN4lGh24sgSGYzFzN6qTUfsgG4/PXQJpPjYG//1Ws/hjdz+a//Ipjd/EBk",
-	"/aWqS/oEs2k2FpqKhEyGvMfOBLNli/9oPGuJ2dSXBjA0SyMRDa2CN7OSE6iqHC8CwPygIe9nbstd9iUv",
-	"BKdn9ZZ7uQ7oeBJ9UdujWGSdRZ9X3hjZ48m3jvk+5/sMn/3cTWJVTz4/A+VZ1OkoBNC018uLn9EK/Yzu",
-	"4xB0H0+gAh86I8Lf6D0cHs/QXS6a61F0LqzyPVj+Sna5GBSRI5jKJEFYpIKvCakThdptZ2VVRqA+S3Zg",
-	"jNyUgrDxvojV52tc1GYohHkZFWtax6Z1mRWnmuwKz5BMymIOA+4QQXl9lnB1mjOhYO9eT8V5kFeLFPnX",
-	"MIWclyHCKABEaSEci/NVVhVdfNQ6cmfK3A8omMIY0xltyodaGnqWdypqVuTr8bWSHZqzq527Hqhly52a",
-	"CyrOW/QA19StNUwJTgh2xS8cTVHwBSQkRDK9UAH+otzrVpTcIQL+AaZ4ItX3crRtd0iC4ZblNv1c53OY",
-	"aSl1DVm+AlVB1jYClUvJdjEDmdA2wNEv44qLHKmkHg35+WWmK105oskTTLDkbgcZkYGhmx68cs4TzEaG",
-	"dFYVbrpKTv3eJDkkQb0Fhb9rmCNKVgqugbPwp5oBzy9rh0tkMYJ4AqRUbQ0Z4Tj76h6ytqTHL0l+LrJU",
-	"WQK0WGTYUJO9nf3XO/v+CvdDQ56uqOuMYjw1InRtyI/ah8psa3sy7O7s7ez6quuLoCETJ/oGAqqTyE/Y",
-	"BKPrGnxEY2PXtW4KH9HY1DY8P3eFOzQewDR9YFeFj2g8TZIvJ3Nht65NSaC9dWX2tJQkOgchBHdyBIDm",
-	"zoxhgo9FYVFGo17YMzK46G6yfgamepaS24FlDVUA7Sb/1aZIuKxPhKBgpsHQWgel31Pfm2q/ohyQd5DW",
-	"D91qsmcETyaIoFC8Ey42Pk+NJ+44BXkPc/h9p0+05fqb6VChAkblyZ30QamnanLO4KDQpz46D+AmZUGu",
-	"dqszFo+ymALtYg1meKL4Wdl6jbmY9ZQf9JT+71e+qS6Jl7UX+ax+vmVsx3otvuZjM3LgPhbkHGEf2Iic",
-	"G0Oy2OfuZDHYQl9RkPEW24/lCt3iGNNpzbyyrpT3zG9W4P390YRXNdipgsoDksWDOh44IRP3VT2XVQZq",
-	"+MDZYpAQp6fIGs1TRiyN3uVnYevopQllE4Lov6OD4TBKAhhNE8oO3rx+tT+cLcIxp/gaHJ9zDrU33xd8",
-	"p4vJSKc12XUYxBFn2TSaAtnSSmkfJTEqSo715avF5X2dAK5LEgudZq2YsfAoVxrIC6Q9LkZZHMu/Lvlb",
-	"h0LxRL4Ta+6p8tK2jtJsV9WW+BVeWEGdhTZTkUpBcmcS9xWRcGvi4kaYtD0/nRYi15XO8yu8KlrPaezj",
-	"IfeSF22sZM55VRFwbD0Ahfk4RWRAGUprywpPIX2P58jK317Pr0Z4jkSa7qFg+2XZuzwfGLglyUzwtPKy",
-	"Vmoj1DGvtSUR5ojAKLI3t9KbW/Rw0BKUOtZ0oSGqUqYVgO2EaZcMpXWSZ5nj1huWK+q7z6wJl4zJmpCI",
-	"I06I5zjMoAFzPmsFbZre848qO7joCXTLphd9bxXxXHyyakVd/owM1Baq76z7gRJD5U9SVyy7/ILTdKmX",
-	"gjJImA9MVcNVsWduki4BUIdWlVRLHlmcdIomK5FT1SApdCtL215y7YxeXdX4Uihw8oWAL2gh1Q75CjQy",
-	"eXhoaIBcdi4iq3vamQHBlnKoDpIQydS4WLPzBgNnA0u4yxRh6H6RM4UaKk0IoyJzcz7shQiv/nn3593v",
-	"n74Li2uuhftDZw8QTi89XfxdtXUBjaIgI5gtRCC40naLqm+HmXR4kP96p/H1t49XFWvybx+vwFuzOqBt",
-	"oNm5iW/i8zFfPICqhXiSFklGFKvFFjrJPxGmIvlUIoCZipW+ie3sMbLW4AH40/r5QK/jJtvdfRWIucSf",
-	"6E++iCuR5kmq/WGE+d2jqiwEyIQC7beP/7ws3kvt2oVCgCnNEJG5i3UtfAWbAhkF0L9zsOL4NslxQdrk",
-	"1cEUFQJ7yp3J6aCUK6ONP6tXZnRyeSWqZt8mxKy7K2JUYxiB49zx4SKCjFMdeRpFUwV2V/UMOKaMmLbl",
-	"3I1C1l5I1ZAAxRMcI0Ro/yYWVY9nuhowmGURwwNZMca0OsggG7s+sEgpDRlU/6SIi0gKg3r9XoQDpBgu",
-	"BcvDFAZTBPbFTbFheXd3twPF552ETIaqLx2+Pz06Obs8Gewr4Qizct3Gw4tTQxN/0JM3kcuTKYphinsH",
-	"vVc7uzuvBM/IpuLKDHfuUBQNvsTJXTxMOPoP8kKRA7PE5QQ5/QNYRmIK7lOBVNa9EKTyw9GFqtlPRY0A",
-	"TANOUN1FRg2zl4RyogtLn4ZCkcFa6qiKQpKCExaQ2N/dzT1YpAeIYVYY/kUlry5fhdYE+M0zi4vmquHa",
-	"AD2L5vUO/vjU79FsNoNkITcL2kfo9xicUFGZSYOK9gQhtrEgRTEOB7Z3aCsGpCg+PQZHSRyrGMSSpf3o",
-	"/WmVup5KYqkQaL+wufSLdHoSIewRVQ1tDQ7FOtehgVjaUcnZdW1nfyTWK6cToqfrtCW0bBC3HrCrU8OZ",
-	"yhpGQ74T6cKbUFZjWUQUQFc6YrAlKtB8ycYoYCL8L1ps7wCh2EMUJES5BVGrcuVO5RT4JItRoYVX9X/e",
-	"JuFiZXAvlp9P9N3mREUliDWevLXLXMp2HH+emk/MVTbOfO/3XstVuSbLVz98C0PtuCW67LV3uY41KUWh",
-	"7PSqvdO7hIxxGCIhWb/xWZl+xKW8IvA6x2QBJNMio/F3lCerttE3Y9P/DA1nskYyxIV7/cbYr4YaoYqb",
-	"/I4equHviRzevmkVjCj5qT6lAxVLhzkA9XFa3K3rSMeQBdOB9iarJ1AnqgWVHFkaodLJKmIi0pdDwJnh",
-	"CIEARlH1rN/yOfWAa6JD1hz5Bd0sJSqtoZ4S2aJJiALht0E3SYPujYBis7lbYsVXzxshu6BijmdOVKwi",
-	"3ppx7oHR7VjhjT+GPSkEO7k3aikn4dbni3NRbvdi7Y0JXSk/dlxsr3KYvVBT20bAP+rTKuokwZj/LIo4",
-	"6iKkB1baowI1Ktq/uqwBTUMX2QM6DFxkOGga2sy9XD/4pzVekFoPc8eF0YlKNM782OwgF2xoacdeF0vF",
-	"wwrDkCoS3coc5qY+1VknDTWsSzUMoopaLqqW0fWKkKXZ6uTI9/Z+rI08OR7SuYkCFxxH4EKIEDLojQ9p",
-	"xQhcwoxCqdeMGMeQwRwvSoTWBZaiyfA9nmEmonl7nMC1tJaFe1XzT+vHwXxjvihoQOwHJ10W0prbruCs",
-	"gR2fvvdrmEutVIEgRnf1eFhFQ9mxPNWaOE33ZJ34zr214agLP8ttgHIgeUI6l9e7f2/vcZTEtxGW5sN7",
-	"o7Y8ZQdyt+B2EzkefgvClLOZ31sJs3KBkI4oubW3w5X4BTHHfehGl8sD8KU/AN31wmntM7JJnHzd3uMs",
-	"Ye+SLA5XximuACET08nlvoyjNZgPn2C52GyMkazO6vuauzb4ZN9o52Yq+OM6IhcikSRCecUsH710CXfM",
-	"jBXNSGNkx1grtsio/MqcvrhibejJIom9i3pRdCk2zhy8hZEzDmBNrFzNcW+aiWtcRkPWMh3f98LPdebn",
-	"TPh10raYNG/4LdbMnCpC5XDMj5C8C66ZqxdAtndegEblpRMvlLedUAimMlONocXslVHcVA16V/NxcIKv",
-	"W5Lt5WGpYq8utP1B+Td5uF1xsH8PSaEF2woh4Ymi2u6jocHPTf7wRt40cyDvtfKZgTFAXzGVyYy9ULYu",
-	"/ekjx9pHxrs8nnuTqSxfT4l36XjvNs/sXKsEnqtgdpaS7GClWmi7fLdRwa6LRPe0JbmVS3DVs/WQ4zYk",
-	"wD205NZK9l5EtaVEte5Ua2nZzEMm68RrrITH0FewLi15dyHsqQlfm0dDh7S2TimtTTp7Cki3+3CE9TnK",
-	"X6uXu4yspiKgq+jsIYk9Ugx9LFzHA16OZyBkrUNm8uM6TPaijdFoDzCSY2zXcSE/fASRvU2vEKJ6VuaH",
-	"dbxSvIl/DFHutrycT6ARYmuH/RbjFplyp5C/IvwoAEt2buLzOFqYDUX0MG8dwTGKwJ9FkPROiOZDNYEY",
-	"v4is/wdHvD9FchQiForCnZv4aoopuMWRqPCRZEzlMDVnU1lujQyhagIZ2NwXN28g+22LV+8mNgKZSRYz",
-	"PDM36oqx5FL3WQHiH8QBMt9Rm7bEwK6npiqJzVPTl8g4Sl8lSfsN2ZE5DIqCDpiK8nYzyHAAo2gh7wMK",
-	"5QXpci1cKCmXd2aEK6zPGbIob/EwXpDFLh1IWsR1PFnly2oipPgVaHpQC0DBiCAYLqSMQFep1LGKN7tu",
-	"m/PNksoc8fd93CeLq+iStc2r0o18n5mL2yRdbj7F5yISrwanhsvF0ZihGnk5WyOh6w64WqSKviexKLrT",
-	"hIf8TbJDbB43KvoH6DzpwJyagJzaSJwGNMsXMGCLtJvnbVFwkPc0kgTKNEtteFUUGBQTrwK1+k82tseE",
-	"Rasx0Ab80zMHltZvOPzaKLEkDg+/BUx+KIDfGuSbnzqQnVQxGmpUHDQW7daOm6u/lFNvBqutmTdEauUG",
-	"mxi4IwtkCq4/vkbcuesV4niR/XwZWn1XriF5D8L90czD/kK8c3hcKdD6E/LiTJ8uMTez8leQvUCVeyD8",
-	"8Ftwt0bCrudpJu55xt0HIfAfjSzcj4zIF+mEnxuhL+98tfi/ZNh8UXJHi4EFXe+DJJXZa6OF0lfLfI8q",
-	"50cL3d8UvVdZSv6VIbL4YR4J70fhx9aU2I+H883oEJtfXMUKrtd6Axo5aFak1FiDPjtf5KYD+e2J62j+",
-	"i/+gv/+ggW9OVO/6LAy/5X+fdfAtzM9uLK2gtQ6GK70fHVicRtbmdUN5/OcbwdWGWst5A+oRmvnhR4Ue",
-	"u5smgM/Gz68dxZwefiOURsLvwXLxy8G3xe+o8gfbrvXpeyyo9uDv+8bR+yUcao3hUKthCO6ZXs1Ik+W0",
-	"FzolwXskV/uhNH/eudgqOdiekIbPnUhtiQxqhhubF6bJ3svni9qknGYv9YH8jhpTVL3kW1tCaHOmtarL",
-	"Z+VFpIff7pdzrSXJ2mpvSzup3XQyNk8Ufy5s+arwExXF3JZjI8wB/PmIE3PaZ81JGJBo4yWss3pqzASy",
-	"T1yjrIUIvvyEMVYXhsKY6/GzFMZiH4ipMMHlwErj8wtj4c9YIAsJa65Bd9o9/Ibi+X3YC2MwJ3+x6svT",
-	"ToKNGTfEY3TA+OfCZ6wdXYcyFSgiA1F70cOvQ3cA16P30qdDEB0cT0T5ahE6NUOM4ICqWh2YdkHvczX+",
-	"9ej9D4vpxh6bfDzOTVAbVR6fE9pb+LamO0ACOIATFDPvSzA6OgSiR34LDk8HaXIn/DlIkjAQwIwiAGMY",
-	"LSjucBNGR4eHfOAfGf2NPTZG9lpAfk74b+38vkh/vzzfrlTR/oKmO8v3445l6Z4j/IfIDd6SE7w1GXgD",
-	"BirvtuU0HLqzP9Jd6OmetWZDQaENd/Oz+eGd3tICLTRS55jiq/pQY3RRe1zk5dwercpDL3HDGg5rWned",
-	"vBfNhrdmoygb6MDubnR6+E391cG/Td+MFu+2Vd4Gb0fmrp5tGvueq19bIyot5dNW69/+C2KPDyV2N0ni",
-	"nosqqwWp/L3YNKXx8mF7FMj1wC/2RtH5xXNtfZ5ra3viG7zbh96VndgUgRClUbIQejvdT8X9NXg1WzFO",
-	"Rnmnh7mxy/mpVgoyvxPRXZwdMpWZ4jR6/R76mkZJiHRSS1etZlv1X9xPzNCMOso252kvISFQXDnKFiI9",
-	"5m1C1p3+w68+1gOUxHroACtXAa0lnE2Xv7bDb+qvnJdPIQumDTlhi8X/jToudKu3eG0ljsd+gVt6vS3g",
-	"uN7HXcJTTdfJ+2DlN9p1m9/aJTteEsg2e5k7Km5shAAUcfwERQhSD60/ns0yJhJSqC6AxjCl04R1fcVH",
-	"esofjQg89ihnBXj/DBg5cjyjN5kU2Llc8HPccFXALUlmIMgIEa5Z+aSUQdYeFK3O74ndm7W64pVh81Al",
-	"1stH1BjApbFCKbBfHsnm2GwNr4d/JIff1F/3KtBe3ldzKO/TvPTtvUYFJB/gDfS7oM8ukPixXrUV5JZa",
-	"7tptNKHUj3r5uiSsyjmm55avqrTxDV9AqcoRGiAnd3ssvlPXPQIsESaYJt9F2f2Ff7WKmBggeSC2Vc3e",
-	"oM8Z5S8hX+0Lr1o1inO4PNSzWXFZNn11V+G+X1z2ivu+9HBq81jOwbB5z/3NvaZ5rycRLPCM3tSa8IDH",
-	"cDc1xfA3nKIwf3HLHK3fXbTCFn9MofIBb2KDYDl6ZuKkadR+oJdxlU+fLOzAH0DntRIFHp7u8/byOm32",
-	"ckhsesiXKSXJLJEOu25h70I2cEt7woKRxFa0tBQBEzZFpHpF1GibThj3yMW/MlQeyJTfLgEWqhmFNy8y",
-	"YOlWq6NcVe647hdaXc2BtzeecXUHuV1CX/Buvnk2Ar145j0lzzz77NrcAsr48eM7BVR2/MD3egl3vdIW",
-	"ZNlQ5/VP5ogQHCIHk3vBZym9FC8OfMs+/FVgPtq3f1TCnhevPjcDwI+0fNU2TSw6WEiDZDbGMQrbTaVb",
-	"VmEs8P+AKwIxo9vNut4naTR9LAbQZ2f4fBiDJxOI7HVdZFMAGYPBFIVC2PV2dpUX5uUuOKpqcsh0KKsp",
-	"AfmMPFGZRp2lcvsvg7mlYI2ni7vrirsogeaBGDe/K3RUQqQX7s0zJqP53q3rQdL16gbmZWuV8Pgtzyvd",
-	"FT3bdTclfNal8C6KyV+uffXaazA99MV33fePDjR4ufJ+V95xhVZTMPIedIBkcZdcbPkWeL+OEVk5WvMp",
-	"X6KyHqZA8SiL27hh64yfEytsb7zlZtZFaF0RPJlwqijTdZljgi1hlt1uvzelsCPj8J666eNSa4InWIB+",
-	"hhm4/PWQCw3SZr2l69Nu99y2D9nJMnugr3CWCnMGHAd7+69e9/plC4jjlu2t9ZY1Pp4cGZhElJd3s3wr",
-	"1Q2quZiP4sUcfiNZfJ/wLHNHfkXHn+Tdb+ll7G3TeqEuN/X5BWg9lgsXJTD0U5/q1iBEtzjGvEX7M/sL",
-	"EjuRs7woT/Ul0TDhb3Xd5RCw1uTseaTEtq+HRhp9NwpEao/eT4iSme+Bu3IsPeuLHsWNuJuLcvK+NCoe",
-	"f/gM0tStKkg/vy/5Vam5ePd6i4pEU4MUpyjCMeqacU73U9fXI+focd75Qs/5I2YhdWzTVcXPAclnlpzU",
-	"hU1mgb8KHP3RniQR8nbehFFUJBYf0CBJRVmRqPBTc2v7cmQcJdFq/TXXiZ6HGZv+x1hxm4osh4wNksdN",
-	"vlejLqvbeoGjh2qdkiv0zWvfiGx17I8L2x5zmvsynm2aSXHPbx/LmfOAX/Lg+7Mr7ivScEO602/50TMx",
-	"vns9dfnx13anKrrgGkwTel6l+00hmxaqX/XFvi9uRXCI5iji2xsY4G9VCTsy8dcssj4x/wv3Xsrl3/k6",
-	"LJXf3xfJf0HsOWP47mN4Syye/uW+mGLAEpfF6aGXB2cYZQt8r4js+8xuyWNh9h7FBX0pobC+Egpr5A6X",
-	"FOuhOaFYlY9w/4Sk+m7i/DMU49cgvleRykuIfxLS+4OJ7R4k/EVOX1JOXw0Fvodg7iWQb4QDWy3ntSLJ",
-	"+xlI3Ju/CU4Rfb2iebtI/qPi+O6DPAgvwransL0OIftvFMCAt5ZpLY3uXmL3D3QTHpwde5jb9+LlsaRg",
-	"fG92jKKAIDYg6BYRFAeoS5iL7AuKvv6l3y9F11Ex62OXkksLbpOVK6D58SNEqlsucLNy3L7o6ZkaoMBJ",
-	"HWY9hzgSZX9wLNyPWvBxo+HVjzQKyisJwMZD/1eDnJU4YnXg3fBw+E38/6rKYOSsvxjVyfGLZW40h8uV",
-	"3uGjyMUiVvNc8rAwc7NLo+qyQasTFCNSCrqhnuTzAYJWHykRfQIRpKuhqHVhoEtEf7owr8mVf5WBXmut",
-	"iGcs9oGqinQJ4HopgdekBq8J9uoe47XhEMnNR0ZuPl7xJUyxykysG1+HlEGW+YUdJnNEYBQB2UXo+FJE",
-	"BpShVP+2PFZfynU8A9yWO21ily1MVwf0RHFWL38VqHsfNri7LqFY5wsnHCV3vmzw02WBV4Skw2/6z5Ur",
-	"GPTAjbR0o2qGj8ZWH4WmISedz0TZcFfabysKZxSRAVukiHomNo5v8SQjKAS8JxA9JV5mbIpipg5ScAOW",
-	"G5Sbql5TRK7E7PdEkzz7f2OuOTXbkdhFtTRAU5ZUx76XxqbVECpjIV72ojs0nibJFzocYzbOgi/yrGsL",
-	"1ASIUkQBjoNkhuMJeKt7ATUQQHO+ZMASnc9HpjFyOFD+CuMwQvkIH+UAveWldBiGWKZKuiB8KoY52kgT",
-	"rb2T6rJTuNBh1PL0k/FfKNh4qkEFhJO5qE3TQML0stWRPJw9dVm0RUFGMFv0Dv74ZCKxRIoqXplES6Fs",
-	"DSJPMJtm405Y/Atmv2bjpVFYdt8k/pYW/IK8jwp57dPphLkR7Iy57+G9MPc93DTmmgt+wdzHhrnG6dRj",
-	"7hTBiE1bmcPzfwJ8K1hEVXYPUyC7LnbANQcfZxIjPEcxopRDdYzc1R5/lRO2ogBDX9kwjSAuHX7hl3X+",
-	"T4dDVuWgL8vrbYaeaAOCKQpMoJ3rXWiwJSmKYYp3NHK2ctbnKYoPL07Bq51dO7eUABybYgr4ZxyD3y7P",
-	"z/iPM+i2LquRRDKee16kUhXJ2iWGSZCpglyOy+0epZRAqwHmXLBx92o4AIKgpGyNkB/xVlXMFZ1FMv8g",
-	"QCkDilhSA5V5E9yGy2L4VaCyHqgDNksANMF1lG+hFZ3niFDsgcmqHcCxRFAhCo6TjAkAiwMUC3RC63c1",
-	"yRqpv5qiifD/Xt1CK3YqzJnnG3AD0h7lW2+MIEGEi2x80O98WDGQ1NCUJNEkgBFQrqbqronSu70pY+nB",
-	"cBjxBtOEsoOfd3/eFYoXtYryUJKG9QsU7gtxXZ8disM0wbFwrFHOsMY2mlxqZzCGE6QWp7rmX11dVSIm",
-	"o6N2NixUa8VQqrVroKIUQ3UonfKqGMgoN1Adyihs7bkuo4drwGPI4EUEYxM+goQYue/yvEcMkgky15r3",
-	"dg0tKiM7xz46HR4dq7TCOL4lkDKSBSwjqBi66O0aW9YMhmMcYbZwzjFLYswSTokE/kTJZCKjOTXWVEZw",
-	"Hl2UUYaIjp1zQcs4Odm4ESilAZ0wqozYDIvSkI2gqQztCQarDhhDszQS/vUiLyIKwXgB+C+cJgEUT3CM",
-	"ZAr9MkpfKc3UN6fPVTFuXoGbCiNIQBJKB0HGhCN/kMQBIrEx/pX2ECyP+0vZzSOfouj80TAG1O57ULUT",
-	"Fqvl+KVcUsobbhp8lERoMIb8zYaCeec7YySJqvpJ5wna2jTH5rFIXjbHISK5oDMVDLZ5ODlLXQ8+gmiS",
-	"kQAB/rYtVMCEiE9KCtqbDzhSrV0jXpY8dp0bq7juVscpMp3KhQVJiIwsnaXjlVkIHcTPkdbOtSBXcrfv",
-	"n77/nwAAAP//oFxYEMp2AgA=",
+	"H4sIAAAAAAAC/+y9C3PbOLYw+FdQ2q+q7V3Jch7dt8dbU1uO7XS7J7E9st2p77azaYiEJXQokg2AcjS5",
+	"2d++hRcJkCAJypIsx56aqXFEPA8ODs77fO0FySxNYhQz2jv42kshgTPEEBH/eoPjEMeTMzhDF/wD/y1E",
+	"NCA4ZTiJewe6BYjhDPX6Pcx/SyGb9vo98dNBb1yM0ev3CPo7wwSFvQNGMtTv0WCKZpCPi77AWRrxHjDF",
+	"A4rIHAdoEKJ5r99ji5R/oIzgeNL79q3fO4oyyhA50ou/WqSoYZmu5g1rDgLWYb2TRC+3aanHkMGLCMYe",
+	"y8ybNi0xTDsskU4hQeEghAymfOCmhV4RiFn7IkWzpgWWRvM9/IwlNIARIu416hM8ieeYJPEMxU1rNVqJ",
+	"pYLbhIAc4wc0SFIUgiRFBPIe1L0VZM/luZNa1NXTN8FYt2kCsDlO96vVvLa2++R7kVZ5j/ScHxLy+TZK",
+	"7nzWp9s2rfGuy6EmwWdEBuMMR6F7lRmhCalZ1nkK/84QSOEExwLhQCCag1uSzAAEKUFznGQUEETTJKZo",
+	"7ya+gJQCNkXgzxh9YXL4P8EcRhmS3YzRZohBfscBS8AtYsFUdOT9eCs+mgbB3xkiCwMGYtieuefq1nwo",
+	"mA/p6kS5QnQLs4i1kK7lqEHtbV/BLX+HZ5jVrOM9/IJn2QzE2WyMCEhuAWZoRvmpEcQyEoMUEXFiNccV",
+	"8cGt01Jg6h283O/3ZnL83sGLff4vHKt/5evEMUMTRMRC38M0xfHkNKxZ7CiJEJjJRuD02A2zmR7ED2ov",
+	"Xr7q924TMoNMruan1z3n4vhB0BQGTSiXt2k409gcx/NkZ4tB3s15xBck+QsFTQinWjQsLC3G8F+W6tS0",
+	"qH9zhKlZ1VscMUQ4jUkyEiAKxguQOlZaQrpi1iWWNUIRgrTpGFWLBliRYgxPWM1f7O3v7bsXlESNq+FY",
+	"37AU1dv32Q1nOHYuo43ZauOy2GrZK4+n1eNFvTNG8SWjkMExpGgwwxPJizWub5TFPkskWdx0iHKQJaQS",
+	"ksWDFy9fvXas8RsfTT7eUoSC4Qj9nSHK+L+CJGYoFn/CNI1wILY6/IvydRuz8ZYhH/fN4fGn0cm/r08u",
+	"r3r9XogYxBHtHfzxtXeLURQq0tbr92aIUv5gHPQwZx/Ufr597PcQIQnpHfRO4zmMcCg+IsoOJENstTZ3",
+	"/r8Iuu0d9P6PYSEgDuVXOjzhQ47UNuWm7RMozQUMsVJwcvFthIPlIHJ0fvb23ekRB4femSazPxRE6AcA",
+	"I4JguADoC6aMrnBvI0U3HTO8TcgYhyGKl9rZ2/PRm9Pj45MzY2v/O8lAmIA4YWAK54gzBjNMKWf2WAJg",
+	"ECDBHYpTlMta6SnS7PYWB5gzTMXM1JoaWTOfxgyRGEYncv1LQOH07OpkdHb47tPJaHQ+6pn4K4cG/BYi",
+	"AuTvq9xtzfhnCXubZHG41HbOzq8+vT2/Pjtuw1d+xLdimjWgqjX4dQwzNk0I/g9abk/XZ4fXV7+ej07/",
+	"+8Tc1mHGpihmqv86yErNDCAhgCWfUQywpDvirVCj8kkPA97+CKZwjCPMFg6BUX/DiAolAQQ0RQG+xQGA",
+	"gXqPUpKkiPAmAlZRlNxJCLqhTsHdFBGk+nNKq7v0e4Lhb4NHseCRccXUiwMJgYueAFGMuy1D9VjhKoof",
+	"krHgAb/1e4dpGuVd8lN1LVN8UTIw78QlDViQlQrgU/w7IhRL9CxhCEdgFOadweHFKZir1n3jOU9SFAfT",
+	"hKBkL0Tz4fwFjNIpfFF90fu9zzgOPWYSzcwpciWEa1DJg7QOql53i88O2saVIovf4Fq88ZV7+r1cW+bS",
+	"b6hP/LXg8p3AMhRz6fOPXkAQZOKXLA31X3EwhfEEhb2P5hqKplUesGDW/jBRQZ1TXzNExTI/upAzY9P3",
+	"iM+N6YzzI3ji0iLx3zO1JUEVYgBtGjTTg1TQlDdiEZop0tpI+Iqmai35hfraTALz6QFvDnbQ3mSvD256",
+	"f92xmx7/I+HrfSn/hin+9Bktbnq71oH/dcdaAS2+9q091YH1P0pBzEWoWu2xVr3ql0gRdC517fwrGyMS",
+	"I4YoOBod7+7dxMfoFseIcqKMGEhuFS3j7AdkIIAxGCMAKcWTGIWcO6GZWBIFcwzlqMoMQaUOzD4prTZr",
+	"O6ZzMeh7xKB401IUtPUow+OS9ynDNp/eB6LK4NIKWHPTLpDycThAlZpetud8nYYdwCE/7VtOMcYLjvnG",
+	"4YMggnj2sLBUkFgZSN9hKaPZYOW/cowL6sFLK0DI31WvB7buiF2vrLlJOXiHHV4qKNs7vFR8jkHlmnZb",
+	"pXO3tyhglhJS8ka9Mvt2kUQ4WADZAeyIRpx3C1G82DUeiqJ3vLDfBf2l8ih1ILYCOCbF5ajMx+C7HPF+",
+	"Hv1Hqm35TMx1FCP6nFEn9KuSzVUj4Qqxb2m0q+6yygvKh6AecMVLwWVkjsdCkGXUfAL/0MrNA8l4yGnE",
+	"D3OM7ox/hihCDPFt51Ct4GKVQTcWVl7nr9kMxgOCYAjHEQLGR756IV7LfReX4G0WRTndFqpFTJliUqRY",
+	"3s43KbDVHx+XCb9ImTAMMW8NowsD9FJRVuJN8pYgkP3luZrH2KubsXIjHeab0vszkFawFGIiJiq/XAF0",
+	"Cm6Be/jfPlzJYatM94QkWUpddEesoHmpskm/rA4eiEFbT0ouVk9Ue15uZis3jTwYuwXuMJviGMBC2HgA",
+	"ruEerFcjz1WBry/XtQy3tT2gvB/n5c1yxU3QXcl7t0Juayk2q3GHz4yWxWj1ewySCWIXkE29el4Vze/J",
+	"pbWzZ3E7oV0Zwq4CUxX0y5q4W0RQHEjKFIO8NUedCn9Y3o1bS/YvHIccQPKpaRzRRMxisw6dgoWojnV5",
+	"6to48a7lseottiakTY1TI7zvQRI2yATnWFewwcVPghF+UL73GM1RxPetjU/qQWz20ujE9l5ZJKZkihff",
+	"Cu1pCtnU8SaDHSUrFJcYiKPcrTKiuSK33QHQ04cvl1RanVG8XTcqkHoDWTA94QwpZMgwbpc8g3mrEvYi",
+	"2Unbbni/MkzU7w3IXB2E+poyyotuo6T5+B/bwVBn32iFg+pYBkSIAkybr3XeBOzgGFBBz0jI7wfNQbPr",
+	"C5tjNVgrUIqFOaFSxysfozRKFoKd1QyyEvpzVOcXiTO+uZde/Y05c5L0C0gEu7z05THnriMAqOpF2OIO",
+	"WPcClZznO3jA90sebXWQiMu+cf5mHtMzrW74dBmSIi2zYRah8ArSzwbCNKHnpasPH0uCyXcUuzXvzyDL",
+	"Wi+H5uxl41rjjD5QbS0p/O/rUe4OjQ8Lq7vnPj44O5VvqjoWtZqyv7jtelj2kLRvoYJSw4V388cX0jcZ",
+	"hSBSNGtF4lut1NbvFf7QbYNcFC3dPLQ1WMPmL3MkKjF44nfBgdVKdRGk7IrAmArVmcuQ/w5SBuQJAJa3",
+	"BAyXLt3L/Zc/DvZfDPZ/unqxf7DP//vfPcPPNoQMDVSvChrm/mMtjJpah25useJRBAgSWEkBJAgI9yjX",
+	"ZARB6sEUqrlUa5sVzB8Tfq5CJ+siNM3nkhs1pdBxGl+QZEKk/vQwYHjOv76FOBKW6MuMpigOy6bqvKEP",
+	"55ThKBTu8Q7akX8rWEz+QB6dDo+OgQg4ADi+JZAykgUsI1WWQVnND138JP+ksYYyOEtXhzqNfL6xLfOD",
+	"OfkFwTNIFmqPwsnf2Ll2JnWqX0NM0wgu3I9UWcSQbauP1bHUpgCxVHDhDjKofcOL/Ql/yp0sxn9nqCKb",
+	"7JbYBBnVILacNs1Y48thqBaLN54DjUtOBiC7eXaM+TulnH3Enjy0NOfOTg2Xz4CYamKuceSmGe6XzdxN",
+	"gfwfG2+e90NVAPHej1Vx7R/6vcpX4qEBAsZJ8esolSzGZrqpgEpYqYiuNVx1CovUWm2X0PKYBMbwLqtc",
+	"y3vrfRwuc7XueYJSmH692sm7KvvElBGIVaTuUmY5HFMG4wANIjRH/LXmGwx06GNlH6lTESLsj5YaxAJi",
+	"fimHMJihodaGpHAxc/qsuR7KowjnvlDuC3ueovj0GBwlccwlkMBy1aoVqi0x/BOKwzTBLlHv/DBj05dl",
+	"qV01B9ejd9aOp4yl9GA45M33So6FuautU9z8Il2OPwVivw5ieciphNB6qKZANrU37K8AUaNI+LqoEaY0",
+	"Q8QBkdPjIyA/dtm/kytDQUYwW3xCMX+YHSTjwxSxKSJlXztMgeoCOCczRcpV21yMvABqznGSRAhKlUby",
+	"GXmcuHQjXuqkpafdUIzQ7k9nL6dfh5kOHHEA0EmDKrS0zWXsO+VAK4CoZUQvRZT8g/Ghavql2NDqJi1u",
+	"VDvW3OGwxImqzADNjOhSjKFaUi1/KGY7PXbIu8kEBzBSJ5AbxknO36bTBRUt1LasDQV4UPzsLRFW4Xdf",
+	"3lRvr40zrczcyRFshVxqlWA8MLPqStrRSsTszAQ5HQvRLY5lXAG/yFECQ8DQLI1yb69qZIeIvWyyqslm",
+	"QMRgAqJ5Z+UmE2prFRUeM5AxGEw5X13ASvKlmCrfbUnrwI3AoJueQHcZ/8n5zT64sVJvHBitrJQcvPHu",
+	"Hji9BWiWsgVn3ZMZZgyFfRAnAJpOWjoRhmQHxUak6kbt7f8GSRwt9Ac0G6MwRPwVEPew0LPzDfxARcjM",
+	"njGKtDIyFO7ZhkYrCtXaVJRMJoh0szOqtX7ICXTrid2ZMaxU0RVMSxuy11zK/CAJJgw+q186rXgrn0nr",
+	"4tQ9kVfqzgiY/ZIMxpCiEMxwQBKl417f+/hLAi7r9eiN72I1X0n+NEK+dBnIqGir/UA2ZSXp9zQxcdMm",
+	"MVtyW5CcHTVUH9yh8cCItuuD3CgyYJB+3vUzH7ifHmtRnu+PBSFfHUnpMbKvz4reI5v8b8eTlGc5aX2O",
+	"inwoFkudI0SYK7IfEy9d7KqFlRbJaApOOiVJmMkwRA2BtbPTfK313DSewQm6yKLoEgUEsRG6pQ1qMRH5",
+	"LLqANIsiQEUn6nwoCJpgyshiIBt1eyAaiZmdY8efx29IobMmFj8hExgrmfbXq6uLi4S4RG+jFeDNQMrb",
+	"GTv4ef/nfTthzKuXjoQx1QkvPWe8rE75+vWrzlP+jgnLYPRrQtsmncuWYJpQ6SSPdfQ5I/D2FgfWAeqP",
+	"e+qnvSCZOW326xGpMjq4Q5QN+PVtEq7SbBzhoP6gL8T3uiP2gnYxxWXrHNVD9T1TOUvjaap5KueY6+lc",
+	"5wjTlLadoSQXlywhHjp6qQPjHQDlPewlOMhTby7sTvLLQPRZQkwuKNDqpOQqzOvvVgXVqohRQ3zqSIQn",
+	"l5RvfEkOqXgPV8QdFZzIdnBG1aeglUWqdrF5pVkSY5YQIbzHIeASosuPYovZJccO6/imIxQzAiNgPccG",
+	"BxUlEyrAMEOM4GDt3JO19CWVko7td2NcLGDUMy+IXI/euRwwKQLXo3faCniuGoPDi9OKcv9gONSD7VnT",
+	"DsQZ7NF5ILiRDb6+Bf43vb0kgIcTFDMvEIyODoFoXQcDEsAB5A06A6Hl5XDgwoYVrdUVdFK4Oi7miki5",
+	"g3RuK033cR6oP/CdMkjjaLHb0ZnARR93hK6yfl6l/TPjTOpBbzke1Ddbyg+hfoktXgkz+OUdiids2jv4",
+	"6ZXI7Kn/+UIY6znf1zvo/b9/wMF/9gf/+Ljzx0D99X/qn3b/n/91f/eGItzGBxOsFBNj+dZIvfJOhCYw",
+	"cBx+43siB6o6TXuF7LRtSqihW3mWK6XyN9gUcQOpeFSFRnEQZIxxpiVI4gCRmD4KjkVurI47ORH2ZgqE",
+	"pTqJGX/TEhGiJNT5ki1bDz9ymLEEXNZkrmxhQIokmt5a35Y8mY5nyOvxEStZUnaQdpXVvDUSyx/6efEJ",
+	"f8rvmBlNLccQnlNJJi1ewyIV1O7eTXxUGNlEnD1QowRJiAT/HJoexKbvUB7RpRyXNhtjna9bBleb/BSM",
+	"ovNbkfrTbwAVq/BRuFuH53G0kN4xnSK28+G8kbYoJ3FPTM2xY71o2rhrlZS4uvHT2SxjgmKprMSAxjCl",
+	"04SVo5o2HsP0QM+KmwKXsjq3p2Z+5JFNNdKPBsN9ZZ1uMTwtT1IJyTvfcI36K7vp+rZty7vkjto+RlQk",
+	"HeVniWRsz1HtZed8hPCoqXdy5DxyxpIZZDiAkfC2wJMJItK3h4Iklq9WmlHL0fYWRtTp6shHkwEyVq4I",
+	"1d5zEfJ95L+rAay4x7spikGRpLHV+zJo9uGp6LRte33h4WIbg+tFRp0eo9zeLUzadmuw4zW7JUaWpnGu",
+	"9qM/22qvJ/csAlhkCZhBdgC+mkb+b8OvQblyy7eSDKnZnaHl0GAIjTtFm/8RuH2bRRSx/wlIEv+VjP+H",
+	"/y8lyZfF7vCe8mWtDJbcxU7fY/4zneIU4FjuX+dLsLyQKvjQSOhNgVxT+5IT0BhFSTyhgCVd4uXNnZor",
+	"+Oh0sDfLbfm79NsYmo8ic01RsCOJofR6kxmFZKJuhUglN7ldl+8/q/F+k8KUDiSgyrFN5oEqH0c38l8r",
+	"lGh3Le+RtCuYTqZaOhWJZmWq1PwU1DzsSpns+RoESSxP2KUgzYjgPORARctcadQdrmoIF0gjyBBtYG+N",
+	"ewbHXMbiS5CdQPm91g+Bw4/OU7Fj3sW6SZyqMTMb8gCOgxcvX7njTcUYv0LqCGfhv7ZNLkS3kmXi5Y8/",
+	"HdRN6YppUXaF8BcU1yZQLr7pFc0SyhmtAMUsWgA9hoUNPoV06jG7RuElr7l5uZtkGk0O3KT2VH0tSrBJ",
+	"r1djCuUBZZ1skw6m73js5U7qHnlmq+x25Ab5Ysopd/q2P61Q7lmqGPPp15NaihVLeaxbeD7+clLtm+yQ",
+	"/hqhsuyDImc1eldQxi2QWAf/sRXPTuM0Y21vikC23F16ebS7lqo+bGGfUu+UXypbun7KmFefen4jmKdY",
+	"mDXhX4upr+C7V6JrbWFsuqujaiIgnkMenkMenkMenkMe6mqzeial+O4jHZYKcVhtTMNWBTPUiMsN+qic",
+	"ilg2M08pr1w50Leq7vK8xTVFZKCVIPnam7jcfo8uKEOzC2vGUvYg0WIwgzGcoNAYDuwQlCYUs4QshKpq",
+	"15HeUDdQCiqrrlHqzjzJfxWscHGL9FU2xjMBujfUpGkIU+wWiedYl1CylzEmMA4cq/gFM6C+WYIadHld",
+	"COXKzCVY8mHkN3D566HNYApp+rWfOJ2RyD24cQZ14fsTzKbZeC9IZsOETIa8x94Ee+Wm8PnFcbVqBJ8P",
+	"zvtkVymX6hX/a1atfV3P0j/Gi2deOBwHUSZS7hmn3kybvosbyNciQ79viQgjWP4+6iTExqUEO0kqz3nX",
+	"+36a749a/8cHvLXmcvicBrj7+TF/bBMyjbP96CmQVrDY6+UdZbHXs0uyGOzIg0dfUJDxls68wh6kF4wR",
+	"vzh8NOY65hDd/vjTf/1cg0vfowuDiOxzJywTXkIM4hgRGQBozapj/czYnqHphjA0NnxQe436bYyTUc+4",
+	"a2Hi79SvIoudPhVZHNc4I2YZDutVhblrvjXcjz/uo59f7+8P0Mt/jAevX4SvB/C/Xvw0eP36p59+/PH1",
+	"6/39/f06kWmVdqt1OoEYlKi7aGTSp5WJSCZt3DZJSesEvIh2rsuvrWi61cqRnPrUKUjeSD+VEoGkIKP8",
+	"fTkWLOb6kneK4WXSpCV0JJZM6pu8s5FpXso7uA6/7nEVNdat/D7muP/gl1Lbtxuyow4oW0SGOb0l/fIV",
+	"dmGLSMDML5FSAauxjGTMtheU41b+uPpMzK4UzLrGg6gHX5N8uasdWpuchc+X0hlrCNxBCijyMkLXZ31+",
+	"D4MpjlGxM9nQcPApDs/0mwySOFC5mbtmflbGdWvk3KyWybTPkcgfeR1/jpO7uGxYy5xHxxp1owXYVJle",
+	"4fq5u4Q3qFLV55yPA4lzcNdcHUmqz+eIEBw6KaRqogwliWpJHXWO597E5CSe/w6Ji3Lc4gj5E6W3OELO",
+	"gZzKGEF7ywHTtYVL1AdhtxI9AQQxuqsP5XYUGBQtRYSlymR66IDwIQh4H1EACJnGXiBCL3Wmz1ISzJ2L",
+	"k/fKC9BGnQH/z5uTX07PwNHJ6Or07enR4dWJ+PUm3tvbu4nF3ydnx5XvW5IHxghve7H/8vUmE8MYU7/8",
+	"8aeuAUbljCyzjDIwRmCZzCzrivHbwhQvYEe5UIi8Oj/v/7y/+wBZX0qreP361e5zIphOiWDWh7JdM8qU",
+	"MWp3Iylm7FnLCLT9SWda4+pd71m3jC0f295lo35mp5c5aCp7Xxde/NgqaRpFNOvfomvrsbEh4Q6WHhQ1",
+	"aarWCWdB4ZVFYPcdNTj9kOTe2FGLFasqo8g5kF6/d0cwkzEnj7NkeBc8q6CCBnwnlGgqz6jwoOSY3Q0Z",
+	"yoFrDtug+N3NXp4rm1ge8Sl5PZixZDCR8jIKAb4FcSL03HMcKofN1qDHbz4b7iquNMakrTc+bAUhYbUx",
+	"UDv+EVBO16Jhs5uTn060Vt55D3EMRieXV+Dw4hQU82xItOGTXrom7STUWHa7ijSjlKPK6rDbYNdbI194",
+	"37gpiVXNDgm+EVCWu/oKQqCkr4jjVSjUSylBgYi9dO7y+ORidMKF++MDcE2N9QhNFF84guEeeCfewXL0",
+	"4y1Gke286nlzlrZ2qf16J2oRVG55Pc6TVty0a2yOt0lVc1HMvgp1TYueptnsU0Bim/U1z4qax6WoeVZw",
+	"PJiCY61qjZOCG+78QjVVwA6Ld88nOXBB8YqYmeI331T0zbn4DOX+TuN8psKkSFzryKr/sfwg3SPZnrG6",
+	"tdb8a3x2DWxoKIOKBsZrSxmc4HhSQoZNmUjU5Cd1k7tf3TCmFwTd4i+Op/fsEqTim7zQxcADqj1QSZIx",
+	"qY4yeE+5Eqe7Hi3Ygw6S7BRTgKlM8KWBXSO71qZYcaPdSakyfEcGo9jqhvI8trDYZ3qZrQRsnIQLyQcL",
+	"byURcyh1EDEjibY2mM6DJaLWdHfyZdTenDOrAq6KQhSnwBCc2fD8cX9/XZfm/QKcGVu0rup+J9pVOGDm",
+	"LkmFqaYPNFZBMIcRDoGzGDD/a7fJf3PbkGxJA0A5hvrZBGAgQbMRII/X9TEENC1OZ4L91u8xSCaI6SiK",
+	"pk5XRctVmAgsRFoBBm3WTPCg1oFjjQfKFlB5pzobB0oYWI95qzMNGO7CnRlu03+5mkVqfTFQOUAkXz+G",
+	"FH0SETK9NKFsQhD9OzoYDqMkgBGXhQ5+fP3q5XC2CMecfuOJtOB8msu8p72D3vzl3ou9/Z7LnqBX0J4N",
+	"q3AhTVSUSenw1FIH+QpaT9Ga3FLfug60obyWo54WQSlBlNMKwXcYj6HWyj3milvtCrsLgmeQLB601tax",
+	"sgF9R8W2aqpstbiGSzg0l9oqyGqD47JBQrVrjqW49g/L2R414ndX0qvg1bdDO/hcUOuxFdRaXSUtS7re",
+	"6lpanYtora5q1taUyzpGQR78bW//MGOivIKkZKFu50glydAXB/gOi2RHujPQjav+Lu6IjJEdgGEsokBO",
+	"zt6CKaTSnUgLFR6OLaHn1gminKXY4bw1+KdVvaXZt6R0Ivl87nOIEEMjxUuOEE2TmDozFMsvIt4eCJcu",
+	"yW7WxvQV9QhcKaT5rGHBwx5enALNxZtATlIUB9OEoGQvRPPh/AWM0il80ZyVrnEmpcY2atsYzgq+ZtTy",
+	"oK5o3qBt3BoWyDm4JmwduJ60NrjpXH9SKGbocKSvntDzJ+zTbZLFoa3KKRo0E2Xj9PuW6cBcmRshuXjS",
+	"wb1NOWLB5Zzajso+cZLbzcf1dV+zsyYUE9ZvkUtgFzhFEXbKeUV5jlQ1elzhs3pr9ZExDMYhJFYlknyr",
+	"XMoAIZr3tRmoL4qWcJlu7TJcfije9CDfq0PPI+WhtGXMdeclmCV8tAvIpg4e7EJ/BylvAMaI3SFkGYWo",
+	"ryfXhTmXi8moYwRzGK6MD/SK/z+JwzTB9fmti3hJGAP0JU0oCgFSnTwTEuk5qic3ZSxtfR4ateJyRXoG",
+	"IwvFMj0F27tER3fYZ77tcmLFmm1/cx6PZSAoT5B/lAQjiCCeCUIhkqg63NsgnlXH+e3DlepaOSBRO8l1",
+	"QnKCxiXpNZSDDmrGLGGzXKue6GMzbOoT15WzaqEvjMCAScN6sVYxG5XMHUs+I1e1NjfwjnLAKeMjQ1Lp",
+	"xo/BnELF/N5ImNKbHv9bGBzoTW+3CvV7K+uMZNsIaHAaqSVrJqk5B3Nm92mIyN5Gm/gcEsyXVvUvQYtq",
+	"z99Va/AZLYbV1+rw6vDN4eXJJ5ktyhdB80Gr2KlV7lWFu1C3u2d4S5KZX9Dz73nzimcJWjSA9HdzmvJm",
+	"ogyBXA2u1BgV6FKtbXWQd6nqqO/rPBnVi3/z5hFUH3WOS6TZ65uo1IxndaYBg9OSZsqt4SRX7dQlTI9N",
+	"bmTPHl0b8Og6NjxRzOpJ4oQQZeusl2nM3duMp1aI5n5eWg/uleVpypmv0nhTs5dW4aVOXjB35S8y9Ht+",
+	"6c+sapvXp8e7XfOhvTRpn8i51pqlERs6EhMkFgK1yzM5WHy1yyUx7z7qZfOFemAF8wkhCanXZ+baB8Tb",
+	"cTqq1JvyzKraZleOmEriHjmYaFy8C28Ojz+NTv59fXJ51ev3rs8Or69+PR+d/vfJca/fe3s+enN6fHxy",
+	"1uv3zs6vPr09vz7jvx+dn719d3rEe5yeXZ2Mzg7ffToZjc5H9ktidnHoZxjEEW1UkcsVq5aaRxdedfKx",
+	"F9/prin+25AR4VLVKd7yn2VVhABmXGgWRICPZl0lNz/UkARKnKvO/VS89XIZFmHRToIMRAhSBl6AYAq5",
+	"8FPjdVONfyuhr1x924uEzAU6k1P9UOR6/EEEy0o9axuB0MAT6OVEec6RQ1avNb3E8SRCIi6rMDMg2Uuq",
+	"g2VHt8eXA4/kM8USPUg5KygM3dlTc9NNEw04zNj0P0eqrYCF4nXanPF0O/56ZAI6nzynvJTN80krit2c",
+	"24KaHJdncB5MSWVSReqSYklfyMpJjCFF7gzNbyBFQn9nHcEQpng4d9pLpk4rdK604Z9dqVZbTfZOI3o+",
+	"rNOAXrWXiwNxudeN3gH1rZIh2fnaE+ygTVkUgevRqTPJcmmLfIG1QHQKacpWLgNqXEetbOkqSLI5Wbds",
+	"9MnFs5zz+/FSD3N6bJQ0kT9V1G6FMW0QRHg52QPZyy/lPHAOKnU8tRuQn8urt72c+MoFe5SS5BZL780Z",
+	"xFEXP6e6GCgN4Hyhrhus86053rkIgVmSddbuiI5OzY7EiL0FnEXOl5FP5qYB78U6OBEAOC7ykZYpQjqU",
+	"U3RQG4nVChLnFqdWqgsy9+g6jII1HxlPQq0skmtDhI74PEXxkbgEwuislbH+tmvDVF3Et9TYqXdXa8we",
+	"LWfENqv1+7vv5pPl3f2sHaN1GMVdomUHMdI3JIOqgtdLQEmrBkr+wDXJ8l3m8RzOrpW9l/xkg0CDOSRy",
+	"xlgLNJVDq2Wscw8PF+tauAzwE5QOCjQTzvK3WRS1G+f0oK69ndWfe+FgWKPTjM0LXRNutXcTH7m/UDBN",
+	"osLVgoIIf0ZA8em0X1QZpdL+bMi3dO8mvpoiao0GiaFEyMsOR3CMIvBn6fqrxYoVFbj7T45kf+7dxI/C",
+	"yN8emibywZgRaY3KnnWEoa0q7Gy3k9pqWTXZcs4+dUqyYlP3tao3a53yeXx1TsWduafGqTjpB9Y3CW72",
+	"giQMBQyF+ll4bzy9Du4XvNzbB6nuVNA4/RQASPMa5jgGo7dH4B//9fJnV0arQqL/JPJVk6YALUsBIJuD",
+	"69G7UmxBLhJlbLpnU69uAQZjBAkin2aITZOQfqJZysVA5OBwLvUnIPtIYzRQPUvLQzDsWjeS1DKMXLIs",
+	"quGXDqRWUizR9FmQuisdyWE+xd52a7+lGG/f+6MLkfnKXWpAijZ+kJeYqYShpeUre899S3fixNYGNHGs",
+	"33kFxV/8yjXoew3qK3sWl22HCwhJJsupDgsWbXfvJn4PWTAVdV45LSVZwDIiTon3nr/YK+bOSblQSdLc",
+	"aWiOofj58OLU9bzDOE4YzCMr3Rzo15b3ufcepnxR8jMXL2nhDiNlbMoS8Q1mX3CEddyUK/2XLrt2lTMV",
+	"G2U8BNe0Xlgo931ZPk2xgC5ItKtFiuLWXra15mI/65ODNmb+2l9eBqtGXjkez0qb4gT4wc6SGGs8j0MQ",
+	"JRORzQPHtwTmt/dRcNiOndax2kcoZgRGwIp3MwIio2Qib8AMMYKD9QdDWmsHHR0eHBtfIg7RgsUq+XQH",
+	"kFfCsTu2vcrAqGY2vjq5Lz/vAMd9OXsHHXhoFr8ukLTBXQnGwHGkhSeRY5fdXJVct32n45SmF5NzQfWL",
+	"tazRzr5LGBlce9L0fQ+8L2V/OT67HLx48fKV1LPs1bhCbSjbS5tPlQQRItejd/W6PN2Iy2SWa4LKT8Hf",
+	"Mgc191T0GdZ/HMsnSiTHIIrSuBWA5pIwBXAOcaSsHXUVlsi1q9gpH0D58el2Ok9w3TNVlb10T6vgZBcz",
+	"3YVFN0qPfUZoQlSd+4Im5ILCHrimiBqSxIA3mEsDCY6VMV26Ud/Ewofs9hYHwihnDMemJMkmUxBBIhW2",
+	"/M2kSGgWq7p29IXJdbniuaBISC4+CxjeIhZMOZYIlRL6IuZFe+ACUpWWRXDBAAqB5ib+U/b9E/ydIbIo",
+	"cnQAHBdDKO+APXA4psLlXtbDQgTdxJAgECdglhAEBDWVeygODi1+e3n6V4LHH37f/9+XP5LzX99n8MPP",
+	"8/CvE/zu6LdFiE9/ev+ff++fvdr/p1uEnkEc43hylGQus+phmpLkC55BhkCczcaIcGIilgLyvgDeMu1r",
+	"JwByE19pv7sYIMpkf527HIwXprgocJLzO4kgP+gLDNjeTXytrub1KZjimCkd8k3v//tx34DHTW8PvIcL",
+	"Qbck+G4TchPf4oghgkIBeIzKYHv90qOwmBu9WTDtlDs95T3MJPGtadPL1bJIElGRJH1g+hkvnR/93imu",
+	"r9oyXNcCTkUfdsjGpaGngwiLfFKVysTF4k7i+XleVazTHk9cPqn2xs16ZZVdrj8kUmUPX+X+xIDN+9KJ",
+	"Xqxpm5jCD5UObqwoYqoqoXNCh1TI/1X9UoNWSVuapBm6uHt5BiojOZegP0UZAOiKm3S9HKb1t5nfzrVn",
+	"hiW0JdaPd7nkTS2RBkbR+W3v4A+/7rLbt4+iYl94HkcLiRRVE2KDfVQN5iuvKO3LfWUUjRfrFUwa9nup",
+	"jqkcPEz5CIKfE0w11DbNqkNZhqPQNynOG6uxUF2UI5k9Azgq/aSrqLR10LLDOL2JOfKbCE+SCeGcsApr",
+	"M24OVkU61RGXGZGm4IhaKDcK636AzotfUifDSbQfu1GUMy/TWYzpWU1BV/V04GXX6qdyBbOEciIXoJhF",
+	"i6IkarGw5bgUESzcrcaLDGa2y9nUBCyXosAEgT6RxTpLxgFJu1EpUMInHELGUTlHlfkdm0etze5bIgTF",
+	"4s0pP9bCVAdgt8R6d4RckdD7dj1ANCagPgClOtOb3JPvBblyzNdq0HJCoW7trpMZHR2KVOuNov/o6FAV",
+	"0ajI/oengzS5E9ICSRLlVw9gDKMFxeuW/+11tSkASADlVlsUAMWopgagdaNVfQAJ4EAM1JoHv3osKm1I",
+	"TQoOYXqVbLDwH3Q4FjpujPNZVjNVXMXK6Ur0qD5OjcV7V6Q/ye9AE8PdEu3ggpTB4HXwj1N71kpsDxnM",
+	"Fr8aQ7+MiDxfyasxy0ZglX5qKO3kCGrYCsnugWxYqCk02echbIg2dMQ61FZ1LM5o0Ba/uMZsK/wwGodX",
+	"bZyDNxiGG8V2i8l2lfrzEdrrzFIa4l0iLR+xAsDlAGfRD/uYq0lnbF1Xs9XNJne+EmyJ3t1Xki3R3Ae2",
+	"tI0Q5/FzjHYhuxAC6FLpG/6FFlqxXcpsCXT+Srvq1VBnfB6mkNK7hIQ1F5/PvHAy3eKL1uoUSTbtqRoG",
+	"n9eFI6i8Eo7keS9abVU1eTfqoypGppNFXRhh5RCmGBFIgunCN3Lv17zDt34PNwVCiPLM3m+0O09RPlgl",
+	"YKohWqEEStW12GkTXH814VGzlnwk6YhXz860la/sAp/YxxF/2QexXnna6RV0MozOWs2lbJpJpDh4WYyA",
+	"01JdqODJVkQ2KyHP0bKVkDsVw/bEMk5gnHUpaB+gWcoWVtlJ8eGe8UDNNRY4ihkJt97DNHXKJuqD1AUK",
+	"wEgnEFTKVSZ0+2Jb9di3ZJz0I6/scr/XohFRZ+pwlq8G71UExo1d+gZaNV2KzebnVod9Hr5GqtyNdMkT",
+	"9qJCjqnFspoovq5lS7b2XrvgeRlMUZhFKLyC9HOtniFvBRiknws5RNcTcgZFioINbgO5CMaVFR1KeRJk",
+	"8QbLmcXc6DAgSTz4Kxkf1EtuSh64ZJChBtUTKydpOAw46fd7Zy8FppvKS3+J7rfL8zMgB7DVmnb5ZdqX",
+	"Yh7tA1W05DZK7kq1Ykr1afKMA4raydIK1aQCBKURDiC1Gr/wM1VUYSH47mPI4GUNs6w4cxFaoLg6Q9/q",
+	"0Pspmaed7tnCUZ7i/18two6hPnRIH3lVm3oxpKwRz2ftG6v/WAusBnmunIdv+3IdO4O4qkfsnSi3gj9d",
+	"eb4KyJoKWvODBQFBwsMfRnSdwZeXGrccIR2UIwFBdHqFXbO8g8LMKFoAdRTuA3zR9QAbszIWQHTJIrR2",
+	"Q+uM1FBgOI0ZInMYOd9+ASesWsjwHqXHWMR2oZAX05bSILQWOLIOSA6ijhiu644UxMo3I3TlbDbnCF+i",
+	"V746ubI66r5KuTLZfGCtnPNA21jSkmLNx7XdwrtKqgtjFZ3vuRyycsdVCZumIWtueWXcVWSmUBkh3Ecg",
+	"lDf1LKsyfvjxqjrdFG3PSOV960sJ1R0ouxYO2dBsPTSTbOcQc6ql+CscQJlEQzoJ1lWoMcTFTzUZuE/K",
+	"ebw7pDE3h5eBkR45zUvKLTureYjm6u9O6i23albBMtfMKn1ERoUEqs77EwwC4RRuaSZUGy+1bRXITsi4",
+	"LqTTlcTHAlo8a0IpCdOUJHNhiGDMbc+h72GcwehQtRzl+6jLKTsT7YuhhZOA6uThgO2mpPfyasqhT/Uu",
+	"6lefe/XoRdN8Jx7JcH01AVdWuV7nVnPfXuEx5XDM3VHK6oIcgiSOFrtNmr01aO/Xr2e/4pK5A07CLmsF",
+	"4IoNUiEqBCShdBBkAq05nQsQcZUX2MLgW7mxOrnqJOb7o0AYGfjjFYE0CUUEBA1gtM7k1ocZS8BlAKN6",
+	"TVzdbjoE0eqd+FcpbuaqxQJ8eWmpBbonAy0R9oHZ5uuUY2CHYJJMdACw1pepmY3R3t+kzM6o1zNnZi4z",
+	"miLBXV/HKrTjoyfX4yh3JVdTDwAVQ9qxzH0OC1Ml/N1XtydOg+aRCQJfe1s5iXC1pHyj5aFydssf2hMq",
+	"KC+hFub7bykRaWUGbDBCqsPIvQEFiexwIIaq3U1d1c++5NVeyWmcZqzVjVpN4bG9vKD9Mht015vfWGH7",
+	"qu/sgjI0u7BmLMk6ooUxDMBxEGWhzE6TJhSzhCxa8gUXDat2EpimNTEBnK9lCWevI+WVrDkDYzwTv/eG",
+	"ig+lXPB28/nzvMhpKeKIwDhwrOIXzID6ZvGo0O1FECSzmYsZvdSaD9kAXP56aJPJcfDi5avXfgxv5vJf",
+	"/0Uwu/mByPpLVZf0CWbTbCw0FQmZDHmPvQlmyxb/0XjWErOpLw1gaJZGIhpaBW9mJSdQVTleBID5QUPe",
+	"z9yWu+xLXghOT+ot93Id0PEk+qK2R7HIOos+r7wxsseTbx3zfc73CT77uZvEqp58fgbKs6jTUQigaa+X",
+	"Zz+jFfoZ3cch6D6eQAU+dEaEH+g9HB7P0F0umutRdC6s8j1Y/kp2uRgUkSOYyiRBWKSCrwmpE4XabWdl",
+	"VUagPkt2YIzclIKw8b6I1edrXNRmKIR5GRVrWsemdZkVp5rsCs+QTMpiDgPuEEF5fZZwdZozoWDvXk/F",
+	"eZBXixT51zCFnJchwigARGkhHIvzVVYVXXzUOnJnytz3KJjCGNMZbcqHWhp6lncqalbk6/G1kh2as6ud",
+	"ux6oZcudmgsqzlv0ANfUrTVMCU4IdsUvHE1R8BkkJEQyvVAB/qLc606U3CEC/gmmeCLV93K0XXdIguGW",
+	"5Tb9XOdzmGkpdQ1ZvgJVQdY2ApVLyXYxA5nQNsDRL+OKixyppB4N+fllpitdOaLJE0yw5G4HGZGBoZse",
+	"vHLOE8xGhnRWFW66Sk793iQ5JEG9BYW/a5gjSlYKroGz8KeaAc8va4dLZDGCeAKkVG0NGeE4++Iesrak",
+	"xy9Jfi6yVFkCtFhk2FCTF3svX++99Fe4HxrydEVdZxTjqRGha0N+1D5UZlvbk2F/78Xevq+6vggaMnGi",
+	"byCgOon8hE0wuq7BBzQ2dl3rpvABjU1tw9NzV7hD4wFM0wd2VfiAxtMk+XwyF3br2pQE2ltXZk9LSaJz",
+	"EEJwJ0cAaO7MGCb4WBQWZTTqhT0jg4vuJutnYKpnKbkdWNZQBdBu8l9tioTL+kQICmYaDK11UPo99b2p",
+	"9ivKAXkHaf3QrSZ7RvBkgggKxTvhYuPz1HjijlOQ9zCHf+n0ibZcfzMdKlTAqDy5kz4o9VRNzhkcFPrU",
+	"rfMAblIW5Gq3OmPxKIsp0C7WYIYnip+VrdeYi1lP+V5P6f9+5ZvqknhZe5HP6udbxnas1+JrPjYjB+5j",
+	"Qc4R9oGNyLkxJIt97k4Wgx30BQUZb7G7LVfoFseYTmvmlXWlvGf+cQXe3x9MeFWDnSqoPCBZPKjjgRMy",
+	"cV/Vc1lloIYPnC0GCXF6iqzRPGXE0uhdfhK2jl6aUDYhiP4dHQyHURLAaJpQdvDj61cvh7NFOOYUX4Pj",
+	"U86h9uYvBd/pYjLSaU12HQZxxFk2jaZAtrRS2kdJjIqSY335anF5XyeA65LEQqdZK2YsPMqVBvICaY+L",
+	"URbH8q9L/tahUDyRb8Wae6q8tK2jNNtVtSV+hRdWUGehzVSkUpDcmcR9RSTcmri4ESZtz0+nhch1pfP8",
+	"Cq+K1nMauz3kXvKijZXMOa8qAo6tB6AwH6eIDChDaW1Z4Smk7/AcWfnb6/nVCM+RSNM9FGy/LHuX5wMD",
+	"tySZCZ5WXtZKbYQ65rW2JMIcERhF9uZWenOLHg5aglLHmi40RFXKtAKwnTDtkqG0TvIsc9x6w3JFffeZ",
+	"NeGSMVkTEnHECfEchxk0YM5nraBN03v+QWUHFz2Bbtn0or9YRTwXn6xaUZc/IwO1heo7636gxFD5k9QV",
+	"yy4/4zRd6qWgDBLmA1PVcFXsmZukSwDUoVUl1ZJHFiedoslK5FQ1SArdytK2l1w7o1dXNb4UCpx8IeAz",
+	"Wki1Q74CjUweHhoaIJedi8jqnnZmQLCjHKqDJEQyNS7W7LzBwNnAEu4yRRi6X+RMoYZKE8KoyNycD3sh",
+	"wqt/3v95/9vHb8Limmvh/tDZA4TTS08Xf1dtXUCjKMgIZgsRCK603aLq22EmHR7kv95qfP3tw1XFmvzb",
+	"hyvwxqwOaBto9m7im/h8zBcPoGohnqRFkhHFarGFTvJPhKlIPpUIYKZipW9iO3uMrDV4AP60fj7Q67jJ",
+	"9vdfBWIu8Sf6ky/iSqR5kmp/GGF+96gqCwEyoUD77cO/Lov3Urt2oRBgSjNEZO5iXQtfwaZARgH0bxys",
+	"OL5NclyQNnl1MEWFwJ5yZ3I6KOXKaOPP6pUZnVxeiarZtwkx6+6KGNUYRuA4d3y4iCDjVEeeRtFUgd1V",
+	"PQOOKSOmbTl3o5C1F1I1JEDxBMcIEdq/iUXV45muBgxmWcTwQFaMMa0OMsjGrg8sUkpDBtU/KeIiksKg",
+	"Xr8X4QAphkvB8jCFwRSBl+Km2LC8u7vbg+LzXkImQ9WXDt+dHp2cXZ4MXirhCLNy3cbDi1NDE3/QkzeR",
+	"y5MpimGKewe9V3v7e68Ez8im4soM9+5QFA0+x8ldPEw4+g/yQpEDs8TlBDn9A1hGYgruU4FU1r0QpPL9",
+	"0YWq2U9FjQBMA05Q3UVGDbOXhHKiC0ufhkKRwVrqqIpCkoITFpB4ub+fe7BIDxDDrDD8i0peXb4KrQnw",
+	"m2cWF81Vw7UBehbN6x388bHfo9lsBslCbha0j9DvMTihojKTBhXtCUJsY0GKYhwObO/QVgxIUXx6DI6S",
+	"OFYxiCVL+9G70yp1PZXEUiHQy8Lm0i/S6UmEsEdUNbQ1OBTrXIcGYmlHJWfXtZ39kVivnE6Inq7TltCy",
+	"Qdx6wK5ODWcqaxgN+U6kC29CWY1lEVEAXemIwY6oQPM5G6OAifC/aLG7B4RiD1GQEOUWRK3KlXuVU+CT",
+	"LEaFFl7V/3mThIuVwb1Yfj7RN5sTFZUg1njy1i5zKdtx/HlqPjFX2Tjzrd97LVflmixf/fANDLXjlujy",
+	"or3LdaxJKQplp1ftnd4mZIzDEAnJ+keflelHXMorAq9zTBZAMi0yGn9HebJqG30zNv3P0HAmayRDXLjX",
+	"b4z9aqgRqrjJ7+ihGv6eyOHtm1bBiJKf6mM6ULF0mANQH6fF3bqOdAxZMB1ob7J6AnWiWlDJkaURKp2s",
+	"IiYifTkEnBmOEAhgFFXP+g2fUw+4JjpkzZFf0M1SotIa6imRLZqEKBB+G3STNOjeCCg2m7slVnz1vBGy",
+	"CyrmeOZExSrirRnnHhjdjhXe+GPYo0Kwk3ujlnISbn2+OBfldi/W3pjQlfJjz8X2KofZCzW1bQT8oz6t",
+	"ok4SjPnPooijLkJ6YKU9KlCjov2ryxrQNHSRPaDDwEWGg6ahzdzL9YN/XOMFqfUwd1wYnahE48z3zQ5y",
+	"wYaWdux1sVQ8rDAMqSLRrcxhbupTnXXSUMO6VMMgqqjlomoZXa8IWZqtTo58Z+/H2sij4yGdmyhwwXEE",
+	"LoTI5xYpQJfHiVIu0Ua0sIqqbAIzrAl9kaO0o0eLH+V9VFCkdBztWDL8GsjyG9+GxTG0PtRFaWPZSQWU",
+	"5NapRoRyPtmu9cs8t9Xn2wXMookTUfgORdh4b62PXSm1rwMzj5wnqcC4Qbx8vf+6vcdZwt4mWRyu7LkL",
+	"Gne/DDaHkEHvNzCtOL6UELUwZDRTvWPIYP4WdsPOd3iGmULFfjsui4riG8Dc8sZ8KasBse+cXbMIsbnt",
+	"Ctoa2PHxW79GoNaKZAhidFePh1U0lB3LU61JunZP1knWfrE2HG2gr3kboJzmHpGe+fX+P9p7HCXxbYSl",
+	"y8S9UVuesgO5W3C7iRwPvwZhKhiLVsKs3L6k810dD9F0JQr+wbwPS3EN+QAb4hiWwmntJ/dU2IV7IGRi",
+	"OvbdV1i2BvPhEyy3wo0Jz9VZfV9z1wYf7Rvt3EwFf1xH5EIkkkQorxLoY4sr4Y6ZpacZaYyMQGvFFpmJ",
+	"pDKnL65YG3q0SGLvol79thQbZw7ewsgZB7AmVq7muDfNxDUuoyFTo45pfubnOvNzJvw6aZhNmjf8Gmtm",
+	"ThXecwQjRUjeBdfM1Qsg2zsvQKPBxokXysNYGEFSmZ3LsNz0yihumkO8K5g5OMHXLQlG81B8sVcX2n6n",
+	"/Js83K442L+HpNCCbYWQ8EhRbX9raPBTkz+8kTfNHMh7rfwEYQzQF0xlAncvlK1L+bzlWLtlvMv23JtM",
+	"ZTZ8TLxLx3u3eWbnWiUtXgWzs5RkBysVktvlu40Kdl0kusctya1cgquerYcctyEB7qElt1ay9yyqLSWq",
+	"dadaS8tmHjJZJ15jJTyGvoJ1pRi6C2GPTfjaPBo6pLV1Smlt0tljQLr9hyOsT1H+Wr3cZWRyFkGsRWcP",
+	"SWxLMXRbuI4HvBxPQMhah8zUiesoKtwsZ0iV/RulpCtdW2fd1tKinpqHiKQ2/lhlpLxgUckIqoBdf9TD",
+	"r4HRct3+omLOJh5BrOJ+7qH5RrbKLVTs/Kl5g1qb9sJNU8ppk3faY7vlGLt1wtB3H7xtb9Mrerteovpu",
+	"/T+ViOQfvp1HjC3nmmxkN7EzrhTjFkUKppAzs/woAEv2buLzOFqYDUXiFt46gmMUgT+L/DR7IZoP1QRi",
+	"/CKp0T854v0p8tIRsVAU7t3EV1NMwS2ORHG1JGMqfbw5myowYCRnVxPInDJ9cfMGst+uYL5vYiOHDMli",
+	"hmfmRl3pLfjDdlaA+Dvxw8531MaRGNj12LiR2Dw1fYmMo/TV1bbfkD2ZPqqopYWpqCw8gwwHMIoW8j6g",
+	"UF6QLtfChZJyeWdGpOj6fLKLymIP44xd7NKBpEVI7aPVAa8mOJ1fgaYHtQAUjAiC4UKqKugqdctm5LLz",
+	"tjnfLKlTFn/fx4u7uIoudt68Kt3I95m5uE3S5eZTfCqaudXg1HC5EGYzSlYn0odGLv09cLVIFX1PYlHv",
+	"sAkP+ZtkRzdvNyr6x0Y/6pjomljo2iDoBjTLFzDoHBltB9wa+Zllhss2vKqER283anULrn7sQdX1wdQN",
+	"caf+aDb8uo7Iao9Q6hXEULsQz0NK2s6Q66cZat0WYn1fHC9qwyxDTu/KFbbvQVs/mFVqNoDm2xrCXYbH",
+	"lQKtPyEvzvTxEnOzZlEF2QtUuQfCD78Gd2sk7HqeZuKe1yN4EAL/wahRsmVEvii28NQIfXnnq8X/JRNs",
+	"FAUJtaRW0PU+SFKZ2z9aKJWyzIatMqK10P1N0XuVw+3fGSKL7+aR8H4Uvm9lhv14ON+MDlk8iqtYwfVa",
+	"v2EjQ9+KhMM1qJzzRW465Yc9cR3Nf/Y09vc0NvDNiepdn4Xh1/zvsw5eyPnZjaWhstYVeaX3owOL08ja",
+	"vHaXXpQ7erKxnm2otZzfsB6hmR/eKvTY3zQBfDIewe0o5vQFHqE0Eq4JljNwDr4dfkeV5+hurffvtqDa",
+	"g7/vG0fv58DJNQZOroYhuGciRiOhntOk55QE75GG8bvS/Hlnbaxka3xEGj53ysUlci0anmZemCZ7L59Z",
+	"bpNymr3UB3INakxm95yZcQmhzZkAry7znReRHn69X3bGlnSMq70t7aR202kbPVH8qbDlq8JPVJS6XY6N",
+	"MAfw5yNOzGmfNCdhQKKNl7DO6rExE8g+cY2yFiL48hPGWF0YCmOu7WcpjMU+EFNhgsuBlcbnZ8bCn7FA",
+	"FhLWXIPutHv4FcXz+7AXxmBO/mLVl6edBBszbojH6IDxT4XPWDu6DmXSYEQGojK1h1+H7gCuR++kT4cg",
+	"OjiegCiZyNQCM8QIDqiqZIZpF/Q+V+Nfj959t5hu7LHJx+PcBLVRA/spob2Fb2u6AySAAzhBMfO+BKOj",
+	"QyB65Lfg8HSQJnfCn4MkCQMBzCgCMIbRguION2F0dHjIB/6e0d/YY2PwrQXkp4T/1s7vi/T3qwjgSirv",
+	"L2i66wFsd0xA92oC30UVgZbqAa1lAxowUHm3Lafh0J39ke5CT/ekNRsKCm24m5/Nd+/0lhZooZE6xxRf",
+	"1Ycao4va4yIvdru1Kg+9xA1rOKxp3VWEnzUb3pqNoqiyA7u70enhV/VXB/82fTNavNtWeRu8HZm7erZp",
+	"7Huqfm2NqLSUT1utf/sviG0fSuxvksQ9FVVWC1L5e7FpSuPlw7YVyPXAL/ZG0fnZc219nmtre+IbvNuH",
+	"3jXg2BSBEKVRshB6O91Pxf01eDVbMU5GIbiHubHL+an2y1B5K6K7ODtkKjPFafT6PfQljZIQ6fS3IlHu",
+	"3xkiiyJTrq36L+4nZmgmDqOUDzdPkAsJgeLKUbYQiXRvE7LuDB1+lfQeoHjeQwdYuUrtLeFsuvy1HX5V",
+	"f+W8fApZMG3IHl0s/gfquNCt3uK1NXu2/QK39HpTwHG9j7uEp5quk/fBym+06za/sYv7PKeabvYyd9Tm",
+	"2QgBKOL4CYoQpB5afzybZUwkpFBdAI1hSqcJ6/qKj/SU3xsR2PYoZwV4/wwYOXI8oTeZFNi5XPBz3HBV",
+	"wC1JZiDICBGuWfmklEHWHhStzu+R3Zu1uuKVYfNA/niVI2oM4NJYoRTYz49kc2y2htfDP5LDr+qv+3jz",
+	"VfbVHMr7OC99e69RAckHeAP9LuiTCyTe1qu2gtxSy127jSaU+l4vX5eEVTnH9NTyVZU2vuELKFU5QgPk",
+	"5G6PxXfqukeAJcIE0+S7KLs/869WnREDJA/EtqrZG/Q5o/wl5Kt95lWrRnEOl4d6Nisuy6av7irc94vL",
+	"XnHflx5ObR7LORg277m/udc07/UoggWe0JtaEx6wDXdTUwx/wykK8xe3zNH63UUrbPH7FCof8CY2CJaj",
+	"JyZOmkbtB3oZV/n0ydoL/AF0XitRg+HxPm/Pr9NmL4fEpod8mVKSzBLpsOsW9i5kA7e0JywYSWxFS0sR",
+	"MGFTRKpXRI226YRxWy7+laHyQKb8dgmwUM0ovHmWAUu3Wh3lqnLHdb/Q6moOvL3xjKs7yO0S+oJ3882z",
+	"EejZM+8xeebZZ9fmFlDGj+/fKaCy4we+10u465W2ICt7Oq9/MkeE4BA5mNwLPkvppXh24Fv24a8Cc2vf",
+	"/lEJe569+twMAD/S8lXbNLHoYCENktkYxyhsN5XuWIWxwP8FZP353WZd76M0mm6LAfTJGT4fxuDJBCJ7",
+	"XRfZFEDGYDBFoRB2vZ1d5YV5vguOqpocMh3KakpAPiFPVKZRZ6nc/stgbilY4/Hi7rriLkqgeSDGze8K",
+	"HZUQ6Zl784zJaL5363qQdL26gXnZWiU8fsvzSndFz3bdTQmfdSm8i2Ly52tfvfYaTA998V33/YMDDZ6v",
+	"vN+Vd1yh1RSMvAcdIFncJRdbvgXer2NEVo7WfMrnqKyHKVA8yuI2btg646fECtsbb7mZdRFaVwRPJpwq",
+	"ynRd5phgR5hld9vvTSnsyDi8x276uNSa4AkWoJ9hBi5/PeRCg7RZ7+j6tLs9t+1DdrLMHugLnKXCnAHH",
+	"wYuXr173+mULiOOWvVjrLWt8PDkyMIkoz+9m+VaqG1RzMbfixRx+JVl8n/Asc0d+Rccf5d1v6WXsbdN6",
+	"oS439ekFaG3LhYsSGPqpT3VrEKJbHGPeov2Z/QWJnchZnpWn+pJomPC3uu5yCFhrcvY0UmLb10Mjjb4b",
+	"BSK1R+8nRMnM98BdOZae9VmP4kbczUU5eV8aFY8/fAJp6lYVpJ/fl/yq1Fy8e71FRaKpQYpTFOEYdc04",
+	"p/up6+uRc/Q473yh5/wes5A6tumq4ueA5BNLTurCJrPAXwWO/mhPkgh5O2/CKCoSiw9okKSirEhU+Km5",
+	"tX05Mo6SaLX+mutEz8OMTf9jrLhNRZZDxgbJdpPv1ajL6rZe4OihWqfkCn3z2jciWx3748K2bU5zX8az",
+	"TTMp7vntYzlzHvBzHnx/dsV9RRpuSHf6LT96JsZ3r6cuP/7a7lRFF1yDaULPq3S/KWTTQvWrvtj3xa0I",
+	"DtEcRXx7AwP8rSphRyb+mkXWJ+Z/5t5Lufw7X4el8vv7IvkviD1lDN/fhrfE4umf74spBixxWZweenlw",
+	"hlG2wPeKyL5P7JZsC7O3FRf0uYTC+koorJE7XFKsh+aEYlU+wv0jkuq7ifNPUIxfg/heRSovIf5RSO8P",
+	"JrZ7kPBnOX1JOX01FPgegrmXQL4RDmy1nNeKJO8nIHFv/iY4RfT1iubtIvn3iuP7D/IgPAvbnsL2OoTs",
+	"HyiAAW8t01oa3b3E7u/oJjw4O/Ywt+/Zy2NJwfje7BhFAUFsQNAtIigOUJcwF9kXFH39S79fiq6jYtZt",
+	"l5JLC26TlSug+f4jRKpbLnCzcty+6OmZGqDASR1mPYc4EmV/cCzcj1rwcYXh1evEQq84/Y1H568Gfyqh",
+	"vupMuqHK8Kv4/1VVqsi5czGqkykXy9xompUrvcOtSJciVvNUUqUwc7NLo+qycaUTFCNSiouhnhTuAeJK",
+	"tzTa8xEEea6GotZFai4RoOnCvCZv+1XGYq21aJ2x2Acq/NElxuq5Sl2TpromHqt7GNaGoxg3H7y4+ZDC",
+	"50jCKjOxbnwdUgZZ5hcZmMwRgVEEZBehhksRGVCGUv3b8lh9KdfxBHBb7rSJXbYwXR3QI8VZvfxVoO59",
+	"2ODu4n6xzmdOOErufNngx8sCrwhJh1/1nytXMOiBG2npRtUMH4ytboWmISedT0TZcFfabysKZxSRAVuk",
+	"iHrmHo5v8SQjKAS8JxA9JV5mbIpipg5ScAOWp5Kbql5TRK7E7PdEkzxBf2M6ODXbkdhFNXt/UyJTx76X",
+	"xqbVECpjIV4mnTs0nibJZzocYzbOgs/yrGtryASIUkQBjoNkhuMJeKN7ATUQQHO+ZMASnXJHZhpy+Dj+",
+	"CuMwQvkIH+QAveWldBiGWGYzuiB8KoY52kgrqr2T6rJTuNCRzvL0k/FfKNh4NkAFhJO5KB/TQML0stWR",
+	"PJzJc1m0RUFGMFv0Dv74aCKxRIoqXplES6FsDSJPMJtm405Y/Atmv2bjpVFYdt8k/pYW/Iy8W4W89ul0",
+	"wtwIdsbcd/BemPsObhpzzQU/Y+62Ya5xOvWYO0UwYtNW5vD8XwDfChZRVcbDFMiuiz1wzcHHmcQIz1GM",
+	"KOVQHSN3QcZf5YStKMDQFzZMI4hLh1+4Tp3/y+EzVTnoy/J6m6En2oBgigITaOd6FxpsSYpimOI9jZyt",
+	"nPV5iuLDi1Pwam/fTv8kAMemmAL+Gcfgt8vzM/7jDLqty2okkS/nnhepVOixdolhEmSqZpbjcrtHKeW4",
+	"aoA5F2zcvRoOgCAoKVsj5Ee8VRVzRWeRbz8IUMqAIpbUQGXeBLfhshh+FaisB+qAzRIATXAd5VtoRec5",
+	"IhR7YLJqB3AsEVSIguMkYwLA4gDFAp3Q+l1Nskbqr6ZoIvy/V7fQip0Kc+b5BtyAtEf52hsjSBDhIhsf",
+	"9BsfVgwkNTQlSTQJYASUN6i6a6I6bm/KWHowHEa8wTSh7ODn/Z/3heJFraI8lKRh/QKF+0Jc12eH4jBN",
+	"cCwca5S/qrGNJq/XGYzhBKnFqa75V1dXlSvJ6Kj9AQvVWjGUau0aqKiWUB1KZ6UqBjIqAlSHMmpPe67L",
+	"6OEa8BgyeBHB2ISPICFGero8NRGDZILMtea9XUOL4sXOsY9Oh0fHKvMvjm8JpIxkAcsIKoYuervGlmV9",
+	"4RhHmC2cc8ySGLOEUyKBP1EymciAS401lRGcRxdllCGiw9tc0DJOTjZuBEppQCeMKiM2w6I0ZCNoKkMv",
+	"BQa7chdDszQSHvEikyEKwXgB+C+cRAEUT3CMZNJ7e2prFI9ZpWNWMVteSZsKS0lAEkoHQcaEQ36QxAEi",
+	"cXXWK+1NWHtLl9xU227uufzadf9SdmXJpyg6fzAMHrX7HlRtocVq+R1SbjflDTcNPkoiNBhDzpdAIaDw",
+	"nTGSRFUdrBNLbY2hY/NY5FCb4xCRXJibCiHCPJxcbKgHH0E0yUiAAH+/FypuQ4RJJcX7kg84Uq1dI16W",
+	"HIedG6t4EFfHKRKuyoUFSYiMZKGl45XJEB0E3pFdz7UgV465bx+//f8BAAD//6UE3c1xjAIA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/openchoreo-api/api/handlers/cluster_scoped_handlers_test.go
+++ b/internal/openchoreo-api/api/handlers/cluster_scoped_handlers_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
+)
+
+// denyAllPDP is a PDP stub that always denies authorization.
+type denyAllPDP struct{}
+
+func (d *denyAllPDP) Evaluate(_ context.Context, _ *authzcore.EvaluateRequest) (*authzcore.Decision, error) {
+	return &authzcore.Decision{Decision: false, Context: &authzcore.DecisionContext{}}, nil
+}
+
+func (d *denyAllPDP) BatchEvaluate(_ context.Context, _ *authzcore.BatchEvaluateRequest) (*authzcore.BatchEvaluateResponse, error) {
+	return nil, nil
+}
+
+func (d *denyAllPDP) GetSubjectProfile(_ context.Context, _ *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
+	return nil, nil
+}
+
+// allowAllPDP is a PDP stub that always allows authorization.
+type allowAllPDP struct{}
+
+func (a *allowAllPDP) Evaluate(_ context.Context, _ *authzcore.EvaluateRequest) (*authzcore.Decision, error) {
+	return &authzcore.Decision{Decision: true, Context: &authzcore.DecisionContext{}}, nil
+}
+
+func (a *allowAllPDP) BatchEvaluate(_ context.Context, _ *authzcore.BatchEvaluateRequest) (*authzcore.BatchEvaluateResponse, error) {
+	return nil, nil
+}
+
+func (a *allowAllPDP) GetSubjectProfile(_ context.Context, _ *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
+	return nil, nil
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	return scheme
+}
+
+func newClusterComponentTypeService(t *testing.T, objects []client.Object, pdp authzcore.PDP) *services.ClusterComponentTypeService {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objects...).
+		Build()
+	return services.NewClusterComponentTypeService(fakeClient, slog.Default(), pdp)
+}
+
+func newClusterTraitService(t *testing.T, objects []client.Object, pdp authzcore.PDP) *services.ClusterTraitService {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objects...).
+		Build()
+	return services.NewClusterTraitService(fakeClient, slog.Default(), pdp)
+}
+
+func newHandlerWithServices(svcs *services.Services) *Handler {
+	return &Handler{
+		services: svcs,
+		logger:   slog.Default(),
+	}
+}
+
+func TestListClusterComponentTypesHandler(t *testing.T) {
+	ctx := context.Background()
+	cct := &openchoreov1alpha1.ClusterComponentType{
+		ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+		Spec: openchoreov1alpha1.ClusterComponentTypeSpec{
+			WorkloadType: "deployment",
+			Resources:    []openchoreov1alpha1.ResourceTemplate{{ID: "deployment"}},
+		},
+	}
+
+	t.Run("returns items when authorized", func(t *testing.T) {
+		svc := newClusterComponentTypeService(t, []client.Object{cct}, &allowAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterComponentTypeService: svc})
+
+		resp, err := h.ListClusterComponentTypes(ctx, gen.ListClusterComponentTypesRequestObject{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		typed, ok := resp.(gen.ListClusterComponentTypes200JSONResponse)
+		if !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+		if len(typed.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(typed.Items))
+		}
+	})
+
+	t.Run("filters unauthorized items", func(t *testing.T) {
+		svc := newClusterComponentTypeService(t, []client.Object{cct}, &denyAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterComponentTypeService: svc})
+
+		resp, err := h.ListClusterComponentTypes(ctx, gen.ListClusterComponentTypesRequestObject{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		typed, ok := resp.(gen.ListClusterComponentTypes200JSONResponse)
+		if !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+		if len(typed.Items) != 0 {
+			t.Fatalf("expected 0 items, got %d", len(typed.Items))
+		}
+	})
+}
+
+func TestGetClusterComponentTypeSchemaHandler(t *testing.T) {
+	ctx := context.Background()
+	paramsRaw, _ := json.Marshal(map[string]any{
+		"replicas": "integer",
+	})
+
+	cct := &openchoreov1alpha1.ClusterComponentType{
+		ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+		Spec: openchoreov1alpha1.ClusterComponentTypeSpec{
+			WorkloadType: "deployment",
+			Resources:    []openchoreov1alpha1.ResourceTemplate{{ID: "deployment"}},
+			Schema: openchoreov1alpha1.ComponentTypeSchema{
+				Parameters: &runtime.RawExtension{Raw: paramsRaw},
+			},
+		},
+	}
+
+	t.Run("returns schema when authorized", func(t *testing.T) {
+		svc := newClusterComponentTypeService(t, []client.Object{cct}, &allowAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterComponentTypeService: svc})
+
+		resp, err := h.GetClusterComponentTypeSchema(ctx, gen.GetClusterComponentTypeSchemaRequestObject{CctName: "go-service"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		typed, ok := resp.(gen.GetClusterComponentTypeSchema200JSONResponse)
+		if !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+		if len(typed) == 0 {
+			t.Fatalf("expected non-empty schema response")
+		}
+	})
+
+	t.Run("returns 404 when not found", func(t *testing.T) {
+		svc := newClusterComponentTypeService(t, nil, &allowAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterComponentTypeService: svc})
+
+		resp, err := h.GetClusterComponentTypeSchema(ctx, gen.GetClusterComponentTypeSchemaRequestObject{CctName: "missing"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := resp.(gen.GetClusterComponentTypeSchema404JSONResponse); !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+	})
+
+	t.Run("returns 403 when forbidden", func(t *testing.T) {
+		svc := newClusterComponentTypeService(t, []client.Object{cct}, &denyAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterComponentTypeService: svc})
+
+		resp, err := h.GetClusterComponentTypeSchema(ctx, gen.GetClusterComponentTypeSchemaRequestObject{CctName: "go-service"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := resp.(gen.GetClusterComponentTypeSchema403JSONResponse); !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+	})
+}
+
+func TestListClusterTraitsHandler(t *testing.T) {
+	ctx := context.Background()
+	ct := &openchoreov1alpha1.ClusterTrait{
+		ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+		Spec:       openchoreov1alpha1.ClusterTraitSpec{},
+	}
+
+	t.Run("returns items when authorized", func(t *testing.T) {
+		svc := newClusterTraitService(t, []client.Object{ct}, &allowAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterTraitService: svc})
+
+		resp, err := h.ListClusterTraits(ctx, gen.ListClusterTraitsRequestObject{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		typed, ok := resp.(gen.ListClusterTraits200JSONResponse)
+		if !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+		if len(typed.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(typed.Items))
+		}
+	})
+
+	t.Run("filters unauthorized items", func(t *testing.T) {
+		svc := newClusterTraitService(t, []client.Object{ct}, &denyAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterTraitService: svc})
+
+		resp, err := h.ListClusterTraits(ctx, gen.ListClusterTraitsRequestObject{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		typed, ok := resp.(gen.ListClusterTraits200JSONResponse)
+		if !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+		if len(typed.Items) != 0 {
+			t.Fatalf("expected 0 items, got %d", len(typed.Items))
+		}
+	})
+}
+
+func TestGetClusterTraitSchemaHandler(t *testing.T) {
+	ctx := context.Background()
+	paramsRaw, _ := json.Marshal(map[string]any{
+		"minReplicas": "integer",
+	})
+
+	ct := &openchoreov1alpha1.ClusterTrait{
+		ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+		Spec: openchoreov1alpha1.ClusterTraitSpec{
+			Schema: openchoreov1alpha1.TraitSchema{
+				Parameters: &runtime.RawExtension{Raw: paramsRaw},
+			},
+		},
+	}
+
+	t.Run("returns schema when authorized", func(t *testing.T) {
+		svc := newClusterTraitService(t, []client.Object{ct}, &allowAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterTraitService: svc})
+
+		resp, err := h.GetClusterTraitSchema(ctx, gen.GetClusterTraitSchemaRequestObject{ClusterTraitName: "autoscaler"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		typed, ok := resp.(gen.GetClusterTraitSchema200JSONResponse)
+		if !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+		if len(typed) == 0 {
+			t.Fatalf("expected non-empty schema response")
+		}
+	})
+
+	t.Run("returns 404 when not found", func(t *testing.T) {
+		svc := newClusterTraitService(t, nil, &allowAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterTraitService: svc})
+
+		resp, err := h.GetClusterTraitSchema(ctx, gen.GetClusterTraitSchemaRequestObject{ClusterTraitName: "missing"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := resp.(gen.GetClusterTraitSchema404JSONResponse); !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+	})
+
+	t.Run("returns 403 when forbidden", func(t *testing.T) {
+		svc := newClusterTraitService(t, []client.Object{ct}, &denyAllPDP{})
+		h := newHandlerWithServices(&services.Services{ClusterTraitService: svc})
+
+		resp, err := h.GetClusterTraitSchema(ctx, gen.GetClusterTraitSchemaRequestObject{ClusterTraitName: "autoscaler"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := resp.(gen.GetClusterTraitSchema403JSONResponse); !ok {
+			t.Fatalf("unexpected response type: %T", resp)
+		}
+	})
+}

--- a/internal/openchoreo-api/api/handlers/clustercomponenttypes.go
+++ b/internal/openchoreo-api/api/handlers/clustercomponenttypes.go
@@ -1,0 +1,99 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+// ListClusterComponentTypes returns a list of cluster-scoped component types
+func (h *Handler) ListClusterComponentTypes(
+	ctx context.Context,
+	request gen.ListClusterComponentTypesRequestObject,
+) (gen.ListClusterComponentTypesResponseObject, error) {
+	h.logger.Debug("ListClusterComponentTypes called")
+
+	componentTypes, err := h.services.ClusterComponentTypeService.ListClusterComponentTypes(ctx)
+	if err != nil {
+		h.logger.Error("Failed to list cluster component types", "error", err)
+		return gen.ListClusterComponentTypes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	items := make([]gen.ClusterComponentType, 0, len(componentTypes))
+	for _, ct := range componentTypes {
+		items = append(items, toGenClusterComponentType(ct))
+	}
+
+	return gen.ListClusterComponentTypes200JSONResponse{
+		Items:      items,
+		Pagination: gen.Pagination{},
+	}, nil
+}
+
+// GetClusterComponentTypeSchema returns the parameter schema for a cluster-scoped component type
+func (h *Handler) GetClusterComponentTypeSchema(
+	ctx context.Context,
+	request gen.GetClusterComponentTypeSchemaRequestObject,
+) (gen.GetClusterComponentTypeSchemaResponseObject, error) {
+	h.logger.Debug("GetClusterComponentTypeSchema called", "name", request.CctName)
+
+	jsonSchema, err := h.services.ClusterComponentTypeService.GetClusterComponentTypeSchema(ctx, request.CctName)
+	if err != nil {
+		if errors.Is(err, services.ErrClusterComponentTypeNotFound) {
+			return gen.GetClusterComponentTypeSchema404JSONResponse{NotFoundJSONResponse: notFound("cluster component type")}, nil
+		}
+		if errors.Is(err, services.ErrForbidden) {
+			return gen.GetClusterComponentTypeSchema403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		h.logger.Error("Failed to get cluster component type schema", "error", err)
+		return gen.GetClusterComponentTypeSchema500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	// Convert JSONSchemaProps to SchemaResponse (map[string]interface{})
+	data, err := json.Marshal(jsonSchema)
+	if err != nil {
+		h.logger.Error("Failed to marshal schema", "error", err)
+		return gen.GetClusterComponentTypeSchema500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	var schemaResp gen.SchemaResponse
+	if err := json.Unmarshal(data, &schemaResp); err != nil {
+		h.logger.Error("Failed to unmarshal schema response", "error", err)
+		return gen.GetClusterComponentTypeSchema500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	return gen.GetClusterComponentTypeSchema200JSONResponse(schemaResp), nil
+}
+
+func toGenClusterComponentType(ct *models.ComponentTypeResponse) gen.ClusterComponentType {
+	result := gen.ClusterComponentType{
+		Name:         ct.Name,
+		DisplayName:  ptr.To(ct.DisplayName),
+		Description:  ptr.To(ct.Description),
+		WorkloadType: ct.WorkloadType,
+		CreatedAt:    ct.CreatedAt,
+	}
+	if len(ct.AllowedWorkflows) > 0 {
+		result.AllowedWorkflows = ptr.To(ct.AllowedWorkflows)
+	}
+	if len(ct.AllowedTraits) > 0 {
+		traitStrings := make([]string, len(ct.AllowedTraits))
+		for i, t := range ct.AllowedTraits {
+			traitStrings[i] = t.Name
+			if t.Kind != "" && t.Kind != "Trait" {
+				traitStrings[i] = t.Kind + ":" + t.Name
+			}
+		}
+		result.AllowedTraits = ptr.To(traitStrings)
+	}
+	return result
+}

--- a/internal/openchoreo-api/api/handlers/clustertraits.go
+++ b/internal/openchoreo-api/api/handlers/clustertraits.go
@@ -1,0 +1,84 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+// ListClusterTraits returns a list of cluster-scoped traits
+func (h *Handler) ListClusterTraits(
+	ctx context.Context,
+	request gen.ListClusterTraitsRequestObject,
+) (gen.ListClusterTraitsResponseObject, error) {
+	h.logger.Debug("ListClusterTraits called")
+
+	traits, err := h.services.ClusterTraitService.ListClusterTraits(ctx)
+	if err != nil {
+		h.logger.Error("Failed to list cluster traits", "error", err)
+		return gen.ListClusterTraits500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	items := make([]gen.ClusterTrait, 0, len(traits))
+	for _, t := range traits {
+		items = append(items, toGenClusterTrait(t))
+	}
+
+	return gen.ListClusterTraits200JSONResponse{
+		Items:      items,
+		Pagination: gen.Pagination{},
+	}, nil
+}
+
+// GetClusterTraitSchema returns the parameter schema for a cluster-scoped trait
+func (h *Handler) GetClusterTraitSchema(
+	ctx context.Context,
+	request gen.GetClusterTraitSchemaRequestObject,
+) (gen.GetClusterTraitSchemaResponseObject, error) {
+	h.logger.Debug("GetClusterTraitSchema called", "name", request.ClusterTraitName)
+
+	jsonSchema, err := h.services.ClusterTraitService.GetClusterTraitSchema(ctx, request.ClusterTraitName)
+	if err != nil {
+		if errors.Is(err, services.ErrClusterTraitNotFound) {
+			return gen.GetClusterTraitSchema404JSONResponse{NotFoundJSONResponse: notFound("cluster trait")}, nil
+		}
+		if errors.Is(err, services.ErrForbidden) {
+			return gen.GetClusterTraitSchema403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+		}
+		h.logger.Error("Failed to get cluster trait schema", "error", err)
+		return gen.GetClusterTraitSchema500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	// Convert JSONSchemaProps to SchemaResponse (map[string]interface{})
+	data, err := json.Marshal(jsonSchema)
+	if err != nil {
+		h.logger.Error("Failed to marshal schema", "error", err)
+		return gen.GetClusterTraitSchema500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	var schemaResp gen.SchemaResponse
+	if err := json.Unmarshal(data, &schemaResp); err != nil {
+		h.logger.Error("Failed to unmarshal schema response", "error", err)
+		return gen.GetClusterTraitSchema500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	return gen.GetClusterTraitSchema200JSONResponse(schemaResp), nil
+}
+
+func toGenClusterTrait(t *models.TraitResponse) gen.ClusterTrait {
+	return gen.ClusterTrait{
+		Name:        t.Name,
+		DisplayName: ptr.To(t.DisplayName),
+		Description: ptr.To(t.Description),
+		CreatedAt:   t.CreatedAt,
+	}
+}

--- a/internal/openchoreo-api/legacyservices/clustercomponenttype_service.go
+++ b/internal/openchoreo-api/legacyservices/clustercomponenttype_service.go
@@ -1,0 +1,172 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package legacyservices
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/schema"
+	"github.com/openchoreo/openchoreo/internal/schema/extractor"
+)
+
+// ClusterComponentTypeService handles ClusterComponentType-related business logic
+type ClusterComponentTypeService struct {
+	k8sClient client.Client
+	logger    *slog.Logger
+	authzPDP  authz.PDP
+}
+
+// NewClusterComponentTypeService creates a new ClusterComponentType service
+func NewClusterComponentTypeService(k8sClient client.Client, logger *slog.Logger, authzPDP authz.PDP) *ClusterComponentTypeService {
+	return &ClusterComponentTypeService{
+		k8sClient: k8sClient,
+		logger:    logger,
+		authzPDP:  authzPDP,
+	}
+}
+
+// ListClusterComponentTypes lists all ClusterComponentTypes
+func (s *ClusterComponentTypeService) ListClusterComponentTypes(ctx context.Context) ([]*models.ComponentTypeResponse, error) {
+	s.logger.Debug("Listing ClusterComponentTypes")
+
+	var ctList openchoreov1alpha1.ClusterComponentTypeList
+	if err := s.k8sClient.List(ctx, &ctList); err != nil {
+		s.logger.Error("Failed to list ClusterComponentTypes", "error", err)
+		return nil, fmt.Errorf("failed to list ClusterComponentTypes: %w", err)
+	}
+
+	cts := make([]*models.ComponentTypeResponse, 0, len(ctList.Items))
+	for i := range ctList.Items {
+		if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewClusterComponentType, ResourceTypeClusterComponentType, ctList.Items[i].Name,
+			authz.ResourceHierarchy{}); err != nil {
+			if errors.Is(err, ErrForbidden) {
+				s.logger.Debug("Skipping unauthorized cluster component type", "clusterComponentType", ctList.Items[i].Name)
+				continue
+			}
+			return nil, err
+		}
+		cts = append(cts, s.toComponentTypeResponse(&ctList.Items[i]))
+	}
+
+	s.logger.Debug("Listed ClusterComponentTypes", "count", len(cts))
+	return cts, nil
+}
+
+// GetClusterComponentType retrieves a specific ClusterComponentType
+func (s *ClusterComponentTypeService) GetClusterComponentType(ctx context.Context, name string) (*models.ComponentTypeResponse, error) {
+	s.logger.Debug("Getting ClusterComponentType", "name", name)
+
+	if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewClusterComponentType, ResourceTypeClusterComponentType, name,
+		authz.ResourceHierarchy{}); err != nil {
+		return nil, err
+	}
+
+	ct := &openchoreov1alpha1.ClusterComponentType{}
+	key := client.ObjectKey{Name: name}
+
+	if err := s.k8sClient.Get(ctx, key, ct); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("ClusterComponentType not found", "name", name)
+			return nil, ErrClusterComponentTypeNotFound
+		}
+		s.logger.Error("Failed to get ClusterComponentType", "error", err)
+		return nil, fmt.Errorf("failed to get ClusterComponentType: %w", err)
+	}
+
+	return s.toComponentTypeResponse(ct), nil
+}
+
+// GetClusterComponentTypeSchema retrieves the JSON schema for a ClusterComponentType
+func (s *ClusterComponentTypeService) GetClusterComponentTypeSchema(ctx context.Context, name string) (*extv1.JSONSchemaProps, error) {
+	s.logger.Debug("Getting ClusterComponentType schema", "name", name)
+
+	if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewClusterComponentType, ResourceTypeClusterComponentType, name,
+		authz.ResourceHierarchy{}); err != nil {
+		return nil, err
+	}
+
+	ct := &openchoreov1alpha1.ClusterComponentType{}
+	key := client.ObjectKey{Name: name}
+
+	if err := s.k8sClient.Get(ctx, key, ct); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("ClusterComponentType not found", "name", name)
+			return nil, ErrClusterComponentTypeNotFound
+		}
+		s.logger.Error("Failed to get ClusterComponentType", "error", err)
+		return nil, fmt.Errorf("failed to get ClusterComponentType: %w", err)
+	}
+
+	// Extract types from RawExtension
+	var types map[string]any
+	if ct.Spec.Schema.Types != nil && ct.Spec.Schema.Types.Raw != nil {
+		if err := yaml.Unmarshal(ct.Spec.Schema.Types.Raw, &types); err != nil {
+			return nil, fmt.Errorf("failed to extract types: %w", err)
+		}
+	}
+
+	// Build schema definition
+	def := schema.Definition{
+		Types: types,
+		Options: extractor.Options{
+			SkipDefaultValidation: true,
+		},
+	}
+
+	// Extract parameters schema from RawExtension
+	if ct.Spec.Schema.Parameters != nil && ct.Spec.Schema.Parameters.Raw != nil {
+		var params map[string]any
+		if err := yaml.Unmarshal(ct.Spec.Schema.Parameters.Raw, &params); err != nil {
+			return nil, fmt.Errorf("failed to extract parameters: %w", err)
+		}
+		def.Schemas = []map[string]any{params}
+	}
+
+	// Convert to JSON Schema
+	jsonSchema, err := schema.ToJSONSchema(def)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to JSON schema: %w", err)
+	}
+
+	s.logger.Debug("Retrieved ClusterComponentType schema successfully", "name", name)
+	return jsonSchema, nil
+}
+
+// toComponentTypeResponse converts a ClusterComponentType CR to a ComponentTypeResponse
+func (s *ClusterComponentTypeService) toComponentTypeResponse(ct *openchoreov1alpha1.ClusterComponentType) *models.ComponentTypeResponse {
+	displayName := ct.Annotations[controller.AnnotationKeyDisplayName]
+	description := ct.Annotations[controller.AnnotationKeyDescription]
+
+	allowedWorkflows := make([]string, 0, len(ct.Spec.AllowedWorkflows))
+	allowedWorkflows = append(allowedWorkflows, ct.Spec.AllowedWorkflows...)
+
+	allowedTraits := make([]models.AllowedTraitResponse, 0, len(ct.Spec.AllowedTraits))
+	for _, ref := range ct.Spec.AllowedTraits {
+		allowedTraits = append(allowedTraits, models.AllowedTraitResponse{
+			Kind: string(ref.Kind),
+			Name: ref.Name,
+		})
+	}
+
+	return &models.ComponentTypeResponse{
+		Name:             ct.Name,
+		DisplayName:      displayName,
+		Description:      description,
+		WorkloadType:     ct.Spec.WorkloadType,
+		AllowedWorkflows: allowedWorkflows,
+		AllowedTraits:    allowedTraits,
+		CreatedAt:        ct.CreationTimestamp.Time,
+	}
+}

--- a/internal/openchoreo-api/legacyservices/clustercomponenttype_service_test.go
+++ b/internal/openchoreo-api/legacyservices/clustercomponenttype_service_test.go
@@ -1,0 +1,386 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package legacyservices
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+func newCCTService(t *testing.T, objects []client.Object, pdp authz.PDP) *ClusterComponentTypeService {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objects...).
+		Build()
+	return &ClusterComponentTypeService{
+		k8sClient: fakeClient,
+		logger:    slog.Default(),
+		authzPDP:  pdp,
+	}
+}
+
+func TestListClusterComponentTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		pdp       authz.PDP
+		wantCount int
+	}{
+		{
+			name:      "Empty list returns no items",
+			objects:   []client.Object{},
+			pdp:       &allowAllPDP{},
+			wantCount: 0,
+		},
+		{
+			name: "Single ClusterComponentType returned",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "go-service",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Go Service",
+							controller.AnnotationKeyDescription: "Go microservice template",
+						},
+					},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			pdp:       &allowAllPDP{},
+			wantCount: 1,
+		},
+		{
+			name: "Multiple ClusterComponentTypes returned",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "python-job"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "job",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "job"}},
+					},
+				},
+			},
+			pdp:       &allowAllPDP{},
+			wantCount: 2,
+		},
+		{
+			name: "Unauthorized items are filtered out",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			pdp:       &denyAllPDP{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newCCTService(t, tt.objects, tt.pdp)
+
+			result, err := svc.ListClusterComponentTypes(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(result), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestGetClusterComponentType(t *testing.T) {
+	tests := []struct {
+		name         string
+		ctName       string
+		objects      []client.Object
+		pdp          authz.PDP
+		wantErr      bool
+		wantNotFound bool
+		wantName     string
+	}{
+		{
+			name:   "Existing ClusterComponentType returned",
+			ctName: "go-service",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "go-service",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Go Service",
+							controller.AnnotationKeyDescription: "Go microservice",
+						},
+					},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			pdp:      &allowAllPDP{},
+			wantName: "go-service",
+		},
+		{
+			name:         "Non-existent ClusterComponentType returns not found",
+			ctName:       "nonexistent",
+			objects:      []client.Object{},
+			pdp:          &allowAllPDP{},
+			wantErr:      true,
+			wantNotFound: true,
+		},
+		{
+			name:   "Unauthorized access returns forbidden",
+			ctName: "go-service",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			pdp:     &denyAllPDP{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newCCTService(t, tt.objects, tt.pdp)
+
+			result, err := svc.GetClusterComponentType(context.Background(), tt.ctName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantNotFound && !errors.Is(err, ErrClusterComponentTypeNotFound) {
+					t.Errorf("expected ErrClusterComponentTypeNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Name != tt.wantName {
+				t.Errorf("got name %q, want %q", result.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestGetClusterComponentTypeSchema(t *testing.T) {
+	paramsRaw, _ := json.Marshal(map[string]any{
+		"replicas": "integer",
+	})
+
+	tests := []struct {
+		name         string
+		ctName       string
+		objects      []client.Object
+		pdp          authz.PDP
+		wantErr      bool
+		wantNotFound bool
+		wantSchema   bool
+	}{
+		{
+			name:   "Schema extracted from ClusterComponentType with parameters",
+			ctName: "go-service",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+						Schema: v1alpha1.ComponentTypeSchema{
+							Parameters: &runtime.RawExtension{Raw: paramsRaw},
+						},
+					},
+				},
+			},
+			pdp:        &allowAllPDP{},
+			wantSchema: true,
+		},
+		{
+			name:   "Schema from ClusterComponentType without parameters",
+			ctName: "empty-ct",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-ct"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			pdp:        &allowAllPDP{},
+			wantSchema: true,
+		},
+		{
+			name:         "Non-existent ClusterComponentType returns not found",
+			ctName:       "nonexistent",
+			objects:      []client.Object{},
+			pdp:          &allowAllPDP{},
+			wantErr:      true,
+			wantNotFound: true,
+		},
+		{
+			name:   "Unauthorized access returns error",
+			ctName: "go-service",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			pdp:     &denyAllPDP{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newCCTService(t, tt.objects, tt.pdp)
+
+			result, err := svc.GetClusterComponentTypeSchema(context.Background(), tt.ctName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantNotFound && !errors.Is(err, ErrClusterComponentTypeNotFound) {
+					t.Errorf("expected ErrClusterComponentTypeNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantSchema && result == nil {
+				t.Fatal("expected non-nil schema, got nil")
+			}
+		})
+	}
+}
+
+func TestClusterComponentTypeToResponse(t *testing.T) {
+	svc := &ClusterComponentTypeService{logger: slog.Default()}
+
+	tests := []struct {
+		name              string
+		ct                *v1alpha1.ClusterComponentType
+		wantName          string
+		wantDisplayName   string
+		wantDescription   string
+		wantWorkloadType  string
+		wantWorkflowCount int
+		wantTraitCount    int
+	}{
+		{
+			name: "Full ClusterComponentType with all fields",
+			ct: &v1alpha1.ClusterComponentType{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "go-service",
+					Annotations: map[string]string{
+						controller.AnnotationKeyDisplayName: "Go Service",
+						controller.AnnotationKeyDescription: "A Go microservice template",
+					},
+				},
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					WorkloadType:     "deployment",
+					AllowedWorkflows: []string{"docker-build", "buildpack-build"},
+					AllowedTraits: []v1alpha1.ClusterTraitRef{
+						{Kind: v1alpha1.ClusterTraitRefKindClusterTrait, Name: "autoscaler"},
+						{Kind: v1alpha1.ClusterTraitRefKindClusterTrait, Name: "logger"},
+					},
+					Resources: []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+				},
+			},
+			wantName:          "go-service",
+			wantDisplayName:   "Go Service",
+			wantDescription:   "A Go microservice template",
+			wantWorkloadType:  "deployment",
+			wantWorkflowCount: 2,
+			wantTraitCount:    2,
+		},
+		{
+			name: "Minimal ClusterComponentType without optional fields",
+			ct: &v1alpha1.ClusterComponentType{
+				ObjectMeta: metav1.ObjectMeta{Name: "minimal"},
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					WorkloadType: "job",
+					Resources:    []v1alpha1.ResourceTemplate{{ID: "job"}},
+				},
+			},
+			wantName:          "minimal",
+			wantDisplayName:   "",
+			wantDescription:   "",
+			wantWorkloadType:  "job",
+			wantWorkflowCount: 0,
+			wantTraitCount:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := svc.toComponentTypeResponse(tt.ct)
+
+			if result.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", result.Name, tt.wantName)
+			}
+			if result.DisplayName != tt.wantDisplayName {
+				t.Errorf("DisplayName = %q, want %q", result.DisplayName, tt.wantDisplayName)
+			}
+			if result.Description != tt.wantDescription {
+				t.Errorf("Description = %q, want %q", result.Description, tt.wantDescription)
+			}
+			if result.WorkloadType != tt.wantWorkloadType {
+				t.Errorf("WorkloadType = %q, want %q", result.WorkloadType, tt.wantWorkloadType)
+			}
+			if len(result.AllowedWorkflows) != tt.wantWorkflowCount {
+				t.Errorf("AllowedWorkflows count = %d, want %d", len(result.AllowedWorkflows), tt.wantWorkflowCount)
+			}
+			if len(result.AllowedTraits) != tt.wantTraitCount {
+				t.Errorf("AllowedTraits count = %d, want %d", len(result.AllowedTraits), tt.wantTraitCount)
+			}
+			for i, trait := range result.AllowedTraits {
+				if trait.Kind != string(v1alpha1.ClusterTraitRefKindClusterTrait) {
+					t.Errorf("AllowedTraits[%d].Kind = %q, want %q", i, trait.Kind, v1alpha1.ClusterTraitRefKindClusterTrait)
+				}
+			}
+		})
+	}
+}

--- a/internal/openchoreo-api/legacyservices/clustertrait_service.go
+++ b/internal/openchoreo-api/legacyservices/clustertrait_service.go
@@ -1,0 +1,158 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package legacyservices
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/schema"
+	"github.com/openchoreo/openchoreo/internal/schema/extractor"
+)
+
+// ClusterTraitService handles ClusterTrait-related business logic
+type ClusterTraitService struct {
+	k8sClient client.Client
+	logger    *slog.Logger
+	authzPDP  authz.PDP
+}
+
+// NewClusterTraitService creates a new ClusterTrait service
+func NewClusterTraitService(k8sClient client.Client, logger *slog.Logger, authzPDP authz.PDP) *ClusterTraitService {
+	return &ClusterTraitService{
+		k8sClient: k8sClient,
+		logger:    logger,
+		authzPDP:  authzPDP,
+	}
+}
+
+// ListClusterTraits lists all ClusterTraits
+func (s *ClusterTraitService) ListClusterTraits(ctx context.Context) ([]*models.TraitResponse, error) {
+	s.logger.Debug("Listing ClusterTraits")
+
+	var traitList openchoreov1alpha1.ClusterTraitList
+	if err := s.k8sClient.List(ctx, &traitList); err != nil {
+		s.logger.Error("Failed to list ClusterTraits", "error", err)
+		return nil, fmt.Errorf("failed to list ClusterTraits: %w", err)
+	}
+
+	traits := make([]*models.TraitResponse, 0, len(traitList.Items))
+	for i := range traitList.Items {
+		if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewClusterTrait, ResourceTypeClusterTrait, traitList.Items[i].Name,
+			authz.ResourceHierarchy{}); err != nil {
+			if errors.Is(err, ErrForbidden) {
+				s.logger.Debug("Skipping unauthorized cluster trait", "clusterTrait", traitList.Items[i].Name)
+				continue
+			}
+			return nil, err
+		}
+		traits = append(traits, s.toTraitResponse(&traitList.Items[i]))
+	}
+
+	s.logger.Debug("Listed ClusterTraits", "count", len(traits))
+	return traits, nil
+}
+
+// GetClusterTrait retrieves a specific ClusterTrait
+func (s *ClusterTraitService) GetClusterTrait(ctx context.Context, name string) (*models.TraitResponse, error) {
+	s.logger.Debug("Getting ClusterTrait", "name", name)
+
+	if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewClusterTrait, ResourceTypeClusterTrait, name,
+		authz.ResourceHierarchy{}); err != nil {
+		return nil, err
+	}
+
+	trait := &openchoreov1alpha1.ClusterTrait{}
+	key := client.ObjectKey{Name: name}
+
+	if err := s.k8sClient.Get(ctx, key, trait); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("ClusterTrait not found", "name", name)
+			return nil, ErrClusterTraitNotFound
+		}
+		s.logger.Error("Failed to get ClusterTrait", "error", err)
+		return nil, fmt.Errorf("failed to get ClusterTrait: %w", err)
+	}
+
+	return s.toTraitResponse(trait), nil
+}
+
+// GetClusterTraitSchema retrieves the JSON schema for a ClusterTrait
+func (s *ClusterTraitService) GetClusterTraitSchema(ctx context.Context, name string) (*extv1.JSONSchemaProps, error) {
+	s.logger.Debug("Getting ClusterTrait schema", "name", name)
+
+	if err := checkAuthorization(ctx, s.logger, s.authzPDP, SystemActionViewClusterTrait, ResourceTypeClusterTrait, name,
+		authz.ResourceHierarchy{}); err != nil {
+		return nil, err
+	}
+
+	trait := &openchoreov1alpha1.ClusterTrait{}
+	key := client.ObjectKey{Name: name}
+
+	if err := s.k8sClient.Get(ctx, key, trait); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			s.logger.Warn("ClusterTrait not found", "name", name)
+			return nil, ErrClusterTraitNotFound
+		}
+		s.logger.Error("Failed to get ClusterTrait", "error", err)
+		return nil, fmt.Errorf("failed to get ClusterTrait: %w", err)
+	}
+
+	// Extract types from RawExtension
+	var types map[string]any
+	if trait.Spec.Schema.Types != nil && trait.Spec.Schema.Types.Raw != nil {
+		if err := yaml.Unmarshal(trait.Spec.Schema.Types.Raw, &types); err != nil {
+			return nil, fmt.Errorf("failed to extract types: %w", err)
+		}
+	}
+
+	// Build schema definition
+	def := schema.Definition{
+		Types: types,
+		Options: extractor.Options{
+			SkipDefaultValidation: true,
+		},
+	}
+
+	// Extract parameters schema from RawExtension
+	if trait.Spec.Schema.Parameters != nil && trait.Spec.Schema.Parameters.Raw != nil {
+		var params map[string]any
+		if err := yaml.Unmarshal(trait.Spec.Schema.Parameters.Raw, &params); err != nil {
+			return nil, fmt.Errorf("failed to extract parameters: %w", err)
+		}
+		def.Schemas = []map[string]any{params}
+	}
+
+	// Convert to JSON Schema
+	jsonSchema, err := schema.ToJSONSchema(def)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to JSON schema: %w", err)
+	}
+
+	s.logger.Debug("Retrieved ClusterTrait schema successfully", "name", name)
+	return jsonSchema, nil
+}
+
+// toTraitResponse converts a ClusterTrait CR to a TraitResponse
+func (s *ClusterTraitService) toTraitResponse(trait *openchoreov1alpha1.ClusterTrait) *models.TraitResponse {
+	displayName := trait.Annotations[controller.AnnotationKeyDisplayName]
+	description := trait.Annotations[controller.AnnotationKeyDescription]
+
+	return &models.TraitResponse{
+		Name:        trait.Name,
+		DisplayName: displayName,
+		Description: description,
+		CreatedAt:   trait.CreationTimestamp.Time,
+	}
+}

--- a/internal/openchoreo-api/legacyservices/clustertrait_service_test.go
+++ b/internal/openchoreo-api/legacyservices/clustertrait_service_test.go
@@ -1,0 +1,329 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package legacyservices
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+func newCTService(t *testing.T, objects []client.Object, pdp authz.PDP) *ClusterTraitService {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objects...).
+		Build()
+	return &ClusterTraitService{
+		k8sClient: fakeClient,
+		logger:    slog.Default(),
+		authzPDP:  pdp,
+	}
+}
+
+func TestListClusterTraits(t *testing.T) {
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		pdp       authz.PDP
+		wantCount int
+	}{
+		{
+			name:      "Empty list returns no items",
+			objects:   []client.Object{},
+			pdp:       &allowAllPDP{},
+			wantCount: 0,
+		},
+		{
+			name: "Single ClusterTrait returned",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "autoscaler",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Auto Scaler",
+							controller.AnnotationKeyDescription: "Enables HPA",
+						},
+					},
+					Spec: v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:       &allowAllPDP{},
+			wantCount: 1,
+		},
+		{
+			name: "Multiple ClusterTraits returned",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "logger"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:       &allowAllPDP{},
+			wantCount: 3,
+		},
+		{
+			name: "Unauthorized items are filtered out",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:       &denyAllPDP{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newCTService(t, tt.objects, tt.pdp)
+
+			result, err := svc.ListClusterTraits(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(result), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestGetClusterTrait(t *testing.T) {
+	tests := []struct {
+		name         string
+		traitName    string
+		objects      []client.Object
+		pdp          authz.PDP
+		wantErr      bool
+		wantNotFound bool
+		wantName     string
+	}{
+		{
+			name:      "Existing ClusterTrait returned",
+			traitName: "autoscaler",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "autoscaler",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Auto Scaler",
+							controller.AnnotationKeyDescription: "Enables horizontal pod autoscaling",
+						},
+					},
+					Spec: v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:      &allowAllPDP{},
+			wantName: "autoscaler",
+		},
+		{
+			name:         "Non-existent ClusterTrait returns not found",
+			traitName:    "nonexistent",
+			objects:      []client.Object{},
+			pdp:          &allowAllPDP{},
+			wantErr:      true,
+			wantNotFound: true,
+		},
+		{
+			name:      "Unauthorized access returns forbidden",
+			traitName: "autoscaler",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:     &denyAllPDP{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newCTService(t, tt.objects, tt.pdp)
+
+			result, err := svc.GetClusterTrait(context.Background(), tt.traitName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantNotFound && !errors.Is(err, ErrClusterTraitNotFound) {
+					t.Errorf("expected ErrClusterTraitNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Name != tt.wantName {
+				t.Errorf("got name %q, want %q", result.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestGetClusterTraitSchema(t *testing.T) {
+	paramsRaw, _ := json.Marshal(map[string]any{
+		"minReplicas": "integer",
+		"maxReplicas": "integer",
+	})
+
+	tests := []struct {
+		name         string
+		traitName    string
+		objects      []client.Object
+		pdp          authz.PDP
+		wantErr      bool
+		wantNotFound bool
+		wantSchema   bool
+	}{
+		{
+			name:      "Schema extracted from ClusterTrait with parameters",
+			traitName: "autoscaler",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec: v1alpha1.ClusterTraitSpec{
+						Schema: v1alpha1.TraitSchema{
+							Parameters: &runtime.RawExtension{Raw: paramsRaw},
+						},
+					},
+				},
+			},
+			pdp:        &allowAllPDP{},
+			wantSchema: true,
+		},
+		{
+			name:      "Schema from ClusterTrait without parameters",
+			traitName: "empty-trait",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-trait"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:        &allowAllPDP{},
+			wantSchema: true,
+		},
+		{
+			name:         "Non-existent ClusterTrait returns not found",
+			traitName:    "nonexistent",
+			objects:      []client.Object{},
+			pdp:          &allowAllPDP{},
+			wantErr:      true,
+			wantNotFound: true,
+		},
+		{
+			name:      "Unauthorized access returns error",
+			traitName: "autoscaler",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			pdp:     &denyAllPDP{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newCTService(t, tt.objects, tt.pdp)
+
+			result, err := svc.GetClusterTraitSchema(context.Background(), tt.traitName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantNotFound && !errors.Is(err, ErrClusterTraitNotFound) {
+					t.Errorf("expected ErrClusterTraitNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantSchema && result == nil {
+				t.Fatal("expected non-nil schema, got nil")
+			}
+		})
+	}
+}
+
+func TestClusterTraitToResponse(t *testing.T) {
+	svc := &ClusterTraitService{logger: slog.Default()}
+
+	tests := []struct {
+		name            string
+		trait           *v1alpha1.ClusterTrait
+		wantName        string
+		wantDisplayName string
+		wantDescription string
+	}{
+		{
+			name: "Full ClusterTrait with all annotations",
+			trait: &v1alpha1.ClusterTrait{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "autoscaler",
+					Annotations: map[string]string{
+						controller.AnnotationKeyDisplayName: "Auto Scaler",
+						controller.AnnotationKeyDescription: "Enables horizontal pod autoscaling",
+					},
+				},
+			},
+			wantName:        "autoscaler",
+			wantDisplayName: "Auto Scaler",
+			wantDescription: "Enables horizontal pod autoscaling",
+		},
+		{
+			name: "ClusterTrait without annotations",
+			trait: &v1alpha1.ClusterTrait{
+				ObjectMeta: metav1.ObjectMeta{Name: "minimal"},
+			},
+			wantName:        "minimal",
+			wantDisplayName: "",
+			wantDescription: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := svc.toTraitResponse(tt.trait)
+
+			if result.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", result.Name, tt.wantName)
+			}
+			if result.DisplayName != tt.wantDisplayName {
+				t.Errorf("DisplayName = %q, want %q", result.DisplayName, tt.wantDisplayName)
+			}
+			if result.Description != tt.wantDescription {
+				t.Errorf("Description = %q, want %q", result.Description, tt.wantDescription)
+			}
+		})
+	}
+}

--- a/internal/openchoreo-api/legacyservices/componenttype_service.go
+++ b/internal/openchoreo-api/legacyservices/componenttype_service.go
@@ -5,7 +5,6 @@ package legacyservices
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -146,7 +145,7 @@ func (s *ComponentTypeService) GetComponentTypeSchema(ctx context.Context, names
 	// Extract parameters schema from RawExtension
 	if ct.Spec.Schema.Parameters != nil && ct.Spec.Schema.Parameters.Raw != nil {
 		var params map[string]any
-		if err := json.Unmarshal(ct.Spec.Schema.Parameters.Raw, &params); err != nil {
+		if err := yaml.Unmarshal(ct.Spec.Schema.Parameters.Raw, &params); err != nil {
 			return nil, fmt.Errorf("failed to extract parameters: %w", err)
 		}
 		def.Schemas = []map[string]any{params}

--- a/internal/openchoreo-api/legacyservices/constants.go
+++ b/internal/openchoreo-api/legacyservices/constants.go
@@ -53,6 +53,9 @@ const (
 	SystemActionViewClusterBuildPlane         systemAction = "clusterbuildplane:view"
 	SystemActionViewClusterObservabilityPlane systemAction = "clusterobservabilityplane:view"
 
+	SystemActionViewClusterComponentType systemAction = "clustercomponenttype:view"
+	SystemActionViewClusterTrait         systemAction = "clustertrait:view"
+
 	SystemActionCreateEnvironment systemAction = "environment:create"
 	SystemActionViewEnvironment   systemAction = "environment:view"
 
@@ -95,6 +98,8 @@ const (
 	ResourceTypeClusterDataPlane           ResourceType = "clusterDataPlane"
 	ResourceTypeClusterBuildPlane          ResourceType = "clusterBuildPlane"
 	ResourceTypeClusterObservabilityPlane  ResourceType = "clusterObservabilityPlane"
+	ResourceTypeClusterComponentType       ResourceType = "clusterComponentType"
+	ResourceTypeClusterTrait               ResourceType = "clusterTrait"
 	ResourceTypeEnvironment                ResourceType = "environment"
 	ResourceTypeDeploymentPipeline         ResourceType = "deploymentPipeline"
 	ResourceTypeWorkflow                   ResourceType = "workflow"

--- a/internal/openchoreo-api/legacyservices/errors.go
+++ b/internal/openchoreo-api/legacyservices/errors.go
@@ -46,6 +46,8 @@ var (
 	ErrBuildPlaneNotFound            = errors.New("build plane not found")
 	ErrClusterDataPlaneNotFound      = errors.New("cluster dataplane not found")
 	ErrClusterDataPlaneAlreadyExists = errors.New("cluster dataplane already exists")
+	ErrClusterComponentTypeNotFound  = errors.New("cluster component type not found")
+	ErrClusterTraitNotFound          = errors.New("cluster trait not found")
 	ErrGitSecretAlreadyExists        = errors.New("git secret already exists")
 	ErrGitSecretNotFound             = errors.New("git secret not found")
 	ErrSecretStoreNotConfigured      = errors.New("secret store not configured")
@@ -104,6 +106,8 @@ const (
 	CodeBuildPlaneNotFound           = "BUILDPLANE_NOT_FOUND"
 	CodeClusterDataPlaneNotFound     = "CLUSTER_DATAPLANE_NOT_FOUND"
 	CodeClusterDataPlaneExists       = "CLUSTER_DATAPLANE_EXISTS"
+	CodeClusterComponentTypeNotFound = "CLUSTER_COMPONENT_TYPE_NOT_FOUND"
+	CodeClusterTraitNotFound         = "CLUSTER_TRAIT_NOT_FOUND"
 	CodeGitSecretExists              = "GIT_SECRET_EXISTS"
 	CodeGitSecretNotFound            = "GIT_SECRET_NOT_FOUND"
 	CodeSecretStoreNotConfigured     = "SECRET_STORE_NOT_CONFIGURED"

--- a/internal/openchoreo-api/legacyservices/services.go
+++ b/internal/openchoreo-api/legacyservices/services.go
@@ -36,6 +36,8 @@ type Services struct {
 	ClusterDataPlaneService          *ClusterDataPlaneService
 	ClusterBuildPlaneService         *ClusterBuildPlaneService
 	ClusterObservabilityPlaneService *ClusterObservabilityPlaneService
+	ClusterComponentTypeService      *ClusterComponentTypeService
+	ClusterTraitService              *ClusterTraitService
 	GatewayClient                    *gatewayClient.Client
 	k8sClient                        client.Client // Direct access to K8s client for apply operations
 }
@@ -105,6 +107,12 @@ func NewServices(k8sClient client.Client, k8sClientMgr *kubernetesClient.KubeMul
 	// Create ClusterObservabilityPlane service
 	clusterObservabilityPlaneService := NewClusterObservabilityPlaneService(k8sClient, logger.With("service", "clusterobservabilityplane"), authzPDP)
 
+	// Create ClusterComponentType service
+	clusterComponentTypeService := NewClusterComponentTypeService(k8sClient, logger.With("service", "clustercomponenttype"), authzPDP)
+
+	// Create ClusterTrait service
+	clusterTraitService := NewClusterTraitService(k8sClient, logger.With("service", "clustertrait"), authzPDP)
+
 	return &Services{
 		ProjectService:                   projectService,
 		ComponentService:                 componentService,
@@ -127,6 +135,8 @@ func NewServices(k8sClient client.Client, k8sClientMgr *kubernetesClient.KubeMul
 		ClusterDataPlaneService:          clusterDataPlaneService,
 		ClusterBuildPlaneService:         clusterBuildPlaneService,
 		ClusterObservabilityPlaneService: clusterObservabilityPlaneService,
+		ClusterComponentTypeService:      clusterComponentTypeService,
+		ClusterTraitService:              clusterTraitService,
 		GatewayClient:                    gwClient,
 		k8sClient:                        k8sClient,
 	}

--- a/internal/openchoreo-api/legacyservices/trait_service.go
+++ b/internal/openchoreo-api/legacyservices/trait_service.go
@@ -5,7 +5,6 @@ package legacyservices
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -146,7 +145,7 @@ func (s *TraitService) GetTraitSchema(ctx context.Context, namespaceName, traitN
 	// Extract parameters schema from RawExtension
 	if trait.Spec.Schema.Parameters != nil && trait.Spec.Schema.Parameters.Raw != nil {
 		var params map[string]any
-		if err := json.Unmarshal(trait.Spec.Schema.Parameters.Raw, &params); err != nil {
+		if err := yaml.Unmarshal(trait.Spec.Schema.Parameters.Raw, &params); err != nil {
 			return nil, fmt.Errorf("failed to extract parameters: %w", err)
 		}
 		def.Schemas = []map[string]any{params}

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -49,6 +49,10 @@ tags:
     description: Cluster-scoped BuildPlane management
   - name: ClusterObservabilityPlanes
     description: Cluster-scoped ObservabilityPlane management
+  - name: ClusterComponentTypes
+    description: Cluster-scoped ComponentType templates defined by platform engineers
+  - name: ClusterTraits
+    description: Cluster-scoped Trait templates for composable cross-cutting concerns
   - name: ComponentTypes
     description: ComponentType templates defined by platform engineers
   - name: Traits
@@ -865,6 +869,102 @@ paths:
           $ref: '#/components/responses/InternalError'
 
   # =============================================================================
+  # ClusterComponentType Endpoints (Cluster-Scoped)
+  # =============================================================================
+
+  /api/v1/clustercomponenttypes:
+    get:
+      operationId: listClusterComponentTypes
+      summary: List cluster component types
+      description: Returns a list of cluster-scoped component types.
+      tags: [ClusterComponentTypes]
+      responses:
+        '200':
+          description: List of cluster component types
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterComponentTypeList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/clustercomponenttypes/{cctName}/schema:
+    get:
+      operationId: getClusterComponentTypeSchema
+      summary: Get cluster component type schema
+      description: Returns the parameter schema for a specific cluster-scoped component type.
+      tags: [ClusterComponentTypes]
+      parameters:
+        - $ref: '#/components/parameters/ClusterComponentTypeNameParam'
+      responses:
+        '200':
+          description: Cluster component type schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
+  # ClusterTrait Endpoints (Cluster-Scoped)
+  # =============================================================================
+
+  /api/v1/clustertraits:
+    get:
+      operationId: listClusterTraits
+      summary: List cluster traits
+      description: Returns a list of cluster-scoped traits.
+      tags: [ClusterTraits]
+      responses:
+        '200':
+          description: List of cluster traits
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTraitList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/clustertraits/{clusterTraitName}/schema:
+    get:
+      operationId: getClusterTraitSchema
+      summary: Get cluster trait schema
+      description: Returns the parameter schema for a specific cluster-scoped trait.
+      tags: [ClusterTraits]
+      parameters:
+        - $ref: '#/components/parameters/ClusterTraitNameParam'
+      responses:
+        '200':
+          description: Cluster trait schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
   # ComponentType Endpoints
   # =============================================================================
 
@@ -876,8 +976,6 @@ paths:
       tags: [ComponentTypes]
       parameters:
         - $ref: '#/components/parameters/NamespaceNameParam'
-        - $ref: '#/components/parameters/LimitParam'
-        - $ref: '#/components/parameters/CursorParam'
       responses:
         '200':
           description: List of component types
@@ -929,8 +1027,6 @@ paths:
       tags: [Traits]
       parameters:
         - $ref: '#/components/parameters/NamespaceNameParam'
-        - $ref: '#/components/parameters/LimitParam'
-        - $ref: '#/components/parameters/CursorParam'
       responses:
         '200':
           description: List of traits
@@ -2979,6 +3075,24 @@ components:
         type: string
         example: go-service
 
+    ClusterComponentTypeNameParam:
+      name: cctName
+      in: path
+      required: true
+      description: ClusterComponentType name
+      schema:
+        type: string
+        example: go-service
+
+    ClusterTraitNameParam:
+      name: clusterTraitName
+      in: path
+      required: true
+      description: ClusterTrait name
+      schema:
+        type: string
+        example: autoscaler
+
     TraitNameParam:
       name: traitName
       in: path
@@ -4672,6 +4786,111 @@ components:
           example: Ready
 
     # -------------------------------------------------------------------------
+    # ClusterComponentTypes
+    # -------------------------------------------------------------------------
+    ClusterComponentTypeList:
+      type: object
+      description: Paginated list of cluster-scoped component types
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterComponentType'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ClusterComponentType:
+      type: object
+      description: Cluster-scoped ComponentType resource defining a workload template
+      required:
+        - name
+        - workloadType
+        - createdAt
+      properties:
+        name:
+          type: string
+          description: ClusterComponentType name (unique across the cluster)
+          example: go-service
+        displayName:
+          type: string
+          description: Human-readable display name
+          example: Go Service
+        description:
+          type: string
+          description: ComponentType description
+          example: Template for Go-based microservices
+        workloadType:
+          type: string
+          description: Type of workload (service, web-application, scheduled-task)
+          example: service
+        allowedWorkflows:
+          type: array
+          description: List of allowed workflow names for this component type
+          items:
+            type: string
+          example: ["docker-build", "buildpack-build"]
+        allowedTraits:
+          type: array
+          description: >-
+            List of allowed trait references that developers can attach to components of this type
+            (format "name" for Trait kind, "ClusterTrait:name" for ClusterTrait kind).
+            If empty or omitted, no additional component-level traits are allowed;
+            only traits embedded in the component type's spec.traits are permitted.
+          items:
+            type: string
+          example: ["autoscaler", "ClusterTrait:logger"]
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: "2025-01-06T10:00:00Z"
+
+    # -------------------------------------------------------------------------
+    # ClusterTraits
+    # -------------------------------------------------------------------------
+    ClusterTraitList:
+      type: object
+      description: Paginated list of cluster-scoped traits
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterTrait'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ClusterTrait:
+      type: object
+      description: Cluster-scoped Trait resource for composable cross-cutting concerns
+      required:
+        - name
+        - createdAt
+      properties:
+        name:
+          type: string
+          description: ClusterTrait name (unique across the cluster)
+          example: autoscaler
+        displayName:
+          type: string
+          description: Human-readable display name
+          example: Auto Scaler
+        description:
+          type: string
+          description: Trait description
+          example: Enables horizontal pod autoscaling
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: "2025-01-06T10:00:00Z"
+
+    # -------------------------------------------------------------------------
     # ComponentTypes
     # -------------------------------------------------------------------------
     ComponentTypeList:
@@ -4720,7 +4939,11 @@ components:
           example: ["docker-build", "buildpack-build"]
         allowedTraits:
           type: array
-          description: List of allowed trait references for this component type (format "name" for Trait kind, "ClusterTrait:name" for ClusterTrait kind)
+          description: >-
+            List of allowed trait references that developers can attach to components of this type
+            (format "name" for Trait kind, "ClusterTrait:name" for ClusterTrait kind).
+            If empty or omitted, no additional component-level traits are allowed;
+            only traits embedded in the component type's spec.traits are permitted.
           items:
             type: string
           example: ["autoscaler", "ClusterTrait:logger"]


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#commit-message-convention
-->

## Purpose
  - Add read-only REST API endpoints for cluster-scoped ClusterComponentType and ClusterTrait resources: list and get-schema for each                 
  - Implement service layer (ClusterComponentTypeService, ClusterTraitService) mirroring existing namespace-scoped ComponentType/Trait services but without namespace parameters                                                                                                                        
  - Add OpenAPI spec definitions, generated server/client code, handler wiring, authorization constants, and error sentinels  

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
