### PR TITLE
fix: wrap ListComponentTraits MCP response in record type

### DIFF
--- a/internal/openchoreo-api/mcphandlers/components.go
+++ b/internal/openchoreo-api/mcphandlers/components.go
@@ -32,6 +32,10 @@ type ListComponentWorkflowsResponse struct {
 	Workflows []*models.WorkflowResponse `json:"workflows"`
 }
 
+type ListComponentTraitsResponse struct {
+	Traits []*models.ComponentTraitResponse `json:"traits"`
+}
+
 func (h *MCPHandler) CreateComponent(ctx context.Context, namespaceName, projectName string, req *models.CreateComponentRequest) (any, error) {
 	return h.Services.ComponentService.CreateComponent(ctx, namespaceName, projectName, req)
 }
@@ -136,7 +140,13 @@ func (h *MCPHandler) GetComponentReleaseSchema(ctx context.Context, namespaceNam
 }
 
 func (h *MCPHandler) ListComponentTraits(ctx context.Context, namespaceName, projectName, componentName string) (any, error) {
-	return h.Services.ComponentService.ListComponentTraits(ctx, namespaceName, projectName, componentName)
+	traits, err := h.Services.ComponentService.ListComponentTraits(ctx, namespaceName, projectName, componentName)
+	if err != nil {
+		return ListComponentTraitsResponse{}, err
+	}
+	return ListComponentTraitsResponse{
+		Traits: traits,
+	}, nil
 }
 
 func (h *MCPHandler) UpdateComponentTraits(ctx context.Context, namespaceName, projectName, componentName string, req *models.UpdateComponentTraitsRequest) (any, error) {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
list_component_traits returned a raw array as structuredContent, but the MCP SDK expects a record (object). Update the tool to match the pattern used by all other list tools and fix validation errors

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
