### PR TITLE
refactor: remove redundant Get before Delete in service delete methods

### DIFF
--- a/internal/openchoreo-api/services/buildplane/service.go
+++ b/internal/openchoreo-api/services/buildplane/service.go
@@ -161,20 +161,13 @@ func (s *buildPlaneService) DeleteBuildPlane(ctx context.Context, namespaceName,
 	s.logger.Debug("Deleting build plane", "namespace", namespaceName, "buildPlane", buildPlaneName)
 
 	bp := &openchoreov1alpha1.BuildPlane{}
-	key := client.ObjectKey{
-		Name:      buildPlaneName,
-		Namespace: namespaceName,
-	}
-
-	if err := s.k8sClient.Get(ctx, key, bp); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrBuildPlaneNotFound
-		}
-		s.logger.Error("Failed to get build plane", "error", err)
-		return fmt.Errorf("failed to get build plane: %w", err)
-	}
+	bp.Name = buildPlaneName
+	bp.Namespace = namespaceName
 
 	if err := s.k8sClient.Delete(ctx, bp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrBuildPlaneNotFound
+		}
 		s.logger.Error("Failed to delete build plane CR", "error", err)
 		return fmt.Errorf("failed to delete build plane: %w", err)
 	}

--- a/internal/openchoreo-api/services/clusterbuildplane/service.go
+++ b/internal/openchoreo-api/services/clusterbuildplane/service.go
@@ -148,17 +148,12 @@ func (s *clusterBuildPlaneService) DeleteClusterBuildPlane(ctx context.Context, 
 	s.logger.Debug("Deleting cluster build plane", "clusterBuildPlane", clusterBuildPlaneName)
 
 	cbp := &openchoreov1alpha1.ClusterBuildPlane{}
-	key := client.ObjectKey{Name: clusterBuildPlaneName}
-
-	if err := s.k8sClient.Get(ctx, key, cbp); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrClusterBuildPlaneNotFound
-		}
-		s.logger.Error("Failed to get cluster build plane", "error", err)
-		return fmt.Errorf("failed to get cluster build plane: %w", err)
-	}
+	cbp.Name = clusterBuildPlaneName
 
 	if err := s.k8sClient.Delete(ctx, cbp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrClusterBuildPlaneNotFound
+		}
 		s.logger.Error("Failed to delete cluster build plane CR", "error", err)
 		return fmt.Errorf("failed to delete cluster build plane: %w", err)
 	}

--- a/internal/openchoreo-api/services/clusterdataplane/service.go
+++ b/internal/openchoreo-api/services/clusterdataplane/service.go
@@ -157,18 +157,12 @@ func (s *clusterDataPlaneService) DeleteClusterDataPlane(ctx context.Context, na
 	s.logger.Debug("Deleting cluster data plane", "clusterDataPlane", name)
 
 	cdp := &openchoreov1alpha1.ClusterDataPlane{}
-	key := client.ObjectKey{Name: name}
-
-	if err := s.k8sClient.Get(ctx, key, cdp); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			s.logger.Warn("Cluster data plane not found", "clusterDataPlane", name)
-			return ErrClusterDataPlaneNotFound
-		}
-		s.logger.Error("Failed to get cluster data plane", "error", err)
-		return fmt.Errorf("failed to get cluster data plane: %w", err)
-	}
+	cdp.Name = name
 
 	if err := s.k8sClient.Delete(ctx, cdp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrClusterDataPlaneNotFound
+		}
 		s.logger.Error("Failed to delete cluster data plane CR", "error", err)
 		return fmt.Errorf("failed to delete cluster data plane: %w", err)
 	}

--- a/internal/openchoreo-api/services/clusterobservabilityplane/service.go
+++ b/internal/openchoreo-api/services/clusterobservabilityplane/service.go
@@ -147,17 +147,12 @@ func (s *clusterObservabilityPlaneService) DeleteClusterObservabilityPlane(ctx c
 	s.logger.Debug("Deleting cluster observability plane", "clusterObservabilityPlane", clusterObservabilityPlaneName)
 
 	cop := &openchoreov1alpha1.ClusterObservabilityPlane{}
-	key := client.ObjectKey{Name: clusterObservabilityPlaneName}
-
-	if err := s.k8sClient.Get(ctx, key, cop); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrClusterObservabilityPlaneNotFound
-		}
-		s.logger.Error("Failed to get cluster observability plane", "error", err)
-		return fmt.Errorf("failed to get cluster observability plane: %w", err)
-	}
+	cop.Name = clusterObservabilityPlaneName
 
 	if err := s.k8sClient.Delete(ctx, cop); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrClusterObservabilityPlaneNotFound
+		}
 		s.logger.Error("Failed to delete cluster observability plane CR", "error", err)
 		return fmt.Errorf("failed to delete cluster observability plane: %w", err)
 	}

--- a/internal/openchoreo-api/services/observabilityalertsnotificationchannel/service.go
+++ b/internal/openchoreo-api/services/observabilityalertsnotificationchannel/service.go
@@ -163,21 +163,13 @@ func (s *observabilityAlertsNotificationChannelService) DeleteObservabilityAlert
 	s.logger.Debug("Deleting observability alerts notification channel", "namespace", namespaceName, "channel", channelName)
 
 	nc := &openchoreov1alpha1.ObservabilityAlertsNotificationChannel{}
