### PR TITLE
feat(api): add logs endpoints for workflowruns in apiserver

### DIFF
--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -464,6 +464,12 @@ type ClientInterface interface {
 	// GetWorkflowRun request
 	GetWorkflowRun(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetWorkflowRunEvents request
+	GetWorkflowRunEvents(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetWorkflowRunLogs request
+	GetWorkflowRunLogs(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetWorkflowRunStatus request
 	GetWorkflowRunStatus(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2126,6 +2132,30 @@ func (c *Client) CreateWorkflowRun(ctx context.Context, namespaceName NamespaceN
 
 func (c *Client) GetWorkflowRun(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetWorkflowRunRequest(c.Server, namespaceName, runName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetWorkflowRunEvents(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkflowRunEventsRequest(c.Server, namespaceName, runName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetWorkflowRunLogs(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkflowRunLogsRequest(c.Server, namespaceName, runName, params)
 	if err != nil {
 		return nil, err
 	}
@@ -7295,6 +7325,148 @@ func NewGetWorkflowRunRequest(server string, namespaceName NamespaceNameParam, r
 	return req, nil
 }
 
+// NewGetWorkflowRunEventsRequest generates requests for GetWorkflowRunEvents
+func NewGetWorkflowRunEventsRequest(server string, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunEventsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "runName", runtime.ParamLocationPath, runName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/workflow-runs/%s/events", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Step != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "step", runtime.ParamLocationQuery, *params.Step); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetWorkflowRunLogsRequest generates requests for GetWorkflowRunLogs
+func NewGetWorkflowRunLogsRequest(server string, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunLogsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "runName", runtime.ParamLocationPath, runName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/workflow-runs/%s/logs", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Step != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "step", runtime.ParamLocationQuery, *params.Step); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SinceSeconds != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sinceSeconds", runtime.ParamLocationQuery, *params.SinceSeconds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetWorkflowRunStatusRequest generates requests for GetWorkflowRunStatus
 func NewGetWorkflowRunStatusRequest(server string, namespaceName NamespaceNameParam, runName WorkflowRunNameParam) (*http.Request, error) {
 	var err error
@@ -8121,6 +8293,12 @@ type ClientWithResponsesInterface interface {
 
 	// GetWorkflowRunWithResponse request
 	GetWorkflowRunWithResponse(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, reqEditors ...RequestEditorFn) (*GetWorkflowRunResp, error)
+
+	// GetWorkflowRunEventsWithResponse request
+	GetWorkflowRunEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunEventsParams, reqEditors ...RequestEditorFn) (*GetWorkflowRunEventsResp, error)
+
+	// GetWorkflowRunLogsWithResponse request
+	GetWorkflowRunLogsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunLogsParams, reqEditors ...RequestEditorFn) (*GetWorkflowRunLogsResp, error)
 
 	// GetWorkflowRunStatusWithResponse request
 	GetWorkflowRunStatusWithResponse(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, reqEditors ...RequestEditorFn) (*GetWorkflowRunStatusResp, error)
@@ -10848,6 +11026,58 @@ func (r GetWorkflowRunResp) StatusCode() int {
 	return 0
 }
 
+type GetWorkflowRunEventsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]WorkflowRunEventEntry
+	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWorkflowRunEventsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWorkflowRunEventsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetWorkflowRunLogsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]WorkflowRunLogEntry
+	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWorkflowRunLogsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWorkflowRunLogsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetWorkflowRunStatusResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -12298,6 +12528,24 @@ func (c *ClientWithResponses) GetWorkflowRunWithResponse(ctx context.Context, na
 		return nil, err
 	}
 	return ParseGetWorkflowRunResp(rsp)
+}
+
+// GetWorkflowRunEventsWithResponse request returning *GetWorkflowRunEventsResp
+func (c *ClientWithResponses) GetWorkflowRunEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunEventsParams, reqEditors ...RequestEditorFn) (*GetWorkflowRunEventsResp, error) {
+	rsp, err := c.GetWorkflowRunEvents(ctx, namespaceName, runName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWorkflowRunEventsResp(rsp)
+}
+
+// GetWorkflowRunLogsWithResponse request returning *GetWorkflowRunLogsResp
+func (c *ClientWithResponses) GetWorkflowRunLogsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, runName WorkflowRunNameParam, params *GetWorkflowRunLogsParams, reqEditors ...RequestEditorFn) (*GetWorkflowRunLogsResp, error) {
+	rsp, err := c.GetWorkflowRunLogs(ctx, namespaceName, runName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWorkflowRunLogsResp(rsp)
 }
 
 // GetWorkflowRunStatusWithResponse request returning *GetWorkflowRunStatusResp
@@ -18014,6 +18262,114 @@ func ParseGetWorkflowRunResp(rsp *http.Response) (*GetWorkflowRunResp, error) {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWorkflowRunEventsResp parses an HTTP response from a GetWorkflowRunEventsWithResponse call
+func ParseGetWorkflowRunEventsResp(rsp *http.Response) (*GetWorkflowRunEventsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWorkflowRunEventsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []WorkflowRunEventEntry
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWorkflowRunLogsResp parses an HTTP response from a GetWorkflowRunLogsWithResponse call
+func ParseGetWorkflowRunLogsResp(rsp *http.Response) (*GetWorkflowRunLogsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWorkflowRunLogsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []WorkflowRunLogEntry
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
 		var dest Forbidden

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -2678,6 +2678,21 @@ type WorkflowRun struct {
 // WorkflowRunStatus Current execution status
 type WorkflowRunStatus string
 
+// WorkflowRunEventEntry A single Kubernetes event from a workflow run
+type WorkflowRunEventEntry struct {
+	// Message Human-readable description of the event
+	Message string `json:"message"`
+
+	// Reason Short machine-understandable reason for the event
+	Reason string `json:"reason"`
+
+	// Timestamp Event timestamp
+	Timestamp time.Time `json:"timestamp"`
+
+	// Type Event type
+	Type string `json:"type"`
+}
+
 // WorkflowRunList Paginated list of workflow runs
 type WorkflowRunList struct {
 	Items []WorkflowRun `json:"items"`
@@ -2685,6 +2700,15 @@ type WorkflowRunList struct {
 	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
 	// for efficient pagination through large result sets.
 	Pagination Pagination `json:"pagination"`
+}
+
+// WorkflowRunLogEntry A single log entry from a workflow run
+type WorkflowRunLogEntry struct {
+	// Log Log message
+	Log string `json:"log"`
+
+	// Timestamp Log entry timestamp
+	Timestamp *time.Time `json:"timestamp,omitempty"`
 }
 
 // WorkflowRunStatusResponse Status of a workflow run including per-step details
@@ -2984,6 +3008,21 @@ type ListWorkflowRunsParams struct {
 	// Cursor Opaque pagination cursor from a previous response.
 	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
 	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// GetWorkflowRunEventsParams defines parameters for GetWorkflowRunEvents.
+type GetWorkflowRunEventsParams struct {
+	// Step Filter events by step name
+	Step *string `form:"step,omitempty" json:"step,omitempty"`
+}
+
+// GetWorkflowRunLogsParams defines parameters for GetWorkflowRunLogs.
+type GetWorkflowRunLogsParams struct {
+	// Step Filter logs by step name
+	Step *string `form:"step,omitempty" json:"step,omitempty"`
+
+	// SinceSeconds Return logs newer than a relative duration in seconds
+	SinceSeconds *int64 `form:"sinceSeconds,omitempty" json:"sinceSeconds,omitempty"`
 }
 
 // ListWorkflowsParams defines parameters for ListWorkflows.

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -141,6 +141,7 @@ func (h *Handler) Routes() http.Handler {
 	api.HandleFunc("POST "+v1+"/namespaces/{namespaceName}/workflow-runs", h.CreateWorkflowRun)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}", h.GetWorkflowRun)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}/status", h.GetWorkflowRunStatus)
+	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}/logs", h.GetWorkflowRunLogs)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/workflow-runs/{runName}/events", h.GetWorkflowRunEvents)
 
 	// ComponentWorkflow endpoints (component-specific workflows)

--- a/internal/openchoreo-api/handlers/workflowruns.go
+++ b/internal/openchoreo-api/handlers/workflowruns.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 
 	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
@@ -160,6 +161,71 @@ func (h *Handler) CreateWorkflowRun(w http.ResponseWriter, r *http.Request) {
 
 	logger.Debug("Created WorkflowRun successfully", "org", namespaceName, "run", wfRun.Name, "workflow", req.WorkflowName)
 	writeSuccessResponse(w, http.StatusCreated, wfRun)
+}
+
+func (h *Handler) GetWorkflowRunLogs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.GetLogger(ctx)
+	log.Debug("GetWorkflowRunLogs handler called")
+
+	namespaceName := r.PathValue("namespaceName")
+	runName := r.PathValue("runName")
+	stepName := r.URL.Query().Get("step")
+
+	// Parse sinceSeconds parameter (optional, in seconds)
+	var sinceSeconds *int64
+	if sinceSecondsStr := r.URL.Query().Get("sinceSeconds"); sinceSecondsStr != "" {
+		parsed, err := strconv.ParseInt(sinceSecondsStr, 10, 64)
+		if err != nil || parsed < 0 {
+			log.Error("Invalid sinceSeconds parameter", "sinceSeconds", sinceSecondsStr, "error", err)
+			writeErrorResponse(w, http.StatusBadRequest, "Invalid sinceSeconds parameter: must be a non-negative integer", services.CodeInvalidInput)
+			return
+		}
+		sinceSeconds = &parsed
+	}
+
+	if namespaceName == "" {
+		log.Error("Namespace name is required")
+		writeErrorResponse(w, http.StatusBadRequest, "Namespace name is required", services.CodeInvalidInput)
+		return
+	}
+
+	if runName == "" {
+		log.Error("Workflow run name is required")
+		writeErrorResponse(w, http.StatusBadRequest, "Workflow run name is required", services.CodeInvalidInput)
+		return
+	}
+
+	log = log.With("namespace", namespaceName, "run", runName, "step", stepName, "sinceSeconds", sinceSeconds)
+
+	logs, err := h.services.WorkflowRunService.GetWorkflowRunLogs(ctx, namespaceName, runName, stepName, h.config.ClusterGateway.URL, sinceSeconds)
+	if err != nil {
+		if errors.Is(err, services.ErrWorkflowRunNotFound) {
+			log.Warn("Workflow run not found")
+			writeErrorResponse(w, http.StatusNotFound, "Workflow run not found", services.CodeWorkflowRunNotFound)
+			return
+		}
+		if errors.Is(err, services.ErrForbidden) {
+			log.Warn("Unauthorized to view workflow run logs")
+			writeErrorResponse(w, http.StatusForbidden, services.ErrForbidden.Error(), services.CodeForbidden)
+			return
+		}
+		if errors.Is(err, services.ErrWorkflowRunReferenceNotFound) {
+			log.Warn("Workflow run reference not ready")
+			writeErrorResponse(w, http.StatusNotFound, "Workflow run reference not ready", services.CodeWorkflowRunReferenceNotFound)
+			return
+		}
+		log.Error("Failed to get workflow run logs", "error", err)
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get workflow run logs", services.CodeInternalError)
+		return
+	}
+
+	// Return logs as JSON array
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(logs); err != nil {
+		log.Error("Failed to encode logs response", "error", err)
+	}
 }
 
 func (h *Handler) GetWorkflowRunEvents(w http.ResponseWriter, r *http.Request) {

--- a/internal/openchoreo-api/handlers/workflowruns_test.go
+++ b/internal/openchoreo-api/handlers/workflowruns_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
+	services "github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+// mockWorkflowRunService is a test double for WorkflowRunServiceInterface.
+// Only GetWorkflowRunLogs is exercised by the tests below; the other methods
+// panic if unexpectedly called so test failures surface immediately.
+type mockWorkflowRunService struct {
+	getLogsResult   []models.ComponentWorkflowRunLogEntry
+	getLogsErr      error
+	getEventsResult []models.ComponentWorkflowRunEventEntry
+	getEventsErr    error
+}
+
+func (m *mockWorkflowRunService) ListWorkflowRuns(_ context.Context, _ string) ([]*models.WorkflowRunResponse, error) {
+	panic("unexpected call to ListWorkflowRuns")
+}
+func (m *mockWorkflowRunService) GetWorkflowRun(_ context.Context, _, _ string) (*models.WorkflowRunResponse, error) {
+	panic("unexpected call to GetWorkflowRun")
+}
+func (m *mockWorkflowRunService) GetWorkflowRunStatus(_ context.Context, _, _, _ string) (*models.ComponentWorkflowRunStatusResponse, error) {
+	panic("unexpected call to GetWorkflowRunStatus")
+}
+func (m *mockWorkflowRunService) CreateWorkflowRun(_ context.Context, _ string, _ *models.CreateWorkflowRunRequest) (*models.WorkflowRunResponse, error) {
+	panic("unexpected call to CreateWorkflowRun")
+}
+func (m *mockWorkflowRunService) GetWorkflowRunLogs(_ context.Context, _, _, _, _ string, _ *int64) ([]models.ComponentWorkflowRunLogEntry, error) {
+	return m.getLogsResult, m.getLogsErr
+}
+func (m *mockWorkflowRunService) GetWorkflowRunEvents(_ context.Context, _, _, _, _ string) ([]models.ComponentWorkflowRunEventEntry, error) {
+	return m.getEventsResult, m.getEventsErr
+}
+
+// newHandlerWithMock returns a Handler wired with the provided mock service.
+func newHandlerWithMock(mock services.WorkflowRunServiceInterface) *Handler {
+	svc := &services.Services{}
+	svc.WorkflowRunService = mock
+	cfg := &config.Config{
+		ClusterGateway: config.ClusterGatewayConfig{URL: "http://test-gateway"},
+	}
+	return &Handler{
+		services: svc,
+		config:   cfg,
+		logger:   slog.Default(),
+	}
+}
+
+// ========== GetWorkflowRunLogs – query parameter validation ==========
+
+func TestGetWorkflowRunLogs_InvalidSinceSeconds(t *testing.T) {
+	tests := []struct {
+		name         string
+		sinceSeconds string
+		wantStatus   int
+		wantCode     string
+	}{
+		{
+			name:         "non-integer sinceSeconds",
+			sinceSeconds: "abc",
+			wantStatus:   http.StatusBadRequest,
+			wantCode:     services.CodeInvalidInput,
+		},
+		{
+			name:         "negative sinceSeconds",
+			sinceSeconds: "-5",
+			wantStatus:   http.StatusBadRequest,
+			wantCode:     services.CodeInvalidInput,
+		},
+	}
+
+	h := newHandlerWithMock(&mockWorkflowRunService{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/namespaces/test-ns/workflow-runs/test-run/logs?sinceSeconds="+tt.sinceSeconds, nil)
+			req.SetPathValue("namespaceName", "test-ns")
+			req.SetPathValue("runName", "test-run")
+
+			w := httptest.NewRecorder()
+			h.GetWorkflowRunLogs(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if !strings.Contains(w.Body.String(), tt.wantCode) {
+				t.Errorf("body %q does not contain code %q", w.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestGetWorkflowRunLogs_MissingPathValues(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespaceName string
+		runName       string
+		wantStatus    int
+		wantCode      string
+	}{
+		{
+			name:          "missing namespaceName",
+			namespaceName: "",
+			runName:       "test-run",
+			wantStatus:    http.StatusBadRequest,
+			wantCode:      services.CodeInvalidInput,
+		},
+		{
+			name:          "missing runName",
+			namespaceName: "test-ns",
+			runName:       "",
+			wantStatus:    http.StatusBadRequest,
+			wantCode:      services.CodeInvalidInput,
+		},
+	}
+
+	h := newHandlerWithMock(&mockWorkflowRunService{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/namespaces/"+tt.namespaceName+"/workflow-runs/"+tt.runName+"/logs", nil)
+			req.SetPathValue("namespaceName", tt.namespaceName)
+			req.SetPathValue("runName", tt.runName)
+
+			w := httptest.NewRecorder()
+			h.GetWorkflowRunLogs(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if !strings.Contains(w.Body.String(), tt.wantCode) {
+				t.Errorf("body %q does not contain code %q", w.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+// ========== GetWorkflowRunLogs – service error mapping ==========
+
+func TestGetWorkflowRunLogs_ServiceErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		serviceErr error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "ErrWorkflowRunNotFound → 404",
+			serviceErr: services.ErrWorkflowRunNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   services.CodeWorkflowRunNotFound,
+		},
+		{
+			name:       "ErrForbidden → 403",
+			serviceErr: services.ErrForbidden,
+			wantStatus: http.StatusForbidden,
+			wantCode:   services.CodeForbidden,
+		},
+		{
+			name:       "ErrWorkflowRunReferenceNotFound → 404",
+			serviceErr: services.ErrWorkflowRunReferenceNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   services.CodeWorkflowRunReferenceNotFound,
+		},
+		{
+			name:       "unexpected error → 500",
+			serviceErr: errors.New("unexpected failure"),
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   services.CodeInternalError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandlerWithMock(&mockWorkflowRunService{getLogsErr: tt.serviceErr})
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/namespaces/test-ns/workflow-runs/test-run/logs", nil)
+			req.SetPathValue("namespaceName", "test-ns")
+			req.SetPathValue("runName", "test-run")
+
+			w := httptest.NewRecorder()
+			h.GetWorkflowRunLogs(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if !strings.Contains(w.Body.String(), tt.wantCode) {
+				t.Errorf("body %q does not contain code %q", w.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+// ========== GetWorkflowRunLogs – success response shape ==========
+
+func TestGetWorkflowRunLogs_Success(t *testing.T) {
+	entries := []models.ComponentWorkflowRunLogEntry{
+		{Timestamp: "2025-01-06T10:00:00Z", Log: "step started"},
+		{Timestamp: "", Log: "no timestamp line"},
+	}
+	h := newHandlerWithMock(&mockWorkflowRunService{getLogsResult: entries})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/namespaces/test-ns/workflow-runs/test-run/logs", nil)
+	req.SetPathValue("namespaceName", "test-ns")
+	req.SetPathValue("runName", "test-run")
+
+	w := httptest.NewRecorder()
+	h.GetWorkflowRunLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got []models.ComponentWorkflowRunLogEntry
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Log != "step started" {
+		t.Errorf("got[0].Log = %q, want %q", got[0].Log, "step started")
+	}
+}

--- a/internal/openchoreo-api/legacyservices/services.go
+++ b/internal/openchoreo-api/legacyservices/services.go
@@ -19,7 +19,7 @@ type Services struct {
 	ComponentService                 *ComponentService
 	ComponentTypeService             *ComponentTypeService
 	WorkflowService                  *WorkflowService
-	WorkflowRunService               *WorkflowRunService
+	WorkflowRunService               WorkflowRunServiceInterface
 	ComponentWorkflowService         *ComponentWorkflowService
 	TraitService                     *TraitService
 	NamespaceService                 *NamespaceService

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -539,7 +539,7 @@ type WorkflowStepStatus struct {
 
 // ComponentWorkflowRunLogEntry represents a log entry from a component workflow run
 type ComponentWorkflowRunLogEntry struct {
-	Timestamp string `json:"timestamp"`
+	Timestamp string `json:"timestamp,omitempty"`
 	Log       string `json:"log"`
 }
 

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -1509,6 +1509,80 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/namespaces/{namespaceName}/workflow-runs/{runName}/logs:
+    get:
+      operationId: getWorkflowRunLogs
+      summary: Get workflow run logs
+      description: Returns logs for a specific workflow run from the build plane. Logs are fetched live from the build plane; no archived logs are returned for completed runs.
+      tags: [Workflows]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/WorkflowRunNameParam'
+        - name: step
+          in: query
+          required: false
+          description: Filter logs by step name
+          schema:
+            type: string
+        - name: sinceSeconds
+          in: query
+          required: false
+          description: Return logs newer than a relative duration in seconds
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        '200':
+          description: Workflow run logs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkflowRunLogEntry'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/workflow-runs/{runName}/events:
+    get:
+      operationId: getWorkflowRunEvents
+      summary: Get workflow run events
+      description: Returns Kubernetes events for a specific workflow run.
+      tags: [Workflows]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/WorkflowRunNameParam'
+        - name: step
+          in: query
+          required: false
+          description: Filter events by step name
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Workflow run events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkflowRunEventEntry'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   # =============================================================================
   # ComponentWorkflow Endpoints
   # =============================================================================
@@ -5601,6 +5675,49 @@ components:
           format: date-time
           description: When the step finished
           example: "2025-01-06T10:01:00Z"
+
+    WorkflowRunLogEntry:
+      type: object
+      description: A single log entry from a workflow run
+      required:
+        - log
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Log entry timestamp
+          example: "2025-01-06T10:00:00Z"
+        log:
+          type: string
+          description: Log message
+          example: "Step 1: Cloning repository..."
+
+    WorkflowRunEventEntry:
+      type: object
+      description: A single Kubernetes event from a workflow run
+      required:
+        - timestamp
+        - type
+        - reason
+        - message
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Event timestamp
+          example: "2025-01-06T10:00:00Z"
+        type:
+          type: string
+          description: Event type
+          example: Normal
+        reason:
+          type: string
+          description: Short machine-understandable reason for the event
+          example: Started
+        message:
+          type: string
+          description: Human-readable description of the event
+          example: "Container main started"
 
     CreateWorkflowRunRequest:
       type: object


### PR DESCRIPTION
## Purpose
Add logs endpoints for workflowruns in apiserver. 
- Fix https://github.com/openchoreo/openchoreo/issues/2162

## Description
  - Added GET /api/v1/namespaces/{namespaceName}/workflow-runs/{runName}/logs
  - Wired up the service layer to fetch live pod logs from the build plane via the cluster gateway, following the same pattern as component workflow runs
  - Updated openapi/openchoreo-api.yaml with the new logs and events endpoint definitions and regenerated the client/server code