### PR TITLE
fix: add short descriptions for default component types

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -103,6 +103,8 @@ kind: ComponentType
 metadata:
   name: worker
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for background workers"
 spec:
   workloadType: deployment
 
@@ -247,6 +249,8 @@ kind: ComponentType
 metadata:
   name: service
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for backend services that expose HTTP endpoints"
 spec:
   workloadType: deployment
 
@@ -470,6 +474,8 @@ kind: ComponentType
 metadata:
   name: web-application
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for web applications"
 spec:
   workloadType: deployment
 
@@ -673,6 +679,8 @@ kind: ComponentType
 metadata:
   name: scheduled-task
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for scheduled tasks"
 spec:
   workloadType: cronjob
 

--- a/samples/getting-started/component-types/scheduled-task.yaml
+++ b/samples/getting-started/component-types/scheduled-task.yaml
@@ -3,6 +3,8 @@ kind: ComponentType
 metadata:
   name: scheduled-task
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for scheduled tasks"
 spec:
   workloadType: cronjob
 

--- a/samples/getting-started/component-types/service.yaml
+++ b/samples/getting-started/component-types/service.yaml
@@ -3,6 +3,8 @@ kind: ComponentType
 metadata:
   name: service
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for backend services that expose HTTP endpoints"
 spec:
   workloadType: deployment
 

--- a/samples/getting-started/component-types/webapp.yaml
+++ b/samples/getting-started/component-types/webapp.yaml
@@ -3,6 +3,8 @@ kind: ComponentType
 metadata:
   name: web-application
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for web applications"
 spec:
   workloadType: deployment
 

--- a/samples/getting-started/component-types/worker.yaml
+++ b/samples/getting-started/component-types/worker.yaml
@@ -3,6 +3,8 @@ kind: ComponentType
 metadata:
   name: worker
   namespace: default
+  annotations:
+    openchoreo.dev/description: "Component type for background workers"
 spec:
   workloadType: deployment
 


### PR DESCRIPTION
This pull request adds descriptive annotations to several `ComponentType` YAML definitions in the `samples/getting-started` directory. These annotations provide clearer descriptions for each component type, improving documentation and maintainability.

Enhancements to component type documentation:

* Added `openchoreo.dev/description` annotation to `worker` component type, describing it as a background worker. (`samples/getting-started/all.yaml`, `samples/getting-started/component-types/worker.yaml`) [[1]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1R106-R107) [[2]](diffhunk://#diff-4eb6ae568aa87ddde85b4ab705a0b31056db5e63e0cf3c776ec4506c898ae949R6-R7)
* Added `openchoreo.dev/description` annotation to `service` component type, describing it as a backend service that exposes HTTP endpoints. (`samples/getting-started/all.yaml`, `samples/getting-started/component-types/service.yaml`) [[1]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1R252-R253) [[2]](diffhunk://#diff-e7fd3afa8933331c071adf4bbe3f680c0af2980651249668094a6e3be5d513dbR6-R7)
* Added `openchoreo.dev/description` annotation to `web-application` component type, describing it as a web application. (`samples/getting-started/all.yaml`, `samples/getting-started/component-types/webapp.yaml`) [[1]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1R477-R478) [[2]](diffhunk://#diff-b13933777368358a92e3d37f39f957b5901c4789656abd599cd5e6ed63c58bccR6-R7)
* Added `openchoreo.dev/description` annotation to `scheduled-task` component type, describing it as a scheduled task. (`samples/getting-started/all.yaml`, `samples/getting-started/component-types/scheduled-task.yaml`) [[1]](diffhunk://#diff-52dc5e708e77cc26324d1ac8587a47c1dc35983432b7a2a6ee169a006e029eb1R682-R683) [[2]](diffhunk://#diff-8eede48db25affad972e443e2f17c19a80c445be15f94cad9d33f831ad89f432R6-R7)