### PR TITLE
fix(controller): surface resource apply errors in ReleaseBinding status conditions

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -12,6 +12,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +27,7 @@ import (
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/controller/renderedrelease"
 	dpkubernetes "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
 	"github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/networkpolicy"
@@ -615,6 +617,19 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 
 	// Set ReleaseSynced condition based on operation results.
 	r.setReleaseSyncedCondition(releaseBinding, dataPlaneRelease.Name, dpOp, len(dataPlaneReleaseResources), obsResult)
+
+	// Check if the Release controller recorded a resource apply failure.
+	// Only act on the condition when it matches the current Release generation
+	// to avoid surfacing stale errors from a previous spec revision.
+	applyCond := meta.FindStatusCondition(dataPlaneRelease.Status.Conditions, renderedrelease.ConditionResourcesApplied)
+	if applyCond != nil && applyCond.Status == metav1.ConditionFalse &&
+		applyCond.ObservedGeneration == dataPlaneRelease.Generation {
+		controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
+			ReasonResourceApplyFailed, applyCond.Message)
+		r.setReadyCondition(releaseBinding)
+		return ctrl.Result{}, nil
+	}
+
 	if dpOp == controllerutil.OperationResultCreated || dpOp == controllerutil.OperationResultUpdated {
 		logger.Info("Releases reconciled",
 			"dataplaneReleaseOp", dpOp,

--- a/internal/controller/releasebinding/controller_conditions.go
+++ b/internal/controller/releasebinding/controller_conditions.go
@@ -81,6 +81,8 @@ const (
 
 	// Resource readiness issues (Status=False)
 
+	// ReasonResourceApplyFailed indicates one or more resources failed to apply to the target plane
+	ReasonResourceApplyFailed controller.ConditionReason = "ResourceApplyFailed"
 	// ReasonResourcesNotReady indicates one or more resources are not ready
 	ReasonResourcesNotReady controller.ConditionReason = "ResourcesNotReady"
 	// ReasonResourcesProgressing indicates resources are being created/updated

--- a/internal/controller/releasebinding/controller_status.go
+++ b/internal/controller/releasebinding/controller_status.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/controller/renderedrelease"
 )
 
 // ResourceCategory defines the category of a resource for status evaluation.
@@ -80,8 +82,16 @@ func (r *Reconciler) setResourcesReadyStatus(
 		"workloadType", workloadType,
 		"resourceCount", len(release.Status.Resources))
 
-	// If Release has no resources yet, mark as Progressing
+	// If Release has no resources yet, check if there's an apply error on the Release
 	if len(release.Status.Resources) == 0 {
+		// Check if the Release controller recorded an apply failure for the current generation
+		applyCond := meta.FindStatusCondition(release.Status.Conditions, renderedrelease.ConditionResourcesApplied)
+		if applyCond != nil && applyCond.Status == metav1.ConditionFalse &&
+			applyCond.ObservedGeneration == release.Generation {
+			controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
+				ReasonResourceApplyFailed, applyCond.Message)
+			return nil
+		}
 		msg := fmt.Sprintf("Release %q has no resources yet", release.Name)
 		controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
 			ReasonResourcesProgressing, msg)

--- a/internal/controller/releasebinding/controller_test.go
+++ b/internal/controller/releasebinding/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller/renderedrelease"
 	"github.com/openchoreo/openchoreo/internal/labels"
 	componentpipeline "github.com/openchoreo/openchoreo/internal/pipeline/component"
 )
