### PR TITLE
feat: add mcp support for cluster traits and cluster component types

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
@@ -24,6 +24,7 @@ rules:
   - clusterdataplanes
   - clustertraits
   - clusterobservabilityplanes
+  - clustertraits
   - componentreleases
   - components
   - componenttypes
@@ -90,6 +91,7 @@ rules:
   - clusterdataplanes/status
   - clustertraits/status
   - clusterobservabilityplanes/status
+  - clustertraits/status
   - componentreleases/status
   - components/status
   - componenttypes/status

--- a/internal/openchoreo-api/mcphandlers/clustercomponenttypes.go
+++ b/internal/openchoreo-api/mcphandlers/clustercomponenttypes.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+type ListClusterComponentTypesResponse struct {
+	ClusterComponentTypes []*models.ComponentTypeResponse `json:"cluster_component_types"`
+}
+
+func (h *MCPHandler) ListClusterComponentTypes(ctx context.Context) (any, error) {
+	clusterComponentTypes, err := h.Services.ClusterComponentTypeService.ListClusterComponentTypes(ctx)
+	if err != nil {
+		return ListClusterComponentTypesResponse{}, fmt.Errorf("list cluster component types failed: %w", err)
+	}
+	return ListClusterComponentTypesResponse{
+		ClusterComponentTypes: clusterComponentTypes,
+	}, nil
+}
+
+func (h *MCPHandler) GetClusterComponentType(ctx context.Context, cctName string) (any, error) {
+	result, err := h.Services.ClusterComponentTypeService.GetClusterComponentType(ctx, cctName)
+	if err != nil {
+		return nil, fmt.Errorf("get cluster component type %q failed: %w", cctName, err)
+	}
+	return result, nil
+}
+
+func (h *MCPHandler) GetClusterComponentTypeSchema(ctx context.Context, cctName string) (any, error) {
+	result, err := h.Services.ClusterComponentTypeService.GetClusterComponentTypeSchema(ctx, cctName)
+	if err != nil {
+		return nil, fmt.Errorf("get cluster component type schema %q failed: %w", cctName, err)
+	}
+	return result, nil
+}

