### PR TITLE
chore: bump thunder version to 0.24

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
@@ -20,7 +20,7 @@ spec:
       port: {{ .Values.gateway.httpPort | default 80 }}
       allowedRoutes:
         namespaces:
-          from: Same
+          from: All
 {{- if .Values.gateway.tls.enabled }}
     - name: https
       protocol: HTTPS
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       allowedRoutes:
         namespaces:
-          from: Same
+          from: All
       tls:
         mode: Terminate
         certificateRefs:
@@ -49,7 +49,7 @@ spec:
       hostname: {{ (index .Values.clusterGateway.tlsRoute.hosts 0).host | quote }}
       allowedRoutes:
         namespaces:
-          from: Same
+          from: All
       tls:
         mode: Passthrough
 {{- end }}

--- a/install/helm/openchoreo-data-plane/templates/api-platform/configuration.yaml
+++ b/install/helm/openchoreo-data-plane/templates/api-platform/configuration.yaml
@@ -305,7 +305,7 @@ data:
               issuer: http://thunder.openchoreo.localhost:8080
               jwks:
                 remote:
-                  uri: http://thunder-service.openchoreo-control-plane:8090/oauth2/jwks
+                  uri: http://thunder-service.thunder:8090/oauth2/jwks
                   skipTlsVerify: true
             jwkscachettl: "5m"
             jwksfetchtimeout: "5s"

--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -112,7 +112,8 @@ bootstrap:
               },
               \"password\": {
                 \"type\": \"string\",
-                \"required\": true
+                \"required\": false,
+                \"credential\": true
               },
               \"given_name\": {
                 \"type\": \"string\"

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -66,8 +66,9 @@ helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgatew
 ```bash
 helm upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
   --kube-context k3d-openchoreo-cp \
-  --namespace openchoreo-control-plane \
-  --version 0.23.0 \
+  --namespace thunder \
+  --create-namespace \
+  --version 0.24.0 \
   --values install/k3d/common/values-thunder.yaml
 ```
 

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -83,9 +83,9 @@ Bootstrap scripts auto-configure the org, users, groups, and OAuth apps on first
 
 ```bash
 helm upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
-  --namespace openchoreo-control-plane \
+  --namespace thunder \
   --create-namespace \
-  --version 0.23.0 \
+  --version 0.24.0 \
   --values install/k3d/common/values-thunder.yaml
 ```
 

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -24,9 +24,9 @@ openSearchDashboards:
 
 security:
   oidc:
-    jwksUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
-    tokenUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/token"
-    authServerBaseUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090"
+    jwksUrl: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/jwks"
+    tokenUrl: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/token"
+    authServerBaseUrl: "http://thunder-service.thunder.svc.cluster.local:8090"
 
 gateway:
   httpPort: 11080

--- a/install/quick-start/.config.sh
+++ b/install/quick-start/.config.sh
@@ -12,6 +12,7 @@ CONTROL_PLANE_NS="openchoreo-control-plane"
 DATA_PLANE_NS="openchoreo-data-plane"
 BUILD_PLANE_NS="openchoreo-build-plane"
 OBSERVABILITY_NS="openchoreo-observability-plane"
+THUNDER_NS="thunder"
 
 # Helm repository
 HELM_REPO="oci://ghcr.io/openchoreo/helm-charts"
@@ -28,4 +29,4 @@ ESO_REPO="oci://ghcr.io/external-secrets/charts"
 KGATEWAY_VERSION="v2.2.1"
 
 # Thunder configuration
