### PR TITLE
feat: add authzTlsInsecureSkipVerify option to observer configuration

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: /etc/openchoreo/auth-config.yaml
         - name: AUTHZ_SERVICE_URL
           value: {{ .Values.observer.controlPlaneApiUrl | quote }}
+        - name: AUTHZ_TLS_INSECURE_SKIP_VERIFY
+          value: {{ .Values.observer.authzTlsInsecureSkipVerify | default false | quote }}
         # UIDResolver configuration for calling openchoreo-api with OAuth2 client credentials
         - name: UID_RESOLVER_OPENCHOREO_API_URL
           value: {{ .Values.observer.controlPlaneApiUrl | quote }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1465,6 +1465,12 @@
       "additionalProperties": true,
       "description": "OpenChoreo Observer service configuration - REST API that abstracts OpenSearch for logging, metrics, and tracing",
       "properties": {
+        "authzTlsInsecureSkipVerify": {
+          "default": false,
+          "description": "Skip TLS certificate verification when calling the control plane authz service (use for self-signed certs)",
+          "title": "authzTlsInsecureSkipVerify",
+          "type": "boolean"
+        },
         "controlPlaneApiUrl": {
           "default": "http://api.openchoreo.localhost:8080",
           "description": "Control plane API base URL used by observer",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -774,6 +774,13 @@ observer:
   controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
 
   # @schema
+  # type: boolean
+  # description: Skip TLS certificate verification when calling the control plane authz service (use for self-signed certs)
+  # default: false
+  # @schema
+  authzTlsInsecureSkipVerify: false
+
+  # @schema
   # type: object
   # description: Configurations for logs adapter connectivity
   # @schema

--- a/internal/observer/authz/client.go
+++ b/internal/observer/authz/client.go
@@ -6,6 +6,7 @@ package authz
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,6 +40,11 @@ func NewClient(cfg *config.AuthzConfig, logger *slog.Logger) (*Client, error) {
 
 	httpClient := &http.Client{
 		Timeout: cfg.Timeout,
+	}
+	if cfg.TLSInsecureSkipVerify {
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // intentional for self-signed certs
+		}
 	}
 
 	logger.Info("Authorization client initialized",

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -85,8 +85,9 @@ type AuthConfig struct {
 
 // AuthzConfig holds authorization configuration
 type AuthzConfig struct {
-	ServiceURL string        `koanf:"service.url"`
-	Timeout    time.Duration `koanf:"timeout"`
+	ServiceURL            string        `koanf:"service.url"`
+	Timeout               time.Duration `koanf:"timeout"`
+	TLSInsecureSkipVerify bool          `koanf:"tls.insecure.skip.verify"`
 }
 
 // LoggingConfig holds application logging configuration
@@ -181,6 +182,7 @@ func Load() (*Config, error) {
 		"AUTH_REQUIRED_ROLE":                    "auth.required.role",
 		"AUTHZ_SERVICE_URL":                     "authz.service.url",
 		"AUTHZ_TIMEOUT":                         "authz.timeout",
+		"AUTHZ_TLS_INSECURE_SKIP_VERIFY":        "authz.tls.insecure.skip.verify",
 		"LOGGING_MAX_LOG_LIMIT":                 "logging.max.log.limit",
 		"LOGGING_DEFAULT_LOG_LIMIT":             "logging.default.log.limit",
 		"LOGGING_DEFAULT_BUILD_LOG_LIMIT":       "logging.default.build.log.limit",
@@ -323,8 +325,9 @@ func getDefaults() map[string]interface{} {
 			"required.role": "user",
 		},
 		"authz": map[string]interface{}{
-			"service.url": "http://localhost:8080",
-			"timeout":     "30s",
+			"service.url":              "http://localhost:8080",
+			"timeout":                  "30s",
+			"tls.insecure.skip.verify": false,
 		},
 		"logging": map[string]interface{}{
 			"max.log.limit":           10000,


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
$subject. For observer to be usable with self signed certs.

## Approach
Introduced a new configuration option `authzTlsInsecureSkipVerify` in the Helm chart for the observability plane. This option allows users to skip TLS verification when calling the control plane authorization service, accommodating scenarios with self-signed certificates. Updated the corresponding schema, values file, and deployment templates to reflect this change.


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
