### PR TITLE
fix: define a global security enable/disable flag for oc-api

### DIFF
--- a/cmd/openchoreo-api/config.yaml
+++ b/cmd/openchoreo-api/config.yaml
@@ -9,7 +9,7 @@
 # Examples:
 #   OC_API__SERVER__PORT=9090
 #   OC_API__LOGGING__LEVEL=debug
-#   OC_API__SECURITY__AUTHENTICATION__JWT__ENABLED=true
+#   OC_API__SECURITY__ENABLED=true
 
 server:
   # Address to bind the HTTP server to.
@@ -49,12 +49,14 @@ server:
   middleware: { }
 
 security:
+  # Enable all security checks (authentication and authorization).
+  # When false, global authentication and authorization enforcement is disabled
+  # and requests are processed as anonymous without any access restrictions.
+  # This overrides all individual security settings.
+  enabled: false
+
   authentication:
     jwt:
-      # Enable JWT authentication.
-      # When disabled, all requests are treated as unauthenticated.
-      enabled: false
-
       # List of acceptable audiences (aud) for the JWT.
       # Tokens must contain at least one of these audiences.
       audiences: [ ]
@@ -104,6 +106,7 @@ security:
   authorization:
     # Enable authorization checks using Casbin.
     # When disabled, all authenticated requests are permitted.
+    # Note: security.enabled=false also disables authorization.
     enabled: false
 
     cache:

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -229,7 +229,7 @@ func setupRuntime(ctx context.Context, cfg *config.Config, k8sClient client.Clie
 	var mgr ctrl.Manager
 
 	// When enabled, create a controller-runtime manager with informers for authz CRDs
-	if authzCfg.Enabled {
+	if cfg.Security.Enabled && authzCfg.Enabled {
 		logger.Info("Setting up controller manager for authorization CRD informers")
 		cacheOpts := cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
@@ -255,7 +255,7 @@ func setupRuntime(ctx context.Context, cfg *config.Config, k8sClient client.Clie
 		}
 	}
 
-	pap, pdp, err := authz.Initialize(ctx, mgr, authzCfg.ToAuthzConfig(), k8sClient, logger)
+	pap, pdp, err := authz.Initialize(ctx, mgr, authzCfg.ToAuthzConfig(cfg.Security.Enabled), k8sClient, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authorization: %w", err)
 	}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -20,9 +20,9 @@ data:
       middleware: {}
 
     security:
+      enabled: {{ .Values.security.enabled }}
       authentication:
         jwt:
-          enabled: {{ .Values.security.enabled }}
           audiences:
             {{- if .Values.security.jwt.audience }}
             - {{ .Values.security.jwt.audience | quote }}

--- a/internal/openchoreo-api/api/handlers/oauth_metadata.go
+++ b/internal/openchoreo-api/api/handlers/oauth_metadata.go
@@ -29,7 +29,7 @@ func (h *Handler) GetOAuthProtectedResourceMetadata(
 		return clients[i].Name < clients[j].Name
 	})
 
-	securityEnabled := h.Config.Security.Authentication.JWT.Enabled
+	securityEnabled := h.Config.Security.Enabled
 	resource := strings.TrimSuffix(h.Config.Server.PublicURL, "/") + "/mcp"
 
 	response := gen.GetOAuthProtectedResourceMetadata200JSONResponse{

--- a/internal/openchoreo-api/handlers/handlers.go
+++ b/internal/openchoreo-api/handlers/handlers.go
@@ -282,7 +282,7 @@ func (h *Handler) InitJWTMiddleware() func(http.Handler) http.Handler {
 		}
 	}
 
-	return jwt.Middleware(jwtCfg.ToJWTMiddlewareConfig(&h.config.Identity.OIDC, h.logger, resolver))
+	return jwt.Middleware(jwtCfg.ToJWTMiddlewareConfig(&h.config.Identity.OIDC, h.logger, resolver, h.config.Security.Enabled))
 }
 
 func (h *Handler) initMCPMiddleware() func(http.Handler) http.Handler {

--- a/internal/openchoreo-api/handlers/oauth_metadata.go
+++ b/internal/openchoreo-api/handlers/oauth_metadata.go
@@ -32,7 +32,7 @@ func (h *Handler) OAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.
 			h.config.Identity.OIDC.Issuer,
 		},
 		Clients:         clients,
