### PR TITLE
fix: add cluster workflow permission to cluster role

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/clusterrole.yaml
@@ -24,6 +24,7 @@ rules:
   - clustertraits
   - clusterobservabilityplanes
   - clustertraits
+  - clusterworkflows
   - componentreleases
   - components
   - componenttypes
@@ -86,6 +87,7 @@ rules:
   - clustertraits/status
   - clusterobservabilityplanes/status
   - clustertraits/status
+  - clusterworkflows/status
   - componentreleases/status
   - components/status
   - componenttypes/status


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
API server call is failing with 500 as the clusterworkflow permission is missing.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
