### PR TITLE
feat(api): add release resource events endpoint

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -38,6 +38,7 @@ rules:
   resources:
   - pods/log
   - pods/status
+  - events
   verbs: ["get", "list"]
 # Batch jobs
 - apiGroups: ["batch"]

--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -465,6 +465,9 @@ type ClientInterface interface {
 	// GetReleaseResourceTree request
 	GetReleaseResourceTree(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetReleaseResourceEvents request
+	GetReleaseResourceEvents(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params *GetReleaseResourceEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetComponentSchema request
 	GetComponentSchema(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2308,6 +2311,18 @@ func (c *Client) UpdateProject(ctx context.Context, namespaceName NamespaceNameP
 
 func (c *Client) GetReleaseResourceTree(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetReleaseResourceTreeRequest(c.Server, namespaceName, projectName, componentName, environmentName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseResourceEvents(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params *GetReleaseResourceEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseResourceEventsRequest(c.Server, namespaceName, projectName, componentName, environmentName, params)
 	if err != nil {
 		return nil, err
 	}
@@ -7894,6 +7909,123 @@ func NewGetReleaseResourceTreeRequest(server string, namespaceName NamespaceName
 	return req, nil
 }
 
+// NewGetReleaseResourceEventsRequest generates requests for GetReleaseResourceEvents
+func NewGetReleaseResourceEventsRequest(server string, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params *GetReleaseResourceEventsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "projectName", runtime.ParamLocationPath, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithLocation("simple", false, "componentName", runtime.ParamLocationPath, componentName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithLocation("simple", false, "environmentName", runtime.ParamLocationPath, environmentName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projects/%s/components/%s/environments/%s/release/resources/events", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "kind", runtime.ParamLocationQuery, params.Kind); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, params.Name); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.Namespace != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "namespace", runtime.ParamLocationQuery, *params.Namespace); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Uid != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "uid", runtime.ParamLocationQuery, *params.Uid); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetComponentSchemaRequest generates requests for GetComponentSchema
 func NewGetComponentSchemaRequest(server string, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam) (*http.Request, error) {
 	var err error
@@ -11016,6 +11148,9 @@ type ClientWithResponsesInterface interface {
 	// GetReleaseResourceTreeWithResponse request
 	GetReleaseResourceTreeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, reqEditors ...RequestEditorFn) (*GetReleaseResourceTreeResp, error)
 
+	// GetReleaseResourceEventsWithResponse request
+	GetReleaseResourceEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params *GetReleaseResourceEventsParams, reqEditors ...RequestEditorFn) (*GetReleaseResourceEventsResp, error)
+
 	// GetComponentSchemaWithResponse request
 	GetComponentSchemaWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, reqEditors ...RequestEditorFn) (*GetComponentSchemaResp, error)
 
@@ -13822,6 +13957,33 @@ func (r GetReleaseResourceTreeResp) StatusCode() int {
 	return 0
 }
 
+type GetReleaseResourceEventsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ResourceEventsResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReleaseResourceEventsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReleaseResourceEventsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetComponentSchemaResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -16416,6 +16578,15 @@ func (c *ClientWithResponses) GetReleaseResourceTreeWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseGetReleaseResourceTreeResp(rsp)
+}
+
+// GetReleaseResourceEventsWithResponse request returning *GetReleaseResourceEventsResp
+func (c *ClientWithResponses) GetReleaseResourceEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params *GetReleaseResourceEventsParams, reqEditors ...RequestEditorFn) (*GetReleaseResourceEventsResp, error) {
+	rsp, err := c.GetReleaseResourceEvents(ctx, namespaceName, projectName, componentName, environmentName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseResourceEventsResp(rsp)
 }
 
 // GetComponentSchemaWithResponse request returning *GetComponentSchemaResp
@@ -22469,6 +22640,67 @@ func ParseGetReleaseResourceTreeResp(rsp *http.Response) (*GetReleaseResourceTre
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReleaseResourceEventsResp parses an HTTP response from a GetReleaseResourceEventsWithResponse call
+func ParseGetReleaseResourceEventsResp(rsp *http.Response) (*GetReleaseResourceEventsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReleaseResourceEventsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResourceEventsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -2418,6 +2418,36 @@ type Resource struct {
 	Type string `json:"type"`
 }
 
+// ResourceEvent A Kubernetes event associated with a resource
+type ResourceEvent struct {
+	// Count Number of times this event has occurred
+	Count *int `json:"count,omitempty"`
+
+	// FirstTimestamp First time this event was recorded
+	FirstTimestamp *time.Time `json:"firstTimestamp,omitempty"`
+
+	// LastTimestamp Most recent time this event was recorded
+	LastTimestamp *time.Time `json:"lastTimestamp,omitempty"`
+
+	// Message Human-readable description of the event
+	Message string `json:"message"`
+
+	// Reason Short machine-readable reason for the event
+	Reason string `json:"reason"`
+
+	// Source Component that generated the event
+	Source *string `json:"source,omitempty"`
+
+	// Type Type of the event (Normal or Warning)
+	Type string `json:"type"`
+}
+
+// ResourceEventsResponse Response containing events for a specific resource
+type ResourceEventsResponse struct {
+	// Events Kubernetes events for the resource
+	Events []ResourceEvent `json:"events"`
+}
+
 // ResourceHierarchy Resource hierarchy scope
 type ResourceHierarchy struct {
 	// Component Component name
@@ -3525,6 +3555,21 @@ type ListProjectsParams struct {
 	// Cursor Opaque pagination cursor from a previous response.
 	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
 	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// GetReleaseResourceEventsParams defines parameters for GetReleaseResourceEvents.
+type GetReleaseResourceEventsParams struct {
+	// Kind Kind of the resource
+	Kind string `form:"kind" json:"kind"`
+
+	// Name Name of the resource
+	Name string `form:"name" json:"name"`
+
+	// Namespace Namespace of the resource
+	Namespace *string `form:"namespace,omitempty" json:"namespace,omitempty"`
+
+	// Uid UID of the resource for precise event matching
+	Uid *string `form:"uid,omitempty" json:"uid,omitempty"`
 }
 
 // ListComponentWorkflowRunsParams defines parameters for ListComponentWorkflowRuns.

--- a/internal/openchoreo-api/api/gen/server.gen.go
+++ b/internal/openchoreo-api/api/gen/server.gen.go
@@ -324,6 +324,9 @@ type ServerInterface interface {
 	// Get release resource tree
 	// (GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources)
 	GetReleaseResourceTree(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam)
+	// Get resource events
+	// (GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources/events)
+	GetReleaseResourceEvents(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params GetReleaseResourceEventsParams)
 	// Get component schema
 	// (GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/schema)
 	GetComponentSchema(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam)
@@ -4047,6 +4050,113 @@ func (siw *ServerInterfaceWrapper) GetReleaseResourceTree(w http.ResponseWriter,
 	handler.ServeHTTP(w, r)
 }
 
+// GetReleaseResourceEvents operation middleware
+func (siw *ServerInterfaceWrapper) GetReleaseResourceEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "namespaceName" -------------
+	var namespaceName NamespaceNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "namespaceName", r.PathValue("namespaceName"), &namespaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespaceName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "projectName" -------------
+	var projectName ProjectNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectName", r.PathValue("projectName"), &projectName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "componentName" -------------
+	var componentName ComponentNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "componentName", r.PathValue("componentName"), &componentName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "componentName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "environmentName" -------------
+	var environmentName ComponentEnvironmentNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "environmentName", r.PathValue("environmentName"), &environmentName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "environmentName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetReleaseResourceEventsParams
+
+	// ------------- Required query parameter "kind" -------------
+
+	if paramValue := r.URL.Query().Get("kind"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "kind"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "kind", r.URL.Query(), &params.Kind)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "name" -------------
+
+	if paramValue := r.URL.Query().Get("name"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "name"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "name", r.URL.Query(), &params.Name)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "namespace" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "namespace", r.URL.Query(), &params.Namespace)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespace", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "uid" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "uid", r.URL.Query(), &params.Uid)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "uid", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReleaseResourceEvents(w, r, namespaceName, projectName, componentName, environmentName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetComponentSchema operation middleware
 func (siw *ServerInterfaceWrapper) GetComponentSchema(w http.ResponseWriter, r *http.Request) {
 
@@ -6360,6 +6470,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}", wrapper.GetProject)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}", wrapper.UpdateProject)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources", wrapper.GetReleaseResourceTree)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources/events", wrapper.GetReleaseResourceEvents)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/schema", wrapper.GetComponentSchema)
 	m.HandleFunc("PATCH "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/workflow-parameters", wrapper.UpdateComponentWorkflowParameters)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/workflow-runs", wrapper.ListComponentWorkflowRuns)
@@ -11993,6 +12104,72 @@ func (response GetReleaseResourceTree500JSONResponse) VisitGetReleaseResourceTre
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetReleaseResourceEventsRequestObject struct {
+	NamespaceName   NamespaceNameParam            `json:"namespaceName"`
+	ProjectName     ProjectNameParam              `json:"projectName"`
+	ComponentName   ComponentNameParam            `json:"componentName"`
+	EnvironmentName ComponentEnvironmentNameParam `json:"environmentName"`
+	Params          GetReleaseResourceEventsParams
+}
+
+type GetReleaseResourceEventsResponseObject interface {
+	VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error
+}
+
+type GetReleaseResourceEvents200JSONResponse ResourceEventsResponse
+
+func (response GetReleaseResourceEvents200JSONResponse) VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseResourceEvents400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetReleaseResourceEvents400JSONResponse) VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseResourceEvents401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetReleaseResourceEvents401JSONResponse) VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseResourceEvents403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetReleaseResourceEvents403JSONResponse) VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseResourceEvents404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetReleaseResourceEvents404JSONResponse) VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseResourceEvents500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetReleaseResourceEvents500JSONResponse) VisitGetReleaseResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetComponentSchemaRequestObject struct {
 	NamespaceName NamespaceNameParam `json:"namespaceName"`
 	ProjectName   ProjectNameParam   `json:"projectName"`
@@ -15173,6 +15350,9 @@ type StrictServerInterface interface {
 	// Get release resource tree
 	// (GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources)
 	GetReleaseResourceTree(ctx context.Context, request GetReleaseResourceTreeRequestObject) (GetReleaseResourceTreeResponseObject, error)
+	// Get resource events
+	// (GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources/events)
+	GetReleaseResourceEvents(ctx context.Context, request GetReleaseResourceEventsRequestObject) (GetReleaseResourceEventsResponseObject, error)
 	// Get component schema
 	// (GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/schema)
 	GetComponentSchema(ctx context.Context, request GetComponentSchemaRequestObject) (GetComponentSchemaResponseObject, error)
@@ -18249,6 +18429,36 @@ func (sh *strictHandler) GetReleaseResourceTree(w http.ResponseWriter, r *http.R
 	}
 }
 
+// GetReleaseResourceEvents operation middleware
+func (sh *strictHandler) GetReleaseResourceEvents(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam, environmentName ComponentEnvironmentNameParam, params GetReleaseResourceEventsParams) {
+	var request GetReleaseResourceEventsRequestObject
+
+	request.NamespaceName = namespaceName
+	request.ProjectName = projectName
+	request.ComponentName = componentName
+	request.EnvironmentName = environmentName
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetReleaseResourceEvents(ctx, request.(GetReleaseResourceEventsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetReleaseResourceEvents")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetReleaseResourceEventsResponseObject); ok {
+		if err := validResponse.VisitGetReleaseResourceEventsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // GetComponentSchema operation middleware
 func (sh *strictHandler) GetComponentSchema(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, projectName ProjectNameParam, componentName ComponentNameParam) {
 	var request GetComponentSchemaRequestObject
@@ -19806,419 +20016,424 @@ func (sh *strictHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+z9C3PcuLUoCv8VVH+pinxOd0v22JOJvtp1r0aWx0psSZHkcZ0d+ToQie5GzCY4ACi5",
-	"4+3722/hRYIkSILspyxV7YdHTbwW1lpY7/VtEJB5QmIUczY4/DZIIIVzxBGV//VriqPwIoIxOoNzdCF+",
-	"E38OEQsoTjgm8eBQfQQS8RWI4RwNhgMs/p5APhsMB/JPh4PbwlSD4YCiP1JMUTg45DRFwwELZmgOxfTo",
-	"K5wnkRgUoglMIz6Sg+UKg+GALxLxG+MUx9PB9+/DwXGUMo7osTnJ9SJp2rDr84adBwHvsOUpGTFE73DQ",
-	"uNXXkMM2uJY/bdpimHTYIptBisJRCDlshen5rTgNvMUR5gvPHVfHNG29aZ1uByL2HE2HuqYQ8/ZzyM/a",
-	"t57N5rlbmHLCAhgh6t6jQcuT+A5TEs9R3LRX6yu5VTAhFGQ0PWIBSVAISIIoFCOY+yiouJY3ed41H6EJ",
-	"xuabJgDb8/hCN8HNBGjm/EeK6KJmc29wxBEFFDGS0gAxcLvIYVrY8B9iFseOB0vu7hJFCDLkBUCqvvUB",
-	"pDVtd3iO7p6PD8YHzRtv472+THeVPNes+ZHQL5OI3Pvsz3zbtMf7LrRCgi+IqpfMvcuUMkJrtnWewD9S",
-	"BBI4xbGkYxDIz8GEkjmAIKHoDpOUCZRNSMzQ+Ca+gIwBPkPgXzH6ytX0/wJ3MEqRGmbNNkccivcAcAIm",
-	"iAczOVCME1+J2eoQXk5bwPbq0XxeO59nrtMrZ2SH5mfuNUoishB87wInKMLNe8w+Bon+umm3zqk77t6s",
-	"49x8vxei9gVYAee31urKX1HNNksIZ3026La3d3iOec2G3sOveJ7OQZzObxEFZAIwR3MmyIEintIYJIhK",
-	"UqjZViQmL2xI3+Dg8MXBcDBX8w8Onx+I/8Kx/q9snzjmaIqo3Oh7mCQ4np6GNZu9JBECc/UROH3tvs+5",
-	"mcTvRp+/+Gk4mBA6h1zt5ueXA+fmBJKwBAZNdJJ904BvsT2PJ9bNF6NsmPOKC1LkUYQoZ2eE4wkOJJs7",
-	"nsE4RlHDzgsTAChnALE1BQjUHA0nI96b8D82mkMcjfTa7UdvY7adJHSyjGhu+Fi7bH5Byb9R0MTI9BcN",
-	"W03yOfxhqwc1baorL0scOy0xjHzVHtvSYtyvOA5xPG0Amf4Q3KovG0BHK1P2EBDrWG+7NHvZKsPSzqJr",
-	"g7gqWGjTbgSHbdiKHu0LoXCOY+c2rlBAEb9EE0RR3MhS1ZeAmk8bdseqk/oTgxrs3Gyb1tymLvPV6ske",
-	"wryHDH9vzeLL0iCHt5Ch0RxPlVLduL/LNPbZIk3jJoxTk/QgSZrGo+cvfnpZu8eIwLBlg+KTFhiaWXrs",
-	"0Ax37PC7mE0pNMoeCcNL9EeKGBf/FZCYCzHw8NsAJkmk39f9fzOxcWs18WUo5v316PXny5N/fDi5uh4M",
-	"ByHiEEdscPjPb4MJRlGopZLBcDBHjAlZ73CAhUqlz/P903CAKCV0cDg4je9ghEP5I2L8UNleCl/bJ/8T",
-	"RZPB4eD/t59bW/fVr2z/REx5qY+pDl28gtJawLLRSu02nkQ46AeR4/OzN+9OjwU4zMnMK/vn/A36M4AR",
-	"RTBcAPQVM85WeLZL/Ww6VnhD6C0OQxT3Otmb88tfT1+/PjmzjvZ/SApCIuQ5MIN3SMj0c8yYEOs4ATAI",
-	"kNSY5S2qba30Flk6meAAS/UxW5kVlkaFlU9jjmgMoxO1/x5QOD27Prk8O3r3+eTy8vxyYOOvmhoIKkQU",
-	"qL+v8rQ1858R/oakcdjrOGfn15/fnH84e92Gr+KKJ3KZNaBqYfIPMUz5jFD8H9TvTB/Ojj5cvz2/PP3v",
-	"E/tYRymfoZgbtWMNbKVmBUAo4OQLigFWfEe+FHpWsehRINUYmBhpvmpEM79hxKQ9GgKWoECoQAAG+sVM",
-	"KEkQFZ9IWEURuVcQdEOdgfsZokiPF5zWDBkOpK7eBo98w5cWiekXB1IKFwMJohh324YescJd5H8gt1IF",
-	"+D4cHE1RzI9JHCO58BWHPGUOMVH+HZAJ0M4JAMVAEGQjWQX0+jfXqT/OEJ+JSeJFaULMQJBSimIeLUA+",
-	"Q7bzW0IiBGOx9exXeQbHps8yo0thjZYVMqPEcBBBZmCDwms8R86TxADGevdiAGCp5LqTNCotkJlBQsjR",
-	"iOO5w9igFn2NWeCxruDrckm1emiN6rTcWwQpv0WQN6wl+A8lkfbHylUpChC+QyEIyHyexobglelYg8R7",
-	"H5loVF79KAyx+CeMAI7VXGIVeEtSXsFCwBQCu4TSKu6nfPYeBTMYYzYX4g6eugz34u8p1WcTTCcGsMji",
-	"5maSCg2Ij3iE5ppzN/LV/FO9l2zP35o5bLY8EJ+DPTSejofgZvDve34zEP8gYr8v1L9hgj9/QYubwTPx",
-	"KGSC87/v3cpZLnT/U/06LJzpUw1Y/6NdnULhrfWDGieieej0eyF05L2/p7eIxogjBo4vXz8b38Sv0QTH",
-	"iAmej7ggasUqhXQDOQhgDG4RgIzhaYxCIfywVG6JgTsM1azaWsGU26F4U8ZT0XZN53LS94hD+WQmKGgb",
-	"UYbHlRhThm22vA9EtTGlFbD2oV0gFfMIgBr2KL8XYqOBHcChuO0JRiG4XQjMty4fBBHE8+3CUkNiZSB9",
-	"h5UKWASr+Kv1jLjAW33+smfb6/2uu2LXI24fUk3e4YRXGsql912LURaXazptlc9NJijgBfeEEr0GZenw",
-	"gkQ4WAA1AOzJj4RoGKJ4IVlSnM7FwfLR8UKcz9Lx9S+VJ6QDs5XAsTmuQGUxhzjlpRjnMf5Sf1u+E3sf",
-	"+Yw+d9QJ/apsc9VIuELs64121VNWZXwtgNYCLn8phAou8FjqyZzZT+A/jen8MKAIcr2M/MMdRvfWf4Yo",
-	"QhyJY2dQreBiVf63Nlbe59t0DuMRRTCEtxEC1o9i91J7V+fOieBNGkW5WBvOcYwZ10KK0vpbn3MDtvrr",
-	"EyrnV6VyZkLYhQV6ZYerFdcCNV7dq32Ng7oVKxTpcDqX3p+RCjxIIKZyofLLFUCnXhi4p//bx2s1rTFL",
-	"WsEglKQJc/EduYPmrapPhmXj/UhO2npTarNmodr7cgtbmdN0a+IWuMd8hmMAQeZl3YLUsITo1ShzVeDr",
-	"K3X1kbZ2B5TLSV7eIlfcBN2VvHcrlLZ6iVmNJ3wStAqC1nDAIZ0ifgH5zGvkdf75klJau3gWtzPalSHs",
-	"KjBVQ79sjzSOYMGZYpB9LVCnIh+WT/MFxw5r399xHAoAqaemcUYbMfPDOmwKBUR17KuCs8qn6GLetTJW",
-	"vX/dhrQ8s56/Ed5LsIQNCsEZ1uVicP4nKQhvVe59je5QJM5tfFv6QWyO3+ok9l4XWEwpFkH+ljnTQAL5",
-	"zPEmgz2tK+REDORVPnNYyU1kd3sou2e8d6aptIY6eQcGVSD1K+TB7EQIpJAjy3deSuERX5WwF6lBxjUk",
-	"xpVhov/egMzVSZivp6S86TZOms3/qR0M2inWHQ56YBkQIQowaybr7BOwh2PAJD+joaAPloHmmS9sXuvJ",
-	"WoGSb8wJlSwnqyarS4UGZlRkC8lqFklTJOVAcNd9mODfERXrCfn5EiUUMenIOT7dP34NZOw7wPGEQsZp",
-	"GvCUoq0Lyvk5lYg8HLDMtwaj6Hwi40M8Z1Ajv38SlwDD8zhaKOW7k+Cdz+eWYy5U2D4KQaRx6zbPwFtW",
-	"crFQwvFK5BkDbfNc5F/6izz54h4yD7AwlFCgxQpr/92EHguGlmxTmK66REG6KXzbQ66xdpBHgQyrsbRL",
-	"SzollHekOTAZCCAIQe7OhrXDQiOhIp27rd5v69vceVYNMPZQOM6dgwSOin+fvnZwYjLFATSe0UyHV+Yo",
-	"cQHJbMHkF/pI45v4fRpxnETIRrbjSybtKjLrUA6U3Fyvq7hXfmkBHunpXFihwi2vOKE+Z74qfu1+8Mvc",
-	"qCb42/t+YTHyoFX1cQYqqDAAZXF0bOlYOfr1jvIvDWkUtucXZ2HmcLExoiHwG4p1WmR1S/lvZhNzon3p",
-	"MiLBzFHcm08GReXKHDEhtfEn8r20A9dMFKMjqoNxCrGOuOhlGMYx4zAO0CgS0rxgSpziLIqkco7EKYpL",
-	"C3hBEC/QR/bs78NgjvaNPJ7Ahdb4PYTc4whnDMX9Zp4nKD59DTReCgyzggVqxbqCIPgZxWFCsEsBOBf6",
-	"yIuy3Kg/Bx8u3xVOPOM8YYf7++LzMUlQHMwIRWQcorv9LJbMac75qmLqPgfyvA46OhIYLuVu/SlQnxYP",
-	"7C+C61kUfF2UhBlLEXVA5PT1MVA/djl/DYtMKeaLzygW2mdTlFIx3AIzoIcAomJwVCyivRlFANWYJRkA",
-	"137jKk6u102rWI99OUN7REdxO8M6zHTgiAOAn5wkVHmZPUJsCvFao1vIykFGDmlBkupRG+r9DqMUvaFk",
-	"XkfxZVGsLsZipXpMyedZr9ZsVoepHLWvKlOdaCUaTWXaTv7zFWo3VbTZvJLjviwfIbxdxdmSLF5b92Ot",
-	"InmVwHdbMq8jLi8Bvf3ud0FOd+1yx8R11xb7Se2OKkKetYZ6PkSlqME79Ys4b2H6rbw9hR0s+fwU51rl",
-	"C1SY2de6VnqOck+BWGVFL1IRi7b2KFVvscO7VDxDTYKHTBJlTv1W6pYM3M9wMAOFEkyCr4fGoaRYPOQc",
-	"BjPASY77mgthJi9mDE7EByjmdCGzRWKbwsCNtJLdDMAejO7hghUWfAZgHIIbqZveDLKkWxxP89PKD8fg",
-	"dALQPOELQCggc8w5CocgJgDa4VWmGJNSo2UeLAPiiVKePYFseySOFgDNb1EYotB8E8rgHiFcygSasTVU",
-	"w/PZ2GaxXQyeci4roXhvnjIOblEREpYt1P67hURdTJyFW7VsnHMcv0PxlM/skhg9rZtlytGAMom2TZ5X",
-	"9SVw1wBiWijBrMQCin7ZUp0fVbkOBl/0Xzo5ZbOaAg4HJ5onERTvhozzmqrnDwHrQckrEoSLGM6FGBUt",
-	"6rFlQqigGMcTdvIOoK9CB2JG79PLCYKYG3EsX07XJBL8cyCtQkIlHRwO/p+bmz/d3Hz7580Nu7m5+vS/",
-	"b26+39yw//Unl/iFHZj7IcZ/pA4x0crXNO4kgWyVW6ouEgdRGqKPMxS3HjtEXBBrLM6MJ6VV2YykUSiI",
-	"Rznjw97n1nEzuUprgofsMkZOX7eSoScycsgUHrKo1x5fEPIT48mo7kXjWDf7oQMDgZlJ8d4iZJ2mxDtI",
-	"XdoCScAdpFhGIciE6/sZikHKxKUY/G3jH1jmkJmjuTjIHMenikaeV2nSLvBTfBf1+zTKbG1il+pzxcix",
-	"0yKC4rvzO0QpDlFHS61VbGmU5VcSM5dEBXFIId0CFE9xjBCtMdzaRT/9NyBkMxzkT3PJrmpNW8OnO653",
-	"iVImoSrzp3KYOuZ3Sey8Rva4oCi7NPP2ZrZvlj/Kkq+42H8NR+1/s+qBtCtimWu1QyorBzR7PnM+xIZ9",
-	"6o/yapFKZpLPestTPLRkCsOYCmLBsFHYUEJOQQgwb65lTdSC9i6IHv1JQ62Tjc5jrPcCEgcUcaRizZn0",
-	"XRcZ4jMnOts8LKvFYd23jywk87lhnXJ/8k6bcPPPAE0jQQI6ciYEYSogAyiKQ0RV4GsN9tcmisrEdKB/",
-	"Fk/nfaz4uAwkSyOULSdrI0xgxJyvt/i09dm+pzBJFO3+6dt4PP6u5CUp65plxCriDns+2uU4pDSyS4j4",
-	"XIupgOI2IVxQPId0AcxX1rMq2GCDVGqeflsekHrbJI2YrPITUBL/m9wOhgP1fxNKvpaiiwujm49eOIct",
-	"vnqrnN0tYmWts26drL6kR6Hl5R0FlfQoWVwzF9Gyu8yhuxWzTXbmJU02+TyrNNdks/Y01eRAX5GZJkei",
-	"rZloijfWwTyT7331XoMp5OgeLtoG/6Y+M7iG53CKLtIoysqgsYagL/kYlAqm2UonoUBOCJI0itTLVFXL",
-	"KZpixmlW56yTOv7wfCM5S+vmGknZ6B4xPkooCbfiJCnzky4vQj2i75CLxN7kbnpI7B0u4yCpYn6XxgEr",
-	"99nPSYw5kUIsjEMQkelUmnS2776vnn7JR9kx4Spf5+r0ndz6BW660lfagXFbe67P696MxtDmenrYK0Mx",
-	"jhbPOoY6OyBfVM0d6xp3Q1Upd0C7oD/Uf7aMHt/AKmpipufwq1H0f/6prPdbet8/4eg/B6O/ftr750j/",
-	"63+ZPz37v/60dPB1M7F3kOecAF1POAiiHy7fubJlGAIfLt+Zq9FvMgVHF6dAG+FduJYLFMVQucP9fbPe",
-	"uDBuJMeN2V1w+MvBLwfOTKp1ilEOZOsmT+WPTpM0RQMowe8F7MvjIyC/XgLaNIAjKRN1BHen176HBOeB",
-	"2jskyjl3u5synXOrywh3nvnJxcpVtwtle5ZPzl6EpjBwvGHup+DYnqiabumVCdzGm5WZubkr1MpDeFQ8",
-	"wTbkTrnykqKmmmOV0qWcsafdRzt6ViJMKmTYmvyYX04H0cD4YkrSgHRNu+pvont33AAn2p9t7PPGTyQD",
-	"apIkKhU+3UxAwWbd+E8e+o176Bud81Uy5MHMhdXvSZjVa5CoLCuLK+eVQSwTNiPr+MgnveRNWAFqU5Qg",
-	"hdkS2eR+XXhlteirlru6Oj+7kLnp+VfyYU2SppAekjgzobTEUPISwVC1CkoiVZ2Bojm5c6OdO9FLbBJc",
-	"ECE2UOlSmyEg6+qL/5iL21h0qMolE0BkvSrEwZ6stxGG+3p7FhieVdCHJAO9xc7BHYq228tJcJLdYxHi",
-	"qk5YNS/r4hTIn7J6Gbmu2uBidyYASqeftYEqQJVQ4d6FJXG07UMWum5FcU7ARHXAUYGbhdejZo+lCzPF",
-	"1czGNQic1L8C5lsgwyWY7zo5oMLDAlPwYYZ1wUnlaITtRSWtMvwoD7maQBmcWww/IkltpuqmY4++twl4",
-	"3XVkI+NV5/UpVNNXfcljrRU707MEJETSnJ4LNqXLyMp86ATfDWs65k+91ZxsgtXoOGY6bwUnb9K9pFaT",
-	"YccWVJpSF9oGBDXtwHri6el8nnIVfxnDhM1IEYianGDeOpfjOdoSSuqjVjGzBTTqQ7CXN0mQiQhDgLPD",
-	"w4lg9lKXEYAZlHG2LczMD4f1hjqjsgH+ylDaoNV6MbswmQ9g/LX38kFqa5BdUDLBrui3Kye65w+sZNJK",
-	"hVf8uQr8vq/xcSH8rC34tyYU15qkGIXrb1I1CpzbbuN6iYNyCp//od9Q8h8UF9VGmapTZi4uIJD72FU7",
-	"4dT4KFgpjUHcneksqQ0Xursjikg8FRJ3Pcq4Y4IvIFVv9ZIV7BpnT3oWs7Npr9jZs3iqT40I1vkyFeaJ",
-	"S2TlWwR7X9BCWwuybofPXHebNbXrs4MsOtAPk8r6r0SrMlpbW2pkWt25latsCpH5tfWlOjgB4qs55Cot",
-	"CXCKp1NEVbI/AyRWMmWSskK5GBkM7CrYIWZT7bkLeqH+3nMTSnoVf9cTFELwpR6XGwZba4gEzZnBBQ9J",
-	"xfZklTRrzqt0BOSXvncHARSjhcGe1+oF939pGedu/WP1S89HnpeIpRltDvkh+GYHGH/f/1aAsGAF3wfu",
-	"yOX9KbGYmOXs38u/+R8rMvp/dFz0/4j/lTHRz/aXjAuodTrVvALn4s9shpNCNyXjtA5qia+RIduBFIWX",
-	"JMeGwluyNKv+tEJ1v4ihuTFD51Hs2UaN3KKbIVIIKqjsLZZcl1KCVPaxqqdfvo6ViCnDrDGt90wmWdUE",
-	"b3i9Cs1PQRerRC1CLuVh7w7XBo+6zJetVz5PK13LVN82Magim5uHwJF+4enJtmmxbhFnSNN8McpTyuFt",
-	"8PzFT85oEjXHW8gctnrx17bFpRZrL8xm8MWrnw/rlnSJ1qsNYrAg3C9ooUh1NWRuEzdsuNbmbLvThjQ7",
-	"vYTx/9k329T02pV955N2lxtR1AHFZsqly4fFBLnmdDyzaDktLz9JyTrZ9virRTMfZFUJaYTKinL02MrS",
-	"7op4dhonKW97UySyZTUt+qOdM8nTlRRfUfIeM+Zl+9wO5mkRZg34565JtIpiRKbvUKar8qwiRcqU+FVN",
-	"Phe4PSV3iMYFiXMG7zChW7K/LlWwaA2VinqVKFptTaJtFyPqV4VoleWHFIHmWvAG6hA5lxwaS4QkHUdx",
-	"ojF4QyjQ/OoQfDPzHYIbxWVUN1n1sfjjfDHi6u/fxWKFAfbKjnGGLZvxD6X6UbcXS6uLHo9Oj+wFN17V",
-	"R2H4GhGeih7tVtGjH7Ce0VMg5FOpoqdSRU+linanVNGKlFS35PVsnQJAU9jlU8WhR1Vx6KmY0EqKCfWu",
-	"ItRaPqjGv9LgwDSum+Ib4+kWKIjfRXdmUcheGeP4wBAdGV0r23vzi8gWjKP5RWHF0oMrvxjNYQynKLRD",
-	"kPYoSgjDnAiFOJ6QZ46+guaDKpHDJHG3fBR/NTkRpgWIlp6t+WyAjve1T5jtwwS7fSh32MTSF7dxS2Hs",
-	"0ht+wxzo3wqWfejKS5TeuLnLE/GbDNASv4Grt0dFi6R0v7z087+kNHJPbt1BXdeSKeaz9HYckPk+odN9",
-	"MWI8xV4teTwjoMukVWMp/+ikJ2UpzojORDn65pFW1N16G/BDJDyb4JRaqB7R7NabedMPQYFiL6p5iFDO",
-	"l6JH0/3XIkqwpxIMYPTMmz7t903v/9MWqdbejljTAvcwu+ZPbaKhdbefPMXIChZ/8mEPl2ns9ezSNAZ7",
-	"6uLRVxSkJvi5EhnpwXrBLRKEI2bjrmsO0eTVz3/5pQaX1hp6qU0zR65ED80MZcAg43CeFCZ+cfDi1ejg",
-	"+ejg5+vnB4cH4n/+2/aph5CjUTHW0DIyzZ0y9q8CQoKrcIhjpGuxFVY1tdfG+k8SR+eLkdUBLj/wYS0Z",
-	"DdsEJ3H9TbAc0TQeNc0tN9N4aXkDaVdMa0OP6zUGzNanDlymsc4WKEx2mcax0qcqM6Wpl72yMN2rVwfo",
-	"l5cHByP04q+3o5fPw5cj+JfnP49evvz551evXr48ODhwVm5ZdaBT7AoRHpYCiIvXbNOSLyfq7pqz+dPK",
-	"XHQ2b9yVvAezp2vLKNvKtDO7q2UbcdUv2Di/a+yMXxUj7d8r3YFZmUEybRF+LUVM5/KYJRFcuPlFuTG/",
-	"+rbKN9T0qlXpoHtIbkEnBXup4gPljv7POgjNNTTbjQoNfi1BilnQwqrpMcP9rROlCYisloPLvB8jxheR",
-	"FX9ZAUYEGb+mMGby52vswpZ3kHGVJKGcVXouwLNxxbB5B1W+8qfKWltfiSTMd/bCF/p5lR4vGDqrEnQN",
-	"XDSmpbxQSg6Be8iAspC1Ri3K0BHmWuw9DGY4RvnJ1IdWRHh+edYbjwISBzhye/DqBAZlQDMm68LMmUVc",
-	"Gi/faEvph/hLTO7jciRW6rw67jRMqrSDiQW2PTSejofgUlzRs9KpnLdWTqJXFr1M8nEgcQbuGtJRrNp4",
-	"RpwdUdUnOrjBTnOvOFi8mclJfPc7pC7OMcER8mdKb3CEnBM5jTGS91plvX5V/oNL9EeKXPxV/2AVCaoU",
-	"PVfVvtQ89YW+0GQi9lDw28iohIrf5oJEOFgANQDsyY+A9CLHC9tfk4+OS/Zn80u1t3LMMY/Q3KNS4on1",
-	"ae3bqWXlYt0zDQl32bKR/tlpBSHROmuhFY+vl/vkgyRLY0ctVsCgxmmUBa4EugyOjFwQc6l4IlYMTRH8",
-	"cjAc3FPMVTxChJQv3T8ipVECLItg+Y9ZjRUSFW9GdkTPWieLaxJ6sU48CALEmL+M5sKzCioYwHdCCXMB",
-	"DXiQZwx0wIIY3TdEN68/j28FqXu1uWp7/plqxRdNmyaKeWo9VZFaFeQ9xDG4PLm6liVD83WsyrjPD168",
-	"XJcSIha9ci364tXPPdIElS5imhYWdRKt7D9rMKetqxzwcLsJ9OVMtUJawQpS1ZSLxsEkc6kuoSiQMWPu",
-	"oj0nF5cnx0fXJ68PwQdm7UcKgGLjCIZj8E4+C+UsVVlObNyDcnobmfR5vSuISi53ZlTivnJUOUfiSZKy",
-	"TK7NslQW4eUjTzVtzpS2zSMdtdOradB1/uUqJK0CIq0AgzYrbW1VyMqCHLVIVTFXdZaxShhYj3mrk7As",
-	"625nGcs2N6+syIuHyzoDyDcZyHsLGfosHZqDhDA+pYj9ER3u70ckgNGMMH746uVPL/bni/BWduObKkH4",
-	"c1bFcHD3Yvx8fDD4XlNlQ+ygPds9t/gR7RQsXZ7e6ijbgVeAUrZ44dl3XWhD/7HVNh6zRhqtYCc6ji3d",
-	"amzFPcY6NxdbXTexbbYR694/7Klx2FYah224Y1jfVmGbbxHWqzfYbjcF2+FuYEu3AXuNAlxTjzjlM0Lx",
-	"f9Q2QvOdo4AIR18dLPoozzI0g4H5uBrQ5narXBa9KNYmchQXQg+YQaZsdUbU9Ii+DD2PThFLIw72xBsG",
-	"/qvQa6nZUlXi+tl6TsYv331d3MNHmtRWNGiqjzlgKv9+1mKoMcXLpMEmm7cA4bvn44PxQXs0vLVg/RGF",
-	"aHOBExRhp7BV+WbZDPiEkjnRWUR8xsAt4vcIxbbNkZWCVXMZjG1YCKucvrc0Vp1pNWJZZV5v+SyvPZzo",
-	"oUsLalWE2oLE5r4zL9Gtun9HvTCFvRcCeV0JI+3Y7ftqXdhr+bkla9HM79VvP3/Ts/1OVUaCdxBH0vCg",
-	"BbnC2+1AO7WFFbzlLoicFO1r5TzL7EeVwBpEEM9lxQDVZ6EqwkM8d/Ry+Hith1bMHKZav28jB3tLZg9l",
-	"12fNnCUSUXs1C31qhk19mk45hwB95RQGMq/bMs6p4+u8bk6+IEfMXg3wjjPA6RxnrmRFeQ32EjrC4UbB",
-	"lKmSC9Jex24Gz6pQZ8sGiFl5lAgYcOaL/FazSM092Cu7b0PGMTgwIk8WNTnS1bqWaOFqCqIzqr+gxX41",
-	"yu3o+ujXo6uTzyo23r/TiJ60ip3GYlW1V0lrlXuFN5TM/UI8fs8+r3SRRIsGkP5uL+Nqm6LlGbuYRRG6",
-	"zKjDjuAf+VPDWOfN6FHiN2+7qh6j77FHUtHQRqVmPOsp453YMhw1Zjab5yvfAMsbHGRm4s1KdtZO+4p0",
-	"9hQrkeWsCX2FuJJYsYzwZuPG5qW28n14iGsxOCmEKRQPHxpFvL3fYsGkYCW253/L8nwteI9v4tMJiImq",
-	"fY0nGIXF8kOWFUVieQhujKPxZmBakEpbkU0DeS8GIrbHkNPu3NyxODe9gr3Gg9m+S9tyUelpXvBl2l/2",
-	"yOm3dtfSg3i51sGWsbRkzFE/OPIjxfZQA1IROoWxNkP8jilPYfSWuCj13Powr+Bxp4YA8S5m65ltukIj",
-	"0tsIB40LXchPOs7sehowu6AkTAO3/SuLHRJEgJlqTKO/rosWqik+3vIuddBXmhnAMgbG4rw7ZmIsbq6X",
-	"kVFWeLhELCGxq7TvFYdxCGkIkKwEQfWHurC4A9KuYN9KBLaaTH6cc51fj15/vjz5x4eTq+vBcPDh7OjD",
-	"9dvzy9P/Pnk9GA7enF/+evr69cnZYDg4O7/+/Ob8w5n4+/H52Zt3p8dixOnZ9cnl2dG7zyeXl+eXRT5l",
-	"D3EEh3GII9ZoJlU71l8a9cOqvSF/l9VA6uplYeQq6/9GtfmbQQ4CKMs/SsYjZitwQreoN/St3JG9Wmob",
-	"hcw4HQcGOYgQZBw8B8EMCr2uxh/fWkdD7b5No0L2Bp1ZBn/Ok/b+LF/XCUnj9pQYAzyJXk4BQ9cSqTXl",
-	"XuF4GiEAC6ZmXYFEWZ3VQHcsiAOPFHPkJCtjUkrvhKE7DTYz3zf6VVI++8+x/tYqA9capmO+EwJvKqHz",
-	"2XPJK/V5tmjF2py95Rok1RWcF/OVIxrD6DjCbrVE/w4C+UFLJr766LMrH/NcwOyFmeb0tVW9Rf2pXKhv",
-	"QBIUBzNCERkFEe4n7aDi9kuBxs5JlUmj9gDq5/Lui25YsXNZDi3RrY+GAzSHOOriiK1JOssAnG3Udasm",
-	"mcLB+yLxsqWdjRlyoNOQoTBivIDzyMktxWLuEgzv5T4SyGdCHs+SDQuz78Mk2VdLdLCSyN1KtI/52k0f",
-	"9hldl2HHA3SQhqElqjeKwnqK9rAiexAwCzuVAC27jmqVgWHdDlS0mnMbKhyt814sNiAAMkrqdB97yrfX",
-	"1xcXhLboBkB8BhLxnbXi878e/PK8KNr99MKZ/lZe8cpzySvHmi9fvuy85pJKUAHMshNyDCO74EG9VuSN",
-	"c+rzpbGtsqovnvms741harJ63NLqYC1WHXjdcL7KVesybkz6qcM6vfTb7FnlFE4mOCilLiSsGYtcEq1W",
-	"wFAHn39WUhfGVh9J48HPmmkqp8gMAd18stxas1uowLmuo1OMFNiDKSejvEM7VraphJI7HJaiI5oCCCpg",
-	"eYtgxGen8YQ4pHv5m+mtqd6MvDCU0vQ8iw5mp5o5M5IB+ppEUNXfFZCc2St3SdYtbnlP/ediCF6jKYUh",
-	"CofggpKprE4YT4dAp+oOAeLB+FmrGqJXdT3C79VBGrRuLG4nO7DRuv1BaKZ26ld5I3uBfBESOMJSGes9",
-	"SVXR5+ajNRVV9OKHvZsox5wSE6aXmUoZmJEotAITI/wFAa1FsqFVX34oHYm2a2J8E1/PECvMBqkVA5i1",
-	"w4rgLYrAv3L+PA7RnZAGxZbkjvLyNf/FaYr+tUI3Rkd/RAbp1Xgjsul8fRE5MJf0ROTYtHk/RBmIXnET",
-	"Z1aSRClcZObsnZUThfogt4cdBRzfiT9cy3Ljsn560aqVfeHBu8+IQGdVW+5E6H8d3Pzic/GEZBOAYAbj",
-	"GEXV6504fatXsgStngiGIVWZunZOFKKc/d8t4h6b86QVY6xtXr2/vsgjpu1K574zSEgVKpKQ+kwfigKc",
-	"SPNB4aColOnDEZwXTtqoiDfUKS9hsi7VJ9sPSki1VECvP2fV8CLP01bgvVRlkISLupnEb/l0qpBPdT4L",
-	"0QV6HII/fZN4Mhbs5btpfIpCAHn2E+OQcnbEv4+dCKSMUHXb0j8DGYnUYXv/zFZHd4hivvj+CYxKu702",
-	"u20XHPQmhwqEbVcnkPwodZk0xC/SiCmeMkO4jSazBDJ2T2jYichkLIJllRgOUiYE8jlaappylUUz5zDf",
-	"pQ9o6ticBI7k37QFKDBtz150Xsj34WDm1GTstcUXFTOWIN9W3depjtlTl7WxV7/8RWZv47l4YH5+9eqn",
-	"V5K/qP9+7lLLeMS6Hv363VVNfTmt5uttSbCqFXzuMZ+2mrn97sphshKDXC3gUJBSdPUFJ78jiicexRLE",
-	"t0CuIeaRe0JA0Hn2Gu4J9YqigMzn4qFTrS1zr6ilKzS6Pqvk8He0aI9ZgCAzqHxBCyBDaSyxWqfdeBlW",
-	"/44Wdt+UbKgV12Vor5cF3LWtItaPAoqk6A0j1l2wKTORqsqn8hjJLYcSTmoXNRGerHQH3ViZHte654/o",
-	"dkbIF39x7F4N8BTIZgiGjcmq/ufSO30rZ5RArqQf57q7tDvpxQXIdYcdE+xiDpG70hwNSxayDkitVJKt",
-	"9ber8zOgP29/t6s1O11Fg/VhAYrDhOCYgw+X78D9DMkWWkJYBfc4isCtoJKSL8cUFBbj2ZhFMPgiK7Zm",
-	"FZvNp5ZlLKXYq9DwJz9ssu/IZfcITetE43qOxUmMhQjgWIpAhII7nBFJfVxjjePjVM0ys5Zbyv/RJi5U",
-	"ACO9ZBeUcBRwFBp/53tLBXd41cCL8YGAhBqUmyqMhgxgob/a5Ztj8Ne/vPjFKTZk3uPP6kluKhNQcDbr",
-	"F/zD5buS8mBwS3w+LtoiumVW3iJIEf08R3xGQvaZpYl4l5HDWXplfgJqjIrpBnpkaXvyrvu1LXOUD7h8",
-	"Z/VcL12Ik+RggktQ2Z8Hibs8uprmc+wd/u23lfMExcdyefD++ELW7anJ75QuUz/IK8zUTtbeftvimYcF",
-	"P70TWxvQxLF/F2+y7Fj1sUVVI2BGbHsN5sD3kAcz2dIOAcZpGvCUylsSo++ej/O1szg4Gf7CxINAZPMc",
-	"DOWfjy5OXcY6GMeE5y146t7P5mpTg/cwEZtSPwsRjeVZJcpSzjiRv8H0K44wpAvpbXW9iaZXw3VWrXej",
-	"FX2lDXS9sNAuRdVzwTSucUCiXdjMjcxeZXebK4TH9WZtC3vtEin+hc39SoYXbOUfTl8/W0ENcd/iTIWM",
-	"emmMYfZjfKyEzzoLadu4ZdNIoZF+FTEhVd9ISmkFIZmNgY72lC1TpYkuDp3ytHICZKxtswkJflDrm6vg",
-	"OftKHAd+a/l6FQrFIIwU7qcFdfM6eKL75l0SHTDDK2vC86DDAYmRRq3Ewe6/ZT4LHVlWU1AYWX6HT9+H",
-	"bZNpwqyd7r6gOX8SuFqq6lb0c3Qy+ud+A9SUKVUIacoEz0JXRxmZ50JTcIsiEk+Felwuh+VsH8JO4rvX",
-	"xlTlXeJTh+mrhFtV09O5GXfSQ7XCZ3MRatfUlk9L4ccwv1r73ObHag3Csomko8Wixh7pOOkSRNclWcGb",
-	"7po3U1MVq/rNCspjzUmMjZgahyAi06lsgBxPKMyF723n8lWPvpJncoXFs6rz9nv+VlJOy4FNW37UPPP0",
-	"yjRUTmtzHKxb3pwD2GCv45J2Sp1zQ/WbLfBF59ge1nfXmQxjGIP3Jg9EpbWA12dXo+fPX/ykAl/GNXl5",
-	"6yoG3DHBr4buuwtB6yrXplO26IfLd44OYJAhYBm79JtBZbVpbTB3XV5ePKxoCTvc3zfrjQvjVDTpmN0F",
-	"h78c/OJsKrWeGmkOyulWLE1+FY7IrdOCTwMo4e0F3cvjIyC/XgK8NIAjWf6sI3y/++Fub1lidwu1Obe5",
-	"Y+mUzj32yqo8z8m9PsozI3OBnHZmpS68K+SriEyViWyOOMUB8w8BtZIXcawOISFATcCrMzTU3hJmeQGf",
-	"hk4/9IPLfyYm0An15jtTOF8e0XGwqjk/42J240OY4P275360dVEQXSoYywjVbdRzGSezPY/BB4aYZZwe",
-	"iQ/uVC4PjnUuoCpwcxPLQLnJBAcyAMyajs8oSaczEEGqQnmFBsaQu35ZjL5ytS+XuxPKhhXyZwnDCeLB",
-	"zIRBi6FiXTQGF5DpetPKxwel+ncT/0uN/Rf4I0V0YXW810xQTqE9smNwdCsrdph27xTdxIJTxwTMCUVA",
-	"0m6ZTaPF316c/pvg24+/H/yfq1f0/O37FH785S789wl+d/y3RYhPf37/n38cnP108F9ur8xcRXYfk9Sl",
-	"bh8lCSVf8VzwmDid3yIqSFpuBWRjAZxwo/lKgNzE1yZZPQaIcTU+83beLmwPhMRJuJAh87cIoK8w4OOb",
-	"+IMmzQ+nYIaFQiSDjG8G/++rAwseN4MxeA8XUo5S4JsQehNPcMRlpJoAPEZlsL180ZPNXEAezDo1E0nE",
-	"CAA79BEpd22iJGKya8jIruXSu2HI0j0frttaPjgBpy39rqJtUinuqTCboHMgq07lUHZVuZGYlndAga56",
-	"aJvVnvXu+6rMZvhK9GQ9ma9yrF03yyrEBi82rwXbsPcpUHiR+apKYbcpjkLfSsm/Fj6W3rpy2T/PmjnV",
-	"2qAysCTULpqSYZHdxAL5bYQ3mTbl9vRMPU6YmSsuPzlNNWJqodwhor8O0MsIw/mcOyYB5xvr9x7JMpXd",
-	"2lupMprIfpPqSmWWwvMkgz5R7QFLkQWKd9tWeFfTCWePRVmVzDmralHSPCvjgvin7UHe2ebtJT/VwtSU",
-	"/mypMtoRcuYTdzm7FQDRWoD5AJSZ0Fl1Jl8CuXas1xoN44RC3d5dN3N5fGSsDvVK3uXxEZD6d1XLOzod",
-	"JeReyoWUEF0ABsAYRguG163pFffVpuplBpYWVS+f1db1Wg9a1fxyA0vn5F2dtOtiOipJdonsQ4hjpgOJ",
-	"BLit8XMY4wlinOlXDYVSKM4LnGlr0obLVusz9xXpzPCViHR6Mt3Wq/Z+9O99r0kMZwAC6xFS114MlS+W",
-	"79v8jehTLnkxZpY13I+v5G1Sz3XTsGUl8BKSbLkJuOOyfITz0iGqoqOlu57Ed+dZ8+NOKrD1RuU1NYp6",
-	"sd1WuXK4xsAGH2Gn5vUn9zFy2a/uZfN+4zhgxaaKUhvWIr6S90vsoBAsUQPP9hIgtt2jrsFl1SeituVR",
-	"YCQTn/3iCktIaa8zLJ3KhZ2NtSEKOlpQ7inhVQNCsSVUbIuYJR3XmIZUNK4mBSkTaAaheqzpfHrMQN5l",
-	"sJLx/CHWrS680p11T89VUpGcsJl6TFuwwrJN3OhjZUD5/hXhFAnTgyt1UGZbGdOSJf2L8/+ZZWVOVlXX",
-	"XwBHJeQ4G1cxEt3JvIw78kU6/ZRCgWAw04V3s25uZp76ko1qFqdPMVtJl/QRIrBVGTib2ZmhYFjNKER3",
-	"ps5QW7an27t/YpKTZH5CMTFFXIdBOSn2VLbj220xh8On1uqPDQJ5R4FiRYLEFkx5tszdQVqoNqXN2YCb",
-	"xTve6AwJXXy+LrAw5oKQXUlw0ltgfte5CoXCRnnRFVkTFbyaD8FPB6wUnD5fv5jwJB84Mijz8kWnXe6Y",
-	"UxgzyYCVHua+6ufla35+wJoyrVhj6kSm7Zn8TVU4PUmihTEuFEoQ1vFsr1QKE7JiJUA5vNvGQ9TNKRUh",
-	"Xkh0zg4meTMuNki1fFQF3hIOsg188qi4q9ss5+GgRlgTIDMQc/KOJCtqnxvjLYnMHl+IdEmqYWr2t814",
-	"7JBzanG4aIHoIuSsTbpZi1jTQCWXGeEJcsDKslQqny9LsvAZwjQ35mcV0WpoRfUOqpoTL061+7KUSOWi",
-	"ElV87cqrwlp1OoNmurTaQFq7DcsamIJzi8FwcJWyRNZWGAwHpj6bhS/WYxbWA9BmAXOoYyeEaDR2pJrl",
-	"UzZHirZBqEOimpbaCnyuSyZapeBkt5ktG5Q3x3uTRlHN/ea1Dl3L5hSe9at2IaL+sR3Q33uKpnPCUaYq",
-	"O8RTqWpo26HKg8exDCMxVSf1Xxkn1LN88YUuMlyoCV2aptgmdt802d5vqr+hl3b1GDJ6rcx/XaLER+1d",
-	"/V68J30aTlSMUqEmaGusb00Hp8vaPPGMvmXsXE3V9mplDIwopMFs4Vso/W02oI3PnL7uIj66M2qyySq1",
-	"yG0ZtRmUemh+0ia4vrXhUbOXbCaVi14vaTe1Na3YEVvg48XxKpO2Zd0mbSFArhmbJPVawJ45m2IcAaba",
-	"DJSZdC4JU+SAsLKiHXGfzG8H2/RL9F6daNBGXFZN2Q0+tat6WFelOMhn1KU0kNsivtnlcWitY73YwV19",
-	"WUin97SgqAFOZ3ousf5e9yZkXMM84lIgyE/pnwt/+toH8CsTJGwWaiYdFnJQ1EYbdTQbem0FvEo35McJ",
-	"VkGjPwK9PSiUacKUa4oaakJnJZ11bwoT911AkqzwtlsDjknoUjCPoqhYq5sZDNSI14ldyOeutYWI3IkT",
-	"GiRCrW3fSaRV3gTROeYchUB1mmFgL0JTGCye1XTnaSrBpGdQ9lOxhJq9VONIt+u5p5grs0qEVIVV/5JH",
-	"hfVbSg9ZP2aYqPro55KJfD5kQ2DMOFVZCiqHxJ9stZVMnrsqoYm5exOxQMrsw5GUHEO5EBsCNE/4QoV8",
-	"qgAZ9UMHUc7ttDC3XYdiVsPj9zBJnAEp+gdlVZKAUamnqNQrWpUSFMeqx76ezZzQZJIJqcaoB6OI3FcM",
-	"ehckwsECqAFgT34EpF0vXtiZqPnouORfNb9ULhkVG2c396jJP/0+XFLHakTUub4cN66Ocu9y1SCtOUzj",
-	"fkiETPlGB3YZCrROax82u7c67PMRCiTC3S60by8OrcyBWixzQ+zSSdMhukORGPyA6NoFzyt5ZfbD6S93",
-	"y8qRaoJibGbucBLrsaGKCGBDQVH3hH6ZROS+cJiycTUvz6vJ9hfZcqVaYpeiJMIBZIWPn/vFW1dhIe0u",
-	"ryGHVzW2Et06WprkTGVDzf+qrUe0caydeItWtO/DvHaqu8isxGktY1hqz1XVGmUsX6N6s1Q5rjdbemgd",
-	"4VMttFSh1joD4KZL7fYQspvH+orYdbPUo1kD1EofLFvhixb02ZLNlKlUE1mwaxEHMvpBO0jyTPQNBniW",
-	"zt43wrM8zUpCPEuT+oZklCvALhubUcafzcdouC7JJ1ajvHNXr/FGQZJl7f5duFwEcQdYWiy/uWmEANCE",
-	"Ijarjwh4KwTHCUeyYylFAYkDHKF9Pa7ObfB85rRtezbdUKfIO22UDdnmh+HAF7e7eIzbbnVpz3H5dlfo",
-	"OI4gEzsXV3ONXU/FR53AXd3EPWRADAcJJUJZRGFtqdDnXUuFqsWuOKEui8OV5e1iulK3DlvK76AD+st1",
-	"GvhJ/SNmRrYXHMq6z17pZ0f10corAFkTegrm9itenaSjt9MJiVZ5ptF76bQO2ncHtIUrR5oiEDylmcKU",
-	"FUXlTsjEI9Y0ZY2QU5m3a3FWt/YnD13Pguor1l/ZVYq18S6NuMB+lxRcL7HUJoBlhZOzzv9ZG8Aa6XQ1",
-	"RY6P8lkkYoVZkEpZrsyhtXQ14XdyAs/16vUn27aiimxUo6V0ecNafcWU+TLDv2QfjTHZD0nwBVHVo+Tf",
-	"TJmGXR9MppVfbiHDwUg3Syn+xNjM/QOXFVBvCeGMU5iMS7+SLyguVRgz2/ZhM8Xe305LrW44JPsKKiHf",
-	"mL+qMa6ZBeVzEEE8dwU559Y2+UmVQyhXSLPl6rMqMt08v/6mYO9V9iSzRIju9L87WXzdPn4Ny8zFr7Eo",
-	"ZdIoo13in2EQyGoohSvT33j5/6tAdkLGxdGcmbU+gciWlIH5DMAkoeROyrmcu9PE2HsYpzA60l9eZuf4",
-	"VlPadC6/z6eW4oMe5FF5JPaNqfZP8s6gz8wp6nefJTmbTbPsJPZiuriro3+Ql3FMHcedOq6PmunmMoHc",
-	"UadkT0c95OIXIHG0eNZk7F5DGMj6AzauKcSuVDiZDLSkCUOChEkFIaCEsVGQSkIQnDFANGaFTixWoGcu",
-	"827WjCFP3dd4oQavxGQhp/I1VCgr7ZLWCYUGm7dJ5BD3sUSoXbrDgxyv3Bm6dwWYSOlJDTKVvjDT6W84",
-	"CziujyGeEHoCAwdzKfZdkuKoFkUF0s9NYch8HzI4BMqbdCepyP5RQpltXSxEXLZMlQWKJ0ax1OTLZiSN",
-	"QkFkOpSqvoDFVgLqG00o/p6NptSKugae1dBcSF2FQEkC7iDFeWcciTlKizcI0SqaNLUmrRKe7PTiMKyR",
-	"0OrZIO1pmPFC8xBLA9KdnAsp0qtBbYoSpDBbV53jgdMcRkzrbcdZ/nZ1fiYLuoH8qywHpn6bJHGVCjTl",
-	"fkqSJQzDgXI5KXWXojm5c6Nd4pQZpMNMBkXLRlB5Ux3xH3NxG4vaHl+OqGHVgowIqRDsydiVMNzX27PA",
-	"8KyaQpIM9BZd+NNo/1S03S4OmWp5Gwy8KsT82htYU+DScCA72rWiOCdAlTAE9zMczIqvR80eSxdm9KdS",
-	"cJST+lfAfAtkuATzXScHVHhYYAo+zFDJGHVial7UU31XTDurJJiuMmm+MV2+b53H1yZKYTSBgZaXrYaY",
-	"JOF1j5d03Hdb7BKlSkSX9JdDzrOqpCycXsfej0/e6Vqz+WeAphFiJkkBhSBMqXq84hBRpWLWsP3aalAn",
-	"lBJqSj4Jaec+zmq4yvWy5ST1Sv3SqcmmUTtjuKcwSVS++Z++jcfj70qLmaeMZ8vIZ4Km7dZVueIwO1m/",
-	"ZHNb8/Dy/Rg5ujLThySEHGmz/CWJTFUDn6J2qRwLYCH4xVS8qNebH3i0F3WGbh7bIPCNLKy0arEDrUz0",
-	"VX2MVeXu+l/aZuNJtxpGqqAWZueXd2M+a76gpnBLfRkGfT7q8KkOV5IbnkzsVbHib7mLfb+n5gNDdGQq",
-	"aLgXqpyNLRhH84vCiiUbr/zCmka3QlZ8PiEMc0IXLT3o8w+rLwFMkprSkJDPjAJhWjJp8541n40A47xH",
-	"MUyw2755h43gWSo8S2Hs0pZ+wxzo3wq2OegOKA7IfO4ywmUpjOoDcPX2qMhHboPnL3566Wfoc3Z8/k0a",
-	"+bIL+XD5zlnAZYr5LL2VlegJnQplhYyn2MvC+L2mjJDAM3fxiArR5Dq8FDsFiZSLfEhX0kjWAfaDhqLP",
-	"LCCs71OXG4wf1WPnFUWcKTWwPSPOMtl7PYPWzB5vYuGal7nfR/guZhHTq3oTxR3o2LBOVyGBZgLgn1IO",
-	"VphysExuwDJJATk+dEaEP7Mlcp/O0H3mPDGzZNVxSnTQnyS7EAZD9BgmyjCDEatPiBNflrL9E0omWHkV",
-	"1KAKSVgzNwWeNNKL3H22x0Vtl2t1TOlgsZd1VeI0BgBXWvc1NvYlexpwj2iuyoer6/EtAwvagu6KMSBu",
-	"qYIher1IUN61s1Iw0rLjqLxFsbayvaRMWRVgHk0iPoNxWLxyV/uS2XsUzGCM2Zw19dQvTT3PBuUGxGw/",
-	"vtGIR/bqefe3ygOFWRLBhVvmKz1QUs4zJGlvKL9vOQJ8YO5UnoRiQrGrLMjxDAVfAKGhLomVgz9EXDX/",
-	"AnsRuUcU/BeY4akKW1CzPXPX9LASW9whLx+yNezW5mg8HQ/BjUS+m4H4Vyn45WZQrDXWJfzFhrYFjmEZ",
-	"V1zsSHoo3lAy942kJBTgWDbAUD6PSu19E2rsF9haSE6pd6ScWkuCPWUUhRGYwCi6hcGXZ36KgA5bqGe5",
-	"V6qPl/EvWNXm3X1I3AHJsutIXqTCh3VVC1RgfmmpolVNrquaOBxMyREN6sNkxCOOBVWkpQI9cB7+XDPh",
-	"+VXtdNroH0+BMiEUpoxwnH51T1lbbeE3kt2LZJ6cAKMDWoFy5Pn4xcvxC//Q3CPLeFAx3uUdr0c19oLW",
-	"gkH600K878H4+fjANxg3dyjZODG0EFDfRHbDNhhdNK+7Rp/cyXC31nx81W1Mh9DL9mNAN6wG6M7ZYUuK",
-	"gSjMlPsGXcnqg2OGZQWUTRPtYrRiIYjqHt2OYNIxVrHWtXBV305CwyzPJAAslQnokzSKnC5h/Xt9gJx4",
-	"7wwg7yGrn7o10o9TPJ0iikLJeVxScNZKTmINA9kIe/oXzqTMQuphapLucxiVF3dinLbu1HTuwUFujrSc",
-	"uUsUBlqduNioa2dWK/vPhS4kacyASfEEczzV4qD62lm9oIvspL+tMq7XZsn3Zkl/jpgdSkpme6lKR9eG",
-	"1cxI8sydxTqvX8/N3vJrbUIc3/g4O3V5mRC5DGG33J8h8yWksQ/tpDHYQ19RkIovnu0KCU1wjNmsZl1V",
-	"UdZ75VedVm5BcAGvatmACiqPaBqP6qQqQqduUj2nUxgbxd0VukuoM8J6jd4dK5nfnPKzdBUMEsL4lCL2",
-	"R3S4vx+RAEYzwvjhq5c/vdifL8JbwfENOD5nMs/g7oWUZFyydjJz9ih6jTjEEQpBhqZAfWkD5zgisXKK",
-	"RYijcKheLaEum4rPzeU93c3q8hWzwrHGgHeBTDGNyzSO1b+uxFuHVEXWN3LPg6EKPiia+OzvqsaG1Ktg",
-	"c7Ga+KsD9MvLg4MRevHX29HL5+HLEfzL859HL1/+/POrVy9fHhwcOHtZNHtaLlQJrnubua+IhRcWzinC",
-	"5u3Z7bQwOSmTnsScLhoKClqhn1IANaG1Nh/07y7Wbi83Uq6FoKpElczRwBKfaE2gLUWQuSSHqxmhHMxh",
-	"MMMxGqVxiCjjMA518XkxKDOKVNe/ql8w56LVyBkJrDUweLclRC9XNuaciSmjdtuGtU09h4ZlcwSNhUxd",
-	"hQaBN6sSHMSDvTuywzsybSOqiEwBEt94UVNEpq6wwalTd7riKAHPD4Fg68WogPF43BGH32XbXDkel6As",
-	"jtgCVqUvNpiTsrrRRXBaERIJoiMm4BPKh7GKfjPI3uE7VGjdX69TRvhOXiXbl0yDyaoheep+VrFaPagm",
-	"VrRVwax7Ws/vEIVRVDzcSl/XfITjvUeJY08XBqK6ancO2E4ELJDWJPi0Ndo0B1Y7GrrvrAmXrMWakEgg",
-	"TojvcJhCC+Zi1QraNMncecEEASbzZRMZPV+B1C25QEXqCISoN9JHqMrCbiFSTpWJjV2x7OoLTpJe0px+",
-	"59thmgsE6+BMGogKAHVoFREYulUf2TBpyWw/eVI1QUBCNDRFOxFlw6w/FJPurIDEMbI8r1Yf5M0m/Jmz",
-	"9835y8avJO3PzHacgcfl9dAVOY4uTi04ZkW63J4JHLvTSN+Se3sSzRflC6GG2JWlTBsxV0y9K8U8zyY2",
-	"eQMy+lrvpTbKu67tV3U6wzp8U29MkQrtM1KpC9bxrX34GuLlQl5R28WYJnffa6mZL1MdIsecUs5Ac0Sn",
-	"W1i3JiunVCXYkTni9kTq627Bd8UonHvQWlUzgkM6ZU2jIZ2mpjG4v1cgIPM5dCUt5RNLwbPSVK91Zn+S",
-	"8RVSTuK73yF1rTXBkSuP8A2OUBFLvNcSQ2sWw3OnRn1+fArkT7K+VhqDvRBPEZO+Yw6nRcsxRVPMOF3Y",
-	"DQL37aI14gU6rOvgWdaM5k1qoUA/01HQFSnEBdPLXq8WJLyFDLnDkn+FTNca0PYDwb3R14TI3BgMlU6f",
-	"91BcygNQiJ5omjSv11mMcKM825tOH7VmmcOveC7YwM+vXv30SuYdqv92BkTUJW6J8+e5Rjpvyx3Npy6m",
-	"1sDg0xNHRYs6T5tTslD9kVRGBVzAno4EVPl+hPJnnQ/vZqsXlHASkGifo2AWk4hMF5lVyeqiqVnt2+vr",
-	"CyG/nlxdD4aD6eXF8WA4+I3CZPaPdwPpt2Uk+CJz6q6PxZcfXl+4s/oww3WqolVMKUP17HuMGLhFCxKH",
-	"AM+TCAeYZ90IrUkt1mH2nheisMtNYS3BSJLX//w07BhOpx8XicFNtN3F3iO+X4WtR8pImy+l8NHVnNcj",
-	"hTHrDmvnMlbpUEnyfQMIMzIzu3PKLpoSs42AL2ihmFC2g5LM15RmUBDufcpLfKwTcC19pS8AHLJ9BQJn",
-	"sltvnVDvlNwCW3TyXF8PsEev4lj5tDWncglyDOzNU57CKFoA9DWIUobvdK2GbMQzdyN3qyXyMjvPXv+a",
-	"jbvffudlNHZ3zYtDmaf5vh7dvHu3kvtYKTHrbOGqF9loJ9dGgu6Q6mrRdHUFhoKUYr6Q1dC1DIcgRfQo",
-	"VVKc+q83xh7zt4/XlYSAv328Br/Kz4CsMleKsR3fxDfx+a3AZAD1F9LkuiCpafnLFwK2dzgUiop4ZlXd",
-	"F4C5rhd+Exd7gcwQDBE9BP8q/PnQ7OMmPTj4KZBryX+if4lNXMtCgSqYUWVjS338C4pNNdK/ffz7VW4P",
-	"NqoBCgFmLDUlpSX9SFuwXCyHq2yv/f27rFszIdmzocwOSqkfnCcoPpbBcwOdkebMMctC7Kx/VulTyERS",
-	"kBYElc8MMhNJlkcPLiLIJ4TO1W3kn2qwM8t/OIp1L5FbxqmdHpBlwigbVqKnBCie4hghyoY3sRCQZBaE",
-	"iomTJX9GqkKDHUuZMzhKIl3BQcxpNTdlSKjsGoMGw0GEA6QdChqWRwkMZgi8kDpQEZb39/djKH8eEzrd",
-	"12PZ/rvT45Ozq5PRC+2gxzwq3ooApxVfeDhQOpaq4hILtf9w8NP4YPyTrkQiSWZ/fI+iaCTbme4Tgf6C",
-	"J3BpPRpRq4OhswTJJeIpjRk4F7gsTgOywblFMivxWez3fvnmGPz1Ly9+Gd/EH7S28v74AgQRRrqDZYhZ",
-	"IMSJUtKEpgMrmFdBOStLcRrKYBoud3VhNmTSZ94bK57sCCY9PRISLw4OSmqLlYe6/2/t9c11okZjZvPK",
-	"ktBK7E9CsAF6BZ43OPznp+GApfM5pAt1WNA+g1CmpkyV/cwreIh5i1iQoBiHo2KCbysGJCg+fQ20hFQy",
-	"YAkKPH53WuWup4pZagR6kVuah3mhcYUQJWPHUJKcAYd2DdWhgdzacSlfeW13fyz3q5aTGozrthW0iiBu",
-	"vWDXoIY7hQnev3u+L4D+n30roarxHmEUZURaJDs9w7gCYnHIo8AIVkvB1Ts/q1pat5gTJoa8PHhed1fZ",
-	"Jvc/xOaUKFSDfmof9IbQWxyGSKoBr9QZm0eYZ015qORNZ3crtw4zAJr7LIgHriu9hTyYjUxGlerh4lKY",
-	"T7LyKVkVu+LNUpWox1R/EB0/EMAoqt71r2JNM+FAyYiI8V9JuFgZARXWMNmF34sSqXTPrJGIS3vQAQEO",
-	"vCvKdiEKMMvxzwMxfoVhdsSeKLs0AsrD5uVvyvlq3gjZBRUzPHOiYhXx1oxzW0a31xpv/DHsQSHYydKo",
-	"pRNlW58vofu4U2yN4g5d5b7HLrlBJ41e6KWLkbz/rO9PZDpNY/HnP1Ika5Zoud+2peaoUdG96yoGN02d",
-	"q/IdJs6rGzdNbVso6if/tEYCqc2ydhCMKVJucGaDlLIF6UFIhqx0Yi/C0kWTZOSYVFs9hMPM5K4Hmx56",
-	"VvhZjYCoS1vJnKILtVqFoFxAyD/Zf4fnmMvKRQOByC1fH6eUEao//7RWeb90sjqh/10RdgWgPTh51XmI",
-	"HO8c1/1JOi1ZXa6KlAlidN+AWlXMUiMri61JSKiu4yUmPF/3Bpzl6/KPTN3oYhriTnPFlwd/bR8hVOwI",
-	"K+vy0kitMMmF1m1Y3chS978F5TFCUPiuiEA2YnY4tyKkyKGeFEyf1SpJqNEukmgVX4zLwA0EKRgkqmqT",
-	"kQtcZxuUKaKbzPCytiCjhdEKdC6M3hB6vmwfcUb4G5LGq5Gg1a32Qc9h85NuogalvyVzK3fhwb8h/nCx",
-	"7WArvLlAySae/UdGXyGkwn7Ym6RO7JUV15lsbm4q6Ddwyz3BIXQVqmdVFC5UX30YWLwz0s3BtqWbVBe7",
-	"e0jSTUf627w49EHXsV2FOJQtnhU476dkllqcN+qZhZYZP5qqWTicr7ZZgt6DVTjL56igY+nqe6qdxWVa",
-	"NM9yg5Y1sufiUtvRPx17cIs5RSA+6aHd9dAiBD2QvY397n8LVBjX91ZG7KUatNFJrh2UiaQbR3ZNIo6x",
-	"Ja7bAesfn3zfGWmXkPJLwO4i6K8fIXfpFdgZeniS19cvr6/x2djPkaTVE1vp7aTyhVf8llxl+UcP5UVR",
-	"O27yYdbQjp7+R39KgsbT98HmrJOaj/6ZVDKMSoiah/o2a6GvIYc/pLMzO5iv9mlB7Af3xxeUVfvYFbS1",
-	"sKOnkppP36KgZkutVznNl9mOYlpa38lSs2+e1NHu6miOcC3o3MSB978FYdLfC2rlWfg5QW3k7yUiZBM0",
-	"igf1jssc5R6739Ibf1bhtWzijrkouSHsONgur3ssRogeiNbb9GAxoi5mh/Uh3K6861vG9ScDw/oNDEsI",
-	"AtVG1ivRyQrT+ihnhWp+P6SWVj2hr7rmAuaDVcKch6lgrQsdeqpljgVb9LPq4utV1BzrbUdjq9uIk8VX",
-	"P37S4brrcA7s9KUGL2aehbxW5+iu9Ll266n2OWmql8DlPkgPRdCBwI9dI1wCG1ehI3qx6lxZ3BpOHWyV",
-	"8Tqp8PH5tZfC1c5qphPoXRTNTSLrzkkqB7smqTxppevXSlcq2lASId0T3q9sRulpsZvKN2uiVgN7ts7K",
-	"JKpxdmVNX6WwcKAHqw0WT1GfKdtL87Mnb1H5rAtYk65Xc92b1vQat+EWN2wwPql43VU8G36dksFtnrf/",
-	"Le6urjUTQEE/KxJAY6KNEy90LVFHik3cllFjVVkM5zgeWaBaIj+xuL3Hrth54uAySlwLtuVq2wNFtYOd",
-	"4cGPzX3ojbxOrU5JpW6lrhllC/rbw8HaHZNddodunpS+9St9Swk7vTS7UskyMU2rfrdRxa6LRvewNbmV",
-	"a3DVu/XQ4zakwG1bc2tle0+qWi9VrTvX6q2beehknWSNlcgYhgSlrLESJeyhKV+bR0OHtrZOLa1NO3sI",
-	"SHewPcb6GPWv1etdf2amzLIq2J8P9tDEdhRDd0Xq2CJxPAIlax06Uyepg1OI+RK1W9T4Ri3pWi3xY4Vg",
-	"ykP5qmMayA9VH+PmAksOV32xPRUyOWuLDiZXWG/EpFpiO0GS1tpuNihhZLSvJ4WrUeHiGlfqkLSO92Vh",
-	"jfLLFVZQqUHwXD422N0rdCfb7YZ5Xju6Pr74sTbUWyIXSYG0S3TY6rFqF3jvtpBZy6BPtv3VyqkrZNZr",
-	"rFvix8GXK1OyST7uX55EIf8jq0pSOLQXbmZdP/plulkt/optB/N5JdqmDFEwgwxAqQgDTsY38XkcLewP",
-	"ZfdC8XUEb1EE/pU3aRyH6G5fLyDnz3u2/5fgtv8CkCJA5UZROL6Jr2eYgQmOBJ4CknLAFoyjub3aHhpP",
-	"x0OQLzLSC6jGikPwJb1FIzXumbTK3MRWXi1NY47n9kFdPd6EFnKWg/gH0SCzE7WpjxZ2PTTVMbZvzRCS",
-	"dZW+OmM7hYxVD9XsvwFmAKaczCHHgexgLOkBhYpAupCFCyXV9s6sbj/rkI/y+TesmJYWruuE9OQP9FZP",
-	"7cZQTkJwPifKDyj/3SW3zk0ibXl1NjZ347Bn9ia75M3lqPRYwylb8aKXay5niy6pdd0XfbBpPvRYTA0e",
-	"yNLBwlDDJbyMDGtAoa0/nxtH2yfHlrfBYDXP5363ZnhVTc3uhiYFSdlRN+e24HqRaHGTxAgkiDaxYiEi",
-	"L9Mwz0VKw4eqDvn313vQffVq+un1aaRnN8Bx4GKNztLU/mZ3WPf2evA1t6d56rrXR/lxt5ep7Svjx8D3",
-	"v9326bnXocneikmlndkWm0Z1UaSeeud5IVkvZaqtO96uosnBJnniIysa4ods/spY52Z2O4R023/9Dzb/",
-	"+j9lfq3PO7w6cSHbweie0C+TiNx3inHM2hOY0YCjeRIpGfwO4gjeRgjgWPrbWhS9rInBx2wnj1rfq8Dj",
-	"WoO2NZqycisPMKTScQbL01xFlSUQfv9bcL/6CInKAdzxEeWT9AyS6If5ldV3J76iylkeS5BF7clXi/8U",
-	"RQiyvqWHs02aaRwGliEgci5p7VNREigUKmU2uuUhuDRb3DA1/CNFdPHDPB8aiv6vRoYZPzKplV4ZmqNa",
-	"hcgyNOxNY/vfgtJkS4VPl3fd/LLoFTdNRNZBt4DtzW+KhtvjySosn3y1aL7kG9Lp7Ugo+TcK2l6OTT0Z",
-	"F2o3P9aD4f1SPKYXwvkydMjpyqU6b0dUtswu+6HyTW46Nay4cB2rf3JC+SeIWfjmRPWuz4Il9nQKzjN3",
-	"11bmfqX00UG06Vz8PjvRo62J2IZaw6UE4WYBeKfQ42DTDPDRybgND3WH0D8DPr+Mwl1Bta2/7xtH7yc3",
-	"0xqTENctEOyHKImIRFa3EP1a/l6UCozyzokk2fgOUxLPna+AGr4lA8j6abNwvAyRNyuG69Ub6oJeZsYW",
-	"sdsfLkV4BSKSgEuTZWYlpDZFsSANNDIL1RLdb/pL+STi+Tzl0otr6I7FMGEzwsGEkrn0hQUppVLXymiU",
-	"ccE/9gp96YdAZYYOwUdCv0QEhs9ccpta+4el2dIBt0S1/cylD6S+yualT3WlfmbWlRBzQsmc8AYavlAf",
-	"uF9OSbgkRvbjqZ5TwmeIVqlSz/YDi7nlE3aiy4MNvqY5VWoceCLHEjnqq1y59MoXydLecjlH/8ioa7mF",
-	"p6goAwt/n7a6vIcbBcX1zVcQWaFEdzeEmLCPL0Ks9yD8EXKj2xKr8sXruLeE/5NzortzQkKuiRL6sPX9",
-	"b0E/F4W8Rl8/xcpop4PoJNbs76+Qx3v0TotWlFvOeyGnb3Zh7CTmHGyNbz6+uJ12DOzj3JDA7Obh2BVM",
-	"3AnJYXsU8OT22IDbY72ixnqyDfzeku1kGWzwRemSYSAJ6tFlF9inXhrFQ8jhElVD8oKHeSxo3GYVeQ05",
-	"fKoLwvYzOLRZQywoPzhLiL33HFstFPC1gFi1Nb0wTY3OFtpl00e+yQ2bPUoLl7Rm8+OTtcPf2pFjaR22",
-	"d+XL+9/CpIOFwyKTFuvGakmjna9m63W1auSI+FgNGu1Y1cuQkU/rFDx3E0EONs39HovNwgfJ/G0VFh/y",
-	"slPsDLJt/XnfOII/mSTWZ5JYmTwgY83mKOajBCcowr01tmwikE3k5U6Umls2+CLbxONW4SoAadXlHPB/",
-	"eEqd6xAWfjvQxFvNq07dwdtdXXmn9b7qbjetANbswBXMXbyTJ53QXyesgq+VWPq/CvvfwsqMXfRHx123",
-	"KZLrIToPGc550E6qpeO0j1bJ7IGm/dTO6kJu/fOB4NXBDrDjR6Ok9kLSDmqrA7Z++uvuIuvuCC67QClP",
-	"rQn8lde1CS5W/kI/NdaewN/zeGIv+6gVVwsSbRpr4a4emqaKijducLeACL6qqZ1008EFaa21y8qovc0N",
-	"a6GVpYu3YP38pHb6q52ogHc1mN+dXe9/Q/HdMlXwGhO/f0N81fTSznWtFTck6HfA+Mci2a8dXffJLUP0",
-	"DtFRSiOv4D0zAHy4fKcC9yTTEXpCRKZMNn2dI05xwOTPfIZZF/Q+1/N/uHz3w2K6dcamoL5zG9Q4nhA6",
-	"l6s9JrQv4NuaaIAGcASnKObeRHB5fATkiIwKjk5HCbmXdR0pIRwEMGUIwBhGC4Y7UMLl8dGRmPhHRn/r",
-	"jE3oXwTyY8L/wsmXRXpFQPAWR5gvRjBClLNRTLiQOyQ4R8EMxjGK+imdhemBmh7Y0wMzvbdH9dye8kjO",
-	"eGZNeGy2+6iVVT8gtemx/rf34LTcDkfLKcwX9XzVY+9NdPDn+u1xl9VqzxNsWOPusiuXoOZzy0+qureq",
-	"7k06vch31W/n/jfitba/1znuwDxanNEb5BjtL+S5N5y6OK39SfCxurLXS0+9nN7eW3KqSj8aVh88qJfs",
-	"sZjg1k02/m54/+fAyzn/A5DPbkumD4uen0IAvEMAdk4yXSJZuXiWUtZyJ0PNU/ZyiVC90phd8H/gppZK",
-	"YrMLTfoZUIqpzh1NJTuf8uzY7TZNILVZUtWvnuwafe0a5TQoN630fhNKZoksua+fCcIrhXpNNNdRhuyV",
-	"VO1A7CdrgT+WrsAGUJ94/VDQ6mCbzFhT6OPUzX2RtK/G3SFxe4eRdXfEloPtiy1PWd7ry/Jen5yju6b2",
-	"U3jNYP8A+Quz3KNWbTUU2vTZ7G5++GaqSY4WBqkzTPHVbvUcXSLn9Rq7rMeaLW5YeS0sW2kgIuH8pKZ6",
-	"q6lJhmcO7O7Gp/e/6X91SLk2lNGibK6SGrwbZHdVKw32PVZdshGVeimNtX3Tf0N891DiYJMs7rHofi1I",
-	"5a/kGU7jpdjtBHJt+cXeKDo/aWjr09DW9sQ3NXur5GDYyQff93VXN3EQktLAx6sZRSDCdwj8Pb1FNJby",
-	"QzY669MpBAk+QwAGXHybNY+TlcfzOtJKCLd2NQQ4DqI0lK0GZjgKrbkj/AWBCxIydyaH6YmoPr+mCG2N",
-	"bfTrTtdh1BaSSCy4NmaR6O8ApwjpPJwyGvzwj6VBd2oDY7lOct0pv0OHgIDMb3GMwrpWAVZH80KNd/C/",
-	"dVvWZ81dAzbaMWBV5LgrHQYeXXOB+r4C6ySXe0K/TCJyP7Jx9NsggTyYValHPemKeszInHpYmW5aO+N8",
-	"1HNc5Is/QGpZvaRcA6YtdVjNe9g6KPajAw20OP0U2NfSK8dBQi76NyDeCB+gaezj8jCOjuwIYlw7/Rda",
-	"s2ZoLZb80YTWXe8FawG/zdtSuOMf3+XioE+qMLSRMut8MdcUT6eCKypnjD0n2LtNcRQ+a6ebUkdZ6/Ie",
-	"HuEUwXNlrK1TLEE/xxxcvT0CnAAJHLBH5KcwejYYDrAY8keK6GIwHAimNzgcqEGDoUUB6CucJ5H4Ed4G",
-	"z1/89FJc3iIRf2CcqjbhnzbR1Na+qKbHUyADV4jy9G6WqVJTUA1h7sSLuf+NpvEypZnsEzVrlQ+a9ltG",
-	"WWfbdBvVLpT6+Hqprp7gtLHoFschjqf9omyMwclM4ojZHwLzfEQLMMERl8VzbhdtQqq2q/5qtrfhto//",
-	"EE/cQ5c1izBskzLLl/njC5qVE+eEVUY/31Cf0pQdkliKK+5y4E9ppxuO/3GtXuZYxTt4CgfyDgcqoW8j",
-	"QfR6Zva/0cJEHWKFyqTVEjO0BnpqZ+2XlcN1iSAqI+5jjSTqgoW9AotKCzQ5dncWfw62yFEfi/zdDRH9",
-	"g5HKrMwrKGkHEXI3ZIttUsJTPQVvt8vaZIuldNd+Oqusf9xY5NXSYXdcebWCen4krddT3X08aq5Dve1O",
-	"apn8voytVU/RJHZt9nnbrKDV9K48MslqKZQkUQfrZRTl/H3EApLIEt5Rbvxxs/AMrS5JtFpj5DoR7Sjl",
-	"s/9YO27jhRlkiiDZbUFmNcyx7ug5Yh7pfaqi5L6GwEZkq7MBurBtly2BZTzbtC3QvX7xWs6cF/xkFPQ3",
-	"CrpJpIFCuvNv9aOnIdC9nzo74NpoqhJJUYNpMkpCR04kkM/ywAn9S5Fe3GEUIbpDkTjeyAJ/a0CFw8ZY",
-	"s8l6U+OTHluyTnYmh14mSl8k/w3xx4zhB7vwlhSE9id6seX8HsTiNKOawHfbiupLImrsI6OSXRH2doJA",
-	"n9JL15deukbpsKdaD+0F5a58lPsHpNV3U+cfoRq/BvW9ilReSvyD0N63prZ7sPAnPb2nnr4aDryEYu6l",
-	"kG9EAlut5LUizfsRaNybpwSnir5e1bxdJf9RcfxgKw/Ck7LtqWyvQ8n+M5M1NUisOkBbw73U7h+IErYu",
-	"jm2H+p7inXoqxkuLYwwFFPERRRNEURz0jHpSs4B8Fu8uMFdy5GW+/KOuk1uCRptGXgH7g1OwqyfIEbqC",
-	"Gr5adnnSDukypTV3Wc8ub3XD2rZz+VIOePkenrRub627jMPNdNGT1+9/Y8W5OuTNVIisJXFmHZTVzrmv",
-	"qufrkjpTweDHmjvTDR176b/lJZwa8O5j0cFWOexjCfTsio/+STQVvuaVRbOTeLkjMsd2KeJJtfRWLdch",
-	"c3BZUbOXUqmGAngHcQRvIwRwLCsUtmiUqobn49YjJQzatEd9NQ9NZeTmfg1u6gv31Q7l+A4qoZx+lxVB",
-	"tcENq3/WouW6aAK8T5qet6bHNX5V0LkLg93/Jv9/B/1NkUGL0rY63G9njtfmAF0UNIVtj1Urq0WdXgqY",
-	"nM2pde0WGhxsiok9FmWqAY389SbFT7yUpa2j01bf4I2h71N46vrCU1f+aHdpcFDT18CXkW+0f8Em2Xl7",
-	"HwJFGI+kBwG3D9sbVftWEJ+iGNFSBVTmqcJvoYL4jiryD6Cc92q0+rqa3D1Kcbswr065X3XV3TWJF5XN",
-	"dmoZ8Xwd6NhaTVebAJ5srU6tv6bybveCuxuuV735MtWbLx79VDO6KkysG1/30Z1sidSGtlafPjWiLPx2",
-	"weATteY28bgSdvpGFgYzh7tdAMZRUog+LfVJEL8XuiSsOsQaczRnHWhGQvUk5lRqm3o3kFK4aKUmjQR9",
-	"n4yHR0rmxOugqIh4VDASHzWREJhQMpcyu2rbkUQwRmPwTgyDFIEJ4sFMOu3ukPPb/z+ICYA0mOE78ZkZ",
-	"R+X6KJRrCzAqC644QhvVirV3kmbl4VZBsUP3bakFYnSPKOAzGKvqxVA2owxTBS+hYTEUkDhkdavjOEBX",
-	"2Sf5LiaEziEfHA5wzH9+ORgO5jjG83Q+ODzIyBjHHE0R3QJXeUem/XiKJINHxFEiMl0PP2Ec8pR5WajI",
-	"HaIwioAaIpM6EkRHkjD03/rLnVdqH49A+lQnbTJoFTBdX9BDRVxm7nV51F3GUNU94iTf55OtKiL3voaq",
-	"h2ukWhGS7n8z/1y5C8BM3MhLN+oI+GgddSd8ARnrfCTugPvSeZdF4YjAsF9gXzZ6hY2dPmY7emrp1I91",
-	"C+j5sG4F5R++vPW9hVA2oai/+QYbmlk6xBuaRXbZH5HtcQv+h3zdKj+XoH6KPezkhdC45sLxjo+BkmfE",
-	"PzvEIWYU0hKKuFKy8BNXzEm6BCRmWPhYYxJbUGrY1yslJqiVZncNMQ42y/EekxOqEbf8wxUztuMVsbgj",
-	"OLbth3zDaP2UuuUdj+j/kKcM0RFfJMjPkhuQeIKnqVDCxEggRyprQ8pnKOb6/qWNt1DN0K2nfWCIXsvV",
-	"N+E/MKsdy1P4uA6MpuM8d29MWo1KYm3Eq+zLPbqdEfKF7d9ifpsGX9Rdu9WWC0oEjSEGcByQuWCRv5pR",
-	"QE9knNKcmKb2ytHn8Ni9hXEYoWyGj2qCQX8mBsMQK7vABRVLcSzQRlVaKp6kuu0ELgxtqNsnt/9GwcbD",
-	"tTUQpHu80TBltq2vZHsMsC/aoiClmC8Gh//8ZCOxQooqXtlMS6NsDSJPMZ+lt52w+DfM36a3vVFYDd8k",
-	"/pY2/IS8O4W8xdvphLkR7Iy57+BSmPsObhpz7Q0/Ye6uYa51O/WYO0Mw4rNW4fD87wBPpIjIEL1DFGAG",
-	"1NDFGHxgOrInwncoRowJqN4id2jPW7VgKwpw9JXvJxHEpcvPyyue/91RV9FRIqK032boyW9AMEOBDbRz",
-	"cwoDNpKgGCZ4bJCzVbI+T1B8dHEKfhofZJYOJUoLwPEZZkD8jGPwt6vzM6Cic5wA1DNdJShYVqoubrd+",
-	"iyEJ0rmY0Unc7lkKMzTCXOj67lENF0ARVJytEfKX4qsq5srBgrfCIEAJB5pZMguVxSe4DZfl9KtAZTNR",
-	"B2xWAGiC62V2hFZ0vkOUYQ9M1t8BHCsElargLUm5BLC8QLlBJ7R+14uskfvrJZoY/+/VI7Rip8acu+wA",
-	"bkAWZ/k2uEWQIipUNjHpdzGtnEjZkkqaKAlgBHTFWE1rKY0Gh4MZ58nh/n4kPpgRxg9/OfjlQJqI9C7K",
-	"UykeNsxReCjVdXN3KA4TglUYqg4StI7RVBl3DmM4RXpzemj2q2voBSWCTVgDjWcsdzDkU+mvXRNl/lfH",
-	"VIkZlk2Ufe2ayupU7Lkva4RrwteQw4sIxjZ8JAu5zw22SUQW8u8c0imy95qNdk39qxD5nHMfn+4fv9aB",
-	"tzieUMg4TQOeUpRPnY92zX1+K5AR3uII84VzjTmJMSeCE0n8ich0qpqyGKypzOC8uihlHFHTAsMFLevm",
-	"1MeNQClN6IRRZcZmWJSmbARNZepeYMhQ9HqRIMDRPImkHzlEExyrEAjxF8GiAIqnOEaCbZSXLszisapK",
-	"iM1XM9HYhMn4t4ASxkZByqXNPCBxgGhcXfXaVBKqpdKeh2o7zZLbr933b+UUwmyJfPBHK4yt9tyjaoRr",
-	"vltBQzrdsXzgpskvSYRGt1DIJVAqKOJknJKoaoN1YmnRYug4POaChd7hENFMmZtJJcK+nExtqM5QKcLm",
-	"2kalpFh1nswTwEhKAwQCEiKFO1i9TYXLMIEp9U+Fbg/tpl3z1WXewf1bTTtt13iPYaZvWMPwX/MeyVWX",
-	"efZmJDhBEa5hQvl3F/qzVmYPYIQoZyAmPBfxgxmMYxQ51yiMPpKDz6yxx2ooG3z/9P3/CwAA//+M4yHu",
-	"a3QDAA==",
+	"H4sIAAAAAAAC/+z9C3PcuLUoCv8VVH+pinxOd0v22JOJvtp1r0aSx0psS5HkcZ0d+ToQie5GzCY4ACi5",
+	"4+3722/hRYIkSILspyxVnbPjUYN4LKy1sN7r2yAg84TEKOZscPhtkEAK54gjKv/r1xRH4UUEY/QeztGF",
+	"+E38OUQsoDjhmMSDQzUIJGIUiOEcDYYDLP6eQD4bDAfyT4eD28JUg+GAoj9STFE4OOQ0RcMBC2ZoDsX0",
+	"6CucJ5H4KEQTmEZ8JD+WKwyGA75IxG+MUxxPB9+/DwfHUco4osfmJNeLpGnDruENOw8C3mHLUzJiiN7h",
+	"oHGrJ5DDNriWhzZtMUw6bJHNIEXhKIQctsL0/FacBt7iCPOF546r3zRtvWmdbgci9hxNh7qmEPP2c8hh",
+	"7VvPZvPcLUw5YQGMEHXv0aDlaXyHKYnnKG7aqzVKbhVMCAUZTY9YQBIUApIgCsUXzH0UVFzLmzzvmo/Q",
+	"BGMzpgnA9jy+0E1wMwGaOf+RIrqo2dxrHHFEAUWMpDRADNwucpgWNvyHmMWx48GSu7tEEYIMeQGQqrE+",
+	"gLSm7Q7P0d3z8cH4oHnjbbzXl+mukueaNT8S+mUSkXuf/ZmxTXu870IrJPiCqHrJ3LtMKSO0ZlvnCfwj",
+	"RSCBUxxLOgaBHA4mlMwBBAlFd5ikTKBsQmKGxjfxBWQM8BkC/4rRV66m/xe4g1GK1GfWbHPEoXgPACdg",
+	"gngwkx+K78QoMVsdwstpC9hePZrPa+fzzHV65Yzs0PzMnaAkIgvB9y5wgiLcvMdsMEj06KbdOqfuuHuz",
+	"jnPz/V6I2hdgBZzfWqsrf0U12ywhnDVs0G1vb/Ec85oNvYNf8Tydgzid3yIKyARgjuZMkANFPKUxSBCV",
+	"pFCzrUhMXtiQvsHB4YuD4WCu5h8cPj8Q/4Vj/V/ZPnHM0RRRudF3MElwPD0LazZ7SSIE5moQODtx3+fc",
+	"TOJ3o89f/DQcTAidQ6528/PLgXNzAklYAoMmOsnGNOBbbM/jiXXzxSj7zHnFBSnyKEKUs/eE4wkOJJs7",
+	"nsE4RlHDzgsTAChnALE1BQjUHA0nI96b8D82mkMcjfTa7UdvY7adJHSyjGhu+Fi7bH5Byb9R0MTI9IiG",
+	"rSb5HP6w1R81baorL0scOy0xjHzVHtvSYtyvOA5xPG0AmR4IbtXIBtDRypQ9BMQ61tsuzV62yrC0s+ja",
+	"IK4KFtq0G8FhG7aiv/aFUDjHsXMbVyigiF+iCaIobmSpaiSgZmjD7lh1Un9iUB87N9umNbepy3y1erKH",
+	"MO8hw99bs/iyNMjhLWRoNMdTpVQ37u8yjX22SNO4CePUJD1Ikqbx6PmLn17W7jEiMGzZoBjSAkMzS48d",
+	"ms8dO/wuZlMKjbJHwvAS/ZEixsV/BSTmQgw8/DaASRLp93X/30xs3FpNjAzFvL8enXy+PP3Hh9Or68Fw",
+	"ECIOccQGh//8NphgFIVaKhkMB3PEmJD1DgdYqFT6PN8/DQeIUkIHh4Oz+A5GOJQ/IsYPle2lMNo++Z8o",
+	"mgwOB/+//dzauq9+ZfunYspLfUx16OIVlNYClo1WarfxJMJBP4gcn79//fbsWIDDnMy8sn/O36A/AxhR",
+	"BMMFQF8x42yFZ7vUz6ZjhdeE3uIwRHGvk70+v/z17OTk9L11tP9DUhASIc+BGbxDQqafY8aEWMcJgEGA",
+	"pMYsb1Fta6W3yNLJBAdYqo/ZyqywNCqsfBZzRGMYnar994DC2fvr08v3R28/n15enl8ObPxVUwNBhYgC",
+	"9fdVnrZm/veEvyZpHPY6zvvz68+vzz+8P2nDV3HFE7nMGlC1MPmHGKZ8Rij+D+p3pg/vjz5cvzm/PPvv",
+	"U/tYRymfoZgbtWMNbKVmBUAo4OQLigFWfEe+FHpWsehRINUYmBhpvmpEM79hxKQ9GgKWoECoQAAG+sVM",
+	"KEkQFUMkrKKI3CsIuqHOwP0MUaS/F5zWfDIcSF29DR75hi8tEtMvDqQULgYSRDHutg39xQp3kf+B3EoV",
+	"4PtwcDRFMT8mcYzkwlcc8pQ5xET5d0AmQDsnABQfgiD7klVAr39znfrjDPGZmCRelCbEDAQppSjm0QLk",
+	"M2Q7vyUkQjAWW89+lWdwbPp9ZnQprNGyQmaUGA4iyAxsUHiN58h5khjAWO9efABYKrnuJI1KC2RmkBBy",
+	"NOJ47jA2qEVPMAs81hV8XS6pVg+trzot9wZBym8R5A1rCf5DSaT9sXJVigKE71AIAjKfp7EheGU61iDx",
+	"3kcmGpVXPwpDLP4JI4BjNZdYBd6SlFewEDCFwC6htIr7KZ+9Q8EMxpjNhbiDpy7Dvfh7SvXZBNOJASyy",
+	"uLmZpEIDYhCP0Fxz7ka+mg/Ve8n2/K2Zw2bLAzEc7KHxdDwEN4N/3/ObgfgHEft9of4NE/z5C1rcDJ6J",
+	"RyETnP9971bOcqH7n+rXYeFMn2rA+h/t6hQKb60f1DgRzUOn3wuhI+/9Pb1FNEYcMXB8efJsfBOfoAmO",
+	"ERM8H3FB1IpVCukGchDAGNwiABnD0xiFQvhhqdwSA3cYqlm1tYIpt0Pxpoynou2azuWk7xCH8slMUND2",
+	"RRkeV+KbMmyz5X0gqo0prYC1D+0CqZhHANSwRzleiI0GdgCH4rYnGIXgdiEw37p8EEQQz7cLSw2JlYH0",
+	"LVYqYBGs4q/WM+ICb/X5y55tr/e77opdj7h9SDV5hxNeaSiX3nctRllcrum0VT43maCAF9wTSvQalKXD",
+	"CxLhYAHUB2BPDhKiYYjihWRJcToXB8u/jhfifJaOr3+pPCEdmK0Ejs1xBSqLOcQpL8V3Ht9f6rHlO7H3",
+	"kc/oc0ed0K/KNleNhCvEvt5oVz1lVcbXAmgt4PKXQqjgAo+lnsyZ/QT+05jODwOKINfLyD/cYXRv/WeI",
+	"IsSROHYG1QouVuV/a2Plfb5J5zAeUQRDeBshYP0odi+1d3XunAhep1GUi7XhHMeYcS2kKK2/9Tk3YKu/",
+	"PqFyflUqZyaEXVigV3a4WnEtUN+re7WvcVC3YoUiHU7n0vszUoEHCcRULlR+uQLo1AsD9/R/+3itpjVm",
+	"SSsYhJI0YS6+I3fQvFU1ZFg23o/kpK03pTZrFqq9L7ewlTlNtyZugXvMZzgGEGRe1i1IDUuIXo0yVwW+",
+	"vlJXH2lrd0C5nOTlLXLFTdBdyXu3Qmmrl5jVeMInQasgaA0HHNIp4heQz7y+vM6HLymltYtncTujXRnC",
+	"rgJTNfTL9kjjCBacKQbZaIE6FfmwfJovOHZY+/6O41AASD01jTPaiJkf1mFTKCCqY18VnFU+RRfzrpWx",
+	"6v3rNqTlmfX8jfBegiVsUAjOsC4Xg/M/SUF4q3LvCbpDkTi38W3pB7E5fquT2HtdYDGlWAT5W+ZMAwnk",
+	"M8ebDPa0rpATMZBX+cxhJTeR3e2h7J7x3pmm0hrq5B0YVIHUr5AHs1MhkEKOLN95KYVHjCphL1IfGdeQ",
+	"+K4ME/33BmSuTsJ8PSXlTbdx0mz+T+1g0E6x7nDQH5YBEaIAs2ayzoaAPRwDJvkZDQV9sAw0z3xhc6In",
+	"awVKvjEnVLKcrJqsLhUamFGRLSSrWSRNkZQDwV33YYJ/R1SsJ+TnS5RQxKQj5/hs//gEyNh3gOMJhYzT",
+	"NOApRVsXlPNzKhF5OGCZbw1G0flExod4zqC+/P5JXAIMz+NooZTvToJ3Pp9bjrlQYfsoBJHGrds8A29Z",
+	"ycVCCccrkWcMtM1zkY/0F3nyxT1kHmBhKKFAixXW/rsJPRYMLdmmMF11iYJ0UxjbQ66xdpBHgQyrsbRL",
+	"SzollHekOTAZCCAIQe7OhrXDQiOhIp27rd5va2zuPKsGGHsoHOfOjwSOin+fnTg4MZniABrPaKbDK3OU",
+	"uIBktmByhD7S+CZ+l0YcJxGyke34kkm7isw6lB9Kbq7XVdwrv7QAj/R0LqxQ4ZZXnFCfM18VR7sf/DI3",
+	"qgn+9r5fWIw8aFV9nIEKKgxAWRwdWzpWjn69o3ykIY3C9vziLMwcLjZGNAR+Q7FOi6xuKf/NbGJOtC9d",
+	"RiSYOYp788mgqFyZIyakNv5Evpd24JqJYnREdTBOIdYRF70MwzhmHMYBGkVCmhdMiVOcRZFUzpE4RXFp",
+	"AS8I4gX6yJ79fRjM0b6RxxO40Bq/h5B7HOGMobjfzPMExWcnQOOlwDArWKBWrCsIgp9RHCYEuxSAc6GP",
+	"vCjLjXo4+HD5tnDiGecJO9zfF8PHJEFxMCMUkXGI7vazWDKnOeeriqn7HMjzOujoSGC4lLv1UKCGFg/s",
+	"L4LrWRR8XZSEGUsRdUDk7OQYqB+7nL+GRaYU88VnFAvtsylKqRhugRnQnwCiYnBULKK9GUUA1ZglGQDX",
+	"fuMqTq7XTatYj305Q3tER3E7wzrMdOCIA4CfnCRUeZk9QmwK8VqjW8jKQUYOaUGS6lEb6v0OoxS9pmRe",
+	"R/FlUawuxmKlekzJ51mv1mxWh6kcta8qU51oJRpNZdpO/vMVajdVtNm8kuO+LB8hvF3F2ZIsXlv3Y60i",
+	"eZXAd1syryMuLwG9/e53QU537XLHxHXXFvtJ7Y4qQp61hno+RKWowTv1izhvYfqtvD2FHSz5/BTnWuUL",
+	"VJjZ17pWeo5yT4FYZUUvUhGLtvYoVW+xw7tUPENNgodMEmVO/Vbqlgzcz3AwA4USTIKvh8ahpFg85BwG",
+	"M8BJjvuaC2EmL2YMTsUAFHO6kNkisU1h4EZayW4GYA9G93DBCgs+AzAOwY3UTW8GWdItjqf5aeXAMTib",
+	"ADRP+AIQCsgcc47CIYgJgHZ4lSnGpNRomQfLgHiilGdPINseiaMFQPNbFIYoNGNCGdwjhEuZQDO2PtXw",
+	"fDa2WWwXg6ecy0oo3punjINbVISEZQu1/24hURcTZ+FWLRvnHMdvUTzlM7skRk/rZplyNKBMom2T51WN",
+	"BO4aQEwLJZiVWEDRL1uq86Mq18Hgi/5LJ6dsVlPA4eBE8ySC4t2QcV5T9fwhYD0oeUWCcBHDuRCjokU9",
+	"tkwIFRTjeMJO3wL0VehAzOh9ejlBEHMjjuXL6ZpEgn8OpFVIqKSDw8H/c3Pzp5ubb/+8uWE3N1ef/vfN",
+	"zfebG/a//uQSv7ADcz/E+I/UISZa+ZrGnSSQrXJL1UXiIEpD9HGG4tZjh4gLYo3FmfGktCqbkTQKBfEo",
+	"Z3zY+9w6biZXaU3wkF3GyOnrVjL0REYOmcJDFvXa3xeE/MR4Mqp70TjWzX7owEBgZlK8twhZpynxDlKX",
+	"tkAScAcpllEIMuH6foZikDJxKQZ/2/gHljlk5mguDjLH8ZmikedVmrQL/BTfRf0+jTJbm9ilGq4YOXZa",
+	"RFB8d36HKMUh6miptYotjbL8SmLmkqggDimkW4DiKY4RojWGW7vop/8GhGyGg/xpLtlVrWlr+HTH9S5R",
+	"yiRUZf5UDlPH/C6JndfIHhcUZZdm3t7M9s3yR1nyFRf7r+Go/W9WPZB2RSxzrXZIZeWAZs/vnQ+xYZ96",
+	"UF4tUslM8llveYqHlkxhGFNBLBg2ChtKyCkIAebNtayJWtDeBdGjP2modbKv8xjrvYDEAUUcqVhzJn3X",
+	"RYb4zInONg/LanFY9+0jC8l8blin3J++1SbcfBigaSRIQEfOhCBMBWQARXGIqAp8rcH+2kRRmZgO9M/i",
+	"6byPFR+XgWRphLLlZG2ECYyY8/UWQ1uf7XsKk0TR7p++jcfj70pekrKuWUasIu6w56NdjkNKI7uEiM+1",
+	"mAoobhPCBcVzSBfAjLKeVcEGG6RS8/Tb8oDU2yZpxGSVn4CS+N/kdjAcqP+bUPK1FF1c+Lr56IVz2OKr",
+	"t8rZ3SJW1jrr1snqS3oUWl7eUVBJj5LFNXMRLbvLHLpbMdtkZ17SZJPPs0pzTTZrT1NNDvQVmWlyJNqa",
+	"iaZ4Yx3MM/neV+81mEKO7uGi7ePf1DCDa3gOp+gijaKsDBprCPqSj0GpYJqtdBIK5IQgSaNIvUxVtZyi",
+	"KWacZnXOOqnjD883krO0bq6RlI3uEeOjhJJwK06SMj/p8iLUI/oOuUjsTe6mh8Te4TIOkirmd2kcsHKf",
+	"/ZzEmBMpxMI4BBGZTqVJZ/vu++rpl3yUHROu8nWuTt/JrV/gpit9pR0Yt7Xn+rzuzWgMba6nh70yFONo",
+	"8axjqLMD8kXV3LGucTdUlXIHtAv6Q/2wZfT4BlZREzM9h1+Nov/zT2W939L7/glH/zkY/fXT3j9H+l//",
+	"y/zp2f/1p6WDr5uJvYM85wToesJBEP1w+daVLcMQ+HD51lyNfpMpOLo4A9oI78K1XKAohsod7u+b9caF",
+	"70byuzG7Cw5/OfjlwJlJtU4xyoFs3eSp/NFpkqZoACX4vYB9eXwE5OgloE0DOJIyUUdwd3rte0hwHqi9",
+	"Q6Kcc7e7KdM5t7qMcOeZn1ysXHW7ULZn+eTsRWgKA8cb5n4Kju2JqumWXpnAbbxZmZmbu0KtPIRHxRNs",
+	"Q+6UKy8paqo5Vildyhl72n20o2clwqRChq3Jj/nldBANjC+mJA1I17Sr/ia6d8cNcKL92cY+b/xEMqAm",
+	"SaJS4dPNBBRs1o3/5KHfuIe+0TlfJUMezFxY/Y6EWb0GicqysrhyXhnEMmEzso6PfNJL3oQVoDZFCVKY",
+	"LZFN7teFV1aLvmq5q6vz9xcyNz0fJR/WJGkK6SGJMxNKSwwlLxEMVaugJFLVGSiakzs32rkTvcQmwQUR",
+	"YgOVLrUZArKuvviPubiNRYeqXDIBRNarQhzsyXobYbivt2eB4VkFfUgy0FvsHNyhaLu9nAQn2T0WIa7q",
+	"hFXzsi7OgPwpq5eR66oNLnZnAqB0+lkbqAJUCRXuXVgSR9s+ZKHrVhTnBExUBxwVuFl4PWr2WLowU1zN",
+	"bFyDwEn9K2C+BTJcgvmukwMqPCwwBR9mWBecVI5G2F5U0irDj/KQqwmUwbnF8COS1Gaqbjr26HubgNdd",
+	"RzYyXnVen0I1fdWXPNZasTM9S0BCJM3puWBTuoyszIdO8N2wpmP+1FvNySZYjY5jpvNWcPIm3UtqNRl2",
+	"bEGlKXWhbUBQ0w6sJ56ezecpV/GXMUzYjBSBqMkJ5q1zOZ6jLaGkPmoVM1tAowaCvbxJgkxEGAKcHR5O",
+	"BLOXuowAzKCMs21hZn44rDfUGZUN8FeG0gat1ovZhcl8AOOvvZcPUluD7IKSCXZFv1050T1/YCWTViq8",
+	"4s9V4Pd9jY8L4Wdtwb81objWJMUoXH+TqlHg3HYb10sclFP4/A/9mpL/oLioNspUnTJzcQGB3Meu2gln",
+	"xkfBSmkM4u5MZ0ltuNDdHVFE4qmQuOtRxh0TfAGpequXrGDXOHvSs5idTXvFzp7FU31qRLDOl6kwT1wi",
+	"K98i2PuCFtpakHU7fOa626ypXZ8dZNGBfphU1n8lWpXR2tpSI9Pqzq1cZVOIzK+tL9XBCRCj5pCrtCTA",
+	"KZ5OEVXJ/gyQWMmUScoK5WJkMLCrYIeYTbXnLuiFerznJpT0Kv6uJyiE4Es9LjcMttYQCZozgwsekort",
+	"ySpp1pxX6QjIL413BwEUo4XBntfqBfd/aRnnbv1j9UvPR56XiKUZbQ75IfhmBxh/3/9WgLBgBd8H7sjl",
+	"/SmxmJjl7N/Lx/yPFRn9Pzou+n/E/5cx0c/2l4wLqHU61bwC5+LPbIaTQjcl47QOaomvkSHbgRSFlyTH",
+	"hsJbsjSr/rRCdb+IobkxQ+dR7NlGjdyimyFSCCqo7C2WXJdSglT2saqnX76OlYgpw6wxrfdMJlnVBG94",
+	"vQrNT0EXq0QtQi7lYe8O1waPusyXrVc+zypdy1TfNvFRRTY3D4Ej/cLTk23TYt0izpCm+WKUp5TD2+D5",
+	"i5+c0SRqjjeQOWz14q9ti0st1l6YzeCLVz8f1i3pEq1XG8RgQbhf0EKR6mrI3CZu2HCtzdl2Zw1pdnoJ",
+	"4/+zb7ap6bUr+84n7S43oqgDis2US5cPiwlyzel4ZtFyWl5+kpJ1su3xV4tmPsiqEtIIlRXl6LGVpd0V",
+	"8ewsTlLe9qZIZMtqWvRHO2eSpyspvqLkPWbMy/a5HczTIswa8M9dk2gVxYhM36FMV+VZRYqUKfGrmnwu",
+	"cHtK7hCNCxLnDN5hQrdkf12qYNEaKhX1KlG02ppE2y5G1K8K0SrLDykCzbXgDdQhci45NJYISTqO4kRj",
+	"8JpQoPnVIfhm5jsEN4rLqG6yarD443wx4urv38VihQ/slR3fGbZsvn8o1Y+6vVhaXfR4dHpkL7jxqj4K",
+	"w9eI8FT0aLeKHv2A9YyeAiGfShU9lSp6KlW0O6WKVqSkuiWvZ+sUAJrCLp8qDj2qikNPxYRWUkyodxWh",
+	"1vJBNf6VBgemcd0U3xhPt0BB/C66M4tC9soYxweG6MjoWtnem19EtmAczS8KK5YeXDliNIcxnKLQDkHa",
+	"oyghDHMiFOJ4Qp45+gqaAVUih0nibvko/mpyIkwLEC09W/PZAB3va58w24cJdvtQ7rCJpS9u45bC2KU3",
+	"/IY50L8VLPvQlZcovXFzlyfiNxmgJX4DV2+OihZJ6X556ed/SWnknty6g7quJVPMZ+ntOCDzfUKn++KL",
+	"8RR7teTxjIAuk1aNpfyjk56UpTgjOhPl6JtHWlF3623AD5HwbIJTaqF6RLNbb+ZNPwQFir2o5iFCOV+K",
+	"Hk33X4sowZ5KMIDRM2/6tN83vf9PW6RaeztiTQvcw+yaP7WJhtbdfvIUIytY/MmHPVymsdezS9MY7KmL",
+	"R19RkJrg50pkpAfrBbdIEI6YjbuuOUSTVz//5ZcaXFpr6KU2zRy5Ej00M5QBg4zDeVKY+MXBi1ejg+ej",
+	"g5+vnx8cHoj/99+2Tz2EHI2KsYaWkWnulLF/FRASXIVDHCNdi62wqqm9NtZ/kjg6X4ysDnD5gQ9ryWjY",
+	"JjiJ62+C5Yim8ahpbrmZxkvLG0i7YlobelyvMWC2PnXgMo11tkBhsss0jpU+VZkpTb3slYXpXr06QL+8",
+	"PDgYoRd/vR29fB6+HMG/PP959PLlzz+/evXy5cHBgbNyy6oDnWJXiPCwFEBcvGablnw5UXfXnM2fVuai",
+	"s3njruQ9mD1dW0bZVqad2V0t24irfsHG+V1jZ/yqGGn/XukOzMoMkmmL8IkUMZ3LY5ZEcOHmF+XG/Gps",
+	"lW+o6VWr0kH3kNyCTgr2UsUHyh39n3UQmmtothsVGvxaghSzoIVV02OG+1snShMQWS0Hl3k/RowvIiv+",
+	"sgKMCDJ+TWHM5M/X2IUtbyHjKklCOav0XIBn3xXD5h1U+cqfKmttfSWSMOPshS/08yo9XjB0ViXoGrho",
+	"TEt5oZQcAveQAWUha41alKEjzLXYOxjMcIzyk6mBVkR4fnnWG48CEgc4cnvw6gQGZUAzJuvCzJlFXBov",
+	"X2tL6Yf4S0zu43IkVuq8Ou40TKq0g4kFtj00no6H4FJc0bPSqZy3Vk6iVxa9TPJxIHEG7hrSUazaeEac",
+	"HVHVEB3cYKe5Vxws3szkNL77HVIX55jgCPkzpdc4Qs6JnMYYyXutsl6/Kv/BJfojRS7+qn+wigRVip6r",
+	"al9qnvpCX2gyEXso+G1kVELFb3NBIhwsgPoA7MlBQHqR44Xtr8m/jkv2Z/NLtbdyzDGP0NyjUuKpNbT2",
+	"7dSycrHumYaEu2zZSP/stIKQaJ210IrH18t98kGSpbGjFitgUOM0ygJXAl0GR0YuiLlUPBErhqYIfjkY",
+	"Du4p5ioeIULKl+4fkdIoAZZFsPzHrMYKiYo3IzuiZ62TxTUJvVgnHgQBYsxfRnPhWQUVDOA7oYS5gAY8",
+	"yDMGOmBBjO4bopvXn8e3gtS92ly1Pf9MteKLpk0TxTy1nqpIrQryDuIYXJ5eXcuSofk6VmXc5wcvXq5L",
+	"CRGLXrkWffHq5x5pgkoXMU0LizqJVvafNZjT1lUOeLjdBPpyplohrWAFqWrKReNgkrlUl1AUyJgxd9Ge",
+	"04vL0+Oj69OTQ/CBWfuRAqDYOILhGLyVz0I5S1WWExv3oJzeRiZ9Xu8KopLLvTcqcV85qpwj8SRJWSbX",
+	"Zlkqi/DykaeaNmdK2+aRjtrp1fTRdT5yFZJWAZFWgEGblba2KmRlQY5apKqYqzrLWCUMrMe81UlYlnW3",
+	"s4xlm5tXVuTFw2WdAeSbDOS9hQx9lg7NQUIYn1LE/ogO9/cjEsBoRhg/fPXypxf780V4K7vxTZUg/Dmr",
+	"Yji4ezF+Pj4YfK+psiF20J7tnlv8iHYKli5Pb3WU7cArQClbvPDsuy60of/YahuPWV8arWAnOo4t3Wps",
+	"xT3GOjcXW103sW22EeveP+ypcdhWGodtuGNY31Zhm28R1qs32G43BdvhbmBLtwE7QQGuqUec8hmh+D9q",
+	"G6EZ5yggwtFXB4s+yrMMzcfADK4GtLndKpdFL4q1iRzFhdADZpApW50RNT2iL0PPo1PE0oiDPfGGgf8q",
+	"9FpqtlSVuH62npPxy3dfF/fwkSa1FQ2a6mMOmMq/v28x1JjiZdJgk81bgPDd8/HB+KA9Gt5asP6IQrS5",
+	"wAmKsFPYqoxZNgM+oWROdBYRnzFwi/g9QrFtc2SlYNVcBmMbFsIqp+8tjVVnWo1YVpnXWz7Law8n+tOl",
+	"BbUqQm1BYnPfmZfoVt2/o16Ywt4LgbyuhJF27PZ9tS7stfzckrVo5vfqt5+/6dl+qyojwTuII2l40IJc",
+	"4e12oJ3awgrechdETov2tXKeZfajSmANIojnsmKA6rNQFeEhnjt6OXy81p9WzBymWr9vIwd7S2YPZddn",
+	"zZwlElF7NQt9aoZNfZpOOYcAfeUUBjKv2zLOqePrvG5OviBHzF4N8I4zwOkcZ65kRXkN9hI6wuFGwZSp",
+	"kgvSXsduBs+qUGfLBohZeZQIGHDmi/xWs0jNPdgru29DxjE4MCJPFjU50tW6lmjhagqiM6q/oMV+Ncrt",
+	"6Pro16Or088qNt6/04ietIqdxmJVtVdJa5V7hdeUzP1CPH7Phle6SKJFA0h/t5dxtU3R8oxdzKIIXWbU",
+	"YUfwj/yp4VvnzeivxG/edlX9jb7HHklFQxuVmvGsp4x3astw1JjZbJ6vfAMsb3CQmYk3K9lZO+0r0tlT",
+	"rESWsyb0FeJKYsUywpuNG5uX2sr34SGuxeC0EKZQPHxoFPH2fosFk4KV2J7/LcvzteA9vonPJiAmqvY1",
+	"nmAUFssPWVYUieUhuDGOxpuBaUEqbUU2DeS9GIjYHkNOu3Nzx+Lc9Ar2Gg9m+y5ty0Wlp3nBl2mP7JHT",
+	"b+2upQfxcq2DLWNpyZijfnDkR4rtoQakInQKY22G+B1TnsLoDXFR6rk1MK/gcac+AeJdzNYz23SFRqS3",
+	"EQ4aF7qQQzrO7HoaMLugJEwDt/0rix0SRICZakyjR9dFC9UUH295lzroK80MYBkDY3HeHTMxFjfXy8go",
+	"KzxcIpaQ2FXa94rDOIQ0BEhWgqB6oC4s7oC0K9i3EoGtJpODc67z69HJ58vTf3w4vboeDAcf3h99uH5z",
+	"fnn236cng+Hg9fnlr2cnJ6fvB8PB+/Prz6/PP7wXfz8+f//67dmx+OLs/fXp5fujt59PLy/PL4t8yv7E",
+	"ERzGIY5Yo5lU7ViPNOqHVXtD/i6rgdTVy8LIVdb/tWrzN4McBFCWf5SMR8xW4IRuUW/oW7kje7XUNgqZ",
+	"cToODHIQIcg4eA6CGRR6XY0/vrWOhtp9m0aF7A06swz+nCft/Vm+rhOSxu0pMQZ4Er2cAoauJVJryr3C",
+	"8TRCABZMzboCibI6qw/dsSAOPFLMkZOsjEkpvROG7jTYzHzf6FdJ+ew/x3qsVQauNUzHjBMCbyqh89lz",
+	"ySs1PFu0Ym3O3nINkuoKzov5yhGNYXQcYbdaon8HgRzQkomvBn125WOeC5i9MNOcnVjVW9SfyoX6BiRB",
+	"cTAjFJFREOF+0g4qbr8UaOycVJk0ag+gfi7vvuiGFTuX5dAS3fpoOEBziKMujtiapLMMwNlGXbdqkikc",
+	"vC8SL1va2ZghP3QaMhRGjBdwHjm5pVjMXYLhndxHAvlMyONZsmFh9n2YJPtqiQ5WErlbifYxX7vpwz6j",
+	"6zLseIAO0jC0RPVGUVhP0R5WZH8EzMJOJUDLrqNaZWBYtwMVrebchgpH67wXiw0IgIySOt3HnvLN9fXF",
+	"BaEtugEQw0AixlkrPv/rwS/Pi6LdTy+c6W/lFa88l7xyrPny5cvOay6pBBXALDshxzCyCx7Ua0XeOKeG",
+	"L41tlVV98cxnfW8MU5PV45ZWB2ux6sDrhvNVrlqXcWPSTx3W6aXfZs8qp3AywUEpdSFhzVjkkmi1AoY6",
+	"+PyzkrowtvpIGg9+1kxTOUVmCOjmk+XWmt1CBc51HZ1ipMAeTDkZ5R3asbJNJZTc4bAUHdEUQFAByxsE",
+	"Iz47iyfEId3L30xvTfVm5IWhlKbnWXQwO9XMmZEM0Nckgqr+roDkzF65S7Jucct76j8XQ3CCphSGKByC",
+	"C0qmsjphPB0Cnao7BIgH42etaohe1fUIv1MHadC6sbid7MBG6/YHoZnaqV/ljewF8kVI4AhLZaz3JFVF",
+	"n5uP1lRU0Ysf9m6iHHNKTJheZiplYEai0ApMjPAXBLQWyYZWffmhdCTaronxTXw9Q6wwG6RWDGDWDiuC",
+	"tygC/8r58zhEd0IaFFuSO8rL1/wXpyn61wrdGB39ERmkV+ONyKbz9UXkwFzSE5Fj0+b9EGUgesVNvLeS",
+	"JErhIjNn76ycKNSA3B52FHB8J/5wLcuNy/rpRatWNsKDd78nAp1VbblTof91cPOL4eIJySYAwQzGMYqq",
+	"1ztx+lavZAlaPREMQ6oyde2cKEQ5+79bxD0250krxljbvHp3fZFHTNuVzn1nkJAqVCQh9Zk+FAU4keaD",
+	"wkFRKdOHIzgvnLRREW+oU17CZF2qT7YflJBqqYBef86q4UWep63Ae6nKIAkXdTOJ3/LpVCGf6nwWogv0",
+	"OAR/+ibxZCzYy3fT+BSFAPLsJ8Yh5eyIfx87EUgZoeq2pX8GMhKpw/b+ma2O7hDFfPH9ExiVdnttdtsu",
+	"OOhNDhUI265OIPlR6jJpiF+kEVM8ZYZwG01mCWTsntCwE5HJWATLKjEcpEwI5HO01DTlKotmzmG+Sx/Q",
+	"1LE5CRzJv2kLUGDanr3ovJDvw8HMqcnYa4sRFTOWIN9W3depjtlTl7WxV7/8RWZv47l4YH5+9eqnV5K/",
+	"qP9+7lLLeMS6Hv367VVNfTmt5uttSbCqFXzuMZ+2mrn99sphshIfuVrAoSCl6OoLTn5HFE88iiWIsUCu",
+	"IeaRe0JA0Hn2Gu4J9YqigMzn4qFTrS1zr6ilKzS6Pqvk8He0aI9ZgCAzqHxBCyBDaSyxWqfdeBlW/44W",
+	"dt+U7FMrrsvQXi8LuGtbRawfBRRJ0RtGrLtgU2YiVZVP5TGSWw4lnNQuaiI8WekOurEy/V3rnj+i2xkh",
+	"X/zFsXv1gadANkMwbExW9T+X3ukbOaMEciX9ONfdpd1JLy5ArjvsmGAXc4jcleZoWLKQdUBqpZJsrb9d",
+	"nb8Henj7u12t2ekqGqwPC1AcJgTHHHy4fAvuZ0i20BLCKrjHUQRuBZWUfDmmoLD4no1ZBIMvsmJrVrHZ",
+	"DLUsYynFXoWGP/lhk31HLrtHaFonGtdzLE5iLEQAx1IEIhTc4YxI6uMaaxwfZ2qWmbXcUv6PNnGhAhjp",
+	"JbughKOAo9D4O99ZKrjDqwZejA8EJNRHuanCaMgAFvqrXb4+Bn/9y4tfnGJD5j3+rJ7kpjIBBWezfsE/",
+	"XL4tKQ8Gt8TwcdEW0S2z8hZBiujnOeIzErLPLE3Eu4wcztIr8xNQ36iYbqC/LG1P3nW/tmWO8gGXb62e",
+	"66ULcZIcTHAJKvvzIHGXR1fTfI69w7/9tnKeoPhYLg/eHV/Iuj01+Z3SZeoHeYWZ2sna229bPPOw4Kd3",
+	"YmsDmjj27+JNlh2rPraoagTMiG2vwRz4DvJgJlvaIcA4TQOeUnlL4uu75+N87SwOToa/MPEgENk8B0P5",
+	"56OLM5exDsYx4XkLnrr3s7na1OAdTMSm1M9CRGN5VomylDNO5G8w/YojDOlCeltdb6Lp1XCdVevdaEVf",
+	"aQNdLyy0S1H1XDCNaxyQaBc2cyOzV9nd5grhcb1Z28Jeu0SKf2Fzv5LhBVv5h7OTZyuoIe5bnKmQUS+N",
+	"Mcx+jI+V8FlnIW37btk0UmikX0VMSNU3klJaQUhmY6CjPWXLVGmii0OnPK2cABlr22xCgh/U+uYqeM6+",
+	"EseB31q+XoVCMQgjhftpQd28Dp7ovnmXRAfM8Mqa8DzocEBipFErcbD7b5nPQkeW1RQURpbf4dP3Ydtk",
+	"mjBrp7svaM6fBK6WqroV/RydjP653wA1ZUoVQpoywbPQ1VFG5rnQFNyiiMRToR6Xy2E524ew0/juxJiq",
+	"vEt86jB9lXCrano6N+NOeqhW+GwuQu2a2vJpKfwY5ldrn9v8WK1BWDaRdLRY1NgjHSddgui6JCt4013z",
+	"ZmqqYlXHrKA81pzE2IipcQgiMp3KBsjxhMJc+N52Ll/16Ct5JldYPKs6b7/nbyXltBzYtOVHzTNPr0xD",
+	"5bQ2x8G65c05gA32Oi5pp9Q5N1S/2QJfdH7bw/ruOpNhDGPwzuSBqLQWcPL+avT8+YufVODLuCYvb13F",
+	"gDsm+NXQfXchaF3l2nTKFv1w+dbRAQwyBCxjl34zqKw2rQ3mrsvLi4cVLWGH+/tmvXHhOxVNOmZ3weEv",
+	"B784m0qtp0aag3K6FUuTo8IRuXVa8GkAJby9oHt5fATk6CXASwM4kuXPOsL3ux/u9pYldrdQm3ObO5ZO",
+	"6dxjr6zK85zc66M8MzIXyGlnVurCu0K+ishUmcjmiFMcMP8QUCt5EcfqEBIC1AS8OkND7S1hlhfwaej0",
+	"Qz+4/GdiAp1Qb8aZwvnyiI6DVc35GRezGx/CBO/fPfejrYuC6FLBWEaobqOeyziZ7XkMPjDELOP0SAy4",
+	"U7k8ONa5gKrAzU0sA+UmExzIADBrOj6jJJ3OQASpCuUVGhhD7vplMfrK1b5c7k4oG1bInyUMJ4gHMxMG",
+	"LT4V66IxuIBM15tWPj4o1b+b+F/q23+BP1JEF1bHe80E5RTaIzsGR7eyYodp907RTSw4dUzAnFAEJO2W",
+	"2TRa/O3F2b8Jvv34+8H/uXpFz9+8S+HHX+7Cf5/it8d/W4T47Od3//nHwfufDv7L7ZWZq8juY5K61O2j",
+	"JKHkK54LHhOn81tEBUnLrYDsWwAn3Gi+EiA38bVJVo8BYlx9n3k7bxe2B0LiJFzIkPlbBNBXGPDxTfxB",
+	"k+aHMzDDQiGSQcY3g//31YEFj5vBGLyDCylHKfBNCL2JJzjiMlJNAB6jMthevujJZi4gD2admokk4gsA",
+	"O/QRKXdtoiRismvIyK7l0rthyNI9H67bWj44Aact/a6ibVIp7qkwm6BzIKtO5VB2VbmRmJZ3QIGuemib",
+	"1Z717vuqzObzlejJejJf5Vi7bpZViA1ebF4LtmHvU6DwIvNVlcJuUxyFvpWSfy0Mlt66ctk/z5o51dqg",
+	"MrAk1C6akmGR3cQC+W2EN5k25fb0TD1OmJkrLj85TTViaqHcIaK/DtDLCMP5nDsmAecb6/ceyTKV3dpb",
+	"qTKayH6T6kpllsLzJIM+Ve0BS5EFinfbVnhX0wlnj0VZlcw5q2pR0jwr44L4p+1B3tnm7SU/1cLUlP5s",
+	"qTLaEXJmiLuc3QqAaC3AfADKTOisOpMvgVw71muNhnFCoW7vrpu5PD4yVod6Je/y+AhI/buq5R2djRJy",
+	"L+VCSoguAANgDKMFw+vW9Ir7alP1MgNLi6qXz2rreq0HrWp+uYGlc/KuTtp1MR2VJLtE9iHEMdOBRALc",
+	"1vdzGOMJYpzpVw2FUijOC5xpa9KGy1brM/cV6cznKxHp9GS6rVft/ejf+16T+JwBCKxHSF17MVS+WL5v",
+	"8zeiT7nkxZhZ1nA/vpK3ST3XTcOWlcBLSLLlJuCOy/IRzkuHqIqOlu56Gt+dZ82PO6nA1huV19Qo6sV2",
+	"W+XK4RoDG3yEnZrXn9zHyGW/upfN+43jgBWbKkptWIv4St4vsYNCsEQNPNtLgNh2j7oGl1WfiNqWR4GR",
+	"THz2iyssIaW9zrB0Khd2NtaGKOhoQbmnhFcNCMWWULEtYpZ0XGMaUtG4mhSkTKAZhOqxpvPpMQN5l8FK",
+	"xvOHWLe68Ep31j09V0lFcsJm6jFtwQrLNnGjj5UPyvevCKdImB5cqYMy28qYlizpX5z/zywrc7Kquv4C",
+	"OCohx9m4ipHoTuZl3JEv0umnFAoEg5kuvJt1czPz1JdsVLM4fYrZSrqkjxCBrcrA2czODAXDakYhujN1",
+	"htqyPd3e/VOTnCTzE4qJKeI6DMpJsaeyHd9uizkcPrVWf2wQyDsKFCsSJLZgyrNl7g7SQrUpbc4G3Cze",
+	"8UZnSOji83WBhTEXhOxKgpPeAvO7zlUoFDbKi67Imqjg1XwIfjpgpeD0+frFhCf5wJFBmZcvOutyx5zC",
+	"mEkGrPQw91U/L1/z8wPWlGnFGlMnMm3P5G+qwulJEi2McaFQgrCOZ3ulUpiQFSsByuHdNh6ibk6pCPFC",
+	"onN2MMmbcbFBquWjKvCWcJBt4JNHxV3dZjkPBzXCmgCZgZiTdyRZUfvcGG9JZPb3hUiXpBqmZo9txmOH",
+	"nFOLw0ULRBchZ23SzVrEmgYqucwIT5ADVpalUvl8WZKFzxCmuTE/q4hWQyuqd1DVnHhxpt2XpUQqF5Wo",
+	"4mtXXhXWqtMZNNOl1QbS2m1Y1sAUnFsMhoOrlCWytsJgODD12Sx8sR6zsB6ANguYQx07IUSjsSPVLJ+y",
+	"OVK0DUIdEtW01Fbgc10y0SoFJ7vNbNmgvDne6zSKau43r3XoWjan8KxftQsR9Y/tgP7eUzSdE44yVdkh",
+	"nkpVQ9sOVR48jmUYiak6qf/KOKGe5YsvdJHhQk3o0jTFNrH7psn2flP9Db20q8eQ0Wtl/usSJT5q7+r3",
+	"4j3p03CiYpQKNUFbY31rOjhd1uaJZ/QtY+dqqrZXK2NgRCENZgvfQulvsg/a+MzZSRfx0Z1Rk01WqUVu",
+	"y6jNoNSf5idtguvpndMQeGQLM+hOyuCMkQBLpU2+O9Cmy/Kb64zjep/FbsksZa03y8lnkAESyAe20Kjg",
+	"J1d9ogmmjDckQ78Wv8s17CXuIZPleqh6T3xznxtXepc71FezXq27r1SawPoxKzR/V1ZgrqzynuL68DRG",
+	"oQnZ2hcqCJFSRUxCNHruluLdbYCvZoRyMC93+KDF7sCOHQUzFKYRcrKZOkLPW+PK6JK8xK17DX2+EdNr",
+	"UX/qM/ls2cRg7724tggQCj5CKjSjovajfvYlSQ3OYWMt1QJlsgYfs/Eq67L1siHjXeZOt7xetXSqhjdq",
+	"aNaMpafY0x5js5k257zeTxNU3tj8u4Z3ZpxP1c6otww04VrF79HCz70ktMqkbVUCkraQRdeMTZaFWsC+",
+	"dzbxOQJMtUUpC5W55k6RA8LK6n/EfSpVOMQ8P2a5OlWmDY2tGtgbVA1WpQisytAhxX6XkYPcFvHNLudF",
+	"awOBMgGcqRhlajeeZF05jDP4J9ewf6+TYTOuYZQOqcDkp/Sv3XF24gP4lSk+NuM0kw4LOXNqo402JRt6",
+	"bQUHSzfkxwlWQaM/Ar09KJRpwpRrilA3oaSCJFmjALfFToijrr5sUVTsLcAMBmrE68Qu5HPX2vJI7sQJ",
+	"DRK5XsuCFkpJpE10CaJzzIXIqjpjMbAXoSkMFs9quok1lYzTMyh/j1hCzV6qyabbi91TzJUZOEKqIrR/",
+	"ibbC+t31EbG3gmQinw/ZwBwzTlVWlcp58ydbbdWX565KaGLu3kQskDIbOJKSYygXYkOA5glfqBB1FdCn",
+	"fuggyrmdrOa261DMatD+DiaJM4BO/6Cs4BIwKlUelXrbq9Kn4lj12Nez+RyaTDIh1TghYBSR+4oD4oJE",
+	"OFgA9QHYk4OA9EPECztzPv86LsWDmF8ql4yKjf6be2rlQ78Pl7QJNSLqXF+OG1dHeTRMVfXWHKZxPyRC",
+	"ptysA7sMBVqntQ+b3Vsd9vkIBRLhbhc6FiEOrUynWixzQ+zSSdMhukOR+PgB0bULnlfyyuyH01/ulpVu",
+	"1QTFWPLcQS7WY0MVwcSGgqLuCf0yich94TBlZ1BeTlyT7S+yRVTV5EZREuEAssLg5375IVVYSDvxCeTw",
+	"qsbko1vdSxeCqcSq+V+1VZI25rcTb9Hq/32Y13p2F8WWOK1lDEvtuapaz42lflRvRi/nIWRLD60jfKqF",
+	"liosXeew2HRp8B5CdvO3viJ23Sz1aNYAtdKAZSsS0oI+W/LxMGW8lAUGF3Ego7W0QzevnLHBgPTS2ftG",
+	"pJenWUlIemlS3xCycsXqZWPJyviz+Zgy1yX5xJaVd16Gg7sQtiVIalDKUq1VXC6CuAMsLZbf3ORGAGhC",
+	"EZvVRzC9EYLjhCPZYZmigMQBjtC+/q7Ozfl85vQGeDYJUqfIOwOVrfzmh+HAF7e7RLi03erSkS7l211h",
+	"oEsEmdi5uJpr7HoqPuqCE9VN3EMGxOcgoUQoi0UHYaG08fOupY3VYlecUJfF4cryzjPdWUCHWeZ30AH9",
+	"5ToN/KT+ETNfthdIy7plX+lnR/X9yyuWWRN6Cub2K16dpGN0hhMSrfJMY7SF0zpo3x3QFi7LD1kAgqc0",
+	"U5iyoqjcKadj05Q1Qk5l3q7FpN3anzx0PQuq77BxZVdV18a7NOIC+11ScL3EUpuwmhV6N27F3KdbI52u",
+	"pij7UT6LRKwwC6ory5U5tJaufv5WTuC5Xr3+ZNtWVFGganSn5b526iumLKH5/Es2aIzJfkiCL4iqnkr/",
+	"Vn5q54DJtPLLLWQ4GOnmTsWfGJu5f+CyYvMtIZxxCpNx6VfyBcWliohm2z5sRrVTO87tWVVLrW6QJvug",
+	"KiHfmL+qMfmZBeVzEEE8dyVl5NY2OaTKIZQrpNly9VkVxW+eX48p2HuVPcksEaI7/e9OFl93VISGZRaS",
+	"pLEoZdIoo13in2Ggon4KV6bHeAVHVIHshIyLozkrAfgkTlhShgxpShJK7qScy7k7rZW9g3EKoyM98jI7",
+	"x7eaUsxzOT6fWooP+iOPSkmxbw6If1GKDPrMnKJ+91lRBrNplp3EXkwXo3b0O/MyjqnjuEtd6KNmurks",
+	"eOGoq7Snox5y8QuQOFo8azJ2ryEMZP0BG9cUYlfqrkxeXNKEIUHCpIIQUMLYKEglIQjOGCAas0LnKCsw",
+	"PZd5N2vGkKfua7xQH6/EZCGn8jVUKCvtktYJhQabt0nkEPexRKhdusODHK/ce3TvCjCR0pP6yFQmxEyn",
+	"6+IsQaI+52FC6CkMHMyl2CdOiqNaFBVIPzeFbPN9yOAQKG/SnVQn+90JZbZ1sRBx2eJZFlSfGMVSky+b",
+	"kTQKBZHpUKr6gjtbSQBqNKH4ezaaUsHqGg5XUwkgdRUuJgm4gxTnnbwk5igt3iBEq2jS1Eq5SniyM5Ur",
+	"Sji0esxIexpmvNDsyNKAdOf5QkmH1aA2RQlSmK2rZPLAaQ4jia4b5jjL367O38sClCAfleXs1W+TJK7S",
+	"pqY8WUmyhGE4UC4npe5SNCd3brRLnDKDdJjJJA7ZuC5vAib+Yy5uY1Hbk9CR5aBaJhIhFYI9GbsShvt6",
+	"exYYnlVT3pKB3qILfxrtn4q228UhU91zg4FXhRwFewNrClwaDmQHzlYU5wSokqvgfoaDWfH1qNlj6cKM",
+	"/lQKjnJS/wqYb4EMl2C+6+SACg8LTMGHGSoZo05MzYsQq3HFNNlKQvwqi3w0lvfoW5f2xEQpjCYw0PKy",
+	"1cCXJLzu8ZKO+26LXaJUieiS/nLIeVbBlY0e6tj78elbXRs7HwZoGslMAJlUhUIQplQ9XnGIqFIxa9h+",
+	"bTrLKaWEmhJ1Qtq5j7Oa03K9bDlJvVK/dGqyadTOGO4pTBJVH+NP38bj8XelxcxTxrNl5DNB03brqlyx",
+	"OYOj3apvax5evh8jR1dm+pCEkCNtlr8kkanC4lOEM5XfAlgIfjEVeur15gce7UWdoZvHNgh8IwsrraXs",
+	"QCsTfVUfY1W5u/6Xttl40q2GkSqohdn55d2YYc0X1BRuqS/DoM9HHT7V4Upyw5OJvSpWKC+FXvV8aj4w",
+	"REem4o97ocrZ2IJxNL8orFiy8coR1jS6dbvi8wlhmBO6KD5rjlAsM7D6EsAkqSllC/nMKBCmhZw271nz",
+	"2QgwznuqwwS77Zt32AiepULZFMYubek3zIH+rWCbg+6A4oDM5y4jXJZyrQaAqzdHRT5yGzx/8dNLP0Of",
+	"s0P9b9LIl13Ih8u3zoJTU8xn6a3snEHoVCgrZDzFXhbG7zVlzwSeuYvdVIgm1+Gl2ClIpFyUSLqSRrJu",
+	"uR80FH1mAWF9n7rcYPyoHjuvKOJMqYHtGXGWyd7rGbRm9ngTC9e8zP0+wncxi5he1Zso7kDHhnW6Cgk0",
+	"EwD/lHKwwpSDZXIDlkkKyPGhMyL8mS2R+/Qe3WfOEzNLlpFeooP+JNmFMBiixzBRhhmMGrL0xchSdZKE",
+	"kglWXgX1UYUkrJmbAk8a6UXuPtvjorYrvzqmdLDYy7oqBxsDgCut+xob+5I9DbhHNFfl6wP3DroG7snA",
+	"gragu2IMiFuqYIheLxKUdxmuFLi17Dgqb1GsrWwvKVNWBZhHk4hhMA6LV+5qtzR7h4IZjDGbu8Rx04O+",
+	"PPU8+yg3IGb78Y1GPLJXz7tVVh4ozJIILtwyX+mBknKeIUl7Q/l9yy/AB+ZO5UkoJhS7yhgdz1DwBRAa",
+	"6hJ+OfhDxFWzQrAXkXtEwX+BGZ6qsAU12zN3DSIrscUd8vIhW8MqHiYLIA7BjUS+m4H4Vyn45WZQrA7S",
+	"JfzFhrYFjmEZV1zsSHooXlMy942kJBTgWDbsUT6PSq8QE2rsF9haSE6pd6ScWUuCPWUUhRGYwCi6hcGX",
+	"Z36KgA5bqGe5V6rvoPEvWN0x3H2T3AHJsktSXqTCh3VVC1RgfmmpolVNrquaOBxMyREN6sNkxCOOBVWk",
+	"pYJicB7+XDPh+VXtdNroH0+BMiEUpoxwnH51T1lbbeE3kt2LZJ6cAKMDWoFy5Pn4xcvxC//Q3CPLeFAx",
+	"3uUd+kc19oLWAmd6aCHe92D8fHzgG4ybO5RsnBhaCKhvIrthG4wumtdd7mVhHY98fNUdUYfQy3aJQDfY",
+	"z0oolZ4oKQaiMFPuG3Qlq2+X+Swr+G6a/hejFQtBVPfodgSTjrGKta6Fq/r2NxpmeSYBYFaJLGeCgPq9",
+	"PkBOvHcGkPeQ1U/dGunHKZ5OEUWh5DysqXyaxBoGsi/s6V84kzILqYepSbrPYVRe3Ilx2rpT02kMB7k5",
+	"sr4yXJfCQKsTFxt17cxqZf+50DUpjRkwKZ5gjqdaHFSjndULushOemyVcZ2YJd+ZJf05YnYoKZntpSod",
+	"XRtWMyPJM3cW67x+PTd7y6+1CXF84+Ps1OVlQuQyhN1yP5nMl5DGPrSTxmAPfUVBKkY82xUSmuAYs1nN",
+	"uqoCtvfKrzqt3ILgAl7VsgEVVB7RNB7VSVWETt2kek6nMDaKuyt0l1BnhPUavTtWMr855WfpKhgkhPEp",
+	"ReyP6HB/PyIBjGaE8cNXL396sT9fhLeC4xtwfM5knsHdCynJuGTtZObsqXaCOMQRCkGGpkCNtIFzHJFY",
+	"OcUixFE4VK+WUJdNhfrmcsTu5pr5ilmha2PAu0CmmMZlGsfqX7IEJlIVOF/LPQ+GKvigaOKzx1WNDalX",
+	"gfli94NXB+iXlwcHI/Tir7ejl8/DlyP4l+c/j16+/PnnV69evjw4OHD23mn2tFyoElz3NnNfEQsvLJxT",
+	"hM3bs9tpYXJSJj2NOV00FBSs1JfVobU2H/TvhtinPKpu7SdzNLDEJ1oTaOtXBjWNQ0QZh7FvMdT6BXl9",
+	"yVkJ3HUweLclRC9XNub41j21ttmlBqqFTF2FBoE3qxIcxIO9O7LDWzJtI6qITAESY7yoKSJTV9jg1Kk7",
+	"XXGUgOeHQLD1YlTAeDzuiMNvs22uHI9LUBZHbAGr0hcbzElZnfsiOK0IiQTRERPwCeXDWEW/GWRv8R06",
+	"t8M563XKCN/Jq2T7uvoupMhK3c8q7KsH1cSKtiqYdU/r+R2iMIqKh1vp65p/4XjvUeLY04WBqO4ykAO2",
+	"EwELpDUJPm2Ngc2B1Y6G7jtrwiVrsSYkEogT4jscptCCuVi1gjZNMndeMEGAyYxsIqPnK5C6JReoSB2B",
+	"EPVG+ghVWdgtRMqpMrGxK5ZdfcFJ0kua0+98O0xzgWAdnEkDUQGgDq0iAkO36iMbvC2Z7SdPqiYISIiG",
+	"pmgnomyY9bNj0p0VkDhGlufV6tu+2YQ/c/a+OX/Z9ytJ+zOzHWfgcXk9dEWOo4szC45ZkS63ZwLH7jTS",
+	"N+TenkTzRflCqE/sylKm7aErpt6VYp5nE5u8ARl9rfdSG+Vd16awOp1hHb6pN6ZIhfYZqdQF6/jWPnwN",
+	"8XIhr6jtYkyTu0+/1MyXqQ6RY04pZ6A5otMtrFuTlVOqEuzIHHF7IvV1t+C7YhTOPWitqhnBIZ2ypq8h",
+	"naZz6Xbo4hUIyHwOXUlL+cRS8Kw0AW2d2Z9kfIWU0/jud0hda01w5MojfI0jVMQS77XEpzWL4blToz4/",
+	"PgPyJ1lfK43BXoiniEnfMYelNhgUTTHjdGE3NN23i9aIF+iwruNwWTOaN6mFAv1MB1RXpBAXTC97vVqQ",
+	"8BYy5A5L/hUyXWtA2w8E90ZfEyJzYzBUOn3e83UpD0AheqJp0rxeZzHCjfJsbzp91JplDr/iuWADP796",
+	"9dMrmXeo/tsZEFGXuCXOn+ca6bwtdzSfuphaA4NPDy8VLeo8bU7JQvVHUhkVcAF7OhJQ5fsRyp91Pryb",
+	"rV5QwklAon2OgllMIjJdZFYlq+uvZrVvrq8vhPx6enU9GA6mlxfHg+HgNwqT2T/eDqTflpHgi8ypuz4W",
+	"Iz+cXLiz+jDDdaqiVUwpQ/VsPEYM3KIFiUOA50mEA8yz7qnWpBbrMHvPC1HY5aawlmAkyet/fhp2DKfT",
+	"j4vE4Cba7mLvEeNXYeuRMtLmSyl8dDUT90hhzLpZ27mMVTpUknzfAMKMzMzunLKLpsRsI+ALWigmlO2g",
+	"JPM1pRkUhHuf8hIf6wRcS1/pCwCHbF+BwHvZXbxOqHdKboEtOnmurz+wv17FsfJpa07lEuQY2JunPIVR",
+	"tADoaxClDN/pWg3ZF8+c4aN2C/dldp69/jUbd7/9zsto7EadF4cyT/N9Pbp595om97FSYtbZclovstHO",
+	"040E3SHV1aLp6goMBSnFfCGroWsZDkGK6FGqpDj1X6+NPeZvH68rCQF/+3gNfpXDgKwyV4qxHd/EN/H5",
+	"rcBkAPUIaXJdkNS0KOcLAds7HApFRTyzqu4LwFzXC7+Ji71AZgiGiB6CfxX+fGj2cZMeHPwUyLXkP9G/",
+	"xCauZaFAFcyosrGlPv4FxaYa6d8+/v0qtwcb1QCFADOWmpLSkn6kLVgulsN1xnky+P5d1q2ZkOzZUGYH",
+	"pdQPzhMUH8vguYHOSHPmmGUhdtY/q/QpZCIpSAuCymcGmYkky6MHFxHkE0Ln6jbyoRrszPIfjmLdS+SW",
+	"cWqnB2SZMMqGlegpAYqnOEaIsuFNLAQkmQWhYuJkyZ+RqtBgx1LmDI6SSFdwEHNazZgZEiq7xqDBcBDh",
+	"AGmHgoblUQKDGQIvpA5UhOX9/f0Yyp/HhE739bds/+3Z8en7q9PRC+2gxzwq3ooApxVfeDhQOpaq4hIL",
+	"tf9w8NP4YPyTrkQiSWZ/fI+iaCTbL+8Tgf6CJ3BpPRpRq+OqswTJJeIpjRk4F7gsTgOyj3OLZFbiEzJg",
+	"4hlwDC5fH4O//uXFL+Ob+IPWVt4dX4Agwkh33A0xC4Q4UUqa0HRgBfMqKGdlKc5CGUzD5a4uzIZM+sw7",
+	"Y8WTHcGkp0dC4sXBQUltsfJQ9/+tvb65TtRozGxeWRJaif1JCDZAr8DzBof//DQcsHQ+h3ShDgvaZxDK",
+	"1JSpsp95BQ8xbxELEhTjcFRM8G3FgATFZydAS0glA5agwOO3Z1XueqaYpUagF7mleZgXGlcIUTJ2DCXJ",
+	"GXBo11AdGsitHZfyldd298dyv2o5qcG4bltBqwji1gt2fdRwpzDB+3fP9wXQ/7NvJVQ13iOMooxIi2Sn",
+	"ZxhXQCwOeRQYwWopuHrnZ1VL6xZzwsQnLw+e191Vtsn9D7E5JQrVRz+1f/Sa0FschkiqAa/UGZu/MM+a",
+	"8lDJm87uVm4dZgA091kQD1xXegt5MBuZjCrVw8WlMJ9m5VOyKnbFm6UqUY+p/iA6fiCAUVS961/FmmbC",
+	"gZIREeO/knCxMgIqrGGyC78XJVLpnlkjEZf2oAMCHHhXlO1CFGCW458HYvwKw+yIPVF2aQSUh83L35Tz",
+	"1bwRsgsqZnjmRMUq4q0Z57aMbicab/wx7EEh2OnSqKUTZVufL6H7uFNsjeIOXeW+xy65QSeNXuili5G8",
+	"/6zvT2Q6TWPx5z9SJGuWaLnftqXmqFHRvesqBjdNnavyHSbOqxs3TW1bKOon/7RGAqnNsnYQjClSbnBm",
+	"g5SyBelBSIasdGIvwtJFk2TkmFRbPYTDzOSuPzY99KzwsxoBUZe2kjlFF2q1CkG5gJAP2X+L55jLykUD",
+	"gcgto49TygjVwz+tVd4vnaxO6H9bhF0BaA9OXnUeIsc7x3V/kk5LVperImWCGN03oFYVs9SXlcXWJCRU",
+	"1/ESE56vewPO8nX5IFM3upiGuNNc8eXBX9u/ECp2hJV1eWmkVpjkQus2rG5kqfvfgvI3QlD4rohANmJ2",
+	"OLcipMihnhRMn9UqSaivXSTRKr4Yl4EbCFIwSFTVJiMXuM42KFNEN5nhZW1BRgujFehcGL0h9HzZ/sV7",
+	"wl+TNF6NBK1utQ96DpufdBM1KP0tmVu5Cw/+DfGHi20HW+HNBUo28ew/MvoKIRX2w94kdWKvrLjOZHNz",
+	"U0G/gVvuCQ6hq1A9q6Jwofrqw8DinZFuDrYt3aS62N1Dkm460t/mxaEPuo7tKsShbPGswHk/JbPU4rxR",
+	"zyy0zPjRVM3C4Xy1zRL0HqzCWT5HBR1LV99T7Swu06J5lhu0rJE9F5fajv7p2INbzCkC8UkP7a6HFiHo",
+	"gext7Hf/W6DCuL63MmIv1aCNTnLtoEwk3TiyaxJxjC1x3Q5Y//jk+85Iu4SUXwJ2F0F//Qi5S6/AztDD",
+	"k7y+fnl9jc/Gfo4krZ7YSm8nlS+84rfkKss/eigvitpxkw+zhnb09D/6UxI0nr4PNmed1Hz0z6SSYVRC",
+	"1DzUt1kLPYEc/pDOzuxgvtqnBbEf3B9fUFbtY1fQ1sKOnkpqPn2LgpottV7lNF9mO4ppaX0nS83GPKmj",
+	"3dXRHOFa0LmJA+9/C8KkvxfUyrPwc4LayN9LRMgmaBQP6h2XOco9dr+lN/6swmvZxB1zUXJD2HGwXV73",
+	"WIwQPRCtt+nBYkRdzA7rQ7hdede3jOtPBob1GxiWEASqjaxXopMVpvVRzgrV/H5ILa16Ql91zQXMB6uE",
+	"OQ9TwVoXOvRUyxwLtuhn1cXXq6g51tuOxla3ESeLrw5+0uG663AO7PSlBi9mnoW8VuforvS5duup9jlp",
+	"qpfA5T5ID0XQgcCPXSNcAhtXoSN6sepcWdwaTh1slfE6qfDx+bWXwtXOaqYT6F0UzU0i685JKge7Jqk8",
+	"aaXr10pXKtpQEiHdE96vbEbpabGbyjdrolYDe7bOyiSqcXZlTV+lsHCgB6sNFk9RnynbS/OzJ29R+awL",
+	"WJOuV3Pdm9b0GrfhFjdsMD6peN1VPBt+nZLBbZ63/y3urq41E0BBPysSQGOijRMvdC1RR4pN3JZRY1VZ",
+	"DOc4HlmgWiI/sbi9x67YeeLgMkpcC7blatsDRbWDneHBj8196I28Tq1OSaVupa4ZZQv628PB2h2TXXaH",
+	"bp6UvvUrfUsJO700u1LJMjFNq363UcWui0b3sDW5lWtw1bv10OM2pMBtW3NrZXtPqlovVa071+qtm3no",
+	"ZJ1kjZXIGIYEpayxEiXsoSlfm0dDh7a2Ti2tTTt7CEh3sD3G+hj1r9XrXX9mpsyyKtiff+yhie0ohu6K",
+	"1LFF4ngEStY6dKZOUgenEPMlareo7xu1pGu1xI8VgikP5auOaSA/VH2MmwssOVz1xfZUyOSsLTqYXGG9",
+	"EZNqie0ESVpru9mghJHRvp4UrkaFi2tcqUPSOt6XhTXKkSusoFKD4Ll8bLC7V+hOttsN87x2dH188WNt",
+	"qLdELpICaZfosNVj1S7w3m0hs5ZBn2z7q5VTV8is11i3xI+DL1emZJN83L88iUL+R1aVpHBoL9zMun70",
+	"y3SzWvwV2w7m80q0TRmiYAYZgFIRBpyMb+LzOFrYA2X3QjE6grcoAv/KmzSOQ3S3rxeQ8+c92/9LcNt/",
+	"AUgRoHKjKBzfxNczzMAERwJPAUk5YAvG0dxebQ+Np+MhyBcZ6QVUY8Uh+JLeopH67pm0ytzEVl4tTWOO",
+	"5/ZBXT3ehBbyPgfxD6JBZidqUx8t7HpoqmNs35ohJOsqfXXGdgoZqx6q2X8DzABMOZlDjgPZwVjSAwoV",
+	"gXQhCxdKqu29t7r9rEM+yuffsGJaWriuE9KTP9BbPbUbQzkJwfmcKD+g/HeX3Do3ibTl1dnY3I3Dvrc3",
+	"2SVvLkelxxpO2YoXvVxzOVt0Sa3rvuiDTfOhx2Jq8ECWDhaGGi7hZWRYAwpt/fncONo+Oba8DQareT73",
+	"uzXDq2pqdjc0KUjKjro5twXXi0SLmyRGIEG0iRULEXmZhnkuUho+VHXIv7/eg+6rV9NPr08jPbsBjgMX",
+	"a3SWpvY3u8O6t9eDr7k9zVPXvT7Kj7u9TG1fGT8Gvv/ttk/PvQ5N9lZMKu3Mttg0qosi9dQ7zwvJeilT",
+	"bd3xdhVNDjbJEx9Z0RA/ZPNXxjo3s9shpNv+63+w+df/KfNrfd7h1YkL2Q5G94R+mUTkvlOMY9aewHwN",
+	"OJonkZLB7yCO4G2EAI6lv61F0cuaGHzMdvKo9b0KPK41aFujKSu38gBDKh1nsDzNVVRZAuH3vwX3q4+Q",
+	"qBzAHR9RPknPIIl+mF9ZfXfiK6qc5bEEWdSefLX4T1GEIOtbejjbpJnGYWAZAiLnktY+FSWBQqFSZl+3",
+	"PASXZosbpoZ/pIgufpjnQ0PR/9XIMONHJrXSK0NzVKsQWYaGvWls/1tQmmyp8OnyrptfFr3iponIOugW",
+	"sL35TdFwezxZheWTrxbNl3xDOr0dCSX/RkHby7GpJ+NC7ebHejC8X4rH9EI4X4YOOV25VOftiMqW2WU/",
+	"VL7JTaeGFReuY/VPTij/BDEL35yo3vVZsMSeTsF55u7aytyvlD46iDadi99nJ3q0NRHbUGu4lCDcLADv",
+	"FHocbJoBPjoZt+Gh7hD6Z8Dnl1G4K6i29fd94+j95GZaYxLiugWC/RAlEZHI6haiT+TvRanAKO+cSJKN",
+	"7zAl8dz5CqjPt2QAWT9tFo6XIfJmxXC9ekNd0MvM2CJ2+8OlCK9ARBJwabLMrITUpigWpIFGZqFaovtN",
+	"j5RPIp7PUy69uIbuWAwTNiMcTCiZS19YkFIqda2MRhkX/GOv0Jd+CFRm6BB8JPRLRGD4zCW3qbV/WJot",
+	"HXBLVNvPXPpA6qtsXvpUV+pnZl0JMSeUzAlvoOELNcD9ckrCJTGyH0/1nBI+Q7RKlXq2H1jMLZ+wE10e",
+	"bPA1zalS48ATOZbIUV/lyqVXvkiW9pbLOfpHRl3LLTxFRRlY+Pu01eU93Cgorm++gsgKJbq7IcSEfXwR",
+	"Yr0H4Y+QG92WWJUvXse9JfyfnBPdnRMSck2U0Iet738L+rko5DX6+ilWRjsdRCexZn9/hTzeo3datKLc",
+	"ct4LOX2zC2MnMedga3zz8cXttGNgH+eGBGY3D8euYOJOSA7bo4Ant8cG3B7rFTXWk23g95ZsJ8tggy9K",
+	"lwwDSVCPLrvAPvXSKB5CDpeoGpIXPMxjQeM2q8gJ5PCpLgjbz+DQZg2xoPzgLCH23nNstVDA1wJi1db0",
+	"wjT1dbbQLps+8k1u2OxRWrikNZsfn6wd/taOHEvrsL0rX97/FiYdLBwWmbRYN1ZLGu18NVuvq1UjR8TH",
+	"atBox6pehox8WqfguZsIcrBp7vdYbBY+SOZvq7D4kJedYmeQbevP+8YR/MkksT6TxMrkARlrNkcxHyU4",
+	"QRHurbFlE4FsIi93otTcso8vsk08bhWuApBWXc4B/4en1LkOYeG3A0281bzq1B283dWVd1rvq+520wpg",
+	"zQ5cwdzFO3nSCf11wir4Woml/6uw/y2szNhFf3TcdZsiuR6i85DhnAftpFo6TvtolcweaNpP7awu5NY/",
+	"HwheHewAO340SmovJO2gtjpg66e/7i6y7o7gsguU8tSawF95XZvgYuUv9FNj7Qn8PY+n9rKPWnG1INGm",
+	"sRbu6qFpqqh44wZ3C4jgq5raSTcdXJDWWrusjNrb3LAWWlm6eAvWz09qp7/aiQp4V4P53dn1/jcU3y1T",
+	"Ba8x8fs3xFdNL+1c11pxQ4J+B4x/LJL92tF1n9wyRO8QHaU08greMx+AD5dvVeCeZDpCT4jIlMmmr3PE",
+	"KQ6Y/JnPMOuC3ud6/g+Xb39YTLfO2BTUd26DGscTQudytceE9gV8WxMN0ACO4BTF3JsILo+PgPwio4Kj",
+	"s1FC7mVdR0oIBwFMGQIwhtGC4Q6UcHl8dCQm/pHR3zpjE/oXgfyY8L9w8mWRXhEQvMUR5osRjBDlbBQT",
+	"LuQOCc5RMINxjKJ+SmdheqCmB/b0wEzv7VE9t6c8kjO+tyY8Ntt91MqqH5Da9Fj/23twWm6Ho+UU5ot6",
+	"vuqx9yY6+HP99rjLarXnCTascXfZlUtQ87nlJ1XdW1X3Jp1e5Lvqt3P/G/Fa29/rHHdgHi3O6A1yjPYX",
+	"8twbTl2c1v4k+Fhd2eulp15Ob+8tOVWlHw2rDx7US/ZYTHDrJht/N7z/c+DlnP8ByGe3JdOHRc9PIQDe",
+	"IQA7J5kukaxcPEspa7mToeYpe7lEqF5pzC74P3BTSyWx2YUm/QwoxVTnjqaSnU95dux2myaQ2iyp6qgn",
+	"u0Zfu0Y5DcpNK73fhJJZIkvu62eC8EqhXhPNdZQheyVVOxD7yVrgj6UrsAHUJ14/FLQ62CYz1hT6OHVz",
+	"XyTtq3F3SNzeYWTdHbHlYPtiy1OW9/qyvNcn5+iuqf0UXvOxf4D8hVnuUau2Ggpt+mx2Nz98M9UkRwuD",
+	"1Bmm+Gq3eo4ukfN6jV3WY80WN6y8FpatNBCRcH5SU73V1CTDMwd2d+PT+9/0vzqkXBvKaFE2V0kN3g2y",
+	"u6qVBvseqy7ZiEq9lMbavum/Ib57KHGwSRb3WHS/FqTyV/IMp/FS7HYCubb8Ym8UnZ80tPVpaGt74pua",
+	"vVVyMOzkg+/7uqubOAhJaeDj1YwiEOE7BP6e3iIaS/kh+zrr0ykECT5DAAZcjM2ax8nK43kdaSWEW7sa",
+	"AhwHURrKVgMzHIXW3BH+gsAFCZk7k8P0RFTDrylCW2Mb/brTdfhqC0kkFlwbs0j0OMApQjoPp4wGP/xj",
+	"adCd2sBYrpPc+il/H915lUKw6F59Ue4nkJ1aN6hzQsOHhk/vNlgkYWeoeFgG/N9xHAqBXMFSgWYwHGDx",
+	"2x8poovBcCCwZXA4+ILjcFAWKYYWicumFIcDxqlqEVlZTGzEczH5P0svJm+qw4py/KDTMh/OTsoLSJxN",
+	"KAowQwqNwRzyYCZmcK+d4rBx1U0wX0UQTez3NKdIcVxNkyh/Rp9izFzsWiMFuivV6NgIo+7QyiUg81sc",
+	"o7Cup0suWRXbZ4P/rftnP2tu77LR1i6r4ri70grm0XWBqW8As05yuSf0yyQi9yMbR78NEsG+q9SjdC9F",
+	"PebLnHpYmW5aW5h91HNc5Is/QGpZvUmjBkxbaoWdNxt3UOxHBxpou8fT69jS1MxBQi76NyDeCB+gaezj",
+	"mzYe6ewI4rt2+i/00M7QWiz5o+klu9602wJ+m1u8cMc/vm/cQZ9UYWgjZdY5za8pnk4FV1Rec3tOsHeb",
+	"4ih81k43pdbf1uU9PMIpgufKGDqmWIJ+jjm4enMEOAESOGCPyKEwelajS6qPCuok+grnSSR+hLfB8xc/",
+	"vRSX16piPl8rlTU+ngIZuEKUp3ezTJWagmoIcydezP1vNI2XqaFnn6hZq3zQtN/ylXW2Tfe77kKpj6/p",
+	"9eoJTtuxb3Ec4njaLxzS2MLNJI7kqiEwz0e0ABMccVnl7HbRJqRq4/mvZnsb7s/7D/HEPXRZswjDNimz",
+	"fJk/vqBZOXFOWGX0843JLE3ZIduwuOIuR2iWdrrhQE3X6mWOVbyDp7hN77jNEvo2EkSvZ2b/Gy1M1CGo",
+	"s0xaLcGda6CndtZ+WTlcl1DPMuI+1pDPLljYKwK0tECT935n8edgixz1scjf3RDRP2q0zMq8okd3ECF3",
+	"Q7bYJiU8Fb7xdrusTbZYSnftp7PKQvWN1bgtHXbHlVcrbutH0no91d3Ho+Y61NvupJbJ78vYWvUUTWLX",
+	"Zp+3zQpaTe/KI5OslkJJEnWwXkZRzt9HLCCJ7LUQ5cYfNwvP0OqSRKs1Rq4T0Y5SPvuPteM2XphBpgiS",
+	"3RZkVsMc646eI+aR3qfqHuFrCGxEtjoboAvbdtkSWMazTdsC3evXRWXbN/BkFPQ3CrpJpIFCuvNv9aOn",
+	"IdC9nzo74NpoqiH+v4BpOrFARk4kkM86pBzkYRQhukORON7IAn9rQIXDxlizyXpT45MeW7JOdiaHXiZK",
+	"XyT/DfHHjOEHu/CWFIT2J3qx5fwexOI0o5rAd9uK6ksi6ttHRiW7IuztBIE+1QFYXx2ANUqHPdV6aC8o",
+	"d+Wj3D8grb6bOv8I1fg1qO9VpPJS4h+E9r41td2DhT/p6T319NVw4CUUcy+FfCMS2GolrxVp3o9A4948",
+	"JThV9PWq5u0q+Y+K4wdbeRCelG1PZXsdSvafmSx+RGLVqt/63Evt/oEoYevi2Hao7yneqadivLQ4xlBA",
+	"ER9RNEEUxUHPqCc1C8hn8W7XdSW/vMyXf9QFzUvQaNPIK2B/cAp29QQ5QldQw1fLLk/aIV2mtOYu69nl",
+	"rW5Y23YuX8oBL9/Dk9btrXWXcbiZLnry+v1vrDhXh7yZCpG1JM6sg7LaOfdV9XxdUmcqGPxYc2e6oWMv",
+	"/be8hFMD3n0sOtgqh30sgZ5d8dE/iabC17yyaHYSL3dE5tguRTyplt6q5TpkDi4ravZSKtWnAN5BHMHb",
+	"KCuV3KJRqhqej1uPlDBo0x711Tw0lZGb+zW4qS/cVzuU33dQCeX0u6wIqg1uWP2zFi3XRRPgfdL0vDU9",
+	"rvGrgs5dGOz+N/m/HfQ3RQYtStvqcL+dOV6bA3RR0BS2PVatrBZ1eilgcjan1rVbaHCwKSb2WJSpBjTy",
+	"15sUP/FSlraOTlt9gzeGvk/hqesLT135o92lwUFNXwNfRr7R/gWbZOftfQgUYTySHgTcPmxvVO1bQXyK",
+	"YkRLFVCZpwq/hQriO6rIP4By3qvR6utqcvcoxe3CvDrlftVVd9ckXlQ226llxPN1oGNrNV1tAniytTq1",
+	"/prKu90L7m64XvXmy1Rvvnj0U83oqjCxbnxdWWPFLhi80d6JbjyuhJ2+loXBzOFuF4BxlBSiT0t9EsTv",
+	"a226hzmasw40I6F6GnMqtU29G0gpXLRSk0aCvk/GwyOlaje91VFURDwqGIlBTSQEJpTMpcyu2nYkEYzR",
+	"GLwVn0GKwATxYCaddnfIOfb/D2ICIA1m+E4MM99RuT4K5doCjMqCK47QRrVi7Z2kWXm4VVDs0H1baoEY",
+	"3SMK+AzGqnoxlF2Dw1TBS2hYDAUkDlnd6jgO0FU2JN/FhNA55IPDAY75zy8Hw8Ecx3iezgeHBxkZ45ij",
+	"KaJb4CpvybQfT5Fk8Ig4SkSm6+EnjEOeMi8LFblDFEYRUJ/IpI4E0ZEkDP23/nLnldrHI5A+1UmbDFoF",
+	"TNcX9FARl5l7XR51lzFUdY84yff5ZKuKyL2voerhGqlWhKT738w/V+4CMBM38tKNOgI+WkfdCV9Axjof",
+	"iTvgvnTeZVE4IjDsF9iXfb3Cxk4fsx09tXTqx7oF9HxYt4LyD1/e+t5CKJtQ1N98gw3NLB3iDc0iu+yP",
+	"yPa4Bf9Dvm6Vn0tQP8UedvJCaFxz4XjHx0DJM+KfHeIQMwppCUVcKVn4iSvmJF0CEjMsfKwxiS0oNezr",
+	"lRIT1Eqzu4YYB5vleI/JCdWIW/7hihnb8YpY3BEc2/ZDvmG0fkrd8o5H9H/IU4boiC8S5GfJDUg8wdNU",
+	"KGHiSyC/VNaGlM9QzPX9SxtvoZqhW0/7wBC9lqtvwn9gVjuWp/BxHRhNx3nu3pi0GpXE2ohX2Zd7dDsj",
+	"5Avbv8X8Ng2+qLt2qy0XlAgaQwzgOCBzwSJ/NV8BPZFxSnNimtorR5/DY/cGxmGEshk+qgkG/ZkYDEOs",
+	"7AIXVCzFsUAbVWmpeJLqthO4MLShbp/c/hsFGw/X1kCQ7vFGw5TZtr6S7THAvmiLgpRivhgc/vOTjcQK",
+	"Kap4ZTMtjbI1iDzFfJbedsLi3zB/k972RmH1+Sbxt7ThJ+TdKeQt3k4nzI1gZ8x9C5fC3Ldw05hrb/gJ",
+	"c3cNc63bqcfcGYIRn7UKh+d/B3giRUSG6B2iADOgPl2MwQemI3sifIdixJiA6i1yh/a8UQu2ogBHX/l+",
+	"EkFcuvy8vOL53x11FR0lIkr7bYaeHAOCGQpsoJ2bUxiwkQTFMMFjg5ytkvV5guKjizPw0/ggs3QoUVoA",
+	"js8wA+JnHIO/XZ2/Byo6xwlAPdNVgoJlperiduu3GJIgnYsZncTtnqUwQyPMha7v/qrhAiiCirM1Qv5S",
+	"jKpirvxY8FYYBCjhQDNLZqGyGILbcFlOvwpUNhN1wGYFgCa4XmZHaEXnO0QZ9sBkPQ7gWCGoVAVvScol",
+	"gOUFyg06ofW7XmSN3F8v0cT4f68eoRU7NebcZQdwA7I4y7fBLYIUUaGyiUm/i2nlRMqWVNJESQAjoCvG",
+	"alpLaTQ4HMw4Tw739yMxYEYYP/zl4JcDaSLSuyhPpXjYMEfhoVTXzd2hOEwIVmGoOkjQOkZTZdw5jOEU",
+	"6c3pT7NfXZ9eUCLYhPWh8YzlDoZ8Kj3aNVHmf3VMlZjPsomy0a6prE7FnvuyvnBNeAI5vIhgbMNHspD7",
+	"3GCbRGQh/84hnSJ7r9nXrql/FSKfc+7js/3jEx14i+MJhYzTNOApRfnU+deuuc9vBTLCWxxhvnCuMScx",
+	"5kRwIok/EZlOVVMWgzWVGZxXF6WMI2paYLigZd2cGtwIlNKEThhVZmyGRWnKRtBUpu4FhgxFrxcJAhzN",
+	"k0j6kUM0wbEKgRB/ESwKoHiKYyTYRnnpwiweq6qE2Hw1E41NmIx/CyhhbBSkXNrMAxIHiMbVVa9NJaFa",
+	"Ku15qLbTLLn92n3/Vk4hzJbIP/5ohbHVnntUjXDNdytoSKc7lg/cNPklidDoFgq5BEoFRZyMUxJVbbBO",
+	"LC1aDB2Hx1yw0DscIpopczOpRNiXk6kN1RkqRdhc26iUFKvOk3kCGElpgEBAQqRwB6u3qXAZJjCl/qnQ",
+	"7aHdtGtGXeYd3L/VtNN2fe/xmekb1vD5r3mP5KrLPHszEpygCNcwoXzchR7WyuwBjBDlDMSE5yJ+MINx",
+	"jCLnGoWvj+TH761vj9WnbPD90/f/LwAA//98dFrsxH4DAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -183,6 +183,7 @@ func (h *Handler) Routes() http.Handler {
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/schema", h.GetComponentSchema)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release", h.GetEnvironmentRelease)
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources", h.GetReleaseResourceTree)
+	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources/events", h.GetResourceEvents)
 
 	// Component trait management
 	api.HandleFunc("GET "+v1+"/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/traits", h.ListComponentTraits)

--- a/internal/openchoreo-api/legacyservices/errors.go
+++ b/internal/openchoreo-api/legacyservices/errors.go
@@ -39,6 +39,7 @@ var (
 	ErrReleaseBindingNotFound        = errors.New("release binding not found")
 	ErrWorkflowSchemaInvalid         = errors.New("workflow schema is invalid")
 	ErrReleaseNotFound               = errors.New("release not found")
+	ErrResourceNotFound              = errors.New("resource not found in release")
 	ErrInvalidCommitSHA              = errors.New("invalid commit SHA format")
 	ErrForbidden                     = errors.New("insufficient permissions to perform this action")
 	ErrDuplicateTraitInstanceName    = errors.New("duplicate trait instance name")
@@ -93,6 +94,7 @@ const (
 	CodeComponentReleaseNotFound     = "COMPONENT_RELEASE_NOT_FOUND"
 	CodeReleaseBindingNotFound       = "RELEASE_BINDING_NOT_FOUND"
 	CodeReleaseNotFound              = "RELEASE_NOT_FOUND"
+	CodeResourceNotFound             = "RESOURCE_NOT_FOUND"
 	CodeInvalidInput                 = "INVALID_INPUT"
 	CodeConflict                     = "CONFLICT"
 	CodeInternalError                = "INTERNAL_ERROR"

--- a/internal/openchoreo-api/legacyservices/resource_tree_test.go
+++ b/internal/openchoreo-api/legacyservices/resource_tree_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -424,6 +425,533 @@ func TestGetReleaseResourceTree(t *testing.T) {
 		)
 		if err == nil {
 			t.Fatal("expected error for nil gateway client")
+		}
+	})
+}
+
+func TestGetResourceEvents(t *testing.T) {
+	const (
+		namespace   = "test-ns"
+		project     = "test-project"
+		component   = "test-component"
+		environment = "test-env"
+		dpName      = "default"
+	)
+
+	newComponent := func(ns, name, projectName string) *openchoreov1alpha1.Component {
+		return &openchoreov1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Spec: openchoreov1alpha1.ComponentSpec{
+				Owner: openchoreov1alpha1.ComponentOwner{
+					ProjectName: projectName,
+				},
+			},
+		}
+	}
+
+	newRelease := func(
+		ns, proj, comp, env string,
+		resources []openchoreov1alpha1.ResourceStatus,
+	) *openchoreov1alpha1.Release {
+		return &openchoreov1alpha1.Release{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      comp + "-" + env + "-release",
+				Labels: map[string]string{
+					labels.LabelKeyNamespaceName:   ns,
+					labels.LabelKeyProjectName:     proj,
+					labels.LabelKeyComponentName:   comp,
+					labels.LabelKeyEnvironmentName: env,
+				},
+			},
+			Status: openchoreov1alpha1.ReleaseStatus{
+				Resources: resources,
+			},
+		}
+	}
+
+	newEnvironment := func(ns, name string) *openchoreov1alpha1.Environment {
+		return &openchoreov1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindDataPlane,
+					Name: dpName,
+				},
+			},
+		}
+	}
+
+	newDataPlane := func(ns, name string) *openchoreov1alpha1.DataPlane {
+		return &openchoreov1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Spec: openchoreov1alpha1.DataPlaneSpec{
+				PlaneID: name,
+			},
+		}
+	}
+
+	deployResources := []openchoreov1alpha1.ResourceStatus{
+		{
+			Group:     "apps",
+			Version:   "v1",
+			Kind:      "Deployment",
+			Namespace: "workload-ns",
+			Name:      "my-deploy",
+		},
+	}
+
+	t.Run("happy path returns events", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []any{
+					map[string]any{
+						"type":           "Normal",
+						"reason":         "Scheduled",
+						"message":        "Successfully assigned",
+						"firstTimestamp": "2026-01-01T00:00:00Z",
+						"lastTimestamp":  "2026-01-01T00:00:00Z",
+						"count":          float64(1),
+						"source":         map[string]any{"component": "default-scheduler"},
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				newEnvironment(namespace, environment),
+				newDataPlane(namespace, dpName),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient(server.URL),
+		}
+
+		resp, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "workload-ns", "",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resp.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(resp.Events))
+		}
+		ev := resp.Events[0]
+		if ev.Type != "Normal" {
+			t.Errorf("expected type Normal, got %s", ev.Type)
+		}
+		if ev.Reason != "Scheduled" {
+			t.Errorf("expected reason Scheduled, got %s", ev.Reason)
+		}
+		if ev.Source != "default-scheduler" {
+			t.Errorf("expected source default-scheduler, got %s", ev.Source)
+		}
+		if ev.Count == nil || *ev.Count != 1 {
+			t.Errorf("expected count 1, got %v", ev.Count)
+		}
+	})
+
+	t.Run("namespace defaults from release resource", func(t *testing.T) {
+		var capturedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		}))
+		defer server.Close()
+
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				newEnvironment(namespace, environment),
+				newDataPlane(namespace, dpName),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient(server.URL),
+		}
+
+		// Pass empty namespace — should be defaulted from the release resource
+		resp, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "", "",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		// The events path should include the namespace from the release resource
+		if !strings.Contains(capturedPath, "namespaces/workload-ns/events") {
+			t.Errorf("expected events path to include namespace from release resource, got %s", capturedPath)
+		}
+	})
+
+	t.Run("child resource kind Pod with parent Deployment succeeds", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		}))
+		defer server.Close()
+
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				newEnvironment(namespace, environment),
+				newDataPlane(namespace, dpName),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient(server.URL),
+		}
+
+		resp, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Pod", "my-pod-abc123", "workload-ns", "",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+	})
+
+	t.Run("child resource kind Pod without parent returns ErrResourceNotFound", func(t *testing.T) {
+		// Release has no parent resources for Pod (empty resources).
+		emptyResources := []openchoreov1alpha1.ResourceStatus{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Service",
+				Name:    "my-svc",
+			},
+		}
+
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, emptyResources),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Pod", "some-pod", "workload-ns", "",
+		)
+		if !errors.Is(err, ErrResourceNotFound) {
+			t.Errorf("expected ErrResourceNotFound, got %v", err)
+		}
+	})
+
+	t.Run("authz denial returns ErrForbidden", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &denyAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "", "",
+		)
+		if !errors.Is(err, ErrForbidden) {
+			t.Errorf("expected ErrForbidden, got %v", err)
+		}
+	})
+
+	t.Run("nil gateway client returns error", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: nil,
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "", "",
+		)
+		if err == nil {
+			t.Fatal("expected error for nil gateway client")
+		}
+	})
+
+	t.Run("component not found returns ErrComponentNotFound", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "", "",
+		)
+		if !errors.Is(err, ErrComponentNotFound) {
+			t.Errorf("expected ErrComponentNotFound, got %v", err)
+		}
+	})
+
+	t.Run("project mismatch returns ErrComponentNotFound", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, "other-project"),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "", "",
+		)
+		if !errors.Is(err, ErrComponentNotFound) {
+			t.Errorf("expected ErrComponentNotFound, got %v", err)
+		}
+	})
+
+	t.Run("no release returns ErrReleaseNotFound", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "", "",
+		)
+		if !errors.Is(err, ErrReleaseNotFound) {
+			t.Errorf("expected ErrReleaseNotFound, got %v", err)
+		}
+	})
+
+	t.Run("resource not in release returns ErrResourceNotFound", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Service", "nonexistent-svc", "", "",
+		)
+		if !errors.Is(err, ErrResourceNotFound) {
+			t.Errorf("expected ErrResourceNotFound, got %v", err)
+		}
+	})
+
+	t.Run("environment not found returns ErrEnvironmentNotFound", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				// No environment.
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "workload-ns", "",
+		)
+		if !errors.Is(err, ErrEnvironmentNotFound) {
+			t.Errorf("expected ErrEnvironmentNotFound, got %v", err)
+		}
+	})
+
+	t.Run("data plane resolution failure returns error", func(t *testing.T) {
+		// Environment references a DataPlane that doesn't exist.
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				newEnvironment(namespace, environment),
+				// No data plane.
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient("http://unused"),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "workload-ns", "",
+		)
+		if err == nil {
+			t.Fatal("expected error for data plane resolution failure")
+		}
+		if errors.Is(err, ErrEnvironmentNotFound) {
+			t.Error("should not be ErrEnvironmentNotFound")
+		}
+	})
+
+	t.Run("gateway fetch error returns error", func(t *testing.T) {
+		// Server returns 500 for events request.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				newEnvironment(namespace, environment),
+				newDataPlane(namespace, dpName),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient(server.URL),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "workload-ns", "",
+		)
+		if err == nil {
+			t.Fatal("expected error for gateway fetch failure")
+		}
+	})
+
+	t.Run("field selector includes uid when provided", func(t *testing.T) {
+		var capturedQuery string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		}))
+		defer server.Close()
+
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme(t)).
+			WithObjects(
+				newComponent(namespace, component, project),
+				newRelease(namespace, project, component, environment, deployResources),
+				newEnvironment(namespace, environment),
+				newDataPlane(namespace, dpName),
+			).
+			Build()
+
+		svc := &ComponentService{
+			k8sClient:     k8s,
+			logger:        slog.Default(),
+			authzPDP:      &allowAllPDP{},
+			gatewayClient: gatewayClient.NewClient(server.URL),
+		}
+
+		_, err := svc.GetResourceEvents(
+			context.Background(), namespace, project, component, environment,
+			"Deployment", "my-deploy", "workload-ns", "uid-123",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(capturedQuery, "involvedObject.uid=uid-123") {
+			t.Errorf("expected query to contain uid, got %s", capturedQuery)
+		}
+		if !strings.Contains(capturedQuery, "involvedObject.kind=Deployment") {
+			t.Errorf("expected query to contain kind, got %s", capturedQuery)
+		}
+		if !strings.Contains(capturedQuery, "involvedObject.name=my-deploy") {
+			t.Errorf("expected query to contain name, got %s", capturedQuery)
 		}
 	})
 }

