### PR TITLE
fix: convert values of LOGS_ADAPTER_ENABLED and TRACING_ADAPTER_ENABLED env variables to boolean

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -98,7 +98,7 @@ spec:
         - name: LOGS_ADAPTER_ENABLED
           value: {{ .Values.observer.logsAdapter.enabled | default false | quote }}
         - name: LOGS_ADAPTER_URL
-          value: {{ .Values.observer.logsAdapter.url | default "http://logs-adapter:9098" | quote }}
+          value: {{ .Values.observer.logsAdapter.url | default "http://logs-adapter:9100" | quote }}
         - name: LOGS_ADAPTER_TIMEOUT
           value: {{ .Values.observer.logsAdapter.timeout | default "30s" | quote }}
         # Tracing adapter configuration

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1819,7 +1819,7 @@
               "type": "string"
             },
             "url": {
-              "default": "http://tracing-adapter:9098",
+              "default": "http://tracing-adapter:9100",
               "description": "URL of the tracing adapter service",
               "title": "url",
               "type": "string"

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -875,7 +875,7 @@ observer:
     # @schema
     # type: string
     # description: URL of the tracing adapter service
-    # default: "http://tracing-adapter:9098"
+    # default: "http://tracing-adapter:9100"
     # @schema
     url: "http://tracing-adapter:9100"
     # @schema

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -207,14 +208,30 @@ func Load() (*Config, error) {
 		"UID_RESOLVER_TIMEOUT":                  "uid_resolver.timeout",
 	}
 
+	// Environment variables that require string-to-boolean conversion
+	boolEnvKeys := map[string]bool{
+		"LOGS_ADAPTER_ENABLED":    true,
+		"TRACING_ADAPTER_ENABLED": true,
+	}
+
 	// Check for environment variables and map them to nested structure
 	for envKey, configKey := range envMappings {
 		if value := os.Getenv(envKey); value != "" {
+			// Convert string value to the appropriate type
+			var parsedValue interface{} = value
+			if boolEnvKeys[envKey] {
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid boolean value for env %s: %q: %w", envKey, value, err)
+				}
+				parsedValue = b
+			}
+
 			// Split the config key and create nested structure
 			parts := strings.Split(configKey, ".")
 			if len(parts) == 1 {
 				// Top-level key
-				envOverrides[configKey] = value
+				envOverrides[configKey] = parsedValue
 			} else if len(parts) == 2 {
 				// Nested key like "server.port"
 				section := parts[0]
@@ -222,7 +239,7 @@ func Load() (*Config, error) {
 				if envOverrides[section] == nil {
 					envOverrides[section] = make(map[string]interface{})
 				}
-				envOverrides[section].(map[string]interface{})[key] = value
+				envOverrides[section].(map[string]interface{})[key] = parsedValue
 			} else if len(parts) >= 3 {
 				// Handle multi-part keys like "logging.max.log.limit"
 				section := parts[0]
@@ -230,7 +247,7 @@ func Load() (*Config, error) {
 				if envOverrides[section] == nil {
 					envOverrides[section] = make(map[string]interface{})
 				}
-				envOverrides[section].(map[string]interface{})[key] = value
+				envOverrides[section].(map[string]interface{})[key] = parsedValue
 			}
 		}
 	}

--- a/internal/observer/config/config_test.go
+++ b/internal/observer/config/config_test.go
@@ -179,6 +179,122 @@ func TestLoad_CORSAllowedOrigins(t *testing.T) {
 	}
 }
 
+func TestLoad_BooleanEnvParsing(t *testing.T) {
+	tests := []struct {
+		name                  string
+		logsAdapterEnabled    string
+		tracingAdapterEnabled string
+		expectedLogs          bool
+		expectedTracing       bool
+	}{
+		{
+			name:                  "true string",
+			logsAdapterEnabled:    "true",
+			tracingAdapterEnabled: "true",
+			expectedLogs:          true,
+			expectedTracing:       true,
+		},
+		{
+			name:                  "false string",
+			logsAdapterEnabled:    "false",
+			tracingAdapterEnabled: "false",
+			expectedLogs:          false,
+			expectedTracing:       false,
+		},
+		{
+			name:                  "1 is true",
+			logsAdapterEnabled:    "1",
+			tracingAdapterEnabled: "1",
+			expectedLogs:          true,
+			expectedTracing:       true,
+		},
+		{
+			name:                  "0 is false",
+			logsAdapterEnabled:    "0",
+			tracingAdapterEnabled: "0",
+			expectedLogs:          false,
+			expectedTracing:       false,
+		},
+		{
+			name:                  "mixed valid values",
+			logsAdapterEnabled:    "true",
+			tracingAdapterEnabled: "false",
+			expectedLogs:          true,
+			expectedTracing:       false,
+		},
+		{
+			name:                  "TRUE uppercase",
+			logsAdapterEnabled:    "TRUE",
+			tracingAdapterEnabled: "FALSE",
+			expectedLogs:          true,
+			expectedTracing:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LOGS_ADAPTER_ENABLED", tt.logsAdapterEnabled)
+			t.Setenv("TRACING_ADAPTER_ENABLED", tt.tracingAdapterEnabled)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+
+			if cfg.Adapters.LogsAdapterEnabled != tt.expectedLogs {
+				t.Errorf("LogsAdapterEnabled: expected %v, got %v (env=%q)",
+					tt.expectedLogs, cfg.Adapters.LogsAdapterEnabled, tt.logsAdapterEnabled)
+			}
+			if cfg.Adapters.TracingAdapterEnabled != tt.expectedTracing {
+				t.Errorf("TracingAdapterEnabled: expected %v, got %v (env=%q)",
+					tt.expectedTracing, cfg.Adapters.TracingAdapterEnabled, tt.tracingAdapterEnabled)
+			}
+		})
+	}
+}
+
+func TestLoad_BooleanEnvParsing_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "yes is invalid", value: "yes"},
+		{name: "no is invalid", value: "no"},
+		{name: "arbitrary string is invalid", value: "notabool"},
+		{name: "numeric non-boolean is invalid", value: "2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LOGS_ADAPTER_ENABLED", tt.value)
+			t.Setenv("TRACING_ADAPTER_ENABLED", tt.value)
+
+			_, err := Load()
+			if err == nil {
+				t.Errorf("Expected error for invalid boolean value %q, but got none", tt.value)
+			}
+		})
+	}
+}
+
+func TestLoad_BooleanEnvParsing_Unset(t *testing.T) {
+	// When env vars are not set, adapters should default to false
+	os.Unsetenv("LOGS_ADAPTER_ENABLED")
+	os.Unsetenv("TRACING_ADAPTER_ENABLED")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if cfg.Adapters.LogsAdapterEnabled != false {
+		t.Errorf("Expected LogsAdapterEnabled default false, got %v", cfg.Adapters.LogsAdapterEnabled)
+	}
+	if cfg.Adapters.TracingAdapterEnabled != false {
+		t.Errorf("Expected TracingAdapterEnabled default false, got %v", cfg.Adapters.TracingAdapterEnabled)
+	}
+}
+
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
When LOGS_ADAPTER_ENABLED or TRACING_ADAPTER_ENABLED environment variables are set to true, the observer still uses the default OpenSearch adapter instead of the configured external adapter. This is because os.Getenv() returns the string "true", but koanf's confmap provider doesn't auto-convert it to a boolean when unmarshalling into the config struct, so the field remains false.

## Approach
Added explicit strconv.ParseBool() conversion for the LOGS_ADAPTER_ENABLED and TRACING_ADAPTER_ENABLED environment variables before storing them in the config overrides map. This ensures koanf receives a boolean value matching the type used in the defaults, so the adapter-enabled flags are correctly set at runtime.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
