### PR TITLE
feat: add default roles for openchoreo

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1060,8 +1060,8 @@ openchoreoApi:
           # default: []
           # @schema
           roles:
-            # Super admin role with full permissions to all resources
-            - name: super-admin
+            # Admin role with full permissions to all resources
+            - name: admin
               system: true
               actions:
                 - "*"
@@ -1117,6 +1117,209 @@ openchoreoApi:
                 - "workload:update"
                 - "workflowrun:view"
                 - "workflowrun:update"
+
+            # Cluster reader role - read-only access to cluster-scoped platform resources.
+            # Assign alongside project-level roles to grant visibility into cluster infrastructure
+            # (e.g. so developers can see the DataPlanes and BuildPlanes their projects depend on).
+            - name: cluster-reader
+              actions:
+                - "clusterdataplane:view"
+                - "clusterbuildplane:view"
+                - "clusterobservabilityplane:view"
+                - "clustercomponenttype:view"
+                - "clustertrait:view"
+                - "clusterworkflow:view"
+
+            # Namespace reader role - read-only access to namespace-scoped platform resources.
+            # Assign alongside project-level roles to bridge the cross-scope visibility gap
+            # (e.g. so developers can see the Environments and DeploymentPipelines their projects reference).
+            - name: namespace-reader
+              actions:
+                - "namespace:view"
+                - "environment:view"
+                - "deploymentpipeline:view"
+                - "dataplane:view"
+                - "buildplane:view"
+                - "observabilityplane:view"
+                - "componenttype:view"
+                - "trait:view"
+                - "workflow:view"
+
+            # Developer role - engineers who build, deploy, and iterate on components.
+            # Assign namespace-reader and cluster-reader alongside this role so developers
+            # can view the platform resources their projects reference.
+            - name: developer
+              actions:
+                - "clusterdataplane:view"
+                - "clusterbuildplane:view"
+                - "clusterobservabilityplane:view"
+                - "clustercomponenttype:view"
+                - "clustertrait:view"
+                - "clusterworkflow:view"
+                - "namespace:view"
+                - "environment:view"
+                - "deploymentpipeline:view"
+                - "dataplane:view"
+                - "buildplane:view"
+                - "observabilityplane:view"
+                - "componenttype:view"
+                - "trait:view"
+                - "workflow:view"
+                - "project:view"
+                - "component:view"
+                - "component:create"
+                - "component:update"
+                - "component:deploy"
+                - "component:delete"
+                - "componentrelease:view"
+                - "componentrelease:create"
+                - "releasebinding:view"
+                - "releasebinding:create"
+                - "releasebinding:update"
+                - "workflowrun:view"
+                - "workflowrun:create"
+                - "secretreference:view"
+                - "secretreference:create"
+                - "secretreference:delete"
+                - "workload:view"
+                - "workload:create"
+                - "workload:update"
+                - "workload:delete"
+                - "logs:view"
+                - "metrics:view"
+                - "traces:view"
+                - "alerts:view"
+                - "rcareport:view"
+
+            # SRE role - operations engineers focused on reliability and incident response.
+            # Assign namespace-reader and cluster-reader alongside this role so SREs
+            # can view the platform infrastructure they monitor and troubleshoot.
+            - name: sre
+              actions:
+                - "clusterdataplane:view"
+                - "clusterbuildplane:view"
+                - "clusterobservabilityplane:view"
+                - "clustercomponenttype:view"
+                - "clustertrait:view"
+                - "clusterworkflow:view"
+                - "namespace:view"
+                - "environment:view"
+                - "deploymentpipeline:view"
+                - "dataplane:view"
+                - "buildplane:view"
+                - "observabilityplane:view"
+                - "componenttype:view"
+                - "trait:view"
+                - "workflow:view"
+                - "project:view"
+                - "component:view"
+                - "componentrelease:view"
+                - "releasebinding:view"
+                - "releasebinding:update"
+                - "workflowrun:view"
+                - "workflowrun:create"
+                - "workload:view"
+                - "workload:create"
+                - "secretreference:view"
+                - "logs:view"
+                - "metrics:view"
+                - "traces:view"
+                - "alerts:view"
+                - "incidents:view"
+                - "rcareport:view"
+                - "rcareport:update"
+                - "rcareport:delete"
+                - "observabilityalertsnotificationchannel:view"
+
+            # Platform engineer role - engineers managing the OpenChoreo platform infrastructure
+            - name: platform-engineer
+              actions:
+                - "namespace:view"
+                - "namespace:create"
+                - "project:view"
+                - "project:create"
+                - "project:delete"
+                - "component:view"
+                - "componentrelease:view"
+                - "releasebinding:view"
+                - "environment:view"
+                - "environment:create"
+                - "environment:update"
+                - "environment:delete"
+                - "dataplane:view"
+                - "dataplane:create"
+                - "dataplane:update"
+                - "dataplane:delete"
+                - "buildplane:view"
+                - "buildplane:create"
+                - "buildplane:update"
+                - "buildplane:delete"
+                - "observabilityplane:view"
+                - "observabilityplane:create"
+                - "observabilityplane:update"
+                - "observabilityplane:delete"
+                - "componenttype:view"
+                - "componenttype:create"
+                - "trait:view"
+                - "trait:create"
+                - "workflow:view"
+                - "workflow:create"
+                - "workflowrun:view"
+                - "workflowrun:create"
+                - "deploymentpipeline:view"
+                - "deploymentpipeline:create"
+                - "deploymentpipeline:update"
+                - "deploymentpipeline:delete"
+                - "secretreference:view"
+                - "secretreference:create"
+                - "secretreference:update"
+                - "secretreference:delete"
+                - "workload:view"
+                - "workload:create"
+                - "logs:view"
+                - "metrics:view"
+                - "traces:view"
+                - "alerts:view"
+                - "incidents:view"
+                - "rcareport:view"
+                - "rcareport:update"
+                - "rcareport:delete"
+                - "observabilityalertsnotificationchannel:view"
+                - "observabilityalertsnotificationchannel:create"
+                - "observabilityalertsnotificationchannel:update"
+                - "observabilityalertsnotificationchannel:delete"
+                - "role:view"
+                - "role:create"
+                - "role:update"
+                - "role:delete"
+                - "rolemapping:view"
+                - "rolemapping:create"
+                - "rolemapping:update"
+                - "rolemapping:delete"
+                - "clusterdataplane:view"
+                - "clusterdataplane:create"
+                - "clusterdataplane:update"
+                - "clusterdataplane:delete"
+                - "clusterbuildplane:view"
+                - "clusterbuildplane:create"
+                - "clusterbuildplane:update"
+                - "clusterbuildplane:delete"
+                - "clusterobservabilityplane:view"
+                - "clusterobservabilityplane:create"
+                - "clusterobservabilityplane:update"
+                - "clusterobservabilityplane:delete"
+                - "clustercomponenttype:view"
+                - "clustercomponenttype:create"
+                - "clustercomponenttype:update"
+                - "clustercomponenttype:delete"
+                - "clustertrait:view"
+                - "clustertrait:create"
+                - "clustertrait:update"
+                - "clustertrait:delete"
+                - "clusterworkflow:view"
+                - "clusterworkflow:create"
+                - "clusterworkflow:update"
+                - "clusterworkflow:delete"
 
             # Observer service role for resolving resource UIDs
             - name: observer
