### PR TITLE
chore: provide a way to provide a system label to bootstrap authz roles and bindings

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/authz/bootstrap-authz.yaml
+++ b/install/helm/openchoreo-control-plane/templates/authz/bootstrap-authz.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    {{- if .system }}
+    openchoreo.io/system: "true"
+    {{- end }}
 spec:
   {{- if and .description (ne .description "") }}
   description: {{ .description | quote }}
@@ -30,6 +33,9 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    {{- if .system }}
+    openchoreo.io/system: "true"
+    {{- end }}
 spec:
   {{- if and .description (ne .description "") }}
   description: {{ .description | quote }}
@@ -58,6 +64,9 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    {{- if .system }}
+    openchoreo.io/system: "true"
+    {{- end }}
 spec:
   roleRef:
     name: {{ .roleRef.name }}
@@ -77,6 +86,9 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    {{- if .system }}
+    openchoreo.io/system: "true"
+    {{- end }}
 spec:
   roleRef:
     name: {{ .roleRef.name }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2639,6 +2639,11 @@
                                 },
                                 "required": [],
                                 "type": "object"
+                              },
+                              "system": {
+                                "default": false,
+                                "description": "Whether this is a system-managed binding (adds openchoreo.io/system label when true, omitted when false)",
+                                "type": "boolean"
                               }
                             },
                             "required": [],
@@ -2666,6 +2671,11 @@
                               "namespace": {
                                 "description": "Namespace for role (empty string for cluster-scoped)",
                                 "type": "string"
+                              },
+                              "system": {
+                                "default": false,
+                                "description": "Whether this is a system-managed role (adds openchoreo.io/system label when true, omitted when false)",
+                                "type": "boolean"
                               }
                             },
                             "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1048,6 +1048,10 @@ openchoreoApi:
           #     namespace:
           #       type: string
           #       description: Namespace for role (empty string for cluster-scoped)
+          #     system:
+          #       type: boolean
+          #       description: Whether this is a system-managed role (adds openchoreo.io/system label when true, omitted when false)
+          #       default: false
           #     actions:
           #       type: array
           #       items:
@@ -1058,11 +1062,13 @@ openchoreoApi:
           roles:
             # Super admin role with full permissions to all resources
             - name: super-admin
+              system: true
               actions:
                 - "*"
 
             # Backstage catalog provider role for reading catalog data from the control plane
             - name: backstage-catalog-reader
+              system: true
               actions:
                 - "component:view"
                 - "componenttype:view"
@@ -1084,6 +1090,7 @@ openchoreoApi:
 
             # Root Cause Analysis (RCA) agent role for troubleshooting and debugging
             - name: rca-agent
+              system: true
               actions:
                 - "component:view"
                 - "project:view"
@@ -1101,6 +1108,7 @@ openchoreoApi:
 
             # Workload publisher role for creating workloads from CI workflows
             - name: workload-publisher
+              system: true
               actions:
                 - "workload:create"
                 - "workload:update"
@@ -1109,6 +1117,7 @@ openchoreoApi:
 
             # Observer service role for resolving resource UIDs
             - name: observer
+              system: true
               actions:
                 - "component:view"
                 - "project:view"
@@ -1124,6 +1133,10 @@ openchoreoApi:
           #     name:
           #       type: string
           #       description: Binding name
+          #     system:
+          #       type: boolean
+          #       description: Whether this is a system-managed binding (adds openchoreo.io/system label when true, omitted when false)
+          #       default: false
           #     roleRef:
           #       type: object
           #       description: Reference to the role
@@ -1165,6 +1178,7 @@ openchoreoApi:
           mappings:
             # Super admin mapping - grants admins group full access
             - name: super-admin-binding
+              system: true
               roleRef:
                 name: super-admin
               entitlement:
@@ -1174,6 +1188,7 @@ openchoreoApi:
 
             # Backstage catalog reader mapping - grants backstage service account read access
             - name: backstage-catalog-reader-binding
+              system: true
               roleRef:
                 name: backstage-catalog-reader
               entitlement:
@@ -1183,6 +1198,7 @@ openchoreoApi:
 
             # RCA agent mapping - grants RCA service account troubleshooting access
             - name: rca-agent-binding
+              system: true
               roleRef:
                 name: rca-agent
               entitlement:
@@ -1192,6 +1208,7 @@ openchoreoApi:
 
             # Workload publisher mapping - grants workload publisher service account workload creation access
             - name: workload-publisher-binding
+              system: true
               roleRef:
                 name: workload-publisher
               entitlement:
@@ -1201,6 +1218,7 @@ openchoreoApi:
 
             # Observer mapping - grants observer service account resource UID resolver access
             - name: observer-binding
+              system: true
               roleRef:
                 name: observer
               entitlement:
@@ -1210,6 +1228,7 @@ openchoreoApi:
 
             # MCP tryout client mapping - grants MCP tryout client full access
             - name: mcp-tryout-client-binding
+              system: true
               roleRef:
                 name: super-admin
               entitlement:


### PR DESCRIPTION


<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose


Here's a PR description:

---

**Add `system` label to distinguish system-managed authz roles and bindings**

Adds an optional `system` boolean field to bootstrap authz roles and mappings in Helm values. When `system: true`, the rendered CRD gets an `openchoreo.io/system: "true"` label. When `false` or omitted, the label is not added.

All default bootstrap roles and bindings are marked as `system: true` since they are platform-managed. User-defined roles/bindings added via values overrides will not have the label unless explicitly set.

**Changes:**
- `bootstrap-authz.yaml`: Conditionally render `openchoreo.io/system: "true"` label on all 4 resource types (AuthzClusterRole, AuthzRole, AuthzClusterRoleBinding, AuthzRoleBinding)
- `values.yaml`: Add `system: true` to all default roles and mappings; update schema comments to document the new field
- 
## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
