### PR TITLE
fix(helm): use generateCerts as the issuer switch in cluster-agent templates

### DIFF
--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/certificate.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/certificate.yaml
@@ -22,10 +22,10 @@ spec:
     - client auth
   issuerRef:
     kind: Issuer
-    {{- if .Values.clusterAgent.tls.caSecretName }}
-    name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-ca-issuer
-    {{- else }}
+    {{- if .Values.clusterAgent.tls.generateCerts }}
     name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-selfsigned-issuer
+    {{- else }}
+    name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-ca-issuer
     {{- end }}
   {{- with .Values.clusterAgent.tls.duration }}
   duration: {{ . }}

--- a/install/helm/openchoreo-build-plane/templates/cluster-agent/issuer.yaml
+++ b/install/helm/openchoreo-build-plane/templates/cluster-agent/issuer.yaml
@@ -1,6 +1,19 @@
 {{- if .Values.clusterAgent.enabled }}
 {{- if .Values.clusterAgent.tls.enabled }}
-{{- if .Values.clusterAgent.tls.caSecretName }}
+{{- if .Values.clusterAgent.tls.generateCerts }}
+---
+# Self-signed issuer for multi-cluster setups where each plane generates its own CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+spec:
+  selfSigned: {}
+{{- else }}
 ---
 # CA Issuer that uses the cluster gateway CA from control plane
 # The CA secret must be copied to this namespace first
@@ -15,19 +28,6 @@ metadata:
 spec:
   ca:
     secretName: {{ .Values.clusterAgent.tls.caSecretName }}
-{{- else }}
----
-# Fallback: Self-signed issuer (not recommended for production)
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ include "openchoreo-build-plane.clusterAgent.name" . }}-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "openchoreo-build-plane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: cluster-agent
-spec:
-  selfSigned: {}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/certificate.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/certificate.yaml
@@ -22,10 +22,10 @@ spec:
     - client auth
   issuerRef:
     kind: Issuer
-    {{- if .Values.clusterAgent.tls.caSecretName }}
-    name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-ca-issuer
-    {{- else }}
+    {{- if .Values.clusterAgent.tls.generateCerts }}
     name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-selfsigned-issuer
+    {{- else }}
+    name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-ca-issuer
     {{- end }}
   {{- with .Values.clusterAgent.tls.duration }}
   duration: {{ . }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/issuer.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/issuer.yaml
@@ -1,6 +1,19 @@
 {{- if .Values.clusterAgent.enabled }}
 {{- if .Values.clusterAgent.tls.enabled }}
-{{- if .Values.clusterAgent.tls.caSecretName }}
+{{- if .Values.clusterAgent.tls.generateCerts }}
+---
+# Self-signed issuer for multi-cluster setups where each plane generates its own CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+spec:
+  selfSigned: {}
+{{- else }}
 ---
 # CA Issuer that uses the cluster gateway CA from control plane
 # The CA secret must be copied to this namespace first
@@ -15,19 +28,6 @@ metadata:
 spec:
   ca:
     secretName: {{ .Values.clusterAgent.tls.caSecretName }}
-{{- else }}
----
-# Fallback: Self-signed issuer (not recommended for production)
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: cluster-agent
-spec:
-  selfSigned: {}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/certificate.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/certificate.yaml
@@ -22,10 +22,10 @@ spec:
     - client auth
   issuerRef:
     kind: Issuer
-    {{- if .Values.clusterAgent.tls.caSecretName }}
-    name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}-ca-issuer
-    {{- else }}
+    {{- if .Values.clusterAgent.tls.generateCerts }}
     name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}-selfsigned-issuer
+    {{- else }}
+    name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}-ca-issuer
     {{- end }}
   {{- with .Values.clusterAgent.tls.duration }}
   duration: {{ . }}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/issuer.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/issuer.yaml
@@ -1,6 +1,19 @@
 {{- if .Values.clusterAgent.enabled }}
 {{- if .Values.clusterAgent.tls.enabled }}
-{{- if .Values.clusterAgent.tls.caSecretName }}
+{{- if .Values.clusterAgent.tls.generateCerts }}
+---
+# Self-signed issuer for multi-cluster setups where each plane generates its own CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+spec:
+  selfSigned: {}
+{{- else }}
 ---
 # CA Issuer that uses the cluster gateway CA from control plane
 # The CA secret must be copied to this namespace first
@@ -15,19 +28,6 @@ metadata:
 spec:
   ca:
     secretName: {{ .Values.clusterAgent.tls.caSecretName }}
-{{- else }}
----
-# Fallback: Self-signed issuer (not recommended for production)
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: cluster-agent
-spec:
-  selfSigned: {}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/k3d/multi-cluster/values-bp.yaml
+++ b/install/k3d/multi-cluster/values-bp.yaml
@@ -4,7 +4,6 @@ clusterAgent:
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"
   tls:
     generateCerts: true
-    caSecretName: ""
 
 argo-workflows:
   server:

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -4,7 +4,6 @@ clusterAgent:
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"
   tls:
     generateCerts: true
-    caSecretName: ""
 
 gateway:
   httpPort: 19080

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -52,7 +52,6 @@ clusterAgent:
   serverUrl: "wss://cluster-gateway.openchoreo.localhost:8443/ws"
   tls:
     generateCerts: true
-    caSecretName: ""
 
 tls:
   enabled: true


### PR DESCRIPTION
fixes #2018

templates were using `caSecretName` emptiness to decide between CA issuer and self-signed issuer, which forced multi-cluster values to include `caSecretName: ""`. `generateCerts` already existed in all three plane charts but nothing referenced it.

changes:
- swapped conditionals from `caSecretName` to `generateCerts` in issuer.yaml and certificate.yaml across data, build, and observability plane charts
- `generateCerts: true` now selects self-signed issuer, `false` (default) selects CA issuer using `caSecretName`
- dropped `caSecretName: ""` from k3d multi-cluster values since it's no longer needed as the switch