### PR TITLE
fix: skip builds for non-matching branches on webhook events

### DIFF
--- a/internal/openchoreo-api/legacyservices/webhook_service.go
+++ b/internal/openchoreo-api/legacyservices/webhook_service.go
@@ -115,8 +115,8 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 			continue
 		}
 
-		// Get repository URL from component workflow via Workflow CR annotation
-		repoURL, appPath, err := s.extractRepoInfoFromComponent(ctx, comp)
+		// Get repository URL, appPath, and branch from component workflow via Workflow CR annotation
+		repoURL, appPath, branch, err := s.extractRepoInfoFromComponent(ctx, comp)
 		if err != nil {
 			logger.V(1).Info("Failed to extract repo info from component",
 				"component", comp.Name,
@@ -129,12 +129,23 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 			continue
 		}
 
+		// Check if the webhook branch matches the component's configured branch.
+		// If the component has no branch configured, all branches trigger builds.
+		if branch != "" && branch != event.Branch {
+			logger.V(1).Info("Skipping component: branch mismatch",
+				"component", comp.Name,
+				"componentBranch", branch,
+				"webhookBranch", event.Branch)
+			continue
+		}
+
 		// Check if modified paths affect this component
 		// If no modified paths (e.g., Bitbucket), trigger all components for the repo
 		if len(event.ModifiedPaths) == 0 || s.isComponentAffected(appPath, event.ModifiedPaths) {
 			logger.Info("Component is affected by webhook event",
 				"component", comp.Name,
 				"appPath", appPath,
+				"branch", branch,
 				"modifiedPaths", len(event.ModifiedPaths))
 			affected = append(affected, comp)
 		}
@@ -143,11 +154,11 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 	return affected, nil
 }
 
-// extractRepoInfoFromComponent extracts repository URL and appPath from a component's workflow parameters
+// extractRepoInfoFromComponent extracts repository URL, appPath, and branch from a component's workflow parameters
 // by looking up the Workflow CR annotation to find the parameter paths.
-func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp *v1alpha1.Component) (repoURL string, appPath string, err error) {
+func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp *v1alpha1.Component) (repoURL string, appPath string, branch string, err error) {
 	if comp.Spec.Workflow == nil || comp.Spec.Workflow.Name == "" {
-		return "", "", fmt.Errorf("component has no workflow configuration")
+		return "", "", "", fmt.Errorf("component has no workflow configuration")
 	}
 
 	// Fetch the Workflow CR to get the annotation mapping
@@ -156,7 +167,7 @@ func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp 
 		Name:      comp.Spec.Workflow.Name,
 		Namespace: comp.Namespace,
 	}, workflow); err != nil {
-		return "", "", fmt.Errorf("failed to get workflow %s: %w", comp.Spec.Workflow.Name, err)
+		return "", "", "", fmt.Errorf("failed to get workflow %s: %w", comp.Spec.Workflow.Name, err)
 	}
 
 	// Parse the annotation that maps logical keys to parameter paths
@@ -166,16 +177,16 @@ func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp 
 	// Get repoUrl path from the annotation
 	repoURLPath, ok := paramMap["repoUrl"]
 	if !ok {
-		return "", "", fmt.Errorf("workflow %s annotation missing repoUrl mapping", comp.Spec.Workflow.Name)
+		return "", "", "", fmt.Errorf("workflow %s annotation missing repoUrl mapping", comp.Spec.Workflow.Name)
 	}
 
 	repoURL, err = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, repoURLPath)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to extract repoUrl from parameters: %w", err)
+		return "", "", "", fmt.Errorf("failed to extract repoUrl from parameters: %w", err)
 	}
 
 	if repoURL == "" {
-		return "", "", fmt.Errorf("repository URL is empty in component parameters")
+		return "", "", "", fmt.Errorf("repository URL is empty in component parameters")
 	}
 
 	// Get appPath (optional - not all workflows may have it)
@@ -183,7 +194,17 @@ func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp 
 		appPath, _ = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, appPathPath)
 	}
 
-	return repoURL, appPath, nil
+	// Get branch (optional - if not configured, all branches trigger builds).
+	// If the annotation maps a branch path but extraction fails, return an error so
+	// the component is not unintentionally treated as unscoped (all-branch).
+	if branchPath, ok := paramMap["branch"]; ok {
+		branch, err = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, branchPath)
+		if err != nil {
+			return "", "", "", fmt.Errorf("extracting branch for component %s: %w", comp.Name, err)
+		}
+	}
+
+	return repoURL, appPath, branch, nil
 }
 
 // getNestedStringFromRawExtension navigates a runtime.RawExtension JSON blob using a dotted path

