### PR TITLE
fix: pin logs and metrics module versions in quickstart

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1056,14 +1056,18 @@ install_observability_plane() {
     log_info "Installing observability modules..."
 
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
+        "--version" "0.3.2" \
         "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials"
 
     # Enable fluent-bit after opensearch is installed and ready
     log_info "Enabling fluent-bit for log collection..."
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--reuse-values" "--set" "fluent-bit.enabled=true"
+        "--version" "0.3.2" \
+        "--reuse-values" \
+        "--set" "fluent-bit.enabled=true"
 
-    install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600"
+    install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
+        "--version" "0.2.2"
 }
 
 # Apply ClusterWorkflowTemplates required by the build plane

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -280,10 +280,12 @@ _e2e.install-op:
 	@$(call log_info, Installing observability modules)
 	$(E2E_HELM) upgrade --install observability-logs-opensearch \
 		oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+		--version 0.3.2 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_HELM) upgrade --install observability-metrics-prometheus \
 		oci://ghcr.io/openchoreo/charts/observability-metrics-prometheus \
+		--version 0.2.2 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_KUBECTL) wait -n $(E2E_OP_NS) \


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Pin observability-logs-opensearch and observability-metrics-prometheus module versions in the quickstart

## Approach
Added `--version` flags to the helm install commands and set the version

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
