### PR TITLE
fix: change default cluster name in k3d.mk

### DIFF
--- a/make/k3d.mk
+++ b/make/k3d.mk
@@ -2,7 +2,7 @@
 # Uses k3d image import for loading locally-built images
 
 # Configuration
-K3D_CLUSTER_NAME ?= openchoreo-dev
+K3D_CLUSTER_NAME ?= openchoreo
 OPENCHOREO_IMAGE_TAG := latest-dev
 
 # Namespaces for each plane


### PR DESCRIPTION
This pull request makes a small configuration change to the `make/k3d.mk` file, updating the default cluster name used for k3d deployments. The default value for `K3D_CLUSTER_NAME` is changed from `openchoreo-dev` to `openchoreo`.