### PR TITLE
fix: move auth server base URL for observability plane

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -66,6 +66,10 @@ spec:
           value: /etc/openchoreo/auth-config.yaml
         - name: AUTHZ_SERVICE_URL
           value: {{ .Values.observer.controlPlaneApiUrl | quote }}
+        {{- if .Values.security.oidc.authServerBaseUrl }}
+        - name: AUTH_SERVER_BASE_URL
+          value: {{ .Values.security.oidc.authServerBaseUrl | quote }}
+        {{- end }}
         {{- if .Values.observer.extraEnvs }}
         {{- toYaml .Values.observer.extraEnvs | nindent 8 }}
         {{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -3699,6 +3699,12 @@
           "additionalProperties": false,
           "description": "OIDC configuration",
           "properties": {
+            "authServerBaseUrl": {
+              "default": "",
+              "description": "Base URL for the authorization server (used for OAuth metadata)",
+              "title": "authServerBaseUrl",
+              "type": "string"
+            },
             "issuer": {
               "default": "",
               "description": "OIDC issuer URL",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -861,8 +861,6 @@ observer:
   extraEnvs:
   - name: OBSERVER_BASE_URL
     value: "http://localhost:11080"
-  - name: AUTH_SERVER_BASE_URL
-    value: "http://thunder.openchoreo.invalid:8080"
   - name: OPENSEARCH_ADDRESS
     value: "https://opensearch:9200"
   - name: PROMETHEUS_ADDRESS
@@ -2784,6 +2782,12 @@ security:
     # default: "false"
     # @schema
     jwksUrlTlsInsecureSkipVerify: "false"
+    # @schema
+    # type: string
+    # description: Base URL for the authorization server (used for OAuth metadata)
+    # default: ""
+    # @schema
+    authServerBaseUrl: ""
   # @schema
   # type: object
   # description: JWT configuration

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -13,8 +13,6 @@ observer:
   extraEnvs:
   - name: OBSERVER_BASE_URL
     value: "http://observer.openchoreo.localhost:11080"
-  - name: AUTH_SERVER_BASE_URL
-    value: "http://thunder.openchoreo.localhost:8080"
   - name: OPENSEARCH_ADDRESS
     value: "https://opensearch:9200"
   - name: PROMETHEUS_ADDRESS
@@ -37,6 +35,7 @@ security:
     jwksUrl: "http://thunder.openchoreo.localhost:8080/oauth2/jwks"
     tokenUrl: "http://thunder.openchoreo.localhost:8080/oauth2/token"
     jwksUrlTlsInsecureSkipVerify: "true"
+    authServerBaseUrl: "http://thunder.openchoreo.localhost:8080"
 
 gateway:
   httpPort: 11080

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -26,6 +26,7 @@ security:
   oidc:
     jwksUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
     tokenUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/token"
+    authServerBaseUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090"
 
 gateway:
   httpPort: 11080


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Currently, the MCP authentication doesn't happen automatically since the oauth protected resource is not returning the auth server base URL correctly.

## Approach
Move the auth server base URL to `security.oidc.authServerBaseUrl`

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
