### PR TITLE
feat: add alert webhook handling to Observer API

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -172,6 +172,8 @@ func main() {
 		k8sClient,
 		cfg,
 		logger.With("component", "alert-service"),
+		cfg.Alerting.RCAServiceURL,
+		cfg.Alerting.AIRCAEnabled,
 	)
 
 	// Initialize new API handler
@@ -279,6 +281,9 @@ func main() {
 		"PUT /api/v1alpha1/alerts/sources/{sourceType}/rules/{ruleName}", newAPIHandler.UpdateAlertRule)
 	internalRoutes.HandleFunc(
 		"DELETE /api/v1alpha1/alerts/sources/{sourceType}/rules/{ruleName}", newAPIHandler.DeleteAlertRule)
+
+	// ===== v1alpha1 Alert Webhook Endpoint  =====
+	internalRoutes.HandleFunc("POST /api/v1alpha1/alerts/webhook", newAPIHandler.HandleAlertWebhook)
 
 	internalAddr := fmt.Sprintf(":%d", cfg.Server.InternalPort)
 	internalServer := &http.Server{

--- a/internal/observer/api/handlers/alerts.go
+++ b/internal/observer/api/handlers/alerts.go
@@ -164,3 +164,30 @@ func (h *Handler) DeleteAlertRule(w http.ResponseWriter, r *http.Request) {
 
 	h.writeJSON(w, http.StatusOK, resp)
 }
+
+// HandleAlertWebhook handles POST /api/v1alpha1/alerts/webhook
+func (h *Handler) HandleAlertWebhook(w http.ResponseWriter, r *http.Request) {
+	var req gen.AlertWebhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "INVALID_REQUEST_BODY", "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.RuleName == nil || *req.RuleName == "" {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "MISSING_RULE_NAME", "ruleName is required")
+		return
+	}
+	if req.RuleNamespace == nil || *req.RuleNamespace == "" {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "MISSING_RULE_NAMESPACE", "ruleNamespace is required")
+		return
+	}
+
+	resp, err := h.alertService.HandleAlertWebhook(r.Context(), req)
+	if err != nil {
+		h.logger.Error("Failed to handle alert webhook", "error", err)
+		h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, "WEBHOOK_FAILED", "failed to handle alert webhook: "+err.Error())
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/observer/service/alerts.go
+++ b/internal/observer/service/alerts.go
@@ -4,20 +4,28 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"reflect"
+	"strconv"
 	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	choreoapis "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
 	"github.com/openchoreo/openchoreo/internal/observer/config"
+	observerlabels "github.com/openchoreo/openchoreo/internal/observer/labels"
+	"github.com/openchoreo/openchoreo/internal/observer/notifications"
 	"github.com/openchoreo/openchoreo/internal/observer/opensearch"
 	"github.com/openchoreo/openchoreo/internal/observer/prometheus"
 	legacytypes "github.com/openchoreo/openchoreo/internal/observer/types"
@@ -41,15 +49,18 @@ type AlertOpenSearchClient interface {
 	CreateMonitor(ctx context.Context, monitor map[string]interface{}) (id string, lastUpdateTime int64, err error)
 	UpdateMonitor(ctx context.Context, monitorID string, monitor map[string]interface{}) (lastUpdateTime int64, err error)
 	DeleteMonitor(ctx context.Context, monitorID string) error
+	WriteAlertEntry(ctx context.Context, entry map[string]interface{}) (string, error)
 }
 
 // AlertService provides CRUD operations for alert rules, backing the v1alpha1 API.
 type AlertService struct {
-	osClient     AlertOpenSearchClient
-	queryBuilder *opensearch.QueryBuilder
-	k8sClient    client.Client
-	config       *config.Config
-	logger       *slog.Logger
+	osClient      AlertOpenSearchClient
+	queryBuilder  *opensearch.QueryBuilder
+	k8sClient     client.Client
+	config        *config.Config
+	logger        *slog.Logger
+	rcaServiceURL string
+	aiRCAEnabled  bool
 }
 
 // NewAlertService creates a new AlertService.
@@ -59,13 +70,17 @@ func NewAlertService(
 	k8sClient client.Client,
 	cfg *config.Config,
 	logger *slog.Logger,
+	rcaServiceURL string,
+	aiRCAEnabled bool,
 ) *AlertService {
 	return &AlertService{
-		osClient:     osClient,
-		queryBuilder: queryBuilder,
-		k8sClient:    k8sClient,
-		config:       cfg,
-		logger:       logger,
+		osClient:      osClient,
+		queryBuilder:  queryBuilder,
+		k8sClient:     k8sClient,
+		config:        cfg,
+		logger:        logger,
+		rcaServiceURL: rcaServiceURL,
+		aiRCAEnabled:  aiRCAEnabled,
 	}
 }
 
