### PR TITLE
fix: pin version of generate workload cr template

### DIFF
--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -63,7 +63,7 @@ spec:
               echo "Found workload.yaml descriptor, using it for workload creation"
               podman run --rm --network=none \
               -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+              ghcr.io/openchoreo/openchoreo-cli:v0.17.0 \
                 workload create \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \
@@ -74,7 +74,7 @@ spec:
               echo "No workload.yaml descriptor found, creating workload without descriptor"
               podman run --rm --network=none \
               -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+              ghcr.io/openchoreo/openchoreo-cli:v0.17.0 \
                 workload create \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \

--- a/samples/getting-started/workflow-templates/generate-workload.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload.yaml
@@ -48,7 +48,7 @@ spec:
               echo "Found workload.yaml descriptor, using it for workload creation"
               podman run --rm --network=none \
               -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+              ghcr.io/openchoreo/openchoreo-cli:v0.17.0 \
                 workload create \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \
@@ -59,7 +59,7 @@ spec:
               echo "No workload.yaml descriptor found, creating workload without descriptor"
               podman run --rm --network=none \
               -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+              ghcr.io/openchoreo/openchoreo-cli:v0.17.0 \
                 workload create \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
`generate-workload-cr` is currently using the latest-dev CLI image. This causes issues with previous releases, as the workload spec is incompatible across versions.

As a temporary fix, pinning the CLI image version in the release branch. However, we need a better approach to handle version compatibility going forward.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
