### PR TITLE
feat: add apiVersion and kind to all CRD API responses

### DIFF
--- a/internal/openchoreo-api/api/handlers/authz.go
+++ b/internal/openchoreo-api/api/handlers/authz.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -16,26 +14,6 @@ import (
 	authzsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/authz"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
-
-var authzClusterRoleTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "AuthzClusterRole",
-}
-
-var authzRoleTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "AuthzRole",
-}
-
-var authzClusterRoleBindingTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "AuthzClusterRoleBinding",
-}
-
-var authzRoleBindingTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "AuthzRoleBinding",
-}
 
 // Helper functions to safely dereference pointers
 func getStringValue(s *string) string {
@@ -283,10 +261,6 @@ func (h *Handler) ListClusterRoles(
 		return gen.ListClusterRoles500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	for i := range result.Items {
-		result.Items[i].TypeMeta = authzClusterRoleTypeMeta
-	}
-
 	items, err := convertList[openchoreov1alpha1.AuthzClusterRole, gen.AuthzClusterRole](result.Items)
 	if err != nil {
 		h.logger.Error("Failed to convert cluster roles", "error", err)
@@ -325,8 +299,6 @@ func (h *Handler) CreateClusterRole(
 		return gen.CreateClusterRole500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	created.TypeMeta = authzClusterRoleTypeMeta
-
 	genRole, err := convert[openchoreov1alpha1.AuthzClusterRole, gen.AuthzClusterRole](*created)
 	if err != nil {
 		h.logger.Error("Failed to convert created cluster role", "error", err)
@@ -355,8 +327,6 @@ func (h *Handler) GetClusterRole(
 		h.logger.Error("Failed to get cluster role", "error", err)
 		return gen.GetClusterRole500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	role.TypeMeta = authzClusterRoleTypeMeta
 
 	genRole, err := convert[openchoreov1alpha1.AuthzClusterRole, gen.AuthzClusterRole](*role)
 	if err != nil {
@@ -397,8 +367,6 @@ func (h *Handler) UpdateClusterRole(
 		h.logger.Error("Failed to update cluster role", "error", err)
 		return gen.UpdateClusterRole500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = authzClusterRoleTypeMeta
 
 	genRole, err := convert[openchoreov1alpha1.AuthzClusterRole, gen.AuthzClusterRole](*updated)
 	if err != nil {
@@ -455,10 +423,6 @@ func (h *Handler) ListClusterRoleBindings(
 		return gen.ListClusterRoleBindings500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	for i := range result.Items {
-		result.Items[i].TypeMeta = authzClusterRoleBindingTypeMeta
-	}
-
 	items, err := convertList[openchoreov1alpha1.AuthzClusterRoleBinding, gen.AuthzClusterRoleBinding](result.Items)
 	if err != nil {
 		h.logger.Error("Failed to convert cluster role bindings", "error", err)
@@ -500,8 +464,6 @@ func (h *Handler) CreateClusterRoleBinding(
 		return gen.CreateClusterRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	created.TypeMeta = authzClusterRoleBindingTypeMeta
-
 	genBinding, err := convert[openchoreov1alpha1.AuthzClusterRoleBinding, gen.AuthzClusterRoleBinding](*created)
 	if err != nil {
 		h.logger.Error("Failed to convert created cluster role binding", "error", err)
@@ -530,8 +492,6 @@ func (h *Handler) GetClusterRoleBinding(
 		h.logger.Error("Failed to get cluster role binding", "error", err)
 		return gen.GetClusterRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	binding.TypeMeta = authzClusterRoleBindingTypeMeta
 
 	genBinding, err := convert[openchoreov1alpha1.AuthzClusterRoleBinding, gen.AuthzClusterRoleBinding](*binding)
 	if err != nil {
@@ -572,8 +532,6 @@ func (h *Handler) UpdateClusterRoleBinding(
 		h.logger.Error("Failed to update cluster role binding", "error", err)
 		return gen.UpdateClusterRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = authzClusterRoleBindingTypeMeta
 
 	genBinding, err := convert[openchoreov1alpha1.AuthzClusterRoleBinding, gen.AuthzClusterRoleBinding](*updated)
 	if err != nil {
@@ -627,10 +585,6 @@ func (h *Handler) ListNamespaceRoles(
 		return gen.ListNamespaceRoles500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	for i := range result.Items {
-		result.Items[i].TypeMeta = authzRoleTypeMeta
-	}
-
 	items, err := convertList[openchoreov1alpha1.AuthzRole, gen.AuthzRole](result.Items)
 	if err != nil {
 		h.logger.Error("Failed to convert namespace roles", "error", err)
@@ -669,8 +623,6 @@ func (h *Handler) CreateNamespaceRole(
 		return gen.CreateNamespaceRole500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	created.TypeMeta = authzRoleTypeMeta
-
 	genRole, err := convert[openchoreov1alpha1.AuthzRole, gen.AuthzRole](*created)
 	if err != nil {
 		h.logger.Error("Failed to convert created namespace role", "error", err)
@@ -699,8 +651,6 @@ func (h *Handler) GetNamespaceRole(
 		h.logger.Error("Failed to get namespace role", "error", err)
 		return gen.GetNamespaceRole500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	role.TypeMeta = authzRoleTypeMeta
 
 	genRole, err := convert[openchoreov1alpha1.AuthzRole, gen.AuthzRole](*role)
 	if err != nil {
@@ -741,8 +691,6 @@ func (h *Handler) UpdateNamespaceRole(
 		h.logger.Error("Failed to update namespace role", "error", err)
 		return gen.UpdateNamespaceRole500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = authzRoleTypeMeta
 
 	genRole, err := convert[openchoreov1alpha1.AuthzRole, gen.AuthzRole](*updated)
 	if err != nil {
@@ -799,10 +747,6 @@ func (h *Handler) ListNamespaceRoleBindings(
 		return gen.ListNamespaceRoleBindings500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	for i := range result.Items {
-		result.Items[i].TypeMeta = authzRoleBindingTypeMeta
-	}
-
 	items, err := convertList[openchoreov1alpha1.AuthzRoleBinding, gen.AuthzRoleBinding](result.Items)
 	if err != nil {
 		h.logger.Error("Failed to convert namespace role bindings", "error", err)
@@ -841,8 +785,6 @@ func (h *Handler) CreateNamespaceRoleBinding(
 		return gen.CreateNamespaceRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	created.TypeMeta = authzRoleBindingTypeMeta
-
 	genBinding, err := convert[openchoreov1alpha1.AuthzRoleBinding, gen.AuthzRoleBinding](*created)
 	if err != nil {
 		h.logger.Error("Failed to convert created namespace role binding", "error", err)
@@ -871,8 +813,6 @@ func (h *Handler) GetNamespaceRoleBinding(
 		h.logger.Error("Failed to get namespace role binding", "error", err)
 		return gen.GetNamespaceRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	binding.TypeMeta = authzRoleBindingTypeMeta
 
 	genBinding, err := convert[openchoreov1alpha1.AuthzRoleBinding, gen.AuthzRoleBinding](*binding)
 	if err != nil {
@@ -913,8 +853,6 @@ func (h *Handler) UpdateNamespaceRoleBinding(
 		h.logger.Error("Failed to update namespace role binding", "error", err)
 		return gen.UpdateNamespaceRoleBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = authzRoleBindingTypeMeta
 
 	genBinding, err := convert[openchoreov1alpha1.AuthzRoleBinding, gen.AuthzRoleBinding](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/buildplanes.go
+++ b/internal/openchoreo-api/api/handlers/buildplanes.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	buildplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/buildplane"
 )
-
-var buildPlaneTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "BuildPlane",
-}
 
 // ListBuildPlanes returns a paginated list of build planes within a namespace.
 func (h *Handler) ListBuildPlanes(
@@ -33,10 +26,6 @@ func (h *Handler) ListBuildPlanes(
 	if err != nil {
 		h.logger.Error("Failed to list build planes", "error", err)
 		return gen.ListBuildPlanes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = buildPlaneTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.BuildPlane, gen.BuildPlane](result.Items)
@@ -70,8 +59,6 @@ func (h *Handler) GetBuildPlane(
 		return gen.GetBuildPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	buildPlane.TypeMeta = buildPlaneTypeMeta
-
 	genBuildPlane, err := convert[openchoreov1alpha1.BuildPlane, gen.BuildPlane](*buildPlane)
 	if err != nil {
 		h.logger.Error("Failed to convert build plane", "error", err)
@@ -97,8 +84,6 @@ func (h *Handler) CreateBuildPlane(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateBuildPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	bpCR.Status = openchoreov1alpha1.BuildPlaneStatus{}
-
 	created, err := h.services.BuildPlaneService.CreateBuildPlane(ctx, request.NamespaceName, &bpCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -110,8 +95,6 @@ func (h *Handler) CreateBuildPlane(
 		h.logger.Error("Failed to create build plane", "error", err)
 		return gen.CreateBuildPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = buildPlaneTypeMeta
 
 	genBP, err := convert[openchoreov1alpha1.BuildPlane, gen.BuildPlane](*created)
 	if err != nil {
@@ -139,8 +122,6 @@ func (h *Handler) UpdateBuildPlane(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateBuildPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	bpCR.Status = openchoreov1alpha1.BuildPlaneStatus{}
-
 	// Ensure the name from the URL path is used
 	bpCR.Name = request.BuildPlaneName
 
@@ -155,8 +136,6 @@ func (h *Handler) UpdateBuildPlane(
 		h.logger.Error("Failed to update build plane", "error", err)
 		return gen.UpdateBuildPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = buildPlaneTypeMeta
 
 	genBP, err := convert[openchoreov1alpha1.BuildPlane, gen.BuildPlane](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/clusterbuildplanes.go
+++ b/internal/openchoreo-api/api/handlers/clusterbuildplanes.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clusterbuildplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clusterbuildplane"
 )
-
-var clusterBuildPlaneTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ClusterBuildPlane",
-}
 
 // ListClusterBuildPlanes returns a paginated list of cluster-scoped build planes.
 func (h *Handler) ListClusterBuildPlanes(
@@ -33,10 +26,6 @@ func (h *Handler) ListClusterBuildPlanes(
 	if err != nil {
 		h.logger.Error("Failed to list cluster build planes", "error", err)
 		return gen.ListClusterBuildPlanes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = clusterBuildPlaneTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ClusterBuildPlane, gen.ClusterBuildPlane](result.Items)
@@ -70,8 +59,6 @@ func (h *Handler) GetClusterBuildPlane(
 		return gen.GetClusterBuildPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	cbp.TypeMeta = clusterBuildPlaneTypeMeta
-
 	genCBP, err := convert[openchoreov1alpha1.ClusterBuildPlane, gen.ClusterBuildPlane](*cbp)
 	if err != nil {
 		h.logger.Error("Failed to convert cluster build plane", "error", err)
@@ -97,8 +84,6 @@ func (h *Handler) CreateClusterBuildPlane(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateClusterBuildPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	cbpCR.Status = openchoreov1alpha1.ClusterBuildPlaneStatus{}
-
 	created, err := h.services.ClusterBuildPlaneService.CreateClusterBuildPlane(ctx, &cbpCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -110,8 +95,6 @@ func (h *Handler) CreateClusterBuildPlane(
 		h.logger.Error("Failed to create cluster build plane", "error", err)
 		return gen.CreateClusterBuildPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = clusterBuildPlaneTypeMeta
 
 	genCBP, err := convert[openchoreov1alpha1.ClusterBuildPlane, gen.ClusterBuildPlane](*created)
 	if err != nil {
@@ -139,8 +122,6 @@ func (h *Handler) UpdateClusterBuildPlane(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateClusterBuildPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	cbpCR.Status = openchoreov1alpha1.ClusterBuildPlaneStatus{}
-
 	// Ensure the name from the URL path is used
 	cbpCR.Name = request.ClusterBuildPlaneName
 
@@ -155,8 +136,6 @@ func (h *Handler) UpdateClusterBuildPlane(
 		h.logger.Error("Failed to update cluster build plane", "error", err)
 		return gen.UpdateClusterBuildPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = clusterBuildPlaneTypeMeta
 
 	genCBP, err := convert[openchoreov1alpha1.ClusterBuildPlane, gen.ClusterBuildPlane](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/clustercomponenttypes.go
+++ b/internal/openchoreo-api/api/handlers/clustercomponenttypes.go
@@ -8,18 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clustercomponenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustercomponenttype"
 )
-
-var clusterComponentTypeTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ClusterComponentType",
-}
 
 // ListClusterComponentTypes returns a paginated list of cluster-scoped component types.
 func (h *Handler) ListClusterComponentTypes(
@@ -37,10 +30,6 @@ func (h *Handler) ListClusterComponentTypes(
 		}
 		h.logger.Error("Failed to list cluster component types", "error", err)
 		return gen.ListClusterComponentTypes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = clusterComponentTypeTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ClusterComponentType, gen.ClusterComponentType](result.Items)
@@ -71,8 +60,6 @@ func (h *Handler) CreateClusterComponentType(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateClusterComponentType400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	cctCR.Status = openchoreov1alpha1.ClusterComponentTypeStatus{}
-
 	created, err := h.services.ClusterComponentTypeService.CreateClusterComponentType(ctx, &cctCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -84,8 +71,6 @@ func (h *Handler) CreateClusterComponentType(
 		h.logger.Error("Failed to create cluster component type", "error", err)
 		return gen.CreateClusterComponentType500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = clusterComponentTypeTypeMeta
 
 	genCCT, err := convert[openchoreov1alpha1.ClusterComponentType, gen.ClusterComponentType](*created)
 	if err != nil {
@@ -113,8 +98,6 @@ func (h *Handler) UpdateClusterComponentType(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateClusterComponentType400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	cctCR.Status = openchoreov1alpha1.ClusterComponentTypeStatus{}
-
 	// Ensure the name from the URL path is used
 	cctCR.Name = request.CctName
 
@@ -129,8 +112,6 @@ func (h *Handler) UpdateClusterComponentType(
 		h.logger.Error("Failed to update cluster component type", "error", err)
 		return gen.UpdateClusterComponentType500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = clusterComponentTypeTypeMeta
 
 	genCCT, err := convert[openchoreov1alpha1.ClusterComponentType, gen.ClusterComponentType](*updated)
 	if err != nil {
@@ -160,8 +141,6 @@ func (h *Handler) GetClusterComponentType(
 		h.logger.Error("Failed to get cluster component type", "error", err)
 		return gen.GetClusterComponentType500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	cct.TypeMeta = clusterComponentTypeTypeMeta
 
 	genCCT, err := convert[openchoreov1alpha1.ClusterComponentType, gen.ClusterComponentType](*cct)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/clusterdataplanes.go
+++ b/internal/openchoreo-api/api/handlers/clusterdataplanes.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clusterdataplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clusterdataplane"
 )
-
-var clusterDataPlaneTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ClusterDataPlane",
-}
 
 // ListClusterDataPlanes returns a paginated list of cluster-scoped data planes.
 func (h *Handler) ListClusterDataPlanes(
@@ -36,10 +29,6 @@ func (h *Handler) ListClusterDataPlanes(
 		}
 		h.logger.Error("Failed to list cluster data planes", "error", err)
 		return gen.ListClusterDataPlanes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = clusterDataPlaneTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ClusterDataPlane, gen.ClusterDataPlane](result.Items)
@@ -70,8 +59,6 @@ func (h *Handler) CreateClusterDataPlane(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateClusterDataPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	cdpCR.Status = openchoreov1alpha1.ClusterDataPlaneStatus{}
-
 	created, err := h.services.ClusterDataPlaneService.CreateClusterDataPlane(ctx, &cdpCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -83,8 +70,6 @@ func (h *Handler) CreateClusterDataPlane(
 		h.logger.Error("Failed to create cluster data plane", "error", err)
 		return gen.CreateClusterDataPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = clusterDataPlaneTypeMeta
 
 	genCDP, err := convert[openchoreov1alpha1.ClusterDataPlane, gen.ClusterDataPlane](*created)
 	if err != nil {
@@ -115,8 +100,6 @@ func (h *Handler) GetClusterDataPlane(
 		return gen.GetClusterDataPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	cdp.TypeMeta = clusterDataPlaneTypeMeta
-
 	genCDP, err := convert[openchoreov1alpha1.ClusterDataPlane, gen.ClusterDataPlane](*cdp)
 	if err != nil {
 		h.logger.Error("Failed to convert cluster data plane", "error", err)
@@ -142,8 +125,6 @@ func (h *Handler) UpdateClusterDataPlane(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateClusterDataPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	cdpCR.Status = openchoreov1alpha1.ClusterDataPlaneStatus{}
-
 	// Ensure the name from the URL path is used
 	cdpCR.Name = request.CdpName
 
@@ -158,8 +139,6 @@ func (h *Handler) UpdateClusterDataPlane(
 		h.logger.Error("Failed to update cluster data plane", "error", err)
 		return gen.UpdateClusterDataPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = clusterDataPlaneTypeMeta
 
 	genCDP, err := convert[openchoreov1alpha1.ClusterDataPlane, gen.ClusterDataPlane](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/clusterobservabilityplanes.go
+++ b/internal/openchoreo-api/api/handlers/clusterobservabilityplanes.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clusterobservabilityplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clusterobservabilityplane"
 )
-
-var clusterObservabilityPlaneTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ClusterObservabilityPlane",
-}
 
 // ListClusterObservabilityPlanes returns a paginated list of cluster-scoped observability planes.
 func (h *Handler) ListClusterObservabilityPlanes(
@@ -33,10 +26,6 @@ func (h *Handler) ListClusterObservabilityPlanes(
 	if err != nil {
 		h.logger.Error("Failed to list cluster observability planes", "error", err)
 		return gen.ListClusterObservabilityPlanes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = clusterObservabilityPlaneTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ClusterObservabilityPlane, gen.ClusterObservabilityPlane](result.Items)
@@ -70,8 +59,6 @@ func (h *Handler) GetClusterObservabilityPlane(
 		return gen.GetClusterObservabilityPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	cop.TypeMeta = clusterObservabilityPlaneTypeMeta
-
 	genCOP, err := convert[openchoreov1alpha1.ClusterObservabilityPlane, gen.ClusterObservabilityPlane](*cop)
 	if err != nil {
 		h.logger.Error("Failed to convert cluster observability plane", "error", err)
@@ -97,8 +84,6 @@ func (h *Handler) CreateClusterObservabilityPlane(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateClusterObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	copCR.Status = openchoreov1alpha1.ClusterObservabilityPlaneStatus{}
-
 	created, err := h.services.ClusterObservabilityPlaneService.CreateClusterObservabilityPlane(ctx, &copCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -110,8 +95,6 @@ func (h *Handler) CreateClusterObservabilityPlane(
 		h.logger.Error("Failed to create cluster observability plane", "error", err)
 		return gen.CreateClusterObservabilityPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = clusterObservabilityPlaneTypeMeta
 
 	genCOP, err := convert[openchoreov1alpha1.ClusterObservabilityPlane, gen.ClusterObservabilityPlane](*created)
 	if err != nil {
@@ -139,8 +122,6 @@ func (h *Handler) UpdateClusterObservabilityPlane(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateClusterObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	copCR.Status = openchoreov1alpha1.ClusterObservabilityPlaneStatus{}
-
 	// Ensure the name from the URL path is used
 	copCR.Name = request.ClusterObservabilityPlaneName
 
@@ -155,8 +136,6 @@ func (h *Handler) UpdateClusterObservabilityPlane(
 		h.logger.Error("Failed to update cluster observability plane", "error", err)
 		return gen.UpdateClusterObservabilityPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = clusterObservabilityPlaneTypeMeta
 
 	genCOP, err := convert[openchoreov1alpha1.ClusterObservabilityPlane, gen.ClusterObservabilityPlane](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/clustertraits.go
+++ b/internal/openchoreo-api/api/handlers/clustertraits.go
@@ -8,18 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clustertraitsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustertrait"
 )
-
-var clusterTraitTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ClusterTrait",
-}
 
 // ListClusterTraits returns a paginated list of cluster-scoped traits.
 func (h *Handler) ListClusterTraits(
@@ -37,10 +30,6 @@ func (h *Handler) ListClusterTraits(
 		}
 		h.logger.Error("Failed to list cluster traits", "error", err)
 		return gen.ListClusterTraits500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = clusterTraitTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ClusterTrait, gen.ClusterTrait](result.Items)
@@ -71,8 +60,6 @@ func (h *Handler) CreateClusterTrait(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateClusterTrait400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	ctCR.Status = openchoreov1alpha1.ClusterTraitStatus{}
-
 	created, err := h.services.ClusterTraitService.CreateClusterTrait(ctx, &ctCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -84,8 +71,6 @@ func (h *Handler) CreateClusterTrait(
 		h.logger.Error("Failed to create cluster trait", "error", err)
 		return gen.CreateClusterTrait500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = clusterTraitTypeMeta
 
 	genCT, err := convert[openchoreov1alpha1.ClusterTrait, gen.ClusterTrait](*created)
 	if err != nil {
@@ -113,8 +98,6 @@ func (h *Handler) UpdateClusterTrait(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateClusterTrait400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	ctCR.Status = openchoreov1alpha1.ClusterTraitStatus{}
-
 	// Ensure the name from the URL path is used
 	ctCR.Name = request.ClusterTraitName
 
@@ -129,8 +112,6 @@ func (h *Handler) UpdateClusterTrait(
 		h.logger.Error("Failed to update cluster trait", "error", err)
 		return gen.UpdateClusterTrait500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = clusterTraitTypeMeta
 
 	genCT, err := convert[openchoreov1alpha1.ClusterTrait, gen.ClusterTrait](*updated)
 	if err != nil {
@@ -160,8 +141,6 @@ func (h *Handler) GetClusterTrait(
 		h.logger.Error("Failed to get cluster trait", "error", err)
 		return gen.GetClusterTrait500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	trait.TypeMeta = clusterTraitTypeMeta
 
 	genTrait, err := convert[openchoreov1alpha1.ClusterTrait, gen.ClusterTrait](*trait)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/component_releases.go
+++ b/internal/openchoreo-api/api/handlers/component_releases.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	componentreleasesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/componentrelease"
 )
-
-var componentReleaseTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ComponentRelease",
-}
 
 // ListComponentReleases returns a paginated list of component releases within a namespace.
 func (h *Handler) ListComponentReleases(
@@ -38,10 +31,6 @@ func (h *Handler) ListComponentReleases(
 	if err != nil {
 		h.logger.Error("Failed to list component releases", "error", err)
 		return gen.ListComponentReleases500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = componentReleaseTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ComponentRelease, gen.ComponentRelease](result.Items)
@@ -76,8 +65,6 @@ func (h *Handler) GetComponentRelease(
 		h.logger.Error("Failed to get component release", "error", err)
 		return gen.GetComponentRelease500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	cr.TypeMeta = componentReleaseTypeMeta
 
 	genCR, err := convert[openchoreov1alpha1.ComponentRelease, gen.ComponentRelease](*cr)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/components.go
+++ b/internal/openchoreo-api/api/handlers/components.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
@@ -20,11 +19,6 @@ import (
 	componentsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/component"
 	projectsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/project"
 )
-
-var componentTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Component",
-}
 
 // ListComponents returns a paginated list of components within a namespace.
 func (h *Handler) ListComponents(
@@ -47,10 +41,6 @@ func (h *Handler) ListComponents(
 		}
 		h.logger.Error("Failed to list components", "error", err)
 		return gen.ListComponents500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = componentTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Component, gen.Component](result.Items)
@@ -84,8 +74,6 @@ func (h *Handler) CreateComponent(
 	if componentCR.Namespace != "" && componentCR.Namespace != request.NamespaceName {
 		return gen.CreateComponent400JSONResponse{BadRequestJSONResponse: badRequest("Namespace in body does not match path")}, nil
 	}
-	componentCR.Status = openchoreov1alpha1.ComponentStatus{}
-
 	created, err := h.services.ComponentService.CreateComponent(ctx, request.NamespaceName, &componentCR)
 	if err != nil {
 		if errors.Is(err, svcerrors.ErrForbidden) {
@@ -100,8 +88,6 @@ func (h *Handler) CreateComponent(
 		h.logger.Error("Failed to create component", "error", err)
 		return gen.CreateComponent500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = componentTypeMeta
 
 	genComponent, err := convert[openchoreov1alpha1.Component, gen.Component](*created)
 	if err != nil {
@@ -204,8 +190,6 @@ func (h *Handler) GetComponent(
 		return gen.GetComponent500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	component.TypeMeta = componentTypeMeta
-
 	genComponent, err := convert[openchoreov1alpha1.Component, gen.Component](*component)
 	if err != nil {
 		h.logger.Error("Failed to convert component", "error", err)
@@ -234,7 +218,6 @@ func (h *Handler) UpdateComponent(
 	if componentCR.Namespace != "" && componentCR.Namespace != request.NamespaceName {
 		return gen.UpdateComponent400JSONResponse{BadRequestJSONResponse: badRequest("Namespace in body does not match path")}, nil
 	}
-	componentCR.Status = openchoreov1alpha1.ComponentStatus{}
 	componentCR.Name = request.ComponentName
 
 	updated, err := h.services.ComponentService.UpdateComponent(ctx, request.NamespaceName, &componentCR)
@@ -252,8 +235,6 @@ func (h *Handler) UpdateComponent(
 		h.logger.Error("Failed to update component", "error", err)
 		return gen.UpdateComponent500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = componentTypeMeta
 
 	genComponent, err := convert[openchoreov1alpha1.Component, gen.Component](*updated)
 	if err != nil {
@@ -514,8 +495,6 @@ func (h *Handler) DeployRelease(
 		return gen.DeployRelease500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	binding.TypeMeta = releaseBindingTypeMeta
-
 	genBinding, err := convert[openchoreov1alpha1.ReleaseBinding, gen.ReleaseBinding](*binding)
 	if err != nil {
 		h.logger.Error("Failed to convert release binding", "error", err)
@@ -572,8 +551,6 @@ func (h *Handler) PromoteComponent(
 		return gen.PromoteComponent500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	binding.TypeMeta = releaseBindingTypeMeta
-
 	genBinding, err := convert[openchoreov1alpha1.ReleaseBinding, gen.ReleaseBinding](*binding)
 	if err != nil {
 		h.logger.Error("Failed to convert release binding", "error", err)
@@ -619,8 +596,6 @@ func (h *Handler) GenerateRelease(
 		h.logger.Error("Failed to generate release", "error", err)
 		return gen.GenerateRelease500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	release.TypeMeta = componentReleaseTypeMeta
 
 	genRelease, err := convert[openchoreov1alpha1.ComponentRelease, gen.ComponentRelease](*release)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/componenttypes.go
+++ b/internal/openchoreo-api/api/handlers/componenttypes.go
@@ -8,18 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	componenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/componenttype"
 )
-
-var componentTypeTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ComponentType",
-}
 
 // ListComponentTypes returns a paginated list of component types within a namespace.
 func (h *Handler) ListComponentTypes(
@@ -34,10 +27,6 @@ func (h *Handler) ListComponentTypes(
 	if err != nil {
 		h.logger.Error("Failed to list component types", "error", err)
 		return gen.ListComponentTypes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = componentTypeTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ComponentType, gen.ComponentType](result.Items)
@@ -68,7 +57,6 @@ func (h *Handler) CreateComponentType(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateComponentType400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	ctCR.Status = openchoreov1alpha1.ComponentTypeStatus{}
 
 	created, err := h.services.ComponentTypeService.CreateComponentType(ctx, request.NamespaceName, &ctCR)
 	if err != nil {
@@ -81,8 +69,6 @@ func (h *Handler) CreateComponentType(
 		h.logger.Error("Failed to create component type", "error", err)
 		return gen.CreateComponentType500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = componentTypeTypeMeta
 
 	genCT, err := convert[openchoreov1alpha1.ComponentType, gen.ComponentType](*created)
 	if err != nil {
@@ -113,8 +99,6 @@ func (h *Handler) GetComponentType(
 		return gen.GetComponentType500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	ct.TypeMeta = componentTypeTypeMeta
-
 	genCT, err := convert[openchoreov1alpha1.ComponentType, gen.ComponentType](*ct)
 	if err != nil {
 		h.logger.Error("Failed to convert component type", "error", err)
@@ -140,7 +124,6 @@ func (h *Handler) UpdateComponentType(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateComponentType400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	ctCR.Status = openchoreov1alpha1.ComponentTypeStatus{}
 
 	// Ensure the name from the URL path is used
 	ctCR.Name = request.CtName
@@ -156,8 +139,6 @@ func (h *Handler) UpdateComponentType(
 		h.logger.Error("Failed to update component type", "error", err)
 		return gen.UpdateComponentType500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = componentTypeTypeMeta
 
 	genCT, err := convert[openchoreov1alpha1.ComponentType, gen.ComponentType](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/dataplanes.go
+++ b/internal/openchoreo-api/api/handlers/dataplanes.go
@@ -8,18 +8,11 @@ import (
 	"errors"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	dataplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/dataplane"
 )
-
-var dataPlaneTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "DataPlane",
-}
 
 // ListDataPlanes returns a paginated list of data planes within a namespace.
 func (h *Handler) ListDataPlanes(
@@ -37,10 +30,6 @@ func (h *Handler) ListDataPlanes(
 		}
 		h.logger.Error("Failed to list data planes", "error", err)
 		return gen.ListDataPlanes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = dataPlaneTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.DataPlane, gen.DataPlane](result.Items)
@@ -75,8 +64,6 @@ func (h *Handler) CreateDataPlane(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateDataPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	dpCR.Status = openchoreov1alpha1.DataPlaneStatus{}
-
 	created, err := h.services.DataPlaneService.CreateDataPlane(ctx, request.NamespaceName, &dpCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -88,8 +75,6 @@ func (h *Handler) CreateDataPlane(
 		h.logger.Error("Failed to create data plane", "error", err)
 		return gen.CreateDataPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = dataPlaneTypeMeta
 
 	genDP, err := convert[openchoreov1alpha1.DataPlane, gen.DataPlane](*created)
 	if err != nil {
@@ -120,8 +105,6 @@ func (h *Handler) GetDataPlane(
 		return gen.GetDataPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	dataPlane.TypeMeta = dataPlaneTypeMeta
-
 	genDP, err := convert[openchoreov1alpha1.DataPlane, gen.DataPlane](*dataPlane)
 	if err != nil {
 		h.logger.Error("Failed to convert data plane", "error", err)
@@ -147,8 +130,6 @@ func (h *Handler) UpdateDataPlane(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateDataPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	dpCR.Status = openchoreov1alpha1.DataPlaneStatus{}
-
 	// Ensure the name from the URL path is used
 	dpCR.Name = request.DpName
 
@@ -163,8 +144,6 @@ func (h *Handler) UpdateDataPlane(
 		h.logger.Error("Failed to update data plane", "error", err)
 		return gen.UpdateDataPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = dataPlaneTypeMeta
 
 	genDP, err := convert[openchoreov1alpha1.DataPlane, gen.DataPlane](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/deployment_pipelines.go
+++ b/internal/openchoreo-api/api/handlers/deployment_pipelines.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	deploymentpipelinesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/deploymentpipeline"
 )
-
-var deploymentPipelineTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "DeploymentPipeline",
-}
 
 // ListDeploymentPipelines returns a paginated list of deployment pipelines within a namespace.
 func (h *Handler) ListDeploymentPipelines(
@@ -36,10 +29,6 @@ func (h *Handler) ListDeploymentPipelines(
 		}
 		h.logger.Error("Failed to list deployment pipelines", "error", err)
 		return gen.ListDeploymentPipelines500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = deploymentPipelineTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.DeploymentPipeline, gen.DeploymentPipeline](result.Items)
@@ -70,8 +59,6 @@ func (h *Handler) CreateDeploymentPipeline(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateDeploymentPipeline400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	dpCR.Status = openchoreov1alpha1.DeploymentPipelineStatus{}
-
 	created, err := h.services.DeploymentPipelineService.CreateDeploymentPipeline(ctx, request.NamespaceName, &dpCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -83,8 +70,6 @@ func (h *Handler) CreateDeploymentPipeline(
 		h.logger.Error("Failed to create deployment pipeline", "error", err)
 		return gen.CreateDeploymentPipeline500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = deploymentPipelineTypeMeta
 
 	genDP, err := convert[openchoreov1alpha1.DeploymentPipeline, gen.DeploymentPipeline](*created)
 	if err != nil {
@@ -115,8 +100,6 @@ func (h *Handler) GetDeploymentPipeline(
 		return gen.GetDeploymentPipeline500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	dp.TypeMeta = deploymentPipelineTypeMeta
-
 	genDP, err := convert[openchoreov1alpha1.DeploymentPipeline, gen.DeploymentPipeline](*dp)
 	if err != nil {
 		h.logger.Error("Failed to convert deployment pipeline", "error", err)
@@ -142,8 +125,6 @@ func (h *Handler) UpdateDeploymentPipeline(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateDeploymentPipeline400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	dpCR.Status = openchoreov1alpha1.DeploymentPipelineStatus{}
-
 	// Ensure the name from the URL path is used
 	dpCR.Name = request.DeploymentPipelineName
 
@@ -158,8 +139,6 @@ func (h *Handler) UpdateDeploymentPipeline(
 		h.logger.Error("Failed to update deployment pipeline", "error", err)
 		return gen.UpdateDeploymentPipeline500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = deploymentPipelineTypeMeta
 
 	genDP, err := convert[openchoreov1alpha1.DeploymentPipeline, gen.DeploymentPipeline](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/environments.go
+++ b/internal/openchoreo-api/api/handlers/environments.go
@@ -8,18 +8,11 @@ import (
 	"errors"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	environmentsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/environment"
 )
-
-var environmentTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Environment",
-}
 
 // ListEnvironments returns a paginated list of environments within a namespace.
 func (h *Handler) ListEnvironments(
@@ -34,10 +27,6 @@ func (h *Handler) ListEnvironments(
 	if err != nil {
 		h.logger.Error("Failed to list environments", "error", err)
 		return gen.ListEnvironments500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = environmentTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Environment, gen.Environment](result.Items)
@@ -72,8 +61,6 @@ func (h *Handler) CreateEnvironment(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateEnvironment400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	envCR.Status = openchoreov1alpha1.EnvironmentStatus{}
-
 	created, err := h.services.EnvironmentService.CreateEnvironment(ctx, request.NamespaceName, &envCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -88,8 +75,6 @@ func (h *Handler) CreateEnvironment(
 		h.logger.Error("Failed to create environment", "error", err)
 		return gen.CreateEnvironment500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = environmentTypeMeta
 
 	genEnv, err := convert[openchoreov1alpha1.Environment, gen.Environment](*created)
 	if err != nil {
@@ -120,8 +105,6 @@ func (h *Handler) GetEnvironment(
 		return gen.GetEnvironment500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	environment.TypeMeta = environmentTypeMeta
-
 	genEnv, err := convert[openchoreov1alpha1.Environment, gen.Environment](*environment)
 	if err != nil {
 		h.logger.Error("Failed to convert environment", "error", err)
@@ -147,8 +130,6 @@ func (h *Handler) UpdateEnvironment(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateEnvironment400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	envCR.Status = openchoreov1alpha1.EnvironmentStatus{}
-
 	// Ensure the name from the URL path is used
 	envCR.Name = request.EnvName
 
@@ -167,8 +148,6 @@ func (h *Handler) UpdateEnvironment(
 		h.logger.Error("Failed to update environment", "error", err)
 		return gen.UpdateEnvironment500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = environmentTypeMeta
 
 	genEnv, err := convert[openchoreov1alpha1.Environment, gen.Environment](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/observability_alerts_notification_channels.go
+++ b/internal/openchoreo-api/api/handlers/observability_alerts_notification_channels.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	observabilityalertsnotificationchannelsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/observabilityalertsnotificationchannel"
 )
-
-var observabilityAlertsNotificationChannelTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ObservabilityAlertsNotificationChannel",
-}
 
 // ListObservabilityAlertsNotificationChannels returns a paginated list of observability alerts notification channels within a namespace.
 func (h *Handler) ListObservabilityAlertsNotificationChannels(
@@ -33,10 +26,6 @@ func (h *Handler) ListObservabilityAlertsNotificationChannels(
 	if err != nil {
 		h.logger.Error("Failed to list observability alerts notification channels", "error", err)
 		return gen.ListObservabilityAlertsNotificationChannels500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ObservabilityAlertsNotificationChannel, gen.ObservabilityAlertsNotificationChannel](result.Items)
@@ -67,8 +56,6 @@ func (h *Handler) CreateObservabilityAlertsNotificationChannel(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateObservabilityAlertsNotificationChannel400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	ncCR.Status = openchoreov1alpha1.ObservabilityAlertsNotificationChannelStatus{}
-
 	created, err := h.services.ObservabilityAlertsNotificationChannelService.CreateObservabilityAlertsNotificationChannel(ctx, request.NamespaceName, &ncCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -80,8 +67,6 @@ func (h *Handler) CreateObservabilityAlertsNotificationChannel(
 		h.logger.Error("Failed to create observability alerts notification channel", "error", err)
 		return gen.CreateObservabilityAlertsNotificationChannel500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 
 	genNC, err := convert[openchoreov1alpha1.ObservabilityAlertsNotificationChannel, gen.ObservabilityAlertsNotificationChannel](*created)
 	if err != nil {
@@ -112,8 +97,6 @@ func (h *Handler) GetObservabilityAlertsNotificationChannel(
 		return gen.GetObservabilityAlertsNotificationChannel500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	nc.TypeMeta = observabilityAlertsNotificationChannelTypeMeta
-
 	genNC, err := convert[openchoreov1alpha1.ObservabilityAlertsNotificationChannel, gen.ObservabilityAlertsNotificationChannel](*nc)
 	if err != nil {
 		h.logger.Error("Failed to convert observability alerts notification channel", "error", err)
@@ -139,8 +122,6 @@ func (h *Handler) UpdateObservabilityAlertsNotificationChannel(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateObservabilityAlertsNotificationChannel400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	ncCR.Status = openchoreov1alpha1.ObservabilityAlertsNotificationChannelStatus{}
-
 	// Ensure the name from the URL path is used
 	ncCR.Name = request.ObservabilityAlertsNotificationChannelName
 
@@ -155,8 +136,6 @@ func (h *Handler) UpdateObservabilityAlertsNotificationChannel(
 		h.logger.Error("Failed to update observability alerts notification channel", "error", err)
 		return gen.UpdateObservabilityAlertsNotificationChannel500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 
 	genNC, err := convert[openchoreov1alpha1.ObservabilityAlertsNotificationChannel, gen.ObservabilityAlertsNotificationChannel](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/observabilityplanes.go
+++ b/internal/openchoreo-api/api/handlers/observabilityplanes.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	observabilityplanesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/observabilityplane"
 )
-
-var observabilityPlaneTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ObservabilityPlane",
-}
 
 // ListObservabilityPlanes returns a paginated list of observability planes within a namespace.
 func (h *Handler) ListObservabilityPlanes(
@@ -36,10 +29,6 @@ func (h *Handler) ListObservabilityPlanes(
 		}
 		h.logger.Error("Failed to list observability planes", "error", err)
 		return gen.ListObservabilityPlanes500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = observabilityPlaneTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ObservabilityPlane, gen.ObservabilityPlane](result.Items)
@@ -73,8 +62,6 @@ func (h *Handler) GetObservabilityPlane(
 		return gen.GetObservabilityPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	op.TypeMeta = observabilityPlaneTypeMeta
-
 	genOP, err := convert[openchoreov1alpha1.ObservabilityPlane, gen.ObservabilityPlane](*op)
 	if err != nil {
 		h.logger.Error("Failed to convert observability plane", "error", err)
@@ -100,8 +87,6 @@ func (h *Handler) CreateObservabilityPlane(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	opCR.Status = openchoreov1alpha1.ObservabilityPlaneStatus{}
-
 	created, err := h.services.ObservabilityPlaneService.CreateObservabilityPlane(ctx, request.NamespaceName, &opCR)
 	if err != nil {
 		if errors.Is(err, services.ErrForbidden) {
@@ -113,8 +98,6 @@ func (h *Handler) CreateObservabilityPlane(
 		h.logger.Error("Failed to create observability plane", "error", err)
 		return gen.CreateObservabilityPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = observabilityPlaneTypeMeta
 
 	genOP, err := convert[openchoreov1alpha1.ObservabilityPlane, gen.ObservabilityPlane](*created)
 	if err != nil {
@@ -142,8 +125,6 @@ func (h *Handler) UpdateObservabilityPlane(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	opCR.Status = openchoreov1alpha1.ObservabilityPlaneStatus{}
-
 	// Ensure the name from the URL path is used
 	opCR.Name = request.ObservabilityPlaneName
 
@@ -158,8 +139,6 @@ func (h *Handler) UpdateObservabilityPlane(
 		h.logger.Error("Failed to update observability plane", "error", err)
 		return gen.UpdateObservabilityPlane500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = observabilityPlaneTypeMeta
 
 	genOP, err := convert[openchoreov1alpha1.ObservabilityPlane, gen.ObservabilityPlane](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/projects.go
+++ b/internal/openchoreo-api/api/handlers/projects.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	projectsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/project"
 )
-
-var projectTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Project",
-}
 
 // ListProjects returns a paginated list of projects within a namespace.
 func (h *Handler) ListProjects(
@@ -33,10 +26,6 @@ func (h *Handler) ListProjects(
 	if err != nil {
 		h.logger.Error("Failed to list projects", "error", err)
 		return gen.ListProjects500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = projectTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Project, gen.Project](result.Items)
@@ -67,7 +56,6 @@ func (h *Handler) CreateProject(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateProject400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	projectCR.Status = openchoreov1alpha1.ProjectStatus{}
 
 	created, err := h.services.ProjectService.CreateProject(ctx, request.NamespaceName, &projectCR)
 	if err != nil {
@@ -80,8 +68,6 @@ func (h *Handler) CreateProject(
 		h.logger.Error("Failed to create project", "error", err)
 		return gen.CreateProject500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = projectTypeMeta
 
 	genProject, err := convert[openchoreov1alpha1.Project, gen.Project](*created)
 	if err != nil {
@@ -112,8 +98,6 @@ func (h *Handler) GetProject(
 		return gen.GetProject500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	project.TypeMeta = projectTypeMeta
-
 	genProject, err := convert[openchoreov1alpha1.Project, gen.Project](*project)
 	if err != nil {
 		h.logger.Error("Failed to convert project", "error", err)
@@ -139,7 +123,6 @@ func (h *Handler) UpdateProject(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateProject400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	projectCR.Status = openchoreov1alpha1.ProjectStatus{}
 
 	// Ensure the name from the URL path is used
 	projectCR.Name = request.ProjectName
@@ -155,8 +138,6 @@ func (h *Handler) UpdateProject(
 		h.logger.Error("Failed to update project", "error", err)
 		return gen.UpdateProject500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = projectTypeMeta
 
 	genProject, err := convert[openchoreov1alpha1.Project, gen.Project](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/release_bindings.go
+++ b/internal/openchoreo-api/api/handlers/release_bindings.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	releasebindingsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/releasebinding"
 )
-
-var releaseBindingTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "ReleaseBinding",
-}
 
 // ListReleaseBindings returns a paginated list of release bindings within a namespace.
 func (h *Handler) ListReleaseBindings(
@@ -44,10 +37,6 @@ func (h *Handler) ListReleaseBindings(
 		}
 		h.logger.Error("Failed to list release bindings", "error", err)
 		return gen.ListReleaseBindings500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = releaseBindingTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.ReleaseBinding, gen.ReleaseBinding](result.Items)
@@ -84,7 +73,6 @@ func (h *Handler) CreateReleaseBinding(
 		return gen.CreateReleaseBinding400JSONResponse{BadRequestJSONResponse: badRequest("Namespace in body does not match path")}, nil
 	}
 	rbCR.Namespace = request.NamespaceName
-	rbCR.Status = openchoreov1alpha1.ReleaseBindingStatus{}
 
 	created, err := h.services.ReleaseBindingService.CreateReleaseBinding(ctx, request.NamespaceName, &rbCR)
 	if err != nil {
@@ -100,8 +88,6 @@ func (h *Handler) CreateReleaseBinding(
 		h.logger.Error("Failed to create release binding", "error", err)
 		return gen.CreateReleaseBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = releaseBindingTypeMeta
 
 	genRB, err := convert[openchoreov1alpha1.ReleaseBinding, gen.ReleaseBinding](*created)
 	if err != nil {
@@ -132,8 +118,6 @@ func (h *Handler) GetReleaseBinding(
 		return gen.GetReleaseBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	rb.TypeMeta = releaseBindingTypeMeta
-
 	genRB, err := convert[openchoreov1alpha1.ReleaseBinding, gen.ReleaseBinding](*rb)
 	if err != nil {
 		h.logger.Error("Failed to convert release binding", "error", err)
@@ -163,7 +147,6 @@ func (h *Handler) UpdateReleaseBinding(
 		return gen.UpdateReleaseBinding400JSONResponse{BadRequestJSONResponse: badRequest("Namespace in body does not match path")}, nil
 	}
 	rbCR.Namespace = request.NamespaceName
-	rbCR.Status = openchoreov1alpha1.ReleaseBindingStatus{}
 
 	// Ensure the name from the URL path is used
 	rbCR.Name = request.ReleaseBindingName
@@ -183,8 +166,6 @@ func (h *Handler) UpdateReleaseBinding(
 		h.logger.Error("Failed to update release binding", "error", err)
 		return gen.UpdateReleaseBinding500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = releaseBindingTypeMeta
 
 	genRB, err := convert[openchoreov1alpha1.ReleaseBinding, gen.ReleaseBinding](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/releases.go
+++ b/internal/openchoreo-api/api/handlers/releases.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	releasesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/release"
 )
-
-var releaseTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Release",
-}
 
 // ListReleases returns a paginated list of releases within a namespace.
 func (h *Handler) ListReleases(
@@ -43,10 +36,6 @@ func (h *Handler) ListReleases(
 	if err != nil {
 		h.logger.Error("Failed to list releases", "error", err)
 		return gen.ListReleases500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = releaseTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Release, gen.Release](result.Items)
@@ -81,8 +70,6 @@ func (h *Handler) GetRelease(
 		h.logger.Error("Failed to get release", "error", err)
 		return gen.GetRelease500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	r.TypeMeta = releaseTypeMeta
 
 	genRelease, err := convert[openchoreov1alpha1.Release, gen.Release](*r)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/secret_references.go
+++ b/internal/openchoreo-api/api/handlers/secret_references.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	secretreferencesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/secretreference"
 )
-
-var secretReferenceTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "SecretReference",
-}
 
 // ListSecretReferences returns a paginated list of secret references within a namespace.
 func (h *Handler) ListSecretReferences(
@@ -33,10 +26,6 @@ func (h *Handler) ListSecretReferences(
 	if err != nil {
 		h.logger.Error("Failed to list secret references", "error", err)
 		return gen.ListSecretReferences500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = secretReferenceTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.SecretReference, gen.SecretReference](result.Items)
@@ -67,7 +56,6 @@ func (h *Handler) CreateSecretReference(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateSecretReference400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	srCR.Status = openchoreov1alpha1.SecretReferenceStatus{}
 
 	created, err := h.services.SecretReferenceService.CreateSecretReference(ctx, request.NamespaceName, &srCR)
 	if err != nil {
@@ -80,8 +68,6 @@ func (h *Handler) CreateSecretReference(
 		h.logger.Error("Failed to create secret reference", "error", err)
 		return gen.CreateSecretReference500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = secretReferenceTypeMeta
 
 	genSR, err := convert[openchoreov1alpha1.SecretReference, gen.SecretReference](*created)
 	if err != nil {
@@ -112,8 +98,6 @@ func (h *Handler) GetSecretReference(
 		return gen.GetSecretReference500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	sr.TypeMeta = secretReferenceTypeMeta
-
 	genSR, err := convert[openchoreov1alpha1.SecretReference, gen.SecretReference](*sr)
 	if err != nil {
 		h.logger.Error("Failed to convert secret reference", "error", err)
@@ -139,7 +123,6 @@ func (h *Handler) UpdateSecretReference(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateSecretReference400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	srCR.Status = openchoreov1alpha1.SecretReferenceStatus{}
 
 	// Ensure the name from the URL path is used
 	srCR.Name = request.SecretReferenceName
@@ -155,8 +138,6 @@ func (h *Handler) UpdateSecretReference(
 		h.logger.Error("Failed to update secret reference", "error", err)
 		return gen.UpdateSecretReference500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = secretReferenceTypeMeta
 
 	genSR, err := convert[openchoreov1alpha1.SecretReference, gen.SecretReference](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/traits.go
+++ b/internal/openchoreo-api/api/handlers/traits.go
@@ -8,18 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	traitsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/trait"
 )
-
-var traitTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Trait",
-}
 
 // ListTraits returns a paginated list of traits within a namespace.
 func (h *Handler) ListTraits(
@@ -34,10 +27,6 @@ func (h *Handler) ListTraits(
 	if err != nil {
 		h.logger.Error("Failed to list traits", "error", err)
 		return gen.ListTraits500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = traitTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Trait, gen.Trait](result.Items)
@@ -68,7 +57,6 @@ func (h *Handler) CreateTrait(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateTrait400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	tCR.Status = openchoreov1alpha1.TraitStatus{}
 
 	created, err := h.services.TraitService.CreateTrait(ctx, request.NamespaceName, &tCR)
 	if err != nil {
@@ -81,8 +69,6 @@ func (h *Handler) CreateTrait(
 		h.logger.Error("Failed to create trait", "error", err)
 		return gen.CreateTrait500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = traitTypeMeta
 
 	genTrait, err := convert[openchoreov1alpha1.Trait, gen.Trait](*created)
 	if err != nil {
@@ -113,8 +99,6 @@ func (h *Handler) GetTrait(
 		return gen.GetTrait500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	t.TypeMeta = traitTypeMeta
-
 	genTrait, err := convert[openchoreov1alpha1.Trait, gen.Trait](*t)
 	if err != nil {
 		h.logger.Error("Failed to convert trait", "error", err)
@@ -140,7 +124,6 @@ func (h *Handler) UpdateTrait(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateTrait400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	tCR.Status = openchoreov1alpha1.TraitStatus{}
 
 	// Ensure the name from the URL path is used
 	tCR.Name = request.TraitName
@@ -156,8 +139,6 @@ func (h *Handler) UpdateTrait(
 		h.logger.Error("Failed to update trait", "error", err)
 		return gen.UpdateTrait500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = traitTypeMeta
 
 	genTrait, err := convert[openchoreov1alpha1.Trait, gen.Trait](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/workflows.go
+++ b/internal/openchoreo-api/api/handlers/workflows.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices"
@@ -18,16 +16,6 @@ import (
 	workflowsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflow"
 	workflowrunsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflowrun"
 )
-
-var workflowRunTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "WorkflowRun",
-}
-
-var workflowTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Workflow",
-}
 
 // ListWorkflows returns a paginated list of workflows within a namespace.
 func (h *Handler) ListWorkflows(
@@ -42,10 +30,6 @@ func (h *Handler) ListWorkflows(
 	if err != nil {
 		h.logger.Error("Failed to list workflows", "error", err)
 		return gen.ListWorkflows500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = workflowTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Workflow, gen.Workflow](result.Items)
@@ -76,8 +60,6 @@ func (h *Handler) CreateWorkflow(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateWorkflow400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	wfCR.Status = openchoreov1alpha1.WorkflowStatus{}
-
 	created, err := h.services.WorkflowService.CreateWorkflow(ctx, request.NamespaceName, &wfCR)
 	if err != nil {
 		if errors.Is(err, svcerrors.ErrForbidden) {
@@ -89,8 +71,6 @@ func (h *Handler) CreateWorkflow(
 		h.logger.Error("Failed to create workflow", "error", err)
 		return gen.CreateWorkflow500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = workflowTypeMeta
 
 	genWf, err := convert[openchoreov1alpha1.Workflow, gen.Workflow](*created)
 	if err != nil {
@@ -121,8 +101,6 @@ func (h *Handler) GetWorkflow(
 		return gen.GetWorkflow500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	wf.TypeMeta = workflowTypeMeta
-
 	genWf, err := convert[openchoreov1alpha1.Workflow, gen.Workflow](*wf)
 	if err != nil {
 		h.logger.Error("Failed to convert workflow", "error", err)
@@ -148,8 +126,6 @@ func (h *Handler) UpdateWorkflow(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateWorkflow400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	wfCR.Status = openchoreov1alpha1.WorkflowStatus{}
-
 	// Ensure the name from the URL path is used
 	wfCR.Name = request.WorkflowName
 
@@ -164,8 +140,6 @@ func (h *Handler) UpdateWorkflow(
 		h.logger.Error("Failed to update workflow", "error", err)
 		return gen.UpdateWorkflow500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = workflowTypeMeta
 
 	genWf, err := convert[openchoreov1alpha1.Workflow, gen.Workflow](*updated)
 	if err != nil {
@@ -258,10 +232,6 @@ func (h *Handler) ListWorkflowRuns(
 		return gen.ListWorkflowRuns500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	for i := range result.Items {
-		result.Items[i].TypeMeta = workflowRunTypeMeta
-	}
-
 	items, err := convertList[openchoreov1alpha1.WorkflowRun, gen.WorkflowRun](result.Items)
 	if err != nil {
 		h.logger.Error("Failed to convert workflow runs", "error", err)
@@ -290,8 +260,6 @@ func (h *Handler) CreateWorkflowRun(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateWorkflowRun400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	wfRunCR.Status = openchoreov1alpha1.WorkflowRunStatus{}
-
 	created, err := h.services.WorkflowRunService.CreateWorkflowRun(ctx, request.NamespaceName, &wfRunCR)
 	if err != nil {
 		if errors.Is(err, workflowrunsvc.ErrWorkflowNotFound) {
@@ -303,8 +271,6 @@ func (h *Handler) CreateWorkflowRun(
 		h.logger.Error("Failed to create workflow run", "error", err)
 		return gen.CreateWorkflowRun500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = workflowRunTypeMeta
 
 	genWfRun, err := convert[openchoreov1alpha1.WorkflowRun, gen.WorkflowRun](*created)
 	if err != nil {
@@ -336,8 +302,6 @@ func (h *Handler) GetWorkflowRun(
 		h.logger.Error("Failed to get workflow run", "error", err)
 		return gen.GetWorkflowRun500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	wfRun.TypeMeta = workflowRunTypeMeta
 
 	genWfRun, err := convert[openchoreov1alpha1.WorkflowRun, gen.WorkflowRun](*wfRun)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/workloads.go
+++ b/internal/openchoreo-api/api/handlers/workloads.go
@@ -7,18 +7,11 @@ import (
 	"context"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	workloadsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workload"
 )
-
-var workloadTypeMeta = metav1.TypeMeta{
-	APIVersion: openchoreov1alpha1.GroupVersion.String(),
-	Kind:       "Workload",
-}
 
 // ListWorkloads returns a paginated list of workloads within a namespace.
 func (h *Handler) ListWorkloads(
@@ -38,10 +31,6 @@ func (h *Handler) ListWorkloads(
 	if err != nil {
 		h.logger.Error("Failed to list workloads", "error", err)
 		return gen.ListWorkloads500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
-	}
-
-	for i := range result.Items {
-		result.Items[i].TypeMeta = workloadTypeMeta
 	}
 
 	items, err := convertList[openchoreov1alpha1.Workload, gen.Workload](result.Items)
@@ -72,7 +61,6 @@ func (h *Handler) CreateWorkload(
 		h.logger.Error("Failed to convert create request", "error", err)
 		return gen.CreateWorkload400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	wCR.Status = openchoreov1alpha1.WorkloadStatus{}
 
 	created, err := h.services.WorkloadService.CreateWorkload(ctx, request.NamespaceName, &wCR)
 	if err != nil {
@@ -88,8 +76,6 @@ func (h *Handler) CreateWorkload(
 		h.logger.Error("Failed to create workload", "error", err)
 		return gen.CreateWorkload500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	created.TypeMeta = workloadTypeMeta
 
 	genWorkload, err := convert[openchoreov1alpha1.Workload, gen.Workload](*created)
 	if err != nil {
@@ -120,8 +106,6 @@ func (h *Handler) GetWorkload(
 		return gen.GetWorkload500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
 
-	w.TypeMeta = workloadTypeMeta
-
 	genWorkload, err := convert[openchoreov1alpha1.Workload, gen.Workload](*w)
 	if err != nil {
 		h.logger.Error("Failed to convert workload", "error", err)
@@ -147,7 +131,6 @@ func (h *Handler) UpdateWorkload(
 		h.logger.Error("Failed to convert update request", "error", err)
 		return gen.UpdateWorkload400JSONResponse{BadRequestJSONResponse: badRequest("Invalid request body")}, nil
 	}
-	wCR.Status = openchoreov1alpha1.WorkloadStatus{}
 
 	// Ensure the name from the URL path is used
 	wCR.Name = request.WorkloadName
@@ -167,8 +150,6 @@ func (h *Handler) UpdateWorkload(
 		h.logger.Error("Failed to update workload", "error", err)
 		return gen.UpdateWorkload500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
-
-	updated.TypeMeta = workloadTypeMeta
 
 	genWorkload, err := convert[openchoreov1alpha1.Workload, gen.Workload](*updated)
 	if err != nil {

--- a/internal/openchoreo-api/services/authz/service.go
+++ b/internal/openchoreo-api/services/authz/service.go
@@ -26,6 +26,26 @@ type authzService struct {
 
 var _ Service = (*authzService)(nil)
 
+var authzClusterRoleTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "AuthzClusterRole",
+}
+
+var authzRoleTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "AuthzRole",
+}
+
+var authzClusterRoleBindingTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "AuthzClusterRoleBinding",
+}
+
+var authzRoleBindingTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "AuthzRoleBinding",
+}
+
 // NewService creates a new authz service without authorization checks.
 func NewService(pap authzcore.PAP, pdp authzcore.PDP, k8sClient client.Client, logger *slog.Logger) Service {
 	return &authzService{
@@ -43,12 +63,22 @@ func (s *authzService) CreateClusterRole(ctx context.Context, role *openchoreov1
 		return nil, fmt.Errorf("cluster role cannot be nil")
 	}
 	s.logger.Debug("Creating cluster role", "name", role.Name)
-	return s.pap.CreateClusterRole(ctx, role)
+	created, err := s.pap.CreateClusterRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+	created.TypeMeta = authzClusterRoleTypeMeta
+	return created, nil
 }
 
 func (s *authzService) GetClusterRole(ctx context.Context, name string) (*openchoreov1alpha1.AuthzClusterRole, error) {
 	s.logger.Debug("Getting cluster role", "name", name)
-	return s.pap.GetClusterRole(ctx, name)
+	role, err := s.pap.GetClusterRole(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	role.TypeMeta = authzClusterRoleTypeMeta
+	return role, nil
 }
 
 func (s *authzService) ListClusterRoles(ctx context.Context, opts services.ListOptions) (*services.ListResult[openchoreov1alpha1.AuthzClusterRole], error) {
@@ -56,6 +86,9 @@ func (s *authzService) ListClusterRoles(ctx context.Context, opts services.ListO
 	paged, err := s.pap.ListClusterRoles(ctx, opts.Limit, opts.Cursor)
 	if err != nil {
 		return nil, err
+	}
+	for i := range paged.Items {
+		paged.Items[i].TypeMeta = authzClusterRoleTypeMeta
 	}
 	return &services.ListResult[openchoreov1alpha1.AuthzClusterRole]{
 		Items:      paged.Items,
@@ -68,7 +101,12 @@ func (s *authzService) UpdateClusterRole(ctx context.Context, role *openchoreov1
 		return nil, fmt.Errorf("cluster role cannot be nil")
 	}
 	s.logger.Debug("Updating cluster role", "name", role.Name)
-	return s.pap.UpdateClusterRole(ctx, role)
+	updated, err := s.pap.UpdateClusterRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+	updated.TypeMeta = authzClusterRoleTypeMeta
+	return updated, nil
 }
 
 func (s *authzService) DeleteClusterRole(ctx context.Context, name string) error {
@@ -93,12 +131,22 @@ func (s *authzService) CreateNamespaceRole(ctx context.Context, namespace string
 	}
 	role.Namespace = namespace
 	s.logger.Debug("Creating namespace role", "namespace", namespace, "name", role.Name)
-	return s.pap.CreateNamespacedRole(ctx, role)
+	created, err := s.pap.CreateNamespacedRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+	created.TypeMeta = authzRoleTypeMeta
+	return created, nil
 }
 
 func (s *authzService) GetNamespaceRole(ctx context.Context, namespace, name string) (*openchoreov1alpha1.AuthzRole, error) {
 	s.logger.Debug("Getting namespace role", "namespace", namespace, "name", name)
-	return s.pap.GetNamespacedRole(ctx, name, namespace)
+	role, err := s.pap.GetNamespacedRole(ctx, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	role.TypeMeta = authzRoleTypeMeta
+	return role, nil
 }
 
 func (s *authzService) ListNamespaceRoles(ctx context.Context, namespace string, opts services.ListOptions) (*services.ListResult[openchoreov1alpha1.AuthzRole], error) {
@@ -106,6 +154,9 @@ func (s *authzService) ListNamespaceRoles(ctx context.Context, namespace string,
 	paged, err := s.pap.ListNamespacedRoles(ctx, namespace, opts.Limit, opts.Cursor)
 	if err != nil {
 		return nil, err
+	}
+	for i := range paged.Items {
+		paged.Items[i].TypeMeta = authzRoleTypeMeta
 	}
 	return &services.ListResult[openchoreov1alpha1.AuthzRole]{
 		Items:      paged.Items,
@@ -119,7 +170,12 @@ func (s *authzService) UpdateNamespaceRole(ctx context.Context, namespace string
 	}
 	role.Namespace = namespace
 	s.logger.Debug("Updating namespace role", "namespace", namespace, "name", role.Name)
-	return s.pap.UpdateNamespacedRole(ctx, role)
+	updated, err := s.pap.UpdateNamespacedRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+	updated.TypeMeta = authzRoleTypeMeta
+	return updated, nil
 }
 
 func (s *authzService) DeleteNamespaceRole(ctx context.Context, namespace, name string) error {
@@ -143,12 +199,22 @@ func (s *authzService) CreateClusterRoleBinding(ctx context.Context, binding *op
 		return nil, fmt.Errorf("cluster role binding cannot be nil")
 	}
 	s.logger.Debug("Creating cluster role binding", "name", binding.Name)
-	return s.pap.CreateClusterRoleBinding(ctx, binding)
+	created, err := s.pap.CreateClusterRoleBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+	created.TypeMeta = authzClusterRoleBindingTypeMeta
+	return created, nil
 }
 
 func (s *authzService) GetClusterRoleBinding(ctx context.Context, name string) (*openchoreov1alpha1.AuthzClusterRoleBinding, error) {
 	s.logger.Debug("Getting cluster role binding", "name", name)
-	return s.pap.GetClusterRoleBinding(ctx, name)
+	binding, err := s.pap.GetClusterRoleBinding(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	binding.TypeMeta = authzClusterRoleBindingTypeMeta
+	return binding, nil
 }
 
 func (s *authzService) ListClusterRoleBindings(ctx context.Context, opts services.ListOptions) (*services.ListResult[openchoreov1alpha1.AuthzClusterRoleBinding], error) {
@@ -156,6 +222,9 @@ func (s *authzService) ListClusterRoleBindings(ctx context.Context, opts service
 	paged, err := s.pap.ListClusterRoleBindings(ctx, opts.Limit, opts.Cursor)
 	if err != nil {
 		return nil, err
+	}
+	for i := range paged.Items {
+		paged.Items[i].TypeMeta = authzClusterRoleBindingTypeMeta
 	}
 	return &services.ListResult[openchoreov1alpha1.AuthzClusterRoleBinding]{
 		Items:      paged.Items,
@@ -168,7 +237,12 @@ func (s *authzService) UpdateClusterRoleBinding(ctx context.Context, binding *op
 		return nil, fmt.Errorf("cluster role binding cannot be nil")
 	}
 	s.logger.Debug("Updating cluster role binding", "name", binding.Name)
-	return s.pap.UpdateClusterRoleBinding(ctx, binding)
+	updated, err := s.pap.UpdateClusterRoleBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+	updated.TypeMeta = authzClusterRoleBindingTypeMeta
+	return updated, nil
 }
 
 func (s *authzService) DeleteClusterRoleBinding(ctx context.Context, name string) error {
@@ -193,12 +267,22 @@ func (s *authzService) CreateNamespaceRoleBinding(ctx context.Context, namespace
 	}
 	binding.Namespace = namespace
 	s.logger.Debug("Creating namespace role binding", "namespace", namespace, "name", binding.Name)
-	return s.pap.CreateNamespacedRoleBinding(ctx, binding)
+	created, err := s.pap.CreateNamespacedRoleBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+	created.TypeMeta = authzRoleBindingTypeMeta
+	return created, nil
 }
 
 func (s *authzService) GetNamespaceRoleBinding(ctx context.Context, namespace, name string) (*openchoreov1alpha1.AuthzRoleBinding, error) {
 	s.logger.Debug("Getting namespace role binding", "namespace", namespace, "name", name)
-	return s.pap.GetNamespacedRoleBinding(ctx, name, namespace)
+	binding, err := s.pap.GetNamespacedRoleBinding(ctx, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	binding.TypeMeta = authzRoleBindingTypeMeta
+	return binding, nil
 }
 
 func (s *authzService) ListNamespaceRoleBindings(ctx context.Context, namespace string, opts services.ListOptions) (*services.ListResult[openchoreov1alpha1.AuthzRoleBinding], error) {
@@ -206,6 +290,9 @@ func (s *authzService) ListNamespaceRoleBindings(ctx context.Context, namespace 
 	paged, err := s.pap.ListNamespacedRoleBindings(ctx, namespace, opts.Limit, opts.Cursor)
 	if err != nil {
 		return nil, err
+	}
+	for i := range paged.Items {
+		paged.Items[i].TypeMeta = authzRoleBindingTypeMeta
 	}
 	return &services.ListResult[openchoreov1alpha1.AuthzRoleBinding]{
 		Items:      paged.Items,
@@ -219,7 +306,12 @@ func (s *authzService) UpdateNamespaceRoleBinding(ctx context.Context, namespace
 	}
 	binding.Namespace = namespace
 	s.logger.Debug("Updating namespace role binding", "namespace", namespace, "name", binding.Name)
-	return s.pap.UpdateNamespacedRoleBinding(ctx, binding)
+	updated, err := s.pap.UpdateNamespacedRoleBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+	updated.TypeMeta = authzRoleBindingTypeMeta
+	return updated, nil
 }
 
 func (s *authzService) DeleteNamespaceRoleBinding(ctx context.Context, namespace, name string) error {

--- a/internal/openchoreo-api/services/buildplane/service.go
+++ b/internal/openchoreo-api/services/buildplane/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -17,6 +18,11 @@ import (
 	argoproj "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes/types/argoproj.io/workflow/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var buildPlaneTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "BuildPlane",
+}
 
 // buildPlaneService handles build plane-related business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -56,6 +62,10 @@ func (s *buildPlaneService) ListBuildPlanes(ctx context.Context, namespaceName s
 		return nil, fmt.Errorf("failed to list build planes: %w", err)
 	}
 
+	for i := range buildPlaneList.Items {
+		buildPlaneList.Items[i].TypeMeta = buildPlaneTypeMeta
+	}
+
 	result := &services.ListResult[openchoreov1alpha1.BuildPlane]{
 		Items:      buildPlaneList.Items,
 		NextCursor: buildPlaneList.Continue,
@@ -87,6 +97,7 @@ func (s *buildPlaneService) GetBuildPlane(ctx context.Context, namespaceName, bu
 		return nil, fmt.Errorf("failed to get build plane: %w", err)
 	}
 
+	buildPlane.TypeMeta = buildPlaneTypeMeta
 	return buildPlane, nil
 }
 
@@ -97,6 +108,7 @@ func (s *buildPlaneService) CreateBuildPlane(ctx context.Context, namespaceName 
 	}
 	s.logger.Debug("Creating build plane", "namespace", namespaceName, "buildPlane", bp.Name)
 
+	bp.Status = openchoreov1alpha1.BuildPlaneStatus{}
 	bp.Namespace = namespaceName
 	if err := s.k8sClient.Create(ctx, bp); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -107,6 +119,7 @@ func (s *buildPlaneService) CreateBuildPlane(ctx context.Context, namespaceName 
 	}
 
 	s.logger.Debug("Build plane created successfully", "namespace", namespaceName, "buildPlane", bp.Name)
+	bp.TypeMeta = buildPlaneTypeMeta
 	return bp, nil
 }
 
@@ -127,6 +140,9 @@ func (s *buildPlaneService) UpdateBuildPlane(ctx context.Context, namespaceName 
 		return nil, fmt.Errorf("failed to get build plane: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	bp.Status = openchoreov1alpha1.BuildPlaneStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = bp.Spec
 	existing.Labels = bp.Labels
@@ -138,6 +154,7 @@ func (s *buildPlaneService) UpdateBuildPlane(ctx context.Context, namespaceName 
 	}
 
 	s.logger.Debug("Build plane updated successfully", "namespace", namespaceName, "buildPlane", bp.Name)
+	existing.TypeMeta = buildPlaneTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/clusterbuildplane/service.go
+++ b/internal/openchoreo-api/services/clusterbuildplane/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -22,6 +23,11 @@ type clusterBuildPlaneService struct {
 }
 
 var _ Service = (*clusterBuildPlaneService)(nil)
+
+var clusterBuildPlaneTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ClusterBuildPlane",
+}
 
 // NewService creates a new cluster build plane service without authorization.
 func NewService(k8sClient client.Client, logger *slog.Logger) Service {
@@ -46,6 +52,10 @@ func (s *clusterBuildPlaneService) ListClusterBuildPlanes(ctx context.Context, o
 	if err := s.k8sClient.List(ctx, &cbpList, listOpts...); err != nil {
 		s.logger.Error("Failed to list cluster build planes", "error", err)
 		return nil, fmt.Errorf("failed to list cluster build planes: %w", err)
+	}
+
+	for i := range cbpList.Items {
+		cbpList.Items[i].TypeMeta = clusterBuildPlaneTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ClusterBuildPlane]{
@@ -78,6 +88,7 @@ func (s *clusterBuildPlaneService) GetClusterBuildPlane(ctx context.Context, clu
 		return nil, fmt.Errorf("failed to get cluster build plane: %w", err)
 	}
 
+	cbp.TypeMeta = clusterBuildPlaneTypeMeta
 	return cbp, nil
 }
 
@@ -88,6 +99,8 @@ func (s *clusterBuildPlaneService) CreateClusterBuildPlane(ctx context.Context, 
 	}
 	s.logger.Debug("Creating cluster build plane", "clusterBuildPlane", cbp.Name)
 
+	cbp.Status = openchoreov1alpha1.ClusterBuildPlaneStatus{}
+
 	if err := s.k8sClient.Create(ctx, cbp); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return nil, ErrClusterBuildPlaneAlreadyExists
@@ -97,6 +110,7 @@ func (s *clusterBuildPlaneService) CreateClusterBuildPlane(ctx context.Context, 
 	}
 
 	s.logger.Debug("Cluster build plane created successfully", "clusterBuildPlane", cbp.Name)
+	cbp.TypeMeta = clusterBuildPlaneTypeMeta
 	return cbp, nil
 }
 
@@ -118,6 +132,7 @@ func (s *clusterBuildPlaneService) UpdateClusterBuildPlane(ctx context.Context, 
 	}
 
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
+	cbp.Status = openchoreov1alpha1.ClusterBuildPlaneStatus{}
 	existing.Spec = cbp.Spec
 	existing.Labels = cbp.Labels
 	existing.Annotations = cbp.Annotations
@@ -128,6 +143,7 @@ func (s *clusterBuildPlaneService) UpdateClusterBuildPlane(ctx context.Context, 
 	}
 
 	s.logger.Debug("Cluster build plane updated successfully", "clusterBuildPlane", cbp.Name)
+	existing.TypeMeta = clusterBuildPlaneTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/clustercomponenttype/service.go
+++ b/internal/openchoreo-api/services/clustercomponenttype/service.go
@@ -10,6 +10,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -27,6 +28,11 @@ type clusterComponentTypeService struct {
 
 var _ Service = (*clusterComponentTypeService)(nil)
 
+var clusterComponentTypeTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ClusterComponentType",
+}
+
 // NewService creates a new cluster component type service without authorization.
 func NewService(k8sClient client.Client, logger *slog.Logger) Service {
 	return &clusterComponentTypeService{
@@ -43,6 +49,7 @@ func (s *clusterComponentTypeService) CreateClusterComponentType(ctx context.Con
 	s.logger.Debug("Creating cluster component type", "clusterComponentType", cct.Name)
 
 	// Set defaults
+	cct.Status = openchoreov1alpha1.ClusterComponentTypeStatus{}
 
 	if err := s.k8sClient.Create(ctx, cct); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -54,6 +61,7 @@ func (s *clusterComponentTypeService) CreateClusterComponentType(ctx context.Con
 	}
 
 	s.logger.Debug("Cluster component type created successfully", "clusterComponentType", cct.Name)
+	cct.TypeMeta = clusterComponentTypeTypeMeta
 	return cct, nil
 }
 
@@ -75,6 +83,7 @@ func (s *clusterComponentTypeService) UpdateClusterComponentType(ctx context.Con
 	}
 
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
+	cct.Status = openchoreov1alpha1.ClusterComponentTypeStatus{}
 	existing.Spec = cct.Spec
 	existing.Labels = cct.Labels
 	existing.Annotations = cct.Annotations
@@ -85,6 +94,7 @@ func (s *clusterComponentTypeService) UpdateClusterComponentType(ctx context.Con
 	}
 
 	s.logger.Debug("Cluster component type updated successfully", "clusterComponentType", cct.Name)
+	existing.TypeMeta = clusterComponentTypeTypeMeta
 	return existing, nil
 }
 
@@ -103,6 +113,10 @@ func (s *clusterComponentTypeService) ListClusterComponentTypes(ctx context.Cont
 	if err := s.k8sClient.List(ctx, &cctList, listOpts...); err != nil {
 		s.logger.Error("Failed to list cluster component types", "error", err)
 		return nil, fmt.Errorf("failed to list cluster component types: %w", err)
+	}
+
+	for i := range cctList.Items {
+		cctList.Items[i].TypeMeta = clusterComponentTypeTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ClusterComponentType]{
@@ -135,6 +149,7 @@ func (s *clusterComponentTypeService) GetClusterComponentType(ctx context.Contex
 		return nil, fmt.Errorf("failed to get cluster component type: %w", err)
 	}
 
+	cct.TypeMeta = clusterComponentTypeTypeMeta
 	return cct, nil
 }
 

--- a/internal/openchoreo-api/services/clusterdataplane/service.go
+++ b/internal/openchoreo-api/services/clusterdataplane/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -23,6 +24,11 @@ type clusterDataPlaneService struct {
 }
 
 var _ Service = (*clusterDataPlaneService)(nil)
+
+var clusterDataPlaneTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ClusterDataPlane",
+}
 
 // NewService creates a new cluster data plane service without authorization.
 func NewService(k8sClient client.Client, logger *slog.Logger) Service {
@@ -47,6 +53,10 @@ func (s *clusterDataPlaneService) ListClusterDataPlanes(ctx context.Context, opt
 	if err := s.k8sClient.List(ctx, &clusterDataPlaneList, listOpts...); err != nil {
 		s.logger.Error("Failed to list cluster data planes", "error", err)
 		return nil, fmt.Errorf("failed to list cluster data planes: %w", err)
+	}
+
+	for i := range clusterDataPlaneList.Items {
+		clusterDataPlaneList.Items[i].TypeMeta = clusterDataPlaneTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ClusterDataPlane]{
@@ -77,6 +87,7 @@ func (s *clusterDataPlaneService) GetClusterDataPlane(ctx context.Context, name 
 		return nil, fmt.Errorf("failed to get cluster data plane: %w", err)
 	}
 
+	cdp.TypeMeta = clusterDataPlaneTypeMeta
 	return cdp, nil
 }
 
@@ -98,6 +109,8 @@ func (s *clusterDataPlaneService) CreateClusterDataPlane(ctx context.Context, cd
 	}
 
 	// Set defaults
+	cdp.Status = openchoreov1alpha1.ClusterDataPlaneStatus{}
+
 	if err := s.k8sClient.Create(ctx, cdp); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			s.logger.Warn("Cluster data plane already exists", "clusterDataPlane", cdp.Name)
@@ -108,6 +121,7 @@ func (s *clusterDataPlaneService) CreateClusterDataPlane(ctx context.Context, cd
 	}
 
 	s.logger.Debug("Cluster data plane created successfully", "clusterDataPlane", cdp.Name)
+	cdp.TypeMeta = clusterDataPlaneTypeMeta
 	return cdp, nil
 }
 
@@ -128,6 +142,7 @@ func (s *clusterDataPlaneService) UpdateClusterDataPlane(ctx context.Context, cd
 	}
 
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
+	cdp.Status = openchoreov1alpha1.ClusterDataPlaneStatus{}
 	existing.Spec = cdp.Spec
 	existing.Labels = cdp.Labels
 	existing.Annotations = cdp.Annotations
@@ -138,6 +153,7 @@ func (s *clusterDataPlaneService) UpdateClusterDataPlane(ctx context.Context, cd
 	}
 
 	s.logger.Debug("Cluster data plane updated successfully", "clusterDataPlane", cdp.Name)
+	existing.TypeMeta = clusterDataPlaneTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/clusterobservabilityplane/service.go
+++ b/internal/openchoreo-api/services/clusterobservabilityplane/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -22,6 +23,11 @@ type clusterObservabilityPlaneService struct {
 }
 
 var _ Service = (*clusterObservabilityPlaneService)(nil)
+
+var clusterObservabilityPlaneTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ClusterObservabilityPlane",
+}
 
 // NewService creates a new cluster observability plane service without authorization.
 func NewService(k8sClient client.Client, logger *slog.Logger) Service {
@@ -46,6 +52,10 @@ func (s *clusterObservabilityPlaneService) ListClusterObservabilityPlanes(ctx co
 	if err := s.k8sClient.List(ctx, &copList, listOpts...); err != nil {
 		s.logger.Error("Failed to list cluster observability planes", "error", err)
 		return nil, fmt.Errorf("failed to list cluster observability planes: %w", err)
+	}
+
+	for i := range copList.Items {
+		copList.Items[i].TypeMeta = clusterObservabilityPlaneTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ClusterObservabilityPlane]{
@@ -78,6 +88,7 @@ func (s *clusterObservabilityPlaneService) GetClusterObservabilityPlane(ctx cont
 		return nil, fmt.Errorf("failed to get cluster observability plane: %w", err)
 	}
 
+	cop.TypeMeta = clusterObservabilityPlaneTypeMeta
 	return cop, nil
 }
 
@@ -88,6 +99,8 @@ func (s *clusterObservabilityPlaneService) CreateClusterObservabilityPlane(ctx c
 	}
 	s.logger.Debug("Creating cluster observability plane", "clusterObservabilityPlane", cop.Name)
 
+	cop.Status = openchoreov1alpha1.ClusterObservabilityPlaneStatus{}
+
 	if err := s.k8sClient.Create(ctx, cop); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return nil, ErrClusterObservabilityPlaneAlreadyExists
@@ -97,6 +110,7 @@ func (s *clusterObservabilityPlaneService) CreateClusterObservabilityPlane(ctx c
 	}
 
 	s.logger.Debug("Cluster observability plane created successfully", "clusterObservabilityPlane", cop.Name)
+	cop.TypeMeta = clusterObservabilityPlaneTypeMeta
 	return cop, nil
 }
 
@@ -117,6 +131,7 @@ func (s *clusterObservabilityPlaneService) UpdateClusterObservabilityPlane(ctx c
 	}
 
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
+	cop.Status = openchoreov1alpha1.ClusterObservabilityPlaneStatus{}
 	existing.Spec = cop.Spec
 	existing.Labels = cop.Labels
 	existing.Annotations = cop.Annotations
@@ -127,6 +142,7 @@ func (s *clusterObservabilityPlaneService) UpdateClusterObservabilityPlane(ctx c
 	}
 
 	s.logger.Debug("Cluster observability plane updated successfully", "clusterObservabilityPlane", cop.Name)
+	existing.TypeMeta = clusterObservabilityPlaneTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/clustertrait/service.go
+++ b/internal/openchoreo-api/services/clustertrait/service.go
@@ -10,6 +10,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -27,6 +28,11 @@ type clusterTraitService struct {
 
 var _ Service = (*clusterTraitService)(nil)
 
+var clusterTraitTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ClusterTrait",
+}
+
 // NewService creates a new cluster trait service without authorization.
 func NewService(k8sClient client.Client, logger *slog.Logger) Service {
 	return &clusterTraitService{
@@ -43,6 +49,7 @@ func (s *clusterTraitService) CreateClusterTrait(ctx context.Context, ct *opench
 	s.logger.Debug("Creating cluster trait", "clusterTrait", ct.Name)
 
 	// Set defaults
+	ct.Status = openchoreov1alpha1.ClusterTraitStatus{}
 
 	if err := s.k8sClient.Create(ctx, ct); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -54,6 +61,7 @@ func (s *clusterTraitService) CreateClusterTrait(ctx context.Context, ct *opench
 	}
 
 	s.logger.Debug("Cluster trait created successfully", "clusterTrait", ct.Name)
+	ct.TypeMeta = clusterTraitTypeMeta
 	return ct, nil
 }
 
@@ -75,6 +83,7 @@ func (s *clusterTraitService) UpdateClusterTrait(ctx context.Context, ct *opench
 	}
 
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
+	ct.Status = openchoreov1alpha1.ClusterTraitStatus{}
 	existing.Spec = ct.Spec
 	existing.Labels = ct.Labels
 	existing.Annotations = ct.Annotations
@@ -85,6 +94,7 @@ func (s *clusterTraitService) UpdateClusterTrait(ctx context.Context, ct *opench
 	}
 
 	s.logger.Debug("Cluster trait updated successfully", "clusterTrait", ct.Name)
+	existing.TypeMeta = clusterTraitTypeMeta
 	return existing, nil
 }
 
@@ -103,6 +113,10 @@ func (s *clusterTraitService) ListClusterTraits(ctx context.Context, opts servic
 	if err := s.k8sClient.List(ctx, &traitList, listOpts...); err != nil {
 		s.logger.Error("Failed to list cluster traits", "error", err)
 		return nil, fmt.Errorf("failed to list cluster traits: %w", err)
+	}
+
+	for i := range traitList.Items {
+		traitList.Items[i].TypeMeta = clusterTraitTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ClusterTrait]{
@@ -135,6 +149,7 @@ func (s *clusterTraitService) GetClusterTrait(ctx context.Context, clusterTraitN
 		return nil, fmt.Errorf("failed to get cluster trait: %w", err)
 	}
 
+	trait.TypeMeta = clusterTraitTypeMeta
 	return trait, nil
 }
 

--- a/internal/openchoreo-api/services/component/service.go
+++ b/internal/openchoreo-api/services/component/service.go
@@ -23,6 +23,21 @@ import (
 	openchoreoschema "github.com/openchoreo/openchoreo/internal/schema"
 )
 
+var componentTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Component",
+}
+
+var releaseBindingTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ReleaseBinding",
+}
+
+var componentReleaseTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ComponentRelease",
+}
+
 // componentService handles component-related business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
 type componentService struct {
@@ -67,6 +82,7 @@ func (s *componentService) CreateComponent(ctx context.Context, namespaceName st
 	}
 
 	// Set defaults
+	component.Status = openchoreov1alpha1.ComponentStatus{}
 	component.Namespace = namespaceName
 	if component.Labels == nil {
 		component.Labels = make(map[string]string)
@@ -83,6 +99,7 @@ func (s *componentService) CreateComponent(ctx context.Context, namespaceName st
 	}
 
 	s.logger.Debug("Component created successfully", "namespace", namespaceName, "component", component.Name)
+	component.TypeMeta = componentTypeMeta
 	return component, nil
 }
 
@@ -102,6 +119,9 @@ func (s *componentService) UpdateComponent(ctx context.Context, namespaceName st
 		s.logger.Error("Failed to get component", "error", err)
 		return nil, fmt.Errorf("failed to get component: %w", err)
 	}
+
+	// Clear status from user input — status is server-managed
+	component.Status = openchoreov1alpha1.ComponentStatus{}
 
 	// Prevent project reassignment: if the incoming component specifies a project,
 	// it must match the existing component's project
@@ -130,6 +150,7 @@ func (s *componentService) UpdateComponent(ctx context.Context, namespaceName st
 	}
 
 	s.logger.Debug("Component updated successfully", "namespace", namespaceName, "component", component.Name)
+	existing.TypeMeta = componentTypeMeta
 	return existing, nil
 }
 
@@ -176,6 +197,10 @@ func (s *componentService) listComponentsResource(namespaceName string) services
 			return nil, fmt.Errorf("failed to list components: %w", err)
 		}
 
+		for i := range componentList.Items {
+			componentList.Items[i].TypeMeta = componentTypeMeta
+		}
+
 		result := &services.ListResult[openchoreov1alpha1.Component]{
 			Items:      componentList.Items,
 			NextCursor: componentList.Continue,
@@ -207,6 +232,7 @@ func (s *componentService) GetComponent(ctx context.Context, namespaceName, comp
 		return nil, fmt.Errorf("failed to get component: %w", err)
 	}
 
+	component.TypeMeta = componentTypeMeta
 	return component, nil
 }
 
@@ -320,6 +346,7 @@ func (s *componentService) DeployRelease(ctx context.Context, namespaceName, com
 	}
 
 	s.logger.Debug("Release deployed successfully", "namespace", namespaceName, "component", componentName, "release", req.ReleaseName, "environment", lowestEnv)
+	binding.TypeMeta = releaseBindingTypeMeta
 	return &binding, nil
 }
 
@@ -391,6 +418,7 @@ func (s *componentService) PromoteComponent(ctx context.Context, namespaceName, 
 
 	s.logger.Debug("Component promoted successfully", "namespace", namespaceName, "component", componentName,
 		"source", req.SourceEnvironment, "target", req.TargetEnvironment)
+	targetBinding.TypeMeta = releaseBindingTypeMeta
 	return &targetBinding, nil
 }
 
@@ -557,6 +585,7 @@ func (s *componentService) GenerateRelease(ctx context.Context, namespaceName, c
 	}
 
 	s.logger.Debug("ComponentRelease created successfully", "namespace", namespaceName, "component", componentName, "release", releaseName)
+	componentRelease.TypeMeta = componentReleaseTypeMeta
 	return componentRelease, nil
 }
 

--- a/internal/openchoreo-api/services/componentrelease/service.go
+++ b/internal/openchoreo-api/services/componentrelease/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -19,6 +20,11 @@ import (
 type componentReleaseService struct {
 	k8sClient client.Client
 	logger    *slog.Logger
+}
+
+var componentReleaseTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ComponentRelease",
 }
 
 var _ Service = (*componentReleaseService)(nil)
@@ -49,6 +55,10 @@ func (s *componentReleaseService) ListComponentReleases(ctx context.Context, nam
 		if err := s.k8sClient.List(ctx, &crList, listOpts...); err != nil {
 			s.logger.Error("Failed to list component releases", "error", err)
 			return nil, fmt.Errorf("failed to list component releases: %w", err)
+		}
+
+		for i := range crList.Items {
+			crList.Items[i].TypeMeta = componentReleaseTypeMeta
 		}
 
 		result := &services.ListResult[openchoreov1alpha1.ComponentRelease]{
@@ -94,5 +104,6 @@ func (s *componentReleaseService) GetComponentRelease(ctx context.Context, names
 		return nil, fmt.Errorf("failed to get component release: %w", err)
 	}
 
+	cr.TypeMeta = componentReleaseTypeMeta
 	return cr, nil
 }

--- a/internal/openchoreo-api/services/componenttype/service.go
+++ b/internal/openchoreo-api/services/componenttype/service.go
@@ -10,6 +10,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -24,6 +25,11 @@ import (
 type componentTypeService struct {
 	k8sClient client.Client
 	logger    *slog.Logger
+}
+
+var componentTypeTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ComponentType",
 }
 
 var _ Service = (*componentTypeService)(nil)
@@ -55,6 +61,7 @@ func (s *componentTypeService) CreateComponentType(ctx context.Context, namespac
 
 	// Set defaults
 	ct.Namespace = namespaceName
+	ct.Status = openchoreov1alpha1.ComponentTypeStatus{}
 	if err := s.k8sClient.Create(ctx, ct); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			s.logger.Warn("Component type already exists", "namespace", namespaceName, "componentType", ct.Name)
@@ -65,6 +72,7 @@ func (s *componentTypeService) CreateComponentType(ctx context.Context, namespac
 	}
 
 	s.logger.Debug("Component type created successfully", "namespace", namespaceName, "componentType", ct.Name)
+	ct.TypeMeta = componentTypeTypeMeta
 	return ct, nil
 }
 
@@ -85,6 +93,9 @@ func (s *componentTypeService) UpdateComponentType(ctx context.Context, namespac
 		return nil, fmt.Errorf("failed to get component type: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	ct.Status = openchoreov1alpha1.ComponentTypeStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = ct.Spec
 	existing.Labels = ct.Labels
@@ -96,6 +107,7 @@ func (s *componentTypeService) UpdateComponentType(ctx context.Context, namespac
 	}
 
 	s.logger.Debug("Component type updated successfully", "namespace", namespaceName, "componentType", ct.Name)
+	existing.TypeMeta = componentTypeTypeMeta
 	return existing, nil
 }
 
@@ -116,6 +128,10 @@ func (s *componentTypeService) ListComponentTypes(ctx context.Context, namespace
 	if err := s.k8sClient.List(ctx, &ctList, listOpts...); err != nil {
 		s.logger.Error("Failed to list component types", "error", err)
 		return nil, fmt.Errorf("failed to list component types: %w", err)
+	}
+
+	for i := range ctList.Items {
+		ctList.Items[i].TypeMeta = componentTypeTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ComponentType]{
@@ -149,6 +165,7 @@ func (s *componentTypeService) GetComponentType(ctx context.Context, namespaceNa
 		return nil, fmt.Errorf("failed to get component type: %w", err)
 	}
 
+	ct.TypeMeta = componentTypeTypeMeta
 	return ct, nil
 }
 

--- a/internal/openchoreo-api/services/dataplane/service.go
+++ b/internal/openchoreo-api/services/dataplane/service.go
@@ -9,11 +9,17 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var dataPlaneTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "DataPlane",
+}
 
 // dataPlaneService handles data plane-related business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -51,6 +57,10 @@ func (s *dataPlaneService) ListDataPlanes(ctx context.Context, namespaceName str
 		return nil, fmt.Errorf("failed to list data planes: %w", err)
 	}
 
+	for i := range dataPlaneList.Items {
+		dataPlaneList.Items[i].TypeMeta = dataPlaneTypeMeta
+	}
+
 	result := &services.ListResult[openchoreov1alpha1.DataPlane]{
 		Items:      dataPlaneList.Items,
 		NextCursor: dataPlaneList.Continue,
@@ -82,6 +92,7 @@ func (s *dataPlaneService) GetDataPlane(ctx context.Context, namespaceName, dpNa
 		return nil, fmt.Errorf("failed to get data plane: %w", err)
 	}
 
+	dataPlane.TypeMeta = dataPlaneTypeMeta
 	return dataPlane, nil
 }
 
@@ -103,6 +114,7 @@ func (s *dataPlaneService) CreateDataPlane(ctx context.Context, namespaceName st
 	}
 
 	// Set defaults
+	dp.Status = openchoreov1alpha1.DataPlaneStatus{}
 	dp.Namespace = namespaceName
 	if err := s.k8sClient.Create(ctx, dp); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -114,6 +126,7 @@ func (s *dataPlaneService) CreateDataPlane(ctx context.Context, namespaceName st
 	}
 
 	s.logger.Debug("Data plane created successfully", "namespace", namespaceName, "dataPlane", dp.Name)
+	dp.TypeMeta = dataPlaneTypeMeta
 	return dp, nil
 }
 
@@ -133,6 +146,9 @@ func (s *dataPlaneService) UpdateDataPlane(ctx context.Context, namespaceName st
 		return nil, fmt.Errorf("failed to get data plane: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	dp.Status = openchoreov1alpha1.DataPlaneStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = dp.Spec
 	existing.Labels = dp.Labels
@@ -144,6 +160,7 @@ func (s *dataPlaneService) UpdateDataPlane(ctx context.Context, namespaceName st
 	}
 
 	s.logger.Debug("Data plane updated successfully", "namespace", namespaceName, "dataPlane", dp.Name)
+	existing.TypeMeta = dataPlaneTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/deploymentpipeline/service.go
+++ b/internal/openchoreo-api/services/deploymentpipeline/service.go
@@ -9,11 +9,17 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var deploymentPipelineTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "DeploymentPipeline",
+}
 
 // deploymentPipelineService handles deployment pipeline business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -50,6 +56,7 @@ func (s *deploymentPipelineService) CreateDeploymentPipeline(ctx context.Context
 	}
 
 	// Set defaults
+	dp.Status = openchoreov1alpha1.DeploymentPipelineStatus{}
 	dp.Namespace = namespaceName
 	if err := s.k8sClient.Create(ctx, dp); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -61,6 +68,7 @@ func (s *deploymentPipelineService) CreateDeploymentPipeline(ctx context.Context
 	}
 
 	s.logger.Debug("Deployment pipeline created successfully", "namespace", namespaceName, "deploymentPipeline", dp.Name)
+	dp.TypeMeta = deploymentPipelineTypeMeta
 	return dp, nil
 }
 
@@ -81,6 +89,9 @@ func (s *deploymentPipelineService) UpdateDeploymentPipeline(ctx context.Context
 		return nil, fmt.Errorf("failed to get deployment pipeline: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	dp.Status = openchoreov1alpha1.DeploymentPipelineStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = dp.Spec
 	existing.Labels = dp.Labels
@@ -92,6 +103,7 @@ func (s *deploymentPipelineService) UpdateDeploymentPipeline(ctx context.Context
 	}
 
 	s.logger.Debug("Deployment pipeline updated successfully", "namespace", namespaceName, "deploymentPipeline", dp.Name)
+	existing.TypeMeta = deploymentPipelineTypeMeta
 	return existing, nil
 }
 
@@ -112,6 +124,10 @@ func (s *deploymentPipelineService) ListDeploymentPipelines(ctx context.Context,
 	if err := s.k8sClient.List(ctx, &dpList, listOpts...); err != nil {
 		s.logger.Error("Failed to list deployment pipelines", "error", err)
 		return nil, fmt.Errorf("failed to list deployment pipelines: %w", err)
+	}
+
+	for i := range dpList.Items {
+		dpList.Items[i].TypeMeta = deploymentPipelineTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.DeploymentPipeline]{
@@ -145,6 +161,7 @@ func (s *deploymentPipelineService) GetDeploymentPipeline(ctx context.Context, n
 		return nil, fmt.Errorf("failed to get deployment pipeline: %w", err)
 	}
 
+	dp.TypeMeta = deploymentPipelineTypeMeta
 	return dp, nil
 }
 

--- a/internal/openchoreo-api/services/environment/service.go
+++ b/internal/openchoreo-api/services/environment/service.go
@@ -9,12 +9,18 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var environmentTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Environment",
+}
 
 // environmentService handles environment-related business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -52,6 +58,10 @@ func (s *environmentService) ListEnvironments(ctx context.Context, namespaceName
 		return nil, fmt.Errorf("failed to list environments: %w", err)
 	}
 
+	for i := range envList.Items {
+		envList.Items[i].TypeMeta = environmentTypeMeta
+	}
+
 	result := &services.ListResult[openchoreov1alpha1.Environment]{
 		Items:      envList.Items,
 		NextCursor: envList.Continue,
@@ -83,6 +93,7 @@ func (s *environmentService) GetEnvironment(ctx context.Context, namespaceName, 
 		return nil, fmt.Errorf("failed to get environment: %w", err)
 	}
 
+	env.TypeMeta = environmentTypeMeta
 	return env, nil
 }
 
@@ -122,6 +133,7 @@ func (s *environmentService) CreateEnvironment(ctx context.Context, namespaceNam
 		env.Spec.DataPlaneRef.Kind = openchoreov1alpha1.DataPlaneRefKindDataPlane
 	}
 
+	env.Status = openchoreov1alpha1.EnvironmentStatus{}
 	env.Namespace = namespaceName
 
 	if err := s.k8sClient.Create(ctx, env); err != nil {
@@ -130,6 +142,7 @@ func (s *environmentService) CreateEnvironment(ctx context.Context, namespaceNam
 	}
 
 	s.logger.Debug("Environment created successfully", "namespace", namespaceName, "env", env.Name)
+	env.TypeMeta = environmentTypeMeta
 	return env, nil
 }
 
@@ -150,6 +163,9 @@ func (s *environmentService) UpdateEnvironment(ctx context.Context, namespaceNam
 		return nil, fmt.Errorf("failed to get environment: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	env.Status = openchoreov1alpha1.EnvironmentStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = env.Spec
 	existing.Labels = env.Labels
@@ -165,6 +181,7 @@ func (s *environmentService) UpdateEnvironment(ctx context.Context, namespaceNam
 	}
 
 	s.logger.Debug("Environment updated successfully", "namespace", namespaceName, "env", env.Name)
+	existing.TypeMeta = environmentTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/observabilityalertsnotificationchannel/service.go
+++ b/internal/openchoreo-api/services/observabilityalertsnotificationchannel/service.go
@@ -9,11 +9,17 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var observabilityAlertsNotificationChannelTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ObservabilityAlertsNotificationChannel",
+}
 
 // observabilityAlertsNotificationChannelService handles business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -51,6 +57,7 @@ func (s *observabilityAlertsNotificationChannelService) CreateObservabilityAlert
 
 	// Set defaults
 	nc.Namespace = namespaceName
+	nc.Status = openchoreov1alpha1.ObservabilityAlertsNotificationChannelStatus{}
 	if err := s.k8sClient.Create(ctx, nc); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			s.logger.Warn("Observability alerts notification channel already exists", "namespace", namespaceName, "channel", nc.Name)
@@ -60,6 +67,7 @@ func (s *observabilityAlertsNotificationChannelService) CreateObservabilityAlert
 		return nil, fmt.Errorf("failed to create observability alerts notification channel: %w", err)
 	}
 
+	nc.TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 	s.logger.Debug("Observability alerts notification channel created successfully", "namespace", namespaceName, "channel", nc.Name)
 	return nc, nil
 }
@@ -86,6 +94,8 @@ func (s *observabilityAlertsNotificationChannelService) UpdateObservabilityAlert
 		return nil, &services.ValidationError{Msg: "spec.environment is immutable"}
 	}
 
+	nc.Status = openchoreov1alpha1.ObservabilityAlertsNotificationChannelStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = nc.Spec
 	existing.Labels = nc.Labels
@@ -96,6 +106,7 @@ func (s *observabilityAlertsNotificationChannelService) UpdateObservabilityAlert
 		return nil, fmt.Errorf("failed to update observability alerts notification channel: %w", err)
 	}
 
+	existing.TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 	s.logger.Debug("Observability alerts notification channel updated successfully", "namespace", namespaceName, "channel", nc.Name)
 	return existing, nil
 }
@@ -117,6 +128,10 @@ func (s *observabilityAlertsNotificationChannelService) ListObservabilityAlertsN
 	if err := s.k8sClient.List(ctx, &ncList, listOpts...); err != nil {
 		s.logger.Error("Failed to list observability alerts notification channels", "error", err)
 		return nil, fmt.Errorf("failed to list observability alerts notification channels: %w", err)
+	}
+
+	for i := range ncList.Items {
+		ncList.Items[i].TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.ObservabilityAlertsNotificationChannel]{
@@ -150,6 +165,7 @@ func (s *observabilityAlertsNotificationChannelService) GetObservabilityAlertsNo
 		return nil, fmt.Errorf("failed to get observability alerts notification channel: %w", err)
 	}
 
+	nc.TypeMeta = observabilityAlertsNotificationChannelTypeMeta
 	return nc, nil
 }
 

--- a/internal/openchoreo-api/services/observabilityplane/service.go
+++ b/internal/openchoreo-api/services/observabilityplane/service.go
@@ -9,11 +9,17 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var observabilityPlaneTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ObservabilityPlane",
+}
 
 // observabilityPlaneService handles observability plane-related business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -51,6 +57,10 @@ func (s *observabilityPlaneService) ListObservabilityPlanes(ctx context.Context,
 		return nil, fmt.Errorf("failed to list observability planes: %w", err)
 	}
 
+	for i := range opList.Items {
+		opList.Items[i].TypeMeta = observabilityPlaneTypeMeta
+	}
+
 	result := &services.ListResult[openchoreov1alpha1.ObservabilityPlane]{
 		Items:      opList.Items,
 		NextCursor: opList.Continue,
@@ -82,6 +92,7 @@ func (s *observabilityPlaneService) GetObservabilityPlane(ctx context.Context, n
 		return nil, fmt.Errorf("failed to get observability plane: %w", err)
 	}
 
+	op.TypeMeta = observabilityPlaneTypeMeta
 	return op, nil
 }
 
@@ -92,6 +103,7 @@ func (s *observabilityPlaneService) CreateObservabilityPlane(ctx context.Context
 	}
 	s.logger.Debug("Creating observability plane", "namespace", namespaceName, "observabilityPlane", op.Name)
 
+	op.Status = openchoreov1alpha1.ObservabilityPlaneStatus{}
 	op.Namespace = namespaceName
 	if err := s.k8sClient.Create(ctx, op); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -102,6 +114,7 @@ func (s *observabilityPlaneService) CreateObservabilityPlane(ctx context.Context
 	}
 
 	s.logger.Debug("Observability plane created successfully", "namespace", namespaceName, "observabilityPlane", op.Name)
+	op.TypeMeta = observabilityPlaneTypeMeta
 	return op, nil
 }
 
@@ -121,6 +134,9 @@ func (s *observabilityPlaneService) UpdateObservabilityPlane(ctx context.Context
 		return nil, fmt.Errorf("failed to get observability plane: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	op.Status = openchoreov1alpha1.ObservabilityPlaneStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = op.Spec
 	existing.Labels = op.Labels
@@ -132,6 +148,7 @@ func (s *observabilityPlaneService) UpdateObservabilityPlane(ctx context.Context
 	}
 
 	s.logger.Debug("Observability plane updated successfully", "namespace", namespaceName, "observabilityPlane", op.Name)
+	existing.TypeMeta = observabilityPlaneTypeMeta
 	return existing, nil
 }
 

--- a/internal/openchoreo-api/services/project/service.go
+++ b/internal/openchoreo-api/services/project/service.go
@@ -9,11 +9,17 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var projectTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Project",
+}
 
 const (
 	defaultPipeline = "default"
@@ -54,6 +60,7 @@ func (s *projectService) CreateProject(ctx context.Context, namespaceName string
 	}
 
 	project.Namespace = namespaceName
+	project.Status = openchoreov1alpha1.ProjectStatus{}
 	if project.Spec.DeploymentPipelineRef == "" {
 		project.Spec.DeploymentPipelineRef = defaultPipeline
 	}
@@ -68,6 +75,7 @@ func (s *projectService) CreateProject(ctx context.Context, namespaceName string
 	}
 
 	s.logger.Debug("Project created successfully", "namespace", namespaceName, "project", project.Name)
+	project.TypeMeta = projectTypeMeta
 	return project, nil
 }
 
@@ -88,6 +96,9 @@ func (s *projectService) UpdateProject(ctx context.Context, namespaceName string
 		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	project.Status = openchoreov1alpha1.ProjectStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = project.Spec
 	existing.Labels = project.Labels
@@ -99,6 +110,7 @@ func (s *projectService) UpdateProject(ctx context.Context, namespaceName string
 	}
 
 	s.logger.Debug("Project updated successfully", "namespace", namespaceName, "project", project.Name)
+	existing.TypeMeta = projectTypeMeta
 	return existing, nil
 }
 
@@ -119,6 +131,10 @@ func (s *projectService) ListProjects(ctx context.Context, namespaceName string,
 	if err := s.k8sClient.List(ctx, &projectList, listOpts...); err != nil {
 		s.logger.Error("Failed to list projects", "error", err)
 		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	for i := range projectList.Items {
+		projectList.Items[i].TypeMeta = projectTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.Project]{
@@ -152,6 +168,7 @@ func (s *projectService) GetProject(ctx context.Context, namespaceName, projectN
 		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
 
+	project.TypeMeta = projectTypeMeta
 	return project, nil
 }
 

--- a/internal/openchoreo-api/services/release/service.go
+++ b/internal/openchoreo-api/services/release/service.go
@@ -8,11 +8,17 @@ import (
 	"fmt"
 	"log/slog"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+var releaseTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Release",
+}
 
 // releaseService handles release business logic without authorization checks.
 // Other services within this layer should use this directly to avoid double authz.
@@ -49,6 +55,10 @@ func (s *releaseService) ListReleases(ctx context.Context, namespaceName, compon
 		if err := s.k8sClient.List(ctx, &rList, listOpts...); err != nil {
 			s.logger.Error("Failed to list releases", "error", err)
 			return nil, fmt.Errorf("failed to list releases: %w", err)
+		}
+
+		for i := range rList.Items {
+			rList.Items[i].TypeMeta = releaseTypeMeta
 		}
 
 		result := &services.ListResult[openchoreov1alpha1.Release]{
@@ -101,5 +111,6 @@ func (s *releaseService) GetRelease(ctx context.Context, namespaceName, releaseN
 		return nil, fmt.Errorf("failed to get release: %w", err)
 	}
 
+	r.TypeMeta = releaseTypeMeta
 	return r, nil
 }

--- a/internal/openchoreo-api/services/releasebinding/service.go
+++ b/internal/openchoreo-api/services/releasebinding/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -21,6 +22,11 @@ import (
 type releaseBindingService struct {
 	k8sClient client.Client
 	logger    *slog.Logger
+}
+
+var releaseBindingTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "ReleaseBinding",
 }
 
 var _ Service = (*releaseBindingService)(nil)
@@ -57,6 +63,7 @@ func (s *releaseBindingService) CreateReleaseBinding(ctx context.Context, namesp
 
 	// Set defaults
 	rb.Namespace = namespaceName
+	rb.Status = openchoreov1alpha1.ReleaseBindingStatus{}
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)
 	}
@@ -73,6 +80,7 @@ func (s *releaseBindingService) CreateReleaseBinding(ctx context.Context, namesp
 	}
 
 	s.logger.Debug("Release binding created successfully", "namespace", namespaceName, "releaseBinding", rb.Name)
+	rb.TypeMeta = releaseBindingTypeMeta
 	return rb, nil
 }
 
@@ -98,6 +106,9 @@ func (s *releaseBindingService) UpdateReleaseBinding(ctx context.Context, namesp
 		return nil, err
 	}
 
+	// Clear status from user input — status is server-managed
+	rb.Status = openchoreov1alpha1.ReleaseBindingStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = rb.Spec
 	existing.Labels = rb.Labels
@@ -120,6 +131,7 @@ func (s *releaseBindingService) UpdateReleaseBinding(ctx context.Context, namesp
 	}
 
 	s.logger.Debug("Release binding updated successfully", "namespace", namespaceName, "releaseBinding", rb.Name)
+	existing.TypeMeta = releaseBindingTypeMeta
 	return existing, nil
 }
 
@@ -141,6 +153,10 @@ func (s *releaseBindingService) ListReleaseBindings(ctx context.Context, namespa
 		if err := s.k8sClient.List(ctx, &rbList, listOpts...); err != nil {
 			s.logger.Error("Failed to list release bindings", "error", err)
 			return nil, fmt.Errorf("failed to list release bindings: %w", err)
+		}
+
+		for i := range rbList.Items {
+			rbList.Items[i].TypeMeta = releaseBindingTypeMeta
 		}
 
 		result := &services.ListResult[openchoreov1alpha1.ReleaseBinding]{
@@ -186,6 +202,7 @@ func (s *releaseBindingService) GetReleaseBinding(ctx context.Context, namespace
 		return nil, fmt.Errorf("failed to get release binding: %w", err)
 	}
 
+	rb.TypeMeta = releaseBindingTypeMeta
 	return rb, nil
 }
 

--- a/internal/openchoreo-api/services/secretreference/service.go
+++ b/internal/openchoreo-api/services/secretreference/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -20,6 +21,11 @@ import (
 type secretReferenceService struct {
 	k8sClient client.Client
 	logger    *slog.Logger
+}
+
+var secretReferenceTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "SecretReference",
 }
 
 var _ Service = (*secretReferenceService)(nil)
@@ -51,6 +57,7 @@ func (s *secretReferenceService) CreateSecretReference(ctx context.Context, name
 
 	// Set defaults
 	sr.Namespace = namespaceName
+	sr.Status = openchoreov1alpha1.SecretReferenceStatus{}
 	if err := s.k8sClient.Create(ctx, sr); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			s.logger.Warn("Secret reference already exists", "namespace", namespaceName, "secretReference", sr.Name)
@@ -61,6 +68,7 @@ func (s *secretReferenceService) CreateSecretReference(ctx context.Context, name
 	}
 
 	s.logger.Debug("Secret reference created successfully", "namespace", namespaceName, "secretReference", sr.Name)
+	sr.TypeMeta = secretReferenceTypeMeta
 	return sr, nil
 }
 
@@ -81,6 +89,9 @@ func (s *secretReferenceService) UpdateSecretReference(ctx context.Context, name
 		return nil, fmt.Errorf("failed to get secret reference: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	sr.Status = openchoreov1alpha1.SecretReferenceStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = sr.Spec
 	existing.Labels = sr.Labels
@@ -92,6 +103,7 @@ func (s *secretReferenceService) UpdateSecretReference(ctx context.Context, name
 	}
 
 	s.logger.Debug("Secret reference updated successfully", "namespace", namespaceName, "secretReference", sr.Name)
+	existing.TypeMeta = secretReferenceTypeMeta
 	return existing, nil
 }
 
@@ -112,6 +124,10 @@ func (s *secretReferenceService) ListSecretReferences(ctx context.Context, names
 	if err := s.k8sClient.List(ctx, &srList, listOpts...); err != nil {
 		s.logger.Error("Failed to list secret references", "error", err)
 		return nil, fmt.Errorf("failed to list secret references: %w", err)
+	}
+
+	for i := range srList.Items {
+		srList.Items[i].TypeMeta = secretReferenceTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.SecretReference]{
@@ -145,6 +161,7 @@ func (s *secretReferenceService) GetSecretReference(ctx context.Context, namespa
 		return nil, fmt.Errorf("failed to get secret reference: %w", err)
 	}
 
+	sr.TypeMeta = secretReferenceTypeMeta
 	return sr, nil
 }
 

--- a/internal/openchoreo-api/services/trait/service.go
+++ b/internal/openchoreo-api/services/trait/service.go
@@ -10,6 +10,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -24,6 +25,11 @@ import (
 type traitService struct {
 	k8sClient client.Client
 	logger    *slog.Logger
+}
+
+var traitTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Trait",
 }
 
 var _ Service = (*traitService)(nil)
@@ -55,6 +61,7 @@ func (s *traitService) CreateTrait(ctx context.Context, namespaceName string, t 
 
 	// Set defaults
 	t.Namespace = namespaceName
+	t.Status = openchoreov1alpha1.TraitStatus{}
 	if err := s.k8sClient.Create(ctx, t); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			s.logger.Warn("Trait already exists", "namespace", namespaceName, "trait", t.Name)
@@ -65,6 +72,7 @@ func (s *traitService) CreateTrait(ctx context.Context, namespaceName string, t 
 	}
 
 	s.logger.Debug("Trait created successfully", "namespace", namespaceName, "trait", t.Name)
+	t.TypeMeta = traitTypeMeta
 	return t, nil
 }
 
@@ -85,6 +93,9 @@ func (s *traitService) UpdateTrait(ctx context.Context, namespaceName string, t 
 		return nil, fmt.Errorf("failed to get trait: %w", err)
 	}
 
+	// Clear status from user input — status is server-managed
+	t.Status = openchoreov1alpha1.TraitStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = t.Spec
 	existing.Labels = t.Labels
@@ -96,6 +107,7 @@ func (s *traitService) UpdateTrait(ctx context.Context, namespaceName string, t 
 	}
 
 	s.logger.Debug("Trait updated successfully", "namespace", namespaceName, "trait", t.Name)
+	existing.TypeMeta = traitTypeMeta
 	return existing, nil
 }
 
@@ -116,6 +128,10 @@ func (s *traitService) ListTraits(ctx context.Context, namespaceName string, opt
 	if err := s.k8sClient.List(ctx, &tList, listOpts...); err != nil {
 		s.logger.Error("Failed to list traits", "error", err)
 		return nil, fmt.Errorf("failed to list traits: %w", err)
+	}
+
+	for i := range tList.Items {
+		tList.Items[i].TypeMeta = traitTypeMeta
 	}
 
 	result := &services.ListResult[openchoreov1alpha1.Trait]{
@@ -149,6 +165,7 @@ func (s *traitService) GetTrait(ctx context.Context, namespaceName, traitName st
 		return nil, fmt.Errorf("failed to get trait: %w", err)
 	}
 
+	t.TypeMeta = traitTypeMeta
 	return t, nil
 }
 

--- a/internal/openchoreo-api/services/workflow/service.go
+++ b/internal/openchoreo-api/services/workflow/service.go
@@ -10,6 +10,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -18,6 +19,11 @@ import (
 	"github.com/openchoreo/openchoreo/internal/schema"
 	"github.com/openchoreo/openchoreo/internal/schema/extractor"
 )
+
+var workflowTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Workflow",
+}
 
 // workflowService handles workflow-related business logic without authorization checks.
 type workflowService struct {
@@ -54,6 +60,10 @@ func (s *workflowService) ListWorkflows(ctx context.Context, namespaceName strin
 		return nil, fmt.Errorf("failed to list workflows: %w", err)
 	}
 
+	for i := range wfList.Items {
+		wfList.Items[i].TypeMeta = workflowTypeMeta
+	}
+
 	result := &services.ListResult[openchoreov1alpha1.Workflow]{
 		Items:      wfList.Items,
 		NextCursor: wfList.Continue,
@@ -85,6 +95,7 @@ func (s *workflowService) GetWorkflow(ctx context.Context, namespaceName, workfl
 		return nil, fmt.Errorf("failed to get workflow: %w", err)
 	}
 
+	wf.TypeMeta = workflowTypeMeta
 	return wf, nil
 }
 
@@ -139,12 +150,14 @@ func (s *workflowService) CreateWorkflow(ctx context.Context, namespaceName stri
 	}
 
 	wf.Namespace = namespaceName
+	wf.Status = openchoreov1alpha1.WorkflowStatus{}
 
 	if err := s.k8sClient.Create(ctx, wf); err != nil {
 		s.logger.Error("Failed to create workflow CR", "error", err)
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 
+	wf.TypeMeta = workflowTypeMeta
 	s.logger.Debug("Workflow created successfully", "namespace", namespaceName, "workflow", wf.Name)
 	return wf, nil
 }
@@ -165,6 +178,8 @@ func (s *workflowService) UpdateWorkflow(ctx context.Context, namespaceName stri
 		return nil, fmt.Errorf("failed to get workflow: %w", err)
 	}
 
+	wf.Status = openchoreov1alpha1.WorkflowStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = wf.Spec
 	existing.Labels = wf.Labels
@@ -179,6 +194,7 @@ func (s *workflowService) UpdateWorkflow(ctx context.Context, namespaceName stri
 		return nil, fmt.Errorf("failed to update workflow: %w", err)
 	}
 
+	existing.TypeMeta = workflowTypeMeta
 	s.logger.Debug("Workflow updated successfully", "namespace", namespaceName, "workflow", wf.Name)
 	return existing, nil
 }

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +37,11 @@ type workflowRunService struct {
 }
 
 var _ Service = (*workflowRunService)(nil)
+
+var workflowRunTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "WorkflowRun",
+}
 
 // NewService creates a new workflow run service without authorization.
 func NewService(k8sClient client.Client, bpClientMgr *kubernetesClient.KubeMultiClientManager, gwClient *gatewayClient.Client, logger *slog.Logger) Service {
@@ -70,6 +76,7 @@ func (s *workflowRunService) CreateWorkflowRun(ctx context.Context, namespaceNam
 
 	// Ensure namespace is set
 	wfRun.Namespace = namespaceName
+	wfRun.Status = openchoreov1alpha1.WorkflowRunStatus{}
 
 	if err := s.k8sClient.Create(ctx, wfRun); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -80,6 +87,7 @@ func (s *workflowRunService) CreateWorkflowRun(ctx context.Context, namespaceNam
 		return nil, fmt.Errorf("failed to create workflow run: %w", err)
 	}
 
+	wfRun.TypeMeta = workflowRunTypeMeta
 	s.logger.Debug("Workflow run created successfully", "namespace", namespaceName, "name", wfRun.Name)
 	return wfRun, nil
 }
@@ -129,6 +137,10 @@ func (s *workflowRunService) listWorkflowRunsResource(namespaceName string) serv
 			return nil, fmt.Errorf("failed to list workflow runs: %w", err)
 		}
 
+		for i := range wfRunList.Items {
+			wfRunList.Items[i].TypeMeta = workflowRunTypeMeta
+		}
+
 		result := &services.ListResult[openchoreov1alpha1.WorkflowRun]{
 			Items:      wfRunList.Items,
 			NextCursor: wfRunList.Continue,
@@ -158,6 +170,7 @@ func (s *workflowRunService) GetWorkflowRun(ctx context.Context, namespaceName, 
 		return nil, fmt.Errorf("failed to get workflow run: %w", err)
 	}
 
+	wfRun.TypeMeta = workflowRunTypeMeta
 	return wfRun, nil
 }
 

--- a/internal/openchoreo-api/services/workload/service.go
+++ b/internal/openchoreo-api/services/workload/service.go
@@ -10,6 +10,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -22,6 +23,11 @@ import (
 type workloadService struct {
 	k8sClient client.Client
 	logger    *slog.Logger
+}
+
+var workloadTypeMeta = metav1.TypeMeta{
+	APIVersion: openchoreov1alpha1.GroupVersion.String(),
+	Kind:       "Workload",
 }
 
 var _ Service = (*workloadService)(nil)
@@ -58,6 +64,7 @@ func (s *workloadService) CreateWorkload(ctx context.Context, namespaceName stri
 
 	// Set defaults
 	w.Namespace = namespaceName
+	w.Status = openchoreov1alpha1.WorkloadStatus{}
 	if w.Labels == nil {
 		w.Labels = make(map[string]string)
 	}
@@ -74,6 +81,7 @@ func (s *workloadService) CreateWorkload(ctx context.Context, namespaceName stri
 	}
 
 	s.logger.Debug("Workload created successfully", "namespace", namespaceName, "workload", w.Name)
+	w.TypeMeta = workloadTypeMeta
 	return w, nil
 }
 
@@ -99,6 +107,9 @@ func (s *workloadService) UpdateWorkload(ctx context.Context, namespaceName stri
 		return nil, err
 	}
 
+	// Clear status from user input — status is server-managed
+	w.Status = openchoreov1alpha1.WorkloadStatus{}
+
 	// Only apply user-mutable fields to the existing object, preserving server-managed fields
 	existing.Spec = w.Spec
 	existing.Labels = w.Labels
@@ -121,6 +132,7 @@ func (s *workloadService) UpdateWorkload(ctx context.Context, namespaceName stri
 	}
 
 	s.logger.Debug("Workload updated successfully", "namespace", namespaceName, "workload", w.Name)
+	existing.TypeMeta = workloadTypeMeta
 	return existing, nil
 }
 
@@ -142,6 +154,10 @@ func (s *workloadService) ListWorkloads(ctx context.Context, namespaceName, comp
 		if err := s.k8sClient.List(ctx, &wList, listOpts...); err != nil {
 			s.logger.Error("Failed to list workloads", "error", err)
 			return nil, fmt.Errorf("failed to list workloads: %w", err)
+		}
+
+		for i := range wList.Items {
+			wList.Items[i].TypeMeta = workloadTypeMeta
 		}
 
 		result := &services.ListResult[openchoreov1alpha1.Workload]{
@@ -187,6 +203,7 @@ func (s *workloadService) GetWorkload(ctx context.Context, namespaceName, worklo
 		return nil, fmt.Errorf("failed to get workload: %w", err)
 	}
 
+	w.TypeMeta = workloadTypeMeta
 	return w, nil
 }
 


### PR DESCRIPTION
fixes https://github.com/openchoreo/openchoreo/issues/2427

## Summary
- Add `apiVersion` and `kind` fields (readOnly) to all CRD resource schemas in the OpenAPI spec
- Set TypeMeta in handler layer before converting K8s objects to API response types
- Remove redundant TypeMeta assignments from service layer (not needed by controller-runtime)
- Covers 22 resources: Component, Project, Environment, DataPlane, BuildPlane, ObservabilityPlane, ClusterDataPlane, ClusterBuildPlane, ClusterObservabilityPlane, ClusterComponentType, ClusterTrait, ComponentType, Trait, Workflow, WorkflowRun, ComponentRelease, ReleaseBinding, Release, SecretReference, Workload, DeploymentPipeline, ObservabilityAlertsNotificationChannel

## Test plan
- [x] Verified `go build` and `go vet` pass
- [x] Deployed to k3d cluster and tested Project CRUD — responses include `apiVersion`/`kind`
- [x] Verified `readOnly` fields are ignored when sent in request bodies