@@ -1198,15 +1401,48 @@ openchoreoApi:
           # default: []
           # @schema
           mappings:
-            # Super admin mapping - grants admins group full access
-            - name: super-admin-binding
+            # Admin mapping - grants admins group full access
+            - name: admin-binding
               system: true
               roleMappings:
                 - roleRef:
-                    name: super-admin
+                    name: admin
               entitlement:
                 claim: groups
                 value: admins
+              effect: allow
+            
+            # Developer mapping - grants developers group developer access
+            - name: developer-binding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: developer
+              entitlement:
+                claim: groups
+                value: developers
+              effect: allow
+
+            # PE mapping - grants platform engineers group platform engineer access
+            - name: platform-engineer-binding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: platform-engineer
+              entitlement:
+                claim: groups
+                value: platform-engineers
+              effect: allow
+
+            # SRE mapping - grants SREs group SRE access
+            - name: sre-binding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: sre
+              entitlement:
+                claim: groups
+                value: sres
               effect: allow
 
             # Backstage catalog reader mapping - grants backstage service account read access
@@ -1258,7 +1494,7 @@ openchoreoApi:
               system: true
               roleMappings:
                 - roleRef:
-                    name: super-admin
+                    name: admin
               entitlement:
                 claim: sub
                 value: service_mcp_client

