### PR TITLE
fix: update UID resolver in observe to new API paths

### DIFF
--- a/internal/observer/service/uid_resolver.go
+++ b/internal/observer/service/uid_resolver.go
@@ -110,10 +110,9 @@ func (r *ResourceUIDResolver) GetComponentUID(
 		return "", nil
 	}
 
-	// Call API: GET /api/v1/namespaces/{ns}/projects/{proj}/components/{componentName}
-	path := fmt.Sprintf("/api/v1/namespaces/%s/projects/%s/components/%s",
+	// Call API: GET /api/v1/namespaces/{ns}/components/{componentName}
+	path := fmt.Sprintf("/api/v1/namespaces/%s/components/%s",
 		url.PathEscape(namespaceName),
-		url.PathEscape(projectName),
 		url.PathEscape(componentName))
 	uid, err := r.fetchResourceUID(ctx, path)
 	if err != nil {
@@ -193,25 +192,32 @@ func (r *ResourceUIDResolver) fetchResourceUID(ctx context.Context, path string)
 	}
 
 	// Parse response to extract data.uid
-	var response struct {
-		Data struct {
-			UID string `json:"uid"`
-		} `json:"data"`
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	r.logger.Debug("Raw UID resolver response", "path", path, "status", resp.StatusCode, "body", string(body))
+
+	var response struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+
+	if err := json.Unmarshal(body, &response); err != nil {
 		return "", fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	if response.Data.UID == "" {
+	if response.Metadata.UID == "" {
 		return "", fmt.Errorf("uid not found in response")
 	}
 
 	r.logger.Debug("Resolved resource UID",
 		"path", path,
-		"uid", response.Data.UID)
+		"uid", response.Metadata.UID)
 
-	return response.Data.UID, nil
+	return response.Metadata.UID, nil
 }
 
 // getAccessToken returns a valid OAuth2 access token, fetching a new one if needed


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

This pull request updates the `ResourceUIDResolver` service to align with changes in the API endpoint and response format, and adds improved logging for debugging. The most important changes are:

### API endpoint and response structure updates

* Changed the API endpoint used in `GetComponentUID` to remove the project name from the path, now calling `/api/v1/namespaces/{ns}/components/{componentName}` instead of `/api/v1/namespaces/{ns}/projects/{proj}/components/{componentName}`.
* Updated the response parsing in `fetchResourceUID` to extract the UID from the `metadata` field instead of the `data` field, and switched from using `json.NewDecoder` to `json.Unmarshal` after reading the entire response body.

### Logging improvements

* Added debug logging to output the raw API response body and status code, aiding in troubleshooting and visibility into the UID resolution process.

## Approach
- Modified the API path in GetComponentUID to exclude the project parameter.
- Enhanced error handling by reading the response body before decoding.
- Updated the response structure to reflect changes from 'data' to 'metadata' for UID extraction.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
