### PR TITLE
feat: add occ get & list cmds for authz related crds

### DIFF
--- a/internal/occ/cmd/authzclusterrole/authzclusterrole.go
+++ b/internal/occ/cmd/authzclusterrole/authzclusterrole.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzclusterrole
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// AuthzClusterRole implements authz cluster role operations
+type AuthzClusterRole struct{}
+
+// New creates a new authz cluster role implementation
+func New() *AuthzClusterRole {
+	return &AuthzClusterRole{}
+}
+
+// List lists all cluster-scoped authorization roles
+func (c *AuthzClusterRole) List() error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := cl.ListClusterRoles(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list authz cluster roles: %w", err)
+	}
+
+	return printList(result)
+}
+
+// Get retrieves a single authz cluster role and outputs it as YAML
+func (c *AuthzClusterRole) Get(params GetParams) error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := cl.GetClusterRole(ctx, params.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get authz cluster role: %w", err)
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal authz cluster role to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+func printList(list *gen.AuthzClusterRoleList) error {
+	if list == nil || len(list.Items) == 0 {
+		fmt.Println("No authz cluster roles found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tDESCRIPTION\tAGE")
+
+	for _, cr := range list.Items {
+		description := ""
+		if cr.Spec != nil && cr.Spec.Description != nil {
+			description = *cr.Spec.Description
+		}
+		age := ""
+		if cr.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*cr.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			cr.Metadata.Name,
+			description,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/authzclusterrole/params.go
+++ b/internal/occ/cmd/authzclusterrole/params.go
@@ -1,0 +1,9 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzclusterrole
+
+// GetParams defines parameters for getting a single authz cluster role
+type GetParams struct {
+	Name string
+}

--- a/internal/occ/cmd/authzclusterrolebinding/authzclusterrolebinding.go
+++ b/internal/occ/cmd/authzclusterrolebinding/authzclusterrolebinding.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzclusterrolebinding
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// AuthzClusterRoleBinding implements authz cluster role binding operations
+type AuthzClusterRoleBinding struct{}
+
+// New creates a new authz cluster role binding implementation
+func New() *AuthzClusterRoleBinding {
+	return &AuthzClusterRoleBinding{}
+}
+
+// List lists all cluster-scoped role bindings
+func (c *AuthzClusterRoleBinding) List() error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := cl.ListClusterRoleBindings(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list authz cluster role bindings: %w", err)
+	}
+
+	return printList(result)
+}
+
+// Get retrieves a single authz cluster role binding and outputs it as YAML
+func (c *AuthzClusterRoleBinding) Get(params GetParams) error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := cl.GetClusterRoleBinding(ctx, params.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get authz cluster role binding: %w", err)
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal authz cluster role binding to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+func printList(list *gen.AuthzClusterRoleBindingList) error {
+	if list == nil || len(list.Items) == 0 {
+		fmt.Println("No authz cluster role bindings found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tROLE\tAGE")
+
+	for _, crb := range list.Items {
+		roleRef := ""
+		if crb.Spec != nil {
+			roleRef = string(crb.Spec.RoleRef.Kind) + "/" + crb.Spec.RoleRef.Name
+		}
+		age := ""
+		if crb.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*crb.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			crb.Metadata.Name,
+			roleRef,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/authzclusterrolebinding/params.go
+++ b/internal/occ/cmd/authzclusterrolebinding/params.go
@@ -1,0 +1,9 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzclusterrolebinding
+
+// GetParams defines parameters for getting a single authz cluster role binding
+type GetParams struct {
+	Name string
+}

--- a/internal/occ/cmd/authzrole/authzrole.go
+++ b/internal/occ/cmd/authzrole/authzrole.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzrole
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/validation"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// AuthzRole implements authz role operations
+type AuthzRole struct{}
+
+// New creates a new authz role implementation
+func New() *AuthzRole {
+	return &AuthzRole{}
+}
+
+// List lists all authz roles in a namespace
+func (r *AuthzRole) List(params ListParams) error {
+	if err := validation.ValidateParams(validation.CmdList, validation.ResourceAuthzRole, params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := c.ListNamespaceRoles(ctx, params.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to list authz roles: %w", err)
+	}
+
+	return printList(result)
+}
+
+// Get retrieves a single authz role and outputs it as YAML
+func (r *AuthzRole) Get(params GetParams) error {
+	if err := validation.ValidateParams(validation.CmdGet, validation.ResourceAuthzRole, params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := c.GetNamespaceRole(ctx, params.Namespace, params.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get authz role: %w", err)
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal authz role to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+func printList(list *gen.AuthzRoleList) error {
+	if list == nil || len(list.Items) == 0 {
+		fmt.Println("No authz roles found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tDESCRIPTION\tAGE")
+
+	for _, r := range list.Items {
+		description := ""
+		if r.Spec != nil && r.Spec.Description != nil {
+			description = *r.Spec.Description
+		}
+		age := ""
+		if r.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*r.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			r.Metadata.Name,
+			description,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/authzrole/params.go
+++ b/internal/occ/cmd/authzrole/params.go
@@ -1,0 +1,21 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzrole
+
+// ListParams defines parameters for listing authz roles
+type ListParams struct {
+	Namespace string
+}
+
+// GetNamespace returns the namespace
+func (p ListParams) GetNamespace() string { return p.Namespace }
+
+// GetParams defines parameters for getting a single authz role
+type GetParams struct {
+	Namespace string
+	Name      string
+}
+
+// GetNamespace returns the namespace
+func (p GetParams) GetNamespace() string { return p.Namespace }

--- a/internal/occ/cmd/authzrolebinding/authzrolebinding.go
+++ b/internal/occ/cmd/authzrolebinding/authzrolebinding.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzrolebinding
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/validation"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// AuthzRoleBinding implements authz role binding operations
+type AuthzRoleBinding struct{}
+
+// New creates a new authz role binding implementation
+func New() *AuthzRoleBinding {
+	return &AuthzRoleBinding{}
+}
+
+// List lists all authz role bindings in a namespace
+func (r *AuthzRoleBinding) List(params ListParams) error {
+	if err := validation.ValidateParams(validation.CmdList, validation.ResourceAuthzRoleBinding, params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := c.ListNamespaceRoleBindings(ctx, params.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to list authz role bindings: %w", err)
+	}
+
+	return printList(result)
+}
+
+// Get retrieves a single authz role binding and outputs it as YAML
+func (r *AuthzRoleBinding) Get(params GetParams) error {
+	if err := validation.ValidateParams(validation.CmdGet, validation.ResourceAuthzRoleBinding, params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := c.GetNamespaceRoleBinding(ctx, params.Namespace, params.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get authz role binding: %w", err)
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal authz role binding to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+func printList(list *gen.AuthzRoleBindingList) error {
+	if list == nil || len(list.Items) == 0 {
+		fmt.Println("No authz role bindings found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tROLE\tAGE")
+
+	for _, rb := range list.Items {
+		roleRef := ""
+		if rb.Spec != nil {
+			roleRef = string(rb.Spec.RoleRef.Kind) + "/" + rb.Spec.RoleRef.Name
+		}
+		age := ""
+		if rb.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*rb.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			rb.Metadata.Name,
+			roleRef,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/authzrolebinding/params.go
+++ b/internal/occ/cmd/authzrolebinding/params.go
@@ -1,0 +1,21 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzrolebinding
+
+// ListParams defines parameters for listing authz role bindings
+type ListParams struct {
+	Namespace string
+}
+
+// GetNamespace returns the namespace
+func (p ListParams) GetNamespace() string { return p.Namespace }
+
+// GetParams defines parameters for getting a single authz role binding
+type GetParams struct {
+	Namespace string
+	Name      string
+}
+
+// GetNamespace returns the namespace
+func (p GetParams) GetNamespace() string { return p.Namespace }

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -869,6 +869,102 @@ func (c *Client) DeleteObservabilityAlertsNotificationChannel(ctx context.Contex
 	return nil
 }
 
+// ListClusterRoles retrieves all cluster-scoped authorization roles
+func (c *Client) ListClusterRoles(ctx context.Context) (*gen.AuthzClusterRoleList, error) {
+	resp, err := c.client.ListClusterRolesWithResponse(ctx, &gen.ListClusterRolesParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster roles: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// GetClusterRole retrieves a specific cluster-scoped authorization role
+func (c *Client) GetClusterRole(ctx context.Context, name string) (*gen.AuthzClusterRole, error) {
+	resp, err := c.client.GetClusterRoleWithResponse(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster role: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// ListClusterRoleBindings retrieves all cluster-scoped role bindings
+func (c *Client) ListClusterRoleBindings(ctx context.Context) (*gen.AuthzClusterRoleBindingList, error) {
+	resp, err := c.client.ListClusterRoleBindingsWithResponse(ctx, &gen.ListClusterRoleBindingsParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster role bindings: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// GetClusterRoleBinding retrieves a specific cluster-scoped role binding
+func (c *Client) GetClusterRoleBinding(ctx context.Context, name string) (*gen.AuthzClusterRoleBinding, error) {
+	resp, err := c.client.GetClusterRoleBindingWithResponse(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster role binding: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// ListNamespaceRoles retrieves all namespace-scoped authorization roles
+func (c *Client) ListNamespaceRoles(ctx context.Context, namespaceName string) (*gen.AuthzRoleList, error) {
+	resp, err := c.client.ListNamespaceRolesWithResponse(ctx, namespaceName, &gen.ListNamespaceRolesParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list roles: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// GetNamespaceRole retrieves a specific namespace-scoped authorization role
+func (c *Client) GetNamespaceRole(ctx context.Context, namespaceName, name string) (*gen.AuthzRole, error) {
+	resp, err := c.client.GetNamespaceRoleWithResponse(ctx, namespaceName, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// ListNamespaceRoleBindings retrieves all namespace-scoped role bindings
+func (c *Client) ListNamespaceRoleBindings(ctx context.Context, namespaceName string) (*gen.AuthzRoleBindingList, error) {
+	resp, err := c.client.ListNamespaceRoleBindingsWithResponse(ctx, namespaceName, &gen.ListNamespaceRoleBindingsParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list role bindings: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// GetNamespaceRoleBinding retrieves a specific namespace-scoped role binding
+func (c *Client) GetNamespaceRoleBinding(ctx context.Context, namespaceName, name string) (*gen.AuthzRoleBinding, error) {
+	resp, err := c.client.GetNamespaceRoleBindingWithResponse(ctx, namespaceName, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role binding: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
 // GetEnvironmentObserverURL retrieves the observer URL for an environment
 func (c *Client) GetEnvironmentObserverURL(ctx context.Context, namespaceName, envName string) (string, error) {
 	resp, err := c.client.GetEnvironmentObserverURLWithResponse(ctx, namespaceName, envName)

--- a/internal/occ/validation/commands.go
+++ b/internal/occ/validation/commands.go
@@ -50,6 +50,10 @@ const (
 	ResourceReleaseBinding                         ResourceType = "releasebinding"
 	ResourceWorkflowRun                            ResourceType = "workflowrun"
 	ResourceObservabilityAlertsNotificationChannel ResourceType = "observabilityalertsnotificationchannel"
+	ResourceAuthzClusterRole                       ResourceType = "authzclusterrole"
+	ResourceAuthzClusterRoleBinding                ResourceType = "authzclusterrolebinding"
+	ResourceAuthzRole                              ResourceType = "authzrole"
+	ResourceAuthzRoleBinding                       ResourceType = "authzrolebinding"
 )
 
 // checkRequiredFields verifies if all required fields are populated

--- a/internal/occ/validation/params.go
+++ b/internal/occ/validation/params.go
@@ -63,6 +63,14 @@ func ValidateParams(cmdType CommandType, resource ResourceType, params interface
 		return validateWorkflowRunParams(cmdType, params)
 	case ResourceObservabilityAlertsNotificationChannel:
 		return validateObservabilityAlertsNotificationChannelParams(cmdType, params)
+	case ResourceAuthzClusterRole:
+		return validateAuthzClusterRoleParams(cmdType, params)
+	case ResourceAuthzClusterRoleBinding:
+		return validateAuthzClusterRoleBindingParams(cmdType, params)
+	case ResourceAuthzRole:
+		return validateAuthzRoleParams(cmdType, params)
+	case ResourceAuthzRoleBinding:
+		return validateAuthzRoleBindingParams(cmdType, params)
 	default:
 		return fmt.Errorf("unknown resource type: %s", resource)
 	}
@@ -974,6 +982,36 @@ func validateDeleteObservabilityAlertsNotificationChannelParams(params interface
 		}
 		if !checkRequiredFields(fields) {
 			return generateHelpError(CmdDelete, ResourceObservabilityAlertsNotificationChannel, fields)
+		}
+	}
+	return nil
+}
+
+// validateAuthzClusterRoleParams validates parameters for authz cluster role operations
+func validateAuthzClusterRoleParams(_ CommandType, _ interface{}) error {
+	return nil
+}
+
+// validateAuthzClusterRoleBindingParams validates parameters for authz cluster role binding operations
+func validateAuthzClusterRoleBindingParams(_ CommandType, _ interface{}) error {
+	return nil
+}
+
+// validateAuthzRoleParams validates parameters for authz role operations
+func validateAuthzRoleParams(cmdType CommandType, params interface{}) error {
+	if cmdType == CmdList || cmdType == CmdGet {
+		if p, ok := params.(namespaceParams); ok {
+			return validateNamespace(cmdType, ResourceAuthzRole, p.GetNamespace())
+		}
+	}
+	return nil
+}
+
+// validateAuthzRoleBindingParams validates parameters for authz role binding operations
+func validateAuthzRoleBindingParams(cmdType CommandType, params interface{}) error {
+	if cmdType == CmdList || cmdType == CmdGet {
+		if p, ok := params.(namespaceParams); ok {
+			return validateNamespace(cmdType, ResourceAuthzRoleBinding, p.GetNamespace())
 		}
 	}
 	return nil

--- a/pkg/cli/cmd/authzclusterrole/authzclusterrole.go
+++ b/pkg/cli/cmd/authzclusterrole/authzclusterrole.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzclusterrole
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/authzclusterrole"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+)
+
+// NewAuthzClusterRoleCmd returns the parent command for authz cluster role operations
+func NewAuthzClusterRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.AuthzClusterRole.Use,
+		Aliases: constants.AuthzClusterRole.Aliases,
+		Short:   constants.AuthzClusterRole.Short,
+		Long:    constants.AuthzClusterRole.Long,
+	}
+
+	cmd.AddCommand(
+		newListAuthzClusterRoleCmd(),
+		newGetAuthzClusterRoleCmd(),
+	)
+
+	return cmd
+}
+
+func newListAuthzClusterRoleCmd() *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListAuthzClusterRole,
+		Flags:   []flags.Flag{},
+		RunE: func(fg *builder.FlagGetter) error {
+			return authzclusterrole.New().List()
+		},
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+	}).Build()
+}
+
+func newGetAuthzClusterRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.GetAuthzClusterRole.Use,
+		Short:   constants.GetAuthzClusterRole.Short,
+		Long:    constants.GetAuthzClusterRole.Long,
+		Example: constants.GetAuthzClusterRole.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authzclusterrole.New().Get(authzclusterrole.GetParams{
+				Name: args[0],
+			})
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/cmd/authzclusterrolebinding/authzclusterrolebinding.go
+++ b/pkg/cli/cmd/authzclusterrolebinding/authzclusterrolebinding.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzclusterrolebinding
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/authzclusterrolebinding"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+)
+
+// NewAuthzClusterRoleBindingCmd returns the parent command for authz cluster role binding operations
+func NewAuthzClusterRoleBindingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.AuthzClusterRoleBinding.Use,
+		Aliases: constants.AuthzClusterRoleBinding.Aliases,
+		Short:   constants.AuthzClusterRoleBinding.Short,
+		Long:    constants.AuthzClusterRoleBinding.Long,
+	}
+
+	cmd.AddCommand(
+		newListAuthzClusterRoleBindingCmd(),
+		newGetAuthzClusterRoleBindingCmd(),
+	)
+
+	return cmd
+}
+
+func newListAuthzClusterRoleBindingCmd() *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListAuthzClusterRoleBinding,
+		Flags:   []flags.Flag{},
+		RunE: func(fg *builder.FlagGetter) error {
+			return authzclusterrolebinding.New().List()
+		},
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+	}).Build()
+}
+
+func newGetAuthzClusterRoleBindingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.GetAuthzClusterRoleBinding.Use,
+		Short:   constants.GetAuthzClusterRoleBinding.Short,
+		Long:    constants.GetAuthzClusterRoleBinding.Long,
+		Example: constants.GetAuthzClusterRoleBinding.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authzclusterrolebinding.New().Get(authzclusterrolebinding.GetParams{
+				Name: args[0],
+			})
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/cmd/authzrole/authzrole.go
+++ b/pkg/cli/cmd/authzrole/authzrole.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzrole
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/authzrole"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+)
+
+// NewAuthzRoleCmd returns the parent command for authz role operations
+func NewAuthzRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.AuthzRole.Use,
+		Aliases: constants.AuthzRole.Aliases,
+		Short:   constants.AuthzRole.Short,
+		Long:    constants.AuthzRole.Long,
+	}
+
+	cmd.AddCommand(
+		newListAuthzRoleCmd(),
+		newGetAuthzRoleCmd(),
+	)
+
+	return cmd
+}
+
+func newListAuthzRoleCmd() *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListAuthzRole,
+		Flags:   []flags.Flag{flags.Namespace},
+		RunE: func(fg *builder.FlagGetter) error {
+			return authzrole.New().List(authzrole.ListParams{
+				Namespace: fg.GetString(flags.Namespace),
+			})
+		},
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+	}).Build()
+}
+
+func newGetAuthzRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.GetAuthzRole.Use,
+		Short:   constants.GetAuthzRole.Short,
+		Long:    constants.GetAuthzRole.Long,
+		Example: constants.GetAuthzRole.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+
+			return authzrole.New().Get(authzrole.GetParams{
+				Namespace: namespace,
+				Name:      args[0],
+			})
+		},
+	}
+
+	flags.AddFlags(cmd, flags.Namespace)
+
+	return cmd
+}

--- a/pkg/cli/cmd/authzrolebinding/authzrolebinding.go
+++ b/pkg/cli/cmd/authzrolebinding/authzrolebinding.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authzrolebinding
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/authzrolebinding"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+)
+
+// NewAuthzRoleBindingCmd returns the parent command for authz role binding operations
+func NewAuthzRoleBindingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.AuthzRoleBinding.Use,
+		Aliases: constants.AuthzRoleBinding.Aliases,
+		Short:   constants.AuthzRoleBinding.Short,
+		Long:    constants.AuthzRoleBinding.Long,
+	}
+
+	cmd.AddCommand(
+		newListAuthzRoleBindingCmd(),
+		newGetAuthzRoleBindingCmd(),
+	)
+
+	return cmd
+}
+
+func newListAuthzRoleBindingCmd() *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListAuthzRoleBinding,
+		Flags:   []flags.Flag{flags.Namespace},
+		RunE: func(fg *builder.FlagGetter) error {
+			return authzrolebinding.New().List(authzrolebinding.ListParams{
+				Namespace: fg.GetString(flags.Namespace),
+			})
+		},
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+	}).Build()
+}
+
+func newGetAuthzRoleBindingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.GetAuthzRoleBinding.Use,
+		Short:   constants.GetAuthzRoleBinding.Short,
+		Long:    constants.GetAuthzRoleBinding.Long,
+		Example: constants.GetAuthzRoleBinding.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+
+			return authzrolebinding.New().Get(authzrolebinding.GetParams{
+				Namespace: namespace,
+				Name:      args[0],
+			})
+		},
+	}
+
+	flags.AddFlags(cmd, flags.Namespace)
+
+	return cmd
+}

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -777,6 +777,98 @@ This command allows you to:
   %[1]s secretreference delete my-secret --namespace acme-corp`, messages.DefaultCLIName),
 	}
 
+	AuthzClusterRole = Command{
+		Use:     "authzclusterrole",
+		Aliases: []string{"authzclusterroles", "cr"},
+		Short:   "Manage authz cluster roles",
+		Long:    `Manage cluster-scoped authorization roles for OpenChoreo.`,
+	}
+
+	ListAuthzClusterRole = Command{
+		Use:   "list",
+		Short: "List authz cluster roles",
+		Long:  `List all cluster-scoped authorization roles.`,
+		Example: `  # List all authz cluster roles
+  occ authzclusterrole list`,
+	}
+
+	GetAuthzClusterRole = Command{
+		Use:   "get [NAME]",
+		Short: "Get an authz cluster role",
+		Long:  `Get an authz cluster role and display its details in YAML format.`,
+		Example: fmt.Sprintf(`  # Get an authz cluster role
+  %[1]s authzclusterrole get my-role`, messages.DefaultCLIName),
+	}
+
+	AuthzClusterRoleBinding = Command{
+		Use:     "authzclusterrolebinding",
+		Aliases: []string{"authzclusterrolebindings", "crb"},
+		Short:   "Manage authz cluster role bindings",
+		Long:    `Manage cluster-scoped authorization role bindings for OpenChoreo.`,
+	}
+
+	ListAuthzClusterRoleBinding = Command{
+		Use:   "list",
+		Short: "List authz cluster role bindings",
+		Long:  `List all cluster-scoped authorization role bindings.`,
+		Example: `  # List all authz cluster role bindings
+  occ authzclusterrolebinding list`,
+	}
+
+	GetAuthzClusterRoleBinding = Command{
+		Use:   "get [NAME]",
+		Short: "Get an authz cluster role binding",
+		Long:  `Get an authz cluster role binding and display its details in YAML format.`,
+		Example: fmt.Sprintf(`  # Get an authz cluster role binding
+  %[1]s authzclusterrolebinding get my-binding`, messages.DefaultCLIName),
+	}
+
+	AuthzRole = Command{
+		Use:     "authzrole",
+		Aliases: []string{"authzroles"},
+		Short:   "Manage authz roles",
+		Long:    `Manage namespace-scoped authorization roles for OpenChoreo.`,
+	}
+
+	ListAuthzRole = Command{
+		Use:   "list",
+		Short: "List authz roles",
+		Long:  `List all authz roles in a namespace.`,
+		Example: `  # List all authz roles in a namespace
+  occ authzrole list --namespace acme-corp`,
+	}
+
+	GetAuthzRole = Command{
+		Use:   "get [NAME]",
+		Short: "Get an authz role",
+		Long:  `Get an authz role and display its details in YAML format.`,
+		Example: fmt.Sprintf(`  # Get an authz role
+  %[1]s authzrole get my-role --namespace acme-corp`, messages.DefaultCLIName),
+	}
+
+	AuthzRoleBinding = Command{
+		Use:     "authzrolebinding",
+		Aliases: []string{"authzrolebindings", "rb"},
+		Short:   "Manage authz role bindings",
+		Long:    `Manage namespace-scoped authorization role bindings for OpenChoreo.`,
+	}
+
+	ListAuthzRoleBinding = Command{
+		Use:   "list",
+		Short: "List authz role bindings",
+		Long:  `List all authz role bindings in a namespace.`,
+		Example: `  # List all authz role bindings in a namespace
+  occ authzrolebinding list --namespace acme-corp`,
+	}
+
+	GetAuthzRoleBinding = Command{
+		Use:   "get [NAME]",
+		Short: "Get an authz role binding",
+		Long:  `Get an authz role binding and display its details in YAML format.`,
+		Example: fmt.Sprintf(`  # Get an authz role binding
+  %[1]s authzrolebinding get my-binding --namespace acme-corp`, messages.DefaultCLIName),
+	}
+
 	// Resource root commands
 
 	BuildPlane = Command{

--- a/pkg/cli/core/root/root.go
+++ b/pkg/cli/core/root/root.go
@@ -7,6 +7,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/apply"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/authzclusterrole"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/authzclusterrolebinding"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/authzrole"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/authzrolebinding"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/buildplane"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clustercomponenttype"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clustertrait"
@@ -63,6 +67,10 @@ func BuildRootCmd(config *config.CLIConfig, impl api.CommandImplementationInterf
 		clustercomponenttype.NewClusterComponentTypeCmd(),
 		trait.NewTraitCmd(),
 		clustertrait.NewClusterTraitCmd(),
+		authzclusterrole.NewAuthzClusterRoleCmd(),
+		authzclusterrolebinding.NewAuthzClusterRoleBindingCmd(),
+		authzrole.NewAuthzRoleCmd(),
+		authzrolebinding.NewAuthzRoleBindingCmd(),
 		workflow.NewWorkflowCmd(),
 		workflowrun.NewWorkflowRunCmd(),
 		secretreference.NewSecretReferenceCmd(),


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
### Summary

  - Add get and list CLI subcommands for four authorization resources: authzrole, authzrolebinding,
  authzclusterrole, and authzclusterrolebinding
  - Introduce OpenAPI client methods (ListRoles, GetRole, ListRoleBindings, GetRoleBinding, ListClusterRoles,
  GetClusterRole, ListClusterRoleBindings, GetClusterRoleBinding) to call the apiserver endpoints
  - Register the new resource definitions, validation params, and commands in the shared CLI framework (pkg/cli/)
  and wire them into the root command

 
### Changes

  - internal/occ/cmd/authz{clusterrole,clusterrolebinding,role,rolebinding}/ — implementation of List (tabular
  output) and Get (YAML output) for each resource
  - internal/occ/resources/client/openapi_client.go — eight new client methods for the authz CRUD endpoints
  - internal/occ/validation/ — add command entries and parameter definitions for the four new resources
  - pkg/cli/cmd/authz{clusterrole,clusterrolebinding,role,rolebinding}/ — shared CLI command setup (cobra commands,
  flags, dispatch)
  - pkg/cli/common/constants/definitions.go — resource definitions (names, aliases, column headers) for the four
  authz resources
  - pkg/cli/core/root/root.go — register the new subcommands on the root command

## Approach
> Summarize the solution and implementation details.

## Related Issues

https://github.com/openchoreo/openchoreo/issues/2202

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