--- a/internal/openchoreo-api/mcphandlers/clustercomponenttypes_test.go
+++ b/internal/openchoreo-api/mcphandlers/clustercomponenttypes_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+func newCCTHandler(t *testing.T, objects []client.Object) *MCPHandler {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objects...).
+		Build()
+	return &MCPHandler{
+		Services: &services.Services{
+			ClusterComponentTypeService: services.NewClusterComponentTypeService(
+				fakeClient, slog.Default(), &allowAllPDP{},
+			),
+		},
+	}
+}
+
+func TestMCPListClusterComponentTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name:      "Empty list returns empty response",
+			objects:   []client.Object{},
+			wantCount: 0,
+		},
+		{
+			name: "Single ClusterComponentType returned in response",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "go-service",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Go Service",
+							controller.AnnotationKeyDescription: "Go microservice template",
+						},
+					},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "Multiple ClusterComponentTypes returned",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "python-job"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "job",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "job"}},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCCTHandler(t, tt.objects)
+
+			result, err := h.ListClusterComponentTypes(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			resp, ok := result.(ListClusterComponentTypesResponse)
+			if !ok {
+				t.Fatalf("expected ListClusterComponentTypesResponse, got %T", result)
+			}
+			if len(resp.ClusterComponentTypes) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(resp.ClusterComponentTypes), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestMCPListClusterComponentTypes_ErrorWrapping(t *testing.T) {
+	h := newCCTHandler(t, nil)
+	// Overwrite with a service that uses a deny-all PDP so that a list with items would fail
+	// But list with deny-all PDP filters items instead of erroring, so we test the error wrapper
+	// by using a broken client scenario. Since the handler wraps errors, we verify the wrapping
+	// by checking the response type on empty lists.
+	result, err := h.ListClusterComponentTypes(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, ok := result.(ListClusterComponentTypesResponse)
+	if !ok {
+		t.Fatalf("expected ListClusterComponentTypesResponse, got %T", result)
+	}
+	if resp.ClusterComponentTypes == nil {
+		t.Error("expected non-nil slice, got nil")
+	}
+}
+
+func TestMCPGetClusterComponentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		cctName  string
+		objects  []client.Object
+		wantErr  bool
+		wantName string
+	}{
+		{
+			name:    "Existing ClusterComponentType returned",
+			cctName: "go-service",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "go-service",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Go Service",
+						},
+					},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			wantName: "go-service",
+		},
+		{
+			name:    "Non-existent ClusterComponentType returns wrapped error",
+			cctName: "nonexistent",
+			objects: []client.Object{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCCTHandler(t, tt.objects)
+
+			result, err := h.GetClusterComponentType(context.Background(), tt.cctName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, services.ErrClusterComponentTypeNotFound) {
+					t.Fatalf("expected ErrClusterComponentTypeNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			resp, ok := result.(*models.ComponentTypeResponse)
+			if !ok {
+				t.Fatalf("expected *models.ComponentTypeResponse, got %T", result)
+			}
+			if resp.Name != tt.wantName {
+				t.Errorf("got name %q, want %q", resp.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMCPGetClusterComponentTypeSchema(t *testing.T) {
+	paramsRaw, _ := json.Marshal(map[string]any{
+		"replicas": "integer",
+	})
+
+	tests := []struct {
+		name       string
+		cctName    string
+		objects    []client.Object
+		wantErr    bool
+		wantSchema bool
+	}{
+		{
+			name:    "Schema returned for existing ClusterComponentType",
+			cctName: "go-service",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "go-service"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+						Schema: v1alpha1.ComponentTypeSchema{
+							Parameters: &runtime.RawExtension{Raw: paramsRaw},
+						},
+					},
+				},
+			},
+			wantSchema: true,
+		},
+		{
+			name:    "Schema returned for ClusterComponentType without parameters",
+			cctName: "empty-ct",
+			objects: []client.Object{
+				&v1alpha1.ClusterComponentType{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-ct"},
+					Spec: v1alpha1.ClusterComponentTypeSpec{
+						WorkloadType: "deployment",
+						Resources:    []v1alpha1.ResourceTemplate{{ID: "deployment"}},
+					},
+				},
+			},
+			wantSchema: true,
+		},
+		{
+			name:    "Non-existent ClusterComponentType returns wrapped error",
+			cctName: "nonexistent",
+			objects: []client.Object{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCCTHandler(t, tt.objects)
+
+			result, err := h.GetClusterComponentTypeSchema(context.Background(), tt.cctName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, services.ErrClusterComponentTypeNotFound) {
+					t.Fatalf("expected ErrClusterComponentTypeNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantSchema && result == nil {
+				t.Fatal("expected non-nil schema, got nil")
+			}
+		})
+	}
+}

--- a/internal/openchoreo-api/mcphandlers/clustertraits.go
+++ b/internal/openchoreo-api/mcphandlers/clustertraits.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+type ListClusterTraitsResponse struct {
+	ClusterTraits []*models.TraitResponse `json:"cluster_traits"`
+}
+
+func (h *MCPHandler) ListClusterTraits(ctx context.Context) (any, error) {
+	clusterTraits, err := h.Services.ClusterTraitService.ListClusterTraits(ctx)
+	if err != nil {
+		return ListClusterTraitsResponse{}, fmt.Errorf("list cluster traits failed: %w", err)
+	}
+	return ListClusterTraitsResponse{
+		ClusterTraits: clusterTraits,
+	}, nil
+}
+
+func (h *MCPHandler) GetClusterTrait(ctx context.Context, ctName string) (any, error) {
+	result, err := h.Services.ClusterTraitService.GetClusterTrait(ctx, ctName)
+	if err != nil {
+		return nil, fmt.Errorf("get cluster trait %q failed: %w", ctName, err)
+	}
+	return result, nil
+}
+
+func (h *MCPHandler) GetClusterTraitSchema(ctx context.Context, ctName string) (any, error) {
+	result, err := h.Services.ClusterTraitService.GetClusterTraitSchema(ctx, ctName)
+	if err != nil {
+		return nil, fmt.Errorf("get cluster trait schema %q failed: %w", ctName, err)
+	}
+	return result, nil
+}

--- a/internal/openchoreo-api/mcphandlers/clustertraits_test.go
+++ b/internal/openchoreo-api/mcphandlers/clustertraits_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+func newCTHandler(t *testing.T, objects []client.Object) *MCPHandler {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objects...).
+		Build()
+	return &MCPHandler{
+		Services: &services.Services{
+			ClusterTraitService: services.NewClusterTraitService(
+				fakeClient, slog.Default(), &allowAllPDP{},
+			),
+		},
+	}
+}
+
+func TestMCPListClusterTraits(t *testing.T) {
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name:      "Empty list returns empty response",
+			objects:   []client.Object{},
+			wantCount: 0,
+		},
+		{
+			name: "Single ClusterTrait returned in response",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "autoscaler",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Auto Scaler",
+							controller.AnnotationKeyDescription: "Enables HPA",
+						},
+					},
+					Spec: v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "Multiple ClusterTraits returned",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "logger"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			wantCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCTHandler(t, tt.objects)
+
+			result, err := h.ListClusterTraits(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			resp, ok := result.(ListClusterTraitsResponse)
+			if !ok {
+				t.Fatalf("expected ListClusterTraitsResponse, got %T", result)
+			}
+			if len(resp.ClusterTraits) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(resp.ClusterTraits), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestMCPListClusterTraits_ResponseFields(t *testing.T) {
+	h := newCTHandler(t, []client.Object{
+		&v1alpha1.ClusterTrait{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "autoscaler",
+				Annotations: map[string]string{
+					controller.AnnotationKeyDisplayName: "Auto Scaler",
+					controller.AnnotationKeyDescription: "Enables HPA",
+				},
+			},
+			Spec: v1alpha1.ClusterTraitSpec{},
+		},
+	})
+
+	result, err := h.ListClusterTraits(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resp := result.(ListClusterTraitsResponse)
+	if len(resp.ClusterTraits) != 1 {
+		t.Fatalf("expected 1 trait, got %d", len(resp.ClusterTraits))
+	}
+
+	trait := resp.ClusterTraits[0]
+	if trait.Name != "autoscaler" {
+		t.Errorf("Name = %q, want %q", trait.Name, "autoscaler")
+	}
+	if trait.DisplayName != "Auto Scaler" {
+		t.Errorf("DisplayName = %q, want %q", trait.DisplayName, "Auto Scaler")
+	}
+	if trait.Description != "Enables HPA" {
+		t.Errorf("Description = %q, want %q", trait.Description, "Enables HPA")
+	}
+}
+
+func TestMCPGetClusterTrait(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctName   string
+		objects  []client.Object
+		wantErr  bool
+		wantName string
+	}{
+		{
+			name:   "Existing ClusterTrait returned",
+			ctName: "autoscaler",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "autoscaler",
+						Annotations: map[string]string{
+							controller.AnnotationKeyDisplayName: "Auto Scaler",
+						},
+					},
+					Spec: v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			wantName: "autoscaler",
+		},
+		{
+			name:    "Non-existent ClusterTrait returns wrapped error",
+			ctName:  "nonexistent",
+			objects: []client.Object{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCTHandler(t, tt.objects)
+
+			result, err := h.GetClusterTrait(context.Background(), tt.ctName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, services.ErrClusterTraitNotFound) {
+					t.Fatalf("expected ErrClusterTraitNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			resp, ok := result.(*models.TraitResponse)
+			if !ok {
+				t.Fatalf("expected *models.TraitResponse, got %T", result)
+			}
+			if resp.Name != tt.wantName {
+				t.Errorf("got name %q, want %q", resp.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMCPGetClusterTraitSchema(t *testing.T) {
+	paramsRaw, _ := json.Marshal(map[string]any{
+		"minReplicas": "integer",
+		"maxReplicas": "integer",
+	})
+
+	tests := []struct {
+		name       string
+		ctName     string
+		objects    []client.Object
+		wantErr    bool
+		wantSchema bool
+	}{
+		{
+			name:   "Schema returned for existing ClusterTrait",
+			ctName: "autoscaler",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "autoscaler"},
+					Spec: v1alpha1.ClusterTraitSpec{
+						Schema: v1alpha1.TraitSchema{
+							Parameters: &runtime.RawExtension{Raw: paramsRaw},
+						},
+					},
+				},
+			},
+			wantSchema: true,
+		},
+		{
+			name:   "Schema returned for ClusterTrait without parameters",
+			ctName: "empty-trait",
+			objects: []client.Object{
+				&v1alpha1.ClusterTrait{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-trait"},
+					Spec:       v1alpha1.ClusterTraitSpec{},
+				},
+			},
+			wantSchema: true,
+		},
+		{
+			name:    "Non-existent ClusterTrait returns wrapped error",
+			ctName:  "nonexistent",
+			objects: []client.Object{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCTHandler(t, tt.objects)
+
+			result, err := h.GetClusterTraitSchema(context.Background(), tt.ctName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, services.ErrClusterTraitNotFound) {
+					t.Fatalf("expected ErrClusterTraitNotFound, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantSchema && result == nil {
+				t.Fatal("expected non-nil schema, got nil")
+			}
+		})
+	}
+}

--- a/internal/openchoreo-api/mcphandlers/helpers_test.go
+++ b/internal/openchoreo-api/mcphandlers/helpers_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	return scheme
+}
+
+// allowAllPDP is a PDP stub that always allows authorization.
+type allowAllPDP struct{}
+
+func (a *allowAllPDP) Evaluate(_ context.Context, _ *authzcore.EvaluateRequest) (*authzcore.Decision, error) {
+	return &authzcore.Decision{Decision: true, Context: &authzcore.DecisionContext{}}, nil
+}
+
+func (a *allowAllPDP) BatchEvaluate(_ context.Context, _ *authzcore.BatchEvaluateRequest) (*authzcore.BatchEvaluateResponse, error) {
+	return nil, nil
+}
+
+func (a *allowAllPDP) GetSubjectProfile(_ context.Context, _ *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
+	return nil, nil
+}

--- a/pkg/mcp/tools/infrastructure.go
+++ b/pkg/mcp/tools/infrastructure.go
@@ -527,3 +527,139 @@ func (t *Toolsets) RegisterListClusterObservabilityPlanes(s *mcp.Server) {
 		return handleToolResult(result, err)
 	})
 }
+
+// RegisterListClusterComponentTypes registers the "list_cluster_component_types" MCP tool
+// which lists all cluster-scoped component types (shared templates managed by platform
+// admins, not scoped to any namespace). Only registered when InfrastructureToolset also
+// implements ClusterPlaneHandler; otherwise it is a no-op.
+func (t *Toolsets) RegisterListClusterComponentTypes(s *mcp.Server) {
+	cp, ok := t.InfrastructureToolset.(ClusterPlaneHandler)
+	if !ok {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "list_cluster_component_types",
+		Description: "List all cluster-scoped component types. These are shared component type templates managed " +
+			"by platform admins that define the structure and capabilities of components across all namespaces.",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
+		result, err := cp.ListClusterComponentTypes(ctx)
+		return handleToolResult(result, err)
+	})
+}
+
+// RegisterGetClusterComponentType registers the "get_cluster_component_type" MCP tool
+// which returns detailed information about a specific cluster-scoped component type.
+// Only registered when InfrastructureToolset also implements ClusterPlaneHandler;
+// otherwise it is a no-op.
+func (t *Toolsets) RegisterGetClusterComponentType(s *mcp.Server) {
+	cp, ok := t.InfrastructureToolset.(ClusterPlaneHandler)
+	if !ok {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_cluster_component_type",
+		Description: "Get detailed information about a cluster-scoped component type including workload type, " +
+			"allowed workflows, allowed traits, and description.",
+		InputSchema: createSchema(map[string]any{
+			"cct_name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
+		}, []string{"cct_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		CctName string `json:"cct_name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := cp.GetClusterComponentType(ctx, args.CctName)
+		return handleToolResult(result, err)
+	})
+}
+
+// RegisterGetClusterComponentTypeSchema registers the "get_cluster_component_type_schema" MCP tool
+// which returns the JSON schema for a specific cluster-scoped component type.
+// Only registered when InfrastructureToolset also implements ClusterPlaneHandler;
+// otherwise it is a no-op.
+func (t *Toolsets) RegisterGetClusterComponentTypeSchema(s *mcp.Server) {
+	cp, ok := t.InfrastructureToolset.(ClusterPlaneHandler)
+	if !ok {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_cluster_component_type_schema",
+		Description: "Get the schema definition for a cluster-scoped component type. Returns the JSON schema " +
+			"showing required fields, optional fields, and their types.",
+		InputSchema: createSchema(map[string]any{
+			"cct_name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
+		}, []string{"cct_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		CctName string `json:"cct_name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := cp.GetClusterComponentTypeSchema(ctx, args.CctName)
+		return handleToolResult(result, err)
+	})
+}
+
+// RegisterListClusterTraits registers the "list_cluster_traits" MCP tool
+// which lists all cluster-scoped traits (shared trait definitions managed by platform
+// admins, not scoped to any namespace). Only registered when InfrastructureToolset also
+// implements ClusterPlaneHandler; otherwise it is a no-op.
+func (t *Toolsets) RegisterListClusterTraits(s *mcp.Server) {
+	cp, ok := t.InfrastructureToolset.(ClusterPlaneHandler)
+	if !ok {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "list_cluster_traits",
+		Description: "List all cluster-scoped traits. These are shared trait definitions managed by platform " +
+			"admins that add capabilities to components across all namespaces (e.g., autoscaling, ingress).",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
+		result, err := cp.ListClusterTraits(ctx)
+		return handleToolResult(result, err)
+	})
+}
+
+// RegisterGetClusterTrait registers the "get_cluster_trait" MCP tool
+// which returns detailed information about a specific cluster-scoped trait.
+// Only registered when InfrastructureToolset also implements ClusterPlaneHandler;
+// otherwise it is a no-op.
+func (t *Toolsets) RegisterGetClusterTrait(s *mcp.Server) {
+	cp, ok := t.InfrastructureToolset.(ClusterPlaneHandler)
+	if !ok {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_cluster_trait",
+		Description: "Get detailed information about a cluster-scoped trait including its name, " +
+			"display name, and description.",
+		InputSchema: createSchema(map[string]any{
+			"ct_name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
+		}, []string{"ct_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		CtName string `json:"ct_name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := cp.GetClusterTrait(ctx, args.CtName)
+		return handleToolResult(result, err)
+	})
+}
+
+// RegisterGetClusterTraitSchema registers the "get_cluster_trait_schema" MCP tool
+// which returns the JSON schema for a specific cluster-scoped trait.
+// Only registered when InfrastructureToolset also implements ClusterPlaneHandler;
+// otherwise it is a no-op.
+func (t *Toolsets) RegisterGetClusterTraitSchema(s *mcp.Server) {
+	cp, ok := t.InfrastructureToolset.(ClusterPlaneHandler)
+	if !ok {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_cluster_trait_schema",
+		Description: "Get the schema definition for a cluster-scoped trait. Returns the JSON schema " +
+			"showing trait configuration options and parameters.",
+		InputSchema: createSchema(map[string]any{
+			"ct_name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
+		}, []string{"ct_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		CtName string `json:"ct_name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := cp.GetClusterTraitSchema(ctx, args.CtName)
+		return handleToolResult(result, err)
+	})
+}

--- a/pkg/mcp/tools/infrastructure_specs_test.go
+++ b/pkg/mcp/tools/infrastructure_specs_test.go
@@ -344,5 +344,91 @@ func infrastructureToolSpecs() []toolTestSpec {
 				// No arguments to validate
 			},
 		},
+		{
+			name:                "list_cluster_component_types",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "component", "type"},
+			descriptionMinLen:   10,
+			testArgs:            map[string]any{},
+			expectedMethod:      "ListClusterComponentTypes",
+			validateCall: func(t *testing.T, args []interface{}) {
+				// No arguments to validate
+			},
+		},
+		{
+			name:                "get_cluster_component_type",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "component", "type"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"cct_name"},
+			testArgs: map[string]any{
+				"cct_name": "go-service",
+			},
+			expectedMethod: "GetClusterComponentType",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != "go-service" {
+					t.Errorf("Expected cct_name %q, got %v", "go-service", args[0])
+				}
+			},
+		},
+		{
+			name:                "get_cluster_component_type_schema",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "component", "type", "schema"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"cct_name"},
+			testArgs: map[string]any{
+				"cct_name": "go-service",
+			},
+			expectedMethod: "GetClusterComponentTypeSchema",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != "go-service" {
+					t.Errorf("Expected cct_name %q, got %v", "go-service", args[0])
+				}
+			},
+		},
+		{
+			name:                "list_cluster_traits",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "trait"},
+			descriptionMinLen:   10,
+			testArgs:            map[string]any{},
+			expectedMethod:      "ListClusterTraits",
+			validateCall: func(t *testing.T, args []interface{}) {
+				// No arguments to validate
+			},
+		},
+		{
+			name:                "get_cluster_trait",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "trait"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"ct_name"},
+			testArgs: map[string]any{
+				"ct_name": "autoscaler",
+			},
+			expectedMethod: "GetClusterTrait",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != "autoscaler" {
+					t.Errorf("Expected ct_name %q, got %v", "autoscaler", args[0])
+				}
+			},
+		},
+		{
+			name:                "get_cluster_trait_schema",
+			toolset:             "infrastructure",
+			descriptionKeywords: []string{"cluster", "trait", "schema"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"ct_name"},
+			testArgs: map[string]any{
+				"ct_name": "autoscaler",
+			},
+			expectedMethod: "GetClusterTraitSchema",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != "autoscaler" {
+					t.Errorf("Expected ct_name %q, got %v", "autoscaler", args[0])
+				}
+			},
+		},
 	}
 }

