### PR TITLE
feat: add aws-rds-postgres-create generic workflow sample

### DIFF
--- a/samples/workflows/generic/aws-rds-postgres-create/README.md
+++ b/samples/workflows/generic/aws-rds-postgres-create/README.md
@@ -1,0 +1,215 @@
+# AWS RDS PostgreSQL Create — Generic Workflow Sample
+
+This sample demonstrates a self-service Generic Workflow that lets a developer quickly spin up a throwaway AWS RDS PostgreSQL instance for feature development or testing — without involving the platform team. Fill in a few parameters, trigger the workflow, and get a ready-to-use connection string at the end.
+
+The instance is a minimal, publicly accessible `db.t3.micro` (free-tier eligible) — sized for dev/test, not production. The workflow clones this repository at runtime to execute the Terraform files in `terraform/`. Terraform state is stored in S3 so the same instance can be updated or destroyed later.
+
+---
+
+## Pipeline Overview
+
+```
+WorkflowRun
+    │
+    ▼
+[clone-step]    — git clone the configured repo/branch to get terraform/
+    │
+    ▼
+[setup-step]    — create the S3 state bucket if it does not already exist
+    │
+    ▼
+[init-step]     — terraform init with S3 backend
+    │
+    ▼
+[plan-step]     — terraform plan (dry run, visible in logs)
+    │
+    ▼
+[apply-step]    — terraform apply -auto-approve; save outputs to shared volume
+    │
+    ▼
+[report-step]   — print host, port, database, username, password, connection string
+```
+
+---
+
+## Infrastructure Provisioned
+
+| Resource | Details |
+|----------|---------|
+| `aws_db_instance` | PostgreSQL `db.t3.micro` (free-tier eligible), 20 GiB gp2 (AWS minimum), single-AZ |
+| `aws_db_subnet_group` | Uses subnets from the default VPC |
+| `aws_security_group` | Allows port 5432 inbound from `0.0.0.0/0` |
+
+The instance is **publicly accessible** so you can connect directly from your workstation to verify it. For production use, set `publicly_accessible = false` in `terraform/main.tf` and restrict the security group `cidr_blocks` to your application's IP range.
+
+---
+
+## Prerequisites
+
+### 1. IAM permissions
+
+The IAM user needs two policy statements. The S3 bucket for Terraform state is created automatically by the workflow on first run — no manual bucket creation needed.
+
+**RDS, EC2, and S3:**
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "rds:CreateDBInstance",
+    "rds:DeleteDBInstance",
+    "rds:DescribeDBInstances",
+    "rds:AddTagsToResource",
+    "rds:ListTagsForResource",
+    "rds:CreateDBSubnetGroup",
+    "rds:DescribeDBSubnetGroups",
+    "rds:DeleteDBSubnetGroup",
+    "ec2:DescribeVpcs",
+    "ec2:DescribeVpcAttribute",
+    "ec2:DescribeSubnets",
+    "ec2:DescribeSecurityGroups",
+    "ec2:DescribeNetworkInterfaces",
+    "ec2:CreateSecurityGroup",
+    "ec2:AuthorizeSecurityGroupIngress",
+    "ec2:AuthorizeSecurityGroupEgress",
+    "ec2:RevokeSecurityGroupEgress",
+    "ec2:DeleteSecurityGroup",
+    "ec2:CreateTags",
+    "s3:CreateBucket",
+    "s3:GetObject",
+    "s3:PutObject",
+    "s3:ListBucket",
+    "s3:DeleteObject"
+  ],
+  "Resource": "*"
+}
+```
+
+### 2. Kubernetes Secret
+
+Create the secret in the workflow execution namespace — `workflows-<namespace>` where `<namespace>` is the namespace your `WorkflowRun` is applied in (e.g. `workflows-default`).
+
+The secret holds three values:
+- `accessKeyId` — AWS access key ID
+- `secretAccessKey` — AWS secret access key
+- `dbPassword` — master password for the PostgreSQL instance
+
+```bash
+kubectl create secret generic aws-rds-credentials \
+  --from-literal=accessKeyId=<your-access-key-id> \
+  --from-literal=secretAccessKey=<your-secret-access-key> \
+  --from-literal=dbPassword=<your-db-password> \
+  --namespace=workflows-default
+```
+
+> The DB password is stored in a Kubernetes Secret and injected into the workflow as an environment variable. It is **not** passed as a plain workflow parameter.
+
+---
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `git.repoUrl` | No | `https://github.com/openchoreo/openchoreo.git` | Git repository URL (HTTPS) that contains the Terraform files. Override to use your own repo. |
+| `git.branch` | No | `main` | Branch or tag to check out |
+| `git.tfPath` | No | `samples/workflows/generic/aws-rds-postgres-create/terraform` | Relative path inside the cloned repo to the directory containing the Terraform files |
+| `aws.region` | No | `us-east-1` | AWS region for the RDS instance |
+| `aws.credentialsSecret` | Yes | — | Name of the Kubernetes Secret (see Prerequisites) |
+| `tfState.s3Bucket` | Yes | — | S3 bucket name for Terraform state. Created automatically on first run if it does not exist. |
+| `db.identifier` | Yes | — | Unique RDS instance identifier (e.g. `my-app-db`). Also used as the S3 state key prefix. |
+| `db.name` | Yes | — | Initial database name inside the instance |
+| `db.username` | Yes | — | Master username |
+| `db.engineVersion` | No | `"16"` | PostgreSQL major version (`"16"`, `"15"`, etc.) |
+
+---
+
+## How to Run
+
+```bash
+# 1. Apply the ClusterWorkflowTemplate and Workflow CRs
+kubectl apply -f aws-rds-postgres-create.yaml
+```
+
+Edit the `WorkflowRun` section at the bottom of the file with your values, then apply, or create a separate `WorkflowRun`:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: my-app-db-run
+spec:
+  workflow:
+    name: aws-rds-postgres-create
+    parameters:
+      # Override these to point to your own repo/branch/terraform path.
+      git:
+        repoUrl: "https://github.com/openchoreo/openchoreo.git"
+        branch: "main"
+        tfPath: "samples/workflows/generic/aws-rds-postgres-create/terraform"
+      aws:
+        region: "us-east-1"
+        credentialsSecret: "aws-rds-credentials"
+      tfState:
+        s3Bucket: "openchoreo-rds-tfstate"
+      db:
+        identifier: "my-app-db"
+        name: "myappdb"
+        username: "dbadmin"
+        engineVersion: "16"
+```
+
+---
+
+## Example Output
+
+```
+=================================================
+  AWS RDS PostgreSQL Instance Created
+=================================================
+Host:              my-app-db.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com
+Port:              5432
+Database:          myappdb
+Username:          dbadmin
+ARN:               arn:aws:rds:us-east-1:111122223333:db:my-app-db
+-------------------------------------------------
+Connection String (template):
+  postgresql://dbadmin:<password>@my-app-db.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com:5432/myappdb
+
+NOTE: Password is stored in the 'aws-rds-credentials'
+      Kubernetes Secret under the 'dbPassword' key.
+      Retrieve it with:
+      kubectl get secret aws-rds-credentials \
+        -o jsonpath='{.data.dbPassword}' | base64 -d
+=================================================
+
+NOTE: The instance is publicly accessible on port 5432.
+```
+
+---
+
+## Deleting the Instance
+
+Use the companion `aws-rds-postgres-delete` workflow to destroy the instance and all associated AWS resources (security group, subnet group). It reads the same Terraform state file from S3, so no manual cleanup is needed.
+
+```bash
+# Apply the delete ClusterWorkflowTemplate and Workflow CRs
+kubectl apply -f aws-rds-postgres-delete.yaml
+```
+
+Edit the `WorkflowRun` section at the bottom of `aws-rds-postgres-delete.yaml` with the **same parameter values used when creating the instance**, then apply:
+
+```bash
+kubectl apply -f aws-rds-postgres-delete.yaml
+```
+
+> **Important:** `db.identifier`, `tfState.s3Bucket`, and `aws.region` must exactly match the values used during creation — Terraform uses these to locate the correct state file.
+
+---
+
+## Terraform State
+
+State is stored at:
+```
+s3://<tfState.s3Bucket>/rds/<db.identifier>/terraform.tfstate
+```
+
+Each `db.identifier` gets its own isolated state key, so running the workflow for a different identifier does not affect existing instances.

--- a/samples/workflows/generic/aws-rds-postgres-create/aws-rds-postgres-create.yaml
+++ b/samples/workflows/generic/aws-rds-postgres-create/aws-rds-postgres-create.yaml
@@ -1,0 +1,442 @@
+# ============================================================
+# ClusterWorkflowTemplate — Argo Workflows execution template
+# Deploy this to the Build Plane cluster
+# ============================================================
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: aws-rds-postgres-create
+spec:
+  entrypoint: pipeline
+  templates:
+    - name: pipeline
+      steps:
+        - - name: clone
+            template: clone-step
+        - - name: setup
+            template: setup-step
+        - - name: init
+            template: init-step
+        - - name: plan
+            template: plan-step
+        - - name: apply
+            template: apply-step
+        - - name: report
+            template: report-step
+
+    # Step 1: Clone the Terraform repo to get the Terraform files
+    - name: clone-step
+      container:
+        image: alpine/git:2.45.2
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            echo "Cloning repository ${GIT_REPO_URL} (branch: ${GIT_BRANCH}) ..."
+            git clone --depth 1 --branch "${GIT_BRANCH}" \
+              "${GIT_REPO_URL}" \
+              /mnt/data/repo
+            echo "Clone complete."
+        env:
+          - name: GIT_REPO_URL
+            value: "{{workflow.parameters.git-repo-url}}"
+          - name: GIT_BRANCH
+            value: "{{workflow.parameters.git-branch}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 2: Create the S3 bucket for Terraform state if it does not exist yet
+    - name: setup-step
+      container:
+        image: amazon/aws-cli:2.22.0
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            echo "Checking S3 bucket ${TFSTATE_S3_BUCKET} ..."
+            HEAD_OUTPUT=$(aws s3api head-bucket --bucket "$TFSTATE_S3_BUCKET" 2>&1) && BUCKET_EXISTS=true || BUCKET_EXISTS=false
+            if [ "$BUCKET_EXISTS" = "true" ]; then
+              echo "Bucket already exists — skipping creation."
+            elif echo "$HEAD_OUTPUT" | grep -q "404\|NoSuchBucket"; then
+              echo "Creating S3 bucket ${TFSTATE_S3_BUCKET} in region ${AWS_REGION} ..."
+              if [ "$AWS_REGION" = "us-east-1" ]; then
+                aws s3api create-bucket \
+                  --bucket "$TFSTATE_S3_BUCKET" \
+                  --region "$AWS_REGION"
+              else
+                aws s3api create-bucket \
+                  --bucket "$TFSTATE_S3_BUCKET" \
+                  --region "$AWS_REGION" \
+                  --create-bucket-configuration LocationConstraint="$AWS_REGION"
+              fi
+              echo "Bucket created."
+            else
+              echo "ERROR: Cannot access bucket ${TFSTATE_S3_BUCKET}."
+              echo "It may be owned by another AWS account. Choose a different bucket name."
+              echo "Details: ${HEAD_OUTPUT}"
+              exit 1
+            fi
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: TFSTATE_S3_BUCKET
+            value: "{{workflow.parameters.tfstate-s3-bucket}}"
+
+    # Step 3: terraform init — configure S3 backend at runtime
+    - name: init-step
+      container:
+        image: hashicorp/terraform:1.9
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            ulimit -n 65535
+            TF_DIR="/mnt/data/repo/${GIT_TF_PATH}"
+            cd "$TF_DIR"
+
+            echo "Running terraform init ..."
+            terraform init \
+              -backend-config="bucket=${TFSTATE_S3_BUCKET}" \
+              -backend-config="key=rds/${DB_IDENTIFIER}/terraform.tfstate" \
+              -backend-config="region=${AWS_REGION}" \
+              -input=false
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: TFSTATE_S3_BUCKET
+            value: "{{workflow.parameters.tfstate-s3-bucket}}"
+          - name: DB_IDENTIFIER
+            value: "{{workflow.parameters.db-identifier}}"
+          - name: GIT_TF_PATH
+            value: "{{workflow.parameters.git-tf-path}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 4: terraform plan — dry run for visibility in logs
+    - name: plan-step
+      container:
+        image: hashicorp/terraform:1.9
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            ulimit -n 65535
+            TF_DIR="/mnt/data/repo/${GIT_TF_PATH}"
+            cd "$TF_DIR"
+
+            echo "Running terraform plan ..."
+            terraform plan \
+              -var="aws_region=${AWS_REGION}" \
+              -var="db_identifier=${DB_IDENTIFIER}" \
+              -var="db_name=${DB_NAME}" \
+              -var="db_username=${DB_USERNAME}" \
+              -var="db_password=${DB_PASSWORD}" \
+              -var="db_engine_version=${DB_ENGINE_VERSION}" \
+              -input=false
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: DB_IDENTIFIER
+            value: "{{workflow.parameters.db-identifier}}"
+          - name: DB_NAME
+            value: "{{workflow.parameters.db-name}}"
+          - name: DB_USERNAME
+            value: "{{workflow.parameters.db-username}}"
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: dbPassword
+          - name: DB_ENGINE_VERSION
+            value: "{{workflow.parameters.db-engine-version}}"
+          - name: GIT_TF_PATH
+            value: "{{workflow.parameters.git-tf-path}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 5: terraform apply — provision the RDS instance and save outputs
+    - name: apply-step
+      container:
+        image: hashicorp/terraform:1.9
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            ulimit -n 65535
+            TF_DIR="/mnt/data/repo/${GIT_TF_PATH}"
+            cd "$TF_DIR"
+
+            echo "Running terraform apply ..."
+            terraform apply \
+              -auto-approve \
+              -var="aws_region=${AWS_REGION}" \
+              -var="db_identifier=${DB_IDENTIFIER}" \
+              -var="db_name=${DB_NAME}" \
+              -var="db_username=${DB_USERNAME}" \
+              -var="db_password=${DB_PASSWORD}" \
+              -var="db_engine_version=${DB_ENGINE_VERSION}" \
+              -input=false
+
+            echo "Saving terraform outputs ..."
+            terraform output -json > /mnt/data/tf-outputs.json
+            echo "Apply complete."
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: DB_IDENTIFIER
+            value: "{{workflow.parameters.db-identifier}}"
+          - name: DB_NAME
+            value: "{{workflow.parameters.db-name}}"
+          - name: DB_USERNAME
+            value: "{{workflow.parameters.db-username}}"
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: dbPassword
+          - name: DB_ENGINE_VERSION
+            value: "{{workflow.parameters.db-engine-version}}"
+          - name: GIT_TF_PATH
+            value: "{{workflow.parameters.git-tf-path}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 6: Parse terraform outputs and print the connection summary
+    - name: report-step
+      container:
+        image: alpine:3
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            apk add --no-cache jq -q
+
+            if ! jq -e '.db_address.value' /mnt/data/tf-outputs.json > /dev/null 2>&1; then
+              echo "ERROR: terraform outputs not found. Apply step may have failed."
+              cat /mnt/data/tf-outputs.json
+              exit 1
+            fi
+
+            ADDRESS=$(jq -r '.db_address.value' /mnt/data/tf-outputs.json)
+            PORT=$(jq -r '.db_port.value' /mnt/data/tf-outputs.json)
+            DB_NAME_OUT=$(jq -r '.db_name.value' /mnt/data/tf-outputs.json)
+            DB_USER=$(jq -r '.db_username.value' /mnt/data/tf-outputs.json)
+            ARN=$(jq -r '.db_arn.value' /mnt/data/tf-outputs.json)
+            CONN_STRING_TEMPLATE="postgresql://${DB_USER}:<password>@${ADDRESS}:${PORT}/${DB_NAME_OUT}"
+
+            echo "================================================="
+            echo "  AWS RDS PostgreSQL Instance Created            "
+            echo "================================================="
+            echo "Host:              ${ADDRESS}"
+            echo "Port:              ${PORT}"
+            echo "Database:          ${DB_NAME_OUT}"
+            echo "Username:          ${DB_USER}"
+            echo "ARN:               ${ARN}"
+            echo "-------------------------------------------------"
+            echo "Connection String (template):"
+            echo "  ${CONN_STRING_TEMPLATE}"
+            echo ""
+            echo "NOTE: Password is stored in the '{{workflow.parameters.credentials-secret}}'"
+            echo "      Kubernetes Secret under the 'dbPassword' key."
+            echo "      Retrieve it with:"
+            echo "      kubectl get secret {{workflow.parameters.credentials-secret}} \\"
+            echo "        -o jsonpath='{.data.dbPassword}' | base64 -d"
+            echo "================================================="
+            echo ""
+            echo "NOTE: The instance is publicly accessible on port 5432."
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi
+
+---
+# ============================================================
+# Workflow — OpenChoreo CR defining the parameter schema
+# Deploy this to the Control Plane cluster
+# ============================================================
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workflow
+metadata:
+  name: aws-rds-postgres-create
+  namespace: default
+  annotations:
+    openchoreo.dev/description: "Provision an AWS RDS PostgreSQL instance using Terraform with state stored in S3"
+spec:
+  # Template Variable Reference (processed by controller):
+  # ${metadata.workflowRunName}  - WorkflowRun CR name
+  # ${metadata.namespaceName}    - Namespace name
+  # ${parameters.*}              - Values from the schema below
+
+  ttlAfterCompletion: "1d"
+
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        git:
+          type: object
+          default: {}
+          description: "Source repository that contains the Terraform files"
+          properties:
+            repoUrl:
+              type: string
+              default: "https://github.com/openchoreo/openchoreo.git"
+              description: "Git repository URL to clone at runtime (HTTPS). Override this to point to your own repo."
+            branch:
+              type: string
+              default: "main"
+              description: "Branch or tag to check out"
+            tfPath:
+              type: string
+              default: "samples/workflows/generic/aws-rds-postgres-create/terraform"
+              description: "Relative path inside the cloned repo that contains the Terraform files"
+        aws:
+          type: object
+          default: {}
+          properties:
+            region:
+              type: string
+              default: "us-east-1"
+              description: "AWS region where the RDS instance will be created"
+            credentialsSecret:
+              type: string
+              description: "Name of the Kubernetes Secret containing 'accessKeyId', 'secretAccessKey', and 'dbPassword' keys"
+        tfState:
+          type: object
+          default: {}
+          properties:
+            s3Bucket:
+              type: string
+              description: "S3 bucket name for storing the Terraform state file"
+        db:
+          type: object
+          default: {}
+          properties:
+            identifier:
+              type: string
+              description: "Unique RDS instance identifier (e.g. my-app-db). Also used as the Terraform state key prefix."
+            name:
+              type: string
+              description: "Name of the initial database to create inside the instance"
+            username:
+              type: string
+              description: "Master username for the database"
+            engineVersion:
+              type: string
+              default: "16"
+              description: "PostgreSQL engine major version (e.g. '16', '15')"
+
+  runTemplate:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      name: ${metadata.workflowRunName}
+      namespace: ${metadata.namespace}
+    spec:
+      arguments:
+        parameters:
+          - name: git-repo-url
+            value: ${parameters.git.repoUrl}
+          - name: git-branch
+            value: ${parameters.git.branch}
+          - name: git-tf-path
+            value: ${parameters.git.tfPath}
+          - name: aws-region
+            value: ${parameters.aws.region}
+          - name: credentials-secret
+            value: ${parameters.aws.credentialsSecret}
+          - name: tfstate-s3-bucket
+            value: ${parameters.tfState.s3Bucket}
+          - name: db-identifier
+            value: ${parameters.db.identifier}
+          - name: db-name
+            value: ${parameters.db.name}
+          - name: db-username
+            value: ${parameters.db.username}
+          - name: db-engine-version
+            value: ${parameters.db.engineVersion}
+      serviceAccountName: workflow-sa
+      workflowTemplateRef:
+        clusterScope: true
+        name: aws-rds-postgres-create
+
+---
+# ============================================================
+# WorkflowRun — triggers a single execution
+# Edit the parameters below and apply to run the workflow
+# ============================================================
+apiVersion: openchoreo.dev/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: aws-rds-postgres-create-run
+spec:
+  workflow:
+    name: aws-rds-postgres-create
+    parameters:
+      git:
+        repoUrl: "https://github.com/openchoreo/openchoreo.git"
+        branch: "main"
+        tfPath: "samples/workflows/generic/aws-rds-postgres-create/terraform"
+      aws:
+        region: "us-east-1"
+        credentialsSecret: "aws-rds-credentials"
+      tfState:
+        s3Bucket: "openchoreo-rds-tfstate"
+      db:
+        identifier: "my-app-db"
+        name: "myappdb"
+        username: "dbadmin"
+        engineVersion: "16"

--- a/samples/workflows/generic/aws-rds-postgres-create/aws-rds-postgres-delete.yaml
+++ b/samples/workflows/generic/aws-rds-postgres-create/aws-rds-postgres-delete.yaml
@@ -1,0 +1,349 @@
+# ============================================================
+# ClusterWorkflowTemplate — Argo Workflows execution template
+# Deploy this to the Workflow Plane cluster
+# ============================================================
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: aws-rds-postgres-delete
+spec:
+  entrypoint: pipeline
+  templates:
+    - name: pipeline
+      steps:
+        - - name: clone
+            template: clone-step
+        - - name: init
+            template: init-step
+        - - name: plan-destroy
+            template: plan-destroy-step
+        - - name: destroy
+            template: destroy-step
+
+    # Step 1: Clone the Terraform repo to get the Terraform files
+    - name: clone-step
+      container:
+        image: alpine/git:2.45.2
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            echo "Cloning repository ${GIT_REPO_URL} (branch: ${GIT_BRANCH}) ..."
+            git clone --depth 1 --branch "${GIT_BRANCH}" \
+              "${GIT_REPO_URL}" \
+              /mnt/data/repo
+            echo "Clone complete."
+        env:
+          - name: GIT_REPO_URL
+            value: "{{workflow.parameters.git-repo-url}}"
+          - name: GIT_BRANCH
+            value: "{{workflow.parameters.git-branch}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 2: terraform init — connect to the existing S3 state
+    - name: init-step
+      container:
+        image: hashicorp/terraform:1.9
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            ulimit -n 65535
+            TF_DIR="/mnt/data/repo/${GIT_TF_PATH}"
+            cd "$TF_DIR"
+
+            echo "Running terraform init ..."
+            terraform init \
+              -backend-config="bucket=${TFSTATE_S3_BUCKET}" \
+              -backend-config="key=rds/${DB_IDENTIFIER}/terraform.tfstate" \
+              -backend-config="region=${AWS_REGION}" \
+              -input=false
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: TFSTATE_S3_BUCKET
+            value: "{{workflow.parameters.tfstate-s3-bucket}}"
+          - name: DB_IDENTIFIER
+            value: "{{workflow.parameters.db-identifier}}"
+          - name: GIT_TF_PATH
+            value: "{{workflow.parameters.git-tf-path}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 3: terraform plan -destroy — dry run showing what will be deleted
+    - name: plan-destroy-step
+      container:
+        image: hashicorp/terraform:1.9
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            ulimit -n 65535
+            TF_DIR="/mnt/data/repo/${GIT_TF_PATH}"
+            cd "$TF_DIR"
+
+            echo "Running terraform plan -destroy ..."
+            terraform plan \
+              -destroy \
+              -var="aws_region=${AWS_REGION}" \
+              -var="db_identifier=${DB_IDENTIFIER}" \
+              -var="db_name=${DB_NAME}" \
+              -var="db_username=${DB_USERNAME}" \
+              -var="db_password=${DB_PASSWORD}" \
+              -var="db_engine_version=${DB_ENGINE_VERSION}" \
+              -input=false
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: DB_IDENTIFIER
+            value: "{{workflow.parameters.db-identifier}}"
+          - name: DB_NAME
+            value: "{{workflow.parameters.db-name}}"
+          - name: DB_USERNAME
+            value: "{{workflow.parameters.db-username}}"
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: dbPassword
+          - name: DB_ENGINE_VERSION
+            value: "{{workflow.parameters.db-engine-version}}"
+          - name: GIT_TF_PATH
+            value: "{{workflow.parameters.git-tf-path}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+    # Step 4: terraform destroy — delete the RDS instance and all associated resources
+    - name: destroy-step
+      container:
+        image: hashicorp/terraform:1.9
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            ulimit -n 65535
+            TF_DIR="/mnt/data/repo/${GIT_TF_PATH}"
+            cd "$TF_DIR"
+
+            echo "Running terraform destroy ..."
+            terraform destroy \
+              -auto-approve \
+              -var="aws_region=${AWS_REGION}" \
+              -var="db_identifier=${DB_IDENTIFIER}" \
+              -var="db_name=${DB_NAME}" \
+              -var="db_username=${DB_USERNAME}" \
+              -var="db_password=${DB_PASSWORD}" \
+              -var="db_engine_version=${DB_ENGINE_VERSION}" \
+              -input=false
+
+            echo "================================================="
+            echo "  AWS RDS PostgreSQL Instance Deleted            "
+            echo "================================================="
+            echo "Identifier: ${DB_IDENTIFIER}"
+            echo "The instance, subnet group, and security group"
+            echo "have been removed from AWS."
+            echo "================================================="
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: accessKeyId
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: secretAccessKey
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
+          - name: DB_IDENTIFIER
+            value: "{{workflow.parameters.db-identifier}}"
+          - name: DB_NAME
+            value: "{{workflow.parameters.db-name}}"
+          - name: DB_USERNAME
+            value: "{{workflow.parameters.db-username}}"
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{workflow.parameters.credentials-secret}}"
+                key: dbPassword
+          - name: DB_ENGINE_VERSION
+            value: "{{workflow.parameters.db-engine-version}}"
+          - name: GIT_TF_PATH
+            value: "{{workflow.parameters.git-tf-path}}"
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/data
+
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi
+
+---
+# ============================================================
+# Workflow — OpenChoreo CR defining the parameter schema
+# Deploy this to the Control Plane cluster
+# ============================================================
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workflow
+metadata:
+  name: aws-rds-postgres-delete
+  namespace: default
+  annotations:
+    openchoreo.dev/description: "Destroy an AWS RDS PostgreSQL instance provisioned by aws-rds-postgres-create"
+spec:
+  # Template Variable Reference (processed by controller):
+  # ${metadata.workflowRunName}  - WorkflowRun CR name
+  # ${metadata.namespaceName}    - Namespace name
+  # ${parameters.*}              - Values from the schema below
+
+  ttlAfterCompletion: "1d"
+
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        git:
+          type: object
+          default: {}
+          description: "Source repository that contains the Terraform files (must match the values used when creating the instance)"
+          properties:
+            repoUrl:
+              type: string
+              default: "https://github.com/openchoreo/openchoreo.git"
+              description: "Git repository URL to clone at runtime (HTTPS)"
+            branch:
+              type: string
+              default: "main"
+              description: "Branch or tag to check out"
+            tfPath:
+              type: string
+              default: "samples/workflows/generic/aws-rds-postgres-create/terraform"
+              description: "Relative path inside the cloned repo that contains the Terraform files"
+        aws:
+          type: object
+          default: {}
+          properties:
+            region:
+              type: string
+              default: "us-east-1"
+              description: "AWS region where the RDS instance was created"
+            credentialsSecret:
+              type: string
+              description: "Name of the Kubernetes Secret containing 'accessKeyId', 'secretAccessKey', and 'dbPassword' keys"
+        tfState:
+          type: object
+          default: {}
+          properties:
+            s3Bucket:
+              type: string
+              description: "S3 bucket name used to store the Terraform state file (must match the value used when creating the instance)"
+        db:
+          type: object
+          default: {}
+          properties:
+            identifier:
+              type: string
+              description: "RDS instance identifier to delete — must exactly match the identifier used when creating the instance"
+            name:
+              type: string
+              description: "Database name used when creating the instance"
+            username:
+              type: string
+              description: "Master username used when creating the instance"
+            engineVersion:
+              type: string
+              default: "16"
+              description: "PostgreSQL engine major version used when creating the instance"
+
+  runTemplate:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      name: ${metadata.workflowRunName}
+      namespace: ${metadata.namespace}
+    spec:
+      arguments:
+        parameters:
+          - name: git-repo-url
+            value: ${parameters.git.repoUrl}
+          - name: git-branch
+            value: ${parameters.git.branch}
+          - name: git-tf-path
+            value: ${parameters.git.tfPath}
+          - name: aws-region
+            value: ${parameters.aws.region}
+          - name: credentials-secret
+            value: ${parameters.aws.credentialsSecret}
+          - name: tfstate-s3-bucket
+            value: ${parameters.tfState.s3Bucket}
+          - name: db-identifier
+            value: ${parameters.db.identifier}
+          - name: db-name
+            value: ${parameters.db.name}
+          - name: db-username
+            value: ${parameters.db.username}
+          - name: db-engine-version
+            value: ${parameters.db.engineVersion}
+      serviceAccountName: workflow-sa
+      workflowTemplateRef:
+        clusterScope: true
+        name: aws-rds-postgres-delete
+
+---
+# ============================================================
+# WorkflowRun — triggers a single deletion
+# Use the same parameter values that were used to create the instance
+# ============================================================
+apiVersion: openchoreo.dev/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: aws-rds-postgres-delete-run
+spec:
+  workflow:
+    name: aws-rds-postgres-delete
+    parameters:
+      git:
+        repoUrl: "https://github.com/openchoreo/openchoreo.git"
+        branch: "main"
+        tfPath: "samples/workflows/generic/aws-rds-postgres-create/terraform"
+      aws:
+        region: "us-east-1"
+        credentialsSecret: "aws-rds-credentials"
+      tfState:
+        s3Bucket: "openchoreo-rds-tfstate"
+      db:
+        identifier: "my-app-db"
+        name: "myappdb"
+        username: "dbadmin"
+        engineVersion: "16"

--- a/samples/workflows/generic/aws-rds-postgres-create/terraform/main.tf
+++ b/samples/workflows/generic/aws-rds-postgres-create/terraform/main.tf
@@ -1,0 +1,95 @@
+terraform {
+  # Backend is configured at init time via -backend-config flags:
+  #   -backend-config="bucket=<s3-bucket>"
+  #   -backend-config="key=rds/<db-identifier>/terraform.tfstate"
+  #   -backend-config="region=<aws-region>"
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  required_version = ">= 1.9"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# ── Networking — use the default VPC's public subnets ────────────────────────
+# The default VPC has public subnets with a route to the internet gateway,
+# which is required for the publicly_accessible flag below to take effect.
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+resource "aws_db_subnet_group" "this" {
+  name        = "${var.db_identifier}-subnet-group"
+  subnet_ids  = data.aws_subnets.default.ids
+  description = "Subnet group for ${var.db_identifier}"
+}
+
+# ── Security group — allow PostgreSQL from anywhere (public sample) ───────────
+# Port 5432 is open to 0.0.0.0/0 so you can connect directly from your
+# workstation to verify the instance after provisioning.
+# For production use, restrict cidr_blocks to your application's IP range.
+
+resource "aws_security_group" "rds" {
+  name        = "${var.db_identifier}-rds-sg"
+  description = "Allow PostgreSQL access from anywhere (sample/test use)"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "PostgreSQL"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ── RDS PostgreSQL instance ───────────────────────────────────────────────────
+
+resource "aws_db_instance" "this" {
+  identifier        = var.db_identifier
+  engine            = "postgres"
+  engine_version    = var.db_engine_version
+  instance_class    = "db.t3.micro"  # free-tier eligible
+  allocated_storage = 20             # minimum allowed by AWS for PostgreSQL RDS
+  storage_type      = "gp2"
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  publicly_accessible = true
+  multi_az            = false
+  storage_encrypted   = false
+  deletion_protection = false
+  skip_final_snapshot = true
+
+  tags = {
+    ManagedBy = "openchoreo-workflow"
+  }
+}

--- a/samples/workflows/generic/aws-rds-postgres-create/terraform/outputs.tf
+++ b/samples/workflows/generic/aws-rds-postgres-create/terraform/outputs.tf
@@ -1,0 +1,29 @@
+output "db_address" {
+  description = "Hostname of the RDS instance (without port)"
+  value       = aws_db_instance.this.address
+}
+
+output "db_port" {
+  description = "Port the database is listening on"
+  value       = aws_db_instance.this.port
+}
+
+output "db_endpoint" {
+  description = "Connection endpoint in address:port format"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "db_name" {
+  description = "Name of the initial database"
+  value       = aws_db_instance.this.db_name
+}
+
+output "db_username" {
+  description = "Master username"
+  value       = aws_db_instance.this.username
+}
+
+output "db_arn" {
+  description = "ARN of the RDS instance"
+  value       = aws_db_instance.this.arn
+}

--- a/samples/workflows/generic/aws-rds-postgres-create/terraform/variables.tf
+++ b/samples/workflows/generic/aws-rds-postgres-create/terraform/variables.tf
@@ -1,0 +1,32 @@
+variable "aws_region" {
+  description = "AWS region where the RDS instance will be created"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "db_identifier" {
+  description = "Unique identifier for the RDS instance (also used as the Terraform state key)"
+  type        = string
+}
+
+variable "db_name" {
+  description = "Name of the initial database to create inside the instance"
+  type        = string
+}
+
+variable "db_username" {
+  description = "Master username for the database"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Master password for the database"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_engine_version" {
+  description = "PostgreSQL engine major version"
+  type        = string
+  default     = "16"
+}


### PR DESCRIPTION
## Purpose
- Fix https://github.com/openchoreo/openchoreo/issues/2395
- Adds a self-service Generic Workflow sample (`aws-rds-postgres-create`) that lets developers spin up a throwaway AWS RDS PostgreSQL instance for feature development or testing without
  involving the platform team
- Adds a companion `aws-rds-postgres-delete` workflow to cleanly destroy the provisioned instance via `terraform destroy`
- Parameterizes the git repo, branch, and Terraform path so users can point the workflow at their own repos; defaults point to the openchoreo repo