### PR TITLE
fix(cli): harden --set value typing and escaped-dot handling

### DIFF
--- a/internal/occ/cmd/setoverride/setoverride.go
+++ b/internal/occ/cmd/setoverride/setoverride.go
@@ -76,7 +76,8 @@ func ToSjsonPath(path string) string {
 
 	// Escape bare numeric segments with sjson's colon prefix so they are
 	// treated as object keys, not array indices.
-	segments := strings.Split(result, ".")
+	// Split on unescaped dots only (preserve backslash-escaped dots like \.).
+	segments := splitUnescaped(result, '.')
 	for i, seg := range segments {
 		if seg == "" {
 			continue
@@ -99,6 +100,30 @@ func ToSjsonPath(path string) string {
 	}
 	result = strings.TrimPrefix(result, ".")
 	return result
+}
+
+// splitUnescaped splits s on the given separator byte, but skips separators
+// preceded by a backslash. The backslash-separator sequences are preserved
+// in the output so that sjson can interpret escaped dots (e.g. foo\.bar).
+func splitUnescaped(s string, sep byte) []string {
+	var segments []string
+	var cur strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			cur.WriteByte(s[i])
+			cur.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		if s[i] == sep {
+			segments = append(segments, cur.String())
+			cur.Reset()
+			continue
+		}
+		cur.WriteByte(s[i])
+	}
+	segments = append(segments, cur.String())
+	return segments
 }
 
 // isNumeric returns true if s is a decimal integer (possibly negative).

--- a/internal/occ/cmd/setoverride/setoverride_test.go
+++ b/internal/occ/cmd/setoverride/setoverride_test.go
@@ -73,6 +73,16 @@ func TestToSjsonPath(t *testing.T) {
 			input:    "spec.items[0].configs.1.name",
 			expected: "spec.items.0.configs.:1.name",
 		},
+		{
+			name:     "escaped dot preserves single key",
+			input:    `labels.foo\.0`,
+			expected: `labels.foo\.0`,
+		},
+		{
+			name:     "escaped dot with deeper path",
+			input:    `metadata.labels.app\.kubernetes\.io/name`,
+			expected: `metadata.labels.app\.kubernetes\.io/name`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Tighten numeric detection in `toJSONLiteral` to match RFC 7159 JSON number grammar — inputs like `01`, `+1`, `+1.5` are now correctly treated as strings instead of raw numbers
- Fix `ToSjsonPath` to split on unescaped dots only, preserving backslash-escaped dots (e.g., `labels.foo\.0`) so sjson interprets them as a single key

## Test plan
- [x] Unit tests for `toJSONLiteral`: valid numbers (`1`, `-1`, `1.5`, `1e10`) → raw; invalid (`01`, `+1`, `+1.5`, `00`) → quoted string
- [x] Unit tests for escaped-dot path preservation (`labels.foo\.0` stays intact)
- [x] Full `internal/occ/...` test suite passes