### PR TITLE
feat(api): add status endpoint for namespace-level workflow runs

### DIFF
--- a/cmd/observer/openapi.yaml
+++ b/cmd/observer/openapi.yaml
@@ -758,6 +758,10 @@ components:
           enum: [asc, desc]
           default: asc
           example: "asc"
+        step:
+          type: string
+          description: Filter logs by a specific workflow step name. When provided, only logs from pods matching {runId}-{step}-* are returned.
+          example: "build-step"
 
     ComponentLogsRequest:
       type: object

--- a/internal/observer/handlers/handlers.go
+++ b/internal/observer/handlers/handlers.go
@@ -126,6 +126,7 @@ type WorkflowRunLogsRequest struct {
 	EndTime       string `json:"endTime" validate:"required"`
 	Limit         int    `json:"limit,omitempty"`
 	SortOrder     string `json:"sortOrder,omitempty"`
+	Step          string `json:"step,omitempty"`
 }
 
 // ComponentLogsRequest represents the request body for component logs
@@ -373,6 +374,7 @@ func (h *Handler) GetWorkflowRunLogs(w http.ResponseWriter, r *http.Request) {
 			NamespaceName: req.NamespaceName,
 		},
 		WorkflowRunID: runID,
+		StepName:      req.Step,
 	}
 
 	// Execute query