@@ -1094,6 +1095,138 @@ var _ = Describe("ReleaseBinding Controller", func() {
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(cond.Reason).To(Equal(string(ReasonReleaseOwnershipConflict)))
+		})
+	})
+
+	// ── Apply failure: generation-aware condition propagation ─────────────────
+	//
+	// Exercises the branch at controller.go:621-631 that checks
+	// ConditionResourcesApplied on the dataplane Release.
+
+	Context("when the dataplane Release has ConditionResourcesApplied=False", func() {
+		const (
+			project  = "apply-fail-proj"
+			compName = "apply-fail-comp"
+			envName  = "apply-fail-env"
+			dpName   = "apply-fail-dp"
+			rbName   = "rb-apply-fail"
+			crName   = "cr-apply-fail"
+		)
+		expectedReleaseName := compName + "-" + envName
+		req := reconcileRequest(rbName)
+
+		AfterEach(func() {
+			forceDelete(rbName)
+			forceDeleteRelease(expectedReleaseName)
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.ComponentRelease{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: crName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: envName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: dpName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: compName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: project},
+			})
+		})
+
+		// createDepsAndRelease creates all dependencies, reconciles twice so the
+		// Release is created and the ReleaseBinding reaches the steady state, then
+		// returns the current Release generation.
+		createDepsAndRelease := func(r *Reconciler) int64 {
+			GinkgoHelper()
+			Expect(k8sClient.Create(ctx, crFixture(crName, project, compName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, dpFixture(dpName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, envFixture(envName, dpName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, componentFixture(compName, project))).To(Succeed())
+			Expect(k8sClient.Create(ctx, projectFixture(project))).To(Succeed())
+			Expect(k8sClient.Create(ctx,
+				rbFixture(rbName, project, compName, envName, crName, true),
+			)).To(Succeed())
+
+			// First reconcile creates the Release (requeue=true).
+			result := mustReconcile(r, req)
+			Expect(result.Requeue).To(BeTrue())
+
+			// Read back the Release to get its generation.
+			rel := &openchoreov1alpha1.RenderedRelease{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: ns, Name: expectedReleaseName},
+				rel,
+			)).To(Succeed())
+			return rel.Generation
+		}
+
+		It("sets ResourcesReady=False/ResourceApplyFailed when ObservedGeneration matches Release.Generation", func() {
+			r := testReconcilerWithPipeline()
+			gen := createDepsAndRelease(r)
+
+			By("Setting ConditionResourcesApplied=False on the Release with matching ObservedGeneration")
+			rel := &openchoreov1alpha1.RenderedRelease{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: ns, Name: expectedReleaseName},
+				rel,
+			)).To(Succeed())
+			apimeta.SetStatusCondition(&rel.Status.Conditions, metav1.Condition{
+				Type:               renderedrelease.ConditionResourcesApplied,
+				Status:             metav1.ConditionFalse,
+				Reason:             renderedrelease.ReasonApplyFailed,
+				Message:            "failed to apply Deployment: admission webhook denied",
+				ObservedGeneration: gen,
+			})
+			Expect(k8sClient.Status().Update(ctx, rel)).To(Succeed())
+
+			By("Reconciling — the apply failure should be surfaced on the ReleaseBinding")
+			mustReconcile(r, req)
+
+			By("Verifying ResourcesReady=False with ReasonResourceApplyFailed")
+			rb := fetchRB(rbName)
+			cond := conditionFor(rb, string(ConditionResourcesReady))
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(string(ReasonResourceApplyFailed)))
+			Expect(cond.Message).To(ContainSubstring("admission webhook denied"))
+
+			By("Verifying Ready=False (aggregated from ResourcesReady)")
+			readyCond := conditionFor(rb, string(ConditionReady))
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("ignores ConditionResourcesApplied=False when ObservedGeneration is stale", func() {
+			r := testReconcilerWithPipeline()
+			gen := createDepsAndRelease(r)
+
+			By("Setting ConditionResourcesApplied=False with a stale (older) ObservedGeneration")
+			rel := &openchoreov1alpha1.RenderedRelease{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: ns, Name: expectedReleaseName},
+				rel,
+			)).To(Succeed())
+			apimeta.SetStatusCondition(&rel.Status.Conditions, metav1.Condition{
+				Type:               renderedrelease.ConditionResourcesApplied,
+				Status:             metav1.ConditionFalse,
+				Reason:             renderedrelease.ReasonApplyFailed,
+				Message:            "stale error from previous revision",
+				ObservedGeneration: gen - 1, // stale generation
+			})
+			Expect(k8sClient.Status().Update(ctx, rel)).To(Succeed())
+
+			By("Reconciling — stale condition should be ignored")
+			mustReconcile(r, req)
+
+			By("Verifying ResourcesReady is NOT set to ResourceApplyFailed")
+			rb := fetchRB(rbName)
+			cond := conditionFor(rb, string(ConditionResourcesReady))
+			if cond != nil {
+				Expect(cond.Reason).NotTo(Equal(string(ReasonResourceApplyFailed)),
+					"stale apply failure should not be propagated to ResourcesReady")
+			}
 		})
 	})
 

