### PR TITLE
fix(api): implement OpenAPI GetReady handler

### DIFF
--- a/internal/openchoreo-api/api/handlers/operations.go
+++ b/internal/openchoreo-api/api/handlers/operations.go
@@ -68,5 +68,5 @@ func (h *Handler) GetReady(
 	ctx context.Context,
 	request gen.GetReadyRequestObject,
 ) (gen.GetReadyResponseObject, error) {
-	return nil, errNotImplemented
+	return gen.GetReady200TextResponse("Ready"), nil
 }


### PR DESCRIPTION
## Summary
- Implement the OpenAPI `GetReady` handler which was returning `errNotImplemented` (HTTP 500)
- The readiness probe (`/ready`) now returns `200 Ready` via the OpenAPI handler, matching the legacy handler behavior
- This fixes readiness probe failures after the default routing was switched to OpenAPI routes

## Test plan
- [x] Verified `/ready` returns 200 via OpenAPI handler (default)
- [x] Verified `/ready` returns 200 via legacy handler (`X-Use-Legacy-Routes: true`)
- [x] Verified `/health` returns 200 on both handlers
- [x] Verified deployment rollout succeeds without readiness probe failures