### PR TITLE
refactor: enhance notification channel handling in release binding

### DIFF
--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -64,7 +64,7 @@ func BuildComponentContext(input *ComponentContextInput) (*ComponentContext, err
 	}
 
 	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
-	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane)
+	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane, input.DefaultNotificationChannel)
 
 	return ctx, nil
 }
@@ -190,19 +190,21 @@ func extractDataPlaneData(dp *v1alpha1.DataPlane) DataPlaneData {
 // If the Environment has gateway configuration, it uses those values.
 // Otherwise, it falls back to the DataPlane gateway configuration.
 // Gateway name and namespace default to "gateway-default" and "openchoreo-data-plane" if not set.
-func extractEnvironmentData(env *v1alpha1.Environment, dp *v1alpha1.DataPlane) EnvironmentData {
+func extractEnvironmentData(env *v1alpha1.Environment, dp *v1alpha1.DataPlane, defaultNotificationChannel string) EnvironmentData {
 	// If environment has gateway configuration, use it
 	if env.Spec.Gateway.PublicVirtualHost != "" {
 		return EnvironmentData{
-			PublicVirtualHost:       env.Spec.Gateway.PublicVirtualHost,
-			OrganizationVirtualHost: env.Spec.Gateway.OrganizationVirtualHost,
+			PublicVirtualHost:          env.Spec.Gateway.PublicVirtualHost,
+			OrganizationVirtualHost:    env.Spec.Gateway.OrganizationVirtualHost,
+			DefaultNotificationChannel: defaultNotificationChannel,
 		}
 	}
 
 	// Fallback to DataPlane gateway configuration
 	return EnvironmentData{
-		PublicVirtualHost:       dp.Spec.Gateway.PublicVirtualHost,
-		OrganizationVirtualHost: dp.Spec.Gateway.OrganizationVirtualHost,
+		PublicVirtualHost:          dp.Spec.Gateway.PublicVirtualHost,
+		OrganizationVirtualHost:    dp.Spec.Gateway.OrganizationVirtualHost,
+		DefaultNotificationChannel: defaultNotificationChannel,
 	}
 }
 

--- a/internal/pipeline/component/context/embedded_trait.go
+++ b/internal/pipeline/component/context/embedded_trait.go
@@ -51,6 +51,10 @@ type EmbeddedTraitContextInput struct {
 
 	// Environment contains the environment configuration.
 	Environment *v1alpha1.Environment `validate:"required"`
+
+	// DefaultNotificationChannel is the default notification channel name for the environment.
+	// Optional - if not provided, the defaultNotificationChannel field in EnvironmentData will be empty.
+	DefaultNotificationChannel string
 }
 
 // ResolveEmbeddedTraitBindings resolves CEL expressions in an embedded trait's parameter
@@ -147,7 +151,7 @@ func BuildEmbeddedTraitContext(input *EmbeddedTraitContextInput) (*TraitContext,
 	}
 
 	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
-	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane)
+	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane, input.DefaultNotificationChannel)
 	ctx.Workload = input.WorkloadData
 	ctx.Configurations = input.Configurations
 

--- a/internal/pipeline/component/context/trait.go
+++ b/internal/pipeline/component/context/trait.go
@@ -65,7 +65,7 @@ func BuildTraitContext(input *TraitContextInput) (*TraitContext, error) {
 	}
 
 	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
-	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane)
+	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane, input.DefaultNotificationChannel)
 	ctx.Workload = input.WorkloadData
 	ctx.Configurations = input.Configurations
 

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -108,6 +108,10 @@ type ComponentContextInput struct {
 	// Metadata provides structured naming and labeling information.
 	// Required - controller must provide this.
 	Metadata MetadataContext `validate:"required"`
+
+	// DefaultNotificationChannel is the default notification channel name for the environment.
+	// Optional - if not provided, the defaultNotificationChannel field in EnvironmentData will be empty.
+	DefaultNotificationChannel string
 }
 
 // TraitContextInput contains all inputs needed to build a trait rendering context.
@@ -151,6 +155,10 @@ type TraitContextInput struct {
 	// Environment contains the environment configuration.
 	// Required - controller must provide this.
 	Environment *v1alpha1.Environment `validate:"required"`
+
+	// DefaultNotificationChannel is the default notification channel name for the environment.
+	// Optional - if not provided, the defaultNotificationChannel field in EnvironmentData will be empty.
+	DefaultNotificationChannel string
 }
 
 // SchemaInput contains schema information for building structural and JSON schemas.
