### PR TITLE
feat(cli): optional --output-path for componentrelease gen (fs mode)

### DIFF
--- a/internal/occ/cmd/componentrelease/componentrelease.go
+++ b/internal/occ/cmd/componentrelease/componentrelease.go
@@ -168,7 +168,7 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 		if params.ProjectName == "" {
 			return fmt.Errorf("project name is required when specifying --component")
 		}
-		return cr.generateForComponent(gen, params.ComponentName, params.ProjectName, namespace, baseDir, customOutputPath, params.ReleaseName, params.DryRun, releaseConfig)
+		return cr.generateForComponent(gen, params.ComponentName, params.ProjectName, namespace, baseDir, customOutputPath, params.ReleaseName, params.DryRun, releaseConfig, resolver)
 	}
 
 	// Project-only scope (all components in project)
@@ -252,7 +252,7 @@ func (cr *ComponentRelease) generateForProject(gen *generator.ReleaseGenerator, 
 	return cr.writeResults(result, baseDir, customOutputPath, dryRun, releaseConfig, resolver)
 }
 
-func (cr *ComponentRelease) generateForComponent(gen *generator.ReleaseGenerator, component, project, namespace, baseDir, customOutputPath, customReleaseName string, dryRun bool, releaseConfig *occonfig.ReleaseConfig) error {
+func (cr *ComponentRelease) generateForComponent(gen *generator.ReleaseGenerator, component, project, namespace, baseDir, customOutputPath, customReleaseName string, dryRun bool, releaseConfig *occonfig.ReleaseConfig, resolver output.OutputDirResolverFunc) error {
 	release, err := gen.GenerateRelease(generator.ReleaseOptions{
 		ComponentName: component,
 		ProjectName:   project,
@@ -270,14 +270,24 @@ func (cr *ComponentRelease) generateForComponent(gen *generator.ReleaseGenerator
 	// Write to file
 	writer := output.NewWriter(baseDir)
 
-	// Determine output directory using config if available
+	// Determine output directory: config → --output-path → resolver → default
 	var componentOutputDir string
 	if releaseConfig != nil {
 		componentOutputDir = releaseConfig.GetReleaseOutputDir(project, component)
 	}
-	// If user provided --output-path, use it; otherwise use config or default
 	if componentOutputDir == "" && customOutputPath != "" {
 		componentOutputDir = customOutputPath
+	}
+	if componentOutputDir == "" && resolver != nil {
+		componentOutputDir = resolver(project, component)
+	}
+
+	// Check for existing release with the same name (only for user-provided names)
+	if customReleaseName != "" && componentOutputDir != "" {
+		candidatePath := filepath.Join(componentOutputDir, customReleaseName+".yaml")
+		if _, err := os.Stat(candidatePath); err == nil {
+			return fmt.Errorf("a component release with name %q already exists at %s", customReleaseName, candidatePath)
+		}
 	}
 
 	writeOpts := output.WriteOptions{

--- a/internal/occ/cmd/componentrelease/resolver.go
+++ b/internal/occ/cmd/componentrelease/resolver.go
@@ -4,7 +4,6 @@
 package componentrelease
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
@@ -17,8 +16,7 @@ import (
 //
 // Resolution priority:
 //  1. If existing releases exist for the component in the index, use the same directory.
-//  2. If no existing releases, use a "releases/" directory alongside the component file.
-//  3. If "releases/" already exists at that location, use "releases-<componentName>/" to avoid conflicts.
+//  2. Otherwise, use a "releases/" directory alongside the component file.
 func buildOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.OutputDirResolverFunc {
 	return func(projectName, componentName string) string {
 		// Priority 1: Use directory of existing releases
@@ -27,21 +25,12 @@ func buildOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.Outp
 			return filepath.Dir(releases[0].FilePath)
 		}
 
-		// Look up the component to find its file path
+		// Priority 2: Use "releases/" next to the component file
 		compEntry, ok := ocIndex.GetComponent(namespace, componentName)
 		if !ok {
 			return "" // fall through to hardcoded default
 		}
 
-		componentDir := filepath.Dir(compEntry.FilePath)
-		releasesDir := filepath.Join(componentDir, "releases")
-
-		// Priority 2: Use "releases/" next to the component file (if it doesn't already exist)
-		if _, err := os.Stat(releasesDir); os.IsNotExist(err) {
-			return releasesDir
-		}
-
-		// Priority 3: Use "releases-<componentName>/" to avoid conflicts
-		return filepath.Join(componentDir, "releases-"+componentName)
+		return filepath.Join(filepath.Dir(compEntry.FilePath), "releases")
 	}
 }

--- a/internal/occ/cmd/componentrelease/resolver_test.go
+++ b/internal/occ/cmd/componentrelease/resolver_test.go
@@ -62,10 +62,10 @@ func TestBuildOutputDirResolver(t *testing.T) {
 		}
 	})
 
-	t.Run("priority 3: releases dir already exists, use releases-<name>", func(t *testing.T) {
+	t.Run("releases dir already exists (empty): still uses releases/", func(t *testing.T) {
 		idx := index.New("/repo")
 
-		// Use a temp directory and create the releases/ dir to simulate conflict
+		// Use a temp directory and create an empty releases/ dir
 		tmpDir := t.TempDir()
 		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
 		releasesDir := filepath.Join(compDir, "releases")
@@ -83,7 +83,7 @@ func TestBuildOutputDirResolver(t *testing.T) {
 		resolver := buildOutputDirResolver(ocIndex, namespace)
 
 		got := resolver("my-proj", "my-comp")
-		want := filepath.Join(compDir, "releases-my-comp")
+		want := filepath.Join(compDir, "releases")
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}

--- a/internal/occ/cmd/releasebinding/resolver.go
+++ b/internal/occ/cmd/releasebinding/resolver.go
@@ -4,7 +4,6 @@
 package releasebinding
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
@@ -17,8 +16,7 @@ import (
 //
 // Resolution priority:
 //  1. If existing bindings exist for the component in the index, use the same directory.
-//  2. If no existing bindings, use a "release-bindings/" directory alongside the component file.
-//  3. If "release-bindings/" already exists at that location, use "release-bindings-<componentName>/" to avoid conflicts.
+//  2. Otherwise, use a "release-bindings/" directory alongside the component file.
 func buildBindingOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.OutputDirResolverFunc {
 	return func(projectName, componentName string) string {
 		// Priority 1: Use directory of existing bindings
@@ -30,21 +28,12 @@ func buildBindingOutputDirResolver(ocIndex *fsmode.Index, namespace string) outp
 			}
 		}
 
-		// Look up the component to find its file path
+		// Priority 2: Use "release-bindings/" next to the component file
 		compEntry, ok := ocIndex.GetComponent(namespace, componentName)
 		if !ok {
 			return "" // fall through to hardcoded default
 		}
 
-		componentDir := filepath.Dir(compEntry.FilePath)
-		bindingsDir := filepath.Join(componentDir, "release-bindings")
-
-		// Priority 2: Use "release-bindings/" next to the component file (if it doesn't already exist)
-		if _, err := os.Stat(bindingsDir); os.IsNotExist(err) {
-			return bindingsDir
-		}
-
-		// Priority 3: Use "release-bindings-<componentName>/" to avoid conflicts
-		return filepath.Join(componentDir, "release-bindings-"+componentName)
+		return filepath.Join(filepath.Dir(compEntry.FilePath), "release-bindings")
 	}
 }

--- a/internal/occ/cmd/releasebinding/resolver_test.go
+++ b/internal/occ/cmd/releasebinding/resolver_test.go
@@ -61,7 +61,7 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 		}
 	})
 
-	t.Run("priority 3: release-bindings dir already exists, use release-bindings-<name>", func(t *testing.T) {
+	t.Run("release-bindings dir already exists (empty): still uses release-bindings/", func(t *testing.T) {
 		idx := index.New("/repo")
 
 		tmpDir := t.TempDir()
@@ -81,7 +81,7 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
 
 		got := resolver("my-proj", "my-comp")
-		want := filepath.Join(compDir, "release-bindings-my-comp")
+		want := filepath.Join(compDir, "release-bindings")
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}

--- a/pkg/cli/cmd/componentrelease/generate.go
+++ b/pkg/cli/cmd/componentrelease/generate.go
@@ -56,7 +56,6 @@ func newGenerateCmd() *cobra.Command {
 			projectSet := isFlagInArgs("--project")
 			componentSet := isFlagInArgs("--component")
 			nameSet := isFlagInArgs("--name")
-			outputPathSet := isFlagInArgs("--output-path")
 
 			// Validation logic:
 			// 1. If --all is set, reject --project, --component, or --name
@@ -73,12 +72,8 @@ func newGenerateCmd() *cobra.Command {
 				if !projectSet {
 					return fmt.Errorf("--component requires --project to be specified")
 				}
-				// 3. If --component is set, --output-path MUST also be set
-				if !outputPathSet {
-					return fmt.Errorf("--output-path is required when specifying --component")
-				}
-				// --component with --project and --output-path is valid
-				// --name is optional when --component is specified
+				// --component with --project is valid
+				// --output-path and --name are optional when --component is specified
 			} else if projectSet {
 				// 4. --project alone is valid (processes all components in that project)
 				// But cannot use --name with --project alone


### PR DESCRIPTION
## Purpose
### Summary
  - Made `--output-path` optional for `componentrelease generate --component`, resolving the directory via: release-config → `--output-path` → filesystem index resolver → default
  - Added duplicate name check: `--name <existing>` now errors with "already exists" instead of silently overwriting
  - Fixed output directory resolvers for both `componentrelease` and `releasebinding` — removed incorrect "priority 3" logic that created `releases-<componentName>/` directories when`releases/` existed but was empty

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
