### PR TITLE
chore: updated samples for v0.16

### DIFF
--- a/docs/install-guide-multi-cluster.md
+++ b/docs/install-guide-multi-cluster.md
@@ -301,7 +301,7 @@ If you want to uninstall `occ` from your host machine, you can use the [script](
 Run the following command to uninstall `occ`:
 
 ```shell
-curl -sL https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/install/occ-uninstall.sh | bash
+curl -sL https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/install/occ-uninstall.sh | bash
 ```
 
 ## Access Your Deployed Services

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -104,7 +104,7 @@ samples-gen: ## Generate samples/getting-started/all.yaml from individual files
 	printf '# environments, pipeline, component types, workflows, and traits.\n'; \
 	printf '#\n'; \
 	printf '# Usage:\n'; \
-	printf '#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/getting-started/all.yaml\n'; \
+	printf '#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/getting-started/all.yaml\n'; \
 	printf '#\n'; \
 	printf '# Or if you have cloned the repository:\n'; \
 	printf '#   kubectl apply -f samples/getting-started/all.yaml\n'; \

--- a/samples/README.md
+++ b/samples/README.md
@@ -7,7 +7,7 @@ This directory contains sample implementations to help you understand, configure
 **[Getting Started](./getting-started)** contains the default resources needed to use OpenChoreo. Apply these after installing the control plane:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/getting-started/all.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/getting-started/all.yaml
 ```
 
 This creates a default project, three environments (development, staging, production), component types (service, web-application, scheduled-task), build workflows, and traits. See the [getting-started README](./getting-started/README.md) for details.

--- a/samples/component-types/component-http-service/README.md
+++ b/samples/component-types/component-http-service/README.md
@@ -62,7 +62,7 @@ The OpenChoreo controller manager uses these resources and generates the Kuberne
 Apply the sample:
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-http-service/http-service-component.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-http-service/http-service-component.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -99,7 +99,7 @@ Hello, Alice!
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-http-service/http-service-component.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-http-service/http-service-component.yaml
 ```
 
 ## Troubleshooting

--- a/samples/component-types/component-web-app/README.md
+++ b/samples/component-types/component-web-app/README.md
@@ -59,7 +59,7 @@ The controller reads these resources and generates the Kubernetes resources (Dep
 Apply the sample:
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-web-app/webapp-component.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-web-app/webapp-component.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -77,7 +77,7 @@ Open your web browser and go to http://demo-app-web-service-development-default.
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-web-app/webapp-component.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-web-app/webapp-component.yaml
 ```
 
 ## Troubleshooting

--- a/samples/component-types/component-with-api-management/README.md
+++ b/samples/component-types/component-with-api-management/README.md
@@ -246,7 +246,7 @@ The `RestApi` resource is processed by the WSO2 API Platform Gateway which:
 Deploy the example:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-api-management/component-with-api-management.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-with-api-management/component-with-api-management.yaml
 ```
 
 Verify resources created:

--- a/samples/component-types/component-with-configs/README.md
+++ b/samples/component-types/component-with-configs/README.md
@@ -94,7 +94,7 @@ The OpenChoreo controller manager uses these resources and generates the Kuberne
 Apply the sample:
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-configs/component-with-configs.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-with-configs/component-with-configs.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -166,7 +166,7 @@ schema_generation:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-configs/component-with-configs.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-with-configs/component-with-configs.yaml
 ```
 
 ## Troubleshooting

--- a/samples/component-types/component-with-embedded-traits/README.md
+++ b/samples/component-types/component-with-embedded-traits/README.md
@@ -100,7 +100,7 @@ Defines deployment settings for the `development` environment:
 Apply the sample:
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
 ```
 
 ## Check the ReleaseBinding status
@@ -168,7 +168,7 @@ Hello, Alice!
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/main/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/refs/heads/release-v0.16/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
 ```
 
 ## Troubleshooting

--- a/samples/from-image/echo-websocket-service/README.md
+++ b/samples/from-image/echo-websocket-service/README.md
@@ -40,7 +40,7 @@ EOF
 The following command will create the relevant resources in OpenChoreo:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
 ```
 
 > [!NOTE]
@@ -99,5 +99,5 @@ If you cannot access the service:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
 ```

--- a/samples/from-image/go-greeter-service/README.md
+++ b/samples/from-image/go-greeter-service/README.md
@@ -20,7 +20,7 @@ Exposed REST endpoints:
 The following command will create the relevant resources in OpenChoreo:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/go-greeter-service/greeter-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/go-greeter-service/greeter-service.yaml
 ```
 
 > [!NOTE]
@@ -82,5 +82,5 @@ If you cannot access the service:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/go-greeter-service/greeter-service.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/go-greeter-service/greeter-service.yaml
 ```

--- a/samples/from-image/issue-reporter-schedule-task/README.md
+++ b/samples/from-image/issue-reporter-schedule-task/README.md
@@ -18,7 +18,7 @@ Features:
 The following command will create the relevant resources in OpenChoreo:
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
 ```
 
 > [!NOTE]
@@ -128,5 +128,5 @@ You can also override the schedule for specific environments by modifying the `R
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
 ```

--- a/samples/from-image/react-starter-web-app/README.md
+++ b/samples/from-image/react-starter-web-app/README.md
@@ -12,7 +12,7 @@ The application is deployed from the pre-built image:
 The following command will create the relevant resources in OpenChoreo:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/react-starter-web-app/react-starter.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/react-starter-web-app/react-starter.yaml
 ```
 
 > [!NOTE]
@@ -74,5 +74,5 @@ If you cannot access the application:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/react-starter-web-app/react-starter.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-image/react-starter-web-app/react-starter.yaml
 ```

--- a/samples/from-source/services/ballerina-buildpack-patient-management/README.md
+++ b/samples/from-source/services/ballerina-buildpack-patient-management/README.md
@@ -42,7 +42,7 @@ https://github.com/wso2/choreo-samples/tree/main/patient-management-service
 The following command will create the relevant resources in OpenChoreo. It will also trigger a workflow by creating a workflow resource.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/services/ballerina-buildpack-patient-management/patient-management-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/services/ballerina-buildpack-patient-management/patient-management-service.yaml
 ```
 
 > [!NOTE]
@@ -186,5 +186,5 @@ If the application is not accessible:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/services/ballerina-buildpack-patient-management/patient-management-service.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/services/ballerina-buildpack-patient-management/patient-management-service.yaml
 ```

--- a/samples/from-source/services/go-docker-greeter/README.md
+++ b/samples/from-source/services/go-docker-greeter/README.md
@@ -21,7 +21,7 @@ https://github.com/wso2/choreo-samples/tree/main/greeting-service-go
 The following command will create the relevant resources in OpenChoreo. It will also trigger a workflow by creating a workflow resource.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/services/go-docker-greeter/greeting-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/services/go-docker-greeter/greeting-service.yaml
 ```
 
 > [!NOTE]
@@ -150,5 +150,5 @@ If the application is not accessible:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/services/go-docker-greeter/greeting-service.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/services/go-docker-greeter/greeting-service.yaml
 ```

--- a/samples/from-source/services/go-google-buildpack-reading-list/README.md
+++ b/samples/from-source/services/go-google-buildpack-reading-list/README.md
@@ -41,7 +41,7 @@ https://github.com/wso2/choreo-samples/tree/main/go-reading-list-rest-api
 The following command will create the relevant resources in OpenChoreo. It will also trigger a workflow by creating a workflow resource.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/services/go-google-buildpack-reading-list/reading-list-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/services/go-google-buildpack-reading-list/reading-list-service.yaml
 ```
 
 > [!NOTE]
@@ -196,5 +196,5 @@ If the application is not accessible:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/services/go-google-buildpack-reading-list/reading-list-service.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/services/go-google-buildpack-reading-list/reading-list-service.yaml
 ```

--- a/samples/from-source/web-apps/react-starter/README.md
+++ b/samples/from-source/web-apps/react-starter/README.md
@@ -12,7 +12,7 @@ https://github.com/openchoreo/sample-workloads/tree/main/webapp-react-nginx
 The following command will create the relevant resources in OpenChoreo:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/web-apps/react-starter/react-web-app.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/web-apps/react-starter/react-web-app.yaml
 ```
 
 > [!NOTE]
@@ -134,5 +134,5 @@ If the application is not accessible:
 Remove all resources:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-source/web-apps/react-starter/react-web-app.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/from-source/web-apps/react-starter/react-web-app.yaml
 ```

--- a/samples/gcp-microservices-demo/README.md
+++ b/samples/gcp-microservices-demo/README.md
@@ -47,7 +47,7 @@ gcp-microservices-demo/
 First, create the project that will contain all the microservices:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
 ```
 
 ## Step 2: Deploy the Components
@@ -56,17 +56,17 @@ Deploy all the microservices components:
 
 ```bash
 kubectl apply \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/ad-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/cart-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/checkout-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/currency-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/email-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/frontend-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/payment-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/productcatalog-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/recommendation-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/redis-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/shipping-component.yaml
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/ad-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/cart-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/checkout-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/currency-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/email-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/frontend-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/payment-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/productcatalog-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/recommendation-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/redis-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/shipping-component.yaml
 ```
 
 This will deploy all the microservices using official Google Container Registry images.
@@ -98,18 +98,18 @@ Remove all resources:
 ```bash
 # Remove components
 kubectl delete \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/ad-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/cart-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/checkout-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/currency-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/email-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/frontend-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/payment-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/productcatalog-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/recommendation-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/redis-component.yaml \
--f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/components/shipping-component.yaml
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/ad-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/cart-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/checkout-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/currency-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/email-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/frontend-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/payment-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/productcatalog-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/recommendation-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/redis-component.yaml \
+-f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/components/shipping-component.yaml
 
 # Remove project
-kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
 ```

--- a/samples/getting-started/README.md
+++ b/samples/getting-started/README.md
@@ -7,7 +7,7 @@ Default resources for OpenChoreo. Apply these after installing the control plane
 Apply all resources with a single command:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/getting-started/all.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/getting-started/all.yaml
 ```
 
 Or if you have cloned the repository:

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -7,7 +7,7 @@
 # environments, pipeline, component types, workflows, and traits.
 #
 # Usage:
-#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/getting-started/all.yaml
+#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/getting-started/all.yaml
 #
 # Or if you have cloned the repository:
 #   kubectl apply -f samples/getting-started/all.yaml

--- a/samples/platform-config/new-deployment-pipeline/README.md
+++ b/samples/platform-config/new-deployment-pipeline/README.md
@@ -9,5 +9,5 @@ In this sample the new deployment pipeline facilitates promoting from developmen
 Use the following command to create the new deployment pipeline.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/platform-config/new-deployment-pipeline/deployment-pipeline.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/platform-config/new-deployment-pipeline/deployment-pipeline.yaml
 ```

--- a/samples/platform-config/new-environments/README.md
+++ b/samples/platform-config/new-environments/README.md
@@ -18,8 +18,8 @@ We will create four such environments in your namespace.
 Use the following command to create new environments.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/platform-config/new-environments/development-environment.yaml
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/platform-config/new-environments/qa-environment.yaml
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/platform-config/new-environments/pre-production-environment.yaml
-kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/platform-config/new-environments/production-environment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/platform-config/new-environments/development-environment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/platform-config/new-environments/qa-environment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/platform-config/new-environments/pre-production-environment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.16/samples/platform-config/new-environments/production-environment.yaml
 ```


### PR DESCRIPTION
updates sample docs and references for v0.16 release

changes:
- version bumps across sample READMEs
- updated install guide reference
- lint config update