### PR TITLE
fix(api): update patch_release_binding tool to use workload_overrides…

### DIFF
--- a/pkg/mcp/tools/component_specs_test.go
+++ b/pkg/mcp/tools/component_specs_test.go
@@ -268,7 +268,7 @@ func componentBindingSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "project_name", "component_name", "binding_name"},
 			optionalParams: []string{
 				"release_name", "environment", "component_type_env_overrides",
-				"trait_overrides", "configuration_overrides",
+				"trait_overrides", "workload_overrides",
 			},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
$subject

## Approach
The input schema previously expected a flat structure (configuration_overrides.env) while the response returned a nested one (workloadOverrides.container.env). Aligned the input to expect the same nesting (workload_overrides.container.env) so the LLM can use the response as a template for the patch.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
