### PR TITLE
fix(cli): include eps and conns in generated ComponentRelease

### DIFF
--- a/internal/occ/fsmode/generator/component_release.go
+++ b/internal/occ/fsmode/generator/component_release.go
@@ -130,6 +130,21 @@ func (g *ReleaseGenerator) buildTraitsData(traitRefs []typed2.TraitRef) (
 	return traitsMap, profileTraits, nil
 }
 
+// buildWorkloadData constructs the workload section for the ComponentRelease spec,
+// including container, endpoints, and connections from the Workload resource.
+func (g *ReleaseGenerator) buildWorkloadData(wl *typed2.Workload) map[string]interface{} {
+	workloadMap := map[string]interface{}{
+		"container": wl.GetContainer(),
+	}
+	if endpoints := wl.GetEndpoints(); len(endpoints) > 0 {
+		workloadMap["endpoints"] = endpoints
+	}
+	if connections := wl.GetConnections(); len(connections) > 0 {
+		workloadMap["connections"] = connections
+	}
+	return workloadMap
+}
+
 // buildRelease constructs the ComponentRelease unstructured object
 func (g *ReleaseGenerator) buildRelease(
 	releaseName, namespace string,
@@ -149,9 +164,7 @@ func (g *ReleaseGenerator) buildRelease(
 			"schema":       ct.GetSchema(),
 			"resources":    ct.GetResources(),
 		},
-		"workload": map[string]interface{}{
-			"container": wl.GetContainer(),
-		},
+		"workload": g.buildWorkloadData(wl),
 	}
 
 	// Build componentProfile only if there's content to add

