### PR TITLE
fix: update authz role binding to match new admins group name

### DIFF
--- a/config/samples/v1alpha1_authzclusterrolebinding.yaml
+++ b/config/samples/v1alpha1_authzclusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   entitlement:
     claim: groups
-    value: platformEngineer
+    value: admins
   roleRef:
     kind: AuthzClusterRole
     name: platform-admin

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1155,13 +1155,13 @@ openchoreoApi:
           # default: []
           # @schema
           mappings:
-            # Super admin mapping - grants platformEngineer group full access
+            # Super admin mapping - grants admins group full access
             - name: super-admin-binding
               roleRef:
                 name: super-admin
               entitlement:
                 claim: groups
-                value: platformEngineer
+                value: admins
               effect: allow
 
             # Backstage catalog reader mapping - grants backstage service account read access

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -18,7 +18,7 @@ openchoreoApi:
                 name: super-admin
               entitlement:
                 claim: groups
-                value: platformEngineer
+                value: admins
               effect: allow
             - name: backstage-catalog-reader-binding
               roleRef:


### PR DESCRIPTION
This pull request updates the group name used for super admin role mappings from `platformEngineer` to `admins` across multiple configuration files. This change ensures consistency in group naming and clarifies which group has super admin access.

Role mapping updates:

* Changed the entitlement value for super admin role bindings from `platformEngineer` to `admins` in `config/samples/v1alpha1_authzclusterrolebinding.yaml` to grant admin privileges to the correct group.
* Updated the group value for super admin access from `platformEngineer` to `admins` in `install/helm/openchoreo-control-plane/values.yaml` for role mapping configuration.
* Modified the entitlement value for super admin role mapping from `platformEngineer` to `admins` in `install/quick-start/.values-cp.yaml`.