--- a/internal/observer/opensearch/queries.go
+++ b/internal/observer/opensearch/queries.go
@@ -150,10 +150,15 @@ func (qb *QueryBuilder) BuildBuildLogsQuery(params BuildQueryParams) map[string]
 
 // BuildWorkflowRunLogsQuery builds a query for workflow run logs with wildcard search
 func (qb *QueryBuilder) BuildWorkflowRunLogsQuery(params WorkflowRunQueryParams) map[string]interface{} {
+	podNamePattern := params.WorkflowRunID + "*"
+	if params.StepName != "" {
+		podNamePattern = fmt.Sprintf("%s-%s-*", params.WorkflowRunID, params.StepName)
+	}
+
 	mustConditions := []map[string]interface{}{
 		{
 			"wildcard": map[string]interface{}{
-				labels.KubernetesPodName + ".keyword": params.WorkflowRunID + "*",
+				labels.KubernetesPodName + ".keyword": podNamePattern,
 			},
 		},
 	}

--- a/internal/observer/opensearch/types.go
+++ b/internal/observer/opensearch/types.go
@@ -143,6 +143,7 @@ type GatewayQueryParams struct {
 type WorkflowRunQueryParams struct {
 	QueryParams
 	WorkflowRunID string `json:"workflowRunId"`
+	StepName      string `json:"stepName,omitempty"`
 }
 
 // ComponentWorkflowRunQueryParams holds component workflow run-specific query parameters

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -145,11 +145,30 @@ const (
 
 // Defines values for WorkflowRunStatus.
 const (
-	Error     WorkflowRunStatus = "Error"
-	Failed    WorkflowRunStatus = "Failed"
-	Pending   WorkflowRunStatus = "Pending"
-	Running   WorkflowRunStatus = "Running"
-	Succeeded WorkflowRunStatus = "Succeeded"
+	WorkflowRunStatusError     WorkflowRunStatus = "Error"
+	WorkflowRunStatusFailed    WorkflowRunStatus = "Failed"
+	WorkflowRunStatusPending   WorkflowRunStatus = "Pending"
+	WorkflowRunStatusRunning   WorkflowRunStatus = "Running"
+	WorkflowRunStatusSucceeded WorkflowRunStatus = "Succeeded"
+)
+
+// Defines values for WorkflowRunStatusResponseStatus.
+const (
+	WorkflowRunStatusResponseStatusError     WorkflowRunStatusResponseStatus = "Error"
+	WorkflowRunStatusResponseStatusFailed    WorkflowRunStatusResponseStatus = "Failed"
+	WorkflowRunStatusResponseStatusPending   WorkflowRunStatusResponseStatus = "Pending"
+	WorkflowRunStatusResponseStatusRunning   WorkflowRunStatusResponseStatus = "Running"
+	WorkflowRunStatusResponseStatusSucceeded WorkflowRunStatusResponseStatus = "Succeeded"
+)
+
+// Defines values for WorkflowStepStatusPhase.
+const (
+	Error     WorkflowStepStatusPhase = "Error"
+	Failed    WorkflowStepStatusPhase = "Failed"
+	Pending   WorkflowStepStatusPhase = "Pending"
+	Running   WorkflowStepStatusPhase = "Running"
+	Skipped   WorkflowStepStatusPhase = "Skipped"
+	Succeeded WorkflowStepStatusPhase = "Succeeded"
 )
 
 // Defines values for ListClusterRoleBindingsParamsEffect.
@@ -2144,6 +2163,39 @@ type WorkflowRunList struct {
 	// for efficient pagination through large result sets.
 	Pagination Pagination `json:"pagination"`
 }
+
+// WorkflowRunStatusResponse Status of a workflow run including per-step details
+type WorkflowRunStatusResponse struct {
+	// HasLiveObservability Whether live logs/events are available from the build plane
+	HasLiveObservability bool `json:"hasLiveObservability"`
+
+	// Status Overall workflow run status
+	Status WorkflowRunStatusResponseStatus `json:"status"`
+
+	// Steps Per-step status details
+	Steps []WorkflowStepStatus `json:"steps"`
+}
+
+// WorkflowRunStatusResponseStatus Overall workflow run status
+type WorkflowRunStatusResponseStatus string
+
+// WorkflowStepStatus Status of an individual workflow step
+type WorkflowStepStatus struct {
+	// FinishedAt When the step finished
+	FinishedAt *time.Time `json:"finishedAt,omitempty"`
+
+	// Name Step name
+	Name string `json:"name"`
+
+	// Phase Step phase
+	Phase WorkflowStepStatusPhase `json:"phase"`
+
+	// StartedAt When the step started
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+}
+
+// WorkflowStepStatusPhase Step phase
+type WorkflowStepStatusPhase string
 
 // WorkloadOverrides Environment-specific workload overrides
 type WorkloadOverrides struct {

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -140,6 +140,7 @@ func (h *Handler) Routes() http.Handler {
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs", h.ListWorkflowRuns)
 	api.HandleFunc("POST "+v1+"/namespaces/{namespaceName}/workflow-runs", h.CreateWorkflowRun)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}", h.GetWorkflowRun)
+	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}/status", h.GetWorkflowRunStatus)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}/events", h.GetWorkflowRunEvents)
 
 	// ComponentWorkflow endpoints (component-specific workflows)

--- a/internal/openchoreo-api/legacyservices/constants.go
+++ b/internal/openchoreo-api/legacyservices/constants.go
@@ -110,5 +110,8 @@ const (
 // Workflow run status constants
 const (
 	WorkflowRunStatusPending   = "Pending"
+	WorkflowRunStatusRunning   = "Running"
+	WorkflowRunStatusSucceeded = "Succeeded"
+	WorkflowRunStatusFailed    = "Failed"
 	WorkflowRunStatusCompleted = "Completed"
 )

--- a/internal/openchoreo-api/legacyservices/workflowrun_service_test.go
+++ b/internal/openchoreo-api/legacyservices/workflowrun_service_test.go
@@ -6,12 +6,16 @@ package legacyservices
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
@@ -182,6 +186,129 @@ func TestGetWorkflowRunEvents(t *testing.T) {
 		}
 		if errors.Is(err, ErrWorkflowRunReferenceNotFound) {
 			t.Errorf("unexpected ErrWorkflowRunReferenceNotFound: RunReference is set")
+		}
+	})
+}
+
+func TestGetWorkflowRunStatus(t *testing.T) {
+	const (
+		namespace = "test-ns"
+		runName   = "my-run"
+	)
+
+	t.Run("authz denial returns ErrForbidden", func(t *testing.T) {
+		svc := &WorkflowRunService{
+			k8sClient: fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build(),
+			logger:    slog.Default(),
+			authzPDP:  &denyAllPDP{},
+		}
+
+		_, err := svc.GetWorkflowRunStatus(context.Background(), namespace, runName, "")
+		if !errors.Is(err, ErrForbidden) {
+			t.Errorf("expected ErrForbidden, got %v", err)
+		}
+	})
+
+	t.Run("workflow run not found returns ErrWorkflowRunNotFound", func(t *testing.T) {
+		svc := &WorkflowRunService{
+			k8sClient: fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build(),
+			logger:    slog.Default(),
+			authzPDP:  &allowAllPDP{},
+		}
+
+		_, err := svc.GetWorkflowRunStatus(context.Background(), namespace, runName, "")
+		if !errors.Is(err, ErrWorkflowRunNotFound) {
+			t.Errorf("expected ErrWorkflowRunNotFound, got %v", err)
+		}
+	})
+
+	t.Run("k8s error returns wrapped error", func(t *testing.T) {
+		injectedErr := fmt.Errorf("connection refused")
+		svc := &WorkflowRunService{
+			k8sClient: fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return injectedErr
+				},
+			}).Build(),
+			logger:   slog.Default(),
+			authzPDP: &allowAllPDP{},
+		}
+
+		_, err := svc.GetWorkflowRunStatus(context.Background(), namespace, runName, "")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if errors.Is(err, ErrWorkflowRunNotFound) {
+			t.Errorf("expected wrapped k8s error, got ErrWorkflowRunNotFound")
+		}
+	})
+
+	t.Run("success path maps tasks and overall status", func(t *testing.T) {
+		startedAt := metav1.NewTime(time.Date(2025, 1, 6, 10, 0, 0, 0, time.UTC))
+		completedAt := metav1.NewTime(time.Date(2025, 1, 6, 10, 1, 0, 0, time.UTC))
+
+		wfRun := &openchoreov1alpha1.WorkflowRun{
+			ObjectMeta: metav1.ObjectMeta{Name: runName, Namespace: namespace},
+			Spec:       openchoreov1alpha1.WorkflowRunSpec{Workflow: openchoreov1alpha1.WorkflowRunConfig{Name: "my-workflow"}},
+			Status: openchoreov1alpha1.WorkflowRunStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "WorkflowSucceeded",
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+				Tasks: []openchoreov1alpha1.WorkflowTask{
+					{Name: "clone-step", Phase: "Succeeded", StartedAt: &startedAt, CompletedAt: &completedAt},
+					{Name: "build-step", Phase: "Running", StartedAt: &startedAt},
+				},
+			},
+		}
+
+		svc := &WorkflowRunService{
+			k8sClient:         fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithStatusSubresource(wfRun).WithObjects(wfRun).Build(),
+			logger:            slog.Default(),
+			authzPDP:          &allowAllPDP{},
+			buildPlaneService: &BuildPlaneService{k8sClient: fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build(), logger: slog.Default()},
+		}
+
+		resp, err := svc.GetWorkflowRunStatus(context.Background(), namespace, runName, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if resp.Status != "Succeeded" {
+			t.Errorf("expected status Succeeded, got %q", resp.Status)
+		}
+		if len(resp.Steps) != 2 {
+			t.Fatalf("expected 2 steps, got %d", len(resp.Steps))
+		}
+
+		cloneStep := resp.Steps[0]
+		if cloneStep.Name != "clone-step" {
+			t.Errorf("expected step name clone-step, got %q", cloneStep.Name)
+		}
+		if cloneStep.Phase != "Succeeded" {
+			t.Errorf("expected phase Succeeded, got %q", cloneStep.Phase)
+		}
+		if cloneStep.StartedAt == nil || !cloneStep.StartedAt.Equal(startedAt.Time) {
+			t.Errorf("expected StartedAt %v, got %v", startedAt.Time, cloneStep.StartedAt)
+		}
+		if cloneStep.FinishedAt == nil || !cloneStep.FinishedAt.Equal(completedAt.Time) {
+			t.Errorf("expected FinishedAt %v, got %v", completedAt.Time, cloneStep.FinishedAt)
+		}
+
+		buildStep := resp.Steps[1]
+		if buildStep.Name != "build-step" {
+			t.Errorf("expected step name build-step, got %q", buildStep.Name)
+		}
+		if buildStep.FinishedAt != nil {
+			t.Errorf("expected nil FinishedAt for running step, got %v", buildStep.FinishedAt)
+		}
+
+		// buildPlaneService has no BuildPlane object -> HasLiveObservability must be false
+		if resp.HasLiveObservability {
+			t.Errorf("expected HasLiveObservability false when build plane is unreachable")
 		}
 	})
 }

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -1110,6 +1110,29 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/namespaces/{namespaceName}/workflow-runs/{runName}/status:
+    get:
+      operationId: getWorkflowRunStatus
+      summary: Get workflow run status
+      description: Returns the overall status and per-step status of a specific workflow run.
+      tags: [Workflows]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/WorkflowRunNameParam'
+      responses:
+        '200':
+          description: Workflow run status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowRunStatusResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   # =============================================================================
   # ComponentWorkflow Endpoints
   # =============================================================================
