### PR TITLE
fix(api): return empty resource tree when release binding has no releases

### DIFF
--- a/internal/openchoreo-api/services/k8sresources/service.go
+++ b/internal/openchoreo-api/services/k8sresources/service.go
@@ -210,7 +210,9 @@ func (s *k8sResourcesService) resolveReleaseContexts(ctx context.Context, namesp
 	}
 
 	if len(ownedReleases) == 0 {
-		return nil, ErrReleaseNotFound
+		// ReleaseBinding exists but has no owned releases yet (e.g. not reconciled).
+		// Return an empty list so the caller can return an empty tree.
+		return nil, nil
 	}
 
 	// 3. Resolve environment and plane info
@@ -243,10 +245,6 @@ func (s *k8sResourcesService) resolveReleaseContexts(ctx context.Context, namesp
 			plane:     pi,
 			namespace: ns,
 		})
-	}
-
-	if len(contexts) == 0 {
-		return nil, ErrReleaseNotFound
 	}
 
 	return contexts, nil


### PR DESCRIPTION
## Purpose
  - Fix the `GET /api/v1/namespaces/{ns}/releasebindings/{name}/k8sresources/tree` endpoint to return `200 { "releases": [] }` instead of `404 "Release not found"` when a ReleaseBinding exists but has no owned Release resources (e.g. hasn't reconciled yet)
  - Remove a second redundant check that returned the same misleading error when all releases failed plane resolution

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
