### PR TITLE
chore: update websocket sample readme

### DIFF
--- a/samples/from-image/echo-websocket-service/README.md
+++ b/samples/from-image/echo-websocket-service/README.md
@@ -52,10 +52,10 @@ You can test the WebSocket service using `wscat` (install via `npm install -g ws
 
 ### Connect to the WebSocket
 
-The service is exposed at the base path `/{component-name}`. For this sample, the component name is `echo-websocket-service`.
+The service is exposed at the base path `/{component-name}-{endpoint-name}`. For this sample, the component name is `echo-websocket-service` and endpoint name is `websocket`.
 
 ```bash
-wscat -c "ws://localhost:19080/echo-websocket-service/.ws" --header "Host: development-default.openchoreoapis.localhost"
+wscat -c "ws://localhost:19080/echo-websocket-service-websocket/.ws" --header "Host: development-default.openchoreoapis.localhost"
 ```
 
 Once connected, type any message and press Enter. The server will echo back the same message.


### PR DESCRIPTION
## Purpose
This PR updates the websocket sample readme related to the endpoint changes we did recently. Previously only component name is used as the gateway basepath and with the new endpoint changes endpoint name will be appended to the gateway basepath as well.
