### PR TITLE
feat(cli): use Helm-style paths for --set flag overrides

### DIFF
--- a/internal/occ/cmd/component/component.go
+++ b/internal/occ/cmd/component/component.go
@@ -7,18 +7,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
 
-	"github.com/tidwall/sjson"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/setoverride"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflow"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflowrun"
@@ -471,60 +469,24 @@ func unmarshalSchema(raw *json.RawMessage) (*extv1.JSONSchemaProps, error) {
 	return &schema, nil
 }
 
-// mergeOverridesWithBinding merges --set override values with existing ReleaseBinding
-// This uses sjson to generically update JSON paths in the existing binding
+// mergeOverridesWithBinding merges --set override values with existing ReleaseBinding.
 func mergeOverridesWithBinding(existingBinding *gen.ReleaseBinding, setValues []string) (*gen.ReleaseBinding, error) {
-	// Marshal existing binding to JSON
 	existingJSON, err := json.Marshal(existingBinding)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal existing binding: %w", err)
 	}
 
-	jsonStr := string(existingJSON)
-
-	// Apply each --set value using sjson
-	for _, setValue := range setValues {
-		parts := strings.SplitN(setValue, "=", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid --set format '%s', expected: key=value", setValue)
-		}
-
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-
-		if key == "" {
-			return nil, fmt.Errorf("empty key in --set flag")
-		}
-
-		// Use sjson.SetRaw with a properly typed JSON literal so that
-		// numeric and boolean values are not quoted as strings.
-		jsonStr, err = sjson.SetRaw(jsonStr, key, toJSONLiteral(value))
-		if err != nil {
-			return nil, fmt.Errorf("failed to set value for key '%s': %w", key, err)
-		}
+	jsonStr, err := setoverride.Apply(string(existingJSON), setValues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge overrides: %w", err)
 	}
 
-	// Unmarshal back to ReleaseBinding
 	var rb gen.ReleaseBinding
 	if err := json.Unmarshal([]byte(jsonStr), &rb); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal merged result: %w", err)
 	}
 
 	return &rb, nil