-THUNDER_VERSION="0.23.0"
+THUNDER_VERSION="0.24.0"

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -581,7 +581,7 @@ install_thunder() {
         thunder_values="/home/openchoreo/install/k3d/common/values-thunder.yaml"
     fi
 
-    install_helm_chart "thunder" "oci://ghcr.io/asgardeo/helm-charts/thunder" "$CONTROL_PLANE_NS" "true" "false" "true" "600" \
+    install_helm_chart "thunder" "oci://ghcr.io/asgardeo/helm-charts/thunder" "$THUNDER_NS" "true" "false" "true" "600" \
         "--version" "$THUNDER_VERSION" \
         "--values" "$thunder_values"
 

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -44,4 +44,4 @@ gateway:
 
 security:
   oidc:
-    jwksUrl: "http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks"
+    jwksUrl: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/jwks"

--- a/install/quick-start/occ-login.sh
+++ b/install/quick-start/occ-login.sh
@@ -28,7 +28,7 @@ fi
 CHOREO_API_ENDPOINT="http://${API_URL}:8080"
 
 # Discover Thunder URL from HTTPRoute
-THUNDER_URL=$(kubectl get httproute -n openchoreo-control-plane thunder-httproute -o jsonpath='{.spec.hostnames[0]}' 2>/dev/null || echo "")
+THUNDER_URL=$(kubectl get httproute -n thunder thunder-httproute -o jsonpath='{.spec.hostnames[0]}' 2>/dev/null || echo "")
 
 if [ -z "$THUNDER_URL" ]; then
   log_error "Failed to discover Thunder URL from HTTPRoute"

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -30,7 +30,7 @@ GATEWAY_API_VERSION    ?= v1.4.1
 CERT_MANAGER_VERSION   ?= v1.19.2
 ESO_VERSION            ?= 1.3.2
 KGATEWAY_VERSION       ?= v2.1.1
-THUNDER_VERSION        ?= 0.23.0
+THUNDER_VERSION        ?= 0.24.0
 
 # Helm chart references: local chart dirs or OCI registry
 ifeq ($(E2E_HELM_SOURCE),oci)
@@ -200,7 +200,7 @@ _e2e.install-thunder:
 		"cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
 	@$(call log_info, Installing Thunder $(THUNDER_VERSION))
 	$(E2E_HELM) upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
-		--namespace $(E2E_CP_NS) --create-namespace \
+		--namespace thunder --create-namespace \
 		--version $(THUNDER_VERSION) \
 		--values $(PROJECT_DIR)/install/k3d/common/values-thunder.yaml \
 		--values $(E2E_K3D_DIR)/values-thunder.yaml \


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2361

This pull request updates the deployment configuration for the Thunder authentication service in the OpenChoreo platform. The main changes include upgrading Thunder to version 0.24.0, moving Thunder to its own dedicated namespace, and updating related configuration references and documentation to reflect this change. Additionally, several service URLs and security settings have been updated to match the new namespace and deployment structure.

**Thunder service upgrade and namespace changes:**

* Upgraded Thunder Helm chart version from `0.23.0` to `0.24.0` across all deployment scripts and documentation. [[1]](diffhunk://#diff-c274cd4f3f8de8434acc449281ffd0045c7e544f095d87185c0a97353581edc0L69-R70) [[2]](diffhunk://#diff-0c0ca444a315238a047afe983167f3482345dbe2eaee8edb95e4d8f35cf3aff0L86-R88) [[3]](diffhunk://#diff-081046352a184781354bfe4f231f7927a7c25fc93a3265e46db001457688a858L31-R32) [[4]](diffhunk://#diff-8a117bbc6863d3e4a11c6c059178d5dc78b0376e9696c25253d99a4a7b62ef7eL33-R33)
* Moved Thunder deployment from the `openchoreo-control-plane` namespace to a new dedicated `thunder` namespace in all relevant scripts, Helm commands, and configuration files. [[1]](diffhunk://#diff-c274cd4f3f8de8434acc449281ffd0045c7e544f095d87185c0a97353581edc0L69-R70) [[2]](diffhunk://#diff-0c0ca444a315238a047afe983167f3482345dbe2eaee8edb95e4d8f35cf3aff0L86-R88) [[3]](diffhunk://#diff-081046352a184781354bfe4f231f7927a7c25fc93a3265e46db001457688a858R15) [[4]](diffhunk://#diff-103cddf3bc93e1c47f23b9b3ea102463fb59768db9157cb81f7268b49487dc65L584-R584) [[5]](diffhunk://#diff-8a117bbc6863d3e4a11c6c059178d5dc78b0376e9696c25253d99a4a7b62ef7eL203-R203) [[6]](diffhunk://#diff-0ff7b2ca2088fa59cfa5a8b20423b34db89cea756309d838a018d6a5a0a3218bL31-R31)

**Configuration and service URL updates:**

* Updated service URLs in configuration files to reference the new `thunder` namespace, ensuring correct service discovery and OIDC integration. This includes changes to JWKS, token, and auth server URLs in `values-op.yaml`, `.values-op.yaml`, and other related files. [[1]](diffhunk://#diff-86cef85b0ba7761388c65e3a4e7fb5849aa25b7b6ed7dc3e786197a3eae74368L27-R29) [[2]](diffhunk://#diff-a7603374aaedd7a6b0f65126ecd63356b34e96e8823c2f6d8a6ed18dc82e866aL47-R47) [[3]](diffhunk://#diff-af84f7ab32df57b8373960858b2cc50af857a64a752af4ceba06a46a9cbe405bL308-R308)
* Changed the HTTPRoute discovery logic to look for Thunder in the `thunder` namespace instead of `openchoreo-control-plane`.

**Gateway and route configuration changes:**

* Broadened allowed route namespaces in Gateway configuration from `Same` to `All`, allowing more flexible routing between namespaces. [[1]](diffhunk://#diff-8ba72a2a70717e93780e4598d11433469901143f8352b81bdff6cdaae8c911f4L23-R23) [[2]](diffhunk://#diff-8ba72a2a70717e93780e4598d11433469901143f8352b81bdff6cdaae8c911f4L33-R33) [[3]](diffhunk://#diff-8ba72a2a70717e93780e4598d11433469901143f8352b81bdff6cdaae8c911f4L52-R52)

**Thunder authentication schema update:**

* Modified the Thunder bootstrap values to mark the `password` field as not required and as a credential, improving flexibility in user creation.