### PR TITLE
feat(api): add k8s resource endpoints under release bindings

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -156,7 +156,7 @@ func main() {
 	legacyRoutes := legacyHandler.Routes()
 
 	// Initialize all handler services
-	services := handlerservices.NewServices(k8sClient, runtime.pap, runtime.pdp, planeK8sClientMgr, gatewayURL, logger)
+	services := handlerservices.NewServices(k8sClient, runtime.pap, runtime.pdp, planeK8sClientMgr, gatewayURL, logger, gwClient)
 
 	// Initialize OpenAPI handlers
 	openapiHandler := openapihandlers.New(legacySvc, services, logger.With("component", "openapi-handlers"), &cfg)

--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -493,6 +493,15 @@ type ClientInterface interface {
 
 	UpdateReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, body UpdateReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetReleaseBindingK8sResourceEvents request
+	GetReleaseBindingK8sResourceEvents(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetReleaseBindingK8sResourceLogs request
+	GetReleaseBindingK8sResourceLogs(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetReleaseBindingK8sResourceTree request
+	GetReleaseBindingK8sResourceTree(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListReleases request
 	ListReleases(ctx context.Context, namespaceName NamespaceNameParam, params *ListReleasesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2447,6 +2456,42 @@ func (c *Client) UpdateReleaseBindingWithBody(ctx context.Context, namespaceName
 
 func (c *Client) UpdateReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, body UpdateReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateReleaseBindingRequest(c.Server, namespaceName, releaseBindingName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseBindingK8sResourceEvents(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseBindingK8sResourceEventsRequest(c.Server, namespaceName, releaseBindingName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseBindingK8sResourceLogs(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseBindingK8sResourceLogsRequest(c.Server, namespaceName, releaseBindingName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseBindingK8sResourceTree(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseBindingK8sResourceTreeRequest(c.Server, namespaceName, releaseBindingName)
 	if err != nil {
 		return nil, err
 	}
@@ -8602,6 +8647,217 @@ func NewUpdateReleaseBindingRequestWithBody(server string, namespaceName Namespa
 	return req, nil
 }
 
+// NewGetReleaseBindingK8sResourceEventsRequest generates requests for GetReleaseBindingK8sResourceEvents
+func NewGetReleaseBindingK8sResourceEventsRequest(server string, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceEventsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "releaseBindingName", runtime.ParamLocationPath, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/releasebindings/%s/k8sresources/events", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "group", runtime.ParamLocationQuery, params.Group); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "version", runtime.ParamLocationQuery, params.Version); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "kind", runtime.ParamLocationQuery, params.Kind); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, params.Name); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetReleaseBindingK8sResourceLogsRequest generates requests for GetReleaseBindingK8sResourceLogs
+func NewGetReleaseBindingK8sResourceLogsRequest(server string, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "releaseBindingName", runtime.ParamLocationPath, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/releasebindings/%s/k8sresources/logs", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "podName", runtime.ParamLocationQuery, params.PodName); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.SinceSeconds != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sinceSeconds", runtime.ParamLocationQuery, *params.SinceSeconds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetReleaseBindingK8sResourceTreeRequest generates requests for GetReleaseBindingK8sResourceTree
+func NewGetReleaseBindingK8sResourceTreeRequest(server string, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "releaseBindingName", runtime.ParamLocationPath, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/releasebindings/%s/k8sresources/tree", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListReleasesRequest generates requests for ListReleases
 func NewListReleasesRequest(server string, namespaceName NamespaceNameParam, params *ListReleasesParams) (*http.Request, error) {
 	var err error
@@ -11541,6 +11797,15 @@ type ClientWithResponsesInterface interface {
 	UpdateReleaseBindingWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateReleaseBindingResp, error)
 
 	UpdateReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, body UpdateReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateReleaseBindingResp, error)
+
+	// GetReleaseBindingK8sResourceEventsWithResponse request
+	GetReleaseBindingK8sResourceEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceEventsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceEventsResp, error)
+
+	// GetReleaseBindingK8sResourceLogsWithResponse request
+	GetReleaseBindingK8sResourceLogsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceLogsResp, error)
+
+	// GetReleaseBindingK8sResourceTreeWithResponse request
+	GetReleaseBindingK8sResourceTreeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceTreeResp, error)
 
 	// ListReleasesWithResponse request
 	ListReleasesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListReleasesParams, reqEditors ...RequestEditorFn) (*ListReleasesResp, error)
@@ -14555,6 +14820,87 @@ func (r UpdateReleaseBindingResp) StatusCode() int {
 	return 0
 }
 
+type GetReleaseBindingK8sResourceEventsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ResourceEventsResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReleaseBindingK8sResourceEventsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReleaseBindingK8sResourceEventsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetReleaseBindingK8sResourceLogsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ResourcePodLogsResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReleaseBindingK8sResourceLogsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReleaseBindingK8sResourceLogsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetReleaseBindingK8sResourceTreeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *K8sResourceTreeResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReleaseBindingK8sResourceTreeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReleaseBindingK8sResourceTreeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListReleasesResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17157,6 +17503,33 @@ func (c *ClientWithResponses) UpdateReleaseBindingWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseUpdateReleaseBindingResp(rsp)
+}
+
+// GetReleaseBindingK8sResourceEventsWithResponse request returning *GetReleaseBindingK8sResourceEventsResp
+func (c *ClientWithResponses) GetReleaseBindingK8sResourceEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceEventsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceEventsResp, error) {
+	rsp, err := c.GetReleaseBindingK8sResourceEvents(ctx, namespaceName, releaseBindingName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseBindingK8sResourceEventsResp(rsp)
+}
+
+// GetReleaseBindingK8sResourceLogsWithResponse request returning *GetReleaseBindingK8sResourceLogsResp
+func (c *ClientWithResponses) GetReleaseBindingK8sResourceLogsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceLogsResp, error) {
+	rsp, err := c.GetReleaseBindingK8sResourceLogs(ctx, namespaceName, releaseBindingName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseBindingK8sResourceLogsResp(rsp)
+}
+
+// GetReleaseBindingK8sResourceTreeWithResponse request returning *GetReleaseBindingK8sResourceTreeResp
+func (c *ClientWithResponses) GetReleaseBindingK8sResourceTreeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceTreeResp, error) {
+	rsp, err := c.GetReleaseBindingK8sResourceTree(ctx, namespaceName, releaseBindingName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseBindingK8sResourceTreeResp(rsp)
 }
 
 // ListReleasesWithResponse request returning *ListReleasesResp
@@ -23660,6 +24033,189 @@ func ParseUpdateReleaseBindingResp(rsp *http.Response) (*UpdateReleaseBindingRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ReleaseBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReleaseBindingK8sResourceEventsResp parses an HTTP response from a GetReleaseBindingK8sResourceEventsWithResponse call
+func ParseGetReleaseBindingK8sResourceEventsResp(rsp *http.Response) (*GetReleaseBindingK8sResourceEventsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReleaseBindingK8sResourceEventsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResourceEventsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReleaseBindingK8sResourceLogsResp parses an HTTP response from a GetReleaseBindingK8sResourceLogsWithResponse call
+func ParseGetReleaseBindingK8sResourceLogsResp(rsp *http.Response) (*GetReleaseBindingK8sResourceLogsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReleaseBindingK8sResourceLogsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResourcePodLogsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReleaseBindingK8sResourceTreeResp parses an HTTP response from a GetReleaseBindingK8sResourceTreeWithResponse call
+func ParseGetReleaseBindingK8sResourceTreeResp(rsp *http.Response) (*GetReleaseBindingK8sResourceTreeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReleaseBindingK8sResourceTreeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest K8sResourceTreeResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -198,6 +198,12 @@ const (
 	ReleaseBindingSpecStateUndeploy ReleaseBindingSpecState = "Undeploy"
 )
 
+// Defines values for ReleaseResourceTreeTargetPlane.
+const (
+	ReleaseResourceTreeTargetPlaneDataplane          ReleaseResourceTreeTargetPlane = "dataplane"
+	ReleaseResourceTreeTargetPlaneObservabilityplane ReleaseResourceTreeTargetPlane = "observabilityplane"
+)
+
 // Defines values for ReleaseSpecTargetPlane.
 const (
 	ReleaseSpecTargetPlaneDataplane          ReleaseSpecTargetPlane = "dataplane"
@@ -251,8 +257,8 @@ const (
 
 // Defines values for TraitSpecPatchesTargetPlane.
 const (
-	Dataplane          TraitSpecPatchesTargetPlane = "dataplane"
-	Observabilityplane TraitSpecPatchesTargetPlane = "observabilityplane"
+	TraitSpecPatchesTargetPlaneDataplane          TraitSpecPatchesTargetPlane = "dataplane"
+	TraitSpecPatchesTargetPlaneObservabilityplane TraitSpecPatchesTargetPlane = "observabilityplane"
 )
 
 // Defines values for UpdateClusterRoleBindingRequestEffect.
@@ -1813,6 +1819,12 @@ type HealthInfo struct {
 	Status string `json:"status"`
 }
 
+// K8sResourceTreeResponse Response containing resource trees for all releases owned by a release binding
+type K8sResourceTreeResponse struct {
+	// Releases Resource trees per release (dataplane and/or observabilityplane)
+	Releases []ReleaseResourceTree `json:"releases"`
+}
+
 // MessageResponse Simple message response
 type MessageResponse struct {
 	// Message Response message
@@ -2314,6 +2326,21 @@ type ReleaseList struct {
 	// for efficient pagination through large result sets.
 	Pagination *Pagination `json:"pagination,omitempty"`
 }
+
+// ReleaseResourceTree Resource tree for a single release
+type ReleaseResourceTree struct {
+	// Name Name of the release
+	Name string `json:"name"`
+
+	// Nodes All resource nodes in the tree
+	Nodes []ResourceNode `json:"nodes"`
+
+	// TargetPlane Target plane of the release
+	TargetPlane ReleaseResourceTreeTargetPlane `json:"targetPlane"`
+}
+
+// ReleaseResourceTreeTargetPlane Target plane of the release
+type ReleaseResourceTreeTargetPlane string
 
 // ReleaseSpec Desired state of a Release
 type ReleaseSpec struct {
@@ -3647,6 +3674,30 @@ type ListReleaseBindingsParams struct {
 	// Cursor Opaque pagination cursor from a previous response.
 	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
 	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// GetReleaseBindingK8sResourceEventsParams defines parameters for GetReleaseBindingK8sResourceEvents.
+type GetReleaseBindingK8sResourceEventsParams struct {
+	// Group API group of the resource (empty string for core resources)
+	Group string `form:"group" json:"group"`
+
+	// Version API version of the resource (e.g. v1)
+	Version string `form:"version" json:"version"`
+
+	// Kind Kind of the resource
+	Kind string `form:"kind" json:"kind"`
+
+	// Name Name of the resource
+	Name string `form:"name" json:"name"`
+}
+
+// GetReleaseBindingK8sResourceLogsParams defines parameters for GetReleaseBindingK8sResourceLogs.
+type GetReleaseBindingK8sResourceLogsParams struct {
+	// PodName Name of the pod
+	PodName string `form:"podName" json:"podName"`
+
+	// SinceSeconds Number of seconds since which to show logs
+	SinceSeconds *int64 `form:"sinceSeconds,omitempty" json:"sinceSeconds,omitempty"`
 }
 
 // ListReleasesParams defines parameters for ListReleases.

--- a/internal/openchoreo-api/api/gen/server.gen.go
+++ b/internal/openchoreo-api/api/gen/server.gen.go
@@ -348,6 +348,15 @@ type ServerInterface interface {
 	// Update release binding
 	// (PUT /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName})
 	UpdateReleaseBinding(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam)
+	// Get K8s resource events for a release binding
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/events)
+	GetReleaseBindingK8sResourceEvents(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingK8sResourceEventsParams)
+	// Get pod logs for a release binding
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs)
+	GetReleaseBindingK8sResourceLogs(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingK8sResourceLogsParams)
+	// Get K8s resource tree for a release binding
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree)
+	GetReleaseBindingK8sResourceTree(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam)
 	// List releases
 	// (GET /api/v1/namespaces/{namespaceName}/releases)
 	ListReleases(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListReleasesParams)
@@ -4585,6 +4594,215 @@ func (siw *ServerInterfaceWrapper) UpdateReleaseBinding(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// GetReleaseBindingK8sResourceEvents operation middleware
+func (siw *ServerInterfaceWrapper) GetReleaseBindingK8sResourceEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "namespaceName" -------------
+	var namespaceName NamespaceNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "namespaceName", r.PathValue("namespaceName"), &namespaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespaceName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "releaseBindingName" -------------
+	var releaseBindingName ReleaseBindingNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "releaseBindingName", r.PathValue("releaseBindingName"), &releaseBindingName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "releaseBindingName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetReleaseBindingK8sResourceEventsParams
+
+	// ------------- Required query parameter "group" -------------
+
+	if paramValue := r.URL.Query().Get("group"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "group"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "group", r.URL.Query(), &params.Group)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "group", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "version" -------------
+
+	if paramValue := r.URL.Query().Get("version"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "version"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "version", r.URL.Query(), &params.Version)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "version", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "kind" -------------
+
+	if paramValue := r.URL.Query().Get("kind"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "kind"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "kind", r.URL.Query(), &params.Kind)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "name" -------------
+
+	if paramValue := r.URL.Query().Get("name"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "name"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "name", r.URL.Query(), &params.Name)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReleaseBindingK8sResourceEvents(w, r, namespaceName, releaseBindingName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetReleaseBindingK8sResourceLogs operation middleware
+func (siw *ServerInterfaceWrapper) GetReleaseBindingK8sResourceLogs(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "namespaceName" -------------
+	var namespaceName NamespaceNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "namespaceName", r.PathValue("namespaceName"), &namespaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespaceName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "releaseBindingName" -------------
+	var releaseBindingName ReleaseBindingNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "releaseBindingName", r.PathValue("releaseBindingName"), &releaseBindingName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "releaseBindingName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetReleaseBindingK8sResourceLogsParams
+
+	// ------------- Required query parameter "podName" -------------
+
+	if paramValue := r.URL.Query().Get("podName"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "podName"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "podName", r.URL.Query(), &params.PodName)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "podName", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sinceSeconds" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sinceSeconds", r.URL.Query(), &params.SinceSeconds)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sinceSeconds", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReleaseBindingK8sResourceLogs(w, r, namespaceName, releaseBindingName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetReleaseBindingK8sResourceTree operation middleware
+func (siw *ServerInterfaceWrapper) GetReleaseBindingK8sResourceTree(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "namespaceName" -------------
+	var namespaceName NamespaceNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "namespaceName", r.PathValue("namespaceName"), &namespaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespaceName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "releaseBindingName" -------------
+	var releaseBindingName ReleaseBindingNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "releaseBindingName", r.PathValue("releaseBindingName"), &releaseBindingName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "releaseBindingName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReleaseBindingK8sResourceTree(w, r, namespaceName, releaseBindingName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListReleases operation middleware
 func (siw *ServerInterfaceWrapper) ListReleases(w http.ResponseWriter, r *http.Request) {
 
@@ -6704,6 +6922,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}", wrapper.DeleteReleaseBinding)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}", wrapper.GetReleaseBinding)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}", wrapper.UpdateReleaseBinding)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/events", wrapper.GetReleaseBindingK8sResourceEvents)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs", wrapper.GetReleaseBindingK8sResourceLogs)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree", wrapper.GetReleaseBindingK8sResourceTree)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releases", wrapper.ListReleases)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releases/{releaseName}", wrapper.GetRelease)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/rolebindings", wrapper.ListNamespaceRoleBindings)
@@ -12881,6 +13102,197 @@ func (response UpdateReleaseBinding500JSONResponse) VisitUpdateReleaseBindingRes
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetReleaseBindingK8sResourceEventsRequestObject struct {
+	NamespaceName      NamespaceNameParam      `json:"namespaceName"`
+	ReleaseBindingName ReleaseBindingNameParam `json:"releaseBindingName"`
+	Params             GetReleaseBindingK8sResourceEventsParams
+}
+
+type GetReleaseBindingK8sResourceEventsResponseObject interface {
+	VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error
+}
+
+type GetReleaseBindingK8sResourceEvents200JSONResponse ResourceEventsResponse
+
+func (response GetReleaseBindingK8sResourceEvents200JSONResponse) VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceEvents400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetReleaseBindingK8sResourceEvents400JSONResponse) VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceEvents401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetReleaseBindingK8sResourceEvents401JSONResponse) VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceEvents403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetReleaseBindingK8sResourceEvents403JSONResponse) VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceEvents404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetReleaseBindingK8sResourceEvents404JSONResponse) VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceEvents500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetReleaseBindingK8sResourceEvents500JSONResponse) VisitGetReleaseBindingK8sResourceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceLogsRequestObject struct {
+	NamespaceName      NamespaceNameParam      `json:"namespaceName"`
+	ReleaseBindingName ReleaseBindingNameParam `json:"releaseBindingName"`
+	Params             GetReleaseBindingK8sResourceLogsParams
+}
+
+type GetReleaseBindingK8sResourceLogsResponseObject interface {
+	VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error
+}
+
+type GetReleaseBindingK8sResourceLogs200JSONResponse ResourcePodLogsResponse
+
+func (response GetReleaseBindingK8sResourceLogs200JSONResponse) VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceLogs400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetReleaseBindingK8sResourceLogs400JSONResponse) VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceLogs401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetReleaseBindingK8sResourceLogs401JSONResponse) VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceLogs403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetReleaseBindingK8sResourceLogs403JSONResponse) VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceLogs404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetReleaseBindingK8sResourceLogs404JSONResponse) VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceLogs500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetReleaseBindingK8sResourceLogs500JSONResponse) VisitGetReleaseBindingK8sResourceLogsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceTreeRequestObject struct {
+	NamespaceName      NamespaceNameParam      `json:"namespaceName"`
+	ReleaseBindingName ReleaseBindingNameParam `json:"releaseBindingName"`
+}
+
+type GetReleaseBindingK8sResourceTreeResponseObject interface {
+	VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error
+}
+
+type GetReleaseBindingK8sResourceTree200JSONResponse K8sResourceTreeResponse
+
+func (response GetReleaseBindingK8sResourceTree200JSONResponse) VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceTree400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetReleaseBindingK8sResourceTree400JSONResponse) VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceTree401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetReleaseBindingK8sResourceTree401JSONResponse) VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceTree403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetReleaseBindingK8sResourceTree403JSONResponse) VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceTree404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetReleaseBindingK8sResourceTree404JSONResponse) VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingK8sResourceTree500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetReleaseBindingK8sResourceTree500JSONResponse) VisitGetReleaseBindingK8sResourceTreeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type ListReleasesRequestObject struct {
 	NamespaceName NamespaceNameParam `json:"namespaceName"`
 	Params        ListReleasesParams
@@ -15905,6 +16317,15 @@ type StrictServerInterface interface {
 	// Update release binding
 	// (PUT /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName})
 	UpdateReleaseBinding(ctx context.Context, request UpdateReleaseBindingRequestObject) (UpdateReleaseBindingResponseObject, error)
+	// Get K8s resource events for a release binding
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/events)
+	GetReleaseBindingK8sResourceEvents(ctx context.Context, request GetReleaseBindingK8sResourceEventsRequestObject) (GetReleaseBindingK8sResourceEventsResponseObject, error)
+	// Get pod logs for a release binding
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs)
+	GetReleaseBindingK8sResourceLogs(ctx context.Context, request GetReleaseBindingK8sResourceLogsRequestObject) (GetReleaseBindingK8sResourceLogsResponseObject, error)
+	// Get K8s resource tree for a release binding
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree)
+	GetReleaseBindingK8sResourceTree(ctx context.Context, request GetReleaseBindingK8sResourceTreeRequestObject) (GetReleaseBindingK8sResourceTreeResponseObject, error)
 	// List releases
 	// (GET /api/v1/namespaces/{namespaceName}/releases)
 	ListReleases(ctx context.Context, request ListReleasesRequestObject) (ListReleasesResponseObject, error)
@@ -19215,6 +19636,89 @@ func (sh *strictHandler) UpdateReleaseBinding(w http.ResponseWriter, r *http.Req
 	}
 }
 