-}
-
-// toJSONLiteral converts a CLI string value to its raw JSON representation.
-// It preserves the correct JSON type: booleans become true/false, numbers stay
-// unquoted, and everything else is quoted as a JSON string.
-func toJSONLiteral(s string) string {
-	if s == "true" || s == "false" || s == "null" {
-		return s
-	}
-	if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
-		return s
-	}
-	b, _ := json.Marshal(s)
-	return string(b)
 }
 
 func printList(items []gen.Component, showProject bool) error {

--- a/internal/occ/cmd/setoverride/setoverride.go
+++ b/internal/occ/cmd/setoverride/setoverride.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setoverride
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/sjson"
+)
+
+// bracketIndex matches bracket-notation array indices like [0], [1], [-1].
+var bracketIndex = regexp.MustCompile(`\[(-?\d+)\]`)
+
+// jsonNumber matches a valid JSON number per RFC 7159:
+// optional minus, integer (no leading zeros except "0"), optional fraction, optional exponent.
+var jsonNumber = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
+
+// Apply parses each "key=value" entry from setValues, converts the key from
+// standard JSON path notation to sjson path notation, and applies the value
+// to the given JSON string. It returns the updated JSON string.
+//
+// Standard JSON path notation uses brackets for array indices:
+//
+//	spec.containers[0].name=nginx
+//
+// sjson expects dot-separated numeric indices:
+//
+//	spec.containers.0.name
+//
+// This function transparently converts between the two so that users can
+// supply the more familiar bracket notation.
+func Apply(jsonStr string, setValues []string) (string, error) {
+	var err error
+	for _, sv := range setValues {
+		parts := strings.SplitN(sv, "=", 2)
+		if len(parts) != 2 {
+			return jsonStr, fmt.Errorf("invalid --set format %q, expected key=value", sv)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if key == "" {
+			return jsonStr, fmt.Errorf("empty key in --set flag")
+		}
+
+		sjsonPath := ToSjsonPath(key)
+
+		jsonStr, err = sjson.SetRaw(jsonStr, sjsonPath, toJSONLiteral(value))
+		if err != nil {
+			return jsonStr, fmt.Errorf("failed to set value for key %q: %w", key, err)
+		}
+	}
+	return jsonStr, nil
+}
+
+// ToSjsonPath converts a standard JSON path (Helm-style) to sjson path syntax.
+//
+// Bracket notation denotes array indices, bare numeric segments are object keys:
+//
+//	spec.containers[0].name  → spec.containers.0.name   (array index)
+//	spec.containers.0.name   → spec.containers.:0.name  (object key "0")
+//	spec.ports[0]            → spec.ports.0              (array index)
+//	metadata.labels          → metadata.labels           (unchanged)
+func ToSjsonPath(path string) string {
+	// First, replace bracket indices [N] with a placeholder that won't be
+	// affected by the bare-numeric escaping pass.
+	// Use \x00 as a temporary marker since it cannot appear in user input.
+	result := bracketIndex.ReplaceAllString(path, ".\x00$1")
+
+	// Escape bare numeric segments with sjson's colon prefix so they are
+	// treated as object keys, not array indices.
+	segments := strings.Split(result, ".")
+	for i, seg := range segments {
+		if seg == "" {
+			continue
+		}
+		// Segments starting with \x00 are array indices from bracket notation.
+		if seg[0] == '\x00' {
+			segments[i] = seg[1:] // strip marker, keep as numeric (array index)
+			continue
+		}
+		// Bare numeric segment → prefix with : so sjson treats it as object key.
+		if isNumeric(seg) {
+			segments[i] = ":" + seg
+		}
+	}
+
+	result = strings.Join(segments, ".")
+	// Clean up empty segments from consecutive dots.
+	for strings.Contains(result, "..") {
+		result = strings.ReplaceAll(result, "..", ".")
+	}
+	result = strings.TrimPrefix(result, ".")
+	return result
+}
+
+// isNumeric returns true if s is a decimal integer (possibly negative).
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	start := 0
+	if s[0] == '-' {
+		start = 1
+	}
+	if start >= len(s) {
+		return false
+	}
+	for _, c := range s[start:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// toJSONLiteral converts a CLI string value to its raw JSON representation.
+// It preserves the correct JSON type: booleans become true/false, numbers stay
+// unquoted, and everything else is quoted as a JSON string.
+// Numbers must conform to RFC 7159 (no leading zeros, no leading "+").
+// Inputs like "01" or "+1" are treated as strings.
+func toJSONLiteral(s string) string {
+	if s == "true" || s == "false" || s == "null" {
+		return s
+	}
+	if jsonNumber.MatchString(s) {
+		if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+			return s
+		}
+	}
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/occ/cmd/setoverride/setoverride_test.go
+++ b/internal/occ/cmd/setoverride/setoverride_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setoverride
+
+import (
+	"testing"
+)
+
+func TestToSjsonPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple dot path unchanged",
+			input:    "spec.replicas",
+			expected: "spec.replicas",
+		},
+		{
+			name:     "bracket index at end",
+			input:    "spec.containers[0]",
+			expected: "spec.containers.0",
+		},
+		{
+			name:     "bracket index in middle",
+			input:    "spec.containers[0].name",
+			expected: "spec.containers.0.name",
+		},
+		{
+			name:     "multiple bracket indices",
+			input:    "spec.containers[0].ports[1].containerPort",
+			expected: "spec.containers.0.ports.1.containerPort",
+		},
+		{
+			name:     "negative index for append",
+			input:    "spec.containers[-1]",
+			expected: "spec.containers.-1",
+		},
+		{
+			name:     "nested array indices",
+			input:    "matrix[0][1]",
+			expected: "matrix.0.1",
+		},
+		{
+			name:     "single key unchanged",
+			input:    "name",
+			expected: "name",
+		},
+		{
+			name:     "deeply nested with mixed notation",
+			input:    "a.b[0].c.d[2].e",
+			expected: "a.b.0.c.d.2.e",
+		},
+		{
+			name:     "bare numeric segment becomes object key",
+			input:    "spec.containers.0.image",
+			expected: "spec.containers.:0.image",
+		},
+		{
+			name:     "multiple bare numeric segments become object keys",
+			input:    "a.1.b.2.c",
+			expected: "a.:1.b.:2.c",
+		},
+		{
+			name:     "bare numeric only",
+			input:    "0",
+			expected: ":0",
+		},
+		{
+			name:     "mixed bracket and bare numeric",
+			input:    "spec.items[0].configs.1.name",
+			expected: "spec.items.0.configs.:1.name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToSjsonPath(tt.input)
+			if got != tt.expected {
+				t.Errorf("ToSjsonPath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToJSONLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Valid JSON numbers (returned raw)
+		{name: "integer", input: "1", expected: "1"},
+		{name: "negative integer", input: "-1", expected: "-1"},
+		{name: "zero", input: "0", expected: "0"},
+		{name: "decimal", input: "1.5", expected: "1.5"},
+		{name: "negative decimal", input: "-1.5", expected: "-1.5"},
+		{name: "exponent", input: "1e10", expected: "1e10"},
+		{name: "exponent uppercase", input: "1E10", expected: "1E10"},
+		{name: "exponent with plus", input: "1.0e+2", expected: "1.0e+2"},
+		{name: "exponent with minus", input: "1.0e-2", expected: "1.0e-2"},
+		// Booleans and null (returned raw)
+		{name: "true", input: "true", expected: "true"},
+		{name: "false", input: "false", expected: "false"},
+		{name: "null", input: "null", expected: "null"},
+		// Invalid JSON numbers (quoted as strings)
+		{name: "leading zero", input: "01", expected: `"01"`},
+		{name: "leading plus", input: "+1", expected: `"+1"`},
+		{name: "leading plus decimal", input: "+1.5", expected: `"+1.5"`},
+		{name: "double zero", input: "00", expected: `"00"`},
+		{name: "leading zero decimal", input: "01.5", expected: `"01.5"`},
+		// Plain strings (quoted)
+		{name: "word", input: "hello", expected: `"hello"`},
+		{name: "empty", input: "", expected: `""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toJSONLiteral(tt.input)
+			if got != tt.expected {
+				t.Errorf("toJSONLiteral(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	tests := []struct {
+		name      string
+		jsonStr   string
+		setValues []string
+		expected  string
+		wantErr   bool
+	}{
+		{
+			name:      "set simple string value",
+			jsonStr:   `{"spec":{"name":"old"}}`,
+			setValues: []string{"spec.name=new"},
+			expected:  `{"spec":{"name":"new"}}`,
+		},
+		{
+			name:      "set numeric value",
+			jsonStr:   `{"spec":{"replicas":1}}`,
+			setValues: []string{"spec.replicas=3"},
+			expected:  `{"spec":{"replicas":3}}`,
+		},
+		{
+			name:      "set boolean value",
+			jsonStr:   `{"spec":{"enabled":false}}`,
+			setValues: []string{"spec.enabled=true"},
+			expected:  `{"spec":{"enabled":true}}`,
+		},
+		{
+			name:      "set array element with bracket notation",
+			jsonStr:   `{"spec":{"items":["a","b","c"]}}`,
+			setValues: []string{"spec.items[1]=x"},
+			expected:  `{"spec":{"items":["a","x","c"]}}`,
+		},
+		{
+			name:      "set nested object in array with bracket notation",
+			jsonStr:   `{"spec":{"containers":[{"name":"app","image":"old"}]}}`,
+			setValues: []string{"spec.containers[0].image=new"},
+			expected:  `{"spec":{"containers":[{"name":"app","image":"new"}]}}`,
+		},
+		{
+			name:      "multiple set values",
+			jsonStr:   `{"spec":{"name":"old","replicas":1}}`,
+			setValues: []string{"spec.name=new", "spec.replicas=5"},
+			expected:  `{"spec":{"name":"new","replicas":5}}`,
+		},
+		{
+			name:      "bare numeric creates object key not array index",
+			jsonStr:   `{"spec":{}}`,
+			setValues: []string{"spec.0=hello"},
+			expected:  `{"spec":{"0":"hello"}}`,
+		},
+		{
+			name:      "empty set values is no-op",
+			jsonStr:   `{"spec":{"name":"old"}}`,
+			setValues: []string{},
+			expected:  `{"spec":{"name":"old"}}`,
+		},
+		{
+			name:      "missing equals sign",
+			jsonStr:   `{}`,
+			setValues: []string{"spec.name"},
+			wantErr:   true,
+		},
+		{
+			name:      "empty key",
+			jsonStr:   `{}`,
+			setValues: []string{"=value"},
+			wantErr:   true,
+		},
+		{
+			name:      "set null value",
+			jsonStr:   `{"spec":{"name":"old"}}`,
+			setValues: []string{"spec.name=null"},
+			expected:  `{"spec":{"name":null}}`,
+		},
+		{
+			name:      "leading zero stays as string",
+			jsonStr:   `{"spec":{}}`,
+			setValues: []string{"spec.id=01"},
+			expected:  `{"spec":{"id":"01"}}`,
+		},
+		{
+			name:      "leading plus stays as string",
+			jsonStr:   `{"spec":{}}`,
+			setValues: []string{"spec.val=+1"},
+			expected:  `{"spec":{"val":"+1"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Apply(tt.jsonStr, tt.setValues)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Apply() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.expected {
+				t.Errorf("Apply() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/occ/cmd/workflow/workflow.go
+++ b/internal/occ/cmd/workflow/workflow.go
@@ -7,17 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
-	"strconv"
-	"strings"
 	"text/tabwriter"
 	"time"
 
-	"github.com/tidwall/sjson"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/setoverride"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
 	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
 	"github.com/openchoreo/openchoreo/internal/occ/validation"
@@ -189,21 +186,9 @@ func applySetOverrides(req gen.WorkflowRun, workflowName string, setValues []str
 		return req, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	jsonStr := string(reqJSON)
-	for _, s := range setValues {
-		parts := strings.SplitN(s, "=", 2)
-		if len(parts) != 2 {
-			return req, fmt.Errorf("invalid --set format %q, expected key=value", s)
-		}
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if key == "" {
-			return req, fmt.Errorf("empty key in --set flag")
-		}
-		jsonStr, err = sjson.SetRaw(jsonStr, key, toJSONLiteral(value))
-		if err != nil {
-			return req, fmt.Errorf("failed to set value for key %q: %w", key, err)
-		}
+	jsonStr, err := setoverride.Apply(string(reqJSON), setValues)
+	if err != nil {
+		return req, err
 	}
 
 	var result gen.WorkflowRun
@@ -217,18 +202,6 @@ func applySetOverrides(req gen.WorkflowRun, workflowName string, setValues []str
 	}
 
 	return result, nil
-}
-
-// toJSONLiteral converts a CLI string value to its raw JSON representation.
-func toJSONLiteral(s string) string {
-	if s == "true" || s == "false" || s == "null" {
-		return s
-	}
-	if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
-		return s
-	}
-	b, _ := json.Marshal(s)
-	return string(b)
 }
 
 func printList(items []gen.Workflow) error {


### PR DESCRIPTION
## Summary
related  https://github.com/openchoreo/openchoreo/issues/2432

- Extract `--set` override logic into shared `setoverride` package, removing duplication between `component deploy` and `workflow run` commands
- Adopt Helm-style path semantics: bracket notation `[0]` for array indices, bare numeric segments treated as object keys (not array indices)
- Bare numeric paths like `spec.containers.0.image` now create object keys (`{"0": ...}`) matching Helm behavior, while `spec.containers[0].image` targets array index 0

## Test plan
- [x] Unit tests for `ToSjsonPath` path conversion (bracket indices, bare numeric as object key, negative indices, nested arrays, mixed notation)
- [x] Unit tests for `Apply` (string/number/boolean/null values, bracket array access, object key creation, error cases)
- [x] `go vet` passes on all modified packages
- [x] Manual test: `occ component deploy --set spec.workloadOverrides.container.env[0].key=MY_VAR`
- [ ] Manual test: `occ workflow run --set spec.workflow.parameters.key=value`