--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -105,6 +105,9 @@ bootstrap:
             \"name\": \"openchoreo-user\",
             \"ouId\": \"$ORG_UNIT_ID\",
             \"allowSelfRegistration\": true,
+            \"systemAttributes\": {
+              \"display\": \"username\"
+            },
             \"schema\": {
               \"username\": {
                 \"type\": \"string\",
@@ -131,63 +134,86 @@ bootstrap:
         log_info "User schema created successfully"
       fi
 
-      log_info "Checking if user 'admin@openchoreo.dev' already exists..."
-      existing_users=$(curl -s --max-time 10 "${THUNDER_URL}/users")
+      # Returns the ID of an existing user by username, or creates and returns it.
+      # Usage: ensure_user <username> <password> <given_name> <family_name>
+      ensure_user() {
+        local username="$1" password="$2" given_name="$3" family_name="$4"
+        local existing_users user_id response
 
-      if echo "$existing_users" | grep -q '"username" *: *"admin@openchoreo.dev"'; then
-        log_info "User 'admin@openchoreo.dev' already exists, getting ID..."
-        USER_ID_0=$(echo "$existing_users" | tr '\n' ' ' | sed 's/" *: *"/":"/g' | grep -o '"username":"admin@openchoreo.dev"[^}]*"id":"[^"]*"\|"id":"[^"]*"[^}]*"username":"admin@openchoreo.dev"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-      else
-        log_info "User does not exist, creating user 'admin@openchoreo.dev'..."
-        USER_RESPONSE=$(curl --location "${THUNDER_URL}/users" \
-          --header 'accept: application/json' \
-          --header 'Content-Type: application/json' \
-          --data "{
-            \"type\": \"openchoreo-user\",
-            \"organizationUnit\": \"$ORG_UNIT_ID\",
-            \"attributes\": {
-              \"username\": \"admin@openchoreo.dev\",
-              \"password\": \"Admin@123\",
-              \"given_name\": \"Admin\",
-              \"family_name\": \"User\"
-            }
-          }" \
-          --fail-with-body \
-          --max-time 30 \
-          --retry 3 \
-          --retry-delay 5)
-
-        log_info "User 'admin@openchoreo.dev' created successfully"
-        USER_ID_0=$(echo "$USER_RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-      fi
-
-      log_info "Checking if group 'admins' already exists..."
-      existing_groups=$(curl -s --max-time 10 "${THUNDER_URL}/groups")
-
-      if echo "$existing_groups" | grep -q '"name" *: *"admins"'; then
-        log_info "Group 'admins' already exists, skipping creation"
-      else
-        log_info "Group does not exist, creating group 'admins' with members..."
-        GROUP_MEMBERS=""
-        if [ -n "$USER_ID_0" ]; then
-          GROUP_MEMBERS="{\"type\":\"user\",\"id\":\"$USER_ID_0\"}"
+        existing_users=$(curl -s --max-time 10 "${THUNDER_URL}/users")
+        if echo "$existing_users" | grep -q "\"username\" *: *\"${username}\""; then
+          log_info "User '${username}' already exists, getting ID..." >&2
+          user_id=$(echo "$existing_users" | tr '\n' ' ' | sed 's/" *: *"/":"/g' \
+            | grep -o "\"username\":\"${username}\"[^}]*\"id\":\"[^\"]*\"\|\"id\":\"[^\"]*\"[^}]*\"username\":\"${username}\"" \
+            | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+        else
+          log_info "Creating user '${username}'..." >&2
+          response=$(curl --location "${THUNDER_URL}/users" \
+            --header 'accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data "{
+              \"type\": \"openchoreo-user\",
+              \"organizationUnit\": \"$ORG_UNIT_ID\",
+              \"attributes\": {
+                \"username\": \"${username}\",
+                \"password\": \"${password}\",
+                \"given_name\": \"${given_name}\",
+                \"family_name\": \"${family_name}\"
+              }
+            }" \
+            --fail-with-body \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 5)
+          log_info "User '${username}' created successfully" >&2
+          user_id=$(echo "$response" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
         fi
+        echo "$user_id"
+      }
+
+      # Creates a group with a single member if it does not already exist.
+      # Usage: ensure_group <group_name> <description> <member_user_id>
+      ensure_group() {
+        local group_name="$1" description="$2" member_id="$3"
+        local existing_groups group_members
+
+        existing_groups=$(curl -s --max-time 10 "${THUNDER_URL}/groups")
+        if echo "$existing_groups" | grep -q "\"name\" *: *\"${group_name}\""; then
+          log_info "Group '${group_name}' already exists, skipping creation"
+          return
+        fi
+
+        group_members=""
+        if [ -n "$member_id" ]; then
+          group_members="{\"type\":\"user\",\"id\":\"${member_id}\"}"
+        fi
+
+        log_info "Creating group '${group_name}'..."
         curl --location "${THUNDER_URL}/groups" \
           --header 'accept: application/json' \
           --header 'Content-Type: application/json' \
           --data "{
-            \"name\": \"admins\",
+            \"name\": \"${group_name}\",
             \"organizationUnitId\": \"$ORG_UNIT_ID\",
-            \"description\": \"Admins group\",
-            \"members\": [$GROUP_MEMBERS]
+            \"description\": \"${description}\",
+            \"members\": [${group_members}]
           }" \
           --fail-with-body \
           --max-time 30 \
           --retry 3 \
           --retry-delay 5
+        log_info "Group '${group_name}' created successfully"
+      }
 
-        log_info "Group 'admins' created successfully with members"
-      fi
+      ADMIN_ID=$(ensure_user "admin@openchoreo.dev"            "Admin@123" "Admin"     "User")
+      DEVELOPER_ID=$(ensure_user "developer@openchoreo.dev"   "Dev@123"   "Developer" "User")
+      PE_ID=$(ensure_user "platform-engineer@openchoreo.dev"  "PE@123"    "Platform"  "Engineer")
+      SRE_ID=$(ensure_user "sre@openchoreo.dev"               "SRE@123"   "SRE"       "User")
+
+      ensure_group "admins"             "Admins group"             "$ADMIN_ID"
+      ensure_group "developers"         "Developers group"         "$DEVELOPER_ID"
+      ensure_group "platform-engineers" "Platform Engineers group" "$PE_ID"
+      ensure_group "sres"               "SREs group"               "$SRE_ID"
 
     51-backstage-app.sh: |
       #!/bin/bash

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -13,11 +13,11 @@ openchoreoApi:
           # Helm replaces lists so all mappings must be specified here.
           # The chart defaults provide the first 3; quick-start adds the CLI binding.
           mappings:
-            - name: super-admin-binding
+            - name: admin-binding
               system: true
               roleMappings:
                 - roleRef:
-                    name: super-admin
+                    name: admin
               entitlement:
                 claim: groups
                 value: admins
@@ -40,10 +40,10 @@ openchoreoApi:
                 claim: sub
                 value: openchoreo-rca-agent
               effect: allow
-            - name: quickstart-cli-super-admin-binding
+            - name: quickstart-cli-admin-binding
               roleMappings:
                 - roleRef:
-                    name: super-admin
+                    name: admin
               entitlement:
                 claim: sub
                 value: openchoreo-cli-quickstart

--- a/internal/authz/casbin/k8s_watcher_test.go
+++ b/internal/authz/casbin/k8s_watcher_test.go
@@ -178,13 +178,13 @@ func TestAuthzInformerHandler_HandleAddClusterRole(t *testing.T) {
 		{
 			name: "add cluster role with global wildcard",
 			clusterRole: &authzv1alpha1.ClusterAuthzRole{
-				ObjectMeta: metav1.ObjectMeta{Name: "super-admin"},
+				ObjectMeta: metav1.ObjectMeta{Name: "admin"},
 				Spec: authzv1alpha1.ClusterAuthzRoleSpec{
 					Actions: []string{"*"},
 				},
 			},
 			wantPolicies: [][]string{
-				{"super-admin", "*", "*"},
+				{"admin", "*", "*"},
 			},
 		},
 	}
@@ -552,14 +552,14 @@ func TestAuthzInformerHandler_HandleAddClusterBinding(t *testing.T) {
 					RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
 						RoleRef: authzv1alpha1.RoleRef{
 							Kind: CRDTypeClusterAuthzRole,
-							Name: "super-admin",
+							Name: "admin",
 						},
 					}},
 					Effect: authzv1alpha1.EffectAllow,
 				},
 			},
 			wantPolicies: [][]string{
-				{"groups:platform-admins", "*", "super-admin", "*", "allow", "{}", "global-admin-binding"},
+				{"groups:platform-admins", "*", "admin", "*", "allow", "{}", "global-admin-binding"},
 			},
 		},
 		{
@@ -757,7 +757,7 @@ func TestAuthzInformerHandler_HandleAddClusterBinding_Idempotent(t *testing.T) {
 			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
 				RoleRef: authzv1alpha1.RoleRef{
 					Kind: CRDTypeClusterAuthzRole,
-					Name: "super-admin",
+					Name: "admin",
 				},
 			}},
 			Effect: authzv1alpha1.EffectAllow,
