### PR TITLE
refactor: remove hyphens from API paths to adhere to the new convention

### DIFF
--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -6655,7 +6655,7 @@ func NewListDeploymentPipelinesRequest(server string, namespaceName NamespaceNam
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deployment-pipelines", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deploymentpipelines", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6738,7 +6738,7 @@ func NewCreateDeploymentPipelineRequestWithBody(server string, namespaceName Nam
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deployment-pipelines", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deploymentpipelines", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6781,7 +6781,7 @@ func NewDeleteDeploymentPipelineRequest(server string, namespaceName NamespaceNa
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deployment-pipelines/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deploymentpipelines/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6822,7 +6822,7 @@ func NewGetDeploymentPipelineRequest(server string, namespaceName NamespaceNameP
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deployment-pipelines/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deploymentpipelines/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6874,7 +6874,7 @@ func NewUpdateDeploymentPipelineRequestWithBody(server string, namespaceName Nam
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deployment-pipelines/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/deploymentpipelines/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -7247,7 +7247,7 @@ func NewListObservabilityAlertsNotificationChannelsRequest(server string, namesp
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observability-alerts-notification-channels", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observabilityalertsnotificationchannels", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -7330,7 +7330,7 @@ func NewCreateObservabilityAlertsNotificationChannelRequestWithBody(server strin
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observability-alerts-notification-channels", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observabilityalertsnotificationchannels", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -7373,7 +7373,7 @@ func NewDeleteObservabilityAlertsNotificationChannelRequest(server string, names
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observability-alerts-notification-channels/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observabilityalertsnotificationchannels/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -7414,7 +7414,7 @@ func NewGetObservabilityAlertsNotificationChannelRequest(server string, namespac
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observability-alerts-notification-channels/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observabilityalertsnotificationchannels/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -7466,7 +7466,7 @@ func NewUpdateObservabilityAlertsNotificationChannelRequestWithBody(server strin
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observability-alerts-notification-channels/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/observabilityalertsnotificationchannels/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -9227,7 +9227,7 @@ func NewListSecretReferencesRequest(server string, namespaceName NamespaceNamePa
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secret-references", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secretreferences", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -9310,7 +9310,7 @@ func NewCreateSecretReferenceRequestWithBody(server string, namespaceName Namesp
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secret-references", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secretreferences", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -9353,7 +9353,7 @@ func NewDeleteSecretReferenceRequest(server string, namespaceName NamespaceNameP
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secret-references/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secretreferences/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -9394,7 +9394,7 @@ func NewGetSecretReferenceRequest(server string, namespaceName NamespaceNamePara
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secret-references/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secretreferences/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -9446,7 +9446,7 @@ func NewUpdateSecretReferenceRequestWithBody(server string, namespaceName Namesp
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secret-references/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/secretreferences/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}

--- a/internal/openchoreo-api/api/gen/server.gen.go
+++ b/internal/openchoreo-api/api/gen/server.gen.go
@@ -247,19 +247,19 @@ type ServerInterface interface {
 	// (PUT /api/v1/namespaces/{namespaceName}/dataplanes/{dpName})
 	UpdateDataPlane(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, dpName DataPlaneNameParam)
 	// List deployment pipelines
-	// (GET /api/v1/namespaces/{namespaceName}/deployment-pipelines)
+	// (GET /api/v1/namespaces/{namespaceName}/deploymentpipelines)
 	ListDeploymentPipelines(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListDeploymentPipelinesParams)
 	// Create deployment pipeline
-	// (POST /api/v1/namespaces/{namespaceName}/deployment-pipelines)
+	// (POST /api/v1/namespaces/{namespaceName}/deploymentpipelines)
 	CreateDeploymentPipeline(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// Delete deployment pipeline
-	// (DELETE /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName})
+	// (DELETE /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName})
 	DeleteDeploymentPipeline(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, deploymentPipelineName DeploymentPipelineNameParam)
 	// Get deployment pipeline
-	// (GET /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName})
+	// (GET /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName})
 	GetDeploymentPipeline(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, deploymentPipelineName DeploymentPipelineNameParam)
 	// Update deployment pipeline
-	// (PUT /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName})
+	// (PUT /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName})
 	UpdateDeploymentPipeline(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, deploymentPipelineName DeploymentPipelineNameParam)
 	// List environments
 	// (GET /api/v1/namespaces/{namespaceName}/environments)
@@ -283,19 +283,19 @@ type ServerInterface interface {
 	// (GET /api/v1/namespaces/{namespaceName}/environments/{envName}/rca-agent-url)
 	GetRCAAgentURL(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, envName EnvironmentNameParam)
 	// List observability alerts notification channels
-	// (GET /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels)
+	// (GET /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels)
 	ListObservabilityAlertsNotificationChannels(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListObservabilityAlertsNotificationChannelsParams)
 	// Create observability alerts notification channel
-	// (POST /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels)
+	// (POST /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels)
 	CreateObservabilityAlertsNotificationChannel(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// Delete observability alerts notification channel
-	// (DELETE /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName})
+	// (DELETE /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName})
 	DeleteObservabilityAlertsNotificationChannel(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, observabilityAlertsNotificationChannelName ObservabilityAlertsNotificationChannelNameParam)
 	// Get observability alerts notification channel
-	// (GET /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName})
+	// (GET /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName})
 	GetObservabilityAlertsNotificationChannel(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, observabilityAlertsNotificationChannelName ObservabilityAlertsNotificationChannelNameParam)
 	// Update observability alerts notification channel
-	// (PUT /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName})
+	// (PUT /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName})
 	UpdateObservabilityAlertsNotificationChannel(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, observabilityAlertsNotificationChannelName ObservabilityAlertsNotificationChannelNameParam)
 	// List observability planes
 	// (GET /api/v1/namespaces/{namespaceName}/observabilityplanes)
@@ -388,19 +388,19 @@ type ServerInterface interface {
 	// (PUT /api/v1/namespaces/{namespaceName}/roles/{name})
 	UpdateNamespaceRole(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, name string)
 	// List secret references
-	// (GET /api/v1/namespaces/{namespaceName}/secret-references)
+	// (GET /api/v1/namespaces/{namespaceName}/secretreferences)
 	ListSecretReferences(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListSecretReferencesParams)
 	// Create secret reference
-	// (POST /api/v1/namespaces/{namespaceName}/secret-references)
+	// (POST /api/v1/namespaces/{namespaceName}/secretreferences)
 	CreateSecretReference(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam)
 	// Delete secret reference
-	// (DELETE /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName})
+	// (DELETE /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName})
 	DeleteSecretReference(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, secretReferenceName SecretReferenceNameParam)
 	// Get secret reference
-	// (GET /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName})
+	// (GET /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName})
 	GetSecretReference(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, secretReferenceName SecretReferenceNameParam)
 	// Update secret reference
-	// (PUT /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName})
+	// (PUT /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName})
 	UpdateSecretReference(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, secretReferenceName SecretReferenceNameParam)
 	// List traits
 	// (GET /api/v1/namespaces/{namespaceName}/traits)
@@ -6524,11 +6524,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/dataplanes/{dpName}", wrapper.DeleteDataPlane)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/dataplanes/{dpName}", wrapper.GetDataPlane)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/dataplanes/{dpName}", wrapper.UpdateDataPlane)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deployment-pipelines", wrapper.ListDeploymentPipelines)
-	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deployment-pipelines", wrapper.CreateDeploymentPipeline)
-	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}", wrapper.DeleteDeploymentPipeline)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}", wrapper.GetDeploymentPipeline)
-	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}", wrapper.UpdateDeploymentPipeline)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deploymentpipelines", wrapper.ListDeploymentPipelines)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deploymentpipelines", wrapper.CreateDeploymentPipeline)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}", wrapper.DeleteDeploymentPipeline)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}", wrapper.GetDeploymentPipeline)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}", wrapper.UpdateDeploymentPipeline)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/environments", wrapper.ListEnvironments)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/environments", wrapper.CreateEnvironment)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/environments/{envName}", wrapper.DeleteEnvironment)
@@ -6536,11 +6536,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/environments/{envName}", wrapper.UpdateEnvironment)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/environments/{envName}/observer-url", wrapper.GetEnvironmentObserverURL)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/environments/{envName}/rca-agent-url", wrapper.GetRCAAgentURL)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels", wrapper.ListObservabilityAlertsNotificationChannels)
-	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels", wrapper.CreateObservabilityAlertsNotificationChannel)
-	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName}", wrapper.DeleteObservabilityAlertsNotificationChannel)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName}", wrapper.GetObservabilityAlertsNotificationChannel)
-	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName}", wrapper.UpdateObservabilityAlertsNotificationChannel)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels", wrapper.ListObservabilityAlertsNotificationChannels)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels", wrapper.CreateObservabilityAlertsNotificationChannel)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName}", wrapper.DeleteObservabilityAlertsNotificationChannel)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName}", wrapper.GetObservabilityAlertsNotificationChannel)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName}", wrapper.UpdateObservabilityAlertsNotificationChannel)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityplanes", wrapper.ListObservabilityPlanes)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityplanes", wrapper.CreateObservabilityPlane)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/observabilityplanes/{observabilityPlaneName}", wrapper.DeleteObservabilityPlane)
@@ -6571,11 +6571,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/roles/{name}", wrapper.DeleteNamespaceRole)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/roles/{name}", wrapper.GetNamespaceRole)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/roles/{name}", wrapper.UpdateNamespaceRole)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secret-references", wrapper.ListSecretReferences)
-	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secret-references", wrapper.CreateSecretReference)
-	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName}", wrapper.DeleteSecretReference)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName}", wrapper.GetSecretReference)
-	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName}", wrapper.UpdateSecretReference)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secretreferences", wrapper.ListSecretReferences)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secretreferences", wrapper.CreateSecretReference)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}", wrapper.DeleteSecretReference)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}", wrapper.GetSecretReference)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}", wrapper.UpdateSecretReference)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/traits", wrapper.ListTraits)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/traits", wrapper.CreateTrait)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/traits/{traitName}", wrapper.DeleteTrait)
@@ -15428,19 +15428,19 @@ type StrictServerInterface interface {
 	// (PUT /api/v1/namespaces/{namespaceName}/dataplanes/{dpName})
 	UpdateDataPlane(ctx context.Context, request UpdateDataPlaneRequestObject) (UpdateDataPlaneResponseObject, error)
 	// List deployment pipelines
-	// (GET /api/v1/namespaces/{namespaceName}/deployment-pipelines)
+	// (GET /api/v1/namespaces/{namespaceName}/deploymentpipelines)
 	ListDeploymentPipelines(ctx context.Context, request ListDeploymentPipelinesRequestObject) (ListDeploymentPipelinesResponseObject, error)
 	// Create deployment pipeline
-	// (POST /api/v1/namespaces/{namespaceName}/deployment-pipelines)
+	// (POST /api/v1/namespaces/{namespaceName}/deploymentpipelines)
 	CreateDeploymentPipeline(ctx context.Context, request CreateDeploymentPipelineRequestObject) (CreateDeploymentPipelineResponseObject, error)
 	// Delete deployment pipeline
-	// (DELETE /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName})
+	// (DELETE /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName})
 	DeleteDeploymentPipeline(ctx context.Context, request DeleteDeploymentPipelineRequestObject) (DeleteDeploymentPipelineResponseObject, error)
 	// Get deployment pipeline
-	// (GET /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName})
+	// (GET /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName})
 	GetDeploymentPipeline(ctx context.Context, request GetDeploymentPipelineRequestObject) (GetDeploymentPipelineResponseObject, error)
 	// Update deployment pipeline
-	// (PUT /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName})
+	// (PUT /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName})
 	UpdateDeploymentPipeline(ctx context.Context, request UpdateDeploymentPipelineRequestObject) (UpdateDeploymentPipelineResponseObject, error)
 	// List environments
 	// (GET /api/v1/namespaces/{namespaceName}/environments)
@@ -15464,19 +15464,19 @@ type StrictServerInterface interface {
 	// (GET /api/v1/namespaces/{namespaceName}/environments/{envName}/rca-agent-url)
 	GetRCAAgentURL(ctx context.Context, request GetRCAAgentURLRequestObject) (GetRCAAgentURLResponseObject, error)
 	// List observability alerts notification channels
-	// (GET /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels)
+	// (GET /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels)
 	ListObservabilityAlertsNotificationChannels(ctx context.Context, request ListObservabilityAlertsNotificationChannelsRequestObject) (ListObservabilityAlertsNotificationChannelsResponseObject, error)
 	// Create observability alerts notification channel
-	// (POST /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels)
+	// (POST /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels)
 	CreateObservabilityAlertsNotificationChannel(ctx context.Context, request CreateObservabilityAlertsNotificationChannelRequestObject) (CreateObservabilityAlertsNotificationChannelResponseObject, error)
 	// Delete observability alerts notification channel
-	// (DELETE /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName})
+	// (DELETE /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName})
 	DeleteObservabilityAlertsNotificationChannel(ctx context.Context, request DeleteObservabilityAlertsNotificationChannelRequestObject) (DeleteObservabilityAlertsNotificationChannelResponseObject, error)
 	// Get observability alerts notification channel
-	// (GET /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName})
+	// (GET /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName})
 	GetObservabilityAlertsNotificationChannel(ctx context.Context, request GetObservabilityAlertsNotificationChannelRequestObject) (GetObservabilityAlertsNotificationChannelResponseObject, error)
 	// Update observability alerts notification channel
-	// (PUT /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName})
+	// (PUT /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName})
 	UpdateObservabilityAlertsNotificationChannel(ctx context.Context, request UpdateObservabilityAlertsNotificationChannelRequestObject) (UpdateObservabilityAlertsNotificationChannelResponseObject, error)
 	// List observability planes
 	// (GET /api/v1/namespaces/{namespaceName}/observabilityplanes)
@@ -15569,19 +15569,19 @@ type StrictServerInterface interface {
 	// (PUT /api/v1/namespaces/{namespaceName}/roles/{name})
 	UpdateNamespaceRole(ctx context.Context, request UpdateNamespaceRoleRequestObject) (UpdateNamespaceRoleResponseObject, error)
 	// List secret references
-	// (GET /api/v1/namespaces/{namespaceName}/secret-references)
+	// (GET /api/v1/namespaces/{namespaceName}/secretreferences)
 	ListSecretReferences(ctx context.Context, request ListSecretReferencesRequestObject) (ListSecretReferencesResponseObject, error)
 	// Create secret reference
-	// (POST /api/v1/namespaces/{namespaceName}/secret-references)
+	// (POST /api/v1/namespaces/{namespaceName}/secretreferences)
 	CreateSecretReference(ctx context.Context, request CreateSecretReferenceRequestObject) (CreateSecretReferenceResponseObject, error)
 	// Delete secret reference
-	// (DELETE /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName})
+	// (DELETE /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName})
 	DeleteSecretReference(ctx context.Context, request DeleteSecretReferenceRequestObject) (DeleteSecretReferenceResponseObject, error)
 	// Get secret reference
-	// (GET /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName})
+	// (GET /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName})
 	GetSecretReference(ctx context.Context, request GetSecretReferenceRequestObject) (GetSecretReferenceResponseObject, error)
 	// Update secret reference
-	// (PUT /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName})
+	// (PUT /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName})
 	UpdateSecretReference(ctx context.Context, request UpdateSecretReferenceRequestObject) (UpdateSecretReferenceResponseObject, error)
 	// List traits
 	// (GET /api/v1/namespaces/{namespaceName}/traits)
@@ -20546,77 +20546,77 @@ var swaggerSpec = []string{
 	"q3no5PTNIuxOYs70zvjmw4tNa8fAPg48CcxuXrxdwcSdkBzujgIeXXtbcO1tVtRYawm6jm/J3ZhEtvii",
 	"dDGLSIJ6cLYR+9Qro3gIOVyhUEJe4y2Pd47brCKvIIePpRDYJINDmzXEgvK9s4TYe8+x1UIBXwuIVU7Q",
 	"C9PU19lCu2z6yDe5ZbNHaeGS1mx+fLR2+Fs7ciytw/aufHnyLUw6WDgsMmmxbqyXNNr5arZeV6tGjogP",
-	"1aDRjlW9DBn5tE7BczcRZLpt7vdQbBY+SOZvq7D4kJedYmeQ7c6f960j+KNJYnMmibXJAzKecoFiPkpw",
-	"giLcW2PLJgLZRF7uRKm5ZR+fZpt42CpcBSCtupwD/vdPqXMdwsJvB5p4q3nVqTt4u6sr77TeV93tthXA",
-	"mh24EhaKd/KoE/rrhFXwtRJL/1dh8i2szNhFf3TcdZsiuRmi85DhnAftpFo6TvtglcweaNpP7awu5NY/",
-	"7wleTXeAHT8YJbUXknZQWx2w9dNfdxdZd0dw2QVKeazG7q+8bkxwsXJ0+qmx9gT+nscje9kHrbhakGjT",
-	"WAt3dd80VVS8cYO7BUTwVU3txLIOLkhrrV1WRu1tblkLrSxdvAXr50e101/tRAW8q8H87ux68g3FN/4K",
-	"ZaGYQZsmuW5SaWe41opddUcbLR+qzuiFY72UxMYSGG8Q311Umd4FX3wo+p8nwvkrfDZ38lL0dgrxdkAM",
-	"uBN0f3RZbs5luXG5YUKuGKI3iI5SGnlFUZsPwIeztyqCWl67oN+IzJhsOLxAnOKAyZ/5HLMuL8iJnv/D",
-	"2dsf9jGxztgUXX1igxrH14Qu5GoP6WUp4NuGaIAGcARnKObeRHB2eADkFxkVHByPEnIri0hTQjgIYMoQ",
-	"gDGMlgx3oISzw4MDMfGPjP7WGZvQvwjkh4T/hZOvivSKgOAVjjBfjmCEKGejmHAh2ktwjoI5jGMU9bP+",
-	"FaYHanpgTw/M9N6hLSf2lAdyxvfWhIdmuw/aaugHpDaDov/t3TtzY4ej5RTmi3q+dkrvTXQIrPHb4y7b",
-	"Nz1PsGXTZ5dduQQ1n1t+tJl620y9SacX+a777Zx8I15rd7HW+jOPFlvuFjlG+wt54g2nLhZgfxJ8qPbh",
-	"zdJTL8Oy95acqtKPhtXTe/WSPRQr96bJxt887v8ceBnPfwDy2W3J9H7R82MslrdVfuck0xWqRhTPUiof",
-	"0clQ81hGokSoXvUkXPC/56aWSoUJF5r0M6AUa050NJXsfO0Jx27v0gRSm65aHfVo1+hr1yjno7pppfeb",
-	"UDJLZFnW/UwQXrUsNkRzHWXIXtUtHIj9aC3wx9I12ADqK2DcF7Sa3iUz1hT6MHVzXyTtq3F3qKCxw8i6",
-	"O2LL9O7FlsfYtc3Frm1OztEt2vspvOZj/0ylU7Pcg1ZtNRTa9Nnsbn74zu1JjhYGqTNM8dVu9RxdUpj0",
-	"Grusx5otbll5LSxb6VYm4fyopnqrqUmGZw7s7sanJ9/0vzrUvjCU0aJsrpMa2pntaX6MLmqlwb6Hqks2",
-	"olIvpVHP6FQUdw8lpttkcQ9F92tBKn8lz3AaL8VuJ5Drjl/sraLzo4a2OQ1tY098U0/LSg6GnXzwfaJb",
-	"yIqDkJQGPl7NKAIRvkHgn+kVorGUH7Kvs6bgQpDgcwRgwMXYrFNtqTmmEsKtXQ0BjoMoDWXPlzmOQmvu",
-	"CH9B4JSEzJ3JYRowq+EXFKE7Yxv9Wm52+OoOkkgsuDZmkehxgFOEdB5OGQ1++MfSoDu1gbFaS8/NU/4E",
-	"3XjVpLHoXn1RbuySnVp3CnVCw4eGj262WK1mZ6h4WAb8P3EcCoFcwVKBZjAcYPHbnymiy8FwILBlsD/4",
-	"guNwUBYphhaJy+5A+wPGqepHXVlMbMRzMfk/Ky8mb6rDinL8oNMyH45flReQOJtQFGCGFBqDBeTBXMzg",
-	"XjvFYeOq22C+iiCa2O9RTpHiuJomUf6MPsaYudi1Rgp0UyqWtJuMOiHhKCKzdlYtM8RL3Dkh4cqM+ZSE",
-	"b8X6D50z28wyIeH2+GTzYoZFrrDied6lLeYQx4hKuyDgBMwQ14hFyaJmF9lX3Rj1SRwtAZXIq5aI0S0S",
-	"nAzGKp17AeMlYCggcchqlmY4DtB5NiRfXeUzD/YHOOY/vRgMBwsc40W6GOxPh2ZrOOZohuiW2LkmoyZ+",
-	"/tZQcJGbi/t/ZORVIxUJJd6sxsE1W7zCsVBD+7k9DWs1kziCKIeAyJlgFC3BNY64rGZwtczVY7d/VPPi",
-	"X8z2ttwQ8V+C3O67d7UIwzYna/kyf3xna+XEOUGV0c/X91qaskNUcXHFXfbElna6ZYesa/UyxyrewaN/",
-	"1ts/W0LfRoLo9cxMvtHCRB2ct2XSanHiboCe2ln7WeVwXVy6ZcR9qK7dLljYy9NbWqBJGdxZ/JneIUd9",
-	"KO7gbojo7x0uszIvL/EOIuRuyBZ3SQmPCa7ejuGNyRYr6a79dFZZkLKx6p6lw+648mpZAX8krddT3X04",
-	"aq5Dve1Oapn8ngnu/cWvJrFru8/bdgWtpnflgUlWK6EkiTpYL6Mo5+8jFpBE1lSNcuOPm4VnaHVGom0b",
-	"I3eUvx6kfP4fCxxtjDYDexHeuy0lrYfz1h09x/oDvU9VgtbXytiIyXUGRhcq77KZsYxn2zY0utevc1na",
-	"N/BocfS3OLpJpIFCuj8O6kdPK6N7P3VGxo3RVINzvIBp2usuXcQJ5PMO/nj0FS6SSAwN0Q2KxPFGFvhb",
-	"A38cBsyaTdbbMR+V5JLpszM59LJ/+iL5G8QfMoZPd+EtKWgEj/RiKxE9iMVpo1UGqqKJ1pdE1LcPjEp2",
-	"RdjbCQJ9TCbaXDLRBqXDnjYDaC8od+VjOXg0GSjq6mYreIA2gg3YBqoY62UhuBemgTuzCXi8D49GgJ5G",
-	"gPWw9xW0fi9tfyvi3XrFujWp9Q9And8+JTj1/83q/e36/o+K49M7eRAeNXlPTX4TGvxfmUzPJrFqJmp9",
-	"7qXT/0CUcOfi2N1Q32OkVk+te2VxjKGAIj6i6BpRFAc947XULCCfxbuhwLn88ixf/kHr4iVotGnkFbDf",
-	"OwW7eoIcoSuo4atllyftkOhTWnOX9ezyVresbTuXL2Xwlu/hUev21rrLONxMFz15/eQbK87VIeOnQmQt",
-	"KT+boKx2zn1ePV+XpJ8KBj/UrJ9u6NhL/y0v4dSAdx+LpnfKYR9KiGpXfPRP/6nwNa/8n53Eyx2ROe6W",
-	"Ih5VS2/VchMyB6cQ96zbrz4F8AbiCF5FWTG3Fo3yQq34oPVICYM27VFfzX1TGbm5X4Ob+sJ9tUP5fQeV",
-	"UE6/y4qg2uCW1T9r0SKw5Q+Pmp6/psc1flXQuQuDnXyT/9tBf1Nk0KK0rQ/325njhTlAFwVNYdtD1cpq",
-	"UaeXAiZnc2pdu4UG020xsYeiTDWgkb/epPiJl7J05+h0p2/w1tD3MfZ1c7Gva3+0J/mVN7JuWXrToDdQ",
-	"H5Xrq7Yw8nO10o/HztXBmmpZKsLQsz0Itm4O2xtVbwn9ch2RW5rGPmq8Ud5nKEYUB8B8DsT3nhr8R/3N",
-	"mVjyQevxFiTatPkCoO+dUl/cfY6sBgBN6v0FxbMZoka/d2FenW5vwXeXNfzKZrOnebtKvw0uByp+tCBu",
-	"LACPplan0m8jZw26d2fPk280jVep/dJMMm8QXze9tLNaa8UtSRFdkPyhaIgbRte19X3pgsBbbe3iRuNK",
-	"zOlrWc/MHO5qCRhHSSH0tFxqnqNkoz1BMEcL1oFkJFSPYk6lqql3AymFy1Zi0kjQ98G4f5RUbfaxNoLq",
-	"3ZujsL9rShZSYL9KcRSqjt5jIBsCQIrANeLBXDrsbpBz7P8fxARAGszxDVJl8eV3qr0CCuXaAorKeiuO",
-	"0Ea0W+z50Y1k5eHWQbBD921VmlHImstQ9jQLUwUvoV7di84UXZnKWzLrx1IkGTwghlLqPLE2dsI45Cnz",
-	"Mk6RG0RhFAH1icznSBAdSbrQf+svdJ6rfTwA0VOdtMmWVUB0fUH3FW+ZudfVMXcVI1X3YJN8n492qojc",
-	"+hqp7q+Bak1IOvlm/rl267+ZuJGXbtUH8NE66k64ATLW+UA8Abel866KwhGBYb+YvuzrNXaj+pjt6LEP",
-	"VT/WLaDnw7oVlH/4mty3FkLZhKL+5htnaGbpEGpoFtllX0S2xzvwPeTrVvm5BPVj2GEnD4TGNReOd3wM",
-	"lDwj/tkhBDGjkJYoxLWShZ+4Yk7SJRYxw8KHGo7YglLDvi4pMUGtNLtriDHdLsd7SB6oRtzyj1TM2I5X",
-	"sOKO4NhdP+RbRuvHrC3vUET/hzxliI74MkF+ltyAxNd4lgolTHwJ5JfK2pDyOYq5vn9p4y0UMnTraR8Y",
-	"ohdy9W24D8xqh/IUPp4Do+k4z90bk9ajklgb8ar4couu5oR8YZMrzK/S4Iu6a7fackqJoDHEAI4DshAs",
-	"8hfzFdATGZc0J4CrcCvl53M47H6FcRihbIaPaoJBfyYGwxAru8ApFUtxLNBGFVkqnqS67QQuDW2o2ydX",
-	"f6Bg65HaGgjSOd5omDLb1ldydwywL9qiIKWYLwf7v3+ykVghRRWvbKalUbYGkWeYz9OrTlj8BvNf06ve",
-	"KKw+3yb+ljb8iLw7hbzF2+mEuRHsjLlv4UqY+xZuG3PtDT9i7q5hrnU7bZgLo2QOG80+M8xVrQC/Ou0z",
-	"bAp2yAyA1ppwb7Cu88LWZwjdEIZlW1UtRetRzAiXFizunQ/U3nuOQ9Zt+ZrG84mkOsFISgOhb4SopFrU",
-	"GcqzNXc/aj/b6h3F7Fvr12Pnm/xCHk3o3iZ0aCFyHUH0Y6uTbzMzSQd7ukVWLRb19dJPu1XrjX2aLjZ1",
-	"CzEfqlXdF8vmCEZ83vogn/wT4Gtp32GI3iAKMAPq0+UYfGA6KjfCNyhGjAmR6Aq5w3J/VQu2vq4cfeWT",
-	"JIK4xLXyssgn/3TUQ3aUdirtt1n0kWNAMEeBLfGcmFMYsJEExTDBY8NVW81iJwmKD06PwfPxNHNTKDuY",
-	"AByfYwbEzzgG/zg/eQ9UZK0TgHqm8wQFq5rEitut32JIgnQhZnRK5u5ZCjM0wvwN4sD9VcMFUATVo9sI",
-	"+TMxqoq58mOhGMEgQAkH+h1nFiqLIbgNl+X060BlM1EHbFYAaILrWXaEVnS+QZRhD0zW4wCOFYJKO+4V",
-	"SbkEsLxAuUEntH7Ti2xQsNZLNAktv1WP0IqdGnNusgO4AVmc5dvgCkGK6EEq+Ovvn8TTpSZST2ZJ0icB",
-	"jICu9K5pLaXRYH8w5zzZn0wiMWBOGN//efrzVD6EehflqRQPG+YoPJS2dnN3KA4TglUGiQ7wt47RVNF+",
-	"AWM4Q3pz+tPsV9enp5QINmF9aMJacnkmn0qPdk2UBU85pkrMZ9lE2WjXVEfxDaYkXrgnc+3L+sI14SvI",
-	"4WkEYxs+koXc5t7WJCJL+XcO6QzZe82+dk39S4qj0Dn34fHk8JVOmsHxNYWM0zTgKUX51PnXrrlPrgQy",
-	"wiscYb50rrEgMeZEcCKJPxGZzVSnNoM1lRmcVxeljCNqWle5oGXdnBrcCJTShE4YVWZshkVpykbQVKbu",
-	"BYYMRS+WCQIcLZJIarohusaxil8UfxEsCqB4hmMk2EZ56cIsHquqQhb5aiaTijAZvB5QwtgoSLl0eAck",
-	"DhCNq6temAqAtVTa81Btp1lx+7X7flPO/c+WyD/+aMWgV15HEqHRFRSiA5RahlicUxJVfZxORCp65Bz7",
-	"w1xwuRscIpoZS+fSSGfDLzPLVWeo1Dd1baNSrbM6T+Zpt40v8nqxej4K8DKBn/XcnKIIQVZDXmbUmRrk",
-	"hHzD9x6fmX6fDZ//Yhr8Oxh/ztYTnKAI1/CJfNypHtbKjwGMEOUMxITnUngwh3GMIucaha8P5MfvrW8P",
-	"1aesBrm0rlzi//UGtnxdS5/8/un7/xcAAP//S8iamZB5AwA=",
+	"1aDRjlW9DBn5tE7BczcRZLpt7vdQbBY+SOZvq7D4kJedYmeQ7c6f960j+KNJYnMmibXJAzKecoFinuAE",
+	"Rbi3wpbNA7KJvLyJUnHLPj7NNvGwNbgKQFpVOQf8759O5zqEhd4ONPHW8qpTd3B2V1feabWvuttt6381",
+	"O3DlKxTv5FEl9FcJq+BrJZbej8LkW1iZsIv26LjqNjVyMzTnIcE5D9pJsXSc9sGqmD2wtJ/SWV3IrX3e",
+	"E7ya7gA3fjAqai8k7aC0OmDrp73uLrLujtyyC5TyWIvdX3XdmNxiZej002LtCfz9jkf2sg9ab7Ug0aaw",
+	"Fu7qvimqqHjjBncLiOCrmdppZR0ckNZau6yL2tvcshJaWbp4C9bPj1qnv9aJCnhXg/nd2fXkG4pv/BXK",
+	"QimDNk1y3aTSznCtFbvqjjZaPlSd0QvHeimJjQUw3iC+u6gyvQu++FD0P0+E81f4bO7kpejtFOLtgBhw",
+	"J+j+6LDcnMNy43LDhFwxRG8QHaU08oqhNh+AD2dvVfy0vHZBvxGZMdlueIE4xQGTP/M5Zl1ekBM9/4ez",
+	"tz/sY2KdsSm2+sQGNY6vCV3I1R7Sy1LAtw3RAA3gCM5QzL2J4OzwAMgvMio4OB4l5FaWkKaEcBDAlCEA",
+	"YxgtGe5ACWeHBwdi4h8Z/a0zNqF/EcgPCf8LJ18V6RUBwSscYb6EEaKcxYQLwV4CM5jDOEZRP9NfYW6g",
+	"Jgf27MBM7x3WcmJPeSBnfG9NeGi2+6BNhn5AarMm+t/evbM1djhaTl6+qOdrpPTeRIegGr897rJx0/ME",
+	"W7Z7dtmVS0rzueVHg6m3wdSbdHqR71ofzsk34rVwFzutP+doseJukV20P48n3nDqYvv1p7+HahneLDH1",
+	"Mil7b8mpJP1oWD29V8/YQ7Fvb5ps/A3j/s+Bl9n8ByCf3RZL7xc9P0Zhedvjd04sXaFaRPEspbIRnaw0",
+	"j+UjSoTqVUfCBf97bmepVJZwoUk/60mx1kRHO8nO15xw7PYu7R+1aarVUY9Gjb5GjXIeqptWer8JJbNE",
+	"ll3dzwThVcNiQzTXUYbsVdXCgdiP1gJ/LF2DDaC+8sV9QavpXTJjTaEPUzf3RdK+GneHyhk7jKy7I7ZM",
+	"715seYxa21zU2ubkHN2avZ/Caz72z1E6Ncs9aNVWQ6FNn83u5ofv2J7kaGGQOsMUX+1Wz9EleUmvsct6",
+	"rNnilpXXwrKVLmUSzo9qqreammR45sDubnx68k3/q0PVC0MZLcrmOqmhndme5sfoolYa7HuoumQjKvVS",
+	"GvWMTkVx91Biuk0W91B0vxak8lfyDKfxUux2Arnu+MXeKjo/amib09A29sQ39bKsZF/YaQffJ7p1rDgI",
+	"SWng49WMIhDhGwT+mV4hGkv5Ifs6awYuBAk+RwAGXIzNOtSWmmIqIdza1RDgOIjSUPZ6meMotOaO8BcE",
+	"TknI3DkcpvGyGn5BEbozttGv1WaHr+4gfcSCa2P+iB4HOEVIZ+CU0eCHfywNulMbGKu18tw85U/QjVc1",
+	"Govu1Rflhi7ZqXWHUCc0fGj46GaLdWp2hoqHZcD/E8ehEMgVLBVoBsMBFr/9mSK6HAwHAlsG+4MvOA4H",
+	"ZZFiaJG47Aq0P2Ccqj7UlcXERjwXk/+z8mLypjqsKMcPOi3z4fhVeQGJswlFAWZIoTFYQB7MxQzutVMc",
+	"Nq66DearCKKJ/R7lFCmOq2kS5c/oY4yZi11rpEA3pTJJu8moExKOIjJrZ9UyN7zEnRMSrsyYT0n4Vqz/",
+	"0DmzzSwTEm6PTzYvZljkCiue593ZYg5xjKi0CwJOwAxxjViULGp2kX3VjVGfxNESUIm8aokY3SLByWCs",
+	"ErkXMF4ChgISh6xmaYbjAJ1nQ/LVVSbzYH+AY/7Ti8FwsMAxXqSLwf50aLaGY45miG6JnWsyauLnbw0F",
+	"F7m5uP9HRl41UpFQ4s1qHFyzxSscCzW0n9vTsFYziSOIcgiInAlG0RJc44jLOgZXy1w9dvtHNS/+xWxv",
+	"y40Q/yXI7b57V4swbHOyli/zx3e2Vk6cE1QZ/Xx9r6UpO0QVF1fcZU9saadbdsi6Vi9zrOIdPPpnvf2z",
+	"JfRtJIhez8zkGy1M1MF5WyatFifuBuipnbWfVQ7XxaVbRtyH6trtgoW9PL2lBZqUwZ3Fn+kdctSH4g7u",
+	"hoj+3uEyK/PyEu8gQu6GbHGXlPCY4OrtGN6YbLGS7tpPZ5WlKBvr7Vk67I4rr5YV8EfSej3V3Yej5jrU",
+	"2+6klsnvmeDeX/xqEru2+7xtV9BqelcemGS1EkqSqIP1Mopy/j5iAUlkNdUoN/64WXiGVmck2rYxckf5",
+	"60HK5/+xwNHGaDOwF+G921LSejhv3dFzrD/Q+1TFZ32tjI2YXGdgdKHyLpsZy3i2bUOje/06l6V9A48W",
+	"R3+Lo5tEGiik++OgfvS0Mrr3U2dk3BhNNTjHC5imve7SRZxAPu/gj0df4SKJxNAQ3aBIHG9kgb818Mdh",
+	"wKzZZL0d81FJLpk+O5NDL/unL5K/QfwhY/h0F96SgkbwSC+2EtGDWJw2WmWgKppofUlEffvAqGRXhL2d",
+	"INDHZKLNJRNtUDrsaTOA9oJyVz6Wg0eTgaKubraCB2gj2IBtoIqxXhaCe2EauDObgMf78GgE6GkEWA97",
+	"X0Hr99L2tyLerVesW5Na/wDU+e1TglP/36ze367v/6g4Pr2TB+FRk/fU5Dehwf+VyfRsEqs2otbnXjr9",
+	"D0QJdy6O3Q31PUZq9dS6VxbHGAoo4hRdI4rioGe4lpoE5LN49xM4l1+e5cs/aFW8BI02hbwC9nunX1dP",
+	"kONzBTV8lezypB3yfEpr7rKaXd7qlpVt5/KlBN7yPTwq3d5KdxmHm+miH6uffGPFqTrk+1RorCXhZxOE",
+	"1c64z6vn65LyU0Hgh5rz0w0be2m/5SWc+u/uY9H0ThnsQwlQ7YqP/sk/Fb7mlf2zk3i5IyLH3VLEo2Lp",
+	"rVhuQuTgFOKeVfvVpwDeQBzBqygr5daiUF6oFR+0Gilh0KY86qu5bxojN/drcFNfuK9yKL/voBHK6XdZ",
+	"D1Qb3LL2Zy1aBLb84VHR81f0uMavCjp3YbCTb/J/O+hvigxalLb14X47c7wwB+iioClse6haWS3q9FLA",
+	"5GxOrWu30GC6LSb2UJSpBjTy15sUP/FSlu4cne70Dd4a+j5Gvm4u8nXtj/Ykv/JG1i0Lbxr0BuqjcnXV",
+	"FkZ+rlb68di5OlhTJUtFGHq2B8HWzWF7o+otoV+uI3JL09hHjTfK+wzFiOIAmM+B+N5Tg/+ovzkTSz5o",
+	"Pd6CRJs2XwD0vVPqi7vPkdUAoEm9v6B4NkPU6PcuzKvT7S347rKGX9ls9jRvV+m3weVAxY8WxI0F4NHU",
+	"6lT6beSsQffu7HnyjabxKpVfmknmDeLrppd2VmutuCUpoguSPxQNccPourauL10QeKuNXdxoXIk4fS2r",
+	"mZnDXS0B4ygpBJ6WC81zlGy0IwjmaME6kIyE6lHMqVQ19W4gpXDZSkwaCfo+GPePkqqtPtZGUL07cxT2",
+	"d03JQgrsVymOQtXPewxkOwBIEbhGPJhLh90Nco79/4OYAEiDOb5Bqii+/E41V0ChXFtAUVlvxRHaiHaL",
+	"HT+6kaw83DoIdui+rUorCllxGcqOZmGq4CXUq3vRl6IrU3lLZv1YiiSDB8RQSn0n1sZOGIc8ZV7GKXKD",
+	"KIwioD6R2RwJoiNJF/pv/YXOc7WPByB6qpM22bIKiK4v6L7iLTP3ujrmrmKk6h5sku/z0U4VkVtfI9X9",
+	"NVCtCUkn38w/1279NxM38tKt+gA+WkfdCTdAxjofiCfgtnTeVVE4IjDsF9OXfb3GXlQfsx09dqHqx7oF",
+	"9HxYt4LyD1+R+9ZCKJtQ1N984wzNLB1CDc0iu+yLyPZ4B76HfN0qP5egfgw77OSB0LjmwvGOj4GSZ8Q/",
+	"O4QgZhTSEoW4VrLwE1fMSbrEImZY+FDDEVtQatjXJSUmqJVmdw0xptvleA/JA9WIW/6Rihnb8QpW3BEc",
+	"u+uHfMto/Zi15R2K6P+QpwzREV8myM+SG5D4Gs9SoYSJL4H8UlkbUj5HMdf3L228hTKGbj3tA0P0Qq6+",
+	"DfeBWe1QnsLHc2A0Hee5e2PSelQSayNe9V5u0dWckC9scoX5VRp8UXftVltOKRE0hhjAcUAWgkX+Yr4C",
+	"eiLjkuYEcBVupfx8DofdrzAOI5TN8FFNMOjPxGAYYmUXOKViKY4F2qgSS8WTVLedwKWhDXX75OoPFGw9",
+	"UlsDQTrHGw1TZtv6Su6OAfZFWxSkFPPlYP/3TzYSK6So4pXNtDTK1iDyDPN5etUJi99g/mt61RuF1efb",
+	"xN/Shh+Rd6eQt3g7nTA3gp0x9y1cCXPfwm1jrr3hR8zdNcy1bqcNc2GUzGGj2WeGuaoV4FelfYZNwQ6Z",
+	"AdBaEu4N1nVe2PoMoRvCsGyrqqFoPYoZ4dKCxb3zgdp7z3HIui1f03g+kVQnGElpIPSNEJVUizpDebbm",
+	"7kftZ1u9o5h9a/167HyTX8ijCd3bhA4tRK4jiH5sdfJtZibpYE+3yKrFor5e+mm3ar2xT9PFpm4h5kO1",
+	"qvti2RzBiM9bH+STfwJ8Le07DNEbRAFmQH26HIMPTEflRvgGxYgxIRJdIXdY7q9qwdbXlaOvfJJEEJe4",
+	"Vl4U+eSfjmrIjtJOpf02iz5yDAjmKLAlnhNzCgM2kqAYJnhsuGqrWewkQfHB6TF4Pp5mbgplBxOA43PM",
+	"gPgZx+Af5yfvgYqsdQJQz3SeoGBVk1hxu/VbDEmQLsSMTsncPUthhkaYv0EcuL9quACKoHp0GyF/JkZV",
+	"MVd+LBQjGAQo4UC/48xCZTEEt+GynH4dqGwm6oDNCgBNcD3LjtCKzjeIMuyByXocwLFCUGnHvSIplwCW",
+	"Fyg36ITWb3qRDQrWeokmoeW36hFasVNjzk12ADcgi7N8G1whSBE9SAV//f2TeLrUROrJLEn6JIAR0HXe",
+	"Na2lNBrsD+acJ/uTSSQGzAnj+z9Pf57Kh1DvojyV4mHDHIWH0tZu7g7FYUKwyiDRAf7WMZrq2S9gDGdI",
+	"b05/mv3q+vSUEsEmrA9NWEsuz+RT6dGuibLgKcdUifksmygb7ZrqKL7BlMQL92SufVlfuCZ8BTk8jWBs",
+	"w0eykNvc25pEZCn/ziGdIXuv2deuqX9JcRQ65z48nhy+0kkzOL6mkHGaBjylKJ86/9o198mVQEZ4hSPM",
+	"l841FiTGnAhOJPEnIrOZ6tNmsKYyg/PqopRxRE3jKhe0rJtTgxuBUprQCaPKjM2wKE3ZCJrK1L3AkKHo",
+	"xTJBgKNFEklNN0TXOFbxi+IvgkUBFM9wjATbKC9dmMVjVVXIIl/NZFIRJoPXA0oYGwUplw7vgMQBonF1",
+	"1QtTAbCWSnsequ00K26/dt9vyrn/2RL5xx+tGPTK60giNLqCQnSAUssQi3NKoqqP04lIRY+cY3+YCy53",
+	"g0NEM2PpXBrpbPhlZrnqDJX6pq5tVKp1VufJPO228UVeL1bPRwFeJvCznptTFCHIasjLjDpTg5yQb/je",
+	"4zPT7bPh819Me38H48/ZeoITFOEaPpGPO9XDWvkxgBGinIGY8FwKD+YwjlHkXKPw9YH8+L317aH6lNUg",
+	"l9aVS/y/3sCWr2vpk98/ff//AgAA//8AFljhhnkDAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -3568,7 +3568,7 @@ paths:
   # Secret Reference Endpoints
   # =============================================================================
 
-  /api/v1/namespaces/{namespaceName}/secret-references:
+  /api/v1/namespaces/{namespaceName}/secretreferences:
     get:
       operationId: listSecretReferences
       summary: List secret references
@@ -3623,7 +3623,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName}:
+  /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}:
     get:
       operationId: getSecretReference
       summary: Get secret reference
@@ -4095,7 +4095,7 @@ paths:
   # Deployment Pipeline Endpoints
   # =============================================================================
 
-  /api/v1/namespaces/{namespaceName}/deployment-pipelines:
+  /api/v1/namespaces/{namespaceName}/deploymentpipelines:
     get:
       operationId: listDeploymentPipelines
       summary: List deployment pipelines
@@ -4150,7 +4150,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}:
+  /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}:
     get:
       operationId: getDeploymentPipeline
       summary: Get deployment pipeline
@@ -4231,7 +4231,7 @@ paths:
   # Observability Alerts Notification Channel Endpoints
   # =============================================================================
 
-  /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels:
+  /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels:
     get:
       operationId: listObservabilityAlertsNotificationChannels
       summary: List observability alerts notification channels
@@ -4286,7 +4286,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName}:
+  /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName}:
     get:
       operationId: getObservabilityAlertsNotificationChannel
       summary: Get observability alerts notification channel


### PR DESCRIPTION
remove hyphens from API paths for secretreferences, deploymentpipelines, and observabilityalertsnotificationchannels

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Hyphens removed from the three path groups:

  - secret-references → secretreferences (2 paths)
  - deployment-pipelines → deploymentpipelines (2 paths)
  - observability-alerts-notification-channels → observabilityalertsnotificationchannels (2 paths)
 

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2008

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