-		SecurityEnabled: h.config.Security.Authentication.JWT.Enabled,
+		SecurityEnabled: h.config.Security.Enabled,
 		Logger:          h.logger,
 	})
 


### PR DESCRIPTION
This pull request introduces a new top-level `security.enabled` configuration flag that globally controls whether all security checks (authentication and authorization) are enforced in the OpenChoreo API. This simplifies security management, especially for development and testing, by allowing all security to be toggled with a single setting. The changes remove the previous per-feature `enabled` flags (such as for JWT authentication) in favor of this unified flag, and propagate its usage throughout configuration, validation, and middleware logic.

Key changes include:

**Configuration and Defaults:**

* Added a new `enabled` flag under the `security` section in `config.yaml` and the Helm chart, and removed the old `jwt.enabled` flag. This flag now controls all security checks globally. [[1]](diffhunk://#diff-2aaad409116ee7032f008605c1c6bff72617a53677b359083aff2538fb5758eeL12-R12) [[2]](diffhunk://#diff-bebe2f11ef7e2bf893c559a8de30e43911451e2b07da12e035a2add4f47c413cR23-L25)
* Updated the `SecurityConfig` struct and default configuration in `security.go` to include the new `Enabled` field, and removed the `Enabled` field from `JWTConfig`. [[1]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4R20-R24) [[2]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4R37) [[3]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4L91-L92) [[4]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4L105)

**Validation and Propagation:**

* Modified validation logic so that if `security.enabled` is `false`, all other security validation is skipped. [[1]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4R46-R49) [[2]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4L115-L118)
* Updated conversion methods (`ToJWTMiddlewareConfig`, `ToAuthzConfig`) to accept and use the top-level `security.enabled` flag, ensuring that middleware and authorization logic are correctly enabled or disabled. [[1]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4L130-R136) [[2]](diffhunk://#diff-ba18b07faafec6290a3e24ef4db48b230dad579627ed7d3f56f1bbf30675c4a4L343-R350)

**Application Logic:**

* Updated handler code and middleware initialization to use the new `security.enabled` flag instead of the removed per-feature flags, ensuring consistent behavior throughout the application. [[1]](diffhunk://#diff-83389a138e126c17d3be9610542e0157325c5287ef71d6d738cc3606e9ae612dL32-R32) [[2]](diffhunk://#diff-9282f97bb075eae66fa1a9f77d2874eba0832b6170d12710521361d38c62314fL35-R35) [[3]](diffhunk://#diff-6291dce7765bcb9a186a3fdc94785a7f48efd9aadfed04bf5753f723c70a064eL285-R285)
* Ensured that authorization CRD informers and initialization are only set up when both `security.enabled` and `authorization.enabled` are true. [[1]](diffhunk://#diff-6a30d8830ceafb48dc9652d4195eb1b085bffe2a673ffc3680173690a84ec707L232-R232) [[2]](diffhunk://#diff-6a30d8830ceafb48dc9652d4195eb1b085bffe2a673ffc3680173690a84ec707L258-R258)

**Documentation:**

* Improved comments and documentation in `config.yaml` and code to clarify the purpose and usage of the new `security.enabled` flag and its impact on other security settings. [[1]](diffhunk://#diff-2aaad409116ee7032f008605c1c6bff72617a53677b359083aff2538fb5758eeL52-R59) [[2]](diffhunk://#diff-2aaad409116ee7032f008605c1c6bff72617a53677b359083aff2538fb5758eeR109)

These changes provide a simpler and more robust way to manage security across the OpenChoreo API, especially for non-production environments.