--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -390,6 +390,36 @@ func (m *MockCoreToolsetHandler) ListClusterObservabilityPlanes(ctx context.Cont
 	return `[{"name":"cop1"}]`, nil
 }
 
+func (m *MockCoreToolsetHandler) ListClusterComponentTypes(ctx context.Context) (any, error) {
+	m.recordCall("ListClusterComponentTypes")
+	return `[{"name":"go-service"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterComponentType(ctx context.Context, cctName string) (any, error) {
+	m.recordCall("GetClusterComponentType", cctName)
+	return `{"name":"go-service"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterComponentTypeSchema(ctx context.Context, cctName string) (any, error) {
+	m.recordCall("GetClusterComponentTypeSchema", cctName)
+	return emptyObjectSchema, nil
+}
+
+func (m *MockCoreToolsetHandler) ListClusterTraits(ctx context.Context) (any, error) {
+	m.recordCall("ListClusterTraits")
+	return `[{"name":"autoscaler"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterTrait(ctx context.Context, ctName string) (any, error) {
+	m.recordCall("GetClusterTrait", ctName)
+	return `{"name":"autoscaler"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterTraitSchema(ctx context.Context, ctName string) (any, error) {
+	m.recordCall("GetClusterTraitSchema", ctName)
+	return emptyObjectSchema, nil
+}
+
 func (m *MockCoreToolsetHandler) ApplyResource(ctx context.Context, resource map[string]interface{}) (any, error) {
 	m.recordCall("ApplyResource", resource)
 	return `{"operation":"created"}`, nil

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -98,6 +98,12 @@ func (t *Toolsets) infrastructureToolRegistrations() []RegisterFunc {
 		t.RegisterCreateClusterDataPlane,
 		t.RegisterListClusterBuildPlanes,
 		t.RegisterListClusterObservabilityPlanes,
+		t.RegisterListClusterComponentTypes,
+		t.RegisterGetClusterComponentType,
+		t.RegisterGetClusterComponentTypeSchema,
+		t.RegisterListClusterTraits,
+		t.RegisterGetClusterTrait,
+		t.RegisterGetClusterTraitSchema,
 	}
 }
 

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -183,6 +183,16 @@ type ClusterPlaneHandler interface {
 
 	// ClusterObservabilityPlane operations
 	ListClusterObservabilityPlanes(ctx context.Context) (any, error)
+
+	// ClusterComponentType operations
+	ListClusterComponentTypes(ctx context.Context) (any, error)
+	GetClusterComponentType(ctx context.Context, cctName string) (any, error)
+	GetClusterComponentTypeSchema(ctx context.Context, cctName string) (any, error)
+
+	// ClusterTrait operations
+	ListClusterTraits(ctx context.Context) (any, error)
+	GetClusterTrait(ctx context.Context, ctName string) (any, error)
+	GetClusterTraitSchema(ctx context.Context, ctName string) (any, error)
 }
 
 // SchemaToolsetHandler handles schema and resource explanation operations


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
 - Add MCP server support for cluster-scoped component types and cluster traits, enabling AI/MCP clients to list, get,  
  and retrieve schemas for ClusterComponentType and ClusterTrait resources                                             
  - Update create_component MCP tool to support ClusterComponentType references via a new componentTypeKind parameter (previously hardcoded to "ComponentType")                                                                              
  - Update update_component_traits MCP tool description to document the kind field for distinguishing namespace-scoped   
  Trait vs cluster-scoped ClusterTrait   

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