--- a/internal/openchoreo-api/models/response.go
+++ b/internal/openchoreo-api/models/response.go
@@ -435,6 +435,22 @@ type ResourceTreeResponse struct {
 	Nodes []ResourceNode `json:"nodes"`
 }
 
+// ResourceEvent represents a Kubernetes event associated with a resource
+type ResourceEvent struct {
+	Type           string     `json:"type"`
+	Reason         string     `json:"reason"`
+	Message        string     `json:"message"`
+	Count          *int32     `json:"count,omitempty"`
+	FirstTimestamp *time.Time `json:"firstTimestamp,omitempty"`
+	LastTimestamp  *time.Time `json:"lastTimestamp,omitempty"`
+	Source         string     `json:"source,omitempty"`
+}
+
+// ResourceEventsResponse is the response for the resource events endpoint
+type ResourceEventsResponse struct {
+	Events []ResourceEvent `json:"events"`
+}
+
 // SecretReferenceResponse represents a SecretReference in API responses
 type SecretReferenceResponse struct {
 	Name            string                 `json:"name"`

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -2500,6 +2500,59 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources/events:
+    get:
+      operationId: getReleaseResourceEvents
+      summary: Get resource events
+      description: Returns Kubernetes events for a specific resource in the release resource tree.
+      tags: [Components]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ProjectNameParam'
+        - $ref: '#/components/parameters/ComponentNameParam'
+        - $ref: '#/components/parameters/ComponentEnvironmentNameParam'
+        - name: kind
+          in: query
+          required: true
+          description: Kind of the resource
+          schema:
+            type: string
+        - name: name
+          in: query
+          required: true
+          description: Name of the resource
+          schema:
+            type: string
+        - name: namespace
+          in: query
+          required: false
+          description: Namespace of the resource
+          schema:
+            type: string
+        - name: uid
+          in: query
+          required: false
+          description: UID of the resource for precise event matching
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Events for the specified resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceEventsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/v1/namespaces/{namespaceName}/components/{componentName}/deploy:
     post:
       operationId: deployRelease
@@ -7727,6 +7780,55 @@ components:
           description: All resource nodes in the tree
           items:
             $ref: '#/components/schemas/ResourceNode'
+
+    ResourceEvent:
+      type: object
+      description: A Kubernetes event associated with a resource
+      required:
+        - type
+        - reason
+        - message
+      properties:
+        type:
+          type: string
+          description: Type of the event (Normal or Warning)
+          example: Normal
+        reason:
+          type: string
+          description: Short machine-readable reason for the event
+          example: Scheduled
+        message:
+          type: string
+          description: Human-readable description of the event
+          example: Successfully assigned default/my-pod to node-1
+        count:
+          type: integer
+          description: Number of times this event has occurred
+          example: 3
+        firstTimestamp:
+          type: string
+          format: date-time
+          description: First time this event was recorded
+        lastTimestamp:
+          type: string
+          format: date-time
+          description: Most recent time this event was recorded
+        source:
+          type: string
+          description: Component that generated the event
+          example: default-scheduler
+
+    ResourceEventsResponse:
+      type: object
+      description: Response containing events for a specific resource
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          description: Kubernetes events for the resource
+          items:
+            $ref: '#/components/schemas/ResourceEvent'
 
     # -------------------------------------------------------------------------
     # Deploy/Promote Requests


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
   Add an API to retrieve Kubernetes events for a specific resource in a component release resource tree, so users can inspect runtime issues directly from OpenChoreo.

## Approach
   - Added `GET /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release/resources/events`.
   - Implemented handler/service flow to query events using `kind` + `name` (with optional `namespace` and `uid`) and return normalized event data.
   - Added `ResourceEvent` / `ResourceEventsResponse` models and OpenAPI spec updates, then regenerated API client/server files.
   - Updated data-plane cluster-agent ClusterRole to include `events` with `get`/`list`.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