@@ -1608,7 +1608,7 @@ func TestAuthzInformerHandler_HandleDeleteClusterBinding(t *testing.T) {
 	handler, enforcer := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
 
 	// Setup: directly add policy to Casbin
-	_, err := enforcer.AddPolicy("groups:platform-admins", "*", "super-admin", "*", "allow", "{}", "global-admin-binding")
+	_, err := enforcer.AddPolicy("groups:platform-admins", "*", "admin", "*", "allow", "{}", "global-admin-binding")
 	if err != nil {
 		t.Fatalf("AddPolicy() error = %v", err)
 	}
@@ -1623,7 +1623,7 @@ func TestAuthzInformerHandler_HandleDeleteClusterBinding(t *testing.T) {
 			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
 				RoleRef: authzv1alpha1.RoleRef{
 					Kind: CRDTypeClusterAuthzRole,
-					Name: "super-admin",
+					Name: "admin",
 				},
 			}},
 			Effect: authzv1alpha1.EffectAllow,
@@ -1634,7 +1634,7 @@ func TestAuthzInformerHandler_HandleDeleteClusterBinding(t *testing.T) {
 		t.Fatalf("handleDeleteClusterBinding() error = %v", err)
 	}
 
-	hasPolicy, _ := enforcer.HasPolicy("groups:platform-admins", "*", "super-admin", "*", "allow", "{}", "global-admin-binding")
+	hasPolicy, _ := enforcer.HasPolicy("groups:platform-admins", "*", "admin", "*", "allow", "{}", "global-admin-binding")
 	if hasPolicy {
 		t.Error("policy should be removed after delete")
 	}


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2239

