### PR TITLE
fix: add missing property field to secret references

### DIFF
--- a/samples/component-types/component-with-configs/component-with-configs.yaml
+++ b/samples/component-types/component-with-configs/component-with-configs.yaml
@@ -236,6 +236,7 @@ spec:
     - secretKey: password
       remoteRef:
         key: password
+        property: value
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: SecretReference
@@ -250,6 +251,7 @@ spec:
     - secretKey: gitPAT
       remoteRef:
         key: github-pat
+        property: value
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component


### PR DESCRIPTION
## Summary
- Adds the missing `property: value` field to `SecretReference` resources (`database-secret` and `github-pat-secret`) in the component-with-configs sample
- Without this field, External Secrets Operator cannot correctly extract values from the vault backend

## Test plan
- [ ] Apply the sample: `kubectl apply --server-side -f samples/component-types/component-with-configs/component-with-configs.yaml`
- [ ] Verify the `ExternalSecret` resources sync successfully
- [ ] Delete the sample: `kubectl delete -f samples/component-types/component-with-configs/component-with-configs.yaml`