+// GetReleaseBindingK8sResourceEvents operation middleware
+func (sh *strictHandler) GetReleaseBindingK8sResourceEvents(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingK8sResourceEventsParams) {
+	var request GetReleaseBindingK8sResourceEventsRequestObject
+
+	request.NamespaceName = namespaceName
+	request.ReleaseBindingName = releaseBindingName
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetReleaseBindingK8sResourceEvents(ctx, request.(GetReleaseBindingK8sResourceEventsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetReleaseBindingK8sResourceEvents")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetReleaseBindingK8sResourceEventsResponseObject); ok {
+		if err := validResponse.VisitGetReleaseBindingK8sResourceEventsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetReleaseBindingK8sResourceLogs operation middleware
+func (sh *strictHandler) GetReleaseBindingK8sResourceLogs(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingK8sResourceLogsParams) {
+	var request GetReleaseBindingK8sResourceLogsRequestObject
+
+	request.NamespaceName = namespaceName
+	request.ReleaseBindingName = releaseBindingName
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetReleaseBindingK8sResourceLogs(ctx, request.(GetReleaseBindingK8sResourceLogsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetReleaseBindingK8sResourceLogs")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetReleaseBindingK8sResourceLogsResponseObject); ok {
+		if err := validResponse.VisitGetReleaseBindingK8sResourceLogsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetReleaseBindingK8sResourceTree operation middleware
+func (sh *strictHandler) GetReleaseBindingK8sResourceTree(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam) {
+	var request GetReleaseBindingK8sResourceTreeRequestObject
+
+	request.NamespaceName = namespaceName
+	request.ReleaseBindingName = releaseBindingName
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetReleaseBindingK8sResourceTree(ctx, request.(GetReleaseBindingK8sResourceTreeRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetReleaseBindingK8sResourceTree")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetReleaseBindingK8sResourceTreeResponseObject); ok {
+		if err := validResponse.VisitGetReleaseBindingK8sResourceTreeResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListReleases operation middleware
 func (sh *strictHandler) ListReleases(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, params ListReleasesParams) {
 	var request ListReleasesRequestObject
@@ -20683,426 +21187,433 @@ func (sh *strictHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+z963LcOJYoCr8KIr+OaHnvzJR8q6nWFxPnqGTZpW7bUktyOfaUfFxIEspEm0mwAVBy",
-	"lsfndfZ77Cc7gRsJkiAJMq+y9GOmXUritrDWwrqvb4OAzBMSo5izweG3QQIpnCOOqPyvX1IchecRjNF7",
-	"OEfn4jfx5xCxgOKEYxIPDtVHIBFfgRjO0WA4wOLvCeSzwXAg/3Q4mBSmGgwHFP07xRSFg0NOUzQcsGCG",
-	"5lBMj77CeRKJQSG6gWnER3KwXGEwHPBFIn5jnOJ4Ovj+fTg4jlLGET02J7laJE0bdn3esPMg4B22PCUj",
-	"hugtDhq3+gpy2AbX8qdNWwyTDltkM0hROAohh60wPZuI08AJjjBfeO64OqZp603rdDsQsedoOtQVhZi3",
-	"n0N+1r71bDbP3cKUExbACFH3Hg1ansS3mJJ4juKmvVpfya2CG0JBRtMjFpAEhYAkiEIxgrmPgopreZPn",
-	"bfMRmmBsvmkCsD2PL3QT3EyAZs5/poguajb3GkccUUARIykNEAOTRQ7Twob/LWZx7Hiw5O4uUIQgQ14A",
-	"pOpbH0Ba03aH5+j26fhgfNC88Tbe68t0V8lzU8oIrdnQWQL/nSKQwCmOJYWAQH4ObiiZAwgSim4xSZlA",
-	"hoTEDI2v43PIGOAzBP6I0Veupv8D3MIoRWqYNdsccSg4LeAE3CAezORAMU58JWarQyU5bQGPqkfzeUd8",
-	"HpBO74d5lZsfkFcoichCcJRznKAIN+8x+xgk+uum3Tqn7rh7s45z8/14by1vXQFPtdbqyrlQzTZLCGd9",
-	"Nui2tzeYX6KAoiZYvcEcMPlRA6im9kSeAJsvRlPMR2pu5/be4jnmNdt6B7/ieToHcTqfIArIDcAczZmg",
-	"Vop4SmOQICoptQZqkZi8AC+NYIPDZwfDwVzNPzh8eiD+C8f6v7J94pijKaJyo+9gkuB4ehrWbPaCRAjM",
-	"1Ufg9JUbhnMziR/8nj57PhzcEDqHXO3mpxcD5+bElbAEBk1knH3TcMexPY//HWfDnFdcEB+PIkQ5e084",
-	"vsGB5MLHMxjHKGrYeWECAOUMILamAIGao+FkxHsT/sdGc4ijkV67/ehtb0En0ZwsI5MbNtsulJ9T8i8U",
-	"NPEO/UXDVpN8Dn/Y6kFNm+rKahPHTksMI1+1x7a0/PYLjkMcTxtApj8EE/VlA+hoZcoekmHdy9Auxl60",
-	"Cq+0s8zaIKcKFtq0G8FhG7aiR/tCKJzj2LkN9cpdoBtEUdzIUtWXgJpPG3bHqpP6E0PD+9mmLrfpyXy1",
-	"CvJHQr/cROSuYUfmk4ZN3Vmz+LI0yOEEMjSa46nSphv3d5HGPlukadyEcWqSHiRJ03j09NnzF7V7jAgM",
-	"WzYoPmmBoZmlxw7NcMcOv4vZlL6lDJEwvED/ThHj4r8CEnMhpR5+G8AkifT7uv8vJjZurSa+DMW8vxy9",
-	"+nxx8s8PJ5dXg+EgRBziiA0Of/82uMEoCrVUMhgO5ogxIesdDrDQ+PR5vn8aDhClhA4OB6fxLYxwKH9E",
-	"jB8qo0vha/vkf6HoZnA4+P/t52bWffUr2z8RU17oY6pDF6+gtBawjLNS5Y5vIhz0g8jx2fvXb0+PBTjM",
-	"ycwr+9f8DforgBFFMFwA9BUzzlZ4tgv9bDpWeE3oBIchinud7PXZxS+nr16dvLeO9r9ICkIi5Dkwg7dI",
-	"yPRzzJgQ6zgBMAiQVOjlLaptrfQWWXpzgwMstdtsZVZYGhVWPo05ojGMTtT+e0Dh9P3VycX7o7efTy4u",
-	"zi4GNv6qqYGgQkSB+vsqT1sz/3vCX5M0Dnsd5/3Z1efXZx/ev2rDV3HFN3KZNaBqYfIPMUz5jFD8J+p3",
-	"pg/vjz5c/Xp2cfpfJ/axjlI+QzE3asca2ErNCoBQwMkXFAOs+I58KfSsYtGjQKoxMDHSfNW6Z37DiElD",
-	"NAQsQYFQgQAM9IuZUJIgKj6RsIoicqcg6IY6A3czRJEeLzitGTIcSF29DR75hi8sEtMvDqQULgYSRDHu",
-	"tg09YoW7yP9AJlIF+D4cHE1RzI9JHCO58CWHPGUOMVH+HZAboL0SAIqBIMhGsgro9W+uU3+cIT4Tk8SL",
-	"0oSYgSClFMU8WoB8hmznE0IiBGOx9exXeQbHpt9nRpfCGi0rZEaJ4SCCzMAGhVd4jpwniQGM9e7FAMBS",
-	"yXVv0qi0QGYGCSFHI47nDmODWvQVZoHHuoKvyyXV6qE1qtNyvyJI+QRB3rCW4D+URNoRK1elKED4FoUg",
-	"IPN5GhuCV5ZtDRLvfWSiUXn1ozDE4p8wAjhWc4lV4ISkvIKFgCkEdgmlVdxP+ewdCmYwxmwuxB08dXkU",
-	"xN9Tqs8mmE4MYJHFzc0kFRoQH/EIzTXnbuSr+ad6L9mevzVz2Gx5ID4He2g8HQ/B9eBfd/x6IP5BxH6f",
-	"qX/DBH/+ghbXgyfiUcgE53/duZWzXOj+Xf06LJzpUw1Y/9Q+TqHw1jpAjffQPHT6vRA68t4/0gmiMeKI",
-	"geOLV0/G1/ErdINjxATPR1wQtWKVQrqBHAQwBhMEIGN4GqNQCD8slVti4BZDNau2VjDlFSnelHGktF3T",
-	"mZz0HeJQPpkJCtpGlOFxKcaUYZst7wNRbUxpBax9aBdIxTwCoIY9yu+F2GhgB3AobvsGoxBMFgLzrcsH",
-	"QQTxfLuw1JBYGUjfYqUCFsEq/mo9Iy7wVp+/7Nn2er/rrtghSuTev7ZJz/Mvy8BRm+oAmUt9OyW5QItf",
-	"FndsglKVP97coIAX3BpKZBuUpcpzEuFgAdQAsCc/EiJliOKFZGVxOhcHy0fHC3E+yzagf6k8PR2YtASO",
-	"zakFCYg5xCkvxDiP8Rf62/Kd2PvIZ/S5o05oW2W3q0beHcDa3uhahU5Vp9ACby3A85dJqPwC/6Vezpn9",
-	"5P5uTPWHAUWQ62XkH24xurP+M0QR4kgcO7uNCg5X9Q1rY+V9/prOYTyiCIZwEiFg/Sh2L60F6tw58bxO",
-	"oygXo8M5jjHjWihSVoZW8cGArf76hIr7Vam4mdB3boFe2f1qxcNAjVf3al/joG7FCiU7fPCl926k4jAS",
-	"iKlcqPxSBtCphwbu6f/+8UpNa8ygVtQJJWnCXPxK7qB5q+qTYdlZMJKTtt6U2qxZqPa+3MJd5qTdmngH",
-	"7jCf4RhAkHl1tyClLCHqNcp4Ffj6Snl9pLvdAeVykp63iBc3QXcl7+QOSHe9xLpGyDwKdgXBbjjgkE4R",
-	"P4d85jXyKv98SamwXRyM2xn0yhB9mxiub61sbzWObsEJY5B9LVCuIseWofAFxw5r5j9wHArAqqetcUYb",
-	"oXMgOWwmBQR37KuC68pn6nosamW6+vgBG9LyzHr+RngvwUo2KHRnaJaL3fmfpOC9VTn7FbpFkTi38d3p",
-	"B7g5Pq2TmH1VYE2lWAv5W+YsBAnkM4cMAPa0bpJTLZBX+cThBTAh6+0x+p6B7Jlm1BrK5R34VIFUnppU",
-	"k5GkotsyQNlyl5pFgo2kHAgC2ocJ/g1RhkksRLILlFDEpC/i+HT/+BWQGUgAxzcUMk7TgKcUbV32ys+p",
-	"pK7hgGXuIRhFZzcyxMFzBjXy+yeBrDA8i6OF0uc6yXL5fO4nTj8YKASR5gqTPHts2UfNQonNv2r54h7P",
-	"GrAwlFCgXw5r/93eNQuG1vNVmK66ROEBK3zb4+mydpAHMgyr4aBLP2YllHckEjDpyxaEIHdnw9qh9Euo",
-	"SP9kqwPX+jb3/1RjZD1k0TPnIIGj4t+nrxxvKJniABrnXqYWKguHuIBktmDyC32k8XX8Lo04TiJkI9vx",
-	"BZOqusyYkwOZuEW9ruJe+aUFeKSnc2GFihi85IT6nPmy+HULT69zcyvIed8vLDrPW6Vip69debKVEcux",
-	"pWPlq9Y7yr80pFHYnl+ogJnDxcaIhsAbFOuUPkeuRfab2cScaHewdKqbOYp780kCqFyZI6yhNoRCvpd2",
-	"7JUJxHMEJjBOIdZBA71sjThmHMYBGkVCYBNMiVOcBUJUzpE4pS1pVC3IWgX6yJ79fRjM0b4RuRK40Mqg",
-	"hxzjYCseLu5CvMRoAlnZye9gdViscNSGfL/BKEWvKZk3brdJ+qp8sgIhrOQDqJfJNiuAVY7aVw6rTrQS",
-	"cawybSc/1ApFsyrabF5Cc1+WjwTRLp9tSZCoTbhfqzxRJfDdFivqiMtLumi/+10QMly73DFZw7XFfiKH",
-	"o3yHZ5GPng9RKWrnVv0izluYfitvT2EHSz4/xblW+QIVZvY1DZSeo9ySJVZZ0YtUxKKtPUrVW+zwLhXP",
-	"UBNgLZO0mFM4l4IxA3czHMxAofaJ4OuhMXgqFg85h8EMcJLjvuZCmMmLGYMT8QGKOV3IaO3YpjBwLVX8",
-	"6wHYg9EdXLDCgk8AjENwLQXr60GW9IbjaX5a+eEYnN4ANE/4AhAKyBxzjsIhiAmAdriBqYKidACZh8aA",
-	"eKKU5Vkg2x6JowVA8wkKQxSab0Lp7BbCpQxgH1tDNTyfjG0W28VaI+eyEvr25injYIKKkLAMOfbfLSTq",
-	"Yp8p3KploJnj+C2Kp0L3ebqsaaZMORpQJtGtyTOgvswxqpC/x7RQglmJBRT9BiEJviCqSkUNhqreVAKD",
-	"L/ovnZwGWU6vwwCP5kkExbsh4x6m6vlDwHpQ8ozgcBHDuRCjokU9ttwQKijG8YSdvAXoq9CBmNH79HKC",
-	"IOZGHMuX0yVLBP8cSJWWIyom+n+ur/9yff3t9+trdn19+el/Xl9/v75m/+MvLvELOzD3Q4z/nTrERCtf",
-	"ytjCBbJVbqm6SBxEaYg+zlDceuwQcUGssTgzvimtymYkjUJBPMpZFPY+t/YH5yqtcYrbVU6cvhglQ99I",
-	"j7ipS2JRrz2+IOQnxgxb3YvGsW7GDwcGAjOT4r1FyDrtILeQurQFkoBbSLH0ksmEx7sZikHKxKUY/G3j",
-	"H1jmcJijuTjIHMenikaeVmnSLrBRfBf1+zQKjJlE7FJ9rhg5dlpEUHx7dosoxSHqaGayarGMsvwmYuaS",
-	"qCAOKaRbgOIpjhGiNVYnu9qe/waEbIaD/GkGQcFCZE1bw6c7rneBUiahKvMXcpg65ndJ7LxG9jinKLs0",
-	"8/ZmhjuWP8qSr7jYfw1H7X+z6oG0C+aYa7VDjCoHNHt+73yIDfvUH+Vl2pTMJJ/1lqd4aMkUhjEVxIJh",
-	"o7ChhJyCEGDeXMuaqAXtXRA9+pOGWicbnccc7gUkDijiSMVeMul4KzLEJ050tnlYlgtv3bePLCTzKWGd",
-	"cn/yVptw888ATSNBAmKvUikKUwEZQFEcIqoCumqwvzZRSyaGAv2zeDrvYsXHZaBDGqFsOZmbfAMj5ny9",
-	"xaetz/YdhUmiaPcv38bj8XclL0lZ1ywjVhF32PPRLt2N3Faep+ZzLaYCgduEcE7xHNIFMF9Zz6pggw1S",
-	"qXn6bXlA6m03acRklY2AkvhfZDIYDtT/Tyj5WoqaK4xuPnrhHLb46q1ydreIlbXOunWy8nMeFU6XdxRU",
-	"0gVk7b1cRMvuMofuVsw22ZmXNNnk86zSXJPN2tNUkwN9RWaaHIm2ZqIp3lgH80y+99V7DaaQozu4aBv8",
-	"Rn1mcA3P4RSdp1GUlSFiDREr8jEoFSyylU5CgZwQJGkUqZepqpZTNMWM06zOUCd1/P75RnKW1s01krLR",
-	"HWJ8lFASbsVJUuYnXV6EekTfIReJvcnd9JDYO1zGQVLF/C4Vu1fus5+TGHMihVgYhyAi06k06WzffV89",
-	"/ZKPsmPCVb7O1ek7ufUL3HSlr7QD47b2XJ/VvRmNcZn19LBXhmIcLZ50jNN0QL6omjvWNe6GqlLugHZB",
-	"f6j/bBk9voFV1AR8zuFXo+j/9Lys91t63+9w9OfB6G+f9n4f6X/9D/OnJ//XX5aOHG0m9g7ynBOg6wkH",
-	"QfTDxVtHfDtkCHy4eGuuRr/JFBydnwJthHfhWi5Q5Pc04zw53N83640L40Zy3JjdBoc/H/x84Iz0X6cY",
-	"5UC2bvJU/ug0SVM0gBL8XsC+OD4C8usloE0DOJIyUUdwd3rte0hwHqi9Q6Kcc7e7KdM5t7qMcOeZP1es",
-	"HDNZKNuzfHL2IjSFgeMNcz8Fx/ZE1XQgr0y1Nt6szMzN7VhWHsKj4gm2IXfKlZcUNdUcq5Qu5Yw97T7a",
-	"0bMSYVIhw9bkx/xyOogGxhdTkgaka9pV/w7dueMGONH+bGOfN34iGVCTJFGp8OBmAgo268Z/9NBv3EPf",
-	"6JyvkiEPZi6sfkfCLJ9YorKs7KucVwaxTNiMrGshn/SSN2EFqE1RghRmS2ST+3XhldUbq1r+5fLs/bkY",
-	"aHXQkg9rkjSF9JDE1WjISAwlLxEMVauOJFLZwxTNya0b7dxZKmKT4JwIsYFKl9oMAVnXWvzHXNzGokOV",
-	"GpkAIuu3IA72ZD54GO7r7VlgeFJBH5IM9BY7B3co2m5Pd+Yku8cixFXdnGohxvNTIH/K8rlzXbXBxe7M",
-	"XpJOP2sDVYAqocK9C0viaNuHLDTbiuKcgBvVgUIFbhZej5o9li7MFBsyG9cgcFL/CphvgQyXYL7r5IAK",
-	"DwtMwYcZ1gUnlaMRtheVtMrwozzk6gbK4Nxi+BFJatPsNh179L1NwOuuIxsZrzqvTyGFvupLHmut2Jme",
-	"JSAhkub0XLApXUZWo0BnJ25Y0zF/6q3mZBOsRscx03krOHl33CW1mgw7tqDSlNo/NiCoacfTE09P5/OU",
-	"q/jLGCZsRopA1OQE856VHM/RllBSH7WKmS2gUR+CvbxIuUxEGAKcHR7eCGYvdRkBmEEZZ9vCzPxwWG+o",
-	"Myob4K8MpQ1arRezC5P5AMZfey8fpLZGzjklN9gV/XbpRPf8gZVMWqnwij9Xgd/3NT4uhJ+1Bf/WhOJa",
-	"kxSjcP1NqkaBc9ttXC9xUE7h8z/0a0r+RHFRbZSpOmXm4gICuYuRQ4Q8NT4KVkpjEHdnOrtpw4XuroYi",
-	"Ek+FxF2PMu6Y4HNI1Vu9ZIWlxtmTnsWWbNordtYrnupTI4J1vkyFeeISWfkWwd4XtNDWgqzb2BPX3WZN",
-	"pfrsIIsO9MOksv4r0aqM1taWGplWd25V9c2knMj82vqGHpwA8dUccpWWBDjF0ymiKtmfARIrmTJJWaHW",
-	"hQwGdjX5ELOp7r0FvVB/77kJJb2Kv+sJCiH4Uo/LDYPZngovaaHvSGNmcMFDUrE9WfWYmvMqHQH5pe/d",
-	"QQDFaGGw57V6wf1fWsa5W/9Y/dLzkeclYmlGm0N+CL7ZAcbf978F5W7f3wfuyOX9Qmtuy9m/l3/z31Zk",
-	"9H/ruOj/Fv8nY6Kf7C8ZF1DrdKp5Bc7En9kMJ4VuJsZpHdQSXyNDtgMpCi9Jjg2Ft2RpVv1phep+EUNz",
-	"Y4bOo9izjRq5RTdDpBBUUNlbLLkqpQSp7GNVX7p8HSsRU4ZZY0jvmUyyqgne8HoVmp+CLlaJWoRcysPe",
-	"Ha4NHnWZL1uvfJ5WugapvkliUEU2Nw+BI/3C05Nt02LdIs6QpvlilKeUw0nw9NlzZzSJmuNXyBy2evHX",
-	"tsWlFmsvzGbw2cufDuuWdInWqw1isCDcL2ihSHU1ZG4TN2y41uZsu9OGNDu9hPH/2Tfb1HTWlX3nk3aX",
-	"G1HUAcVmyqV1h8UEueZ0PLNoOS0vP0nJOtn2+KtFMx9kVQlphMqKcvTYytLuinh2Gicpb3tTJLJlNS36",
-	"o50zydOVFF9R8h4y5mX73A7maRFmDfjnrkm0imJEpg9HpqvyrCJFypT4VU0+F7g9JbeIxgWJcwZvMaFb",
-	"sr8uVbBoDZWKepUoWm1Nom0XI+pXhWiV5YcUgeZa8AbqEDmXHBpLhCQdR3GiMXhNKND86hB8M/MdgmvF",
-	"ZVQ3R/Wx+ON8MeLq79/FYoUB9sqOcYYtm/H3pfpRtxdLq4sej06P7AU3XtVHYfgaER6LHu1W0aMfsJ7R",
-	"YyDkY6mix1JFj6WKdqdU0YqUVLfk9WSdAkBT2OVjxaEHVXHosZjQSooJ9a4i1Fo+qMa/0uDANK6b4hvj",
-	"6RYoiN9Fd2ZRyF4Z4/jAEB0ZXSvbe/OLyBaMo/l5YcXSgyu/GM1hDKcotEOQ9ihKCMOcCIU4viHV1L/8",
-	"gyqRwyRxtyQTfzU5EaaNnJaerflsgI73tU+Y7cMEu30ot9jE0he3MaEwdukNbzAH+reCZR+68hKlN27u",
-	"8kS8kQFa4jdw+etR0SIp3S8v/PwvKY3ck1t38OHibSU5mB3u708xn6WTcUDm+4RO98WI8RR79RPxjIAu",
-	"k1aNpfyjk56UpTgjOhPl6JtHWlF3623A95HwbIJTaqF6RLNbb+ZNPwQFir2o5iFCOV+KHk13SosowZ5K",
-	"MIDRE2/6tN83vf9PW6RaeztiTQvcw+yaP7WJhtbdfvIUIytY7H7TjS+/WskkU9xHjC8iK3SggskRZPyK",
-	"wpjJn6+wixm8hYyr+D5lZ9FzCf1AjytGfA2eHTx7OTp4Ojr46erpweHBweHBy/+yndIh5GhUDNbLcaxW",
-	"TC21ATXf2QubvpXSWANDZ0JdV5+7kYryHN8cAneQASXctTrcpdeDuRZ7B4MZjlF+MvWhFcyUX15+1Ask",
-	"9BYcuY1PdWHySvYz2lZh5kyZk3L3ay3kf4i/xOQuLjsRU+fVcadMrSLmbiyw7aHxdDwEF+KKnpRO5by1",
-	"cv6XEkb1IYcuJM7AXUM6HOIYUaPUO5t5qU+0Xd7O0KrYBrxdRyfx7W+QutSSGxwhfxfUaxwh50ROOULa",
+	"H4sIAAAAAAAC/+z963LcOJYoCr8KIr+OaHnvzJR8qZpqfTFxjkqWXeqyLbUkl2NPyceFJKFMlJkEGwAl",
+	"Z3l8Xme/x36yE7iRIAmSIPMqSz9m2qUkbgtrLaz7+joIyDwhMYo5Gxx+HSSQwjniiMr/+jnFUXgewRi9",
+	"g3N0Ln4Tfw4RCyhOOCbx4FB9BBLxFYjhHA2GAyz+nkA+GwwH8k+Hg0lhqsFwQNG/U0xRODjkNEXDAQtm",
+	"aA7F9OgLnCeRGBSiG5hGfCQHyxUGwwFfJOI3ximOp4Nv34aD4yhlHNFjc5KrRdK0YdfnDTsPAt5hy1My",
+	"Yoje4qBxqy8hh21wLX/atMUw6bBFNoMUhaMQctgK07OJOA2c4AjzheeOq2Oatt60TrcDEXuOpkNdUYh5",
+	"+znkZ+1bz2bz3C1MOWEBjBB179Gg5Ul8iymJ5yhu2qv1ldwquCEUZDQ9YgFJUAhIgigUI5j7KKi4ljd5",
+	"3jYfoQnG5psmANvz+EI3wc0EaOb8V4roomZzr3DEEQUUMZLSADEwWeQwLWz432IWx44HS+7uAkUIMuQF",
+	"QKq+9QGkNW13eI5un44PxgfNG2/jvb5Md5U8N6WM0JoNnSXw3ykCCZziWFIICOTn4IaSOYAgoegWk5QJ",
+	"ZEhIzND4Oj6HjAE+Q+CPGH3havo/wC2MUqSGWbPNEYeC0wJOwA3iwUwOFOPEV2K2OlSS0xbwqHo0n3fE",
+	"5wHp9H6YV7n5AXmJkogsBEc5xwmKcPMes49Bor9u2q1z6o67N+s4N9+P99by1hXwVGutrpwL1WyzhHDW",
+	"Z4Nue3uN+SUKKGqC1WvMAZMfNYBqak/kCbD5YjTFfKTmdm7vDZ5jXrOtt/ALnqdzEKfzCaKA3ADM0ZwJ",
+	"aqWIpzQGCaKSUmugFonJC/DSCDY4fHYwHMzV/IPDpwfiv3Cs/yvbJ445miIqN/oWJgmOp6dhzWYvSITA",
+	"XH0ETl+6YTg3k/jB7+mz58PBDaFzyNVufnwxcG5OXAlLYNBExtk3DXcc2/P433E2zHnFBfHxKEKUs3eE",
+	"4xscSC58PINxjKKGnRcmAFDOAGJrChCoORpORrw34X9sNIc4Gum124/e9hZ0Es3JMjK5YbPtQvk5JX+i",
+	"oIl36C8atprkc/jDVg9q2lRXVps4dlpiGPmqPbal5befcRzieNoAMv0hmKgvG0BHK1P2kAzrXoZ2Mfai",
+	"VXilnWXWBjlVsNCm3QgO27AVPdoXQuEcx85tqFfuAt0giuJGlqq+BNR82rA7Vp3Unxga3s82dblNT+ar",
+	"VZA/EPr5JiJ3DTsynzRs6s6axZelQQ4nkKHRHE+VNt24v4s09tkiTeMmjFOT9CBJmsajp8+ev6jdY0Rg",
+	"2LJB8UkLDM0sPXZohjt2+E3MpvQtZYiE4QX6d4oYF/8VkJgLKfXw6wAmSaTf1/0/mdi4tZr4MhTz/nz0",
+	"8tPFyb/en1xeDYaDEHGIIzY4/P3r4AajKNRSyWA4mCPGhKx3OMBC49Pn+fZxOECUEjo4HJzGtzDCofwR",
+	"MX6ojC6Fr+2T/42im8Hh4P+3n5tZ99WvbP9ETHmhj6kOXbyC0lrAMs5KlTu+iXDQDyLHZ+9evTk9FuAw",
+	"JzOv7N/zN+jvAEYUwXAB0BfMOFvh2S70s+lY4RWhExyGKO51sldnFz+fvnx58s462v8iKQiJkOfADN4i",
+	"IdPPMWNCrOMEwCBAUqGXt6i2tdJbZOnNDQ6w1G6zlVlhaVRY+TTmiMYwOlH77wGF03dXJxfvjt58Orm4",
+	"OLsY2PirpgaCChEF6u+rPG3N/O8If0XSOOx1nHdnV59enb1/97INX8UV38hl1oCqhcnfxzDlM0LxX6jf",
+	"md6/O3p/9cvZxel/ndjHOkr5DMXcqB1rYCs1KwBCASefUQyw4jvypdCzikWPAqnGwMRI81XrnvkNIyYN",
+	"0RCwBAVCBQIw0C9mQkmCqPhEwiqKyJ2CoBvqDNzNEEV6vOC0ZshwIHX1NnjkG76wSEy/OJBSuBhIEMW4",
+	"2zb0iBXuIv8DmUgV4NtwcDRFMT8mcYzkwpcc8pQ5xET5d0BugPZKACgGgiAbySqg17+5Tv1hhvhMTBIv",
+	"ShNiBoKUUhTzaAHyGbKdTwiJEIzF1rNf5Rkcm36XGV0Ka7SskBklhoMIMgMbFF7hOXKeJAYw1rsXAwBL",
+	"Jde9SaPSApkZJIQcjTieO4wNatGXmAUe6wq+LpdUq4fWqE7L/YIg5RMEecNagv9QEmlHrFyVogDhWxSC",
+	"gMznaWwIXlm2NUi895GJRuXVj8IQi3/CCOBYzSVWgROS8goWAqYQ2CWUVnE/5bO3KJjBGLO5EHfw1OVR",
+	"EH9PqT6bYDoxgEUWNzeTVGhAfMQjNNecu5Gv5p/qvWR7/trMYbPlgfgc7KHxdDwE14M/7/j1QPyDiP0+",
+	"U/+GCf70GS2uB0/Eo5AJzn/euZWzXOj+Xf06LJzpYw1Y/9I+TqHw1jpAjffQPHT6vRA68t6v6QTRGHHE",
+	"wPHFyyfj6/glusExYoLnIy6IWrFKId1ADgIYgwkCkDE8jVEohB+Wyi0xcIuhmlVbK5jyihRvyjhS2q7p",
+	"TE76FnEon8wEBW0jyvC4FGPKsM2W94GoNqa0AtY+tAukYh4BUMMe5fdCbDSwAzgUt32DUQgmC4H51uWD",
+	"IIJ4vl1YakisDKRvsFIBi2AVf7WeERd4q89f9mx7vd91V+wQJXLvX9uk5/mXZeCoTXWAzKW+nZJcoMUv",
+	"izs2QanKH29uUMALbg0lsg3KUuU5iXCwAGoA2JMfCZEyRPFCsrI4nYuD5aPjhTifZRvQv1Seng5MWgLH",
+	"5tSCBMQc4pQXYpzH+Av9bflO7H3kM/rcUSe0rbLbVSPvDmBtb3StQqeqU2iBtxbg+cskVH6B/1Iv58x+",
+	"cn83pvrDgCLI9TLyD7cY3Vn/GaIIcSSOnd1GBYer+oa1sfI+f0nnMB5RBEM4iRCwfhS7l9YCde6ceF6l",
+	"UZSL0eEcx5hxLRQpK0Or+GDAVn99QsX9olTcTOg7t0Cv7H614mGgxqt7ta9xULdihZIdPvjSezdScRgJ",
+	"xFQuVH4pA+jUQwP39P/8cKWmNWZQK+qEkjRhLn4ld9C8VfXJsOwsGMlJW29KbdYsVHtfbuEuc9JuTbwD",
+	"d5jPcAwgyLy6W5BSlhD1GmW8Cnx9pbw+0t3ugHI5Sc9bxIuboLuSd3IHpLteYl0jZB4Fu4JgNxxwSKeI",
+	"n0M+8xp5lX++pFTYLg7G7Qx6ZYi+TQzXt1a2txpHt+CEMci+FihXkWPLUPiMY4c181cchwKw6mlrnNFG",
+	"6BxIDptJAcEd+6rguvKZuh6LWpmuPn7AhrQ8s56/Ed5LsJINCt0ZmuVid/4nKXhvVc5+iW5RJM5tfHf6",
+	"AW6OT+skZl8VWFMp1kL+ljkLQQL5zCEDgD2tm+RUC+RVPnF4AUzIenuMvmcge6YZtYZyeQc+VSCVpybV",
+	"ZCSp6LYMULbcpWaRYCMpB4KA9mGCf0OUYRILkewCJRQx6Ys4Pt0/fglkBhLA8Q2FjNM04ClFW5e98nMq",
+	"qWs4YJl7CEbR2Y0McfCcQY389lEgKwzP4mih9LlOslw+n/uJ0w8GCkGkucIkzx5b9lGzUGLzr1q+uMez",
+	"BiwMJRTol8Paf7d3zYKh9XwVpqsuUXjACt/2eLqsHeSBDMNqOOjSj1kJ5R2JBEz6sgUhyN3ZsHYo/RIq",
+	"0j/Z6sC1vs39P9UYWQ9Z9Mw5SOCo+PfpS8cbSqY4gMa5l6mFysIhLiCZLZj8Qh9pfB2/TSOOkwjZyHZ8",
+	"waSqLjPm5EAmblGvq7hXfmkBHunpXFihIgYvOaE+Z74sft3C0+vc3Apy3vcLi87zVqnY6WtXnmxlxHJs",
+	"6Vj5qvWO8i8NaRS25xcqYOZwsTGiIfAaxTqlz5Frkf1mNjEn2h0snepmjuLefJIAKlfmCGuoDaGQ76Ud",
+	"e2UC8RyBCYxTiHXQQC9bI44Zh3GARpEQ2ART4hRngRCVcyROaUsaVQuyVoE+smd/HwZztG9ErgQutDLo",
+	"Icc42IqHi7sQLzGaQFZ28jtYHRYrHLUh328wStErSuaN222SviqfrEAIK/kA6mWyzQpglaP2lcOqE61E",
+	"HKtM28kPtULRrIo2m5fQ3JflI0G0y2dbEiRqE+7XKk9UCXy3xYo64vKSLtrvfheEDNcud0zWcG2xn8jh",
+	"KN/hWeSj50NUitq5Vb+I8xam38rbU9jBks9Pca5VvkCFmX1NA6XnKLdkiVVW9CIVsWhrj1L1Fju8S8Uz",
+	"1ARYyyQt5hTOpWDMwN0MBzNQqH0i+HpoDJ6KxUPOYTADnOS4r7kQZvJixuBEfIBiThcyWju2KQxcSxX/",
+	"egD2YHQHF6yw4BMA4xBcS8H6epAlveF4mp9WfjgGpzcAzRO+AIQCMseco3AIYgKgHW5gqqAoHUDmoTEg",
+	"nihleRbItkfiaAHQfILCEIXmm1A6u4VwKQPYx9ZQDc8nY5vFdrHWyLmshL69eco4mKAiJCxDjv13C4m6",
+	"2GcKt2oZaOY4foPiqdB9ni5rmilTjgaUSXRr8gyoL3OMKuTvMS2UYFZiAUW/QUiCz4iqUlGDoao3lcDg",
+	"s/5LJ6dBltPrMMCjeRJB8W7IuIepev4QsB6UPCM4XMRwLsSoaFGPLTeECopxPGEnbwD6InQgZvQ+vZwg",
+	"iLkRx/LldMkSwT8HUqXliIqJ/p/r679dX3/9/fqaXV9ffvyf19ffrq/Z//ibS/zCDsx9H+N/pw4x0cqX",
+	"MrZwgWyVW6ouEgdRGqIPMxS3HjtEXBBrLM6Mb0qrshlJo1AQj3IWhb3Prf3BuUprnOJ2lROnL0bJ0DfS",
+	"I27qkljUa48vCPmJMcNW96JxrJvxw4GBwMykeG8Rsk47yC2kLm2BJOAWUiy9ZDLh8W6GYpAycSkGf9v4",
+	"B5Y5HOZoLg4yx/GpopGnVZq0C2wU30X9Po0CYyYRu1SfK0aOnRYRFN+e3SJKcYg6mpmsWiyjLL+JmLkk",
+	"KohDCukWoHiKY4RojdXJrrbnvwEhm+Egf5pBULAQWdPW8OmO612glEmoyvyFHKaO+V0SO6+RPc4pyi7N",
+	"vL2Z4Y7lj7LkKy72X8NR+9+seiDtgjnmWu0Qo8oBzZ7fOR9iwz71R3mZNiUzyWe95SkeWjKFYUwFsWDY",
+	"KGwoIacgBJg317ImakF7F0SP/qSh1slG5zGHewGJA4o4UrGXTDreigzxiROdbR6W5cJb9+0jC8l8Slin",
+	"3J+80Sbc/DNA00iQgNirVIrCVEAGUBSHiKqArhrsr03UkomhQP8sns67WPFxGeiQRihbTuYm38CIOV9v",
+	"8Wnrs31HYZIo2v3b1/F4/E3JS1LWNcuIVcQd9ny0S3cjt5Xnqflci6lA4DYhnFM8h3QBzFfWsyrYYINU",
+	"ap5+Wx6QettNGjFZZSOgJP6TTAbDgfr/CSVfSlFzhdHNRy+cwxZfvVXO7haxstZZt05Wfs6jwunyjoJK",
+	"uoCsvZeLaNld5tDditkmO/OSJpt8nlWaa7JZe5pqcqCvyEyTI9HWTDTFG+tgnsn3vnqvwRRydAcXbYNf",
+	"q88MruE5nKLzNIqyMkSsIWJFPgalgkW20kkokBOCJI0i9TJV1XKKpphxmtUZ6qSO3z/fSM7SurlGUja6",
+	"Q4yPEkrCrThJyvyky4tQj+g75CKxN7mbHhJ7h8s4SKqY36Vi98p99nMSY06kEAvjEERkOpUmne2776un",
+	"X/JRdky4yte5On0nt36Bm670lXZg3Nae67O6N6MxLrOeHvbKUIyjxZOOcZoOyBdVc8e6xt1QVcod0C7o",
+	"D/WfLaPHN7CKmoDPOfxiFP0fn5f1fkvv+x2O/joY/ePj3u8j/a//Yf705P/629KRo83E3kGecwJ0PeEg",
+	"iL6/eOOIb4cMgfcXb8zV6DeZgqPzU6CN8C5cywWK/J5mnCeH+/tmvXFh3EiOG7Pb4PCng58OnJH+6xSj",
+	"HMjWTZ7KH50maYoGUILfC9gXx0dAfr0EtGkAR1Im6gjuTq99DwnOA7V3SJRz7nY3ZTrnVpcR7jzz54qV",
+	"YyYLZXuWT85ehKYwcLxh7qfg2J6omg7klanWxpuVmbm5HcvKQ3hUPME25E658pKipppjldKlnLGn3Uc7",
+	"elYiTCpk2Jr8mF9OB9HA+GJK0oB0Tbvq36E7d9wAJ9qfbezzxk8kA2qSJCoVHtxMQMFm3fiPHvqNe+gb",
+	"nfNVMuTBzIXVb0mY5RNLVJaVfZXzyiCWCZuRdS3kk17yJqwAtSlKkMJsiWxyvy68snpjVcu/XJ69OxcD",
+	"rQ5a8mFNkqaQHpK4Gg0ZiaHkJYKhatWRRCp7mKI5uXWjnTtLRWwSnBMhNlDpUpshIOtai/+Yi9tYdKhS",
+	"IxNAZP0WxMGezAcPw329PQsMTyroQ5KB3mLn4A5F2+3pzpxk91iEuKqbUy3EeH4K5E9ZPneuqza42J3Z",
+	"S9LpZ22gClAlVLh3YUkcbfuQhWZbUZwTcKM6UKjAzcLrUbPH0oWZYkNm4xoETupfAfMtkOESzHedHFDh",
+	"YYEp+DDDuuCkcjTC9qKSVhl+lIdc3UAZnFsMPyJJbZrdpmOPvrUJeN11ZCPjVef1KaTQV33JY60VO9Oz",
+	"BCRE0pyeCzaly8hqFOjsxA1rOuZPvdWcbILV6DhmOm8FJ++Ou6RWk2HHFlSaUvvHBgQ17Xh64unpfJ5y",
+	"FX8Zw4TNSBGImpxg3rOS4znaEkrqo1YxswU06kOwlxcpl4kIQ4Czw8MbweylLiMAMyjjbFuYmR8O6w11",
+	"RmUD/JWhtEGr9WJ2YTIfwPhr7+WD1NbIOafkBrui3y6d6J4/sJJJKxVe8ecq8Pu+xseF8LO24N+aUFxr",
+	"kmIUrr9J1ShwbruN6yUOyil8/od+RclfKC6qjTJVp8xcXEAgdzFyiJCnxkfBSmkM4u5MZzdtuNDd1VBE",
+	"4qmQuOtRxh0TfA6pequXrLDUOHvSs9iSTXvFznrFU31sRLDOl6kwT1wiK98i2PuMFtpakHUbe+K626yp",
+	"VJ8dZNGBfphU1n8lWpXR2tpSI9Pqzq2qvpmUE5lfW9/QgxMgvppDrtKSAKd4OkVUJfszQGIlUyYpK9S6",
+	"kMHAriYfYjbVvbegF+rvPTehpFfxdz1BIQRf6nG5YTDbU+ElLfQdacwMLnhIKrYnqx5Tc16lIyC/9L07",
+	"CKAYLQz2vFYvuP9Lyzh36x+rX3o+8rxELM1oc8gPwVc7wPjb/teg3O3728AdubxfaM1tOfv38m/+24qM",
+	"/m8dF/3f4v9kTPST/SXjAmqdTjWvwJn4M5vhpNDNxDitg1ria2TIdiBF4SXJsaHwlizNqj+uUN0vYmhu",
+	"zNB5FHu2USO36GaIFIIKKnuLJVellCCVfazqS5evYyViyjBrDOk9k0lWNcEbXq9C81PQxSpRi5BLedi7",
+	"w7XBoy7zZeuVz9NK1yDVN0kMqsjm5iFwpF94erJtWqxbxBnSNF+M8pRyOAmePnvujCZRc/wCmcNWL/7a",
+	"trjUYu2F2Qw+++HHw7olXaL1aoMYLAj3C1ooUl0NmdvEDRuutTnb7rQhzU4vYfx/9s02NZ11Zd/5pN3l",
+	"RhR1QLGZcmndYTFBrjkdzyxaTsvLT1KyTrY9/mrRzAdZVUIaobKiHD22srS7Ip6dxknK294UiWxZTYv+",
+	"aOdM8nQlxVeUvIeMedk+t4N5WoRZA/65axKtohiR6cOR6ao8q0iRMiV+VZPPBW5PyS2icUHinMFbTOiW",
+	"7K9LFSxaQ6WiXiWKVluTaNvFiPpVIVpl+SFFoLkWvIE6RM4lh8YSIUnHUZxoDF4RCjS/OgRfzXyH4Fpx",
+	"GdXNUX0s/jhfjLj6+zexWGGAvbJjnGHLZvx9qX7U7cXS6qLHo9Mje8GNV/VRGL5GhMeiR7tV9Og7rGf0",
+	"GAj5WKrosVTRY6mi3SlVtCIl1S15PVmnANAUdvlYcehBVRx6LCa0kmJCvasItZYPqvGvNDgwjeum+MZ4",
+	"ugUK4nfRnVkUslfGON4zREdG18r23vwisgXjaH5eWLH04MovRnMYwykK7RCkPYoSwjAnQiGOb0g19S//",
+	"oErkMEncLcnEX01OhGkjp6Vnaz4boON97RNm+zDBbh/KLTax9MVtTCiMXXrDa8yB/q1g2YeuvETpjZu7",
+	"PBGvZYCW+A1c/nJUtEhK98sLP/9LSiP35NYdvL94U0kOZof7+1PMZ+lkHJD5PqHTfTFiPMVe/UQ8I6DL",
+	"pFVjKf/gpCdlKc6IzkQ5+uaRVtTdehvwfSQ8m+CUWqge0ezWm3nTd0GBYi+qeYhQzpeiR9Od0iJKsKcS",
+	"DGD0xJs+7fdN7//jFqnW3o5Y0wL3MLvmj22ioXW3Hz3FyAoWu99048uvVjLJFPcR44vICh2oYHIEGb+i",
+	"MGby5yvsYgZvIOMqvk/ZWfRcQj/Q44oRX4NnB89+GB08HR38ePX04PDg4PDgh/+yndIh5GhUDNbLcaxW",
+	"TC21ATXf2QubvpXSWANDZ0JdV5+7kYryHN8cAneQASXctTrcpdeDuRZ7C4MZjlF+MvWhFcyUX15+1Ask",
+	"9BYcuY1PdWHySvYz2lZh5kyZk3L3Ky3kv48/x+QuLjsRU+fVcadMrSLmbiyw7aHxdDwEF+KKnpRO5by1",
+	"cv6XEkb1IYcuJM7AXUM6HOIYUaPUO5t5qU+0Xd7O0KrYBrxdRyfx7W+QutSSGxwhfxfUKxwh50ROOULa",
 	"KK2KFLpn+QX6d4pcDjT9g5XfXqnXWWyWX1ej4r51L7cal9ebK7TxpViyQ0PCXXFjlHd3rz7gJFpnGY+h",
 	"o++5myTKSLI0dtRixapaUAt+ORgO7ijmypQeIWUG3l7badmJMOv6J64JM64fEtWI2j/0woVnFVQwgO+E",
-	"Ek2trTUe5MFuHbAgRncNgTnrD0FfQdR5bZj1nn+QdfFF0xJ8McS6ggKNiJhvyv67vcg7iGNwcXJ5Jatd",
-	"5etYRd2eHjx74VoYsySCC7eduUwB6tsqFopFL12LPnv5U48Id2nOzvrtpIoOtKako6efNCThrKuS3XC7",
-	"uV/lIOtCRNwKoqyVdcHBJHOpLqEokO5Od775yfnFyfHR1cmrQ/CBWfuRAqDYOILhGLyVz0I5wUJWwhj3",
-	"oJzegeD6vN7FrySXe4O5qbHcwhgnJFwoGwzV9U0gmGIOdGXlMndUf25PSyhMUQiNnWI+yn6pKUXsZnpH",
-	"KZ8JMSFwFj6ZQIaDEUxlV13GZuqfBdmr8El1aTb7B1o4dJHLX0FC8a14PL6gBdgz9yDBZlZ6Uj/laeie",
-	"VEx2+krOcvTxEhyTUDxoc9lhQ9sk2pfg5IsrTKAMK/FVaec5NJwTpwzRmhdf/5LPIl4/e7mCTaX5rbcQ",
-	"qnD79bj93kSe9tURyqGrj1pCDpIWPSFzvPvoCk2bMxUH8wAUbYtsGnSVf7kKLaKASCvAoM1qEltVILLY",
-	"E60uGLEnA0xn/aGEgfWYtzrtwbywF2ncWX/I7Pw0jVeWe+/hScgA8k3GV00gQ5+lnXmQEManFLF/R4f7",
-	"+xEJYDQjjB++fPH82f58EU5kk6SpUvI+Z8WlBrfPxk/HB4PvNcnPYgftr322V1mfDQUpL12e3uoo24GX",
-	"3zhbvCDSui60oS3MavvBWCONxrsTjWCW7gCz4tYvnXu+rK7Jyza7u3Rv6/LYz2Ur/Vw23MilbweXzXdu",
-	"6dWyZbd7texwk5alu7O8QgGuKROZ8hmh+E+1jdB858jr5uirg0Uf5ckfZjAwH1fjDNwuw4uih9DaRI7i",
-	"QugBM8iUHdqImh5BMaHn0SliacTBnnjDwH8WWmA0W2FLXD9bz8n45buvc659pEltIYamKIwDpvLv71uM",
-	"kKamjFTIs3kLEL59Oj4YH7QHKVoL1h9RiDbnOEERdgpblW+WTUxMKJkTHdzNZwxMEL9DKLbt6awUQ5TL",
-	"YGzDQljl9L2lsepMqxHLKvN6y2d5SchED11aUKsi1BYkNvedeYlu1f07yrgo7D0XyOuK423Hbt9X69xe",
-	"y8/lXotmfq9++/mbnu23qmAFvIU4koYHLcgV3m4H2qktrOAtd0HkpGhfK6e/ZD+qvKIggnguEzlV+euq",
-	"CA/x3FFi++OVHloxc5giyr71te0tmT2U3fo1c5ZIRO3VLPSpGTb10dPl0E70lVMYSMeCZZxTx9fpdtI4",
-	"zXyBd5wBTqeecSUrymuwl9DRO9cKpkxlwkp7HbsePKlC3enz7uJ3tNJbEDDgzBd5U7NIzT3YK7tvQ8bo",
-	"ODAiz+ExqWvVcmMuR8dvJtHtC1rsVzDz1dHV0S9HlyefVciifwF4PWkVO43FqmqvktYq9wqvKZn7hS/9",
-	"ln1eae6FFg0g/c1exlXNXsszdo6xy0nmbKijVLCGsc6b0aPEb952VT1G32OPWO+hjUrNeNZTxjuxZThq",
-	"zGw2z1e+AZbXnc7MxJuV7Kyd9hXp7ClWIstZE/oKcSWxYhnhzcaNzUtt5fvwENdicFIIwSkePjSKeHsb",
-	"rIJJwco3zP+WpV9Z8B5fx6c3ICaqJCm+wSgsVoWwrCgSy0NwbRyN1wPTGU7aimwayEtkE7E9hpx25+ZG",
-	"klZT873Gg9m+S9tyUWk1W/Bl2l/2SLW0dtfSGnK5jo49jaXsnJIwDdx2oCw+TCADZqpuvv66LiKspjZq",
-	"C3/uILc3E8IyhrbivDtmaiturpexTSagXiCWkNhVefCSwziENARIJqpS/aGue+qAtCuguxJlryaTH+fU",
-	"98vRq88XJ//8cHJ5NRgOPrw/+nD169nF6X+dvBoMB6/PLn45ffXq5P1gOHh/dvX59dmH9+Lvx2fvX789",
-	"PRYjTt9fnVy8P3r7+eTi4uyiSK/2EEcAIIc4Yo3mQrVj/aURw63UYPm7TFauK+eBkavq8GvVhWgGOQig",
-	"rE4lrlvOVuAIbpFn6JtYnHFvtY1C+JKO9YMcRAgyDp6CYAaFflPjl25N81W7b9MskL1BZybJX/PKrn+V",
-	"r8wNSeOwlSka4En0cj60OtW51qR5ieNphGQAUG5y1QnSyvqqBrpjIhx4FOiApSzLunBeHQLhyPjKzNiN",
-	"/oWUz/481t9aVWpaw1XMd0LwSyV0Pnsueak+zxatWF2zN02DpLqC62JMaoWDSiLBA9PO6p8c6FT9VJLh",
-	"eAHnkZOuxGLuXMJ3ch8J5DMhwQQmWaUw+z5Mkn21RAe9Uu5WAijma1cW7TO6LkMLBSdxmBBcJ5Lqj3Jl",
-	"CenPW5I4Z5wnnlKJ0APEe2ikE5lN2HNsu2RWPlCdfKcCgpxTqYifDvPxqN95vtffWuHD2luL9Fdtl0Vc",
-	"TPI3THkKIyB+zSxEZkbXMc1v7aE32b5I7A3EhFCXukgoB3E6n8gt2QLS82eeApJe/D3id4R+cQP05CtH",
-	"VIgJMA6B7DIo/kNL3xlNOPLX9DjP6y/QoqxUs8TwhrM2Y021exbA8ZQiplq4IPXPWMFLNauoHlx+5Llv",
-	"G/Ty1L0HO8+sS7V18HNm1d1gbLU0Ml7LrK+TMgTPENB9kMpdnrq5R89M+HTBO7oHU05GebNQrPTxhJJb",
-	"HJY8wk1O0ypYTLS9YCX1+oGJ9sxj4xuMMD5DvTQsKxVAb8xtrkH1+p74NecM1Yxh8fsl/tPFqeQgsXO5",
-	"V5AgKmdzTsMJh9GxeGgdWSXiN72HbDo3V/KzIFXB4kzVZ8Zem3HTrkXh+2ZCdHk569doCMh1YfKvCEZ8",
-	"dhrfEIdOIn8zDctkK1er2obSTz0rOWX0OXPmygP0NYmgKmoojjezV+6SRl7c8p76z8UQvEJTCkMUDsE5",
-	"JZJD4ng6BDqJfAgQD8YeqQtqVRd2vVMHabAVYHFH2YGNrcAfhGZqp1aYdwcWDCFCgtuxVEZq36Sqkmbz",
-	"0ZoqVb33QczenSljTokJssuQl4EZiUIrrDDCXxDQui8bWkV7h/JdtR0L4+v4aoZYYTZIrQi+rMdIBCco",
-	"An+QBMXBjFBExiG6FZqJ2JLcUU5O/8lpiv5YoROiozchg/RqfAnZdL6ehByYS/oRcmzavBehDESvqIf3",
-	"FkctBXvMnA1JcqJQH+RWvKOA41vxhytZw1Wm3xVtcdkXHrz7PeFZp/STOcRRBye9+FwIQ9kEIJjBOEZR",
-	"9XpvnJ7RS1nXT08Ew5CqHHI7owlRzv5v/YdxICv5VBn5vF3Xtc95+e7qPI93tsvH+s4gIWUqEisppF78",
-	"oijACRYiUeGgqJSnwxGcF07aGM/cUPy1hMm6/pHs6SQh1VJWtv6cVa1Mnqetam6pdBMJF3UzybTSbDpV",
-	"L7c6n4XoAj0OwV++STwZC/by3XSTQyGAPPuJcUg5O+Lfx04EUqazum3pn4GMI+qwvd+z1dEtopgvvn8C",
-	"o9Jur8xu2wUHvcmhAmHb1QkkP0pd5jXxSzn3stk+kUDG7ggNOxGZlCwtC1kxObT3NOXSVWbOYb5LH9DU",
-	"sTkJHMm/24w2MG3PPXReyPdhjcHHXlt8UTGpCvIdtzBDt5nGnlp+YU378uf/kHUF8Fw8MD+9fPn8peQv",
-	"6r+fOpWudoNa+ehXby9rupNJYOiNDwcm0TpiXveYT1vV/t5eOqoGikGuvjooSCm6/IKT3xDFNx5lPMS3",
-	"QK4h5pF7QkDQefYa7sVE+hTJfC4eOpVAnftyLV2h0WFbJYd/oEV7xAEEWbHtL2gBZCCMJVbXpOo7jfz/",
-	"QAu7GL1Dacxor5e33rWtItaPAoqk6A0j1l2wKTORqsqnshDJhEMJJ63Au+MzWekOurEyPa51zx/RZEbI",
-	"F39x7E4N8BTIZgiGjamm/ufSO/1VziiBXEkeznX3X6+uzoFeXIBcty0woSrmELkD0FEFfiEr1NRKJdla",
-	"f788ew/05+3vdrWWgasSoz5s7ob5cPEW3M2Q7EsihFVwh6MITASVlBptmSqNYjwbswgGX2SpxqwMpvnU",
-	"sqOnFHtVb/zkh032HbnsHqHpR2Uc5rE4ibF1AhxLEYhQcIthbuWqi0qsccKdqllm1nJL+eLaxIUKYM7E",
-	"M3xOCUcBR6Hx0r6zVPASQonvwbPxgYCEGpSbKoyGDGChac3F62Pwt/949rNTbMh83p/Vk9yU5F9wkesX",
-	"/MPF25LyYHBLfD4u2iK65UVOEKSIfp4jPiMh+8zSRLzLyFWMxPwE1BhdLkSPLG1P3nXHDM3sFJ+DCMvg",
-	"Qwepo/hYfgPQV45imW+2Z2AP/s//fvZkDNT1qTmKAoE0SF7HxkkkHUtT85MOQTl+e/pkDD7otmZ6JzJn",
-	"CrOA3Mo4LYTpdax++oxDaUzKiqao2HFl8/GybeRnOpYztsBGCi6YLz6jGE4i10V5Aek0DqUEwwQzk+Fn",
-	"RQ3hOpaRiTeEBihUbkPMND6OwccZilXp/KFh3Syz2KlIfQApuo5hEKCEo7CUslpX0MyOtChVPbh4azUz",
-	"LhGlk+3CBJcoY38eJO66w2qaz7F3AL/fVqybeHd8LquK1WToSqTxoz6F3mrEwJ/AaiJKPmulw44wcXKs",
-	"Blbh2L/rfbJsmfVRcVVDcMZw9xpMwu8gD2ayVxQCjNM04CmVtyRG3z4d52tnnnUZuMWEUEBkVwoM5Z+P",
-	"zk9dBlsYx4TnvS3qZKjmWniDdzARm1I/CzGd5XlBylvCOJG/wfQrjjCkCxna6pKLTBH0KzxHjMN54hAa",
-	"9Sey3rH6prmy8YF/ZWNpB18vLAidwhj/qYqZm44QDki0Kxy5o6FYgC8zUD/xboDe6HOzsNf2qfk624aD",
-	"1K93mO0v+XD6qrj7ly8P0M8vDg5G6NnfJqMXT8MXI/gfT38avXjx008vX754cXBwcNC/+1yhJoI0yDFb",
-	"IDtWCkidlbxt3LKJwNBoQIqYkKpQJSX1gqLExkD7rWUvQmmmjUOnTqUcQRlr22xKiR/U+mabeM6+EueR",
-	"31q+nqVCOQ+jiflpwt08T57ovnm3VAfM8Mp78TzocEBipFErcbD7b5nfSlLV4FNNuXNk+Z4+fR+2TaYJ",
-	"s3a6u4L15JPA1VJ8VNHX1cnxk/uOUFOum/3g5IJnoV2aFKJdaAomKCLxVCga5YJmzuaP7CS+fWXMld4F",
-	"iHWCiUqZVhWHnZsxIlIx+aQqrjeXyHdNbfk1FX4M86u1z21+rFZILZvJOlqtamzSjpMuQXRd0my86a55",
-	"MzV1zarfrKDA2ZzE2IipcQgiMp3KzqLxDYW58L3tbMzq0VfyTK6w/Fl13n7P30oKojmwacuPmmemZZmG",
-	"yomJjoN1y3x0ABvsdVzSTop0bqh+swW+6BzbwwPjOpNhDGPwzmQwqYQs8Or95ejp02fPVfDTuCazcl2l",
-	"yjumaNbQfXchaF0F93SyIf1w8ba6q18gQ8Ayduk3g8pa+Npp4rq8vPxb0RJ2uL9v1hsXxo3kuDG7DQ5/",
-	"Pvj5wOlaXkuVOwfldCt3J78KR2Ti9OLQAEp4e0H34vgIyK+XAC8N4EgWsOsI3+9+uNtbltjdUnvObe5Y",
-	"IrBzj73ygc9ycq+P9M3IXCCnnROsSycL+SoiU2UimyNOsSMHpDYM2Eq7xbE6hIQANUHPzvBge0uY5SWY",
-	"GvqQ0Q8uH6qYQJdEMN+Zth7yiI6DVc35GRez4mGEiLp/+9STtsp+lhq/n8txpG4iBiXXStmJZPuQHA+H",
-	"9hfVLPzMrHz6qgCAXJUcBRHu99zrma2tlhrv4HqvRO121c+550sGSGOmFys6BMUhZIf7hJIbHGUWgFUF",
-	"PWovRg7jbPcuEeG8IMVWmBcjVLeqzsXdzA0hfYPM8lOMxAe3Ks0Ux6nVSoFdxzJu9uYGB1inyJjp+IyS",
-	"dDoDEaQqsl8o4wy5ixHG6CtX+3J5+6DsrCR/lnh6g3gwM1kRYqhMphmDc8h08Xjl8ofSEnAd/6HG/gH+",
-	"nSK6sLqK6/dQTqG9fGNwNJHld0xLbenkowjEBMwJRSrlpvxio8Xfn53+i+DJx98O/tflS3r267sUfvz5",
-	"NvzXCX57/PdFiE9/evfnPw/ePz/4T7eDbq4SPWryfo6ShJKveC6em1L2D8jGAnjDjRFEAuQ6vjIVN2KA",
-	"GFfjs+CHycJ2Rkn2BBcyF2yCAPoKAz6+jj9oLv3hFMyw0I1lzsH14P99eWDB43owBu/gQorUCnzSD32D",
-	"Iy4DVwXgMSqD7cWzni/OOeTBrFPXq0SMALBDw6tye0FKIibbW43swky9O1st3Zzoqq03kRNwJHxLpicx",
-	"p45THgGmqhhERFapowuVjwhBQsJqK1IydcrNWTJPnpWe08klh1R117G66uoHk8QykBPUCeu83g2YeQiz",
-	"dODsBCpy5fnz53/LC5AUHIQvRgdPR08Prp4+O3z+4vDlT+P/+Plvvk7CsqnWckIK8Dg5s3a7uWpgSgtV",
-	"T+uVyQICsohfjueuomE6nsOYGKCrvORmTVl6933tV2b4SoxWejJfS5X2oy5rnTJ4sXmTlA17n3qv55nj",
-	"uJQHkeIo9C08/0vhY+k6L1dR9SxBVi21LCP9Qu0vLVn52XUskN9GeJP6WG7CzpR4gJm54vKj31RyqxbK",
-	"HVKs6gC9jGaaz7lj6mi+sX4Sgaz6260TpqpKjGypoK7ycCleWjLoE9VJuBTmY2qa5C4xVw8f5/smizw6",
-	"Z1Udn5pnZVwQ/7Q96ybbvL3kp1qYmkrKLUWbO0LOfOKuDroCIFoLMB+AMpPLoM7kSyBXjvVaQ9OcUKjb",
-	"u+tmLo6PjAmw3uJycXwEpDGsanI5Oh0l5E5K5pQQXUcMwBhGC4bXbXYp7qvN7pJZO1vsLvmstuGl9aBV",
-	"M0xu7WzMS3IxIV0PxMV0VP2NJdLBIY6ZjuoT4LbGz2GMb2R8qnrVUCjVkrxepDbtbrgLgD5zX5HODF+J",
-	"SKcn010Sa+9H/973msRwBiCwHiF17cXcpWI11M3fiD7lkhdjZlnD/fhK3qaqje7BuKwEXkKS9Qrihcna",
-	"QeItnJcOURUdLevBSXx7dosoxSHqaISw3qhRhtdFywTJZnYcrjHKyEfYqXn9yV2MXBZE8efci8eK/Zel",
-	"NqxFfCXvl9hBIXKpBp7tFcpsy1NdL+yqg1Jtq332PJrXL8i3hJT2OsPSqVzY2Vh2qqCjBeUWPV7lpRRb",
-	"QsUus1kViBrjnAqN16QgZQLNIFTLytx+nzdtrZSg+BDrzkFe9Sd0++9VUpGcsJl6TJfFwrJN3OhjZUD5",
-	"/hXhFAnTgyt1UGZbGdOSHVKK8/+VZRXUVtUmRQDHFOVzlSEi0a1MlLslX6QHXikUCAYzXcc8a45p5qmv",
-	"/KtmcTr4s5WSdBLhQMrQVqH1bGZnupBhNaMQ3Y40YbWl37t9b6YwoEoWKmYKiuswKCfFnsp2fJvX5nD4",
-	"1FpEuEEg7yhQrEiQ2IIpz5a5O0gL1VqLORtws3jHG50hoYvP10X5xlwQsisrWfprzO86cahQMzGvgiV9",
-	"0uDlfAieH7BSpsh8/WLCo3zgSGnP68mddrljTmHMJANWepj7qp+Wr/npAWtKe2SNeUyZtmcS6lUfiiSJ",
-	"Fsa4kCvTDTzbK6/JxI811aUlWe2ebm7BCPFC5YnsYJI342K/actLWOAt4SDbwCePwu26a30em22ENQEy",
-	"AzEn70iyHiG5Md6SyOzxhbCzpBozan/bjMcOOacWh4sWiC5Cztqkm7WINQ1UcpERnvTXKstSqRuJrJEl",
-	"M8ZzY35WorKGVlQrtqo58fxUuy9LWY0uKlHVMC+9Sl5WpzNopmtdDqS127CsgakAuhgMB5cpS2Sxm8Fw",
-	"YApmWvhiPWZhPQBtFjCHOnpFiEZjR95nPmVz2HYbhDpkjWqprcDnlirF2m1mywblzfFep1FUc795GWXX",
-	"sjmFZ+3/XYiof2wH9PeeoumccJSpyq465Dg2LZF0YRIcy0AeE5en/8o4oZ69Dc51BwLpFK2Zpth1e19A",
-	"cAIZ2m8qiKSXdrVsM3qtTEZfouZS7V39VrwnfRpOVJSYPf/T1sD7moZ4F7VFGzL6luGTNc0/qqWKMKKQ",
-	"BrOFb7+NX7MBbXymFFrZIj6609uyyUwmo9UBI5dRW0Jh1ND8pE1wPbl1GgKPbGEG3UoZnDESYKm0yXcH",
-	"1pekDtyRdHkpbhmto/VmOfkMMkAC+cAW+t08dxWMu8GU8YbKBK/F73INe4k7yGT9NKreE99CBI0rvcsd",
-	"6qtZr9bdV6oTYv1oqE+uWoz4suoti+vD0xiFJmhuX6ggREoVMQnR6Klbind3Vb+cEcrBvNwoihabrTt2",
-	"FMxQmEbIyWbqCD3vNC6jS/Lq+e419PlGTK9F/anPJJdmE4O99+LaIkAo+Aip0IyK2o/62ZckNTiHjcWt",
-	"C5TJGnzMxquse9rI/ra3mTvd8nrV0qn6vFFDs2YsPcWe9hibzbQ55/V+mqDyq82/a3hnxvlUFHm9ZaAJ",
-	"1yp+jxZ+7iWhVSZtK9mRtIUsumZssizUAva9sxdcFpdaFipzzZ0iB4SV1f+I+5SNcYh5fsxydapMGxpb",
-	"TQk2qBqsShFYlaFDiv0uIweZFPHNrq9IawOBMgGcqShxavfxZV05jDP4J9ewf6uTYTOuYZQOqcDkp/Qv",
-	"pHP6ygfwK1N8bMZpJh0WEljVRhttSub0Kji942sjU6tKb01NuPpJzCl2mTne6mhxjFiuOqpJ/GJ3raj6",
-	"tufF2kcTLHyq4Zaw1Y8rroJf/Qi8516RTwum1JkQSvji4prGrhemqtqF9FLeROQO0NRRIy6Ld3Jmsxm8",
-	"qL3y5ttsho+19rA1Rd4A54oi1I2fVCgoa/HjNu0KvcXVBzaKil2BmCFPTZWd3hUpF7VxFrUTJzRI5BKr",
-	"CuYKSiJty00QnWMudBvViZOBvQhNYbB4UtO9tKnYq55BOQbFEmr2UjVV3c70jmKu/AURUr0c/IurFtbv",
-	"rriKvRVEWClnwHCOY8w4VQmQKlPZn6dp9488d1WUF3P35nACKbMPR1LFCOVCbAjQPOELlcugIj/VD916",
-	"Yjm88ea261DsJOaYR2iOYv4OJokz0lL/oNwlEjCqwAnKx+YJS/JY9djXs9kturnJtBnjrYJRRO4qnqpz",
-	"EuFgAdQAsCc/AtJhFS/seif56LgUOGR+qVyydd72zqz5p9+HSxoPGxF1ri/HjaujPGyqaqPRHKZxPyRC",
-	"plC8A7sMBVqntQ+b3Vsd9vlITBLhJgsdtBKHVkpcLZa5IXbhpOkQ3aJIDL5HdO2C56W8Mvvh9FfQZI16",
-	"NUEx6SCPpBDrsaEKdWNDQVFG6igcpuw1zBuBaLL9+eDnA5dtliKZXMoKHz/1SySqwkI6FF5BDi9rbIPq",
-	"C+VrMjXUNf+rtuvUXp924i26h74P8y4N7nYWEqe1jGFJepdVN4tx6Yzq/S3lhJVs6aF1hE+10FItITzF",
-	"0rU39eihgaymH2XdLPVo1gC10gfL1pGlBcNHyRnIlJVbloVdxIEM69Oe/7ze0QYzF0pn75u6UJ5mJbkL",
-	"pUl9Yw3LvSaWDTos48/mgw9dl+QThFjeeRkO7hYWliCpQSkLbFdxuQjiDrC0WH5zpRYBoBuK2Kw+1O1X",
-	"ITjecBSLDVIUkDjAEdrX4+r84U9nTreRZ3s/dYq8p1/ZHWR+GA58cbtLKFTbrS4dElW+3RVGREWQiZ2L",
-	"q7nCrqfio64NU93EHWRADAcJJUJZLHqSCwXpn3YtSK8Wu+SEuiwOl1YYB9M9gXQ8bn4HHdBfrtPAT+of",
-	"MTOyvaxl1gT/Uj87qmNvXmfSmrBHz+nqJB3DeJyQaJVnGsNynKZT++6Atm1ZDusCEDylmcKUFUXlVnmn",
-	"m6asEXIq83ZtAeDW/uSh61lQfW+sS7sXhjbepZGsMeOSguslltrM5qw9h/E/587/Gul0Na00jvJZJGKF",
-	"WfRlWa7MobV0z4q3cgLP9er1J9u2oup3VcOArTgHp75iisma4V+yj8aY7Ick+IKoqmH3LxXQ4PzgZlr5",
-	"ZQIZDka6LWPxJ8Zm7h+4rLM/IYQzTmEyLv1KvqC4VMfWbNuHzahGqMe5PatqqdWNi2QHcyXkG/NXNXkj",
-	"s6B8DiKI567sndzaJj+pcgjlJ2q2XH1WrUya59ffFOy9yp5klgjRrf53J4uvO3xGwzKLXdNYlDJplNGx",
-	"E59hoMLDClemv/GKoqkC2QkZF0dzlozwybCxpAwZ+5YklNxKOZdzd/4zewfjFEZH+suL7Bzfagroz+X3",
-	"+dQ4r37oU9Qs9k0W8q9ekkGfmVPU7z6r3mE2zbKT2IvpFgKOTqVexjF1HHdNFH3UTDeXlVEcBbj2dHhM",
-	"Ln4BEkeLJ03G7jXEC60/sueKQuzK8ZZZrkuaMCRImFQQAkoYGwWpJATBGQNEY1bo+WhlMOQy72bNGPLU",
-	"fY0XavBKTBZyKl9DhbLSLmmdUGiweZtEDnEfS4TapTuOzPHKvUd3Lp+6lJ7UIFNEFDOd142zTJr65Jgb",
-	"Qk9g4GAuxQ6vUhzVoqhA+rkpP57vQ1dvFDfpzr6UnWqFMtu6WIg4onPlIsc3RrHU5MtmJI1CQWQ65q6+",
-	"MtNWMsUaTSj+no2mnEH1JNf24LVyTiB1BSCRBNxCivP+ixJzlBZvEKJVNDGn8kncS1Q/QVc4eWh1BpP2",
-	"NMx4oUWdpQHJkgqoWPtjNahNUYIUZuuCtjxwmsNIogvMOc7y98uz97JWLMi/ypI767dJEmfPUV3HriRZ",
-	"wjAcKJeTUncpmpNbN9olTplBOsxkto9sOZu3bhT/MRe3sajtJuxIh1HNjomQCsGejF0Jw329PQsMT6q5",
-	"kclAb9GFP432T0Xb7eKQKcS7wai0QjKLvYE1RXUNB7J3diuKcwJUdWRwN8PBrPh61OyxdGFGfypFjjmp",
-	"fwXMt0CGSzDfdXJAhYcFpuDDDJWMUSem5vXC1XfFfOpK5YRVVoNprAPTt4T0KxOlMLqBgZaXrU4AJOF1",
-	"j5d03Hdb7AKlSkSX9JdDzrNgtWzPU8fej0/e6jL2+WeAppFMGZHZd3lkI0VxiKhSMWvYfm3e0wmlhGZ1",
-	"rdmM3MVZeXi5XracpF6pXzo12TRqZwx3FCaJKqTyl2/j8fi70mLmKePZMvKZoGm7dVWu2Jzq027VtzUP",
-	"L9+PkaMrM31IQsiRNstfkMiU6/Gp1prKsQAWgl9MKad6vfmeR3tRZ+jmsQ0C38jCSkNAO9DKRF/Vx1hV",
-	"7q7/pW02nnSrYaQKamF2fnk35rOWgOeGcEs1bRZw0peUcoPUgyImryjFTGiC7alZlknQi8ysmT1ornDN",
-	"y9zvA6S7LCJzVTQn7kDHnnS6Cgk0E2D7GNK8wpDmZWKPlwk6zvGhMyL8lS2RW/Ee3WXGWTNLlhpdooP+",
-	"JNmFMBiixzBRih9GDQl84stSmQzdLisLFa6ShDVzk2O7kV7k7rM9VjnO4B1McnhKA669rKuErVEwXPnF",
-	"V9jor/Y04A7RXFWoDww66BoYJB2XbUE9RR+zU9AX13O1SFDee7pSabXcMQ6ItZVulzKltcDcWy0+g3FY",
-	"vHJX56XZOxTMYIzZ3BXZlCYJoTIhqTj1PBuUGyiy/fhGOx3Zq+c9TCsPFGZJBBfuSnulB0qaLwxJ2hvK",
-	"71uOAB+YO1UgoZhQ7KqnczxDwRdAaKhryeXgDxFXLSzBXkTuEAX/CWZ4qtyiarYn7mI4VuC826X+IVvD",
-	"qmKlGwFeS+S7Hoh/lZzr14NimYou7nUb2hY4hmVccbEjaQF9TcncN1KLUIBj2TlG2VQrTStMKKNf4Fwh",
-	"+L3eUHtqLQn2lNEFRuAGRtEEBl+e+PlXtVu0nuVequZaxn5ptWlwN/BxBzzKdj3A7m/VyrqqlRIwv0C3",
-	"2G1jfYM5CMh8jjm4/PWoqM5OgqfPnr9wTkmOaFDvhhePOBZUkZYqW8F5+FPNhGeXtdNpo2I8BWzBOJoX",
-	"poxwnH51T1mb9v+GZPcimScnQN5BMRCHPB0/ezF+5h/6d2T1VqsYB6xmmzDBvSpt6U8L8YQH46fjA99g",
-	"v9xgbePE0EJAfRPZDdtgdNH8RzSZEfJFVnjxyPdVjRJ1iK7Oe1YzZLV8Sk+UFANRmPm5GnQlq4GUGZZV",
-	"HterlKKhCkEad2gygknHWKha0+VlfR8WDbM8Uhkwq1aTMwBZ/V4fgCPeOwPIO8jqp26NJOIUT6eIolBy",
-	"HtZUx0tiDQPZCHv6Z86kr0JqU2qSenMYlRd3YpzOWHOZkdcVP2LW7BtCko1fSRSJmc03kMTO8VsmliSD",
-	"/JY7dJh91FcHNFHL5VANGINci3GWZVCytV2LYVyFWoeCw3a0hpUiZxYYLxseolvuqRgRoelkDMFeWf47",
-	"DgVljQfbC8sY+1VBbgynyC4/jbfBAS7SeFkmIKZYKR+4SOM6xdF8UvI0moBWU3cj+0yXWr/F0hytva4q",
-	"pHbsm6BtRPAwn1aLH464jGUdqVlP5Xwqq1xdthNDb60IWBt8agFbCjttrXwrFTR1TFhjmZeVFoDUzctk",
-	"cDEWwiOkNRFifoUeU8FAGIexb7nH+gUbOgpL4HZTePxsNW4VWy9XthL4Vna0ttmlyqOFTF0fcYE3q3rI",
-	"BQ/dlbc8jfv0x26kprZG2SVsRQl4egiOI9MCISEMc0IX4/G4Iw6/zba5cjyuFjVrA6t3EK6NFWVQch4d",
-	"CdVNdztwaqlCfxxxMorwrRW3ZN+QVv+CbBKwF5onSR1QNbl/ehA+nT0/mD9xAv7OUgA8sdxYF0vQy2Zq",
-	"A2GHEIwmKOqDG9O1H99qytfNH5kR44vI7ju8+g4FXQsy1ufD0zQuZHV2nlC/ZV3AyCH70p1DXkH2xS9W",
-	"p4IuDZbBrHZ+kYEBJfgLMhCiDRMcKUQc4qjK8GeQvcW36MyO/Ks3D0iSjMiU7euKvpAiK8s7K70oNfqs",
-	"bH+rrYDV0cUtojCKiofLWlMYT+c5MlWNLtI4Vv+SRauRqpn9GmJVK1pGgRV9ofkIR0sDlDj2dG4gqjsX",
-	"5IDthBDimTDSe1uzYXNgtaOh+86aWM9lTXRkJY6wEh4p+W8GfkvMLuPRQwhlLFhvuryEjipCtR1brLxl",
-	"d18jpYArr5xscQRl8yocooJFwJgcuglyxhLiZrZXq1fvXQdyvvljFw7kYb9eNKe+FmfrI4ZYnBngWCgw",
-	"sq/O8qJIJeQzB3QjVfeQJjpV8VivVNBIYTl3bHr1xD2E+BaHKbQeCcEmK+cUpM5mbmd/XgxE8HXzZZOk",
-	"/bSTxlhT30EsVvHuBBGJ0UgfoWrnmEFWN5X6rcezePkFJ0ndA2mPcHX9odwHprnNYB3KiwaiAkATxUgp",
-	"rF4rFKLdvtxvlvCbIRX6ioLU6XTtJYxbBhr/Wrs1t3+sG4plW1SoYAw64lStl9cX6nXQjggM3VZE2VN0",
-	"ybxhiVdqgoCEaGjK/yI6zDqoMvmgBCSOkRViBXPn3mYzh83RlzH6yvErs/iK2Y4z8LjCG3Rpn6PzUwuO",
-	"WbU/dwgCjt356L8q27GZREvNUn9QQ+wSdabRris5x1WrIi9LYBKQpKSk91KbLlLXGLc6Xa3huSY0JPMb",
-	"qeAQlQNlHd/ah6/HXS7klf5RDF6+dbf3FOL6MmVmcswpSewFHaGhuEzNZOXczAQ7UtDcIUf6ulvwXfEJ",
-	"5x60lbsZwSGdsqbRkE7TuYwv6OL+D8h8Dl3Zj/nE0hBYaTvdOrM/yfjKdCfx7W+Quta6wZFLpXmNleyY",
-	"Y4n3WmJozWJ47vRwnB2fAvmTVC1SIY/jKWIySIzDUuMliqaYcbqwW2jv29WvxAN0WNfjvmypnjeZ6QX6",
-	"mZ7brpBgLphe9nq1IOEEMuSuX/KLePll0RL9/Avujb4mRCbZYah8LHmX8SqZ9w2TbJo0L/xbDGWnPNub",
-	"zkO3ZpnDr3gu2MBPL18+fykTmNV/OyMf6zJAxfkte4b+zBm2ry6m1uHj0zVSpYU4T5tTcoQZR9I5IOAC",
-	"9nTIv0ocJpQ/6Xx4N1s9p4STgET7HAWzmERkusi8fFafec1qf726OhfKwsnl1WA4mF6cHw+GgzcUJrN/",
-	"vh3IAC1Ggi8yOffqWHz54dW5Oz0YM1xnSLSsGxmqZ99jxMAELUgcAjxPIhxgnvXrtia1WIfZe17Rxq5b",
-	"h7UEI0le//PTsGPcvH5cJAY30XYX/5v4fhW+Nykjbb4mi1m6kCftkQttjl5Iiq7SYfZAtxgW1IdmE/UG",
-	"hUzs9jXZOUVPS5Pom8TgkLorcpXgu2GtuO2UqbxhVpWCpHyg9aVlT5U9bjVncj9tzhM1tvfPi6iZl+eu",
-	"/s68m/eTu1jJ6Ovs4a8X2Wgr/0aq6GhB1ECursBQkFLMF9LCqkUUBCmiR6kSUtR/vTZWhr9/vKoktv39",
-	"4xX4RX4GZDXGUq7I+Dq+js8mAnEB1F9If9OCpFTHy/GFDjrS5mQdAAcw13X1r+Niz5wZgiGih+CPwp8P",
-	"zT6u04OD54FcS/4T/SE2cSULaqqgfFW1QKqbX1Bsqvb+/eM/LnNnmJF8hYbLWGpKr0v6kY4wuVgO1xnn",
-	"yeD7dxnAd0Myrqi0aqWzDs4SFB/LIPDBcJDSSA9jh/v7U8xn6URKsnmouPXPKn2KJ1/KiYKg8plBZgHI",
-	"nDTgPIL8htC5uo38Uw12ZoUrjWLdc2fCOLXT3LKMTmWiSfSUAMVTHCNE2fA6Fu+/zOZTsd2yNNZIVTKx",
-	"cwJUdKAADyWRrnQi5rS62zMkNFKNQYPhIMIB0t5UDcujBAYzBJ5JEb8Iy7u7uzGUP48Jne7rsWz/7enx",
-	"yfvLk5EYI0M4eFS8FQFOK07+cKBUCFXtKBZa7eHg+fhg/FxX7JEksz++Q1E0kv3s94lAf8ETuDSOjKgV",
-	"pOos1XOBeEpjBs4ELovTgGxwbm/LSuFCpqRilfF18foY/O0/nv08vo4/aGH83fE5CCKMjCVNFol6eypk",
-	"1BCzQDzhpURATRNWgsp1LG1wcpaSAlhCoFxIEJJarGpIYRSFDOyZzYH/87+fPTm8jkfgjxybP+s9/nGo",
-	"D+5cTeKdlJfNH3T20/Hb0yfj8pSGm31GsVBzwj8OgXGAl/LXMANIHDdAISC6TpwCg0K2rIrNaTg4HLxB",
-	"XO7x3NyLcbe9M7Y6GSkhvf0SIZ4dHJSUE5hnhuz/S8fa+TnBWlaW/Kb0Ckh4NiBRgfUPDn//NBywdD6H",
-	"dKEOC9pnECrTlKkqwXnBHzGv0Lz3b5/uC4j/uW/l0jYiP4yiDK+L2KlnGFduRQjuR4GRRZaCv3dqbrVq",
-	"czEdWAx5cfC07k6zTe5/iM0pUagGPW8f9JrQCQ5DJMXPl+qMzSPMS6AcRPLas4uWW4cZAM19Fl5U15Vm",
-	"FXdUZyCX9nSSFeUhMQKEgjmhqHSvVGVoM9V4RntyAhhF1ZvOphsogQox/gsJF/2uuNFCphcyaeVOBMhF",
-	"Omm+XxXqNe3rFQpUppYHRhYFpVCPzJogMinWyixWqBwyOE5Snl/HnhnyO/4EAkLV6UIdwiA/+h1/eqKQ",
-	"1gMFf4GhBc5exLE0qpt7raRDeyO9TpZv5WMCoO40e6P0QFdJ8bHrzdGJ4+d66WK0/O/1PZBM23Ms/vzv",
-	"FNGFadh5WDCz5EhY0VvqqhI3TZ2rQR0mzisoN01ta3f1k39a4ytcW2nBQYGmELrBmQ1SyhaeESEvsNKJ",
-	"vQhLF2aSIYdS5PeQEjJrnB5s+vRZcYs1koIunyXzCs/VahWCcgEh/2T/LZ5jfi7+eyAQueXr45QyQvXn",
-	"60TNysmkRbNBVjEVsWyg3TvBxXmIHO8c1/1J+jNc4sqxqjMNIIjRXQNqVTFLjawstoSc0umm/QSSp+ve",
-	"gLNEXv6RqU1dTEXeaa744uBv7SOOSXwTYWWZWxqpFSa50LoNqxtZ6v63oDxGCArfFRHIZs8O63qEFDnU",
-	"k4Lp5VolCTXaRRKt4osxt7qBIAWDRFVuM3KB62yDMkV0kxle1BZ9tDBagc6F0RtCzxftI94T/pqk8Wok",
-	"aHWrfdBz2Pykm4AiaavOjEldePAbxO8vth1shTcXKNkkQvzI6CuEVNgPe5PUib2yqjuTDdRNlf4Gbrkn",
-	"OISuRPekisKFCq/3A4t3Rro52LZ0k+qCl/dJuulIf5sXhxRFrEYcyhbPMo/6KZmlNuqNemahLcePpmoW",
-	"DuerbZagd28VzvI5KuhYuvqeamdxmRbNs9wEZo3subjUdvRPxx7cYk4RiI96aHc9tAhBD2RvY7/73wIV",
-	"AtNPBS3dqJ8WWiaPbrzYNYk4QC2/rdcgC3M8eCWyM26tQpVs46u5NrlhrDnYFS758PTBHojYWyssAbuL",
-	"Yrh+hNwlqWFn6OFRv1u/frdGMWM/R5JWz32l35hKPV3xW3KZpbLclxdF7bjJ511DOyyr3PBDPyVB4+n7",
-	"YHPW3c/HXpFUklVKiJqH1TZbLV5BDn9I53h2MF9rhQWxHzx+o2DcsI9dQVsLO3oaNfLpWwwa2VLrNWbk",
-	"y2zHkFFa38lSs28ezRfdzRc5wrWgcxMH3v8WhEl/k4WV0+BnrrCRv5eIkE3Q00yRo9xDN1F4488qTBNN",
-	"3DEXJTeEHQfb5XUPxQjRA9F6mx4sRtTF7LA+hNuVd33LuP5oYFi/gWEJQaDaXH0lOllhWh/lrFA29IfU",
-	"0qon9FXXXMC8t0qY8zAVrHWhQ0+1zLFgi35WXXy9ippjve1obHUbcbL46sePOlx3Hc6Bnb7U4MXMsxDp",
-	"6hzdlT7Xbj3VPidN9RK43AfpoQg6EPiha4RLYOMqdEQvVp0ri1vDqYOtMl4nFT48v/ZSuNpZzXQCvYui",
-	"uUlk3TlJ5WDXJJVHrXT9WulKRRtKIjTBsna4X72N0tMixgMzQaMmekEi9ItZ6QdRQY9SPvuzej5fBbQA",
-	"vHureRZPUZ/F3UvLtCdvUS+tC1iTXllz3ZvWKhu34RZtbDA+qpPd1Ukbfp0KFdj8df9b3F01bCaAgi5Y",
-	"JIDGJDAnXuji4470r7gt28uqnhjOcTyyQLVE7mxxew9difTEwWUUxhZsy1XEe4pqBzvDgx+aq9IbeZ0a",
-	"pJKA3QpkM8oWdMX7g7U7JrvsDt08KpjrVzCXEnZ6aZGlIn9imlZd8odVIrtoj/dba1y5tljFIw+dcUPK",
-	"4ra1xFYW+6gW9lILu3PI3nqgh/7XSa5ZiTxjSFDKNStR+O6bord5NHRohuvUCNs0wfuAdAfbY6wPUddb",
-	"vY73V2bqTqui//lgD61vRzF0V6SOLRLHA1Do1qGfdZI6OIWYL1HDSI1v1Miu1BI/VmipPJSvOqaBfF/1",
-	"MW4usORI1hfbUyGTs7boYHKF9UaCqiW2E/xpre1mgxJGRvt6VLgaFS6ucaUOSet4XxauKb/sn5an7sov",
-	"NNPgda9gpGyfPQIw5dgH7y5rQ5VVBFbWsLdcO1ozDhxsiVk9vKjIdmzqnWGnQNol5nH1WLULL++2kFlr",
-	"II9epNVqKSt8qtdYjcePgy9XfGeTfNy/6I5C/gdWa6dwaC/czHof9cvftJpEFhtX5vNKtE0ZomAGGYBS",
-	"WgOcjK/jszha2B/K/pfi6whOUGR3MRyH6HZfLyDnz5va/6fgtn8ASBGgcqMoHF/HVzPMwA2OBJ4CknLA",
-	"Foyjub2abpqYLzLSC6jWnEPwJZ2gkRr3RNrkrmMrW5ymMcdz+6CuLolCB32fg/gHsR9kJ2ozHljYdd8M",
-	"B7F9a4aQrKv0tRi0U8hYdeHN/htgBmDKyRxyHMAoWih6QKEikC5k4UJJtb33Vs+zdchH+fwbNkuUFq7r",
-	"B/foDfY2Ttjt8ZyE4HxOlBdY/ruLPcJNIm0mCRubu3HY9/YmuxgjclR6qJaIVrzoZYLI2aJLal33RR9s",
-	"mg89FFODB7J0sDDUcAkvI8MaUGjrz+fG0fbRreltMFjN87nfrSVoVVOze0JKQVK2mM65LbhaJFrcJDEC",
-	"CaJNrFiIyMu0DXWR0vC+qkP+XUbvdXfRmq6ifdqJ2m3AHLhYo7M0NQHbHda9vU6kzU26HnuP9lF+3E22",
-	"artr+THw/W+TPp1HO7QaXTGptDPbYuu8LorUYwdRLyTrpUy19QjdVTQ52CRPfGClcPyQzV8Z69zSc4eQ",
-	"bvuv/8HmX//HHMP1eYdXJy5kO6AoQpD1ra+aNd8w0zjk7SEgci6p/CmnGQqFhJGNromNNT9fmC1uhp6z",
-	"df+ZIrq479pjGYqtAbmVK/2hnywVxVs9s+XdrqBhbxrb/xaUJsvE8z7RdOVduwMxSitumoisg24B250h",
-	"HGW4PZwUo/LJV4vmS74hnd6OhJJ/oaDt5djUk3GudvNjPRjeL8VDeiGcL0OHBI+MAv3tktkyu2yWzDe5",
-	"6TyR4sJ1rP7RJumfLWLhmxPVuz4LltjTKVbD3F1bwshK6aODaNM5wSQ70YPNLmlDreFSgnCzALxT6HGw",
-	"aQb44GTchoe6QySIAZ9fgsmuoNrW3/eNo/ej1XGNOSnrFgj2Q5RERCKrW4h+JX8vSgVGeedEkmx8iymJ",
-	"585XQA3fkgFk/bRZOF6GyJsVw/XqDQUJLzJji9jtD5cxtgIRScClyTKzElKboliQBhqZhWqJ7o3+Uj6J",
-	"eD5POZxEKKM7FsOEzQgHN5TMZV5NkFIqda2MRhkX/GOv0Hx7CFSi0BB8JPRLRGD4xCW3qbV/WJotHXBL",
-	"VNvPXHpPii1sXvpUV+pnZl0JMSeUzAlvoOFz9YH75ZSES2JkP57qOSV8hmiVKvVsP7CYWz5hJ7o82OBr",
-	"mlOlxoFHciyRo77KDUivHfKrAzKf4BiFdYnWlsJZeDTB/9Sv5pNmG0fPVOv7YenwyM7OJY8HkpldPvBq",
-	"cJwvkqUjQuQcAN5CHEm5EceSAlqi/gtY/8AD/wuw8I/bUJd37yqplfbvQGSFEt1dbWLCPv42sd698LnJ",
-	"jW5LdcgXr+PFEv6PDrjuDjgJuSZK6MPW978F/dxw8hp9fXEro50OYohYs79PTh7vwTvmWlFuOQ+dnL5Z",
-	"hN1JzDnYGt98eLFp7RjYx4EngdnNi7crmLgTksP2KODRtbcB1956RY2VlqDr+JZsxySywReli1lEEtSD",
-	"s43Yp14axUPI4RKFEvIab3m8c9xmFXkFOXwshcD2Mzi0WUMsKN87S4i99xxbLRTwtYBY5QS9ME2Nzhba",
-	"ZdNHvskNmz1KC5e0ZvPjo7XD39qRY2kdtnfly/vfwqSDhcMikxbrxmpJo52vZut1tWrkiPhQDRrtWNXL",
-	"kJFP6xQ8dxNBDjbN/R6KzcIHyfxtFRYf8rJT7Ayybf153ziCP5ok1meSWJk8IOMp5yjmCU5QhHsrbNk8",
-	"IJvIy5soFbds8Hm2iYetwVUA0qrKOeB//3Q61yEs9HagibeWV526g7O7uvJOq33V3W5a/6vZgStfoXgn",
-	"jyqhv0pYBV8rsfR+FPa/hZUJu2iPjqtuUyPXQ3MeEpzzoJ0US8dpH6yK2QNL+ymd1YXc2uc9wauDHeDG",
-	"D0ZF7YWkHZRWB2z9tNfdRdbdkVt2gVIea7H7q65rk1usDJ1+Wqw9gb/f8cRe9kHrrRYk2hTWwl3dN0UV",
-	"FW/c4G4BEXw1UzutrIMD0lprl3VRe5sbVkIrSxdvwfr5Uev01zpRAe9qML87u97/huJbf4WyUMqgTZNc",
-	"Nam0M1xrxa66o42WD1Vn9MKxXkpiYwGMN4jvLqocbIMvPhT9zxPh/BU+mzt5KXo7hXg7IAZsBd0fHZbr",
-	"c1iuXW7YJxOG6C2io5RGXjHUZgD4cPFWxU/Laxf0G5Epk+2G54hTHDD5M59h1uUFOdPzf7h4+8M+JtYZ",
-	"m2Krz2xQ4/iG0Llc7SG9LAV8WxMN0ACO4BTF3JsILo6PgByRUcHR6Sghd7KENCWEgwCmDAEYw2jBcAdK",
-	"uDg+OhIT/8job52xCf2LQH5I+F84+bJIrwgITnCE+QJGiHIWEy4EewnMYAbjGEX9TH+FuYGaHNizAzO9",
-	"d1jLmT3lkZzxvTXhsdnugzYZ+gGpzZrof3v3ztbY4Wg5efminq+R0nsTHYJq/Pa4y8ZNzxNs2O7ZZVcu",
-	"Kc3nlh8Npt4GU2/S6UW+K304978Rr4W72Gn9OUeLFXeD7KL9eTzzhlMX268//T1Uy/B6iamXSdl7S04l",
-	"6UfD6oN79Yw9FPv2usnG3zDu/xx4mc1/APLZbbH0ftHzYxSWtz1+58TSJapFFM9SKhvRyUrzWD6iRKhe",
-	"dSRc8L/ndpZKZQkXmvSznhRrTXS0k+x8zQnHbrdp/6hNU61+9WjU6GvUKOehumml95tQMktk2dX9TBBe",
-	"NSzWRHMdZcheVS0ciP1oLfDH0hXYAOorX9wXtDrYJjPWFPowdXNfJO2rcXeonLHDyLo7YsvB9sWWx6i1",
-	"9UWtrU/O0a3Z+ym8ZrB/jtK5We5Bq7YaCm36bHY3P3zH9iRHC4PUGab4ard6ji7JS3qNXdZjzRY3rLwW",
-	"lq10KZNwflRTvdXUJMMzB3Z349P73/S/OlS9MJTRomyukhrame15fowuaqXBvoeqSzaiUi+lUc/oVBR3",
-	"DyUONsniHoru14JU/kqe4TReit1OINeWX+yNovOjhrY+DW1tT3xTL8tK9oWddvB9X7eOFQchKQ18vJpR",
-	"BCJ8i8A/0gmisZQfstFZM3AhSPAZAjDg4tusQ22pKaYSwq1dDQGOgygNZa+XGY5Ca+4If0HgnITMncNh",
-	"Gi+rz68oQltjG/1abXYYtYX0EQuujfkj+jvAKUI6A6eMBj/8Y2nQndrAWK6V5/opfx/delWjsehejSg3",
-	"dMlOrTuEOqHhQ8MntxusU7MzVDwsA/4fOA6FQK5gqUAzGA6w+O3fKaKLwXAgsGVwOPiC43BQFimGFonL",
-	"rkCHA8ap6kNdWUxsxHMx+T9LLyZvqsOK8vtBp2U+nL4qLyBxNqEowAwpNAZzyIOZmMG9dorDxlU3wXwV",
-	"QTSx35OcIsVxNU2i/Bl9jDFzsWuNFOi2VCZpNxl1QsJRRKbtrFrmhpe4c0LCpRnzOQnfivUfOme2mWVC",
-	"ws3xyebFDItcYsXLvDtbzCGOEZV2QcAJmCKuEYuSec0uslHdGPVZHC0AlcirlojRHRKcDMYqkXsO4wVg",
-	"KCBxyGqWZjgO0GX2Sb66ymQeHA5wzH96MRgO5jjG83Q+ODwYmq3hmKMpohti55qMmvj5W0PBRW4u7v+R",
-	"kVeNVCSUeLMcB9dscYJjoYb2c3sa1momcQRRDgGRM8EoWoAbHHFZx2CyyNVjt39U8+JfzPY23Ajxn4Lc",
-	"7rt3tQjDNidr+TJ/fGdr5cQ5QZXRz9f3WpqyQ1RxccVd9sSWdrphh6xr9TLHKt7Bo3/W2z9bQt9Gguj1",
-	"zOx/o4WJOjhvy6TV4sRdAz21s/aLyuG6uHTLiPtQXbtdsLCXp7e0QJMyuLP4c7BFjvpQ3MHdENHfO1xm",
-	"ZV5e4h1EyN2QLbZJCY8Jrt6O4bXJFkvprv10VlmKsrHenqXD7rjyalkBfySt11PdfThqrkO97U5qmfye",
-	"Ce79xa8msWuzz9tmBa2md+WBSVZLoSSJOlgvoyjn7yMWkERWU41y44+bhWdodUGiTRsjd5S/HqV89qcF",
-	"jjZGm4G9CO/dlpJWw3nrjp5j/ZHepyo+62tlbMTkOgOjC5V32cxYxrNNGxrd69e5LO0beLQ4+lsc3STS",
-	"QCHdHwf1o6eV0b2fOiPj2miqwTlewDTtdZcu4gTyWQd/PPoK50kkPg3RLYrE8UYW+FsDfxwGzJpN1tsx",
-	"H5XkkumzMzn0sn/6IvkbxB8yhh/swltS0Age6cVWInoQi9NGqwxURROtL4mosQ+MSnZF2NsJAn1MJlpf",
-	"MtEapcOeNgNoLyh35WM5eDQZKOrqZit4gDaCNdgGqhjrZSG4F6aBrdkEPN6HRyNATyPAatj7Elq/l7a/",
-	"EfFutWLditT6B6DOb54SnPr/evX+dn3/R8Xxg608CI+avKcmvw4N/q9MpmeTWLURtYZ76fQ/ECVsXRzb",
-	"DvU9Rmr11LqXFscYCijiFN0giuKgZ7iWmgTks3j3E7iUIy/y5R+0Kl6CRptCXgH7vdOvqyfI8bmCGr5K",
-	"dnnSDnk+pTV3Wc0ub3XDyrZz+VICb/keHpVub6W7jMPNdNGP1e9/Y8WpOuT7VGisJeFnHYTVzrgvq+fr",
-	"kvJTQeCHmvPTDRt7ab/lJZz67+5j0cFWGexDCVDtio/+yT8VvuaV/bOTeLkjIsd2KeJRsfRWLNchcnAK",
-	"cc+q/WoogLcQR3ASZaXcWhTKK7Xig1YjJQzalEd9NfdNY+Tmfg1u6gv3VQ7l+A4aoZx+l/VAtcENa3/W",
-	"okVgyx8eFT1/RY9r/KqgcxcGu/9N/m8H/U2RQYvStjrcb2eOV+YAXRQ0hW0PVSurRZ1eCpiczal17RYa",
-	"HGyKiT0UZaoBjfz1JsVPvJSlraPTVt/gjaHvY+Tr+iJfV/5o7+dX3si6ZeFNg95ADSpXV21h5JdqpR+P",
-	"nauDNVWyVIShZ3sQbN0ctjeq3hH65SYidzSNfdR4o7xPUYwoDoAZDsR4Tw3+ox5zIZZ80Hq8BYk2bb4A",
-	"6Hun1Bd3nyOrAUCTen9F8XSKqNHvXZhXp9tb8N1lDd/e5ob1/MrSRdh/tIBslP5H66pTz7fxsQbDu3Pk",
-	"/W80jZcp9tJMJW8QXzWJtHNXa8UNCQ5dkPyhKIVrRteVNXrpgsAb7eXiRuNKkOlrWcDMHG6yAIyjpBBr",
-	"Wq4tz1Gy1iYgmKM560AyEqonMadSu9S7gZTCRSsxaSTo+2DcP0qqdvdYGUH1bsZR2N8NJXMpo09SHIWq",
-	"hfcYyA4AkCJwg3gwkz66W+T89v8PYgIgDWb4Fqk6+HKc6qeAQrm2gKIy2IojtBHtBpt8dCNZebhVEOzQ",
-	"fVuV7hOyyDKUTczCVMFLaFT3ohVFV6bylkz7sRRJBg+IoZRaTayMnTAOecq87FHkFlEYRUANkQkcCaIj",
-	"SRf6b/2Fzku1jwcgeqqTNpmvCoiuL+i+4i0z97o85i5jl+oeX5Lv89E0FZE7X7vU/bVJdbVHFcNNKuYo",
-	"/8gTs9h9ME1tyy7VyCYfo1A6W6dWw5D3v5l/dohIySikJShlpWThLxN0DU3JsPChRqe0oNRwGXNlo9S4",
-	"S4hxsFmO99Csk/VPs3fgSsZ2vGJXdgTHtv2QbxitH0NZ1hfKstaXf5VhLV68f6PBLRt+AdrjWzKCeSAh",
-	"Lnel8y6LwhGBYb9klWz0Cpusfsx29Nhetd/DIqDnY6BQUP7hW83cWQhlE4r6m69Fw8zS0ZIhhuy6JUPu",
-	"cQuWjHzdKj+XoH60ZHSyZGhcc+F4x8dAyTPinx0tGfLaPCwZKyMLP3HFnKSrJUMe5yFbMhpQqrclQ0xQ",
-	"K83uGmIcbJbjPSRLRiNudbNkSNh5WzJ2AMe2/ZBvGK0fyxF0Mkz4PeQpQ3TEFwnyi1cISHyDp6lQwsRI",
-	"IEcqa0PKZyjm+v5lJEOhPrdbT/vAEL2Sq28iSMasdixP4RMfYzQd57l7Y9JqVBJrI16FDO/QZEbIF7Y/",
-	"wXySBl/UXbvVlnNKBI0hBnAckLlgkb+YUUBPZAIvOQFc5RGoaDZHWNqvMA4jlM3wUU0w6M/EYBhiZRc4",
-	"p2IpjgXaqNqhxZNUt53AhaENdftk8i8UbDwFUQNBhoA2GqbMtvWVbI8B9kVbFKQU88Xg8PdPNhIrpKji",
-	"lc20NMrWIPIU81k66YTFbzD/NZ30RmE1fJP4W9rwI/LuFPIWb6cT5kawM+a+hUth7lu4acy1N/yIubuG",
-	"udbttGEujJIZbDT7TDFXRbD82g9NsalEJ1NbW2sdv8G6gCFbnSF0TRiWbVV1yq9HMSNcWrC4d5F+9t5z",
-	"HLJuyzvYL5tIqhOMpDQQ+kaISqpFnaE8W3OXLeWlrWasYbN2c2v9eux8k1/Iownd24QOLUSuI4h+bHX/",
-	"29RM0sGebpFVi0V9tfTTbtV6Y5+mi03dQsyHalX3xbIZghGftT7IZ/8A+Ebadxiit4gCzIAauhiDD0zn",
-	"nkX4FsWIMSESTZA7+exXtWDr68rRV76fRBCXuFbe7ePsH442H46apaX9Nos+8hsQzFBgSzxn5hQGbCRB",
-	"MUzw2HDVVrPYWYLio/NT8Hx8kLkplB1MAI7PMAPiZxyDv1+evQcqf8wJQD3TZYKCZU1ixe3WbzEkQToX",
-	"Mzolc/cshRkaYf4GceAe1XABFEH16DZC/kJ8VcVcOVgoRjAIUMKBfseZhcriE9yGy3L6VaCymagDNisA",
-	"NMH1IjtCKzrfIsqwBybr7wCOFYJKO+6EpFwCWF6g3KATWr/pRdYoWOslmoSW36pHaMVOjTm32QHcgCzO",
-	"8m0wQZAiepQK/vr7J/F0qYnUk1mS9EkAI6AbGGlaS2k0OBzMOE8O9/cj8cGMMH7488HPB/Ih1LsoT6V4",
-	"2DBH4aG0tZu7Q3GYEKzypHUaq3WMpkZNcxjDKdKb00OzX11DzykRbMIaaMJacnkmn0p/7ZooC55yTJWY",
-	"YdlE2deuqU7iW0xJPHdP5tqXNcI14SvI4XkEYxs+koXc5d7WJCIL+XcO6RTZe81Gu6b+JcVR6Jz7+HT/",
-	"+JVODcfxDYWM0zTgKUX51Plo19xnE4GMcIIjzBfONeYkxpwITiTxJyLTqWpAbLCmMoPz6qKUcURNR1YX",
-	"tKybUx83AqU0oRNGlRmbYVGashE0lal7gSFD0atFggBH8ySSmm6IbnCs4hfFXwSLAiie4hgJtlFeujCL",
-	"x6qqQlu+mqkXQJhM0QwoYWwUpFw6vAMSB4jG1VWvTGnrWirteai20yy5/dp9vylnEWZL5IM/WpmWldeR",
-	"RGg0gUJ0gFLLEItzSqKqj9OJSEWPnGN/mAsud4tDRDNj6Uwa6Wz4ZWa56gyVwv2ubVTK0FfnyTzttvFF",
-	"Xi9Wz0cBXibws56bUxQhyGrIy3x1oT5yQr5hvMcw08a+Ybjuie9k/DlbT3CCIlzDJ/LvzvVnrfwYwAhR",
-	"zkBMeC6FBzMYxyhyrlEYfSQHv7fGHquhrAa5tK5c4v/1BrZ8XUuf/P7p+/8XAAD//1jI/jRZigMA",
+	"Ek2trTUe5MFuHbAgRncNgTnrD0FfQdR5bZj1nn+QdfFF0xJ8McS6ggKNiJhvyv67vchbiGNwcXJ5Jatd",
+	"5etYRd2eHjx74VoYsySCC7eduUwB6tsqFopFL12LPvvhxx4R7tKcnfXbSRUdaE1JR08/aUjCWVclu+F2",
+	"c7/KQdaFiLgVRFkr64KDSeZSXUJRIN2d7nzzk/OLk+Ojq5OXh+A9s/YjBUCxcQTDMXgjn4VygoWshDHu",
+	"QTm9A8H1eb2LX0ku9xpzU2O5hTFOSLhQNhiq65tAMMUc6MrKZe6o/tyellCYohAaO8V8lP1SU4rYzfSO",
+	"Uj4TYkLgLHwygQwHI5jKrrqMzdQ/C7JX4ZPq0mz2K1o4dJHLX0BC8a14PD6jBdgz9yDBZlZ6Uj/laeie",
+	"VEx2+lLOcvThEhyTUDxoc9lhQ9sk2pfg5LMrTKAMK/FVaec5NJwTpwzRmhdf/5LPIl4/e7mCTaX5rbcQ",
+	"qnD79bj9zkSe9tURyqGrj1pCDpIWPSFzvPvoCk2bMxUH8wAUbYtsGnSVf7kKLaKASCvAoM1qEltVILLY",
+	"E60uGLEnA0xn/aGEgfWYtzrtwbywF2ncWX/I7Pw0jVeWe+/hScgA8lXGV00gQ5+knXmQEManFLF/R4f7",
+	"+xEJYDQjjB/+8OL5s/35IpzIJklTpeR9yopLDW6fjZ+ODwbfapKfxQ7aX/tsr7I+GwpSXro8vdVRtgMv",
+	"v3G2eEGkdV1oQ1uY1faDsUYajXcnGsEs3QFmxa1fOvd8WV2Tl212d+ne1uWxn8tW+rlsuJFL3w4um+/c",
+	"0qtly273atnhJi1Ld2d5iQJcUyYy5TNC8V9qG6H5zpHXzdEXB4s+ypM/zGBgPq7GGbhdhhdFD6G1iRzF",
+	"hdADZpApO7QRNT2CYkLPo1PE0oiDPfGGgf8stMBotsKWuH62npPxy3df51z7SJPaQgxNURgHTOXf37UY",
+	"IU1NGamQZ/MWIHz7dHwwPmgPUrQWrD+iEG3OcYIi7BS2Kt8sm5iYUDInOribzxiYIH6HUGzb01kphiiX",
+	"wdiGhbDK6XtLY9WZViOWVeb1ls/ykpCJHrq0oFZFqC1IbO478xLdqvt3lHFR2HsukNcVx9uO3b6v1rm9",
+	"lp/LvRbN/F799vM3PdtvVMEKeAtxJA0PWpArvN0OtFNbWMFb7oLISdG+Vk5/yX5UeUVBBPFcJnKq8tdV",
+	"ER7iuaPE9ocrPbRi5jBFlH3ra9tbMnsou/Vr5iyRiNqrWehjM2zqo6fLoZ3oC6cwkI4Fyzinjq/T7aRx",
+	"mvkC7zgDnE4940pWlNdgL6Gjd64VTJnKhJX2OnY9eFKFutPn3cXvaKW3IGDAmS/yumaRmnuwV3bfhozR",
+	"cWBEnsNjUteq5cZcjo7fTKLbZ7TYr2Dmy6Oro5+PLk8+qZBF/wLwetIqdhqLVdVeJa1V7hVeUTL3C1/6",
+	"Lfu80twLLRpA+pu9jKuavZZn7Bxjl5PM2VBHqWANY503o0eJ37ztqnqMvscesd5DG5Wa8aynjHdiy3DU",
+	"mNlsnq98AyyvO52ZiTcr2Vk77SvS2VOsRJazJvQV4kpixTLCm40bm5fayvfhIa7F4KQQglM8fGgU8fY2",
+	"WAWTgpVvmP8tS7+y4D2+jk9vQExUSVJ8g1FYrAphWVEklofg2jgarwemM5y0Fdk0kJfIJmJ7DDntzs2N",
+	"JK2m5nuNB7N9l7blotJqtuDLtL/skWpp7a6lNeRyHR17GkvZOSVhGrjtQFl8mEAGzFTdfP11XURYTW3U",
+	"Fv7cQW5vJoRlDG3FeXfM1FbcXC9jm0xAvUAsIbGr8uAlh3EIaQiQTFSl+kNd99QBaVdAdyXKXk0mP86p",
+	"7+ejl58uTv71/uTyajAcvH939P7ql7OL0/86eTkYDl6dXfx8+vLlybvBcPDu7OrTq7P378Tfj8/evXpz",
+	"eixGnL67Orl4d/Tm08nFxdlFkV7tIY4AQA5xxBrNhWrH+ksjhlupwfJ3maxcV84DI1fV4VeqC9EMchBA",
+	"WZ1KXLecrcAR3CLP0DexOOPeahuF8CUd6wc5iBBkHDwFwQwK/abGL92a5qt236ZZIHuDzkySv+eVXf8u",
+	"X5kbksZhK1M0wJPo5XxodapzrUnzEsfTCMkAoNzkqhOklfVVDXTHRDjwKNABS1mWdeG8OgTCkfGVmbEb",
+	"/Qspn/11rL+1qtS0hquY74Tgl0rofPJc8lJ9ni1asbpmb5oGSXUF18WY1AoHlUSCB6ad1T850Kn6qSTD",
+	"8QLOIyddicXcuYRv5T4SyGdCgglMskph9n2YJPtqiQ56pdytBFDM164s2md0XYYWCk7iMCG4TiTVH+XK",
+	"EtKftyRxzjhPPKUSoQeI99BIJzKbsOfYdsmsfKA6+U4FBDmnUhE/HebjUb/zfKu/tcKHtbcW6a/aLou4",
+	"mORvmPIURkD8mlmIzIyuY5rf2kNvsn2R2BuICaEudZFQDuJ0PpFbsgWk5888BSS9+DvE7wj97AboyReO",
+	"qBATYBwC2WVQ/IeWvjOacOSv6XGe11+gRVmpZonhDWdtxppq9yyA4ylFTLVwQeqfsYKXalZRPbj8yHPf",
+	"NujlqXsPdp5Zl2rr4OfMqrvB2GppZLyWWV8nZQieIaD7IJW7PHVzj56Z8OmCd3QPppyM8mahWOnjCSW3",
+	"OCx5hJucplWwmGh7wUrq9QMT7ZnHxjcYYXyGemlYViqA3pjbXIPq9T3xa84ZqhnD4vdL/JeLU8lBYudy",
+	"ryBBVM7mnIYTDqNj8dA6skrEb3oP2XRuruRnQaqCxZmqz4y9NuOmXYvC982E6PJy1q/REJDrwuRfEIz4",
+	"7DS+IQ6dRP5mGpbJVq5WtQ2ln3pWcsroc+bMlQfoSxJBVdRQHG9mr9wljby45T31n4sheImmFIYoHIJz",
+	"SiSHxPF0CHQS+RAgHow9UhfUqi7s+vUnZlSGK4pQPY6ZX4xsbDc2BpwiHUIHo4yXMUDudGMMmLeOyqLx",
+	"nVySNTWilYsIwjST7WWVG8UjtU8oqJZvfOLLfrKnIoeG0xPriERxg/atwpEGMwwW6J/hkjHD+GNndicu",
+	"hTtvvCwOGyHxkLBUBsHfpKpIaTPWNBUBe+dD872bfsacEhO/mPEFBmYkCq2IzQh/RkCbFdjQqoc8lCKL",
+	"7bMZX8dXM8QKs0FqBUdm7VsiOEER+IMkKA5mhCIyDtGtUPrEluSOck71n5ym6I8V+nc6OmoySK/GTZNN",
+	"5+ukyYG5pIsmx6bNO2jKQPQKKHlnPValOJqZs9dLThTqg9xAehRwfCv+cCXL48rMxqKZM/vC41l8R3jW",
+	"hP5kDnHUIf5BfC7kzGwCEMxgHKOoer03TqfzpSyZqCeCYUhVer6dLIYoZ/+3/sM4kEWSqm/kvN2MYJ/z",
+	"8u3VeR5Kblfm9Z1BQsoUe1YCXr1kS1GAEyykzcJBUSkFiiM4L5y0MVS8oa5uCZN1aSnZLktCqqVib/05",
+	"qwqvPE9bQeJSVSwSLupmkhm72XSqFHF1PgvRBXocgr99lXgyFuzlm2nUh0IAefYT45BydsS/jZ0IpKyS",
+	"ddvSPwMZotVhe79nq6NbRDFffPsIRqXdXpndtstkepNDBcK2qxNIfpS6LJfil3Jaa7PpJ4GM3REadiIy",
+	"KbRbxsdi3m3vacpVwcycw3yXPqCpY3MSOJJ/t9nDYNqe1um8kG/DGluavbb4omKtFuQ7bmGGbguYPbX8",
+	"wpr2h5/+Q5ZswHPxwPz4ww/Pf5D8Rf33U6c+226rLB/96s1lTeM3CQy98eHA5LBHzOse82mrivWbS0dB",
+	"RjHI1bIIBSlFl59x8hui+MajQor4Fsg1xDxyTwgIOs9ew72YSHctmc/FQ6dy03M3uaWGNfrCq+TwK1q0",
+	"B3NAkNUx/4wWQMYYWWJ1TRUEp//kV7Sw6/w79PGM9noFQri2VcT6UUCRFL1hxLoLNmUmUtWmVYInmQhF",
+	"VUBO2Ubcoa+sdAfdWJke17rnD2gyI+Szvzh2pwZ4CmQzBMPGLF7/c+md/iJnlECu5GXnZpFfrq7OgV5c",
+	"gFx3hDBRQOYQuW/VUWB/IYv/1Eol2Vr/vDx7B/Tn7e92tUyEq8ilPmzu4Xp/8QbczZBs+SKEVXCHowhM",
+	"BJWUepiZAphiPBuzCAafZRXMrMKo+dRyUaQUexXG/OiHTfYduUxKoWn1ZWIRYnESY0YGOJYiEKHgFsPc",
+	"gFgX8Fnj3zxVs8ys5ZZyc7aJCxXAnIln+JwSjgKOQmO/eWup4CWEEt+DZ+MDAQk1KDdVGA0ZwEI/oItX",
+	"x+Af//HsJ6fYkIUTfFJPclP9hEL0gX7B31+8KSkPBrfE5+OiLaJbyukEQYropzniMxKyTyxNxLuMXHVe",
+	"zE9AjdGVWPTI0vbkXXdMfs1O8SmIsIzrdJA6io/lNwB94SiWqXx7Bvbg//zvZ0/GQF2fmqMoEEgL5HVs",
+	"/G/SZzc1P+nonuM3p0/G4L3uGKd3ItPRMAvIrQyBQ5hex+qnTziUxqSsHo0Ky1c2Hy/bRn6mYzljC2yk",
+	"4IL54hOK4SRyXZQXkE7jUEowTDAzGdlX1BCuYxn0eUNogELlkcVM4+MYfJihWHUlGBrWzTKLnUqCAJCi",
+	"6xgGAUo4CkvZwHW14uwgllJBiYs3Vp/oElE62S5McIky9udB4i7prKb5FHvnRvhtxbqJt8fnsmBbTfKz",
+	"RBo/6lPorUYM/AmsJljnk1Y67OAdJ8dqYBWO/bveJ8uWWR9wWDUEZwx3r8Ek/BbyYCbbcCHAOE0DnlJ5",
+	"S2L07dNxvnYWtCBj4pgQCohs+IGh/PPR+anLYAvjmPC8bUidDNVcZnDwFiZiU+pnIaazPOVKuUcYJ/I3",
+	"mH7BEYZ0IaOGXXKRqS9/heeIcThPHEKj/kSWklbfNBeNPvAvGi3t4OuFBaFTGOO/bEeSs35fu8KROxqK",
+	"tQ0zA/UT797yje5MC3ttd6WvH3M4SP3astn+kvenL4u7/+GHA/TTi4ODEXr2j8noxdPwxQj+x9MfRy9e",
+	"/PjjDz+8eHFwcHDQv7FfodyENMgxWyA7VgpInZW8bdyyOdbQaECKmJAq/iUl9YKixMZAhwTINo/STBuH",
+	"Tp1KOYIy1rbZbB0/qPVN5PGcfSXOI7+1fD1LBTeu0cT8NOFunidPdN+8W6oDZnilFHkedDggMdKolTjY",
+	"/dfMbyWpavCxppI8snxPH78N2ybThFk73V3BevJR4Gop9Kzo6+rk+Ml9R6gpjdB+cHLBs9CJTgrRLjQF",
+	"ExSReCoUjXKtOGdfTXYS37405krv2s46d0dlo6tizs7NGBGpmNdTFdebuw+4prb8mgo/hvnV2uc2P1aL",
+	"z5bNZB2tVjU2acdJlyC6LhlM3nTXvJmaknHVb1ZQO25OYmzE1DgEEZlOZdPW+IbCXPjedqJr9egreSZX",
+	"WFmuOm+/528lteYc2LTlR80zibVMQ+WcT8fBuiWVOoAN9jouaeebOjdUv9kCX3SO7eGBcZ3JMIYxeGuS",
+	"w1SuG3j57nL09Omz5yr4aVyTtLquKvAds19r6L67ELSuWoY6j5O+v3hT3dXPkCFgGbv0m0FlmwHtNHFd",
+	"Xl5Zr2gJO9zfN+uNC+NGctyY3QaHPx38dOB0La+lgKCDcrpVEpRfhSMycXpxaAAlvL2ge3F8BOTXS4CX",
+	"BnAkawN2hO83P9ztLUvsbhVD5zZ3LMfaucdeqdZnObnXR/pmZC6Q00631lWphXwVkakykc0Rp9iRXlMb",
+	"BmxlNONYHUJCgJp4cmd4sL0lzPLqVg0t3uh7lw9VTKCrTZjvTMcUeUTHwarm/IyLWfEwQkTdv33qSVtl",
+	"P0uN38/lOFI3EYOSa6XsRLJ9SI6HQ/uLahZ+ZlY+fVkAQK5KjoII93vu9czWVks9jXC9V6J2u+rn3PMl",
+	"A6Qx04sVHYLiEDhUMLnBUWYBWFXQo/Zi5DDOdu8SEc4LUmyFeTFCdRfwXNzN3BDSN8gsP8VIfHCr0h5w",
+	"nFpdKth1LONmb25wgHX2kZmOzyhJpzMQQaoi+4UyzpC7zmOMvnC1L5e3D8qmVfJniac3iAczk3Aihso8",
+	"pTE4h0zX5VcufygtAdfxH2rsH+DfKaILq2G7fg/lFNrLNwZHE1nZyHQrl04+ikBMwJxQpLKZyi82Wvzz",
+	"2emfBE8+/Hbwvy5/oGe/vE3hh59uwz9P8Jvjfy5CfPrj27/+dfDu+cF/uh10c5VQUpNSdZQklHzBc/Hc",
+	"lBKrQDYWwBtujCASINfxlSlmEgPEuBqfBT9MFrYzSrInuJBpdhME0BcY8PF1/F5z6fenYIaFbixzDq4H",
+	"/+8PBxY8rgdj8BYupEitwCf90Dc44jJwVQAeozLYXjzr+eKcQx7MOjUUS8QIADv0Eit3bqQkYrJz2Miu",
+	"edW7adjSfZ+u2to+OQFHwjdkehJz6jjlEWCqQEREZAFAulCpnhAkJKx2eSVTp9ycJfPkCf85nVxySFXj",
+	"IqthsX4wSSwDOUGdsM7r3YCZhzDLtM5OoCJXnj9//o+8tkvBQfhidPB09PTg6umzw+cvDn/4cfwfP/3D",
+	"10lYNtVaTkgBHidn1m43V3lRaaHqab0yWUBA1kfM8dxVj03HcxgTA3RV7tysKUvvvq/9ygxfidFKT+Zr",
+	"qdJ+1GWtUwYvNm+SsmHvU0r3PHMcl/IgUhyFvjX9fy58LF3n5QK1ntXdqlWsZaRfqP2lJSs/u44F8tsI",
+	"b7JKy/3tmRIPMDNXXH70m6qZ1UK5Q4pVHaCX0UzzOXdMHc031k8ikAWVuzUZVQWfkS0V1BV1LsVLSwZ9",
+	"opo0l8J8TLmY3CXmao/kfN9k/UznrKqZVvOsjAvin7Zn3WSbt5f8WAtTU6S6pR52R8iZT9yFV1cARGsB",
+	"5gNQZnIZ1Jl8CeTKsV5raJoTCnV7d93MxfGRMQE2pKsfHwFpDKuaXI5ORwm5k5I5JUSXaAMwhtGC4XWb",
+	"XYr7arO7ZNbOFrtLPqtteGk9aNUMk1s7G/OSXExI58+7mI7K1l8iHRzimOmoPgFua/wcxvhGxqeqVw2F",
+	"Ui3JS3Fq0+6GGyzoM/cV6czwlYh0ejLdgLL2fvTvfa9JDGcAAusRUtdezF0qFprd/I3oUy55MWaWNdyP",
+	"r+RdKqixrAReQpL1CuKFydpB4i2clw5RFR0t68FJfHt2iyjFIepohLDeqFGG10XLBMlmdhyuMcrIR9ip",
+	"ef3JXYxcFkTx59yLx4qtraU2rEV8Je+X2EEhcqkGnu3F32zLU12b8aqDUm2rffY8mtcvyLeElPY6w9Kp",
+	"XNjZWNGroKMF5e5HXpW7FFtCxQa+WRWIGuOcCo3XpCBlAs0gVDfQ3H6fV+CplKB4H+umTF71J3Rn9VVS",
+	"kZywmXpMA8vCsk3c6ENlQPn+FeEUCdODK3VQZlsZ05LNZ4rz/51lxelW1YFGAMfUO3RWaIpuZaLcLfks",
+	"PfBKoUAwmOkS8VnfUTNPfVFlNYvTwZ+tlKSTCAdShrZq2GczO9OFDKsZheh2pAmrLf3e7XszNRdVslAx",
+	"U1Bch0E5KfZUtuPbFziHw8fW+swNAnlHgWJFgsQWTHmuAl7N1cR0bTht+K/rb+eTf2JGVhGIhC4f61EU",
+	"FUvSMYM7Yl/+JcvUDO9I6AS4bljujh3VkobSkioHMW9DVmFtUOpfmpjoNS9ctndigNJwh10lvmop0pyV",
+	"u59ph5yVMRLXW10XqR1zARJXZrn0uZnfdfJXoaRoXslMxhWAH+ZD8PyAlbJ95usX9R5lPEdZgrzc4mmX",
+	"O+YUxkw+okqXdl/10/I1Pz1gTamrrDEXLS/DqIsiqDYtSRItjIEoN4g0vLteuWkmBrCpbDPJ6i91c+1G",
+	"iBeqh2QHk+8rLrZjtzy9hfchHGQb+OjR16DCI43AbXO+Bs6pWrsZh0onzllsO5+4w33bZdVaHC5akboI",
+	"qmuTUNcimjZQyUVGeNLnrqyDpWY9ss6ZzPrPHTJZBdcaWlGdCqvP+vmpdkGXMlNdVKKKxV56VYStTmfQ",
+	"TJeCHUiPhWFZA1MgdzEYDi5TlsiCRYPhwNSTdTzcQycDyOQliwXMoY5AEuLt2JG7m0/ZHHrfBqEOmb9a",
+	"eirwuaUqFXeb2bIjenO8V2kU1dxvXmXctWxO4bfK/upGRP1jO6C/9VQv5oSjzNzhKtOPY9MxTBeXwbEM",
+	"xjKxlfqvjBPq2frjXDfokI7tmmmKTen3BQQnkKH9pqJWemlXR0Njm5AFBZaom1V7V78V70mfhhMV6WfP",
+	"/7Q1eaKmX+RFbeGNjL6lKlTTG6dabgojCmkwW/hqKL9kA9r4TCk8tkV8dKco5kqezka1GsTkMmpLOJMa",
+	"mp+0Ca4nt05j7pEtzKBbKYMzRgIsFW/57sD6iu2BOxoyr1QvI6607UNOPoMMkEA+sIV2UM9dRf9uMGW8",
+	"obrEK/G7XMNe4g4yWQOPqvfEt5hE40pv86CI1axX67It1XqxfjTUJ1ctRu1ZNbPF9eFpjEIT+LgvVBAi",
+	"pQqh1I6euqV4yFyEfzkjlIN5uY+a+jzP0q3uKJihMI2Qk83UEXreiF9GCOXNJdxr6PONmF6L+lOfSRDO",
+	"JgZ778S1RYBQ8AFSoRkVtR/1sy9JanAOGwuUFyiTdStrLzdtGgdktulaOlWfN2po1oylp7iTnUexmbYA",
+	"C72fJqj8YvPvGt6ZcT6VCVBvGWjCtYrvqoWfe0lolUnbyq4kbWGnrhmbLAu1gH3nbJV4lJsYi0JloYFC",
+	"FcLKc3PEfUr/OMQ8P2a5OlWmDY2tnh0bVA1WpQisytAhxX6XkYNMivhm18iktcFcmQDOVKQ/tdtcs64c",
+	"xhnAlWvYv9XJsBnXMEqHVGDyU/oXQzp96QP4lSk+NuM0kw4LSchqo402JXN6lWDQ8bWR6XGlt6Ym5eAk",
+	"5hS7zBxvdMQ/RixXHdUkfvHXVmZE2/Ni7aMJFj4VjUvY6scVV8Gvvgfec6/IpwVT6kwIJXxxcU1j1wtT",
+	"VbFEeppvInIHaOqo85fFrDkzEg1e1F558202w8dae9ha5qB/U6YKBWUdsGrcm9vzUJZ9hfVuQRK5xKqC",
+	"uYKSSNtyE0TnmAvdRjWqZWAvQlMYLJ7UNPdtKtirZ1COQbGEmr1UEVd3+72jmCt/QYRUPw7/ArmF9bsr",
+	"rmJvBRFWyhkwnOMYM05VEqvKNvfnadr9I89dFeXF3L05nEDK7MORVDFCuRAbAjRP+ELlo6joXfVDt5Zx",
+	"Di+0ue06FDuJOeYRmqOYv4VJ4oyW1T8od4kEjCpSg/KxedKZPFY99vXsBY1ubjJtxnirYBSRu4qn6pxE",
+	"OFgANQDsyY+AdFjFC7tmTT46LgV/mV8ql2ydt71xcf7pt+GSxsNGRJ3ry3Hj6igPfavaaDSHadwPiZAp",
+	"9u/ALkOB1mntw2b3Vod9PhKTRLjJQgcexaGV1liLZW6IXThpOkS3KBKD7xFdu+B5Ka/Mfjj9FTTZZ0BN",
+	"UEwcySMpxHpsqMIV2VBQlJE6Cocpew3zZi6abH86+OnAZZulSCYIs8LHT/2SwaqwkA6Fl5DDyxrboPpC",
+	"+ZpMHXzN/6p9GrXXp514i+6hb8O804a7JYnEaS1jWJLeZdXNYlw6o3p/SznpKFt6aB3hYy20VFsPT7F0",
+	"7Y1Zemggq2nXWjdLPZo1QK30wbK1gGnB8FFyBjJl5ZalfRdxIEMztec/r1m1weyT0tn7pp+Up1lJ/klp",
+	"Ut940XK/kGUDR8v4s/kAUtcl+QQhlndehoO7DYklSGpQyiLpVVwugrgDLC2W31xtRwDohiI2qw91+0UI",
+	"jjccxWKDFAUkDnCE9vW4On/405nTbeTZolGdIu/LWHYHmR+GA1/c7hIK1XarS4dElW93hRFREWRi5+Jq",
+	"rrDrqfig6/tUN3EHGRDDQUKJUBaLnuRCU4GnXZsKqMUuOaEui8OlFcbBdF8nHY+b30EH9JfrNPCT+kfM",
+	"jGwvTXpiSPVSPzuq63JeK9SasEdgeXWSjmE8Tki0yjONYTlO06l9d0DbtiyHdQEIntJMYcqKonKrvNNN",
+	"U9YIOZV5u7ZxcGt/8tD1LKi+v9ml3c9EG+/SSNYJcknB9RJLbXZ61mLF+J9z53+NdLqadihH+SwSscIs",
+	"+rIsV+bQWrrvyBs5ged69fqTbVtRNdiqYcBWnINTXzEFgc3wz9lHY0z2QxJ8RlTVIfxTBTQ4P7iZVn6Z",
+	"QIaDkW6tWfyJsZn7By57JUwI4YxTmIxLv5LPKC7VIjbb9mEzqpntcW7PqlpqdfMp2YVeCfnG/FVN3sgs",
+	"KJ+CCOK5KwMrt7bJT6ocQvmJmi1Xn1Q7mub59TcFe6+yJ5klQnSr/93J4usOn9GwzGLXNBalTBpldOzE",
+	"Jxio8LDClelvvKJoqkB2QsbF0ZxlP3wybCwpQ8a+JQklt1LO5dydw87ewjiF0ZH+8iI7x9eaJghz+X0+",
+	"Nc4rWPoUpot9k4X8K9Bk0GfmFPW7zyqwmE2z7CT2YroNhKPbrJdxTB3HXddGHzXTzWV1G0cRtT0dHpOL",
+	"X4DE0eJJk7F7DfFC64/suaIQu/L0ZabykiYMCRImFYSAEsZGQSoJQXDGANGYFfp2WhkMucy7WTOGPHVf",
+	"44UavBKThZzK11ChrLRLWicUGmzeJpFD3McSoXbpjiNzvHLv0J3Lpy6lJzXIFILFTOfm4yyTpj455obQ",
+	"Exg4mEuxS68UR7UoKpB+bkrI5/vQFTjFTbqzL2W3YaHMti4WIo7oXLnI8Y1RLDX5shlJo1AQmY65q6+u",
+	"tZVMsUYTir9noylnUD3JtX2UrZwTSF0BSCQBt5DivIemxBylxRuEaBVNzKl8EvcS1RPSFU4eWt3dpD0N",
+	"M15oM2hpQLIsBirWb1kNalOUIIXZuigxD5zmMJLoIoGOs/zz8uydrPcL8q+y5M76bZLE2TdW1yIsSZYw",
+	"DAfK5aTUXYrm5NaNdolTZpAOM5ntI9sG5+03xX/MxW0sajtCO9JhVMNqIqRCsCdjV8JwX2/PAsOTam5k",
+	"MtBbdOFPo/1T0Xa7OGSKKW8wKq2QzGJvYE1RXcOB7H/eiuKcAFXhGtzNcDArvh41eyxdmNGfSpFjTupf",
+	"AfMtkOESzHedHFDhYYEp+DBDJWPUial5zXf1XTGfulI5YZUVfRpr+fQtA/7SRCmMbmCg5WWrmwNJeN3j",
+	"JR333Ra7QKkS0SX95ZDzLDouWyzVsffjkze6FUH+GaBpJFNGZPZdHtlIURwiqlTMGrZfm/d0QimhWW1y",
+	"NiN3cVbiX66XLSepV+qXTk02jdoZwx2FSaKK4fzt63g8/qa0mHnKeLaMfCZo2m5dlSs2p/q0W/VtzcPL",
+	"92Pk6MpM75MQcqTN8hckMiWXfCrupnIsgIXgF1OOq15vvufRXtQZunlsg8A3srDS1NEOtDLRV/UxVpW7",
+	"639pm40n3WoYqYJamJ1f3o35rCXguSHcUk2bBZz0JaXcIPWgiMkrSjETmmB7apZlEvQiM2tmD5orXPMy",
+	"9/sA6S6LyFwVzYk70LEnna5CAs0E2D6GNK8wpHmZ2ONlgo5zfOiMCH9nS+RWvEN3mXHWzJKlRpfooD9J",
+	"diEMhugxTJTih1FDAp/4slQmQ7c8y0KFqyRhzdzk2G6kF7n7bI9VjjN4C5McntKAay/rKkNsFAxXfvEV",
+	"NvqrPQ24QzRXFeoDgw66BgZJx2VbUE/Rx+wU9MX1XC0SlPcPr1TLLXf9A2JtpdulTGktMPdWi89gHBav",
+	"3NU9a/YWBTMYYzZ3RTalSUKoTEgqTj3PBuUGimw/vtFOR/bqeR/aygOFWRLBhbvSXumBkuYLQ5L2hvL7",
+	"liPAe+ZOFUgoJhS76ukcz1DwGRAa6lpyOfhDxFUbUrAXkTtEwX+CGZ4qt6ia7Ym7GI4VOO92qb/P1rCq",
+	"WOlmjtcS+a4H4l8l5/r1oFimoot73Ya2BY5hGVdc7EhaQF9RMveN1CIU4Fh2/1E21UrjERPK6Bc4Vwh+",
+	"rzfUnlpLgj1ldIERuIFRNIHB5yd+/lXtFq1nuZeqQZqxX1qtNtxNmNwBj7LlErB7lLWyrmqlBMwv0C12",
+	"21hfYw4CMp9jDi5/OSqqs5Pg6bPnL5xTkiMa1LvhxSOOBVWkpcpWcB7+WDPh2WXtdNqoGE8BWzCO5oUp",
+	"IxynX9xT1qb9vybZvUjmyQmQd1AMxCFPx89ejJ/5h/4dWf3xKsYBq2EqTHCvSlv600I84cH46fjAN9gv",
+	"N1jbODG0EFDfRHbDNhhdNP8BTWaEfJYVXjzyfVWzSx2iq/Oe1QxZLZ/SEyXFQBRmfq4GXclqAmaGZdXj",
+	"9SqlaKhCkMYdmoxg0jEWqtZ0eVnfS0fDLI9UBsyq1eQMQFa/1wfgiPfOAPIOsvqpWyOJOMXTKaIolJyH",
+	"NdXxkljDQDbCnv6ZM+mrkNqUmqTeHEblxZ0YpzPWXGbkdcWPmDX7hpBk41cSRWJm8w0ksXP8loklySC/",
+	"5S4rZh/11QFN1HI5VAPGINdinGUZlGxt12IYV6HWoeCwHa1hpciZBcbLhofotokqRkRoOhlDsFeW/45D",
+	"QVnjwfbCMsZ+VZAbwymyy0/jbXCAizRelgmIKVbKBy7SuE5xNJ+UPI0moNXU3cg+06XWb7E0R2uvqwqp",
+	"HfsmaBsRPMynNdX0q3EZyzpSs77Y+VRWubpsJ4beWhGwNvjUArYUdtraMVcqaOqYsMYyLystAKkb0Mng",
+	"YiyER0hrIsT8Cj2mgoEwDmPfco/1CzZ0hZbA7abw+Nlq3Cq2Xq5sJfCt7Ghts0uVRwuZuj7iAm9W9ZAL",
+	"Hrorb3ka9+lx3khNbc3OS9iKEvD0EBxHpgVCQhjmhC7G43FHHH6TbXPleFwtatYGVu8gXBsryqDkPDoS",
+	"qpvuduDUUoX+OOJkFOFbK27JviGt/gXZJGAvNE+SOiCI8GcEnh6ET2fPD+ZPnIC/sxQATyw31sUS9LKZ",
+	"2kDYIQSjCYr64MZ07ce3mvJ180dmxPgisntHr75DQdeCjPX58DSNC1mdnSfUb1kXMHLIPnfnkFeQffaL",
+	"1amgS4NlMKudX2RgQAn+ggyEaMMERwoRhziqMvwZZG/wLTqzI//qzQOSJCMyZfu6oi+kyMryzkovSo0+",
+	"K9vfaitgdXRxiyiMouLhstYUxtN5jkxVo4s0jtW/ZNFqpGpmv4JY1YqWUWBFX2g+wtHSACWOPZ0biOrO",
+	"BTlgOyGEeCaM9N7WMNocWO1o6L6zJtZzWRMdWYkjrIRHSv6bgd8Ss8t49BBCGQvWmy4voaOKUG3HFitv",
+	"2d3XSCngyisnWxxB2bwKh6hgETAmh26CnLGEuJnt1erVe9eBnG/+2IUDedivF82pr8XZ+oghFmcGOBYK",
+	"jOyrs7woUgn5zAHdSNU9pIlOVTzWKxU0UljOHZtePXEPIb7FYQqtR0Kwyco5BamzmdvZnxcDEXzdfNkk",
+	"aT/tpDHW1HcQi1W8O0FEYjTSR6jaOWaQ1U2lfuvxLF5+xklS90DaI1xdfyj3gWluM1iH8qKBqADQRDFS",
+	"CqvXCoVoty/3myX8ZkiFvqAgdTpdewnjloHGv9Zuze0f64Zi2RYVKhiDjjhV6+X1hXodtCMCQ7cVUfaF",
+	"XTJvWOKVmiAgIRqa8r+IDrMuuEw+KAGJY2SFWMHcubfZzGFz9GWMvnL8yiy+YrbjDDyu8AZd2ufo/NSC",
+	"Y1btzx2CgGN3PvovynZsJtFSs9Qf1BC7RJ1pluxKznHVqsjLEpgEJCkp6b3UpovUNTeuTldreK4JDcn8",
+	"Rio4ROVAWce39uHrcZcLeaV/FIOXb93tPYW4vkyZmRxzShJ7QUdoKC5TM1k5NzPB7T12TbBYXNugwMJ3",
+	"xSece9BW7mYEh3TKmkZDOk3nMr6gi/s/IPM5dGU/5hNLQ2CldXjrzP4k4yvTncS3v0HqWusGRy6V5hVW",
+	"smOOJd5riaE1i+G508NxdnwK5E9StUiFPI6niMkgMQ5LjZcommLG6cJug75vV78SD9Dh7dPxgUdsjNpQ",
+	"E/qZvumukGAumF72erUg4QQy5K5f8rN4+WXREv38C+6NviREJtlhqHwseaf4Kpn3DZNsmjQv/FsMZac8",
+	"25vOQ7dmmcMveC7YwI8//PD8B5nArP7bGflYlwEqzm/ZM/RnzrB9dTG1Dh+frpEqLcR52pySI8w4ks4B",
+	"ARewp0P+VeIwofxJ58O72eo5JZwEJNrnKJjFJCLTRebly8FsWO0vV1fnQlk4ubwaDAfTi/PjwXDwmsJk",
+	"9q83AxmgxUjwWSbnXh2LL9+/PHenB2OG6wyJlnUjQ/Xse4wYmKAFiUOA50mEA8yzft3WpBbrMHvPK9rY",
+	"deuwlmAkyet/fhx2jJvXj4vE4Cba7uJ/E9+vwvcmZaTN12QxSxfypD1yoc3RC0nRVTrMHugWw4L60Gyi",
+	"3qCQid2+Jjun6GlpEn2TGBxSd0WuEnw3rBW3nTKVN8yqUpCUD7S+tOypsset5kzup815osb2/nkRNfPy",
+	"3NXfmXfzfnIXKxl9nT389SIbbeXfSBUdLYgayNUVGApSivlCWli1iIIgRfQoVUKK+q9Xxsrwzw9XlcS2",
+	"f364Aj/Lz4CsxljKFRlfx9fx2UQgLoD6C+lvWpCU6ng5vtBBR9qcrAPgAOa6rv51XOyZM0MwRPQQ/FH4",
+	"86HZx3V6cPA8kGvJf6I/xCauZEFNFZSvqhZIdfMzik3V3n9++PUyd4YZyVdouIylpvS6pB/pCJOL5XCd",
+	"cZ4Mvn2TAXw3JOOKSqtWOuvgLEHxsQwCHwwHKY30MHa4vz/FfJZOpCSbh4pb/6zSp3jypZwoCCqfGWQW",
+	"gMxJA84jyG8InavbyD/VYGdWuNIo1j13JoxTO80ty+hUJppETwlQPMUxQpQNr2Px/stsPhXbLUtjjVQl",
+	"EzsnQEUHCvBQEulKJ2JOq7s9Q0Ij1Rg0GA4iHCDtTdWwPEpgMEPgmRTxi7C8u7sbQ/nzmNDpvh7L9t+c",
+	"Hp+8uzwZiTEyhINHxVsR4LTi5A8HSoVQ1Y5iodUeDp6PD8bPdcUeSTL74zsURSPZz36fCPQXPIFL48iI",
+	"WkGqzlI9F4inNGbgTOCyOA3IBuf2tqwULmRKKlYZXxevjsE//uPZT+Pr+L0Wxt8en4MgwshY0mSRqDen",
+	"QkYNMQvEE15KBNQ0YSWoXMfSBidnKSmAJQTKhQQhqcWqhhRGUcjAntkc+D//+9mTw+t4BP7IsfmT3uMf",
+	"h/rgztUk3kl52fxBZz8dvzl9Mi5PabjZJxQLNSf84xAYB3gpfw0zgMRxAxQCouvEKTAoZMuq2JyGg8PB",
+	"a8TlHs/NvRh321tjq5OREtLbLxHi2cFBSTmBeWbI/p861s7PCdaysuQ3pVdAwrMBiQqsf3D4+8fhgKXz",
+	"OaQLdVjQPoNQmaZMVQnOC/6IeYXmvX/7dF9A/K99K5e2EflhFGV4XcROPcO4citCcD8KjCyyFPy9U3Or",
+	"VZuL6cBiyIuDp3V3mm1y/31sTolCNeh5+6BXhE5wGCIpfv6gztg8wrwEykEkrz27aLl1mAHQ3GfhRXVd",
+	"aVZxR3UGcmlPJ1lRHhIjQCiYE4pK90pVhjZTjWe0JyeAUVS96Wy6gRKoEOM/k3DR74obLWR6IZNW7kSA",
+	"XKST5vtVoV7Tvl6iQGVqeWBkUVAK9cisCSKTYq3MYoXKIYPjJOX5deyZIb/jjyAgVJ0u1CEM8qPf8ccn",
+	"Cmk9UPBnGFrg7EUcS6O6uddKOrQ30utk+VY+JgDqTrM3Sg90lRQfu94cnTh+rpcuRsv/Xt8DybQ9x+LP",
+	"/04RXZiGnYcFM0uOhBW9pa4qcdPUuRrUYeK8gnLT1LZ2Vz/5xzW+wrWVFhwUaAqhG5zZIKVs4RkR8gIr",
+	"ndiLsHRhJhlyKEV+Dykhs8bpwaZPnxW3WCMp6PJZMq/wXK1WISgXEPJP9t/gOebn4r8HApFbvj5OKSNU",
+	"f75O1KycTFo0G2QVUxHLBtq9E1ych8jxznHdH6U/wyWuHKs60wCCGN01oFYVs9TIymJLyCmdbtpPIHm6",
+	"7g04S+TlH5na1MVU5J3mii8O/tE+4pjENxFWlrmlkVphkgut27C6kaXufw3KY4Sg8E0RgWz27LCuR0iR",
+	"Qz0pmF6uVZJQo10k0Sq+GHOrGwhSMEhU5TYjF7jONihTRDeZ4UVt0UcLoxXoXBi9IfR80T7iHeGvSBqv",
+	"RoJWt9oHPYfNT7oJKJK26syY1IUHv0b8/mLbwVZ4c4GSTSLE94y+QkiF/bA3SZ3YK6u6M9lA3VTpb+CW",
+	"e4JD6Ep0T6ooXKjwej+weGekm4NtSzepLnh5n6SbjvS3eXFIUcRqxKFs8SzzqJ+SWWqj3qhnFtpyfG+q",
+	"ZuFwvtpmCXr3VuEsn6OCjqWr76l2Fpdp0TzLTWDWyJ6LS21H/3TswS3mFIH4qId210OLEPRA9jb2u/81",
+	"UCEw/VTQ0o36aaFl8ujGi12TiAPU8tt6DbIwx4NXIjvj1ipUyTa+mmuTG8aag13hkg9PH+yBiL21whKw",
+	"uyiG60fIXZIadoYeHvW79et3axQz9nMkafXcV/qNqdTTFb8ll1kqy315UdSOm3zeNbTDssoN3/VTEjSe",
+	"vg82Z939fOwVSSVZpYSoeVhts9XiJeTwu3SOZwfztVZYEPvO4zcKxg372BW0tbCjp1Ejn77FoJEttV5j",
+	"Rr7MdgwZpfWdLDX75tF80d18kSNcCzo3ceD9r0GY9DdZWDkNfuYKG/l7iQjZBD3NFDnKPXQThTf+rMI0",
+	"0cQdc1FyQ9hxsF1e91CMED0QrbfpwWJEXcwO60O4XXnXt4zrjwaG9RsYlhAEqs3VV6KTFab1Uc4KZUO/",
+	"Sy2tekJfdc0FzHurhDkPU8FaFzr0VMscC7boZ9XF16uoOdbbjsZWtxEni69+/KjDddfhHNjpSw1ezDwL",
+	"ka7O0V3pc+3WU+1z0lQvgct9kB6KoAOBH7pGuAQ2rkJH9GLVubK4NZw62CrjdVLhw/NrL4WrndVMJ9C7",
+	"KJqbRNadk1QOdk1SedRK16+VrlS0oSRCEyxrh/vV2yg9LWI8MBM0aqIXJEI/m5W+ExX0KOWzv6rn81VA",
+	"C8C7t5pn8RT1Wdy9tEx78hb10rqANemVNde9aa2ycRtu0cYG46M62V2dtOHXqVCBzV/3v8bdVcNmAijo",
+	"gkUCaEwCc+KFLj7uSP+K27K9rOqJ4RzHIwtUS+TOFrf30JVITxxcRmFswbZcRbynqHawMzz4obkqvZHX",
+	"qUEqCditQDajbEFXvD9Yu2Oyy+7QzaOCuX4Fcylhp5cWWSryJ6Zp1SW/WyWyi/Z4v7XGlWuLVTzy0Bk3",
+	"pCxuW0tsZbGPamEvtbA7h+ytB3rof53kmpXIM4YEpVyzEoXvvil6m0dDh2a4To2wTRO8D0h3sD3G+hB1",
+	"vdXreH9npu60KvqfD/bQ+nYUQ3dF6tgicTwAhW4d+lknqYNTiPkSNYzU+EaN7Eot8X2FlspD+apjGsj3",
+	"VR/j5gJLjmR9sT0VMjlriw4mV1hvJKhaYjvBn9babjYoYWS0r0eFq1Hh4hpX6pC0jvdl4Zryy/5peequ",
+	"/EIzDV73CkbK9tkjAFOOffDusjZUWUVgZQ17y7WjNePAwZaY1cOLimzHpt4ZdgqkXWIeV49Vu/DybguZ",
+	"tQby6EVarZaywqd6jdV4/Dj4csV3NsnH/YvuKOR/YLV2Cof2ws2s91G//E2rSWSxcWU+r0TblCEKZpAB",
+	"KKU1wMn4Oj6Lo4X9oex/Kb6O4ARFdhfDcYhu9/UCcv68qf1/Cm77B4AUASo3isLxdXw1wwzc4EjgKSAp",
+	"B2zBOJrbq+mmifkiI72Aas05BJ/TCRqpcU+kTe46trLFaRpzPLcP6uqSKHTQdzmIvxP7QXaiNuOBhV33",
+	"zXAQ27dmCMm6Sl+LQTuFjFUX3uy/AWYAppzMIccBjKKFogcUKgLpQhYulFTbe2f1PFuHfJTPv2GzRGnh",
+	"un5wj95gb+OE3R7PSQjO50R5geW/u9gj3CTSZpKwsbkbh31nb7KLMSJHpYdqiWjFi14miJwtuqTWdV/0",
+	"wab50EMxNXggSwcLQw2X8DIyrAGFtv58bhxtH92a3gaD1Tyf+91aglY1NbsnpBQkZYvpnNuCq0WixU0S",
+	"I5Ag2sSKhYi8TNtQFykN76s65N9l9F53F63pKtqnnajdBsyBizU6S1MTsN1h3dvrRNrcpOux92gf5cfd",
+	"ZKu2u5YfA9//OunTebRDq9EVk0o7sy22zuuiSD12EPVCsl7KVFuP0F1Fk4NN8sQHVgrHD9n8lbHOLT13",
+	"COm2//ofbP71f8wxXJ93eHXiQrYDiiIEWd/6qlnzDTONQ94eAiLnksqfcpqhUEgY2eia2Fjz84XZ4mbo",
+	"OVv3Xymii/uuPZah2BqQW7nS7/rJUlG81TNb3u0KGvamsf2vQWmyTDzvE01X3rU7EKO04qaJyDroFrDd",
+	"GcJRhtvDSTEqn3y1aL7kG9Lp7Ugo+RMFbS/Hpp6Mc7Wb7+vB8H4pHtIL4XwZOiR4ZBTob5fMltlls2S+",
+	"yU3niRQXrmP1jzZJ/2wRC9+cqN71WbDEnk6xGubu2hJGVkofHUSbzgkm2YkebHZJG2oNlxKEmwXgnUKP",
+	"g00zwAcn4zY81B0iQQz4/BJMdgXVtv6+bxy9H62Oa8xJWbdAsB+iJCISWd1C9Ev5e1EqMMo7J5Jk41tM",
+	"STx3vgJq+JYMIOunzcLxMkTerBiuV28oSHiRGVvEbr+7jLEViEgCLk2WmZWQ2hTFgjTQyCxUS3Sv9Zfy",
+	"ScTzecrhJEIZ3bEYJmxGOLihZC7zaoKUUqlrZTTKuOAfe4Xm20OgEoWG4AOhnyMCwycuuU2t/d3SbOmA",
+	"W6LafubSe1JsYfPSp7pSPzPrSog5oWROeAMNn6sP3C+nJFwSI/vxVM8p4TNEq1SpZ/uOxdzyCTvR5cEG",
+	"X9OcKjUOPJJjiRz1VW5Aeu2QXx2Q+QTHKKxLtLYUzsKjCf6nfjWfNNs4eqZa3w9Lh0d2di55PJDM7PKB",
+	"V4PjfJEsHREi5wDwFuJIyo04lhTQEvVfwPoHHvhfgIV/3Ia6vHtXSa20fwciK5To7moTE/bxt4n17oXP",
+	"TW50W6pDvngdL5bwf3TAdXfAScg1UUIftr7/NejnhpPX6OuLWxntdBBDxJr9fXLyeA/eMdeKcst56OT0",
+	"zSLsTmLOwdb45sOLTWvHwD4OPAnMbl68XcHEnZActkcBj669Dbj21itqrLQEXce3ZDsmkQ2+KF3MIpKg",
+	"HpxtxD710igeQg6XKJSQ13jL453jNqvIS8jhYykEtp/Boc0aYkH53llC7L3n2GqhgK8FxCon6IVpanS2",
+	"0C6bPvJNbtjsUVq4pDWbHx+tHf7WjhxL67C9K1/e/xomHSwcFpm0WDdWSxrtfDVbr6tVI0fEh2rQaMeq",
+	"XoaMfFqn4LmbCHKwae73UGwWPkjmb6uw+JCXnWJnkG3rz/vGEfzRJLE+k8TK5AEZTzlHMU9wgiLcW2HL",
+	"5gHZRF7eRKm4ZYPPs008bA2uApBWVc4B//un07kOYaG3A028tbzq1B2c3dWVd1rtq+520/pfzQ5c+QrF",
+	"O3lUCf1Vwir4Woml96Ow/zWsTNhFe3RcdZsauR6a85DgnAftpFg6TvtgVcweWNpP6awu5NY+7wleHewA",
+	"N34wKmovJO2gtDpg66e97i6y7o7csguU8liL3V91XZvcYmXo9NNi7Qn8/Y4n9rIPWm+1INGmsBbu6r4p",
+	"qqh44wZ3C4jgq5naaWUdHJDWWrusi9rb3LASWlm6eAvWz49ap7/WiQp4V4P53dn1/lcU3/orlIVSBm2a",
+	"5KpJpZ3hWit21R1ttHyoOqMXjvVSEhsLYLxGfHdR5WAbfPGh6H+eCOev8NncyUvR2ynE2wExYCvo/uiw",
+	"XJ/Dcu1ywz6ZMERvER2lNPKKoTYDwPuLNyp+Wl67oN+ITJlsNzxHnOKAyZ/5DLMuL8iZnv/9xZvv9jGx",
+	"ztgUW31mgxrHN4TO5WoP6WUp4NuaaIAGcASnKObeRHBxfATkiIwKjk5HCbmTJaQpIRwEMGUIwBhGC4Y7",
+	"UMLF8dGRmPh7Rn/rjE3oXwTyQ8L/wsmXRXpFQHCCI8wXMEKUs5hwIdhLYAYzGMco6mf6K8wN1OTAnh2Y",
+	"6b3DWs7sKY/kjO+sCY/Ndh+0ydAPSG3WRP/bu3e2xg5Hy8nLF/V8jZTem+gQVOO3x102bnqeYMN2zy67",
+	"cklpPrf8aDD1Nph6k04v8l3pw7n/lXgt3MVO6885Wqy4G2QX7c/jmTecuth+/envoVqG10tMvUzK3lty",
+	"KknfG1Yf3Ktn7KHYt9dNNv6Gcf/nwMts/h2Qz26LpfeLnh+jsLzt8Tsnli5RLaJ4llLZiE5WmsfyESVC",
+	"9aoj4YL/PbezVCpLuNCkn/WkWGuio51k52tOOHa7TftHbZpq9atHo0Zfo0Y5D9VNK73fhJJZIsuu7meC",
+	"8KphsSaa6yhD9qpq4UDsR2uBP5auwAZQX/nivqDVwTaZsabQh6mb+yJpX427Q+WMHUbW3RFbDrYvtjxG",
+	"ra0vam19co5uzd5P4TWD/XOUzs1yD1q11VBo02ezu/nuO7YnOVoYpM4wxVe71XN0SV7Sa+yyHmu2uGHl",
+	"tbBspUuZhPOjmuqtpiYZnjmwuxuf3v+q/9Wh6oWhjBZlc5XU0M5sz/NjdFErDfY9VF2yEZV6KY16Rqei",
+	"uHsocbBJFvdQdL8WpPJX8gyn8VLsdgK5tvxibxSdHzW09Wloa3vim3pZVrIv7LSDb/u6daw4CElp4OPV",
+	"jCIQ4VsEfk0niMZSfshGZ83AhSDBZwjAgItvsw61paaYSgi3djUEOA6iNJS9XmY4Cq25I/wZgXMSMncO",
+	"h2m8rD6/oghtjW30a7XZYdQW0kcsuDbmj+jvAKcI6QycMhp894+lQXdqA2O5Vp7rp/x9dOtVjcaiezWi",
+	"3NAlO7XuEOqEhg8Nn9xusE7NzlDxsAz4X3EcCoFcwVKBZjAcYPHbv1NEF4PhQGDL4HDwGcfhoCxSDC0S",
+	"l12BDgeMU9WHurKY2IjnYvJ/ll5M3lSHFeX3g07LvD99WV5A4mxCUYAZUmgM5pAHMzGDe+0Uh42rboL5",
+	"KoJoYr8nOUWK42qaRPkz+hhj5mLXGinQbalM0m4y6oSEo4hM21m1zA0vceeEhEsz5nMSvhHrP3TObDPL",
+	"hISb45PNixkWucSKl3l3tphDHCMq7YKAEzBFXCMWJfOaXWSjujHqszhaACqRVy0RozskOBmMVSL3HMYL",
+	"wFBA4pDVLM1wHKDL7JN8dZXJPDgc4Jj/+GIwHMxxjOfpfHB4MDRbwzFHU0Q3xM41GTXx8zeGgovcXNz/",
+	"IyOvGqlIKPFmOQ6u2eIEx0IN7ef2NKzVTOIIohwCImeCUbQANzjiso7BZJGrx27/qObFP5vtbbgR4r8E",
+	"ud1372oRhm1O1vJlfv/O1sqJc4Iqo5+v77U0ZYeo4uKKu+yJLe10ww5Z1+pljlW8g0f/rLd/toS+jQTR",
+	"65nZ/0oLE3Vw3pZJq8WJuwZ6amftF5XDdXHplhH3obp2u2BhL09vaYEmZXBn8edgixz1obiDuyGiv3e4",
+	"zMq8vMQ7iJC7IVtskxIeE1y9HcPbkS32P//ENuf80Vv5O/O3NurN/voT24pDqJbAK2aro/NTMKUkTSpe",
+	"hj00T/gCKIuXBFVAaP47e1JjxJKzLWfBE5u6RZRhEju2NZ6Owe3TuuX1uOU28N24rXbDs3NRclI8stKK",
+	"UPLrT6zsy9HsaRc47Co9Nivhpht04fjzUj+XSkLCd8t7VdL5BFGxmPYoAOk7AHczHMwAJ4DNyJ2xJ3//",
+	"roZzYzx/5Cy1joUdYicypKjdNTHDiEIazHAAI3CL0Z1U+DvF8OmtMEDuYvNXzMpAaIrc2xO6Hg7gJeJs",
+	"KEP4huCfZMKedGNYG4zp24q5oXTUJmItPHUSFR6ptlkeyOIR10i+S/kK+/kIZen/xvrmls9wx52FVtTF",
+	"9+Rl9HQvPhy3osOd2J3Usicyc5T0N3c3PUObfXA2a9husuM9MEv2UihJog7RIlGU8/cRC0giu1dEubPd",
+	"zcIztLog0aaDP3aUvx6lfPaXBY42RpuBvQjv3RadVsN5646eY/2R3qdq9uEb1dGIyXUBHS5U3uWwjjKe",
+	"bTqww71+XYiofQOPER7+ER5uEmmgkO6Pg/rRM6rDvZ+6oI610VRDMHIB07RZXdrJEshnHQzu6AucJ5H4",
+	"NES3KBLHG1ngbzXHOwJGajZZHzfyqDmXQk06k0OveBNfJH+N+EPG8INdeEsKGsEjvdhKRA9iccbEqICA",
+	"YkiML4mosQ+MSnZF2NsJAn0s3rC+4g1rlA572gygvaDclY/l4NFkoKirm63gAdoI1mAbqGKsl4XgXpgG",
+	"tmYT8HgfHo0APY0Aq2HvS2j9Xtr+RsS71Yp1K1LrH4A6v3lKcOr/69X72/X97xXHD7byIDxq8p6a/Do0",
+	"+L8zWQ6LCLk+DoE13Eun/44oYevi2Hao7zEzpqfWvbQ4xlBAEafoBlEUBz3DtdQkIJ/Fu3/bpRx5kS//",
+	"oFXxEjTaFPIK2O+dfl09QY7PFdTwVbLLk3aoq1Bac5fV7PJWN6xsO5cvFUwq38Oj0u2tdJdxuJku+rH6",
+	"/a+sOFWH+goVGmspsLAOwmpn3JfV83UpsVBB4IdaY6EbNvbSfstLOPXf3ceig60y2IcSoNoVH/2LLVT4",
+	"mle1hZ3Eyx0RObZLEY+KpbdiuQ6Rg1OIe3ZJU0MBvIU4gpMoq57QolBeqRUftBopYdCmPOqruW8aIzf3",
+	"a3BTX7ivcijHd9AI5fS7rAeqDW5Y+7MWLQJb/vCo6PkrelzjVwWduzDY/a/yfzvob4oMWpS21eF+O3O8",
+	"MgfooqApbHuoWlkt6vRSwORsTq1rt9DgYFNM7KEoUw1o5K83KX7ipSxtHZ22+gZvDH0fI1/XF/m68kd7",
+	"P7/yRtYtSwAZ9AZqULk2Ugsjv1QrfX/sXB2sqUKIIgw924Ng6+awvVH1jtDPNxG5o2nso8Yb5X2KYkRx",
+	"AMxwIMZ7avAf9JgLseSD1uMtSLRp8wVA3zulvrj7HFkNAJrU+yuKp1NEjX7vwrw63d6C7y5r+PY2N6zn",
+	"V5Yuwv6DBWSj9D9aV516vo2PNRjenSPvf6VpvEyxl2YqeY34qkmknbtaK25IcOiC5A9FKVwzuq6stnIX",
+	"BN5oqWQ3GleCTF/JAmbmcJMFYBwlhVjTcoFNjpK1Nl3EHM1ZB5KRUD2JOZXapd4NpBQuWolpybK994+S",
+	"qt0UV0ZQvUvpFvZ3Q8lcyuiTFEchSCIYozGQHdcgReAG8WAmfXS3yPnt/x/EBMjamrdIlweFsri3WB+F",
+	"utz3PFEGW3GENqLdYEXebiQrD7cKgh26b6vS7U8WaYSyaXSYKngJjepetP7rylTekGk/lrJUtd57yFBK",
+	"rf1Wxk4YhzxlXvYocosojCKghsgEjgTRkaQL/bf+Quel2scDED3VSZvMVwVE1xd0X/GWmXtdHnOXsUt1",
+	"jy/J9/lomorIna9d6v7apLrao4rhJhVzlH/kiVnsPpimtmWXamSTj1Eona1Tq2HI+1/NPztEpGQU0hKU",
+	"slKy8JcJuoamZFj4UKNTWlBquIy5slFq3CXEONgsx3to1sn6p9k7cCVjO16xKzuCY9t+yDeM1o+hLOsL",
+	"ZVnry7/KsBYv3r/R4JYNvwDt8S0ZwTyQEJe70nmXReGIwLBfsko2ulfDmnpLg9rRTneo2WEDhYCej4FC",
+	"Qfm7bzVzZyGUTSjqb74WDTNLR0uGGLLrlgy5xy1YMvJ1q/xcgvrRktHJkqFxzYXjHR8DJc+If3a0ZMhr",
+	"87BkrIws/MQVc5Kulgx5nIdsyWhAqd6WDDFBrTS7a4hxsFmO95AsGY241c2SIWHnbcnYARzb9kO+YbR+",
+	"LEfQyTDh95CnDNERXyTIL14hIPENnqZCCRMjgRyprA0pn6GY6/uXkQyF+txuPe09Q/RKrr6JIBmz2rE8",
+	"hU98jNF0nOfujUmrUUmsjXgVMrxDkxkhn9n+BPNJGnxWd+1WW84pETSGGMBxQOaCRf5sRgE9kQm85ARw",
+	"lUegotkcYWm/wDiMUDbDBzXBoD8Tg2GIlV3gnIqlOBZoo2qHFk9S3XYCF4Y21O2TyZ8o2HgKogaCDAFt",
+	"NEyZbesr2R4D7Iu2KEgp5ovB4e8fbSRWSFHFK5tpaZStQeQp5rN00gmLX2P+SzrpjcJq+Cbxt7ThR+Td",
+	"KeQt3k4nzI1gZ8x9A5fC3Ddw05hrb/gRc3cNc63bacNcGCUz2Gj2mWKuimD5tR+aYlOJTqa2ttY6fo11",
+	"AUO2OkPomjAs26rqlF+PYka4tGBx7yL97L3nOGTdlnewXzaRVCcYSWkg9I0QlVSLOkN5tuYuW8pLW81Y",
+	"w2bt5tb69dj5Or+QRxO6twkdWohcRxD92Or+16mZpIM93SKrFov6aumn3ar12j5NF5u6hZgP1arui2Uz",
+	"BCM+a32Qz34F+Ebadxiit4gCzIAauhiD90znnkX4FsWIMSESTZA7+ewXtWDr68rRF76fRBCXuFbe7ePs",
+	"V0ebD0fN0tJ+m0Uf+Q0IZiiwJZ4zcwoDNpKgGCZ4bLhqq1nsLEHx0fkpeD4+yNwUyg4mAMdnmAHxM47B",
+	"Py/P3gGVP+YEoJ7pMkHBsiax4nbrtxiSIJ2LGZ2SuXuWwgyNMH+NOHCPargAiqB6dBshfyG+qmKuHCwU",
+	"IxgEKOFAv+PMQmXxCW7DZTn9KlDZTNQBmxUAmuB6kR2hFZ1vEWXYA5P1dwDHCkGlHXdCUi4BLC9QbtAJ",
+	"rd/0ImsUrPUSTULLb9UjtGKnxpzb7ABuQBZn+TqYIEgRPUoFf/39o3i61ETqySxJ+iSAEdANjDStpTQa",
+	"HA5mnCeH+/uR+GBGGD/86eCnA/kQ6l2Up1I8bJij8FDa2s3doThMCFZ50jqN1TpGU6OmOYzhFOnN6aHZ",
+	"r66h55QINmENNGEtuTyTT6W/dk2UBU85pkrMsGyi7GvXVCfxLaYknrsnc+3LGuGa8CXk8DyCsQ0fyULu",
+	"cm9rEpGF/DuHdIrsvWajXVP/nOIodM59fLp//FKnhuP4hkLGaRrwlKJ86ny0a+6ziUBGOMER5gvnGnMS",
+	"Y04EJ5L4E5HpVDUgNlhTmcF5dVHKOKKmI6sLWtbNqY8bgVKa0AmjyozNsChN2QiaytS9wJCh6NUiQYCj",
+	"eRJJTTdENzhW8YviL4JFARRPcYwE2ygvXZjFY1VVoS1fzdQLIEymaAaUMDYKUi4d3gGJA0Tj6qpXprR1",
+	"LZX2PFTbaZbcfu2+X5ezCLMl8sEfrEzLyutIIjSaQCE6QKlliMU5JVHVx+lEpKJHzrE/zAWXu8Uhopmx",
+	"dCaNdDb8MrNcdYZK4X7XNipl6KvzZJ522/girxer56MALxP4Wc/NKYoQZDXkZb66UB85Id8w3mOYaWPf",
+	"MFz3xHcy/pytJzhBEa7hE/l35/qzVn4MYIQoZyAmPJfCgxmMYxQ51yiMPpKD31ljj9VQVoNcWlcu8f96",
+	"A1u+rqVPfvv47f8LAAD//0gSwbXomgMA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/openchoreo-api/api/handlers/releasebinding_k8sresources.go
+++ b/internal/openchoreo-api/api/handlers/releasebinding_k8sresources.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+	k8sresourcessvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/k8sresources"
+)
+
+// GetReleaseBindingK8sResourceTree returns all live Kubernetes resources deployed by the releases
+// owned by a release binding.
+func (h *Handler) GetReleaseBindingK8sResourceTree(
+	ctx context.Context,
+	request gen.GetReleaseBindingK8sResourceTreeRequestObject,
+) (gen.GetReleaseBindingK8sResourceTreeResponseObject, error) {
+	h.logger.Debug("GetReleaseBindingK8sResourceTree called",
+		"namespace", request.NamespaceName,
+		"releaseBinding", request.ReleaseBindingName)
+
+	result, err := h.services.K8sResourcesService.GetResourceTree(ctx, request.NamespaceName, request.ReleaseBindingName)
+	if err != nil {
+		return h.handleK8sResourceTreeError(err)
+	}
+
+	genReleases := make([]gen.ReleaseResourceTree, 0, len(result.Releases))
+	for _, r := range result.Releases {
+		nodes, err := convertList[models.ResourceNode, gen.ResourceNode](r.Nodes)
+		if err != nil {
+			h.logger.Error("Failed to convert resource nodes", "error", err)
+			return gen.GetReleaseBindingK8sResourceTree500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+		}
+		genReleases = append(genReleases, gen.ReleaseResourceTree{
+			Name:        r.Name,
+			TargetPlane: gen.ReleaseResourceTreeTargetPlane(r.TargetPlane),
+			Nodes:       nodes,
+		})
+	}
+
+	return gen.GetReleaseBindingK8sResourceTree200JSONResponse{
+		Releases: genReleases,
+	}, nil
+}
+
+// GetReleaseBindingK8sResourceEvents returns Kubernetes events for a specific resource
+// in the release binding's resource tree.
+func (h *Handler) GetReleaseBindingK8sResourceEvents(
+	ctx context.Context,
+	request gen.GetReleaseBindingK8sResourceEventsRequestObject,
+) (gen.GetReleaseBindingK8sResourceEventsResponseObject, error) {
+	h.logger.Debug("GetReleaseBindingK8sResourceEvents called",
+		"namespace", request.NamespaceName,
+		"releaseBinding", request.ReleaseBindingName,
+		"kind", request.Params.Kind,
+		"name", request.Params.Name)
+
+	resp, err := h.services.K8sResourcesService.GetResourceEvents(
+		ctx,
+		request.NamespaceName,
+		request.ReleaseBindingName,
+		request.Params.Group,
+		request.Params.Version,
+		request.Params.Kind,
+		request.Params.Name,
+	)
+	if err != nil {
+		return h.handleK8sResourceEventsError(err)
+	}
+
+	result, err := convert[models.ResourceEventsResponse, gen.ResourceEventsResponse](*resp)
+	if err != nil {
+		h.logger.Error("Failed to convert resource events response", "error", err)
+		return gen.GetReleaseBindingK8sResourceEvents500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	return gen.GetReleaseBindingK8sResourceEvents200JSONResponse(result), nil
+}
+
+// GetReleaseBindingK8sResourceLogs returns logs for a specific pod in the release binding's resource tree.
+func (h *Handler) GetReleaseBindingK8sResourceLogs(
+	ctx context.Context,
+	request gen.GetReleaseBindingK8sResourceLogsRequestObject,
+) (gen.GetReleaseBindingK8sResourceLogsResponseObject, error) {
+	h.logger.Debug("GetReleaseBindingK8sResourceLogs called",
+		"namespace", request.NamespaceName,
+		"releaseBinding", request.ReleaseBindingName,
+		"podName", request.Params.PodName)
+
+	resp, err := h.services.K8sResourcesService.GetResourceLogs(
+		ctx,
+		request.NamespaceName,
+		request.ReleaseBindingName,
+		request.Params.PodName,
+		request.Params.SinceSeconds,
+	)
+	if err != nil {
+		return h.handleK8sResourceLogsError(err)
+	}
+
+	result, err := convert[models.ResourcePodLogsResponse, gen.ResourcePodLogsResponse](*resp)
+	if err != nil {
+		h.logger.Error("Failed to convert resource pod logs response", "error", err)
+		return gen.GetReleaseBindingK8sResourceLogs500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	return gen.GetReleaseBindingK8sResourceLogs200JSONResponse(result), nil
+}
+
+func (h *Handler) handleK8sResourceTreeError(err error) (gen.GetReleaseBindingK8sResourceTreeResponseObject, error) {
+	if errors.Is(err, services.ErrForbidden) {
+		return gen.GetReleaseBindingK8sResourceTree403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrReleaseBindingNotFound) {
+		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrReleaseNotFound) {
+		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("Release")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound) {
+		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
+	}
+	h.logger.Error("Failed to get k8s resource tree", "error", err)
+	return gen.GetReleaseBindingK8sResourceTree500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+}
+
+func (h *Handler) handleK8sResourceEventsError(err error) (gen.GetReleaseBindingK8sResourceEventsResponseObject, error) {
+	if errors.Is(err, services.ErrForbidden) {
+		return gen.GetReleaseBindingK8sResourceEvents403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrReleaseBindingNotFound) {
+		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrReleaseNotFound) {
+		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("Release")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound) {
+		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrResourceNotFound) {
+		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("Resource")}, nil
+	}
+	h.logger.Error("Failed to get k8s resource events", "error", err)
+	return gen.GetReleaseBindingK8sResourceEvents500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+}
+
+func (h *Handler) handleK8sResourceLogsError(err error) (gen.GetReleaseBindingK8sResourceLogsResponseObject, error) {
+	if errors.Is(err, services.ErrForbidden) {
+		return gen.GetReleaseBindingK8sResourceLogs403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrReleaseBindingNotFound) {
+		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrReleaseNotFound) {
+		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("Release")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound) {
+		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
+	}
+	if errors.Is(err, k8sresourcessvc.ErrResourceNotFound) {
+		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("Resource")}, nil
+	}
+	h.logger.Error("Failed to get k8s resource logs", "error", err)
+	return gen.GetReleaseBindingK8sResourceLogs500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+}

--- a/internal/openchoreo-api/services/handlerservices/services.go
+++ b/internal/openchoreo-api/services/handlerservices/services.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	gatewayClient "github.com/openchoreo/openchoreo/internal/clients/gateway"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
 	authzsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/authz"
 	buildplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/buildplane"
@@ -24,6 +25,7 @@ import (
 	deploymentpipelinesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/deploymentpipeline"
 	environmentsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/environment"
 	gitsecretsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/gitsecret"
+	k8sresourcessvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/k8sresources"
 	namespacesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/namespace"
 	observabilityalertsnotificationchannelsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/observabilityalertsnotificationchannel"
 	observabilityplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/observabilityplane"
@@ -58,6 +60,7 @@ type Services struct {
 	ObservabilityAlertsNotificationChannelService observabilityalertsnotificationchannelsvc.Service
 	ObservabilityPlaneService                     observabilityplanesvc.Service
 	ReleaseService                                releasesvc.Service
+	K8sResourcesService                           k8sresourcessvc.Service
 	ReleaseBindingService                         releasebindingsvc.Service
 	SecretReferenceService                        secretreferencesvc.Service
 	TraitService                                  traitsvc.Service
@@ -67,7 +70,7 @@ type Services struct {
 }
 
 // NewServices creates all K8s-native API services with authorization wrappers.
-func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, bpClientMgr *kubernetesClient.KubeMultiClientManager, gatewayURL string, logger *slog.Logger) *Services {
+func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, bpClientMgr *kubernetesClient.KubeMultiClientManager, gatewayURL string, logger *slog.Logger, gwClient *gatewayClient.Client) *Services {
 	return &Services{
 		AuthzService:                                  authzsvc.NewServiceWithAuthz(pap, pdp, k8sClient, logger.With("component", "authz-service")),
 		ProjectService:                                projectsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "project-service")),
@@ -88,6 +91,7 @@ func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, 
 		ObservabilityAlertsNotificationChannelService: observabilityalertsnotificationchannelsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "observabilityalertsnotificationchannel-service")),
 		ObservabilityPlaneService:                     observabilityplanesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "observabilityplane-service")),
 		ReleaseService:                                releasesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "release-service")),
+		K8sResourcesService:                           k8sresourcessvc.NewServiceWithAuthz(k8sClient, gwClient, pdp, logger.With("component", "k8sresources-service")),
 		ReleaseBindingService:                         releasebindingsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "releasebinding-service")),
 		SecretReferenceService:                        secretreferencesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "secretreference-service")),
 		TraitService:                                  traitsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "trait-service")),

