### PR TITLE
fix: use OpenAPI client for scaffold schema requests

### DIFF
--- a/internal/occ/cmd/component/component.go
+++ b/internal/occ/cmd/component/component.go
@@ -336,7 +336,7 @@ func (cp *Component) applyOverrides(ctx context.Context, c *client.Client, param
 func scaffoldComponent(params ScaffoldParams) error {
 	// Validate required parameters
 	if params.ComponentName == "" {
-		return fmt.Errorf("component name is required (--name)")
+		return fmt.Errorf("component name is required")
 	}
 	if params.ComponentType == "" {
 		return fmt.Errorf("component type is required (--type)")
@@ -355,7 +355,7 @@ func scaffoldComponent(params ScaffoldParams) error {
 	}
 
 	// Create API client
-	apiClient, err := client.NewAPIClient()
+	apiClient, err := client.NewClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}

--- a/internal/occ/resources/client/legacy_client.go
+++ b/internal/occ/resources/client/legacy_client.go
@@ -252,63 +252,6 @@ func (c *APIClient) ListComponents(ctx context.Context, namespaceName, projectNa
 	return listResp.Data.Items, nil
 }
 
-// GetComponentTypeSchema fetches ComponentType schema from the API
-func (c *APIClient) GetComponentTypeSchema(ctx context.Context, namespaceName, ctName string) (*json.RawMessage, error) {
-	path := fmt.Sprintf("/api/v1/namespaces/%s/component-types/%s/schema", namespaceName, ctName)
-	return c.getSchema(ctx, path)
-}
-
-// GetTraitSchema fetches Trait schema from the API
-func (c *APIClient) GetTraitSchema(ctx context.Context, namespaceName, traitName string) (*json.RawMessage, error) {
-	path := fmt.Sprintf("/api/v1/namespaces/%s/traits/%s/schema", namespaceName, traitName)
-	return c.getSchema(ctx, path)
-}
-
-// GetWorkflowSchema fetches Workflow schema from the API
-func (c *APIClient) GetWorkflowSchema(ctx context.Context, namespaceName, workflowName string) (*json.RawMessage, error) {
-	path := fmt.Sprintf("/api/v1/namespaces/%s/workflows/%s/schema", namespaceName, workflowName)
-	return c.getSchema(ctx, path)
-}
-
-// getSchema is a helper to fetch schema from the API
-func (c *APIClient) getSchema(ctx context.Context, path string) (*json.RawMessage, error) {
-	resp, err := c.get(ctx, path)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Handle non-OK status codes
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Parse wrapped API response
-	var apiResponse struct {
-		Success bool             `json:"success"`
-		Data    *json.RawMessage `json:"data"`
-		Error   string           `json:"error,omitempty"`
-		Code    string           `json:"code,omitempty"`
-	}
-	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		return nil, fmt.Errorf("invalid API response format: %w", err)
-	}
-
-	if !apiResponse.Success {
-		if apiResponse.Code != "" {
-			return nil, fmt.Errorf("%s (error code: %s)", apiResponse.Error, apiResponse.Code)
-		}
-		return nil, fmt.Errorf("%s", apiResponse.Error)
-	}
-
-	return apiResponse.Data, nil
-}
-
 // Get performs a GET request to the API
 func (c *APIClient) Get(ctx context.Context, path string) (*http.Response, error) {
 	return c.doRequest(ctx, "GET", path, nil)

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -1131,4 +1132,58 @@ func (c *Client) GetEnvironmentObserverURL(ctx context.Context, namespaceName, e
 		return "", fmt.Errorf("observer URL not configured for environment")
 	}
 	return *resp.JSON200.ObserverUrl, nil
+}
+
+// GetComponentTypeSchema retrieves the parameter schema for a component type
+func (c *Client) GetComponentTypeSchema(ctx context.Context, namespaceName, ctName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetComponentTypeSchemaWithResponse(ctx, namespaceName, ctName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get component type schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("component type %q not found", ctName)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+// GetTraitSchema retrieves the parameter schema for a trait
+func (c *Client) GetTraitSchema(ctx context.Context, namespaceName, traitName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetTraitSchemaWithResponse(ctx, namespaceName, traitName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trait schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("trait %q not found", traitName)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+// GetWorkflowSchema retrieves the parameter schema for a workflow
+func (c *Client) GetWorkflowSchema(ctx context.Context, namespaceName, workflowName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetWorkflowSchemaWithResponse(ctx, namespaceName, workflowName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("workflow %q not found", workflowName)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+func schemaResponseToRaw(schema *gen.SchemaResponse) (*json.RawMessage, error) {
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal schema: %w", err)
+	}
+	raw := json.RawMessage(data)
+	return &raw, nil
 }

--- a/pkg/cli/cmd/component/component.go
+++ b/pkg/cli/cmd/component/component.go
@@ -102,25 +102,16 @@ func newDeleteComponentCmd() *cobra.Command {
 }
 
 func newScaffoldComponentCmd() *cobra.Command {
-	componentFlags := []flags.Flag{
-		flags.Name,
-		flags.ScaffoldType,
-		flags.Traits,
-		flags.Workflow,
-		flags.Project,
-		flags.Namespace,
-		flags.OutputFile,
-		flags.SkipComments,
-		flags.SkipOptional,
-	}
-
-	return (&builder.CommandBuilder{
-		Command: constants.ScaffoldComponent,
-		Flags:   componentFlags,
+	cmd := &cobra.Command{
+		Use:     constants.ScaffoldComponent.Use,
+		Short:   constants.ScaffoldComponent.Short,
+		Long:    constants.ScaffoldComponent.Long,
+		Example: constants.ScaffoldComponent.Example,
+		Args:    cobra.ExactArgs(1),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
-		RunE: func(fg *builder.FlagGetter) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse traits from comma-separated string
-			traitsStr := fg.GetString(flags.Traits)
+			traitsStr, _ := cmd.Flags().GetString(flags.Traits.Name)
 			var traits []string
 			if traitsStr != "" {
 				parts := strings.Split(traitsStr, ",")
@@ -132,20 +123,41 @@ func newScaffoldComponentCmd() *cobra.Command {
 				}
 			}
 
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+			project, _ := cmd.Flags().GetString(flags.Project.Name)
+			componentType, _ := cmd.Flags().GetString(flags.ScaffoldType.Name)
+			workflow, _ := cmd.Flags().GetString(flags.Workflow.Name)
+			outputFile, _ := cmd.Flags().GetString(flags.OutputFile.Name)
+			skipComments, _ := cmd.Flags().GetBool(flags.SkipComments.Name)
+			skipOptional, _ := cmd.Flags().GetBool(flags.SkipOptional.Name)
+
 			compImpl := component.New()
 			return compImpl.Scaffold(component.ScaffoldParams{
-				ComponentName: fg.GetString(flags.Name),
-				ComponentType: fg.GetString(flags.ScaffoldType),
+				ComponentName: args[0],
+				ComponentType: componentType,
 				Traits:        traits,
-				WorkflowName:  fg.GetString(flags.Workflow),
-				Namespace:     fg.GetString(flags.Namespace),
-				ProjectName:   fg.GetString(flags.Project),
-				OutputPath:    fg.GetString(flags.OutputFile),
-				SkipComments:  fg.GetBool(flags.SkipComments),
-				SkipOptional:  fg.GetBool(flags.SkipOptional),
+				WorkflowName:  workflow,
+				Namespace:     namespace,
+				ProjectName:   project,
+				OutputPath:    outputFile,
+				SkipComments:  skipComments,
+				SkipOptional:  skipOptional,
 			})
 		},
-	}).Build()
+	}
+
+	flags.AddFlags(cmd,
+		flags.ScaffoldType,
+		flags.Traits,
+		flags.Workflow,
+		flags.Project,
+		flags.Namespace,
+		flags.OutputFile,
+		flags.SkipComments,
+		flags.SkipOptional,
+	)
+
+	return cmd
 }
 
 func newDeployComponentCmd() *cobra.Command {

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -149,11 +149,11 @@ Examples:
 
 Examples:
   # Scaffold a component from a ComponentType
-  %[1]s scaffold component --name my-app --type deployment/web-app`, messages.DefaultCLIName),
+  %[1]s scaffold component my-app --type deployment/web-app`, messages.DefaultCLIName),
 	}
 
 	ScaffoldComponent = Command{
-		Use:   "scaffold",
+		Use:   "scaffold COMPONENT_NAME",
 		Short: "Scaffold a Component YAML from ComponentType and Traits",
 		Long: fmt.Sprintf(`Generate a Component YAML file based on a ComponentType definition.
 
@@ -165,16 +165,16 @@ The --namespace and --project flags can be omitted if set in the current context
 
 Examples:
   # Scaffold a basic component
-  %[1]s component scaffold --name my-app --type deployment/web-app
+  %[1]s component scaffold my-app --type deployment/web-app
 
   # Scaffold with traits
-  %[1]s component scaffold --name my-app --type deployment/web-app --traits storage,ingress
+  %[1]s component scaffold my-app --type deployment/web-app --traits storage,ingress
 
   # Scaffold with workflow
-  %[1]s component scaffold --name my-app --type deployment/web-app --workflow docker-build
+  %[1]s component scaffold my-app --type deployment/web-app --workflow docker-build
 
   # Output to file
-  %[1]s component scaffold --name my-app --type deployment/web-app -o my-app.yaml`, messages.DefaultCLIName),
+  %[1]s component scaffold my-app --type deployment/web-app -o my-app.yaml`, messages.DefaultCLIName),
 	}
 
 	ListNamespace = Command{


### PR DESCRIPTION
## Summary
- Migrate schema methods (`GetComponentTypeSchema`, `GetTraitSchema`, `GetWorkflowSchema`) from legacy client to OpenAPI client, fixing the 404/empty-error on `component scaffold` caused by response format mismatch
- Change `--name` flag to a positional argument for `component scaffold` (e.g., `occ component scaffold my-app --type deployment/web-app`)

## Test plan
- [ ] `occ component scaffold my-app --type deployment/web-application` returns scaffold YAML instead of 404
- [ ] `occ component scaffold --help` shows `COMPONENT_NAME` as positional arg