### PR TITLE
feat: add occ delete cmds for authz related crds

### DIFF
--- a/internal/occ/cmd/authzclusterrole/authzclusterrole.go
+++ b/internal/occ/cmd/authzclusterrole/authzclusterrole.go
@@ -64,6 +64,23 @@ func (c *AuthzClusterRole) Get(params GetParams) error {
 	return nil
 }
 
+// Delete deletes a single authz cluster role
+func (c *AuthzClusterRole) Delete(params DeleteParams) error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := cl.DeleteClusterRole(ctx, params.Name); err != nil {
+		return fmt.Errorf("failed to delete authz cluster role: %w", err)
+	}
+
+	fmt.Printf("Authz cluster role '%s' deleted\n", params.Name)
+	return nil
+}
+
 func printList(list *gen.AuthzClusterRoleList) error {
 	if list == nil || len(list.Items) == 0 {
 		fmt.Println("No authz cluster roles found")

--- a/internal/occ/cmd/authzclusterrole/params.go
+++ b/internal/occ/cmd/authzclusterrole/params.go
@@ -7,3 +7,8 @@ package authzclusterrole
 type GetParams struct {
 	Name string
 }
+
+// DeleteParams defines parameters for deleting a single authz cluster role
+type DeleteParams struct {
+	Name string
+}

--- a/internal/occ/cmd/authzclusterrolebinding/authzclusterrolebinding.go
+++ b/internal/occ/cmd/authzclusterrolebinding/authzclusterrolebinding.go
@@ -64,6 +64,23 @@ func (c *AuthzClusterRoleBinding) Get(params GetParams) error {
 	return nil
 }
 
+// Delete deletes a single authz cluster role binding
+func (c *AuthzClusterRoleBinding) Delete(params DeleteParams) error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := cl.DeleteClusterRoleBinding(ctx, params.Name); err != nil {
+		return fmt.Errorf("failed to delete authz cluster role binding: %w", err)
+	}
+
+	fmt.Printf("Authz cluster role binding '%s' deleted\n", params.Name)
+	return nil
+}
+
 func printList(list *gen.AuthzClusterRoleBindingList) error {
 	if list == nil || len(list.Items) == 0 {
 		fmt.Println("No authz cluster role bindings found")

--- a/internal/occ/cmd/authzclusterrolebinding/params.go
+++ b/internal/occ/cmd/authzclusterrolebinding/params.go
@@ -7,3 +7,8 @@ package authzclusterrolebinding
 type GetParams struct {
 	Name string
 }
+
+// DeleteParams defines parameters for deleting a single authz cluster role binding
+type DeleteParams struct {
+	Name string
+}

--- a/internal/occ/cmd/authzrole/authzrole.go
+++ b/internal/occ/cmd/authzrole/authzrole.go
@@ -73,6 +73,27 @@ func (r *AuthzRole) Get(params GetParams) error {
 	return nil
 }
 
+// Delete deletes a single authz role
+func (r *AuthzRole) Delete(params DeleteParams) error {
+	if err := validation.ValidateParams(validation.CmdDelete, validation.ResourceAuthzRole, params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := c.DeleteNamespaceRole(ctx, params.Namespace, params.Name); err != nil {
+		return fmt.Errorf("failed to delete authz role: %w", err)
+	}
+
+	fmt.Printf("Authz role '%s' deleted\n", params.Name)
+	return nil
+}
+
 func printList(list *gen.AuthzRoleList) error {
 	if list == nil || len(list.Items) == 0 {
 		fmt.Println("No authz roles found")

--- a/internal/occ/cmd/authzrole/params.go
+++ b/internal/occ/cmd/authzrole/params.go
@@ -19,3 +19,12 @@ type GetParams struct {
 
 // GetNamespace returns the namespace
 func (p GetParams) GetNamespace() string { return p.Namespace }
+
+// DeleteParams defines parameters for deleting a single authz role
+type DeleteParams struct {
+	Namespace string
+	Name      string
+}
+
+// GetNamespace returns the namespace
+func (p DeleteParams) GetNamespace() string { return p.Namespace }

--- a/internal/occ/cmd/authzrolebinding/authzrolebinding.go
+++ b/internal/occ/cmd/authzrolebinding/authzrolebinding.go
@@ -73,6 +73,27 @@ func (r *AuthzRoleBinding) Get(params GetParams) error {
 	return nil
 }
 
+// Delete deletes a single authz role binding
+func (r *AuthzRoleBinding) Delete(params DeleteParams) error {
+	if err := validation.ValidateParams(validation.CmdDelete, validation.ResourceAuthzRoleBinding, params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	c, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := c.DeleteNamespaceRoleBinding(ctx, params.Namespace, params.Name); err != nil {
+		return fmt.Errorf("failed to delete authz role binding: %w", err)
+	}
+
+	fmt.Printf("Authz role binding '%s' deleted\n", params.Name)
+	return nil
+}
+
 func printList(list *gen.AuthzRoleBindingList) error {
 	if list == nil || len(list.Items) == 0 {
 		fmt.Println("No authz role bindings found")

--- a/internal/occ/cmd/authzrolebinding/params.go
+++ b/internal/occ/cmd/authzrolebinding/params.go
@@ -19,3 +19,12 @@ type GetParams struct {
 
 // GetNamespace returns the namespace
 func (p GetParams) GetNamespace() string { return p.Namespace }
+
+// DeleteParams defines parameters for deleting a single authz role binding
+type DeleteParams struct {
+	Namespace string
+	Name      string
+}
+
+// GetNamespace returns the namespace
+func (p DeleteParams) GetNamespace() string { return p.Namespace }

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -965,6 +965,54 @@ func (c *Client) GetNamespaceRoleBinding(ctx context.Context, namespaceName, nam
 	return resp.JSON200, nil
 }
 
+// DeleteClusterRole deletes a cluster-scoped authorization role
+func (c *Client) DeleteClusterRole(ctx context.Context, name string) error {
+	resp, err := c.client.DeleteClusterRoleWithResponse(ctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete cluster role: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return nil
+}
+
+// DeleteClusterRoleBinding deletes a cluster-scoped role binding
+func (c *Client) DeleteClusterRoleBinding(ctx context.Context, name string) error {
+	resp, err := c.client.DeleteClusterRoleBindingWithResponse(ctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete cluster role binding: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return nil
+}
+
+// DeleteNamespaceRole deletes a namespace-scoped authorization role
+func (c *Client) DeleteNamespaceRole(ctx context.Context, namespaceName, name string) error {
+	resp, err := c.client.DeleteNamespaceRoleWithResponse(ctx, namespaceName, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete role: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return nil
+}
+
+// DeleteNamespaceRoleBinding deletes a namespace-scoped role binding
+func (c *Client) DeleteNamespaceRoleBinding(ctx context.Context, namespaceName, name string) error {
+	resp, err := c.client.DeleteNamespaceRoleBindingWithResponse(ctx, namespaceName, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete role binding: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return nil
+}
+
 // GetEnvironmentObserverURL retrieves the observer URL for an environment
 func (c *Client) GetEnvironmentObserverURL(ctx context.Context, namespaceName, envName string) (string, error) {
 	resp, err := c.client.GetEnvironmentObserverURLWithResponse(ctx, namespaceName, envName)

--- a/internal/occ/validation/params.go
+++ b/internal/occ/validation/params.go
@@ -999,7 +999,7 @@ func validateAuthzClusterRoleBindingParams(_ CommandType, _ interface{}) error {
 
 // validateAuthzRoleParams validates parameters for authz role operations
 func validateAuthzRoleParams(cmdType CommandType, params interface{}) error {
-	if cmdType == CmdList || cmdType == CmdGet {
+	if cmdType == CmdList || cmdType == CmdGet || cmdType == CmdDelete {
 		if p, ok := params.(namespaceParams); ok {
 			return validateNamespace(cmdType, ResourceAuthzRole, p.GetNamespace())
 		}
@@ -1009,7 +1009,7 @@ func validateAuthzRoleParams(cmdType CommandType, params interface{}) error {
 
 // validateAuthzRoleBindingParams validates parameters for authz role binding operations
 func validateAuthzRoleBindingParams(cmdType CommandType, params interface{}) error {
-	if cmdType == CmdList || cmdType == CmdGet {
+	if cmdType == CmdList || cmdType == CmdGet || cmdType == CmdDelete {
 		if p, ok := params.(namespaceParams); ok {
 			return validateNamespace(cmdType, ResourceAuthzRoleBinding, p.GetNamespace())
 		}

--- a/pkg/cli/cmd/authzclusterrole/authzclusterrole.go
+++ b/pkg/cli/cmd/authzclusterrole/authzclusterrole.go
@@ -26,6 +26,7 @@ func NewAuthzClusterRoleCmd() *cobra.Command {
 	cmd.AddCommand(
 		newListAuthzClusterRoleCmd(),
 		newGetAuthzClusterRoleCmd(),
+		newDeleteAuthzClusterRoleCmd(),
 	)
 
 	return cmd
@@ -52,6 +53,24 @@ func newGetAuthzClusterRoleCmd() *cobra.Command {
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return authzclusterrole.New().Get(authzclusterrole.GetParams{
+				Name: args[0],
+			})
+		},
+	}
+
+	return cmd
+}
+
+func newDeleteAuthzClusterRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.DeleteAuthzClusterRole.Use,
+		Short:   constants.DeleteAuthzClusterRole.Short,
+		Long:    constants.DeleteAuthzClusterRole.Long,
+		Example: constants.DeleteAuthzClusterRole.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authzclusterrole.New().Delete(authzclusterrole.DeleteParams{
 				Name: args[0],
 			})
 		},

--- a/pkg/cli/cmd/authzclusterrolebinding/authzclusterrolebinding.go
+++ b/pkg/cli/cmd/authzclusterrolebinding/authzclusterrolebinding.go
@@ -26,6 +26,7 @@ func NewAuthzClusterRoleBindingCmd() *cobra.Command {
 	cmd.AddCommand(
 		newListAuthzClusterRoleBindingCmd(),
 		newGetAuthzClusterRoleBindingCmd(),
+		newDeleteAuthzClusterRoleBindingCmd(),
 	)
 
 	return cmd
@@ -52,6 +53,24 @@ func newGetAuthzClusterRoleBindingCmd() *cobra.Command {
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return authzclusterrolebinding.New().Get(authzclusterrolebinding.GetParams{
+				Name: args[0],
+			})
+		},
+	}
+
+	return cmd
+}
+
+func newDeleteAuthzClusterRoleBindingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.DeleteAuthzClusterRoleBinding.Use,
+		Short:   constants.DeleteAuthzClusterRoleBinding.Short,
+		Long:    constants.DeleteAuthzClusterRoleBinding.Long,
+		Example: constants.DeleteAuthzClusterRoleBinding.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authzclusterrolebinding.New().Delete(authzclusterrolebinding.DeleteParams{
 				Name: args[0],
 			})
 		},

--- a/pkg/cli/cmd/authzrole/authzrole.go
+++ b/pkg/cli/cmd/authzrole/authzrole.go
@@ -26,6 +26,7 @@ func NewAuthzRoleCmd() *cobra.Command {
 	cmd.AddCommand(
 		newListAuthzRoleCmd(),
 		newGetAuthzRoleCmd(),
+		newDeleteAuthzRoleCmd(),
 	)
 
 	return cmd
@@ -56,6 +57,29 @@ func newGetAuthzRoleCmd() *cobra.Command {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
 
 			return authzrole.New().Get(authzrole.GetParams{
+				Namespace: namespace,
+				Name:      args[0],
+			})
+		},
+	}
+
+	flags.AddFlags(cmd, flags.Namespace)
+
+	return cmd
+}
+
+func newDeleteAuthzRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.DeleteAuthzRole.Use,
+		Short:   constants.DeleteAuthzRole.Short,
+		Long:    constants.DeleteAuthzRole.Long,
+		Example: constants.DeleteAuthzRole.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+
+			return authzrole.New().Delete(authzrole.DeleteParams{
 				Namespace: namespace,
 				Name:      args[0],
 			})

--- a/pkg/cli/cmd/authzrolebinding/authzrolebinding.go
+++ b/pkg/cli/cmd/authzrolebinding/authzrolebinding.go
@@ -26,6 +26,7 @@ func NewAuthzRoleBindingCmd() *cobra.Command {
 	cmd.AddCommand(
 		newListAuthzRoleBindingCmd(),
 		newGetAuthzRoleBindingCmd(),
+		newDeleteAuthzRoleBindingCmd(),
 	)
 
 	return cmd
@@ -56,6 +57,29 @@ func newGetAuthzRoleBindingCmd() *cobra.Command {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
 
 			return authzrolebinding.New().Get(authzrolebinding.GetParams{
+				Namespace: namespace,
+				Name:      args[0],
+			})
+		},
+	}
+
+	flags.AddFlags(cmd, flags.Namespace)
+
+	return cmd
+}
+
+func newDeleteAuthzRoleBindingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.DeleteAuthzRoleBinding.Use,
+		Short:   constants.DeleteAuthzRoleBinding.Short,
+		Long:    constants.DeleteAuthzRoleBinding.Long,
+		Example: constants.DeleteAuthzRoleBinding.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+
+			return authzrolebinding.New().Delete(authzrolebinding.DeleteParams{
 				Namespace: namespace,
 				Name:      args[0],
 			})

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -800,6 +800,14 @@ This command allows you to:
   %[1]s authzclusterrole get my-role`, messages.DefaultCLIName),
 	}
 
+	DeleteAuthzClusterRole = Command{
+		Use:   "delete [NAME]",
+		Short: "Delete an authz cluster role",
+		Long:  `Delete a cluster-scoped authorization role by name.`,
+		Example: fmt.Sprintf(`  # Delete an authz cluster role
+  %[1]s authzclusterrole delete my-role`, messages.DefaultCLIName),
+	}
+
 	AuthzClusterRoleBinding = Command{
 		Use:     "authzclusterrolebinding",
 		Aliases: []string{"authzclusterrolebindings", "crb"},
@@ -821,6 +829,14 @@ This command allows you to:
 		Long:  `Get an authz cluster role binding and display its details in YAML format.`,
 		Example: fmt.Sprintf(`  # Get an authz cluster role binding
   %[1]s authzclusterrolebinding get my-binding`, messages.DefaultCLIName),
+	}
+
+	DeleteAuthzClusterRoleBinding = Command{
+		Use:   "delete [NAME]",
+		Short: "Delete an authz cluster role binding",
+		Long:  `Delete a cluster-scoped authorization role binding by name.`,
+		Example: fmt.Sprintf(`  # Delete an authz cluster role binding
+  %[1]s authzclusterrolebinding delete my-binding`, messages.DefaultCLIName),
 	}
 
 	AuthzRole = Command{
@@ -846,6 +862,14 @@ This command allows you to:
   %[1]s authzrole get my-role --namespace acme-corp`, messages.DefaultCLIName),
 	}
 
+	DeleteAuthzRole = Command{
+		Use:   "delete [NAME]",
+		Short: "Delete an authz role",
+		Long:  `Delete an authorization role by name.`,
+		Example: fmt.Sprintf(`  # Delete an authz role
+  %[1]s authzrole delete my-role --namespace acme-corp`, messages.DefaultCLIName),
+	}
+
 	AuthzRoleBinding = Command{
 		Use:     "authzrolebinding",
 		Aliases: []string{"authzrolebindings", "rb"},
@@ -867,6 +891,14 @@ This command allows you to:
 		Long:  `Get an authz role binding and display its details in YAML format.`,
 		Example: fmt.Sprintf(`  # Get an authz role binding
   %[1]s authzrolebinding get my-binding --namespace acme-corp`, messages.DefaultCLIName),
+	}
+
+	DeleteAuthzRoleBinding = Command{
+		Use:   "delete [NAME]",
+		Short: "Delete an authz role binding",
+		Long:  `Delete an authorization role binding by name.`,
+		Example: fmt.Sprintf(`  # Delete an authz role binding
+  %[1]s authzrolebinding delete my-binding --namespace acme-corp`, messages.DefaultCLIName),
 	}
 
 	// Resource root commands


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
  ### Summary
  - Add `delete` subcommands for all 4 authz CLI resources: `authzrole`, `authzrolebinding`, `authzclusterrole`,
  `authzclusterrolebinding`
  - Add corresponding delete client methods, params, constants, and validation

  ### Usage
  occ authzrole delete  --namespace
  occ authzrolebinding delete  --namespace
  occ authzclusterrole delete
  occ authzclusterrolebinding delete
## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2202

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