@@ -216,8 +224,9 @@ type ObservabilityPlaneRefData struct {
 // EnvironmentData provides environment-specific gateway configuration in templates.
 // If the environment does not have gateway configuration, values fallback to DataPlane gateway.
 type EnvironmentData struct {
-	PublicVirtualHost       string `json:"publicVirtualHost,omitempty"`
-	OrganizationVirtualHost string `json:"organizationVirtualHost,omitempty"`
+	PublicVirtualHost          string `json:"publicVirtualHost,omitempty"`
+	OrganizationVirtualHost    string `json:"organizationVirtualHost,omitempty"`
+	DefaultNotificationChannel string `json:"defaultNotificationChannel,omitempty"`
 }
 
 // WorkloadData contains workload information for templates.

--- a/internal/pipeline/component/pipeline.go
+++ b/internal/pipeline/component/pipeline.go
@@ -90,14 +90,15 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 	// Build component context
 	componentContext, err := context.BuildComponentContext(&context.ComponentContextInput{
-		Component:      input.Component,
-		ComponentType:  input.ComponentType,
-		ReleaseBinding: input.ReleaseBinding,
-		DataPlane:      input.DataPlane,
-		Environment:    input.Environment,
-		WorkloadData:   workloadData,
-		Configurations: configurations,
-		Metadata:       input.Metadata,
+		Component:                  input.Component,
+		ComponentType:              input.ComponentType,
+		ReleaseBinding:             input.ReleaseBinding,
+		DataPlane:                  input.DataPlane,
+		Environment:                input.Environment,
+		WorkloadData:               workloadData,
+		Configurations:             configurations,
+		Metadata:                   input.Metadata,
+		DefaultNotificationChannel: input.DefaultNotificationChannel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build component context: %w", err)
@@ -158,17 +159,18 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Build embedded trait context
 		traitContext, err := context.BuildEmbeddedTraitContext(&context.EmbeddedTraitContextInput{
-			Trait:                t,
-			InstanceName:         embeddedTrait.InstanceName,
-			ResolvedParameters:   resolvedParams,
-			ResolvedEnvOverrides: resolvedEnvOverrides,
-			Component:            input.Component,
-			WorkloadData:         workloadData,
-			Configurations:       configurations,
-			Metadata:             input.Metadata,
-			SchemaCache:          schemaCache,
-			DataPlane:            input.DataPlane,
-			Environment:          input.Environment,
+			Trait:                      t,
+			InstanceName:               embeddedTrait.InstanceName,
+			ResolvedParameters:         resolvedParams,
+			ResolvedEnvOverrides:       resolvedEnvOverrides,
+			Component:                  input.Component,
+			WorkloadData:               workloadData,
+			Configurations:             configurations,
+			Metadata:                   input.Metadata,
+			SchemaCache:                schemaCache,
+			DataPlane:                  input.DataPlane,
+			Environment:                input.Environment,
+			DefaultNotificationChannel: input.DefaultNotificationChannel,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build embedded trait context for %s/%s: %w",
@@ -206,16 +208,17 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Build trait context (BuildTraitContext will handle schema caching)
 		traitContext, err := context.BuildTraitContext(&context.TraitContextInput{
-			Trait:          t,
-			Instance:       traitInstance,
-			Component:      input.Component,
-			ReleaseBinding: input.ReleaseBinding,
-			WorkloadData:   workloadData,
-			Configurations: configurations,
-			Metadata:       input.Metadata,
-			SchemaCache:    schemaCache,
-			DataPlane:      input.DataPlane,
-			Environment:    input.Environment,
+			Trait:                      t,
+			Instance:                   traitInstance,
+			Component:                  input.Component,
+			ReleaseBinding:             input.ReleaseBinding,
+			WorkloadData:               workloadData,
+			Configurations:             configurations,
+			Metadata:                   input.Metadata,
+			SchemaCache:                schemaCache,
+			DataPlane:                  input.DataPlane,
+			Environment:                input.Environment,
+			DefaultNotificationChannel: input.DefaultNotificationChannel,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build trait context for %s/%s: %w",

--- a/internal/pipeline/component/types.go
+++ b/internal/pipeline/component/types.go
@@ -54,6 +54,10 @@ type RenderInput struct {
 	// Metadata provides structured naming information.
 	// Required - controller must compute and provide this.
 	Metadata pipelinecontext.MetadataContext `validate:"required"`
+
+	// DefaultNotificationChannel is the default notification channel name for the environment.
+	// Optional - if not provided, traits won't have access to a default notification channel.
+	DefaultNotificationChannel string
 }
 
 // ApplyTargetPlaneDefaults normalizes empty targetPlane fields to "dataplane".

--- a/samples/component-alerts/alert-rule-trait.yaml
+++ b/samples/component-alerts/alert-rule-trait.yaml
@@ -25,7 +25,11 @@ spec:
       # Platform engineers can override per environment
       enabled: "boolean | default=true | description=\"Controls whether this alert rule is active. When disabled, the rule will not trigger alerts.\""
       enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enables AI-powered root cause analysis for alerts triggered by this rule. When enabled, provides automated reports of root causes for alert conditions.\""
-      notificationChannel: "string | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers.\""
+      notificationChannel: "string | default=\"\" | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers. If not provided, defaults to the environment's default notification channel.\""
+
+  validations:
+    - rule: "${(has(envOverrides.notificationChannel) && envOverrides.notificationChannel != '') || (has(environment.defaultNotificationChannel) && environment.defaultNotificationChannel != '')}"
+      message: "A notification channel must be provided either in envOverrides or as the environment default."
 
   creates:
     - targetPlane: observabilityplane
@@ -47,7 +51,10 @@ spec:
           severity: ${parameters.severity}
           enabled: ${envOverrides.enabled}
           enableAiRootCauseAnalysis: ${envOverrides.enableAiRootCauseAnalysis}
-          notificationChannel: ${envOverrides.notificationChannel}
+          notificationChannel: >-
+            ${has(envOverrides.notificationChannel) && envOverrides.notificationChannel != ""
+              ? envOverrides.notificationChannel
+              : environment.defaultNotificationChannel}
           source:
             type: ${parameters.source.type}
             query: ${parameters.source.query}

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -1457,7 +1457,11 @@ spec:
       # Platform engineers can override per environment
       enabled: "boolean | default=true | description=\"Controls whether this alert rule is active. When disabled, the rule will not trigger alerts.\""
       enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enables AI-powered root cause analysis for alerts triggered by this rule. When enabled, provides automated reports of root causes for alert conditions.\""
-      notificationChannel: "string | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers.\""
+      notificationChannel: "string | default=\"\" | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers. If not provided, defaults to the environment's default notification channel.\""
+
+  validations:
+    - rule: "${(has(envOverrides.notificationChannel) && envOverrides.notificationChannel != '') || (has(environment.defaultNotificationChannel) && environment.defaultNotificationChannel != '')}"
+      message: "A notification channel must be provided either in envOverrides or as the environment default."
 
   creates:
     - targetPlane: observabilityplane
@@ -1479,7 +1483,10 @@ spec:
           severity: ${parameters.severity}
           enabled: ${envOverrides.enabled}
           enableAiRootCauseAnalysis: ${envOverrides.enableAiRootCauseAnalysis}
-          notificationChannel: ${envOverrides.notificationChannel}
+          notificationChannel: >-
+            ${has(envOverrides.notificationChannel) && envOverrides.notificationChannel != ""
+              ? envOverrides.notificationChannel
+              : environment.defaultNotificationChannel}
           source:
             type: ${parameters.source.type}
             query: ${parameters.source.query}

--- a/samples/getting-started/component-traits/alert-rule-trait.yaml
+++ b/samples/getting-started/component-traits/alert-rule-trait.yaml
@@ -25,7 +25,11 @@ spec:
       # Platform engineers can override per environment
       enabled: "boolean | default=true | description=\"Controls whether this alert rule is active. When disabled, the rule will not trigger alerts.\""
       enableAiRootCauseAnalysis: "boolean | default=false | description=\"Enables AI-powered root cause analysis for alerts triggered by this rule. When enabled, provides automated reports of root causes for alert conditions.\""
-      notificationChannel: "string | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers.\""
+      notificationChannel: "string | default=\"\" | description=\"The notification channel identifier where alerts should be delivered. Configured per environment by platform engineers. If not provided, defaults to the environment's default notification channel.\""
+
+  validations:
+    - rule: "${(has(envOverrides.notificationChannel) && envOverrides.notificationChannel != '') || (has(environment.defaultNotificationChannel) && environment.defaultNotificationChannel != '')}"
+      message: "A notification channel must be provided either in envOverrides or as the environment default."
 
   creates:
     - targetPlane: observabilityplane
@@ -47,7 +51,10 @@ spec:
           severity: ${parameters.severity}
           enabled: ${envOverrides.enabled}
           enableAiRootCauseAnalysis: ${envOverrides.enableAiRootCauseAnalysis}
-          notificationChannel: ${envOverrides.notificationChannel}
+          notificationChannel: >-
+            ${has(envOverrides.notificationChannel) && envOverrides.notificationChannel != ""
+              ? envOverrides.notificationChannel
+              : environment.defaultNotificationChannel}
           source:
             type: ${parameters.source.type}
             query: ${parameters.source.query}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces a new mechanism for providing default notification channels to alert rule traits, ensuring that traits can access environment-specific notification channels in a more flexible and robust way. The changes remove the previous controller-side injection logic and instead make the default notification channel available to the rendering pipeline and trait CEL contexts, allowing templates to reference it directly. Additionally, the CEL environment setup is improved to support nested types, and sample YAMLs are updated to use the new defaulting logic.

**Default Notification Channel Integration**

* The controller now fetches the default notification channel for the environment and passes it to the rendering pipeline, instead of injecting it directly into trait overrides (`internal/controller/releasebinding/controller.go`). [[1]](diffhunk://#diff-440c67a69f0874087394cbd13c783e3bfd5465ecbac9df9f2dce3cf2dbd95fbeL385-R391) [[2]](diffhunk://#diff-440c67a69f0874087394cbd13c783e3bfd5465ecbac9df9f2dce3cf2dbd95fbeL419-R422) [[3]](diffhunk://#diff-440c67a69f0874087394cbd13c783e3bfd5465ecbac9df9f2dce3cf2dbd95fbeL1196-L1263)
* `RenderInput`, trait context inputs, and environment data structures are updated to include an optional `DefaultNotificationChannel` field, making it accessible in CEL contexts and templates (`internal/pipeline/component/types.go`, `internal/pipeline/component/context/types.go`, `internal/pipeline/component/context/component.go`, `internal/pipeline/component/context/trait.go`, `internal/pipeline/component/context/embedded_trait.go`). [[1]](diffhunk://#diff-24f2ba2a19a59694415af52a2c9af98c27db5e72bb347e7bb5bd9fe1fa19ce1cR57-R60) [[2]](diffhunk://#diff-a5112b6db8b9697337d2eb8b4be650758feff352f4b5e999099faf5f9ffc1d4aR154-R157) [[3]](diffhunk://#diff-a5112b6db8b9697337d2eb8b4be650758feff352f4b5e999099faf5f9ffc1d4aR225) [[4]](diffhunk://#diff-9d27423b1068c4cdd28d32f53d9854c402225e5d1f1ab89fcf2fc37a63119fadL67-R67) [[5]](diffhunk://#diff-9d27423b1068c4cdd28d32f53d9854c402225e5d1f1ab89fcf2fc37a63119fadL193-R207) [[6]](diffhunk://#diff-3aa9cace9b010f0abf3d64896a980561da1022efb972b4be07604ec85008fd8cL68-R68) [[7]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042R54-R57) [[8]](diffhunk://#diff-c1adecbffdc63d35535796ebebdc7da53d94e1356a241c572fd892099a441042L150-R154)

**CEL Environment Improvements**

* The CEL environment builder now recursively registers all nested object types, ensuring fields like `environment.defaultNotificationChannel` are available for trait validation and expression evaluation (`internal/validation/component/cel_env.go`). [[1]](diffhunk://#diff-c9e8c17337539103e19a1f1c4ea1628d4d6c31c04c51e1d88a8591edd0d852ccL72-R95) [[2]](diffhunk://#diff-c9e8c17337539103e19a1f1c4ea1628d4d6c31c04c51e1d88a8591edd0d852ccL111-R157) [[3]](diffhunk://#diff-c9e8c17337539103e19a1f1c4ea1628d4d6c31c04c51e1d88a8591edd0d852ccR188-R222)
* Unit tests are updated to verify access to the new `defaultNotificationChannel` field in CEL expressions (`internal/validation/component/cel_env_test.go`).

**Template and YAML Updates**

* Alert rule trait YAMLs and templates are updated to default the `notificationChannel` parameter to the environment's default notification channel if not explicitly overridden (`samples/component-alerts/alert-rule-trait.yaml`, `samples/getting-started/all.yaml`, `samples/getting-started/component-traits/alert-rule-trait.yaml`). [[1]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L28-R28) [[2]](diffhunk://#diff-811cf10f4da21c532e33a3403d4a1ccf58120a8aaf6b00a3bd2376f495520f75L50-R53) [[3]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1292-R1292) [[4]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1L1314-R1317)

These changes collectively improve the flexibility and maintainability of notification channel handling for alert rule traits, and make the default channel accessible throughout the rendering and validation pipeline.

## Approach
- Introduced a default notification channel for environments, allowing traits to access it during rendering.
- Updated the reconcileRelease method to fetch the default notification channel instead of applying it directly.
- Modified RenderInput and related context structures to include the default notification channel.
- Adjusted embedded and trait context builders to utilize the new default notification channel.
- Updated sample YAML files to reflect changes in notification channel handling.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/1991

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