--- a/internal/occ/fsmode/generator/component_release_test.go
+++ b/internal/occ/fsmode/generator/component_release_test.go
@@ -1,0 +1,332 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
+)
+
+// addComponent adds a Component resource entry to the index.
+func addComponent(t *testing.T, idx *index.Index, namespace, name, project, componentTypeName string, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName": project,
+					},
+					"componentType": map[string]any{
+						"name": componentTypeName,
+						"kind": "ComponentType",
+					},
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// addComponentType adds a ComponentType resource entry to the index.
+func addComponentType(t *testing.T, idx *index.Index, name, workloadType string, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentType",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"workloadType": workloadType,
+					"resources":    []any{},
+					"schema":       map[string]any{},
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// addWorkload adds a Workload resource entry to the index.
+func addWorkload(t *testing.T, idx *index.Index, namespace, name, project, component string, workloadObj map[string]any, filePath string) {
+	t.Helper()
+	spec := map[string]any{
+		"owner": map[string]any{
+			"projectName":   project,
+			"componentName": component,
+		},
+	}
+	for k, v := range workloadObj {
+		spec[k] = v
+	}
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Workload",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": spec,
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateRelease_WorkloadEndpointsIncluded(t *testing.T) {
+	const (
+		namespace     = "default"
+		projectName   = "doclet"
+		componentName = "document-svc"
+		releaseName   = "document-svc-abc123"
+	)
+
+	idx := index.New("/repo")
+
+	addComponent(t, idx, namespace, componentName, projectName, "deployment/service",
+		"/repo/projects/doclet/components/document-svc/component.yaml")
+
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+
+	addWorkload(t, idx, namespace, "document-svc-workload", projectName, componentName,
+		map[string]any{
+			"container": map[string]any{
+				"image": "my-registry/document-svc:v1",
+				"env": []any{
+					map[string]any{"key": "PORT", "value": "8080"},
+				},
+			},
+			"endpoints": map[string]any{
+				"http": map[string]any{
+					"type": "REST",
+					"port": int64(8080),
+				},
+			},
+		},
+		"/repo/projects/doclet/components/document-svc/workload.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	release, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: componentName,
+		ProjectName:   projectName,
+		Namespace:     namespace,
+		ReleaseName:   releaseName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the release has the workload section
+	workload, ok, err := unstructured.NestedMap(release.Object, "spec", "workload")
+	if err != nil || !ok {
+		t.Fatalf("expected spec.workload to exist, ok=%v, err=%v", ok, err)
+	}
+
+	// Verify container is present
+	container, ok := workload["container"]
+	if !ok || container == nil {
+		t.Fatal("expected spec.workload.container to exist")
+	}
+
+	// Verify endpoints are present
+	endpoints, ok := workload["endpoints"]
+	if !ok || endpoints == nil {
+		t.Fatal("expected spec.workload.endpoints to exist — this was the bug: endpoints were dropped during ComponentRelease generation")
+	}
+
+	endpointsMap, ok := endpoints.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected endpoints to be a map, got %T", endpoints)
+	}
+
+	httpEndpoint, ok := endpointsMap["http"]
+	if !ok {
+		t.Fatal("expected 'http' endpoint in endpoints map")
+	}
+
+	httpMap, ok := httpEndpoint.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected http endpoint to be a map, got %T", httpEndpoint)
+	}
+
+	if httpMap["type"] != "REST" {
+		t.Errorf("endpoint type = %v, want REST", httpMap["type"])
+	}
+	if httpMap["port"] != int64(8080) {
+		t.Errorf("endpoint port = %v, want 8080", httpMap["port"])
+	}
+}
+
+func TestGenerateRelease_WorkloadConnectionsIncluded(t *testing.T) {
+	const (
+		namespace     = "default"
+		projectName   = "doclet"
+		componentName = "document-svc"
+		releaseName   = "document-svc-abc123"
+	)
+
+	idx := index.New("/repo")
+
+	addComponent(t, idx, namespace, componentName, projectName, "deployment/service",
+		"/repo/projects/doclet/components/document-svc/component.yaml")
+
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+
+	addWorkload(t, idx, namespace, "document-svc-workload", projectName, componentName,
+		map[string]any{
+			"container": map[string]any{
+				"image": "my-registry/document-svc:v1",
+			},
+			"endpoints": map[string]any{
+				"http": map[string]any{
+					"type": "REST",
+					"port": int64(8080),
+				},
+			},
+			"connections": []any{
+				map[string]any{
+					"component":  "postgres",
+					"endpoint":   "tcp",
+					"visibility": "project",
+					"envBindings": map[string]any{
+						"address": "DATABASE_URL",
+					},
+				},
+				map[string]any{
+					"component":  "nats",
+					"endpoint":   "tcp",
+					"visibility": "project",
+					"envBindings": map[string]any{
+						"address": "NATS_URL",
+					},
+				},
+			},
+		},
+		"/repo/projects/doclet/components/document-svc/workload.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	release, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: componentName,
+		ProjectName:   projectName,
+		Namespace:     namespace,
+		ReleaseName:   releaseName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify connections are present
+	workload, _, _ := unstructured.NestedMap(release.Object, "spec", "workload")
+	connections, ok := workload["connections"]
+	if !ok || connections == nil {
+		t.Fatal("expected spec.workload.connections to exist — this was the bug: connections were dropped during ComponentRelease generation")
+	}
+
+	connSlice, ok := connections.([]interface{})
+	if !ok {
+		t.Fatalf("expected connections to be a slice, got %T", connections)
+	}
+
+	if len(connSlice) != 2 {
+		t.Fatalf("expected 2 connections, got %d", len(connSlice))
+	}
+
+	first := connSlice[0].(map[string]interface{})
+	if first["component"] != "postgres" {
+		t.Errorf("first connection component = %v, want postgres", first["component"])
+	}
+
+	second := connSlice[1].(map[string]interface{})
+	if second["component"] != "nats" {
+		t.Errorf("second connection component = %v, want nats", second["component"])
+	}
+}
+
+func TestGenerateRelease_WorkloadWithoutEndpoints(t *testing.T) {
+	const (
+		namespace     = "default"
+		projectName   = "doclet"
+		componentName = "worker-svc"
+		releaseName   = "worker-svc-abc123"
+	)
+
+	idx := index.New("/repo")
+
+	addComponent(t, idx, namespace, componentName, projectName, "deployment/worker",
+		"/repo/projects/doclet/components/worker-svc/component.yaml")
+
+	addComponentType(t, idx, "worker", "deployment",
+		"/repo/platform/component-types/worker.yaml")
+
+	addWorkload(t, idx, namespace, "worker-svc-workload", projectName, componentName,
+		map[string]any{
+			"container": map[string]any{
+				"image": "my-registry/worker-svc:v1",
+			},
+		},
+		"/repo/projects/doclet/components/worker-svc/workload.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	release, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: componentName,
+		ProjectName:   projectName,
+		Namespace:     namespace,
+		ReleaseName:   releaseName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the release has the workload section with container only
+	workload, ok, err := unstructured.NestedMap(release.Object, "spec", "workload")
+	if err != nil || !ok {
+		t.Fatalf("expected spec.workload to exist, ok=%v, err=%v", ok, err)
+	}
+
+	// Container should be present
+	if _, ok := workload["container"]; !ok {
+		t.Fatal("expected spec.workload.container to exist")
+	}
+
+	// Endpoints and connections should not be present when empty
+	if _, ok := workload["endpoints"]; ok {
+		t.Error("expected spec.workload.endpoints to be absent when workload has no endpoints")
+	}
+	if _, ok := workload["connections"]; ok {
+		t.Error("expected spec.workload.connections to be absent when workload has no connections")
+	}
+}

--- a/internal/occ/fsmode/typed/workload.go
+++ b/internal/occ/fsmode/typed/workload.go
@@ -108,6 +108,97 @@ func (w *Workload) GetContainer() map[string]interface{} {
 	return containerMap
 }
 
+// GetEndpoints returns the endpoints definition as a map for template processing.
+// The returned map is keyed by endpoint name, matching the WorkloadTemplateSpec.Endpoints structure.
+func (w *Workload) GetEndpoints() map[string]interface{} {
+	if len(w.Spec.Endpoints) == 0 {
+		return nil
+	}
+
+	endpointsMap := make(map[string]interface{}, len(w.Spec.Endpoints))
+	for name, ep := range w.Spec.Endpoints {
+		epMap := map[string]interface{}{
+			"type": string(ep.Type),
+			"port": int64(ep.Port),
+		}
+		if ep.TargetPort != 0 {
+			epMap["targetPort"] = int64(ep.TargetPort)
+		}
+		if ep.DisplayName != "" {
+			epMap["displayName"] = ep.DisplayName
+		}
+		if ep.BasePath != "" {
+			epMap["basePath"] = ep.BasePath
+		}
+		if len(ep.Visibility) > 0 {
+			vis := make([]interface{}, len(ep.Visibility))
+			for i, v := range ep.Visibility {
+				vis[i] = string(v)
+			}
+			epMap["visibility"] = vis
+		}
+		if ep.Schema != nil {
+			schemaMap := make(map[string]interface{})
+			if ep.Schema.Type != "" {
+				schemaMap["type"] = ep.Schema.Type
+			}
+			if ep.Schema.Content != "" {
+				schemaMap["content"] = ep.Schema.Content
+			}
+			epMap["schema"] = schemaMap
+		}
+		endpointsMap[name] = epMap
+	}
+	return endpointsMap
+}
+
+// GetConnections returns the connections definition as a slice for template processing.
+func (w *Workload) GetConnections() []interface{} {
+	if len(w.Spec.Connections) == 0 {
+		return nil
+	}
+
+	connections := make([]interface{}, len(w.Spec.Connections))
+	for i, conn := range w.Spec.Connections {
+		connMap := map[string]interface{}{
+			"component":  conn.Component,
+			"endpoint":   conn.Endpoint,
+			"visibility": string(conn.Visibility),
+		}
+		if conn.Namespace != "" {
+			connMap["namespace"] = conn.Namespace
+		}
+		if conn.Project != "" {
+			connMap["project"] = conn.Project
+		}
+		if len(conn.EnvironmentMapping) > 0 {
+			envMapping := make(map[string]interface{}, len(conn.EnvironmentMapping))
+			for k, v := range conn.EnvironmentMapping {
+				envMapping[k] = v
+			}
+			connMap["environmentMapping"] = envMapping
+		}
+
+		envBindings := map[string]interface{}{}
+		if conn.EnvBindings.Address != "" {
+			envBindings["address"] = conn.EnvBindings.Address
+		}
+		if conn.EnvBindings.Host != "" {
+			envBindings["host"] = conn.EnvBindings.Host
+		}
+		if conn.EnvBindings.Port != "" {
+			envBindings["port"] = conn.EnvBindings.Port
+		}
+		if conn.EnvBindings.BasePath != "" {
+			envBindings["basePath"] = conn.EnvBindings.BasePath
+		}
+		connMap["envBindings"] = envBindings
+
+		connections[i] = connMap
+	}
+	return connections
+}
+
 // stringsToInterfaceSlice converts []string to []interface{} for JSON compatibility
 // This is needed because DeepCopyJSONValue cannot handle []string directly
 func stringsToInterfaceSlice(strs []string) []interface{} {

--- a/internal/occ/fsmode/typed/workload_test.go
+++ b/internal/occ/fsmode/typed/workload_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package typed
+
+import (
+	"testing"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+func TestGetEndpoints(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints map[string]v1alpha1.WorkloadEndpoint
+		wantNil   bool
+		wantKeys  []string
+		validate  func(t *testing.T, result map[string]interface{})
+	}{
+		{
+			name:      "Nil endpoints returns nil",
+			endpoints: nil,
+			wantNil:   true,
+		},
+		{
+			name:      "Empty endpoints returns nil",
+			endpoints: map[string]v1alpha1.WorkloadEndpoint{},
+			wantNil:   true,
+		},
+		{
+			name: "Single REST endpoint with required fields only",
+			endpoints: map[string]v1alpha1.WorkloadEndpoint{
+				"http": {
+					Type: v1alpha1.EndpointTypeREST,
+					Port: 8080,
+				},
+			},
+			wantKeys: []string{"http"},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				ep := result["http"].(map[string]interface{})
+				if ep["type"] != "REST" {
+					t.Errorf("type = %v, want REST", ep["type"])
+				}
+				if ep["port"] != int64(8080) {
+					t.Errorf("port = %v, want 8080", ep["port"])
+				}
+				// Optional fields should be absent
+				if _, ok := ep["targetPort"]; ok {
+					t.Error("targetPort should not be set when zero")
+				}
+				if _, ok := ep["displayName"]; ok {
+					t.Error("displayName should not be set when empty")
+				}
+				if _, ok := ep["basePath"]; ok {
+					t.Error("basePath should not be set when empty")
+				}
+				if _, ok := ep["visibility"]; ok {
+					t.Error("visibility should not be set when empty")
+				}
+				if _, ok := ep["schema"]; ok {
+					t.Error("schema should not be set when nil")
+				}
+			},
+		},
+		{
+			name: "Endpoint with all optional fields",
+			endpoints: map[string]v1alpha1.WorkloadEndpoint{
+				"api": {
+					Type:        v1alpha1.EndpointTypeHTTP,
+					Port:        9090,
+					TargetPort:  8080,
+					DisplayName: "My API",
+					BasePath:    "/api/v1",
+					Visibility:  []v1alpha1.EndpointVisibility{v1alpha1.EndpointVisibilityExternal, v1alpha1.EndpointVisibilityProject},
+					Schema: &v1alpha1.Schema{
+						Type:    "openapi",
+						Content: "openapi: 3.0.0",
+					},
+				},
+			},
+			wantKeys: []string{"api"},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				ep := result["api"].(map[string]interface{})
+				if ep["type"] != "HTTP" {
+					t.Errorf("type = %v, want HTTP", ep["type"])
+				}
+				if ep["port"] != int64(9090) {
+					t.Errorf("port = %v, want 9090", ep["port"])
+				}
+				if ep["targetPort"] != int64(8080) {
+					t.Errorf("targetPort = %v, want 8080", ep["targetPort"])
+				}
+				if ep["displayName"] != "My API" {
+					t.Errorf("displayName = %v, want My API", ep["displayName"])
+				}
+				if ep["basePath"] != "/api/v1" {
+					t.Errorf("basePath = %v, want /api/v1", ep["basePath"])
+				}
+
+				vis := ep["visibility"].([]interface{})
+				if len(vis) != 2 {
+					t.Fatalf("visibility length = %d, want 2", len(vis))
+				}
+				if vis[0] != "external" {
+					t.Errorf("visibility[0] = %v, want external", vis[0])
+				}
+				if vis[1] != "project" {
+					t.Errorf("visibility[1] = %v, want project", vis[1])
+				}
+
+				schema := ep["schema"].(map[string]interface{})
+				if schema["type"] != "openapi" {
+					t.Errorf("schema.type = %v, want openapi", schema["type"])
+				}
+				if schema["content"] != "openapi: 3.0.0" {
+					t.Errorf("schema.content = %v, want openapi: 3.0.0", schema["content"])
+				}
+			},
+		},
+		{
+			name: "Multiple endpoints",
+			endpoints: map[string]v1alpha1.WorkloadEndpoint{
+				"http": {
+					Type: v1alpha1.EndpointTypeREST,
+					Port: 8080,
+				},
+				"grpc": {
+					Type: v1alpha1.EndpointTypeGRPC,
+					Port: 9090,
+				},
+				"tcp": {
+					Type: v1alpha1.EndpointTypeTCP,
+					Port: 5432,
+				},
+			},
+			wantKeys: []string{"http", "grpc", "tcp"},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				if len(result) != 3 {
+					t.Errorf("expected 3 endpoints, got %d", len(result))
+				}
+				http := result["http"].(map[string]interface{})
+				if http["port"] != int64(8080) {
+					t.Errorf("http port = %v, want 8080", http["port"])
+				}
+				grpc := result["grpc"].(map[string]interface{})
+				if grpc["type"] != "gRPC" {
+					t.Errorf("grpc type = %v, want gRPC", grpc["type"])
+				}
+				tcp := result["tcp"].(map[string]interface{})
+				if tcp["type"] != "TCP" {
+					t.Errorf("tcp type = %v, want TCP", tcp["type"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wl := &Workload{
+				Workload: &v1alpha1.Workload{
+					Spec: v1alpha1.WorkloadSpec{
+						WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+							Container: v1alpha1.Container{Image: "test:latest"},
+							Endpoints: tt.endpoints,
+						},
+					},
+				},
+			}
+			result := wl.GetEndpoints()
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			for _, key := range tt.wantKeys {
+				if _, ok := result[key]; !ok {
+					t.Errorf("expected key %q in result", key)
+				}
+			}
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+func TestGetConnections(t *testing.T) {
+	tests := []struct {
+		name        string
+		connections []v1alpha1.WorkloadConnection
+		wantNil     bool
+		wantLen     int
+		validate    func(t *testing.T, result []interface{})
+	}{
+		{
+			name:        "Nil connections returns nil",
+			connections: nil,
+			wantNil:     true,
+		},
+		{
+			name:        "Empty connections returns nil",
+			connections: []v1alpha1.WorkloadConnection{},
+			wantNil:     true,
+		},
+		{
+			name: "Single connection with required fields only",
+			connections: []v1alpha1.WorkloadConnection{
+				{
+					Component:  "postgres",
+					Endpoint:   "tcp",
+					Visibility: v1alpha1.EndpointVisibilityProject,
+					EnvBindings: v1alpha1.ConnectionEnvBindings{
+						Address: "DATABASE_URL",
+					},
+				},
+			},
+			wantLen: 1,
+			validate: func(t *testing.T, result []interface{}) {
+				conn := result[0].(map[string]interface{})
+				if conn["component"] != "postgres" {
+					t.Errorf("component = %v, want postgres", conn["component"])
+				}
+				if conn["endpoint"] != "tcp" {
+					t.Errorf("endpoint = %v, want tcp", conn["endpoint"])
+				}
+				if conn["visibility"] != "project" {
+					t.Errorf("visibility = %v, want project", conn["visibility"])
+				}
+				// Optional fields should be absent
+				if _, ok := conn["namespace"]; ok {
+					t.Error("namespace should not be set when empty")
+				}
+				if _, ok := conn["project"]; ok {
+					t.Error("project should not be set when empty")
+				}
+				if _, ok := conn["environmentMapping"]; ok {
+					t.Error("environmentMapping should not be set when empty")
+				}
+
+				envBindings := conn["envBindings"].(map[string]interface{})
+				if envBindings["address"] != "DATABASE_URL" {
+					t.Errorf("envBindings.address = %v, want DATABASE_URL", envBindings["address"])
+				}
+			},
+		},
+		{
+			name: "Connection with all optional fields",
+			connections: []v1alpha1.WorkloadConnection{
+				{
+					Namespace:  "other-ns",
+					Project:    "other-project",
+					Component:  "redis",
+					Endpoint:   "tcp",
+					Visibility: v1alpha1.EndpointVisibilityInternal,
+					EnvironmentMapping: v1alpha1.EnvironmentMapping{
+						"dev":     "staging",
+						"staging": "prod",
+					},
+					EnvBindings: v1alpha1.ConnectionEnvBindings{
+						Address:  "REDIS_URL",
+						Host:     "REDIS_HOST",
+						Port:     "REDIS_PORT",
+						BasePath: "REDIS_PATH",
+					},
+				},
+			},
+			wantLen: 1,
+			validate: func(t *testing.T, result []interface{}) {
+				conn := result[0].(map[string]interface{})
+				if conn["namespace"] != "other-ns" {
+					t.Errorf("namespace = %v, want other-ns", conn["namespace"])
+				}
+				if conn["project"] != "other-project" {
+					t.Errorf("project = %v, want other-project", conn["project"])
+				}
+				if conn["visibility"] != "internal" {
+					t.Errorf("visibility = %v, want internal", conn["visibility"])
+				}
+
+				envMapping := conn["environmentMapping"].(map[string]interface{})
+				if len(envMapping) != 2 {
+					t.Fatalf("environmentMapping length = %d, want 2", len(envMapping))
+				}
+				if envMapping["dev"] != "staging" {
+					t.Errorf("environmentMapping[dev] = %v, want staging", envMapping["dev"])
+				}
+
+				envBindings := conn["envBindings"].(map[string]interface{})
+				if envBindings["address"] != "REDIS_URL" {
+					t.Errorf("envBindings.address = %v, want REDIS_URL", envBindings["address"])
+				}
+				if envBindings["host"] != "REDIS_HOST" {
+					t.Errorf("envBindings.host = %v, want REDIS_HOST", envBindings["host"])
+				}
+				if envBindings["port"] != "REDIS_PORT" {
+					t.Errorf("envBindings.port = %v, want REDIS_PORT", envBindings["port"])
+				}
+				if envBindings["basePath"] != "REDIS_PATH" {
+					t.Errorf("envBindings.basePath = %v, want REDIS_PATH", envBindings["basePath"])
+				}
+			},
+		},
+		{
+			name: "Multiple connections preserves order",
+			connections: []v1alpha1.WorkloadConnection{
+				{
+					Component:  "postgres",
+					Endpoint:   "tcp",
+					Visibility: v1alpha1.EndpointVisibilityProject,
+					EnvBindings: v1alpha1.ConnectionEnvBindings{
+						Address: "DB_URL",
+					},
+				},
+				{
+					Component:  "nats",
+					Endpoint:   "tcp",
+					Visibility: v1alpha1.EndpointVisibilityProject,
+					EnvBindings: v1alpha1.ConnectionEnvBindings{
+						Address: "NATS_URL",
+					},
+				},
+			},
+			wantLen: 2,
+			validate: func(t *testing.T, result []interface{}) {
+				first := result[0].(map[string]interface{})
+				if first["component"] != "postgres" {
+					t.Errorf("first connection component = %v, want postgres", first["component"])
+				}
+				second := result[1].(map[string]interface{})
+				if second["component"] != "nats" {
+					t.Errorf("second connection component = %v, want nats", second["component"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wl := &Workload{
+				Workload: &v1alpha1.Workload{
+					Spec: v1alpha1.WorkloadSpec{
+						WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+							Container:   v1alpha1.Container{Image: "test:latest"},
+							Connections: tt.connections,
+						},
+					},
+				},
+			}
+			result := wl.GetConnections()
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if len(result) != tt.wantLen {
+				t.Fatalf("length = %d, want %d", len(result), tt.wantLen)
+			}
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

  - Fix `occ componentrelease generate` dropping `endpoints` and `connections` from the workload snapshot in the generated ComponentRelease
  - The `buildRelease` function only copied `container`, causing ReleaseBinding reconciliation to fail with: `CEL evaluation error in expression 'workload.toServicePorts()[0].port':
  index out of bounds: 0`
  - Add `GetEndpoints()` and `GetConnections()` typed helpers on `Workload` (matching the existing `GetContainer()` pattern)
  - Add unit tests for the new helpers and integration tests for the release generator

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
