### PR TITLE
fix: add clustercomponenttype and clustertrait view permission to choreoapi

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1078,6 +1078,8 @@ openchoreoApi:
                 - "observabilityplane:view"
                 - "clusterobservabilityplane:view"
                 - "clusterdataplane:view"
+                - "clustercomponenttype:view"
+                - "clustertrait:view"
 
             # Root Cause Analysis (RCA) agent role for troubleshooting and debugging
             - name: rca-agent


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Openchoreo API is not showing cluster component types and cluster traits

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
