### PR TITLE
fix: remove unsupported required=true marker from schema docs and samples

### DIFF
--- a/api/v1alpha1/componenttype_types.go
+++ b/api/v1alpha1/componenttype_types.go
@@ -102,7 +102,7 @@ type ComponentTypeSchema struct {
 	// Parameters are static across environments and exposed as inputs to developers
 	// when creating a Component of this type. This is a nested map structure where
 	// keys are field names and values are either nested maps or type definition strings.
-	// Type definition format: "type | default=value | required=true | enum=val1,val2"
+	// Type definition format: "type | default=value | enum=val1,val2"
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object

--- a/api/v1alpha1/trait_types.go
+++ b/api/v1alpha1/trait_types.go
@@ -70,8 +70,8 @@ type TraitCreate struct {
 // Example:
 //
 //	parameters:
-//	  volumeName: "string | required=true"
-//	  mountPath: "string | required=true"
+//	  volumeName: "string"
+//	  mountPath: "string"
 //	  containerName: "string | default=app"
 //	envOverrides:
 //	  size: "string | default=10Gi"
@@ -87,7 +87,7 @@ type TraitSchema struct {
 	// Parameters are developer-facing configuration options.
 	// This is a nested map structure where keys are field names and values
 	// are either nested maps or type definition strings.
-	// Type definition format: "type | default=value | required=true | enum=val1,val2"
+	// Type definition format: "type | default=value | enum=val1,val2"
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object

--- a/config/crd/bases/openchoreo.dev_clustercomponenttypes.yaml
+++ b/config/crd/bases/openchoreo.dev_clustercomponenttypes.yaml
@@ -160,7 +160,7 @@ spec:
                       Parameters are static across environments and exposed as inputs to developers
                       when creating a Component of this type. This is a nested map structure where
                       keys are field names and values are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/config/crd/bases/openchoreo.dev_clustertraits.yaml
+++ b/config/crd/bases/openchoreo.dev_clustertraits.yaml
@@ -212,7 +212,7 @@ spec:
                       Parameters are developer-facing configuration options.
                       This is a nested map structure where keys are field names and values
                       are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -210,7 +210,7 @@ spec:
                           Parameters are static across environments and exposed as inputs to developers
                           when creating a Component of this type. This is a nested map structure where
                           keys are field names and values are either nested maps or type definition strings.
-                          Type definition format: "type | default=value | required=true | enum=val1,val2"
+                          Type definition format: "type | default=value | enum=val1,val2"
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       types:
@@ -506,7 +506,7 @@ spec:
                             Parameters are developer-facing configuration options.
                             This is a nested map structure where keys are field names and values
                             are either nested maps or type definition strings.
-                            Type definition format: "type | default=value | required=true | enum=val1,val2"
+                            Type definition format: "type | default=value | enum=val1,val2"
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         types:

--- a/config/crd/bases/openchoreo.dev_componenttypes.yaml
+++ b/config/crd/bases/openchoreo.dev_componenttypes.yaml
@@ -155,7 +155,7 @@ spec:
                       Parameters are static across environments and exposed as inputs to developers
                       when creating a Component of this type. This is a nested map structure where
                       keys are field names and values are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/config/crd/bases/openchoreo.dev_traits.yaml
+++ b/config/crd/bases/openchoreo.dev_traits.yaml
@@ -209,7 +209,7 @@ spec:
                       Parameters are developer-facing configuration options.
                       This is a nested map structure where keys are field names and values
                       are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/config/samples/openchoreo_v1alpha1_clustertrait.yaml
+++ b/config/samples/openchoreo_v1alpha1_clustertrait.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schema:
     parameters:
-      volumeName: "string | required=true"
-      mountPath: "string | required=true"
+      volumeName: "string"
+      mountPath: "string"
       containerName: "string | default=app"
 
     envOverrides:

--- a/docs/templating/validations.md
+++ b/docs/templating/validations.md
@@ -90,7 +90,7 @@ metadata:
 spec:
   schema:
     parameters:
-      endpointName: "string | required=true"
+      endpointName: "string"
     envOverrides:
       maxConnectionsPerPod: "integer | default=1000"
   validations:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clustercomponenttypes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clustercomponenttypes.yaml
@@ -159,7 +159,7 @@ spec:
                       Parameters are static across environments and exposed as inputs to developers
                       when creating a Component of this type. This is a nested map structure where
                       keys are field names and values are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clustertraits.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_clustertraits.yaml
@@ -211,7 +211,7 @@ spec:
                       Parameters are developer-facing configuration options.
                       This is a nested map structure where keys are field names and values
                       are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -209,7 +209,7 @@ spec:
                           Parameters are static across environments and exposed as inputs to developers
                           when creating a Component of this type. This is a nested map structure where
                           keys are field names and values are either nested maps or type definition strings.
-                          Type definition format: "type | default=value | required=true | enum=val1,val2"
+                          Type definition format: "type | default=value | enum=val1,val2"
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       types:
@@ -505,7 +505,7 @@ spec:
                             Parameters are developer-facing configuration options.
                             This is a nested map structure where keys are field names and values
                             are either nested maps or type definition strings.
-                            Type definition format: "type | default=value | required=true | enum=val1,val2"
+                            Type definition format: "type | default=value | enum=val1,val2"
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         types:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componenttypes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componenttypes.yaml
@@ -154,7 +154,7 @@ spec:
                       Parameters are static across environments and exposed as inputs to developers
                       when creating a Component of this type. This is a nested map structure where
                       keys are field names and values are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_traits.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_traits.yaml
@@ -208,7 +208,7 @@ spec:
                       Parameters are developer-facing configuration options.
                       This is a nested map structure where keys are field names and values
                       are either nested maps or type definition strings.
-                      Type definition format: "type | default=value | required=true | enum=val1,val2"
+                      Type definition format: "type | default=value | enum=val1,val2"
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   types:


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
### Issue                                                                                         
                                                                                                
  - The schema extractor intentionally rejects the required marker (fields without a default are  
  required by default), but CRD descriptions, Go type comments, samples, and docs all documented  
  required=true as valid syntax                                                                   
  - This caused ClusterTrait schema GET requests to fail with: marker "required" is not allowed -
  use default values to make fields optional
  - Removed required=true from all documented type definition formats, the sample ClusterTrait,
  and the templating docs

  ### Changes

  - Updated Go type comments in trait_types.go and componenttype_types.go to remove required=true
  from the format string
  - Regenerated CRDs via make manifests and synced Helm CRDs
  - Fixed sample config/samples/openchoreo_v1alpha1_clustertrait.yaml ("string | required=true" →
  "string")
  - Fixed docs/templating/validations.md example

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
