### PR TITLE
refactor: add default observability modules as openchoreo-observability-plane helm chart dependencies

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -17,5 +17,14 @@ dependencies:
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:1d57eda2881ed0d2be479caab959a82d6b87f3de4af23995bedc49d8045e3cda
-generated: "2026-02-14T17:38:58.767705+05:30"
+- name: observability-logs-opensearch
+  repository: oci://ghcr.io/openchoreo/charts
+  version: 0.3.2
+- name: observability-metrics-prometheus
+  repository: oci://ghcr.io/openchoreo/charts
+  version: 0.2.2
+- name: observability-tracing-opensearch
+  repository: oci://ghcr.io/openchoreo/charts
+  version: 0.3.3
+digest: sha256:5d920df68bbfd9b031fb9628eafd7de345dfec45e9a48743d54466a9ed97cded
+generated: "2026-03-07T11:24:36.413336+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -55,3 +55,15 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     version: 3.3.0
     condition: openSearchDashboards.enabled
+  - name: observability-logs-opensearch
+    repository: oci://ghcr.io/openchoreo/charts
+    version: 0.3.2
+    condition: observability-logs-opensearch.enabled
+  - name: observability-metrics-prometheus
+    repository: oci://ghcr.io/openchoreo/charts
+    version: 0.2.2
+    condition: observability-metrics-prometheus.enabled
+  - name: observability-tracing-opensearch
+    repository: oci://ghcr.io/openchoreo/charts
+    version: 0.3.3
+    condition: observability-tracing-opensearch.enabled

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1461,6 +1461,96 @@
       "title": "kubernetesClusterDomain",
       "type": "string"
     },
+    "observability-logs-opensearch": {
+      "additionalProperties": true,
+      "description": "OpenChoreo observability logs module based on OpenSearch",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable observability-logs-opensearch subchart deployment",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "openSearchSetup": {
+          "additionalProperties": true,
+          "description": "OpenSearch setup configuration",
+          "properties": {
+            "openSearchSecretName": {
+              "default": "opensearch-admin-credentials",
+              "description": "Name of the Kubernetes Secret containing OpenSearch admin credentials",
+              "title": "openSearchSecretName",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "openSearchSetup",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "observability-logs-opensearch",
+      "type": "object"
+    },
+    "observability-metrics-prometheus": {
+      "additionalProperties": true,
+      "description": "OpenChoreo observability metrics module based on Prometheus",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable observability-metrics-prometheus subchart deployment",
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "title": "observability-metrics-prometheus",
+      "type": "object"
+    },
+    "observability-tracing-opensearch": {
+      "additionalProperties": true,
+      "description": "OpenChoreo observability tracing module based on OpenSearch",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable observability-tracing-opensearch subchart deployment",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "openSearch": {
+          "additionalProperties": true,
+          "description": "OpenSearch Helm subchart toggle (disabled when using external or operator-managed OpenSearch)",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable OpenSearch deployment within the tracing subchart",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "openSearch",
+          "type": "object"
+        },
+        "openSearchSetup": {
+          "additionalProperties": true,
+          "description": "OpenSearch setup configuration",
+          "properties": {
+            "openSearchSecretName": {
+              "default": "opensearch-admin-credentials",
+              "description": "Name of the Kubernetes Secret containing OpenSearch admin credentials",
+              "title": "openSearchSecretName",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "openSearchSetup",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "observability-tracing-opensearch",
+      "type": "object"
+    },
     "observer": {
       "additionalProperties": true,
       "description": "OpenChoreo Observer service configuration - REST API that abstracts OpenSearch for logging, metrics, and tracing",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -462,6 +462,84 @@ data-prepper:
       # @schema
       memory: 500Mi
 
+# @schema
+# type: object
+# additionalProperties: true
+# description: OpenChoreo observability logs module based on OpenSearch
+# @schema
+observability-logs-opensearch:
+  # @schema
+  # type: boolean
+  # description: Enable observability-logs-opensearch subchart deployment
+  # default: false
+  # @schema
+  enabled: false
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: OpenSearch setup configuration
+  # @schema
+  openSearchSetup:
+    # @schema
+    # type: string
+    # description: Name of the Kubernetes Secret containing OpenSearch admin credentials
+    # default: opensearch-admin-credentials
+    # @schema
+    openSearchSecretName: "opensearch-admin-credentials"
+
+# @schema
+# type: object
+# additionalProperties: true
+# description: OpenChoreo observability metrics module based on Prometheus
+# @schema
+observability-metrics-prometheus:
+  # @schema
+  # type: boolean
+  # description: Enable observability-metrics-prometheus subchart deployment
+  # default: false
+  # @schema
+  enabled: false
+
+# @schema
+# type: object
+# additionalProperties: true
+# description: OpenChoreo observability tracing module based on OpenSearch
+# @schema
+observability-tracing-opensearch:
+  # @schema
+  # type: boolean
+  # description: Enable observability-tracing-opensearch subchart deployment
+  # default: false
+  # @schema
+  enabled: false
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: OpenSearch Helm subchart toggle (disabled when using external or operator-managed OpenSearch)
+  # @schema
+  openSearch:
+    # @schema
+    # type: boolean
+    # description: Enable OpenSearch deployment within the tracing subchart
+    # default: false
+    # @schema
+    enabled: false
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: OpenSearch setup configuration
+  # @schema
+  openSearchSetup:
+    # @schema
+    # type: string
+    # description: Name of the Kubernetes Secret containing OpenSearch admin credentials
+    # default: opensearch-admin-credentials
+    # @schema
+    openSearchSecretName: "opensearch-admin-credentials"
+
 
 # @schema
 # type: object

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -1,5 +1,14 @@
 # Helm values for OpenChoreo Observability Plane in k3d single-cluster setup
 
+observability-logs-opensearch:
+  enabled: true
+
+observability-metrics-prometheus:
+  enabled: true
+
+observability-tracing-opensearch:
+  enabled: true
+
 # Use standalone OpenSearch (not operator-managed cluster)
 openSearch:
   enabled: false


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Install default Observability modules through the `openchoreo-observability-plane` helm chart itself instead of installing them manually

## Approach
Added `observability-logs-opensearch`, `observability-metrics-prometheus` and `observability-tracing-opensearch` charts as dependencies of the `openchoreo-observability-plane` helm chart

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2431

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