--- a/internal/openchoreo-api/legacyservices/webhook_service_test.go
+++ b/internal/openchoreo-api/legacyservices/webhook_service_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices/git"
 )
 
 func TestParseWorkflowParameterAnnotation(t *testing.T) {
@@ -199,6 +200,7 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 		workflow    *v1alpha1.Workflow
 		wantRepo    string
 		wantAppPath string
+		wantBranch  string
 		wantErr     bool
 	}{
 		{
@@ -370,6 +372,64 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 			wantRepo:    "https://github.com/example/repo",
 			wantAppPath: "",
 		},
+		{
+			name: "branch path configured but missing from parameters is an error",
+			component: &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec: v1alpha1.ComponentSpec{
+					Workflow: &v1alpha1.WorkflowRunConfig{
+						Name: "wf1",
+						Parameters: makeRaw(map[string]interface{}{
+							"repository": map[string]interface{}{
+								"url": "https://github.com/example/repo",
+							},
+						}),
+					},
+				},
+			},
+			workflow: &v1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wf1",
+					Namespace: "ns1",
+					Annotations: map[string]string{
+						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nbranch: parameters.repository.revision.branch\n",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "extracts repoUrl, appPath, and branch",
+			component: &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec: v1alpha1.ComponentSpec{
+					Workflow: &v1alpha1.WorkflowRunConfig{
+						Name: "wf1",
+						Parameters: makeRaw(map[string]interface{}{
+							"repository": map[string]interface{}{
+								"url": "https://github.com/example/repo",
+								"revision": map[string]interface{}{
+									"branch": "main",
+								},
+							},
+							"appPath": "/src/app",
+						}),
+					},
+				},
+			},
+			workflow: &v1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wf1",
+					Namespace: "ns1",
+					Annotations: map[string]string{
+						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nappPath: parameters.appPath\nbranch: parameters.repository.revision.branch\n",
+					},
+				},
+			},
+			wantRepo:    "https://github.com/example/repo",
+			wantAppPath: "/src/app",
+			wantBranch:  "main",
+		},
 	}
 
 	for _, tt := range tests {
@@ -382,7 +442,7 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 
 			svc := &WebhookService{k8sClient: k8sClient}
 
-			gotRepo, gotAppPath, err := svc.extractRepoInfoFromComponent(context.Background(), tt.component)
+			gotRepo, gotAppPath, gotBranch, err := svc.extractRepoInfoFromComponent(context.Background(), tt.component)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -397,6 +457,162 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 			}
 			if gotAppPath != tt.wantAppPath {
 				t.Errorf("appPath: got %q, want %q", gotAppPath, tt.wantAppPath)
+			}
+			if gotBranch != tt.wantBranch {
+				t.Errorf("branch: got %q, want %q", gotBranch, tt.wantBranch)
+			}
+		})
+	}
+}
+
+// makeAutoBuildComponent returns a Component with autoBuild enabled, pointing at the given
+// Workflow CR and carrying repository parameters including an optional branch.
+func makeAutoBuildComponent(name, ns, workflowName, repoURL, branch string, makeRaw func(interface{}) *runtime.RawExtension) *v1alpha1.Component {
+	autoBuild := true
+	params := map[string]interface{}{
+		"repository": map[string]interface{}{
+			"url": repoURL,
+			"revision": map[string]interface{}{
+				"branch": branch,
+			},
+		},
+	}
+	return &v1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1alpha1.ComponentSpec{
+			AutoBuild: &autoBuild,
+			Workflow: &v1alpha1.WorkflowRunConfig{
+				Name:       workflowName,
+				Parameters: makeRaw(params),
+			},
+		},
+	}
+}
+
+// makeWorkflowWithBranch returns a Workflow CR whose annotation maps repoUrl and branch.
+func makeWorkflowWithBranch(name, ns string) *v1alpha1.Workflow {
+	return &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Annotations: map[string]string{
+				controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nbranch: parameters.repository.revision.branch\n",
+			},
+		},
+	}
+}
+
+// makeWorkflowNoBranch returns a Workflow CR whose annotation does NOT map branch.
+func makeWorkflowNoBranch(name, ns string) *v1alpha1.Workflow {
+	return &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Annotations: map[string]string{
+				controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\n",
+			},
+		},
+	}
+}
+
+func TestWebhookBranchFilter_Match(t *testing.T) {
+	makeRaw := func(v interface{}) *runtime.RawExtension {
+		b, _ := json.Marshal(v)
+		return &runtime.RawExtension{Raw: b}
+	}
+
+	scheme := newTestScheme(t)
+	comp := makeAutoBuildComponent("svc", "ns1", "wf1", "https://github.com/example/repo", "main", makeRaw)
+	workflow := makeWorkflowWithBranch("wf1", "ns1")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp, workflow).Build()
+	svc := &WebhookService{k8sClient: k8sClient}
+
+	event := &git.WebhookEvent{
+		RepositoryURL: "https://github.com/example/repo",
+		Branch:        "main",
+	}
+
+	affected, err := svc.findAffectedComponents(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(affected) != 1 {
+		t.Fatalf("expected 1 affected component, got %d", len(affected))
+	}
+	if affected[0].Name != "svc" {
+		t.Errorf("expected component %q, got %q", "svc", affected[0].Name)
+	}
+}
+
+func TestWebhookBranchFilter_Mismatch(t *testing.T) {
+	makeRaw := func(v interface{}) *runtime.RawExtension {
+		b, _ := json.Marshal(v)
+		return &runtime.RawExtension{Raw: b}
+	}
+
+	scheme := newTestScheme(t)
+	comp := makeAutoBuildComponent("svc", "ns1", "wf1", "https://github.com/example/repo", "main", makeRaw)
+	workflow := makeWorkflowWithBranch("wf1", "ns1")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp, workflow).Build()
+	svc := &WebhookService{k8sClient: k8sClient}
+
+	event := &git.WebhookEvent{
+		RepositoryURL: "https://github.com/example/repo",
+		Branch:        "feature/new-api",
+	}
+
+	affected, err := svc.findAffectedComponents(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(affected) != 0 {
+		t.Fatalf("expected 0 affected components for branch mismatch, got %d", len(affected))
+	}
+}
+
+func TestWebhookBranchFilter_NoConfiguredBranch(t *testing.T) {
+	makeRaw := func(v interface{}) *runtime.RawExtension {
+		b, _ := json.Marshal(v)
+		return &runtime.RawExtension{Raw: b}
+	}
+
+	scheme := newTestScheme(t)
+	// Component has a branch value in parameters but the Workflow annotation does NOT map "branch",
+	// so no branch filtering should occur and any push branch triggers a build.
+	autoBuild := true
+	comp := &v1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns1"},
+		Spec: v1alpha1.ComponentSpec{
+			AutoBuild: &autoBuild,
+			Workflow: &v1alpha1.WorkflowRunConfig{
+				Name: "wf1",
+				Parameters: makeRaw(map[string]interface{}{
+					"repository": map[string]interface{}{
+						"url": "https://github.com/example/repo",
+					},
+				}),
+			},
+		},
+	}
+	workflow := makeWorkflowNoBranch("wf1", "ns1")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp, workflow).Build()
+	svc := &WebhookService{k8sClient: k8sClient}
+
+	for _, pushBranch := range []string{"main", "feature/foo", "release/v1"} {
+		t.Run(pushBranch, func(t *testing.T) {
+			event := &git.WebhookEvent{
+				RepositoryURL: "https://github.com/example/repo",
+				Branch:        pushBranch,
+			}
+			affected, err := svc.findAffectedComponents(context.Background(), event)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(affected) != 1 {
+				t.Fatalf("expected 1 affected component for branch %q (no branch filter), got %d", pushBranch, len(affected))
 			}
 		})
 	}


### PR DESCRIPTION
## Purpose
- Fix https://github.com/openchoreo/openchoreo/issues/2423
- Auto-build was triggering builds for all branches of a matching repository, ignoring the branch configured in the component's workflow parameters                                                                                                                                   
- Added branch extraction in `extractRepoInfoFromComponent()` using the existing `branch` key from the Workflow CR annotation mapping                                                                                         
- Added branch validation in `findAffectedComponents()` to skip components where the webhook push branch does not match the component's configured branch