-	key := client.ObjectKey{
-		Name:      channelName,
-		Namespace: namespaceName,
-	}
-
-	if err := s.k8sClient.Get(ctx, key, nc); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			s.logger.Warn("Observability alerts notification channel not found", "namespace", namespaceName, "channel", channelName)
-			return ErrObservabilityAlertsNotificationChannelNotFound
-		}
-		s.logger.Error("Failed to get observability alerts notification channel", "error", err)
-		return fmt.Errorf("failed to get observability alerts notification channel: %w", err)
-	}
+	nc.Name = channelName
+	nc.Namespace = namespaceName
 
 	if err := s.k8sClient.Delete(ctx, nc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrObservabilityAlertsNotificationChannelNotFound
+		}
 		s.logger.Error("Failed to delete observability alerts notification channel CR", "error", err)
 		return fmt.Errorf("failed to delete observability alerts notification channel: %w", err)
 	}

--- a/internal/openchoreo-api/services/observabilityplane/service.go
+++ b/internal/openchoreo-api/services/observabilityplane/service.go
@@ -155,20 +155,13 @@ func (s *observabilityPlaneService) DeleteObservabilityPlane(ctx context.Context
 	s.logger.Debug("Deleting observability plane", "namespace", namespaceName, "observabilityPlane", observabilityPlaneName)
 
 	op := &openchoreov1alpha1.ObservabilityPlane{}
-	key := client.ObjectKey{
-		Name:      observabilityPlaneName,
-		Namespace: namespaceName,
-	}
-
-	if err := s.k8sClient.Get(ctx, key, op); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrObservabilityPlaneNotFound
-		}
-		s.logger.Error("Failed to get observability plane", "error", err)
-		return fmt.Errorf("failed to get observability plane: %w", err)
-	}
+	op.Name = observabilityPlaneName
+	op.Namespace = namespaceName
 
 	if err := s.k8sClient.Delete(ctx, op); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrObservabilityPlaneNotFound
+		}
 		s.logger.Error("Failed to delete observability plane CR", "error", err)
 		return fmt.Errorf("failed to delete observability plane: %w", err)
 	}

--- a/internal/openchoreo-api/services/releasebinding/service.go
+++ b/internal/openchoreo-api/services/releasebinding/service.go
@@ -188,23 +188,11 @@ func (s *releaseBindingService) DeleteReleaseBinding(ctx context.Context, namesp
 	s.logger.Debug("Deleting release binding", "namespace", namespaceName, "releaseBinding", releaseBindingName)
 
 	rb := &openchoreov1alpha1.ReleaseBinding{}
-	key := client.ObjectKey{
-		Name:      releaseBindingName,
-		Namespace: namespaceName,
-	}
-
-	if err := s.k8sClient.Get(ctx, key, rb); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			s.logger.Warn("Release binding not found", "namespace", namespaceName, "releaseBinding", releaseBindingName)
-			return ErrReleaseBindingNotFound
-		}
-		s.logger.Error("Failed to get release binding", "error", err)
-		return fmt.Errorf("failed to get release binding: %w", err)
-	}
+	rb.Name = releaseBindingName
+	rb.Namespace = namespaceName
 
 	if err := s.k8sClient.Delete(ctx, rb); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			s.logger.Warn("Release binding not found during delete", "namespace", namespaceName, "releaseBinding", releaseBindingName)
+		if apierrors.IsNotFound(err) {
 			return ErrReleaseBindingNotFound
 		}
 		s.logger.Error("Failed to delete release binding CR", "error", err)

--- a/internal/openchoreo-api/services/workload/service.go
+++ b/internal/openchoreo-api/services/workload/service.go
@@ -188,23 +188,11 @@ func (s *workloadService) DeleteWorkload(ctx context.Context, namespaceName, wor
 	s.logger.Debug("Deleting workload", "namespace", namespaceName, "workload", workloadName)
 
 	w := &openchoreov1alpha1.Workload{}
-	key := client.ObjectKey{
-		Name:      workloadName,
-		Namespace: namespaceName,
-	}
-
-	if err := s.k8sClient.Get(ctx, key, w); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			s.logger.Warn("Workload not found", "namespace", namespaceName, "workload", workloadName)
-			return ErrWorkloadNotFound
-		}
-		s.logger.Error("Failed to get workload", "error", err)
-		return fmt.Errorf("failed to get workload: %w", err)
-	}
+	w.Name = workloadName
+	w.Namespace = namespaceName
 
 	if err := s.k8sClient.Delete(ctx, w); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			s.logger.Warn("Workload not found during delete", "namespace", namespaceName, "workload", workloadName)
+		if apierrors.IsNotFound(err) {
 			return ErrWorkloadNotFound
 		}
 		s.logger.Error("Failed to delete workload CR", "error", err)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The K8s controller-runtime client.Delete already returns a NotFound error when the resource doesn't exist, making the preceding Get call  an unnecessary extra round trip to the API server. Replace the get-then-delete pattern with a direct Delete + apierrors.IsNotFound check across all 15 affected services.
## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2008

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