--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -32,6 +32,15 @@ const (
 
 	targetPlaneDataPlane          = "dataplane"
 	targetPlaneObservabilityPlane = "observabilityplane"
+
+	// ConditionResourcesApplied indicates whether resources were successfully applied to the target plane.
+	// When False, it contains the error message from the failed apply operation.
+	ConditionResourcesApplied = "ResourcesApplied"
+
+	// ReasonApplySucceeded indicates all resources were applied successfully
+	ReasonApplySucceeded = "ApplySucceeded"
+	// ReasonApplyFailed indicates one or more resources failed to apply
+	ReasonApplyFailed = "ApplyFailed"
 )
 
 // Reconciler reconciles a RenderedRelease object
@@ -145,7 +154,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// This ensures all resources in the spec are created/updated with proper tracking labels
 	if err := r.applyResources(ctx, planeClient, desiredResources); err != nil {
 		logger.Error(err, "Failed to apply resources to target plane", "targetPlane", targetPlane)
+		// Persist the apply error in Release status so upstream controllers (e.g., ReleaseBinding) can surface it
+		changed := controller.MarkFalseCondition(release, controller.ConditionType(ConditionResourcesApplied),
+			controller.ConditionReason(ReasonApplyFailed),
+			fmt.Sprintf("Failed to apply resources to target plane: %v", err))
+		if changed {
+			if statusErr := r.Status().Update(ctx, release); statusErr != nil {
+				logger.Error(statusErr, "Failed to update Release status with apply error")
+			}
+		}
 		return ctrl.Result{}, err
+	}
+
+	// Mark resources as successfully applied and persist to API
+	if changed := controller.MarkTrueCondition(release, controller.ConditionType(ConditionResourcesApplied),
+		controller.ConditionReason(ReasonApplySucceeded), "All resources applied successfully"); changed {
+		if statusErr := r.Status().Update(ctx, release); statusErr != nil {
+			logger.Error(statusErr, "Failed to update Release status with apply success")
+			return ctrl.Result{}, statusErr
+		}
 	}
 
 	// PHASE 2: Discover live resources that we manage in the target plane

--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -34,6 +34,11 @@ func (r *Reconciler) updateStatus(ctx context.Context, old, release *openchoreov
 	// Update the status
 	release.Status.Resources = resourceStatuses
 
+	// Sync conditions in old to match release before comparison, because conditions
+	// (e.g., ResourcesApplied) were already persisted earlier in the reconcile loop.
+	// Without this, DeepEqual sees a false diff and triggers a redundant status update.
+	old.Status.Conditions = release.Status.Conditions
+
 	// Check if the entire status actually changed and skip update if not
 	if apiequality.Semantic.DeepEqual(old.Status, release.Status) {
 		return false, nil


### PR DESCRIPTION
## Purpose

### Summary 
                                                                                                                                                                       
  - When the Release controller fails to apply resources to the target plane (e.g.,                                                                                                       
    Kubernetes rejects a Deployment due to `requests > limits`), the error was only                                                                                                       
    logged but never persisted to status, causing the ReleaseBinding to show a
    misleading `ResourcesProgressing` condition indefinitely.
  - Add a `ResourcesApplied` condition to Release status that captures apply failures
    with the actual Kubernetes error message.
  - Surface the apply error in ReleaseBinding as `ResourcesReady=False` with reason
    `ResourceApplyFailed`, checked before the early return in the reconcile loop to
    ensure errors are detected regardless of the Release sync operation result.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
