### PR TITLE
fix: expose observer via ingress in quick-start setup

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -892,7 +892,7 @@ spec:
     clientCA:
       value: |
 $(echo "$agent_ca" | sed 's/^/        /')
-  observerURL: http://observer.openchoreo-observability-plane.svc.cluster.local:8080
+  observerURL: http://observer.openchoreo.localhost:11080
 OPEOF
 
     log_success "ObservabilityPlane resource created"

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -41,6 +41,13 @@ openchoreoApi:
                 claim: sub
                 value: openchoreo-cli-quickstart
               effect: allow
+            - name: observer-binding
+              roleRef:
+                name: observer
+              entitlement:
+                claim: sub
+                value: openchoreo-observer
+              effect: allow
 
 backstage:
   secretName: backstage-secrets

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -19,6 +19,10 @@ openSearchCluster:
 
 # OpenChoreo Observer Service Configuration
 observer:
+  http:
+    hostnames:
+    - host.k3d.internal
+    - observer.openchoreo.localhost
   openSearchSecretName: observer-opensearch-credentials
   extraEnvs:
     - name: OPENSEARCH_ADDRESS


### PR DESCRIPTION
## Summary
- Update the observer URL in the ObservabilityPlane resource to use the ingress hostname (`observer.openchoreo.localhost:11080`) instead of the internal cluster service URL
- Add HTTP hostnames (`host.k3d.internal`, `observer.openchoreo.localhost`) to the observer service configuration
- Add an observer role binding in the control plane API authorization config