@@ -130,6 +145,241 @@ func (s *AlertService) DeleteAlertRule(ctx context.Context, ruleName, sourceType
 		return s.deletePrometheusAlertRule(ctx, ruleName)
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", sourceType)
+	}
+}
+
+// HandleAlertWebhook processes an incoming alert webhook in the normalized v1alpha1 format.
+// It fetches the ObservabilityAlertRule CR, enriches alert details, stores the alert entry,
+// sends a notification, and optionally triggers AI RCA analysis.
+func (s *AlertService) HandleAlertWebhook(ctx context.Context, req gen.AlertWebhookRequest) (*gen.AlertWebhookResponse, error) {
+	if s.k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client not configured")
+	}
+
+	// Validate required fields
+	ruleName := stringPtrVal(req.RuleName)
+	ruleNamespace := stringPtrVal(req.RuleNamespace)
+	if ruleName == "" {
+		return nil, fmt.Errorf("ruleName is required")
+	}
+	if ruleNamespace == "" {
+		return nil, fmt.Errorf("ruleNamespace is required")
+	}
+
+	// Derive alertValue and timestamp from the request
+	var alertValue string
+	if req.AlertValue != nil {
+		alertValue = strconv.FormatFloat(float64(*req.AlertValue), 'f', -1, 64)
+	}
+
+	var alertTimestamp string
+	if req.AlertTimestamp != nil {
+		alertTimestamp = req.AlertTimestamp.Format(time.RFC3339)
+	}
+
+	// Fetch the ObservabilityAlertRule CR
+	alertRule := &choreoapis.ObservabilityAlertRule{}
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{
+		Name:      ruleName,
+		Namespace: ruleNamespace,
+	}, alertRule); err != nil {
+		return nil, fmt.Errorf("failed to get ObservabilityAlertRule %s/%s: %w", ruleNamespace, ruleName, err)
+	}
+
+	// Enrich alert details from the CR
+	alertDetails := &legacytypes.AlertDetails{
+		AlertName:                       alertRule.Spec.Name,
+		AlertTimestamp:                  alertTimestamp,
+		AlertSeverity:                   string(alertRule.Spec.Severity),
+		AlertDescription:                alertRule.Spec.Description,
+		AlertThreshold:                  strconv.FormatInt(alertRule.Spec.Condition.Threshold, 10),
+		AlertValue:                      alertValue,
+		AlertType:                       string(alertRule.Spec.Source.Type),
+		Namespace:                       alertRule.Labels[labels.LabelKeyNamespaceName],
+		ComponentID:                     alertRule.Labels[labels.LabelKeyComponentUID],
+		EnvironmentID:                   alertRule.Labels[labels.LabelKeyEnvironmentUID],
+		ProjectID:                       alertRule.Labels[labels.LabelKeyProjectUID],
+		Component:                       alertRule.Labels[labels.LabelKeyComponentName],
+		Project:                         alertRule.Labels[labels.LabelKeyProjectName],
+		Environment:                     alertRule.Labels[labels.LabelKeyEnvironmentName],
+		NotificationChannel:             alertRule.Spec.NotificationChannel,
+		AlertAIRootCauseAnalysisEnabled: alertRule.Spec.EnableAiRootCauseAnalysis,
+	}
+
+	// Store alert entry in OpenSearch
+	// TODO: Use a dedicated storage for alert entries
+	alertEntry := map[string]interface{}{
+		"@timestamp":      alertDetails.AlertTimestamp,
+		"alert_rule_name": alertDetails.AlertName,
+		"alert_value":     alertDetails.AlertValue,
+		"labels": map[string]interface{}{
+			observerlabels.NamespaceName:   alertDetails.Namespace,
+			observerlabels.ComponentName:   alertDetails.Component,
+			observerlabels.EnvironmentName: alertDetails.Environment,
+			observerlabels.ProjectName:     alertDetails.Project,
+			observerlabels.ComponentID:     alertDetails.ComponentID,
+			observerlabels.EnvironmentID:   alertDetails.EnvironmentID,
+			observerlabels.ProjectID:       alertDetails.ProjectID,
+		},
+		"enable_ai_rca": alertDetails.AlertAIRootCauseAnalysisEnabled,
+	}
+
+	alertID, err := s.osClient.WriteAlertEntry(ctx, alertEntry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store alert entry: %w", err)
+	}
+
+	s.logger.Debug("Alert entry stored", "alertID", alertID, "ruleName", ruleName)
+
+	// Send notification in background
+	go func() {
+		notifCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.sendAlertNotification(notifCtx, alertDetails); err != nil {
+			s.logger.Warn("Failed to send alert notification", "error", err, "alertID", alertID)
+		}
+	}()
+
+	// Trigger AI RCA analysis in background if enabled
+	if alertDetails.AlertAIRootCauseAnalysisEnabled && s.aiRCAEnabled {
+		go s.triggerRCAAnalysis(alertID, alertDetails, alertRule)
+	}
+
+	successStatus := gen.Success
+	msg := fmt.Sprintf("alert acknowledged, alertID: %s", alertID)
+	return &gen.AlertWebhookResponse{
+		Status:  &successStatus,
+		Message: &msg,
+	}, nil
+}
+
+// sendAlertNotification fetches the notification channel config from K8s and dispatches the notification.
+func (s *AlertService) sendAlertNotification(ctx context.Context, alertDetails *legacytypes.AlertDetails) error {
+	if alertDetails.NotificationChannel == "" {
+		s.logger.Warn("Missing notification channel in alert details, skipping notification",
+			"ruleName", alertDetails.AlertName)
+		return nil
+	}
+
+	channelConfig, err := s.getNotificationChannelConfig(ctx, alertDetails.NotificationChannel)
+	if err != nil {
+		return fmt.Errorf("failed to get notification channel config: %w", err)
+	}
+
+	return notifications.SendAlertNotification(ctx, channelConfig, alertDetails, s.logger)
+}
+
+// getNotificationChannelConfig reads the K8s ConfigMap/Secret for the notification channel.
+func (s *AlertService) getNotificationChannelConfig(ctx context.Context, channelName string) (*notifications.NotificationChannelConfig, error) {
+	if s.k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client not configured")
+	}
+
+	labelSelector := client.MatchingLabels{
+		labels.LabelKeyNotificationChannelName: channelName,
+	}
+
+	configMapList := &corev1.ConfigMapList{}
+	if err := s.k8sClient.List(ctx, configMapList, labelSelector); err != nil {
+		return nil, fmt.Errorf("failed to list ConfigMaps: %w", err)
+	}
+	if len(configMapList.Items) == 0 {
+		return nil, fmt.Errorf("failed to find notification channel ConfigMap with label %s=%s",
+			labels.LabelKeyNotificationChannelName, channelName)
+	}
+	configMap := configMapList.Items[0].DeepCopy()
+
+	secretList := &corev1.SecretList{}
+	if err := s.k8sClient.List(ctx, secretList, labelSelector); err != nil {
+		return nil, fmt.Errorf("failed to list Secrets: %w", err)
+	}
+	if len(secretList.Items) == 0 {
+		return nil, fmt.Errorf("failed to find notification channel Secret with label %s=%s",
+			labels.LabelKeyNotificationChannelName, channelName)
+	}
+	secret := secretList.Items[0].DeepCopy()
+
+	channelType := configMap.Data["type"]
+	if channelType == "" {
+		return nil, fmt.Errorf("notification channel type not found in ConfigMap")
+	}
+
+	cfg := &notifications.NotificationChannelConfig{Type: channelType}
+	switch channelType {
+	case "email":
+		emailConfig, err := notifications.PrepareEmailNotificationConfig(configMap, secret, s.logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare email notification config: %w", err)
+		}
+		cfg.Email = emailConfig
+	case "webhook":
+		webhookConfig, err := notifications.PrepareWebhookNotificationConfig(configMap, secret, s.logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare webhook notification config: %w", err)
+		}
+		cfg.Webhook = webhookConfig
+	default:
+		return nil, fmt.Errorf("unsupported notification channel type: %s", channelType)
+	}
+
+	return cfg, nil
+}
+
+// triggerRCAAnalysis sends an AI RCA analysis request to the configured RCA service.
+func (s *AlertService) triggerRCAAnalysis(alertID string, alertDetails *legacytypes.AlertDetails, alertRule *choreoapis.ObservabilityAlertRule) {
+	ruleInfo := map[string]interface{}{
+		"name": alertDetails.AlertName,
+	}
+	if alertRule != nil {
+		if alertRule.Spec.Description != "" {
+			ruleInfo["description"] = alertRule.Spec.Description
+		}
+		if alertRule.Spec.Severity != "" {
+			ruleInfo["severity"] = string(alertRule.Spec.Severity)
+		}
+		ruleInfo["source"] = map[string]interface{}{
+			"type":   string(alertRule.Spec.Source.Type),
+			"query":  alertRule.Spec.Source.Query,
+			"metric": alertRule.Spec.Source.Metric,
+		}
+		ruleInfo["condition"] = map[string]interface{}{
+			"window":    alertRule.Spec.Condition.Window.Duration.String(),
+			"interval":  alertRule.Spec.Condition.Interval.Duration.String(),
+			"operator":  alertRule.Spec.Condition.Operator,
+			"threshold": alertRule.Spec.Condition.Threshold,
+		}
+	}
+
+	rcaPayload := map[string]interface{}{
+		"componentUid":   alertDetails.ComponentID,
+		"projectUid":     alertDetails.ProjectID,
+		"environmentUid": alertDetails.EnvironmentID,
+		"alert": map[string]interface{}{
+			"id":        alertID,
+			"value":     alertDetails.AlertValue,
+			"timestamp": alertDetails.AlertTimestamp,
+			"rule":      ruleInfo,
+		},
+	}
+
+	payloadBytes, err := json.Marshal(rcaPayload)
+	if err != nil {
+		s.logger.Error("Failed to marshal RCA request payload", "error", err)
+		return
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Post(s.rcaServiceURL+"/api/v1alpha1/rca-agent/analyze", "application/json", bytes.NewReader(payloadBytes))
+	if err != nil {
+		s.logger.Error("Failed to send RCA analysis request", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.logger.Error("RCA analysis request returned non-success status", "statusCode", resp.StatusCode, "alertID", alertID)
+	} else {
+		s.logger.Debug("AI RCA analysis triggered", "alertID", alertID)
 	}
 }
 

--- a/internal/observer/types/alerting.go
+++ b/internal/observer/types/alerting.go
@@ -62,6 +62,7 @@ type AlertDetails struct {
 	AlertAIRootCauseAnalysisEnabled bool   `json:"alertAIRootCauseAnalysisEnabled"`
 
 	// Component information
+	Namespace     string `json:"namespace"`
 	Component     string `json:"component"`
 	Project       string `json:"project"`
 	Environment   string `json:"environment"`


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request adds support for handling alert webhooks in the observer service. It introduces a new API endpoint to receive alert events, processes them by enriching with Kubernetes CRD data, stores the alert in OpenSearch, sends notifications, and optionally triggers AI-based root cause analysis (RCA). The changes also include necessary wiring of configuration and dependencies.

**New Alert Webhook Handling:**

* Added a new API endpoint `POST /api/v1alpha1/alerts/webhook` to receive alert webhook events and route them to the handler (`cmd/observer/main.go`, `internal/observer/api/handlers/alerts.go`). [[1]](diffhunk://#diff-c396d8ee377761a43fca284545cb4ee535f868ea2b16db01db81a21741855ed8R285-R287) [[2]](diffhunk://#diff-18ee0bbda9b566571f33f5deecf78af519e628a770ac66ddf374b594409f50f3R167-R193)
* Implemented `HandleAlertWebhook` in `AlertService` to:
  - Validate and enrich the alert using the `ObservabilityAlertRule` CR.
  - Store the alert entry in OpenSearch.
  - Send notifications based on the configured channel.
  - Optionally trigger AI RCA analysis if enabled (`internal/observer/service/alerts.go`).

**Configuration and Dependency Updates:**

* Extended `AlertService` to accept `rcaServiceURL` and `aiRCAEnabled` flags, and updated the service constructor and main wiring accordingly (`cmd/observer/main.go`, `internal/observer/service/alerts.go`). [[1]](diffhunk://#diff-c396d8ee377761a43fca284545cb4ee535f868ea2b16db01db81a21741855ed8R175-R176) [[2]](diffhunk://#diff-cb5a8af45777bdb3d6057f1ab9b91534fc6035f1526355072127cbae40c99349R62-R63) [[3]](diffhunk://#diff-cb5a8af45777bdb3d6057f1ab9b91534fc6035f1526355072127cbae40c99349R73-R83)

**Supporting Features and Types:**

* Added `WriteAlertEntry` method to the `AlertOpenSearchClient` interface to allow storing alert entries (`internal/observer/service/alerts.go`).
* Updated `AlertDetails` struct to include the `Namespace` field for better alert context (`internal/observer/types/alerting.go`).

**Notification and RCA Logic:**

* Implemented logic to fetch notification channel configs from Kubernetes resources and dispatch notifications.
* Added background triggering of AI RCA analysis via HTTP POST to the RCA service when enabled (`internal/observer/service/alerts.go`).

These changes enable the observer service to act as a central receiver for alert events, integrate with notification channels, and leverage AI for automated incident analysis.

## Approach
- Introduced a new endpoint for handling alert webhooks at POST /api/v1alpha1/alerts/webhook.
- Implemented the HandleAlertWebhook function to process incoming alert requests, validate required fields, and store alert entries in OpenSearch.
- Enhanced the AlertService to support AI root cause analysis and notification dispatching based on alert details.
- Updated main application to initialize the new API handler and include necessary configuration options.

This endpoint is internally exposed, and to be used by adaptors
This update expands the Observer's alerting capabilities, allowing for more dynamic and responsive alert management.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/1626

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
