### PR TITLE
fix: pod health incorrectly returning Progressing for CrashLoopBackOff

### DIFF
--- a/internal/controller/release/controller_status.go
+++ b/internal/controller/release/controller_status.go
@@ -319,16 +319,16 @@ func getPodHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.HealthStat
 	case corev1.PodRunning:
 		// Check if all containers are ready
 		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if !containerStatus.Ready {
-				return openchoreov1alpha1.HealthStatusProgressing, nil
-			}
-			// Check if container is in a waiting state with error
+			// Check if container is in a waiting state with error before checking readiness
 			if containerStatus.State.Waiting != nil {
 				if containerStatus.State.Waiting.Reason == "CrashLoopBackOff" ||
 					containerStatus.State.Waiting.Reason == "ImagePullBackOff" ||
 					containerStatus.State.Waiting.Reason == "ErrImagePull" {
 					return openchoreov1alpha1.HealthStatusDegraded, nil
 				}
+			}
+			if !containerStatus.Ready {
+				return openchoreov1alpha1.HealthStatusProgressing, nil
 			}
 		}
 		return openchoreov1alpha1.HealthStatusHealthy, nil


### PR DESCRIPTION
## Purpose
The readiness check was evaluated before the waiting state check, causing containers in CrashLoopBackOff, ImagePullBackOff, or ErrImagePull to return Progressing instead of Degraded.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
