### PR TITLE
fix(cli): prevent cache from skipping entire tree when root-dir is "."

### DIFF
--- a/pkg/fsindex/cache/cache.go
+++ b/pkg/fsindex/cache/cache.go
@@ -234,14 +234,15 @@ func (pi *PersistentIndex) computeDirectoryState() (string, map[string]FileState
 			return nil // Skip errors
 		}
 
-		// Skip cache directory
-		if d.IsDir() && d.Name() == DirName {
-			return filepath.SkipDir
-		}
-
-		// Skip hidden directories
-		if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
-			return filepath.SkipDir
+		if d.IsDir() && path != pi.repoPath {
+			// Skip cache directory
+			if d.Name() == DirName {
+				return filepath.SkipDir
+			}
+			// Skip hidden directories
+			if strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
 		}
 
 		if !d.IsDir() && isYAMLFile(path) {
@@ -300,7 +301,7 @@ func (pi *PersistentIndex) computeCurrentDirectoryHash() (string, error) {
 		if err != nil {
 			return nil
 		}
-		if d.IsDir() && (d.Name() == DirName || strings.HasPrefix(d.Name(), ".")) {
+		if d.IsDir() && path != pi.repoPath && (d.Name() == DirName || strings.HasPrefix(d.Name(), ".")) {
 			return filepath.SkipDir
 		}
 		if !d.IsDir() && isYAMLFile(path) {
@@ -377,7 +378,7 @@ func (pi *PersistentIndex) getChangedFiles() ([]string, error) {
 		if err != nil {
 			return nil
 		}
-		if d.IsDir() && (d.Name() == DirName || strings.HasPrefix(d.Name(), ".")) {
+		if d.IsDir() && path != pi.repoPath && (d.Name() == DirName || strings.HasPrefix(d.Name(), ".")) {
 			return filepath.SkipDir
 		}
 		if d.IsDir() || !isYAMLFile(path) {


### PR DESCRIPTION
## Purpose

### Summary
  - Fixed a cache invalidation bug in the filesystem index where passing `--root-dir .` (relative path) caused the cache to never invalidate
  - The root cause: `filepath.WalkDir(".")` visits the root as `d.Name() == "."`, which the hidden-directory filter (`strings.HasPrefix(d.Name(), ".")`) incorrectly matched, skipping the entire directory tree
  - This resulted in an empty directory hash and empty file states, so subsequent runs always used the stale cached index

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
