### PR TITLE
docs: fix marking of required parameters in scm-create-repo workflows

### DIFF
--- a/samples/workflows/generic/scm-create-repo/README.md
+++ b/samples/workflows/generic/scm-create-repo/README.md
@@ -50,7 +50,7 @@ kubectl create secret generic github-token \
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `github.owner` | Yes | — | GitHub organization or user that will own the repository |
-| `github.tokenSecret` | No | `github-token` | Name of the Kubernetes Secret containing the PAT under the key `token` |
+| `github.tokenSecret` | Yes | — | Name of the Kubernetes Secret containing the PAT under the key `token` (e.g. `github-token`) |
 | `repo.name` | Yes | — | Name of the repository to create |
 | `repo.description` | No | `""` | Short description of the repository |
 | `repo.visibility` | No | `private` | Repository visibility: `public` or `private` |
@@ -149,8 +149,8 @@ kubectl create secret generic aws-credentials \
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `aws.region` | No | `us-east-1` | AWS region where the repository will be created |
-| `aws.credentialsSecret` | No | `aws-credentials` | Name of the Kubernetes Secret containing `accessKeyId` and `secretAccessKey` keys |
+| `aws.region` | Yes | — | AWS region where the repository will be created (e.g. `us-east-1`) |
+| `aws.credentialsSecret` | Yes | — | Name of the Kubernetes Secret containing `accessKeyId` and `secretAccessKey` keys (e.g. `aws-credentials`) |
 | `repo.name` | Yes | — | Name of the CodeCommit repository to create |
 | `repo.description` | No | `""` | Short description of the repository |
 

--- a/samples/workflows/generic/scm-create-repo/codecommit-create-repo.yaml
+++ b/samples/workflows/generic/scm-create-repo/codecommit-create-repo.yaml
@@ -119,11 +119,11 @@ spec:
   schema:
     parameters:
       aws:
-        region: string | default="us-east-1" description="AWS region where the CodeCommit repository will be created"
-        credentialsSecret: string | default="aws-credentials" description="Name of the Kubernetes Secret in the openchoreo-ci-<namespace> namespace containing 'accessKeyId' and 'secretAccessKey' keys"
+        region: string | description="AWS region where the CodeCommit repository will be created"
+        credentialsSecret: string | description="Name of the Kubernetes Secret containing 'accessKeyId' and 'secretAccessKey' keys"
       repo:
         name: string | description="Name of the CodeCommit repository to create"
-        description: string | default="" description="Short description of the repository"
+        description: string | default="" description="Workflow originated repository"
 
   runTemplate:
     apiVersion: argoproj.io/v1alpha1

--- a/samples/workflows/generic/scm-create-repo/github-create-repo.yaml
+++ b/samples/workflows/generic/scm-create-repo/github-create-repo.yaml
@@ -138,7 +138,7 @@ spec:
     parameters:
       github:
         owner: string | description="GitHub organization or user that will own the repository"
-        tokenSecret: string | default="github-token" description="Name of the Kubernetes Secret in the openchoreo-ci-<namespace> namespace containing the GitHub token under the key 'token'"
+        tokenSecret: string | description="Name of the Kubernetes Secret in the namespace containing the GitHub token under the key 'token'"
       repo:
         name: string | description="Name of the repository to create"
         description: string | default="" description="Short description of the repository"


### PR DESCRIPTION

## Purpose
Apart from descriptions and SCM API defaults everything else needs to be required.