@@ -4895,6 +4918,56 @@ components:
           type: string
           description: Detailed execution phase
           example: "Clone completed, build in progress"
+
+    WorkflowRunStatusResponse:
+      type: object
+      description: Status of a workflow run including per-step details
+      required:
+        - status
+        - steps
+        - hasLiveObservability
+      properties:
+        status:
+          type: string
+          enum: [Pending, Running, Succeeded, Failed, Error]
+          description: Overall workflow run status
+          example: Running
+        steps:
+          type: array
+          description: Per-step status details
+          items:
+            $ref: '#/components/schemas/WorkflowStepStatus'
+        hasLiveObservability:
+          type: boolean
+          description: Whether live logs/events are available from the build plane
+          example: true
+
+    WorkflowStepStatus:
+      type: object
+      description: Status of an individual workflow step
+      required:
+        - name
+        - phase
+      properties:
+        name:
+          type: string
+          description: Step name
+          example: clone-step
+        phase:
+          type: string
+          description: Step phase
+          enum: [Pending, Running, Succeeded, Failed, Skipped, Error]
+          example: Succeeded
+        startedAt:
+          type: string
+          format: date-time
+          description: When the step started
+          example: "2025-01-06T10:00:00Z"
+        finishedAt:
+          type: string
+          format: date-time
+          description: When the step finished
+          example: "2025-01-06T10:01:00Z"
 
     CreateWorkflowRunRequest:
       type: object


### PR DESCRIPTION
## Purpose
- Add status endpoint for namespace-level workflow runs
- Fix https://github.com/openchoreo/openchoreo/issues/2092

## Description
The Backstage UI was showing only a single synthetic step for namespace-level workflow runs                                                                          
  because there was no `/status` endpoint for them. The controller already populates                                                                                   
  `Status.Tasks` on the `WorkflowRun` CRD with per-step status, but there was no API
  endpoint to expose it. This adds `GET /api/v1/namespaces/{namespaceName}/workflow-runs/{runName}/status`
  to surface that data, mirroring the equivalent endpoint that already exists for component
  workflow runs.