### PR TITLE
refactor: update helm chart path of observability modules

### DIFF
--- a/install/helm/openchoreo-observability-plane/Chart.lock
+++ b/install/helm/openchoreo-observability-plane/Chart.lock
@@ -18,13 +18,13 @@ dependencies:
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
 - name: observability-logs-opensearch
-  repository: oci://ghcr.io/openchoreo/charts
+  repository: oci://ghcr.io/openchoreo/helm-charts
   version: 0.3.2
 - name: observability-metrics-prometheus
-  repository: oci://ghcr.io/openchoreo/charts
+  repository: oci://ghcr.io/openchoreo/helm-charts
   version: 0.2.2
 - name: observability-tracing-opensearch
-  repository: oci://ghcr.io/openchoreo/charts
+  repository: oci://ghcr.io/openchoreo/helm-charts
   version: 0.3.3
-digest: sha256:5d920df68bbfd9b031fb9628eafd7de345dfec45e9a48743d54466a9ed97cded
-generated: "2026-03-07T11:24:36.413336+05:30"
+digest: sha256:436d5a7c138432e33b7eb59f75c7053e4de0f769084bda971396f03378dc1268
+generated: "2026-03-07T15:57:05.002175+05:30"

--- a/install/helm/openchoreo-observability-plane/Chart.yaml
+++ b/install/helm/openchoreo-observability-plane/Chart.yaml
@@ -56,14 +56,14 @@ dependencies:
     version: 3.3.0
     condition: openSearchDashboards.enabled
   - name: observability-logs-opensearch
-    repository: oci://ghcr.io/openchoreo/charts
+    repository: oci://ghcr.io/openchoreo/helm-charts
     version: 0.3.2
     condition: observability-logs-opensearch.enabled
   - name: observability-metrics-prometheus
-    repository: oci://ghcr.io/openchoreo/charts
+    repository: oci://ghcr.io/openchoreo/helm-charts
     version: 0.2.2
     condition: observability-metrics-prometheus.enabled
   - name: observability-tracing-opensearch
-    repository: oci://ghcr.io/openchoreo/charts
+    repository: oci://ghcr.io/openchoreo/helm-charts
     version: 0.3.3
     condition: observability-tracing-opensearch.enabled

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1083,7 +1083,7 @@ install_observability_plane() {
 
     # Install logs and metrics observability modules
     # See https://github.com/openchoreo/community-modules for more details
-    local modules_repo="oci://ghcr.io/openchoreo/charts"
+    local modules_repo="oci://ghcr.io/openchoreo/helm-charts"
 
     log_info "Installing observability modules..."
 

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -279,12 +279,12 @@ _e2e.install-op:
 	$(call e2e_patch_gateway,$(E2E_OP_NS))
 	@$(call log_info, Installing observability modules)
 	$(E2E_HELM) upgrade --install observability-logs-opensearch \
-		oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 		--version 0.3.2 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_HELM) upgrade --install observability-metrics-prometheus \
-		oci://ghcr.io/openchoreo/charts/observability-metrics-prometheus \
+		oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
 		--version 0.2.2 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Update the helm chart paths to adapt to https://github.com/openchoreo/community-modules/pull/27

## Approach
Changed the helm chart path from `charts` to `helm-charts`

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2501

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