This pull request updates the role-based access control configuration and related tests, primarily replacing the `super-admin` role with a new `admin` role and expanding the role definitions. The changes ensure more granular and clearly defined permissions for various user types and align test cases with the updated role structure.

Role definition and mapping updates:

* Replaced the `super-admin` role with an `admin` role, granting full permissions to all resources.
* Added new roles: `developer`, `sre`, and `platform-engineer`, each with distinct sets of actions to better reflect typical responsibilities and access requirements.

Role-to-entitlement mapping changes:

* Updated mappings and bindings to reference the `admin` role instead of `super-admin`, including renaming mapping names and role references in both `install/helm/openchoreo-control-plane/values.yaml` and `install/quick-start/.values-cp.yaml`. [[1]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L1149-R1271) [[2]](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9L1179-R1298) [[3]](diffhunk://#diff-71f7677939b8ba22cd9c67bae1a973dfad964b07cb75be634cdbb87f0c8c1977L16-R18) [[4]](diffhunk://#diff-71f7677939b8ba22cd9c67bae1a973dfad964b07cb75be634cdbb87f0c8c1977L37-R39)

Test updates for new role structure:

* Modified test cases in `internal/authz/casbin/k8s_watcher_test.go` to use `admin` instead of `super-admin` in cluster role and binding scenarios, ensuring tests reflect the updated role naming and logic. [[1]](diffhunk://#diff-6f0f662d751cf37c5d3400ac774e04cd69f7de06569735fb4585a95af117e7e4L181-R187) [[2]](diffhunk://#diff-6f0f662d751cf37c5d3400ac774e04cd69f7de06569735fb4585a95af117e7e4L480-R485) [[3]](diffhunk://#diff-6f0f662d751cf37c5d3400ac774e04cd69f7de06569735fb4585a95af117e7e4L540-R540) [[4]](diffhunk://#diff-6f0f662d751cf37c5d3400ac774e04cd69f7de06569735fb4585a95af117e7e4L819-R819) [[5]](diffhunk://#diff-6f0f662d751cf37c5d3400ac774e04cd69f7de06569735fb4585a95af117e7e4L833-R833) [[6]](diffhunk://#diff-6f0f662d751cf37c5d3400ac774e04cd69f7de06569735fb4585a95af117e7e4L843-R843)