--- a/internal/openchoreo-api/services/k8sresources/errors.go
+++ b/internal/openchoreo-api/services/k8sresources/errors.go
@@ -1,0 +1,13 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sresources
+
+import "errors"
+
+var (
+	ErrReleaseBindingNotFound = errors.New("release binding not found")
+	ErrReleaseNotFound        = errors.New("release not found")
+	ErrEnvironmentNotFound    = errors.New("environment not found")
+	ErrResourceNotFound       = errors.New("resource not found in release")
+)

--- a/internal/openchoreo-api/services/k8sresources/interface.go
+++ b/internal/openchoreo-api/services/k8sresources/interface.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sresources
+
+import (
+	"context"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+// ReleaseResourceTree represents the resource tree for a single release.
+type ReleaseResourceTree struct {
+	Name        string
+	TargetPlane string
+	Nodes       []models.ResourceNode
+}
+
+// K8sResourceTreeResult is the result of GetResourceTree.
+type K8sResourceTreeResult struct {
+	Releases []ReleaseResourceTree
+}
+
+// Service defines the k8s resources service interface for release bindings.
+type Service interface {
+	GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (*K8sResourceTreeResult, error)
+	GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (*models.ResourceEventsResponse, error)
+	GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName, podName string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error)
+}

--- a/internal/openchoreo-api/services/k8sresources/service.go
+++ b/internal/openchoreo-api/services/k8sresources/service.go
@@ -1,0 +1,804 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sresources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/clients/gateway"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	releasecontroller "github.com/openchoreo/openchoreo/internal/controller/release"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+const (
+	planeTypeDataPlane          = "dataplane"
+	planeTypeObservabilityPlane = "observabilityplane"
+	maxResponseBytes            = 10 * 1024 * 1024 // 10MB
+)
+
+// planeInfo holds the resolved plane coordinates for gateway proxy calls.
+type planeInfo struct {
+	planeType   string
+	planeID     string
+	crNamespace string
+	crName      string
+}
+
+// releaseContext holds a release and its resolved plane info.
+type releaseContext struct {
+	release   *openchoreov1alpha1.Release
+	plane     planeInfo
+	namespace string // data plane namespace derived from Release.Status.Resources
+}
+
+type k8sResourcesService struct {
+	k8sClient     client.Client
+	gatewayClient *gateway.Client
+	logger        *slog.Logger
+}
+
+// NewService creates a new k8s resources service.
+func NewService(k8sClient client.Client, gatewayClient *gateway.Client, logger *slog.Logger) Service {
+	return &k8sResourcesService{
+		k8sClient:     k8sClient,
+		gatewayClient: gatewayClient,
+		logger:        logger,
+	}
+}
+
+// GetResourceTree returns hierarchical views of all live Kubernetes resources
+// deployed by the releases owned by a release binding.
+func (s *k8sResourcesService) GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (*K8sResourceTreeResult, error) {
+	s.logger.Debug("Getting k8s resource tree", "namespace", namespaceName, "releaseBinding", releaseBindingName)
+
+	if s.gatewayClient == nil {
+		return nil, fmt.Errorf("gateway client is not configured")
+	}
+
+	releaseContexts, err := s.resolveReleaseContexts(ctx, namespaceName, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	releases := make([]ReleaseResourceTree, 0, len(releaseContexts))
+	for _, rc := range releaseContexts {
+		nodes := s.buildResourceTreeNodes(ctx, &rc)
+		releases = append(releases, ReleaseResourceTree{
+			Name:        rc.release.Name,
+			TargetPlane: rc.release.Spec.TargetPlane,
+			Nodes:       nodes,
+		})
+	}
+
+	return &K8sResourceTreeResult{Releases: releases}, nil
+}
+
+// GetResourceEvents returns Kubernetes events for a specific resource in the release binding's resource tree.
+func (s *k8sResourcesService) GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (*models.ResourceEventsResponse, error) {
+	s.logger.Debug("Getting k8s resource events", "namespace", namespaceName, "releaseBinding", releaseBindingName,
+		"group", group, "version", version, "kind", kind, "name", name)
+
+	if s.gatewayClient == nil {
+		return nil, fmt.Errorf("gateway client is not configured")
+	}
+
+	releaseContexts, err := s.resolveReleaseContexts(ctx, namespaceName, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find which release context contains the requested resource
+	rc, resourceNS := s.findResourceRelease(releaseContexts, group, version, kind, name)
+	if rc == nil {
+		return nil, ErrResourceNotFound
+	}
+
+	// Build field selector to filter events
+	fieldSelector := fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", kind, name)
+	if resourceNS != "" {
+		fieldSelector += ",involvedObject.namespace=" + resourceNS
+	}
+
+	eventsPath := "api/v1/events"
+	if resourceNS != "" {
+		eventsPath = fmt.Sprintf("api/v1/namespaces/%s/events", resourceNS)
+	}
+
+	rawQuery := "fieldSelector=" + fieldSelector
+
+	items, err := s.fetchK8sList(ctx, rc.plane, eventsPath, rawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch events: %w", err)
+	}
+
+	events := make([]models.ResourceEvent, 0, len(items))
+	for _, item := range items {
+		events = append(events, mapEventItem(item))
+	}
+
+	return &models.ResourceEventsResponse{Events: events}, nil
+}
+
+// GetResourceLogs returns logs for a specific pod in the release binding's resource tree.
+func (s *k8sResourcesService) GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName, podName string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error) {
+	s.logger.Debug("Getting k8s resource logs", "namespace", namespaceName, "releaseBinding", releaseBindingName, "pod", podName)
+
+	if s.gatewayClient == nil {
+		return nil, fmt.Errorf("gateway client is not configured")
+	}
+
+	releaseContexts, err := s.resolveReleaseContexts(ctx, namespaceName, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find a release context with a dataplane target that has parent resources for pods
+	var targetRC *releaseContext
+	for i := range releaseContexts {
+		rc := &releaseContexts[i]
+		if rc.release.Spec.TargetPlane == planeTypeDataPlane && hasParentResourceInRelease("Pod", rc.release.Status.Resources) {
+			targetRC = rc
+			break
+		}
+	}
+	if targetRC == nil {
+		return nil, ErrResourceNotFound
+	}
+
+	rawLogs, err := s.gatewayClient.GetPodLogsFromPlane(ctx, targetRC.plane.planeType, targetRC.plane.planeID,
+		targetRC.plane.crNamespace, targetRC.plane.crName,
+		&gateway.PodReference{
+			Namespace: targetRC.namespace,
+			Name:      podName,
+		},
+		&gateway.PodLogsOptions{
+			IncludeTimestamps: true,
+			SinceSeconds:      sinceSeconds,
+		})
+	if err != nil {
+		if gateway.IsPermanentError(err) {
+			return nil, ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to fetch pod logs: %w", err)
+	}
+
+	logEntries := parseLogLines(rawLogs)
+	return &models.ResourcePodLogsResponse{LogEntries: logEntries}, nil
+}
+
+// resolveReleaseContexts fetches the ReleaseBinding, finds its owned Releases,
+// and resolves plane info for each.
+func (s *k8sResourcesService) resolveReleaseContexts(ctx context.Context, namespaceName, releaseBindingName string) ([]releaseContext, error) {
+	// 1. Fetch the ReleaseBinding
+	var rb openchoreov1alpha1.ReleaseBinding
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: releaseBindingName}, &rb); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, ErrReleaseBindingNotFound
+		}
+		return nil, fmt.Errorf("failed to get release binding: %w", err)
+	}
+
+	// 2. List Releases in the same namespace, filter by owner
+	var releaseList openchoreov1alpha1.ReleaseList
+	if err := s.k8sClient.List(ctx, &releaseList, client.InNamespace(namespaceName)); err != nil {
+		return nil, fmt.Errorf("failed to list releases: %w", err)
+	}
+
+	var ownedReleases []*openchoreov1alpha1.Release
+	for i := range releaseList.Items {
+		release := &releaseList.Items[i]
+		if metav1.IsControlledBy(release, &rb) {
+			ownedReleases = append(ownedReleases, release)
+		}
+	}
+
+	if len(ownedReleases) == 0 {
+		return nil, ErrReleaseNotFound
+	}
+
+	// 3. Resolve environment and plane info
+	env := &openchoreov1alpha1.Environment{}
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: rb.Spec.Environment}, env); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, ErrEnvironmentNotFound
+		}
+		return nil, fmt.Errorf("failed to get environment: %w", err)
+	}
+
+	dpResult, err := controller.GetDataPlaneOrClusterDataPlaneOfEnv(ctx, s.k8sClient, env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve data plane: %w", err)
+	}
+
+	contexts := make([]releaseContext, 0, len(ownedReleases))
+	for _, release := range ownedReleases {
+		pi, err := s.resolvePlaneInfo(ctx, release, dpResult)
+		if err != nil {
+			s.logger.Warn("Failed to resolve plane info for release, skipping",
+				"release", release.Name, "targetPlane", release.Spec.TargetPlane, "error", err)
+			continue
+		}
+
+		ns := deriveNamespace(release)
+
+		contexts = append(contexts, releaseContext{
+			release:   release,
+			plane:     pi,
+			namespace: ns,
+		})
+	}
+
+	if len(contexts) == 0 {
+		return nil, ErrReleaseNotFound
+	}
+
+	return contexts, nil
+}
+
+// resolvePlaneInfo resolves gateway proxy coordinates for a release based on its target plane.
+func (s *k8sResourcesService) resolvePlaneInfo(ctx context.Context, release *openchoreov1alpha1.Release, dpResult *controller.DataPlaneResult) (planeInfo, error) {
+	switch release.Spec.TargetPlane {
+	case planeTypeObservabilityPlane:
+		obsResult, err := dpResult.GetObservabilityPlane(ctx, s.k8sClient)
+		if err != nil {
+			return planeInfo{}, fmt.Errorf("failed to resolve observability plane: %w", err)
+		}
+		return resolveObservabilityPlaneInfo(obsResult), nil
+	default: // dataplane
+		pi := resolveDataPlaneInfo(dpResult)
+		return pi, nil
+	}
+}
+
+// resolveDataPlaneInfo extracts planeInfo from a DataPlaneResult.
+func resolveDataPlaneInfo(dpResult *controller.DataPlaneResult) planeInfo {
+	if dpResult.DataPlane != nil {
+		dp := dpResult.DataPlane
+		id := dp.Spec.PlaneID
+		if id == "" {
+			id = dp.Name
+		}
+		return planeInfo{planeType: planeTypeDataPlane, planeID: id, crNamespace: dp.Namespace, crName: dp.Name}
+	}
+	if dpResult.ClusterDataPlane != nil {
+		cdp := dpResult.ClusterDataPlane
+		id := cdp.Spec.PlaneID
+		if id == "" {
+			id = cdp.Name
+		}
+		return planeInfo{planeType: planeTypeDataPlane, planeID: id, crNamespace: "_cluster", crName: cdp.Name}
+	}
+	return planeInfo{}
+}
+
+// resolveObservabilityPlaneInfo extracts planeInfo from an ObservabilityPlaneResult.
+func resolveObservabilityPlaneInfo(obsResult *controller.ObservabilityPlaneResult) planeInfo {
+	if obsResult.ObservabilityPlane != nil {
+		op := obsResult.ObservabilityPlane
+		id := op.Spec.PlaneID
+		if id == "" {
+			id = op.Name
+		}
+		return planeInfo{planeType: planeTypeObservabilityPlane, planeID: id, crNamespace: op.Namespace, crName: op.Name}
+	}
+	if obsResult.ClusterObservabilityPlane != nil {
+		cop := obsResult.ClusterObservabilityPlane
+		id := cop.Spec.PlaneID
+		if id == "" {
+			id = cop.Name
+		}
+		return planeInfo{planeType: planeTypeObservabilityPlane, planeID: id, crNamespace: "_cluster", crName: cop.Name}
+	}
+	return planeInfo{}
+}
+
+// deriveNamespace extracts the data plane namespace from the first resource in the release status.
+func deriveNamespace(release *openchoreov1alpha1.Release) string {
+	if len(release.Status.Resources) > 0 {
+		return release.Status.Resources[0].Namespace
+	}
+	return ""
+}
+
+// buildResourceTreeNodes builds resource nodes for a single release.
+func (s *k8sResourcesService) buildResourceTreeNodes(ctx context.Context, rc *releaseContext) []models.ResourceNode {
+	allNodes := make([]models.ResourceNode, 0, len(rc.release.Status.Resources))
+
+	for i := range rc.release.Status.Resources {
+		rs := &rc.release.Status.Resources[i]
+
+		plural, err := s.resolveResourcePlural(rs.Group, rs.Version, rs.Kind)
+		if err != nil {
+			s.logger.Warn("Failed to resolve resource plural, skipping", "kind", rs.Kind, "name", rs.Name, "error", err)
+			continue
+		}
+
+		k8sPath := buildK8sGetPath(rs.Group, rs.Version, plural, rs.Namespace, rs.Name)
+		obj, err := s.fetchLiveResource(ctx, rc.plane, k8sPath)
+		if err != nil {
+			s.logger.Warn("Failed to fetch live resource, skipping", "kind", rs.Kind, "name", rs.Name, "error", err)
+			continue
+		}
+
+		node, ok := buildResourceNode(obj, nil, rs.HealthStatus)
+		if !ok {
+			s.logger.Warn("Skipping resource node with missing required fields", "kind", rs.Kind, "name", rs.Name)
+			continue
+		}
+		allNodes = append(allNodes, node)
+
+		childNodes := s.fetchChildResources(ctx, rc.plane, obj, rs)
+		allNodes = append(allNodes, childNodes...)
+	}
+
+	return allNodes
+}
+
+// findResourceRelease finds which release context contains the requested resource
+// and returns its namespace.
+func (s *k8sResourcesService) findResourceRelease(contexts []releaseContext, group, version, kind, name string) (*releaseContext, string) {
+	// First try exact match in release status resources
+	for i := range contexts {
+		rc := &contexts[i]
+		for _, rs := range rc.release.Status.Resources {
+			if rs.Group == group && rs.Version == version && rs.Kind == kind && rs.Name == name {
+				return rc, rs.Namespace
+			}
+		}
+	}
+
+	// For child resource kinds (Pod, ReplicaSet, Job), check if a parent exists
+	if isChildResourceKind(kind) {
+		for i := range contexts {
+			rc := &contexts[i]
+			if hasParentResourceInRelease(kind, rc.release.Status.Resources) {
+				return rc, rc.namespace
+			}
+		}
+	}
+
+	return nil, ""
+}
+
+// --- Fetching helpers ---
+
+func (s *k8sResourcesService) fetchLiveResource(ctx context.Context, pi planeInfo, k8sPath string) (map[string]any, error) {
+	resp, err := s.gatewayClient.ProxyK8sRequest(ctx, pi.planeType, pi.planeID, pi.crNamespace, pi.crName, k8sPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("proxy request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, k8sPath)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return obj, nil
+}
+
+func (s *k8sResourcesService) fetchK8sList(ctx context.Context, pi planeInfo, k8sPath, rawQuery string) ([]map[string]any, error) {
+	resp, err := s.gatewayClient.ProxyK8sRequest(ctx, pi.planeType, pi.planeID, pi.crNamespace, pi.crName, k8sPath, rawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("proxy request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, k8sPath)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var listObj map[string]any
+	if err := json.Unmarshal(body, &listObj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal list response: %w", err)
+	}
+
+	items, ok := listObj["items"].([]any)
+	if !ok {
+		return nil, nil
+	}
+
+	var result []map[string]any
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			result = append(result, m)
+		}
+	}
+
+	return result, nil
+}
+
+func (s *k8sResourcesService) fetchChildResources(ctx context.Context, pi planeInfo, parentObj map[string]any, rs *openchoreov1alpha1.ResourceStatus) []models.ResourceNode {
+	var nodes []models.ResourceNode
+
+	parentUID := getNestedString(parentObj, "metadata", "uid")
+	parentRef := models.ResourceRef{
+		Group:     rs.Group,
+		Version:   rs.Version,
+		Kind:      rs.Kind,
+		Namespace: rs.Namespace,
+		Name:      rs.Name,
+		UID:       parentUID,
+	}
+
+	switch rs.Kind {
+	case "Deployment":
+		replicaSets := s.fetchOwnedResources(ctx, pi, "apps", "ReplicaSet", rs.Namespace, parentUID)
+		for _, rsObj := range replicaSets {
+			rsUID := getNestedString(rsObj, "metadata", "uid")
+			pods := s.fetchOwnedResources(ctx, pi, "", "Pod", rs.Namespace, rsUID)
+			for _, podObj := range pods {
+				if podNode, ok := buildResourceNode(podObj, &parentRef, ""); ok {
+					nodes = append(nodes, podNode)
+				}
+			}
+		}
+
+	case "CronJob":
+		jobs := s.fetchOwnedResources(ctx, pi, "batch", "Job", rs.Namespace, parentUID)
+		for _, jobObj := range jobs {
+			jobNode, ok := buildResourceNode(jobObj, &parentRef, "")
+			if !ok {
+				continue
+			}
+			nodes = append(nodes, jobNode)
+
+			jobUID := getNestedString(jobObj, "metadata", "uid")
+			jobRef := models.ResourceRef{
+				Group:     "batch",
+				Version:   "v1",
+				Kind:      "Job",
+				Namespace: getNestedString(jobObj, "metadata", "namespace"),
+				Name:      getNestedString(jobObj, "metadata", "name"),
+				UID:       jobUID,
+			}
+			pods := s.fetchOwnedResources(ctx, pi, "", "Pod", rs.Namespace, jobUID)
+			for _, podObj := range pods {
+				if podNode, ok := buildResourceNode(podObj, &jobRef, ""); ok {
+					nodes = append(nodes, podNode)
+				}
+			}
+		}
+
+	case "Job":
+		pods := s.fetchOwnedResources(ctx, pi, "", "Pod", rs.Namespace, parentUID)
+		for _, podObj := range pods {
+			if podNode, ok := buildResourceNode(podObj, &parentRef, ""); ok {
+				nodes = append(nodes, podNode)
+			}
+		}
+	}
+
+	return nodes
+}
+
+func (s *k8sResourcesService) fetchOwnedResources(ctx context.Context, pi planeInfo, group, kind, namespace, ownerUID string) []map[string]any {
+	plural, err := s.resolveResourcePlural(group, "v1", kind)
+	if err != nil {
+		s.logger.Warn("Failed to resolve resource plural", "kind", kind, "group", group, "error", err)
+		return nil
+	}
+	k8sPath := buildK8sListPath(group, "v1", plural, namespace)
+	items, err := s.fetchK8sList(ctx, pi, k8sPath, "")
+	if err != nil {
+		s.logger.Warn("Failed to fetch child resources", "kind", kind, "namespace", namespace, "error", err)
+		return nil
+	}
+
+	apiVersion := "v1"
+	if group != "" {
+		apiVersion = group + "/v1"
+	}
+
+	var owned []map[string]any
+	for _, item := range items {
+		if hasOwnerReference(item, ownerUID) {
+			item["kind"] = kind
+			item["apiVersion"] = apiVersion
+			owned = append(owned, item)
+		}
+	}
+
+	return owned
+}
+
+func (s *k8sResourcesService) resolveResourcePlural(group, version, kind string) (string, error) {
+	gk := schema.GroupKind{Group: group, Kind: kind}
+	mapping, err := s.k8sClient.RESTMapper().RESTMapping(gk, version)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve plural for %s.%s/%s: %w", kind, group, version, err)
+	}
+	return mapping.Resource.Resource, nil
+}
+
+// --- Pure utility functions ---
+
+func buildK8sGetPath(group, version, plural, namespace, name string) string {
+	var basePath string
+	if group == "" {
+		basePath = fmt.Sprintf("api/%s", version)
+	} else {
+		basePath = fmt.Sprintf("apis/%s/%s", group, version)
+	}
+	if namespace != "" {
+		return fmt.Sprintf("%s/namespaces/%s/%s/%s", basePath, namespace, plural, name)
+	}
+	return fmt.Sprintf("%s/%s/%s", basePath, plural, name)
+}
+
+func buildK8sListPath(group, version, plural, namespace string) string {
+	var basePath string
+	if group == "" {
+		basePath = fmt.Sprintf("api/%s", version)
+	} else {
+		basePath = fmt.Sprintf("apis/%s/%s", group, version)
+	}
+	if namespace != "" {
+		return fmt.Sprintf("%s/namespaces/%s/%s", basePath, namespace, plural)
+	}
+	return fmt.Sprintf("%s/%s", basePath, plural)
+}
+
+func buildResourceNode(obj map[string]any, parentRef *models.ResourceRef, healthStatus openchoreov1alpha1.HealthStatus) (models.ResourceNode, bool) {
+	metadata, _ := obj["metadata"].(map[string]any)
+
+	group := getAPIGroup(obj)
+	version := getAPIVersion(obj)
+	kind := getStringField(obj, "kind")
+	name := getNestedString(obj, "metadata", "name")
+	uid := getNestedString(obj, "metadata", "uid")
+
+	if version == "" || kind == "" || name == "" || uid == "" {
+		return models.ResourceNode{}, false
+	}
+
+	node := models.ResourceNode{
+		Group:           group,
+		Version:         version,
+		Kind:            kind,
+		Namespace:       getNestedString(obj, "metadata", "namespace"),
+		Name:            name,
+		UID:             uid,
+		ResourceVersion: getNestedString(obj, "metadata", "resourceVersion"),
+		Object:          sanitizeObject(obj, kind),
+	}
+
+	if createdStr, ok := metadata["creationTimestamp"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, createdStr); err == nil {
+			node.CreatedAt = &t
+		}
+	}
+
+	if parentRef != nil {
+		node.ParentRefs = []models.ResourceRef{*parentRef}
+	}
+
+	if healthStatus != "" {
+		node.Health = &models.HealthInfo{Status: string(healthStatus)}
+	} else {
+		node.Health = computeHealthFromObject(obj, group, kind)
+	}
+
+	return node, true
+}
+
+func computeHealthFromObject(obj map[string]any, group, kind string) *models.HealthInfo {
+	gvk := schema.GroupVersionKind{Group: group, Kind: kind}
+	healthCheckFunc := releasecontroller.GetHealthCheckFunc(gvk)
+	if healthCheckFunc == nil {
+		return nil
+	}
+
+	unstrObj := &unstructured.Unstructured{Object: obj}
+	health, err := healthCheckFunc(unstrObj)
+	if err != nil {
+		return &models.HealthInfo{Status: string(openchoreov1alpha1.HealthStatusUnknown), Message: err.Error()}
+	}
+
+	return &models.HealthInfo{Status: string(health)}
+}
+
+func sanitizeObject(obj map[string]any, kind string) map[string]any {
+	sanitized := make(map[string]any, len(obj))
+	maps.Copy(sanitized, obj)
+
+	if metadata, ok := sanitized["metadata"].(map[string]any); ok {
+		metaCopy := make(map[string]any, len(metadata))
+		maps.Copy(metaCopy, metadata)
+		delete(metaCopy, "managedFields")
+		sanitized["metadata"] = metaCopy
+	}
+
+	if kind == "Secret" {
+		delete(sanitized, "data")
+		delete(sanitized, "stringData")
+	}
+
+	return sanitized
+}
+
+func mapEventItem(item map[string]any) models.ResourceEvent {
+	event := models.ResourceEvent{
+		Type:    getNestedString(item, "type"),
+		Reason:  getNestedString(item, "reason"),
+		Message: getNestedString(item, "message"),
+	}
+
+	if countVal, ok := item["count"]; ok {
+		if v, ok := countVal.(float64); ok {
+			c := int32(v) //nolint:gosec // event count will not overflow int32
+			event.Count = &c
+		}
+	}
+
+	if ts := getNestedString(item, "firstTimestamp"); ts != "" {
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			event.FirstTimestamp = &t
+		}
+	} else if ts := getNestedString(item, "eventTime"); ts != "" {
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			event.FirstTimestamp = &t
+		}
+	}
+
+	if ts := getNestedString(item, "lastTimestamp"); ts != "" {
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			event.LastTimestamp = &t
+		}
+	} else if event.FirstTimestamp != nil {
+		event.LastTimestamp = event.FirstTimestamp
+	}
+
+	if src := getNestedString(item, "source", "component"); src != "" {
+		event.Source = src
+	} else {
+		event.Source = getNestedString(item, "reportingComponent")
+	}
+
+	return event
+}
+
+func parseLogLines(rawLogs string) []models.PodLogEntry {
+	lines := strings.Split(rawLogs, "\n")
+	entries := make([]models.PodLogEntry, 0, len(lines))
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
+			continue
+		}
+
+		spaceIndex := strings.Index(trimmedLine, " ")
+		if spaceIndex > 0 {
+			timestampCandidate := trimmedLine[:spaceIndex]
+			if _, err := time.Parse(time.RFC3339, timestampCandidate); err == nil {
+				entries = append(entries, models.PodLogEntry{
+					Timestamp: timestampCandidate,
+					Log:       trimmedLine[spaceIndex+1:],
+				})
+				continue
+			}
+			if _, err := time.Parse(time.RFC3339Nano, timestampCandidate); err == nil {
+				entries = append(entries, models.PodLogEntry{
+					Timestamp: timestampCandidate,
+					Log:       trimmedLine[spaceIndex+1:],
+				})
+				continue
+			}
+		}
+	}
+	return entries
+}
+
+func hasOwnerReference(obj map[string]any, ownerUID string) bool {
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		return false
+	}
+	refs, ok := metadata["ownerReferences"].([]any)
+	if !ok {
+		return false
+	}
+	for _, ref := range refs {
+		refMap, ok := ref.(map[string]any)
+		if !ok {
+			continue
+		}
+		if uid, ok := refMap["uid"].(string); ok && uid == ownerUID {
+			return true
+		}
+	}
+	return false
+}
+
+func getNestedString(obj map[string]any, keys ...string) string {
+	current := obj
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			if v, ok := current[key].(string); ok {
+				return v
+			}
+			return ""
+		}
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+	return ""
+}
+
+func getStringField(obj map[string]any, key string) string {
+	if v, ok := obj[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func getAPIGroup(obj map[string]any) string {
+	apiVersion := getStringField(obj, "apiVersion")
+	if idx := strings.Index(apiVersion, "/"); idx >= 0 {
+		return apiVersion[:idx]
+	}
+	return ""
+}
+
+func getAPIVersion(obj map[string]any) string {
+	apiVersion := getStringField(obj, "apiVersion")
+	if idx := strings.Index(apiVersion, "/"); idx >= 0 {
+		return apiVersion[idx+1:]
+	}
+	return apiVersion
+}
+
+var childResourceParentKinds = map[string][]string{
+	"Pod":        {"Deployment", "Job", "CronJob"},
+	"ReplicaSet": {"Deployment"},
+	"Job":        {"CronJob"},
+}
+
+func isChildResourceKind(kind string) bool {
+	_, ok := childResourceParentKinds[kind]
+	return ok
+}
+
+func hasParentResourceInRelease(childKind string, resources []openchoreov1alpha1.ResourceStatus) bool {
+	parentKinds := childResourceParentKinds[childKind]
+	for i := range resources {
+		if slices.Contains(parentKinds, resources[i].Kind) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/openchoreo-api/services/k8sresources/service_authz.go
+++ b/internal/openchoreo-api/services/k8sresources/service_authz.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sresources
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/clients/gateway"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+)
+
+const (
+	actionViewReleaseBinding   = "releasebinding:view"
+	resourceTypeReleaseBinding = "releasebinding"
+)
+
+// k8sResourcesServiceWithAuthz wraps a Service and adds authorization checks.
+type k8sResourcesServiceWithAuthz struct {
+	internal  Service
+	k8sClient client.Client
+	authz     *services.AuthzChecker
+}
+
+var _ Service = (*k8sResourcesServiceWithAuthz)(nil)
+
+// NewServiceWithAuthz creates a k8s resources service with authorization checks.
+func NewServiceWithAuthz(k8sClient client.Client, gatewayClient *gateway.Client, authzPDP authz.PDP, logger *slog.Logger) Service {
+	return &k8sResourcesServiceWithAuthz{
+		internal:  NewService(k8sClient, gatewayClient, logger),
+		k8sClient: k8sClient,
+		authz:     services.NewAuthzChecker(authzPDP, logger),
+	}
+}
+
+func (s *k8sResourcesServiceWithAuthz) GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (*K8sResourceTreeResult, error) {
+	if err := s.checkReleaseBindingAuthz(ctx, namespaceName, releaseBindingName); err != nil {
+		return nil, err
+	}
+	return s.internal.GetResourceTree(ctx, namespaceName, releaseBindingName)
+}
+
+func (s *k8sResourcesServiceWithAuthz) GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (*models.ResourceEventsResponse, error) {
+	if err := s.checkReleaseBindingAuthz(ctx, namespaceName, releaseBindingName); err != nil {
+		return nil, err
+	}
+	return s.internal.GetResourceEvents(ctx, namespaceName, releaseBindingName, group, version, kind, name)
+}
+
+func (s *k8sResourcesServiceWithAuthz) GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName, podName string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error) {
+	if err := s.checkReleaseBindingAuthz(ctx, namespaceName, releaseBindingName); err != nil {
+		return nil, err
+	}
+	return s.internal.GetResourceLogs(ctx, namespaceName, releaseBindingName, podName, sinceSeconds)
+}
+
+// checkReleaseBindingAuthz fetches the release binding and checks authorization.
+func (s *k8sResourcesServiceWithAuthz) checkReleaseBindingAuthz(ctx context.Context, namespaceName, releaseBindingName string) error {
+	var rb openchoreov1alpha1.ReleaseBinding
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: releaseBindingName}, &rb); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return ErrReleaseBindingNotFound
+		}
+		return fmt.Errorf("failed to get release binding: %w", err)
+	}
+
+	return s.authz.Check(ctx, services.CheckRequest{
+		Action:       actionViewReleaseBinding,
+		ResourceType: resourceTypeReleaseBinding,
+		ResourceID:   releaseBindingName,
+		Hierarchy: authz.ResourceHierarchy{
+			Namespace: namespaceName,
+			Project:   rb.Spec.Owner.ProjectName,
+			Component: rb.Spec.Owner.ComponentName,
+		},
+	})
+}

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -4189,6 +4189,125 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree:
+    get:
+      operationId: getReleaseBindingK8sResourceTree
+      summary: Get K8s resource tree for a release binding
+      description: Returns a hierarchical view of all live Kubernetes resources deployed by the releases owned by this release binding, including child resources (ReplicaSets, Pods, Jobs).
+      tags: [ReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ReleaseBindingNameParam'
+      responses:
+        '200':
+          description: K8s resource tree
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/K8sResourceTreeResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/events:
+    get:
+      operationId: getReleaseBindingK8sResourceEvents
+      summary: Get K8s resource events for a release binding
+      description: Returns Kubernetes events for a specific resource in the release binding's resource tree.
+      tags: [ReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ReleaseBindingNameParam'
+        - name: group
+          in: query
+          required: true
+          description: API group of the resource (empty string for core resources)
+          schema:
+            type: string
+        - name: version
+          in: query
+          required: true
+          description: API version of the resource (e.g. v1)
+          schema:
+            type: string
+        - name: kind
+          in: query
+          required: true
+          description: Kind of the resource
+          schema:
+            type: string
+        - name: name
+          in: query
+          required: true
+          description: Name of the resource
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceEventsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs:
+    get:
+      operationId: getReleaseBindingK8sResourceLogs
+      summary: Get pod logs for a release binding
+      description: Returns logs for a specific pod in the release binding's resource tree.
+      tags: [ReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ReleaseBindingNameParam'
+        - name: podName
+          in: query
+          required: true
+          description: Name of the pod
+          schema:
+            type: string
+        - name: sinceSeconds
+          in: query
+          required: false
+          description: Number of seconds since which to show logs
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        '200':
+          description: Pod logs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourcePodLogsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   # =============================================================================
   # Deployment Pipeline Endpoints
   # =============================================================================
@@ -7922,6 +8041,39 @@ components:
           description: Log entries from the pod
           items:
             $ref: '#/components/schemas/PodLogEntry'
+
+    K8sResourceTreeResponse:
+      type: object
+      description: Response containing resource trees for all releases owned by a release binding
+      required:
+        - releases
+      properties:
+        releases:
+          type: array
+          description: Resource trees per release (dataplane and/or observabilityplane)
+          items:
+            $ref: '#/components/schemas/ReleaseResourceTree'
+
+    ReleaseResourceTree:
+      type: object
+      description: Resource tree for a single release
+      required:
+        - name
+        - targetPlane
+        - nodes
+      properties:
+        name:
+          type: string
+          description: Name of the release
+        targetPlane:
+          type: string
+          description: Target plane of the release
+          enum: [dataplane, observabilityplane]
+        nodes:
+          type: array
+          description: All resource nodes in the tree
+          items:
+            $ref: '#/components/schemas/ResourceNode'
 
     # -------------------------------------------------------------------------
     # Deploy/Promote Requests


### PR DESCRIPTION
## Purpose
                                                                                                                                                                           
  - Add three new ReleaseBinding-scoped endpoints for K8s resources: `GET .../k8sresources/tree`, `GET .../k8sresources/events`, and `GET .../k8sresources/logs`
  - Implement OpenAPI-first with new paths and schemas (`K8sResourceTreeResponse`, `ReleaseResourceTree`) in the OpenAPI spec, followed by code generation                                
  - Support multi-release resource trees (dataplane + observabilityplane) by resolving owned releases via `metav1.IsControlledBy`                                                         
  - Add `k8sresources` service package with authorization wrapper using `releasebinding:view` action

## Approach
> Summarize the solution and implementation details.

## Related Issues
resolves https://github.com/openchoreo/openchoreo/issues/2172

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
