### PR TITLE
feat: add occ list commands for cluster component types and cluster traits

### DIFF
--- a/internal/occ/cmd/list/list.go
+++ b/internal/occ/cmd/list/list.go
@@ -186,6 +186,40 @@ func (l *ListImpl) ListTraits(params api.ListTraitsParams) error {
 	return output.PrintTraits(result)
 }
 
+// ListClusterComponentTypes lists all cluster-scoped component types
+func (l *ListImpl) ListClusterComponentTypes() error {
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := c.ListClusterComponentTypes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list cluster component types: %w", err)
+	}
+
+	return output.PrintClusterComponentTypes(result)
+}
+
+// ListClusterTraits lists all cluster-scoped traits
+func (l *ListImpl) ListClusterTraits() error {
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := c.ListClusterTraits(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list cluster traits: %w", err)
+	}
+
+	return output.PrintClusterTraits(result)
+}
+
 // ListWorkflows lists all workflows in a namespace
 func (l *ListImpl) ListWorkflows(params api.ListWorkflowsParams) error {
 	if err := validation.ValidateParams(validation.CmdList, validation.ResourceWorkflow, params); err != nil {

--- a/internal/occ/cmd/list/output/output.go
+++ b/internal/occ/cmd/list/output/output.go
@@ -237,6 +237,57 @@ func PrintTraits(list *gen.TraitList) error {
 	return w.Flush()
 }
 
+// PrintClusterComponentTypes prints cluster component types in table format
+func PrintClusterComponentTypes(list *gen.ClusterComponentTypeList) error {
+	if list == nil || len(list.Items) == 0 {
+		fmt.Println("No cluster component types found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tWORKLOAD TYPE\tAGE")
+
+	for _, ct := range list.Items {
+		workloadType := ""
+		if ct.Spec != nil {
+			workloadType = string(ct.Spec.WorkloadType)
+		}
+		age := ""
+		if ct.Metadata.CreationTimestamp != nil {
+			age = formatAge(*ct.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			ct.Metadata.Name,
+			workloadType,
+			age)
+	}
+
+	return w.Flush()
+}
+
+// PrintClusterTraits prints cluster traits in table format
+func PrintClusterTraits(list *gen.ClusterTraitList) error {
+	if list == nil || len(list.Items) == 0 {
+		fmt.Println("No cluster traits found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tAGE")
+
+	for _, trait := range list.Items {
+		age := ""
+		if trait.Metadata.CreationTimestamp != nil {
+			age = formatAge(*trait.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\n",
+			trait.Metadata.Name,
+			age)
+	}
+
+	return w.Flush()
+}
+
 // PrintWorkflows prints workflows in table format
 func PrintWorkflows(list *gen.WorkflowList) error {
 	if list == nil || len(list.Items) == 0 {

--- a/internal/occ/cmd/list/output/output_cluster_test.go
+++ b/internal/occ/cmd/list/output/output_cluster_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// captureStdout captures stdout output from a function call.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+	r.Close()
+
+	return buf.String()
+}
+
+func TestPrintClusterComponentTypes_Nil(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := PrintClusterComponentTypes(nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No cluster component types found") {
+		t.Errorf("expected empty message, got %q", out)
+	}
+}
+
+func TestPrintClusterComponentTypes_Empty(t *testing.T) {
+	list := &gen.ClusterComponentTypeList{Items: []gen.ClusterComponentType{}}
+	out := captureStdout(t, func() {
+		if err := PrintClusterComponentTypes(list); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No cluster component types found") {
+		t.Errorf("expected empty message, got %q", out)
+	}
+}
+
+func TestPrintClusterComponentTypes_WithItems(t *testing.T) {
+	now := time.Now()
+	workloadType := gen.ClusterComponentTypeSpecWorkloadTypeDeployment
+	list := &gen.ClusterComponentTypeList{
+		Items: []gen.ClusterComponentType{
+			{
+				Metadata: gen.ObjectMeta{
+					Name:              "web-app",
+					CreationTimestamp: &now,
+				},
+				Spec: &gen.ClusterComponentTypeSpec{
+					WorkloadType: workloadType,
+				},
+			},
+			{
+				Metadata: gen.ObjectMeta{
+					Name: "batch-job",
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := PrintClusterComponentTypes(list); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	// Verify header
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "WORKLOAD TYPE") || !strings.Contains(out, "AGE") {
+		t.Errorf("expected table header with NAME, WORKLOAD TYPE, AGE columns, got %q", out)
+	}
+
+	// Verify items
+	if !strings.Contains(out, "web-app") {
+		t.Errorf("expected output to contain 'web-app', got %q", out)
+	}
+	if !strings.Contains(out, "deployment") {
+		t.Errorf("expected output to contain 'deployment', got %q", out)
+	}
+	if !strings.Contains(out, "batch-job") {
+		t.Errorf("expected output to contain 'batch-job', got %q", out)
+	}
+}
+
+func TestPrintClusterComponentTypes_NilSpec(t *testing.T) {
+	now := time.Now()
+	list := &gen.ClusterComponentTypeList{
+		Items: []gen.ClusterComponentType{
+			{
+				Metadata: gen.ObjectMeta{
+					Name:              "no-spec-type",
+					CreationTimestamp: &now,
+				},
+				Spec: nil,
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := PrintClusterComponentTypes(list); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no-spec-type") {
+		t.Errorf("expected output to contain 'no-spec-type', got %q", out)
+	}
+}
+
+func TestPrintClusterTraits_Nil(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := PrintClusterTraits(nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No cluster traits found") {
+		t.Errorf("expected empty message, got %q", out)
+	}
+}
+
+func TestPrintClusterTraits_Empty(t *testing.T) {
+	list := &gen.ClusterTraitList{Items: []gen.ClusterTrait{}}
+	out := captureStdout(t, func() {
+		if err := PrintClusterTraits(list); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No cluster traits found") {
+		t.Errorf("expected empty message, got %q", out)
+	}
+}
+
+func TestPrintClusterTraits_WithItems(t *testing.T) {
+	now := time.Now()
+	list := &gen.ClusterTraitList{
+		Items: []gen.ClusterTrait{
+			{
+				Metadata: gen.ObjectMeta{
+					Name:              "ingress",
+					CreationTimestamp: &now,
+				},
+			},
+			{
+				Metadata: gen.ObjectMeta{
+					Name: "storage",
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := PrintClusterTraits(list); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	// Verify header
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "AGE") {
+		t.Errorf("expected table header with NAME, AGE columns, got %q", out)
+	}
+
+	// Verify items
+	if !strings.Contains(out, "ingress") {
+		t.Errorf("expected output to contain 'ingress', got %q", out)
+	}
+	if !strings.Contains(out, "storage") {
+		t.Errorf("expected output to contain 'storage', got %q", out)
+	}
+}
+
+func TestPrintClusterTraits_NilTimestamp(t *testing.T) {
+	list := &gen.ClusterTraitList{
+		Items: []gen.ClusterTrait{
+			{
+				Metadata: gen.ObjectMeta{
+					Name:              "no-timestamp",
+					CreationTimestamp: nil,
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := PrintClusterTraits(list); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no-timestamp") {
+		t.Errorf("expected output to contain 'no-timestamp', got %q", out)
+	}
+}

--- a/internal/occ/impl.go
+++ b/internal/occ/impl.go
@@ -224,6 +224,16 @@ func (c *CommandImplementation) ListTraits(params api.ListTraitsParams) error {
 	return listImpl.ListTraits(params)
 }
 
+func (c *CommandImplementation) ListClusterComponentTypes() error {
+	listImpl := list.NewListImpl()
+	return listImpl.ListClusterComponentTypes()
+}
+
+func (c *CommandImplementation) ListClusterTraits() error {
+	listImpl := list.NewListImpl()
+	return listImpl.ListClusterTraits()
+}
+
 func (c *CommandImplementation) ListWorkflows(params api.ListWorkflowsParams) error {
 	listImpl := list.NewListImpl()
 	return listImpl.ListWorkflows(params)

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -230,6 +230,30 @@ func (c *Client) DeleteComponentType(ctx context.Context, namespaceName, ctName 
 	return nil
 }
 
+// ListClusterComponentTypes retrieves all cluster-scoped component types
+func (c *Client) ListClusterComponentTypes(ctx context.Context) (*gen.ClusterComponentTypeList, error) {
+	resp, err := c.client.ListClusterComponentTypesWithResponse(ctx, &gen.ListClusterComponentTypesParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster component types: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// ListClusterTraits retrieves all cluster-scoped traits
+func (c *Client) ListClusterTraits(ctx context.Context) (*gen.ClusterTraitList, error) {
+	resp, err := c.client.ListClusterTraitsWithResponse(ctx, &gen.ListClusterTraitsParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster traits: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
 // ListTraits retrieves all traits for a namespace
 func (c *Client) ListTraits(ctx context.Context, namespaceName string) (*gen.TraitList, error) {
 	resp, err := c.client.ListTraitsWithResponse(ctx, namespaceName, &gen.ListTraitsParams{})

--- a/pkg/cli/cmd/clustercomponenttype/clustercomponenttype.go
+++ b/pkg/cli/cmd/clustercomponenttype/clustercomponenttype.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustercomponenttype
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+	"github.com/openchoreo/openchoreo/pkg/cli/types/api"
+)
+
+func NewClusterComponentTypeCmd(impl api.CommandImplementationInterface) *cobra.Command {
+	clusterComponentTypeCmd := &cobra.Command{
+		Use:     constants.ClusterComponentType.Use,
+		Aliases: constants.ClusterComponentType.Aliases,
+		Short:   constants.ClusterComponentType.Short,
+		Long:    constants.ClusterComponentType.Long,
+	}
+
+	clusterComponentTypeCmd.AddCommand(
+		newListClusterComponentTypeCmd(impl),
+	)
+
+	return clusterComponentTypeCmd
+}
+
+func newListClusterComponentTypeCmd(impl api.CommandImplementationInterface) *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListClusterComponentType,
+		Flags:   []flags.Flag{},
+		RunE: func(fg *builder.FlagGetter) error {
+			return impl.ListClusterComponentTypes()
+		},
+		PreRunE: auth.RequireLogin(impl),
+	}).Build()
+}

--- a/pkg/cli/cmd/clustercomponenttype/clustercomponenttype_test.go
+++ b/pkg/cli/cmd/clustercomponenttype/clustercomponenttype_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustercomponenttype
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openchoreo/openchoreo/pkg/cli/types/api"
+)
+
+// mockImpl satisfies api.CommandImplementationInterface for testing command wiring.
+type mockImpl struct {
+	api.CommandImplementationInterface
+	listClusterComponentTypesCalled bool
+	listClusterComponentTypesErr    error
+}
+
+func (m *mockImpl) ListClusterComponentTypes() error {
+	m.listClusterComponentTypesCalled = true
+	return m.listClusterComponentTypesErr
+}
+
+func (m *mockImpl) IsLoggedIn() bool       { return true }
+func (m *mockImpl) GetLoginPrompt() string { return "" }
+
+func TestNewClusterComponentTypeCmd(t *testing.T) {
+	impl := &mockImpl{}
+	cmd := NewClusterComponentTypeCmd(impl)
+
+	if cmd.Use != "clustercomponenttype" {
+		t.Errorf("expected Use to be 'clustercomponenttype', got %q", cmd.Use)
+	}
+
+	expectedAliases := map[string]bool{"cct": true, "clustercomponenttypes": true}
+	for _, alias := range cmd.Aliases {
+		if !expectedAliases[alias] {
+			t.Errorf("unexpected alias %q", alias)
+		}
+	}
+	if len(cmd.Aliases) != len(expectedAliases) {
+		t.Errorf("expected %d aliases, got %d", len(expectedAliases), len(cmd.Aliases))
+	}
+
+	// Verify list subcommand exists
+	listCmd, _, err := cmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("expected 'list' subcommand to exist: %v", err)
+	}
+	if listCmd.Use != "list" {
+		t.Errorf("expected list subcommand Use to be 'list', got %q", listCmd.Use)
+	}
+}
+
+func TestNewClusterComponentTypeCmd_NoNamespaceFlag(t *testing.T) {
+	impl := &mockImpl{}
+	cmd := NewClusterComponentTypeCmd(impl)
+
+	listCmd, _, err := cmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("expected 'list' subcommand to exist: %v", err)
+	}
+
+	// Cluster-scoped commands should NOT have a namespace flag
+	nsFlag := listCmd.Flags().Lookup("namespace")
+	if nsFlag != nil {
+		t.Error("cluster-scoped command should not have a --namespace flag")
+	}
+}
+
+func TestListClusterComponentTypeCmd_Execute(t *testing.T) {
+	impl := &mockImpl{}
+	cmd := NewClusterComponentTypeCmd(impl)
+	cmd.SetArgs([]string{"list"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error executing list command: %v", err)
+	}
+
+	if !impl.listClusterComponentTypesCalled {
+		t.Error("expected ListClusterComponentTypes to be called")
+	}
+}
+
+func TestListClusterComponentTypeCmd_ExecuteError(t *testing.T) {
+	impl := &mockImpl{
+		listClusterComponentTypesErr: fmt.Errorf("api error"),
+	}
+	cmd := NewClusterComponentTypeCmd(impl)
+	cmd.SetArgs([]string{"list"})
+	// Silence usage output on error
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "api error" {
+		t.Errorf("expected 'api error', got %q", err.Error())
+	}
+}

--- a/pkg/cli/cmd/clustertrait/clustertrait.go
+++ b/pkg/cli/cmd/clustertrait/clustertrait.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustertrait
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+	"github.com/openchoreo/openchoreo/pkg/cli/types/api"
+)
+
+func NewClusterTraitCmd(impl api.CommandImplementationInterface) *cobra.Command {
+	clusterTraitCmd := &cobra.Command{
+		Use:     constants.ClusterTrait.Use,
+		Aliases: constants.ClusterTrait.Aliases,
+		Short:   constants.ClusterTrait.Short,
+		Long:    constants.ClusterTrait.Long,
+	}
+
+	clusterTraitCmd.AddCommand(
+		newListClusterTraitCmd(impl),
+	)
+
+	return clusterTraitCmd
+}
+
+func newListClusterTraitCmd(impl api.CommandImplementationInterface) *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListClusterTrait,
+		Flags:   []flags.Flag{},
+		RunE: func(fg *builder.FlagGetter) error {
+			return impl.ListClusterTraits()
+		},
+		PreRunE: auth.RequireLogin(impl),
+	}).Build()
+}

--- a/pkg/cli/cmd/clustertrait/clustertrait_test.go
+++ b/pkg/cli/cmd/clustertrait/clustertrait_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustertrait
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openchoreo/openchoreo/pkg/cli/types/api"
+)
+
+// mockImpl satisfies api.CommandImplementationInterface for testing command wiring.
+type mockImpl struct {
+	api.CommandImplementationInterface
+	listClusterTraitsCalled bool
+	listClusterTraitsErr    error
+}
+
+func (m *mockImpl) ListClusterTraits() error {
+	m.listClusterTraitsCalled = true
+	return m.listClusterTraitsErr
+}
+
+func (m *mockImpl) IsLoggedIn() bool       { return true }
+func (m *mockImpl) GetLoginPrompt() string { return "" }
+
+func TestNewClusterTraitCmd(t *testing.T) {
+	impl := &mockImpl{}
+	cmd := NewClusterTraitCmd(impl)
+
+	if cmd.Use != "clustertrait" {
+		t.Errorf("expected Use to be 'clustertrait', got %q", cmd.Use)
+	}
+
+	expectedAliases := map[string]bool{"clustertraits": true}
+	for _, alias := range cmd.Aliases {
+		if !expectedAliases[alias] {
+			t.Errorf("unexpected alias %q", alias)
+		}
+	}
+	if len(cmd.Aliases) != len(expectedAliases) {
+		t.Errorf("expected %d aliases, got %d", len(expectedAliases), len(cmd.Aliases))
+	}
+
+	// Verify list subcommand exists
+	listCmd, _, err := cmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("expected 'list' subcommand to exist: %v", err)
+	}
+	if listCmd.Use != "list" {
+		t.Errorf("expected list subcommand Use to be 'list', got %q", listCmd.Use)
+	}
+}
+
+func TestNewClusterTraitCmd_NoNamespaceFlag(t *testing.T) {
+	impl := &mockImpl{}
+	cmd := NewClusterTraitCmd(impl)
+
+	listCmd, _, err := cmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("expected 'list' subcommand to exist: %v", err)
+	}
+
+	// Cluster-scoped commands should NOT have a namespace flag
+	nsFlag := listCmd.Flags().Lookup("namespace")
+	if nsFlag != nil {
+		t.Error("cluster-scoped command should not have a --namespace flag")
+	}
+}
+
+func TestListClusterTraitCmd_Execute(t *testing.T) {
+	impl := &mockImpl{}
+	cmd := NewClusterTraitCmd(impl)
+	cmd.SetArgs([]string{"list"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error executing list command: %v", err)
+	}
+
+	if !impl.listClusterTraitsCalled {
+		t.Error("expected ListClusterTraits to be called")
+	}
+}
+
+func TestListClusterTraitCmd_ExecuteError(t *testing.T) {
+	impl := &mockImpl{
+		listClusterTraitsErr: fmt.Errorf("api error"),
+	}
+	cmd := NewClusterTraitCmd(impl)
+	cmd.SetArgs([]string{"list"})
+	// Silence usage output on error
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "api error" {
+		t.Errorf("expected 'api error', got %q", err.Error())
+	}
+}

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -497,6 +497,36 @@ This command allows you to:
   occ trait list --namespace acme-corp`,
 	}
 
+	ClusterComponentType = Command{
+		Use:     "clustercomponenttype",
+		Aliases: []string{"cct", "clustercomponenttypes"},
+		Short:   "Manage cluster component types",
+		Long:    `Manage cluster-scoped component types for OpenChoreo.`,
+	}
+
+	ListClusterComponentType = Command{
+		Use:   "list",
+		Short: "List cluster component types",
+		Long:  `List all cluster-scoped component types available across the cluster.`,
+		Example: `  # List all cluster component types
+  occ clustercomponenttype list`,
+	}
+
+	ClusterTrait = Command{
+		Use:     "clustertrait",
+		Aliases: []string{"clustertraits"},
+		Short:   "Manage cluster traits",
+		Long:    `Manage cluster-scoped traits for OpenChoreo.`,
+	}
+
+	ListClusterTrait = Command{
+		Use:   "list",
+		Short: "List cluster traits",
+		Long:  `List all cluster-scoped traits available across the cluster.`,
+		Example: `  # List all cluster traits
+  occ clustertrait list`,
+	}
+
 	ListWorkflow = Command{
 		Use:   "list",
 		Short: "List workflows",

--- a/pkg/cli/core/root/root.go
+++ b/pkg/cli/core/root/root.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/apply"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/buildplane"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clustercomponenttype"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clustertrait"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/component"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/componentrelease"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/componenttype"
@@ -60,7 +62,9 @@ func BuildRootCmd(config *config.CLIConfig, impl api.CommandImplementationInterf
 		buildplane.NewBuildPlaneCmd(impl),
 		observabilityplane.NewObservabilityPlaneCmd(impl),
 		componenttype.NewComponentTypeCmd(impl),
+		clustercomponenttype.NewClusterComponentTypeCmd(impl),
 		trait.NewTraitCmd(impl),
+		clustertrait.NewClusterTraitCmd(impl),
 		workflow.NewWorkflowCmd(impl),
 		componentworkflow.NewComponentWorkflowCmd(impl),
 		workflowrun.NewWorkflowRunCmd(impl),

--- a/pkg/cli/types/api/api.go
+++ b/pkg/cli/types/api/api.go
@@ -20,6 +20,8 @@ type CommandImplementationInterface interface {
 	WorkloadAPI
 	ComponentTypeAPI
 	TraitAPI
+	ClusterComponentTypeAPI
+	ClusterTraitAPI
 	SecretReferenceAPI
 	ComponentReleaseAPI
 	ReleaseBindingAPI
@@ -114,6 +116,16 @@ type ComponentTypeAPI interface {
 // TraitAPI defines trait operations
 type TraitAPI interface {
 	ListTraits(params ListTraitsParams) error
+}
+
+// ClusterComponentTypeAPI defines cluster component type operations
+type ClusterComponentTypeAPI interface {
+	ListClusterComponentTypes() error
+}
+
+// ClusterTraitAPI defines cluster trait operations
+type ClusterTraitAPI interface {
+	ListClusterTraits() error
 }
 
 // SecretReferenceAPI defines secret reference operations


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
  - Add occ clustercomponenttype list and occ clustertrait list CLI commands for interacting with cluster-scoped         
  ClusterComponentType and ClusterTrait resources                                                                      
  - These mirror the existing namespace-scoped componenttype list and trait list commands but do not require a           
  --namespace flag since the resources are cluster-scoped                                                                
  - Add unit tests for command wiring (aliases, subcommands, absence of namespace flag) and output formatters            
  (nil/empty/populated lists, nil spec/timestamp handling)   

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
