### PR TITLE
refactor: remove experimental prefix from observability adapter configs and pass them as env variables to observer

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -79,16 +79,16 @@ func main() {
 	// Initialize prometheus metrics service for the legacy logging service
 	promService := prometheus.NewMetricsService(promClient, logger)
 
-	// Initialize logs adapter (optional - based on experimental flag)
+	// Initialize logs adapter (optional)
 	var logsAdapter observability.LogsAdapter
-	if cfg.Experimental.UseLogsAdapter {
-		logger.Info("Experimental feature active: Using logs adapter",
-			"adapter_url", cfg.Experimental.LogsAdapterURL)
+	if cfg.Adapters.LogsAdapterEnabled {
+		logger.Info("Using logs adapter",
+			"adapter_url", cfg.Adapters.LogsAdapterURL)
 
 		// Initialize HTTP-based adapter (e.g., OpenObserve)
 		adapterConfig := service.LogsAdapterConfig{
-			BaseURL: cfg.Experimental.LogsAdapterURL,
-			Timeout: cfg.Experimental.LogsAdapterTimeout,
+			BaseURL: cfg.Adapters.LogsAdapterURL,
+			Timeout: cfg.Adapters.LogsAdapterTimeout,
 		}
 		logsAdapter = service.NewLogsAdapter(adapterConfig)
 		logger.Info("Logs adapter initialized")
@@ -96,15 +96,15 @@ func main() {
 		logger.Info("Using OpenSearch for component logs")
 	}
 
-	// Initialize tracing adapter (optional - based on experimental flag)
+	// Initialize tracing adapter (optional)
 	var tracingAdapter observability.TracingAdapter
-	if cfg.Experimental.UseTracingAdapter {
-		logger.Info("Experimental feature active: Using tracing adapter",
-			"adapter_url", cfg.Experimental.TracingAdapterURL)
+	if cfg.Adapters.TracingAdapterEnabled {
+		logger.Info("Using tracing adapter",
+			"adapter_url", cfg.Adapters.TracingAdapterURL)
 
 		adapterConfig := service.TracingAdapterConfig{
-			BaseURL: cfg.Experimental.TracingAdapterURL,
-			Timeout: cfg.Experimental.TracingAdapterTimeout,
+			BaseURL: cfg.Adapters.TracingAdapterURL,
+			Timeout: cfg.Adapters.TracingAdapterTimeout,
 		}
 		tracingAdapter = service.NewTracingAdapter(adapterConfig)
 		logger.Info("Tracing adapter initialized")

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -92,6 +92,20 @@ spec:
         - name: CORS_ALLOWED_ORIGINS
           value: {{ join "," .Values.observer.cors.allowedOrigins | quote }}
         {{- end }}
+        # Logs adapter configuration
+        - name: LOGS_ADAPTER_ENABLED
+          value: {{ .Values.observer.logsAdapter.enabled | default false | quote }}
+        - name: LOGS_ADAPTER_URL
+          value: {{ .Values.observer.logsAdapter.url | default "http://logs-adapter:9098" | quote }}
+        - name: LOGS_ADAPTER_TIMEOUT
+          value: {{ .Values.observer.logsAdapter.timeout | default "30s" | quote }}
+        # Tracing adapter configuration
+        - name: TRACING_ADAPTER_ENABLED
+          value: {{ .Values.observer.tracingAdapter.enabled | default false | quote }}
+        - name: TRACING_ADAPTER_URL
+          value: {{ .Values.observer.tracingAdapter.url | default "http://tracing-adapter:9098" | quote }}
+        - name: TRACING_ADAPTER_TIMEOUT
+          value: {{ .Values.observer.tracingAdapter.timeout | default "30s" | quote }}
         {{- if .Values.observer.extraEnvs }}
         {{- toYaml .Values.observer.extraEnvs | nindent 8 }}
         {{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1488,14 +1488,6 @@
           "title": "cors",
           "type": "object"
         },
-        "experimental": {
-          "additionalProperties": true,
-          "default": true,
-          "description": "Control experimental features in the Observer service",
-          "required": [],
-          "title": "experimental",
-          "type": "object"
-        },
         "extraEnvs": {
           "description": "Extra environment variables for the Observer container",
           "items": {
@@ -1598,6 +1590,33 @@
           ],
           "required": [],
           "title": "logLevel"
+        },
+        "logsAdapter": {
+          "additionalProperties": false,
+          "description": "Configurations for logs adapter connectivity",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable logs adapter for fetching logs from an external adapter",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "timeout": {
+              "default": "30s",
+              "description": "Timeout for logs adapter requests",
+              "title": "timeout",
+              "type": "string"
+            },
+            "url": {
+              "default": "http://logs-adapter:9098",
+              "description": "URL of the logs adapter service",
+              "title": "url",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "logsAdapter",
+          "type": "object"
         },
         "oauthClientId": {
           "default": "openchoreo-observer",
@@ -1781,6 +1800,33 @@
           },
           "required": [],
           "title": "service",
+          "type": "object"
+        },
+        "tracingAdapter": {
+          "additionalProperties": false,
+          "description": "Configurations for tracing adapter connectivity",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable tracing adapter for fetching traces from an external adapter",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "timeout": {
+              "default": "30s",
+              "description": "Timeout for tracing adapter requests",
+              "title": "timeout",
+              "type": "string"
+            },
+            "url": {
+              "default": "http://tracing-adapter:9098",
+              "description": "URL of the tracing adapter service",
+              "title": "url",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "tracingAdapter",
           "type": "object"
         }
       },

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -775,11 +775,27 @@ observer:
 
   # @schema
   # type: object
-  # additionalProperties: true
-  # description: Control experimental features in the Observer service
-  # default: true
+  # description: Configurations for logs adapter connectivity
   # @schema
-  experimental: {}
+  logsAdapter:
+    # @schema
+    # type: boolean
+    # description: Enable logs adapter for fetching logs from an external adapter
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: string
+    # description: URL of the logs adapter service
+    # default: "http://logs-adapter:9098"
+    # @schema
+    url: "http://logs-adapter:9098"
+    # @schema
+    # type: string
+    # description: Timeout for logs adapter requests
+    # default: "30s"
+    # @schema
+    timeout: "30s"
 
   # @schema
   # type: integer
@@ -844,6 +860,30 @@ observer:
             entitlement:
               claim: "sub"
               display_name: "Client ID"
+
+  # @schema
+  # type: object
+  # description: Configurations for tracing adapter connectivity
+  # @schema
+  tracingAdapter:
+    # @schema
+    # type: boolean
+    # description: Enable tracing adapter for fetching traces from an external adapter
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: string
+    # description: URL of the tracing adapter service
+    # default: "http://tracing-adapter:9098"
+    # @schema
+    url: "http://tracing-adapter:9100"
+    # @schema
+    # type: string
+    # description: Timeout for tracing adapter requests
+    # default: "30s"
+    # @schema
+    timeout: "30s"
 
   # @schema
   # type: string

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -18,26 +18,26 @@ import (
 
 // Config holds all configuration for the logging service
 type Config struct {
-	Server       ServerConfig       `koanf:"server"`
-	OpenSearch   OpenSearchConfig   `koanf:"opensearch"`
-	Prometheus   PrometheusConfig   `koanf:"prometheus"`
-	Auth         AuthConfig         `koanf:"auth"`
-	Authz        AuthzConfig        `koanf:"authz"`
-	Logging      LoggingConfig      `koanf:"logging"`
-	Alerting     AlertingConfig     `koanf:"alerting"`
-	Experimental ExperimentalConfig `koanf:"experimental"`
-	UIDResolver  UIDResolverConfig  `koanf:"uid_resolver"`
-	CORS         CORSConfig         `koanf:"cors"`
-	LogLevel     string             `koanf:"loglevel"`
+	Server      ServerConfig      `koanf:"server"`
+	OpenSearch  OpenSearchConfig  `koanf:"opensearch"`
+	Prometheus  PrometheusConfig  `koanf:"prometheus"`
+	Auth        AuthConfig        `koanf:"auth"`
+	Authz       AuthzConfig       `koanf:"authz"`
+	Logging     LoggingConfig     `koanf:"logging"`
+	Alerting    AlertingConfig    `koanf:"alerting"`
+	Adapters    AdaptersConfig    `koanf:"adapters"`
+	UIDResolver UIDResolverConfig `koanf:"uid_resolver"`
+	CORS        CORSConfig        `koanf:"cors"`
+	LogLevel    string            `koanf:"loglevel"`
 }
 
-// ExperimentalConfig holds experimental feature flags
-type ExperimentalConfig struct {
-	UseLogsAdapter     bool          `koanf:"use.logs.adapter"`
+// AdaptersConfig holds adapter configuration
+type AdaptersConfig struct {
+	LogsAdapterEnabled bool          `koanf:"logs.adapter.enabled"`
 	LogsAdapterURL     string        `koanf:"logs.adapter.url"`
 	LogsAdapterTimeout time.Duration `koanf:"logs.adapter.timeout"`
 
-	UseTracingAdapter     bool          `koanf:"use.tracing.adapter"`
+	TracingAdapterEnabled bool          `koanf:"tracing.adapter.enabled"`
 	TracingAdapterURL     string        `koanf:"tracing.adapter.url"`
 	TracingAdapterTimeout time.Duration `koanf:"tracing.adapter.timeout"`
 }
@@ -193,12 +193,12 @@ func Load() (*Config, error) {
 		"JWT_SECRET":                            "auth.jwt.secret",       // Common alias
 		"ENABLE_AUTH":                           "auth.enable.auth",      // Common alias
 		"MAX_LOG_LIMIT":                         "logging.max.log.limit", // Common alias
-		"EXPERIMENTAL_USE_LOGS_ADAPTER":         "experimental.use.logs.adapter",
-		"EXPERIMENTAL_LOGS_ADAPTER_URL":         "experimental.logs.adapter.url",
-		"EXPERIMENTAL_LOGS_ADAPTER_TIMEOUT":     "experimental.logs.adapter.timeout",
-		"EXPERIMENTAL_USE_TRACING_ADAPTER":      "experimental.use.tracing.adapter",
-		"EXPERIMENTAL_TRACING_ADAPTER_URL":      "experimental.tracing.adapter.url",
-		"EXPERIMENTAL_TRACING_ADAPTER_TIMEOUT":  "experimental.tracing.adapter.timeout",
+		"LOGS_ADAPTER_ENABLED":                  "adapters.logs.adapter.enabled",
+		"LOGS_ADAPTER_URL":                      "adapters.logs.adapter.url",
+		"LOGS_ADAPTER_TIMEOUT":                  "adapters.logs.adapter.timeout",
+		"TRACING_ADAPTER_ENABLED":               "adapters.tracing.adapter.enabled",
+		"TRACING_ADAPTER_URL":                   "adapters.tracing.adapter.url",
+		"TRACING_ADAPTER_TIMEOUT":               "adapters.tracing.adapter.timeout",
 		"UID_RESOLVER_OPENCHOREO_API_URL":       "uid_resolver.openchoreo.api.url",
 		"UID_RESOLVER_OAUTH_TOKEN_URL":          "uid_resolver.oauth.token.url",
 		"UID_RESOLVER_OAUTH_CLIENT_ID":          "uid_resolver.oauth.client.id",
@@ -320,11 +320,11 @@ func getDefaults() map[string]interface{} {
 			"ai.rca.enabled":          false,
 			"observability.namespace": "openchoreo-observability-plane",
 		},
-		"experimental": map[string]interface{}{
-			"use.logs.adapter":        false,
+		"adapters": map[string]interface{}{
+			"logs.adapter.enabled":    false,
 			"logs.adapter.url":        "http://logs-adapter:9098",
 			"logs.adapter.timeout":    "30s",
-			"use.tracing.adapter":     false,
+			"tracing.adapter.enabled": false,
 			"tracing.adapter.url":     "http://tracing-adapter:9100",
 			"tracing.adapter.timeout": "30s",
 		},

--- a/internal/observer/service/legacy/service.go
+++ b/internal/observer/service/legacy/service.go
@@ -249,10 +249,10 @@ func (s *LoggingService) GetComponentLogs(ctx context.Context, params opensearch
 		"component_id", params.ComponentID,
 		"environment_id", params.EnvironmentID,
 		"search_phrase", params.SearchPhrase,
-		"use_adapter", s.config.Experimental.UseLogsAdapter)
+		"use_adapter", s.config.Adapters.LogsAdapterEnabled)
 
 	// Check if adapter is enabled and available
-	if s.config.Experimental.UseLogsAdapter && s.logsAdapter != nil {
+	if s.config.Adapters.LogsAdapterEnabled && s.logsAdapter != nil {
 		// Parse time parameters for adapter
 		startTime, err := time.Parse(time.RFC3339, params.StartTime)
 		if err != nil {

--- a/internal/observer/service/logs.go
+++ b/internal/observer/service/logs.go
@@ -43,7 +43,7 @@ func NewLogsService(
 ) (*LogsService, error) {
 	var defaultAdaptor *adaptor.DefaultLogsAdaptor
 	// Initialize default logs adaptor (queries OpenSearch when logs adapter is not enabled)
-	if !cfg.Experimental.UseLogsAdapter || logsAdapter == nil {
+	if !cfg.Adapters.LogsAdapterEnabled || logsAdapter == nil {
 		var err error
 		defaultAdaptor, err = adaptor.NewDefaultLogsAdaptor(&cfg.OpenSearch, logger)
 		if err != nil {
@@ -88,7 +88,7 @@ func (s *LogsService) QueryLogs(ctx context.Context, req *types.LogsQueryRequest
 		"endTime", req.EndTime,
 		"hasSearchPhrase", req.SearchPhrase != "",
 		"limit", req.Limit,
-		"useLogsAdapter", s.config.Experimental.UseLogsAdapter)
+		"useLogsAdapter", s.config.Adapters.LogsAdapterEnabled)
 
 	// Convert request to internal representation with resolved UIDs
 	scope, err := s.resolveSearchScope(ctx, req.SearchScope)
@@ -147,7 +147,7 @@ func (s *LogsService) queryComponentLogs(
 	var err error
 
 	// Check if adapter is enabled and available
-	if s.config.Experimental.UseLogsAdapter && s.logsAdapter != nil {
+	if s.config.Adapters.LogsAdapterEnabled && s.logsAdapter != nil {
 		s.logger.Debug("Using logs adapter for component logs query")
 		result, err = s.getComponentLogsFromAdapter(ctx, params)
 	} else {
@@ -190,7 +190,7 @@ func (s *LogsService) queryWorkflowLogs(
 	var err error
 
 	// Check if adapter is enabled and available
-	if s.config.Experimental.UseLogsAdapter && s.logsAdapter != nil {
+	if s.config.Adapters.LogsAdapterEnabled && s.logsAdapter != nil {
 		s.logger.Debug("Using logs adapter for workflow logs query")
 		result, err = s.getWorkflowLogsFromAdapter(ctx, params)
 	} else {

--- a/internal/observer/service/traces.go
+++ b/internal/observer/service/traces.go
@@ -64,7 +64,7 @@ func (s *TracesService) QueryTraces(ctx context.Context, req *types.TracesQueryR
 	s.logger.Info("QueryTraces called",
 		"startTime", req.StartTime,
 		"endTime", req.EndTime,
-		"useTracingAdapter", s.config.Experimental.UseTracingAdapter)
+		"useTracingAdapter", s.config.Adapters.TracingAdapterEnabled)
 
 	// Resolve search scope to UIDs
 	projectUID, componentUID, environmentUID, err := s.resolveSearchScope(ctx, &req.SearchScope)
@@ -87,7 +87,7 @@ func (s *TracesService) QueryTraces(ctx context.Context, req *types.TracesQueryR
 
 	// Route to tracing adapter or OpenSearch
 	var result *observability.TracesQueryResult
-	if s.config.Experimental.UseTracingAdapter && s.tracingAdapter != nil {
+	if s.config.Adapters.TracingAdapterEnabled && s.tracingAdapter != nil {
 		s.logger.Debug("Using tracing adapter for query")
 		result, err = s.tracingAdapter.GetTraces(ctx, params)
 	} else {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Remove the EXPERIMENTAL_ prefix from observer logs and tracing adapter environment variables, as these features are no longer experimental. Also rename EXPERIMENTAL_USE_LOGS_ADAPTER / EXPERIMENTAL_USE_TRACING_ADAPTER to the clearer LOGS_ADAPTER_ENABLED / TRACING_ADAPTER_ENABLED. Additionally, wire up the adapter configuration from the Helm chart values into the observer deployment.

## Approach
- Renamed the ExperimentalConfig struct to AdaptersConfig in the observer config package, updating the koanf section from experimental to adapters.
- Renamed UseLogsAdapter / UseTracingAdapter fields to LogsAdapterEnabled / TracingAdapterEnabled.
- Updated environment variable mappings: EXPERIMENTAL_USE_LOGS_ADAPTER → LOGS_ADAPTER_ENABLED, EXPERIMENTAL_LOGS_ADAPTER_URL → LOGS_ADAPTER_URL, EXPERIMENTAL_LOGS_ADAPTER_TIMEOUT → LOGS_ADAPTER_TIMEOUT, and the same for tracing adapter variables.
- Updated all references across cmd/observer/main.go, internal/observer/service/logs.go, internal/observer/service/traces.go, and internal/observer/service/legacy/service.go.
- Added the six adapter environment variables (LOGS_ADAPTER_ENABLED, LOGS_ADAPTER_URL, LOGS_ADAPTER_TIMEOUT, TRACING_ADAPTER_ENABLED, TRACING_ADAPTER_URL, TRACING_ADAPTER_TIMEOUT) to the observer deployment template, sourced from the corresponding Helm values.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
