### PR TITLE
feat: add --tail flag to component logs command

### DIFF
--- a/internal/occ/cmd/component/logs.go
+++ b/internal/occ/cmd/component/logs.go
@@ -114,11 +114,23 @@ func (cp *Component) fetchAndPrintLogs(
 		return err
 	}
 
+	// When --tail is used, logs are fetched in desc order; reverse for chronological display
+	if params.Tail > 0 {
+		reverseLogs(logs)
+	}
+
 	for _, log := range logs {
 		fmt.Printf("%s %s\n", log.Timestamp, log.Log)
 	}
 
 	return nil
+}
+
+// reverseLogs reverses a slice of log entries in place
+func reverseLogs(logs []client.LogEntry) {
+	for i, j := 0, len(logs)-1; i < j; i, j = i+1, j-1 {
+		logs[i], logs[j] = logs[j], logs[i]
+	}
 }
 
 // followLogs continuously fetches and prints new logs
@@ -135,10 +147,15 @@ func (cp *Component) followLogs(
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Initial fetch
+	// Initial fetch (respects --tail for the initial batch)
 	logs, err := cp.fetchLogs(ctx, observerURL, token, environmentID, params, startTime, endTime)
 	if err != nil {
 		return err
+	}
+
+	// When --tail is used, initial logs are fetched in desc order; reverse for chronological display
+	if params.Tail > 0 {
+		reverseLogs(logs)
 	}
 
 	// Print initial logs
@@ -154,6 +171,9 @@ func (cp *Component) followLogs(
 			startTime = lastTimestamp.Add(1 * time.Millisecond) // Add 1ms to avoid duplicate
 		}
 	}
+
+	// Clear tail for subsequent polls — fetch all new logs in ascending order
+	params.Tail = 0
 
 	// Poll for new logs
 	ticker := time.NewTicker(2 * time.Second)
@@ -208,6 +228,11 @@ func (cp *Component) fetchLogs(
 	startTime time.Time,
 	endTime time.Time,
 ) ([]client.LogEntry, error) {
+	sortOrder := "asc"
+	if params.Tail > 0 {
+		sortOrder = "desc"
+	}
+
 	reqBody := client.ComponentLogsRequest{
 		StartTime:       startTime.Format(time.RFC3339),
 		EndTime:         endTime.Format(time.RFC3339),
@@ -216,7 +241,8 @@ func (cp *Component) fetchLogs(
 		ProjectName:     params.Project,
 		NamespaceName:   params.Namespace,
 		EnvironmentName: params.Environment,
-		SortOrder:       "asc",
+		Limit:           int64(params.Tail),
+		SortOrder:       sortOrder,
 		LogType:         "runtime",
 	}
 

--- a/internal/occ/cmd/component/params.go
+++ b/internal/occ/cmd/component/params.go
@@ -96,4 +96,5 @@ type LogsParams struct {
 	Environment string
 	Follow      bool
 	Since       string // duration like "1h", "30m", "5m"
+	Tail        int    // number of lines to show from the end of logs (0 means no limit)
 }

--- a/pkg/cli/cmd/component/component.go
+++ b/pkg/cli/cmd/component/component.go
@@ -160,6 +160,7 @@ func newScaffoldComponentCmd() *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl // deploy and logs commands follow the same pattern but are distinct
 func newDeployComponentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     constants.DeployComponent.Use,
@@ -209,6 +210,7 @@ func newDeployComponentCmd() *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl // logs and deploy commands follow the same pattern but are distinct
 func newLogsComponentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs COMPONENT_NAME",
@@ -224,6 +226,9 @@ If --env is not specified, uses the lowest environment from the deployment pipel
   # Get logs with custom since duration
   occ component logs my-component --env dev --since 30m
 
+  # Show the last 100 lines of logs
+  occ component logs my-component --tail 100
+
   # Follow logs in real-time
   occ component logs my-component --env dev -f`,
 		Args: cobra.ExactArgs(1), // Requires COMPONENT_NAME
@@ -237,6 +242,7 @@ If --env is not specified, uses the lowest environment from the deployment pipel
 			environment, _ := cmd.Flags().GetString(flags.Environment.Name)
 			follow, _ := cmd.Flags().GetBool(flags.Follow.Name)
 			since, _ := cmd.Flags().GetString(flags.Since.Name)
+			tail, _ := cmd.Flags().GetInt(flags.Tail.Name)
 
 			// Create params
 			params := component.LogsParams{
@@ -246,6 +252,7 @@ If --env is not specified, uses the lowest environment from the deployment pipel
 				Environment: environment,
 				Follow:      follow,
 				Since:       since,
+				Tail:        tail,
 			}
 
 			// Execute logs
@@ -261,6 +268,7 @@ If --env is not specified, uses the lowest environment from the deployment pipel
 		flags.Environment,
 		flags.Follow,
 		flags.Since,
+		flags.Tail,
 	)
 
 	return cmd

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -120,6 +120,7 @@ var (
 	Tail = Flag{
 		Name:  "tail",
 		Usage: messages.FlagTailDesc,
+		Type:  "int",
 	}
 	Follow = Flag{
 		Name:      "follow",
@@ -418,6 +419,8 @@ func AddFlags(cmd *cobra.Command, flags ...Flag) {
 		switch flag.Type {
 		case "bool":
 			cmd.Flags().BoolP(flag.Name, flag.Shorthand, false, flag.Usage)
+		case "int":
+			cmd.Flags().IntP(flag.Name, flag.Shorthand, 0, flag.Usage)
 		case "stringArray":
 			cmd.Flags().StringArrayP(flag.Name, flag.Shorthand, nil, flag.Usage)
 		default:


### PR DESCRIPTION
## Summary

related https://github.com/openchoreo/openchoreo/issues/2432

- Add `--tail` flag to `occ component logs` to show the last N lines of logs
- When `--tail N` is specified, fetches logs in descending order (most recent first) with a limit of N, then reverses for chronological display
- In follow mode (`-f`), `--tail` applies only to the initial batch; subsequent polls fetch all new logs in ascending order
- Add `int` type support to the CLI flags framework

## Test plan
- [x] `occ component logs my-component --tail 10` shows the last 10 log lines
- [x] `occ component logs my-component --tail 5 -f` shows last 5 lines then streams new logs
- [x] `occ component logs my-component` (no --tail) works as before with no limit
- [x] `occ component logs --help` shows the --tail flag with description