### PR TITLE
fix(helm): add workload:view to backstage-catalog-reader role

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1071,6 +1071,7 @@ openchoreoApi:
                 - "dataplane:view"
                 - "environment:view"
                 - "trait:view"
+                - "workload:view"
                 - "buildplane:view"
                 - "clusterbuildplane:view"
                 - "workflow:view"


### PR DESCRIPTION
  The Backstage catalog entity provider needs to read workload endpoints
  to create API/Endpoint entities in the catalog. Without this permission,
  the authz layer filters out all workloads, returning empty lists
