### PR TITLE
feat: add openbao helm values for k3d setup

### DIFF
--- a/install/k3d/common/values-openbao.yaml
+++ b/install/k3d/common/values-openbao.yaml
@@ -1,0 +1,45 @@
+injector:
+  enabled: false
+
+server:
+  dev:
+    enabled: true
+    devRootToken: root
+
+  postStart:
+    - /bin/sh
+    - -c
+    - |
+      sleep 5
+      export BAO_ADDR=http://127.0.0.1:8200
+      export BAO_TOKEN=root
+
+      bao auth enable kubernetes 2>/dev/null || true
+      bao write auth/kubernetes/config \
+        kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443"
+
+      bao policy write openchoreo-secret-reader-policy - <<POLICY
+      path "secret/data/*" { capabilities = ["read"] }
+      path "secret/metadata/*" { capabilities = ["list", "read"] }
+      POLICY
+
+      bao policy write openchoreo-secret-writer-policy - <<POLICY
+      path "secret/data/*" { capabilities = ["create", "read", "update", "delete"] }
+      path "secret/metadata/*" { capabilities = ["create", "read", "update", "delete", "list"] }
+      POLICY
+
+      bao write auth/kubernetes/role/openchoreo-secret-reader-role \
+        bound_service_account_names=default \
+        bound_service_account_namespaces="dp*" \
+        policies=openchoreo-secret-reader-policy ttl=20m
+
+      bao write auth/kubernetes/role/openchoreo-secret-writer-role \
+        bound_service_account_names="*" \
+        bound_service_account_namespaces="openbao,openchoreo-build-plane" \
+        policies=openchoreo-secret-writer-policy ttl=20m
+
+      bao kv put secret/backstage-backend-secret value="local-dev-backend-secret"
+      bao kv put secret/backstage-client-secret value="backstage-portal-secret"
+      bao kv put secret/backstage-jenkins-api-key value="placeholder-not-in-use"
+      bao kv put secret/opensearch-username value="admin"
+      bao kv put secret/opensearch-password value="ThisIsTheOpenSearchPassword1"


### PR DESCRIPTION
adds the openbao helm values file to install/k3d/common for local dev setup.

configures dev mode with kubernetes auth, secret reader/writer policies, and default secrets for backstage and opensearch.