### PR TITLE
feat: add finalizer to deploymentpipeline

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,18 +110,19 @@ func setupControlPlaneControllers(
 		return fmt.Errorf("failed to setup shared indexes: %w", err)
 	}
 
+	if err := (&deploymentpipeline.Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
 	if enableLegacyCRDs {
 		if err := (&environment.Reconciler{
 			Client:       mgr.GetClient(),
 			K8sClientMgr: k8sClientMgr,
 			Scheme:       mgr.GetScheme(),
 			GatewayURL:   clusterGatewayURL,
-		}).SetupWithManager(mgr); err != nil {
-			return err
-		}
-		if err := (&deploymentpipeline.Reconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
 		}).SetupWithManager(mgr); err != nil {
 			return err
 		}

--- a/internal/controller/deploymentpipeline/controller_finalize.go
+++ b/internal/controller/deploymentpipeline/controller_finalize.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deploymentpipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+const (
+	// PipelineCleanupFinalizer prevents the DeploymentPipeline from being deleted
+	// while Projects that reference it are still finalizing. Projects depend on
+	// the DeploymentPipeline to resolve environment names and compute data plane
+	// namespace names during their own cleanup.
+	PipelineCleanupFinalizer = "openchoreo.dev/deployment-pipeline-cleanup"
+)
+
+// finalize removes the finalizer once no Projects reference this DeploymentPipeline.
+func (r *Reconciler) finalize(ctx context.Context, pipeline *openchoreov1alpha1.DeploymentPipeline) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("deploymentPipeline", pipeline.Name)
+
+	if !controllerutil.ContainsFinalizer(pipeline, PipelineCleanupFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	hasRefs, err := r.hasReferencingProjects(ctx, pipeline)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check referencing projects: %w", err)
+	}
+
+	if hasRefs {
+		logger.Info("Waiting for referencing Projects to be deleted before removing finalizer")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	if controllerutil.RemoveFinalizer(pipeline, PipelineCleanupFinalizer) {
+		if err := r.Update(ctx, pipeline); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		}
+	}
+
+	logger.Info("Successfully finalized DeploymentPipeline")
+	return ctrl.Result{}, nil
+}
+
+// hasReferencingProjects checks if any Projects in the same namespace reference this DeploymentPipeline.
+func (r *Reconciler) hasReferencingProjects(ctx context.Context, pipeline *openchoreov1alpha1.DeploymentPipeline) (bool, error) {
+	projectList := &openchoreov1alpha1.ProjectList{}
+	if err := r.List(ctx, projectList,
+		client.InNamespace(pipeline.Namespace),
+		client.MatchingFields{controller.IndexKeyProjectDeploymentPipelineRef: pipeline.Name},
+	); err != nil {
+		return false, fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	return len(projectList.Items) > 0, nil
+}

--- a/internal/controller/deploymentpipeline/suite_test.go
+++ b/internal/controller/deploymentpipeline/suite_test.go
@@ -14,12 +14,16 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -68,10 +72,56 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	// Create a manager with cache enabled for Project (needed for field index queries
+	// in the DeploymentPipeline finalizer). All other types bypass cache.
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&openchoreov1alpha1.Project{}: {},
+			},
+			DefaultNamespaces: map[string]cache.Config{},
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&openchoreov1alpha1.DataPlane{},
+					&openchoreov1alpha1.Environment{},
+					&openchoreov1alpha1.DeploymentPipeline{},
+				},
+			},
+		},
+	})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
 
+	// Register the field index used by the DeploymentPipeline finalizer to find referencing Projects
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},
+		controller.IndexKeyProjectDeploymentPipelineRef, func(obj client.Object) []string {
+			project := obj.(*openchoreov1alpha1.Project)
+			if project.Spec.DeploymentPipelineRef == "" {
+				return nil
+			}
+			return []string{project.Spec.DeploymentPipelineRef}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Start the manager in a goroutine
+	go func() {
+		defer GinkgoRecover()
+		err := mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// Wait for cache to sync before running tests
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+	// Use the manager's client which has field index support for Project
+	// but reads directly from API server for other types
+	k8sClient = mgr.GetClient()
+	Expect(k8sClient).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
## Purpose
> 
```
When a namespace is deleted via `kubectl delete namespace`, Kubernetes garbage-collects all resources within it. The `DeploymentPipeline` CRD has **no finalizer**, so it is deleted immediately. However, `Project` resources have the `openchoreo.dev/project-cleanup` finalizer, so they survive and enter finalization.

The finalization call chain fails:

1. `finalize()` → `deleteChildAndLinkedResources()`
2. → `deleteExternalResourcesAndWait()` → `makeProjectContext()`
3. → `findDeploymentPipeline()` → **NotFound error** (pipeline already deleted)
4. Error propagates up → finalizer never removed → **namespace stuck in Terminating forever**
```

## Approach
> Summarize the solution and implementation details.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/2236

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
