### PR TITLE
feat: add uidResolverTlsInsecureSkipVerify option to security settings

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -43,6 +43,8 @@ spec:
         {{- end }}
         - name: JWKS_URL_TLS_INSECURE_SKIP_VERIFY
           value: {{ .Values.security.oidc.jwksUrlTlsInsecureSkipVerify | default "false" | quote }}
+        - name: UID_RESOLVER_TLS_INSECURE_SKIP_VERIFY
+          value: {{ .Values.security.oidc.uidResolverTlsInsecureSkipVerify | default "false" | quote }}
         {{- if .Values.security.jwt.audience }}
         - name: JWT_AUDIENCE
           value: {{ .Values.security.jwt.audience | quote }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -3831,6 +3831,12 @@
               "description": "OIDC token endpoint URL",
               "title": "tokenUrl",
               "type": "string"
+            },
+            "uidResolverTlsInsecureSkipVerify": {
+              "default": "false",
+              "description": "Skip TLS verification for the UID resolver OAuth token endpoint (for self-signed certs)",
+              "title": "uidResolverTlsInsecureSkipVerify",
+              "type": "string"
             }
           },
           "required": [],

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -2857,6 +2857,12 @@ security:
     jwksUrlTlsInsecureSkipVerify: "false"
     # @schema
     # type: string
+    # description: Skip TLS verification for the UID resolver OAuth token endpoint (for self-signed certs)
+    # default: "false"
+    # @schema
+    uidResolverTlsInsecureSkipVerify: "false"
+    # @schema
+    # type: string
     # description: Base URL for the authorization server (used for OAuth metadata)
     # default: ""
     # @schema


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request adds support for configuring whether to skip TLS verification for the UID resolver OAuth token endpoint in the OpenChoreo Observability Plane Helm chart. This is useful for environments where self-signed certificates are used.

Configuration enhancements:

* Added a new `uidResolverTlsInsecureSkipVerify` field under the `security.oidc` section in `values.yaml` to allow users to skip TLS verification for the UID resolver OAuth token endpoint, with documentation and a default value of `"false"`.
* Updated the Helm values schema (`values.schema.json`) to include the new `uidResolverTlsInsecureSkipVerify` property, ensuring validation and documentation in the Helm chart.

Deployment template update:

* Modified the `observer-deployment.yaml` template to inject the new `UID_RESOLVER_TLS_INSECURE_SKIP_VERIFY` environment variable into the deployment, based on the new Helm value.

## Approach
Introduced a new configuration option `uidResolverTlsInsecureSkipVerify` in the Helm chart for the observability plane. This option allows users to skip TLS verification for the UID resolver OAuth token endpoint, accommodating scenarios with self-signed certificates. Updated the corresponding schema and deployment templates to reflect this change.


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
