### PR TITLE
feat(helm): enable refresh_token grant for Backstage OAuth client

### DIFF
--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -217,7 +217,8 @@ bootstrap:
               ],
               "grant_types": [
                 "authorization_code",
-                "client_credentials"
+                "client_credentials",
+                "refresh_token"
               ],
               "response_types": [
                 "code"


### PR DESCRIPTION
  Allow Thunder to issue real refresh tokens for the Backstage application,
  enabling proper token rotation and forcing re-login when the IDP is recreated.
