### PR TITLE
fix: update openchoreo-api RBAC for RenderedRelease

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
   - observabilityplanes
   - projects
   - releasebindings
-  - releases
+  - renderedreleases
   - scheduledtaskbindings
   - scheduledtaskclasses
   - scheduledtasks
@@ -100,7 +100,7 @@ rules:
   - observabilityplanes/status
   - projects/status
   - releasebindings/status
-  - releases/status
+  - renderedreleases/status
   - scheduledtaskbindings/status
   - scheduledtaskclasses/status
   - scheduledtasks/status


### PR DESCRIPTION
## Summary
related https://github.com/openchoreo/openchoreo/issues/2474

- Updates the openchoreo-api Helm ClusterRole to reference `renderedreleases` instead of the old `releases` resource
- This was missed in the Release → RenderedRelease CRD rename (#2484), causing the openchoreo-api to fail with RBAC forbidden errors when accessing RenderedRelease resources

## Test plan
- [x] Verified the k8s resource tree endpoint returns successfully after applying the fix
- [x] Confirmed no other Helm templates reference the old `releases` resource