### PR TITLE
fix: migrate remaining refs to cluster-scoped kinds

### DIFF
--- a/samples/component-alerts/alert-rule-trait.yaml
+++ b/samples/component-alerts/alert-rule-trait.yaml
@@ -1,7 +1,7 @@
 ---
 # Trait for Alert Rules
 apiVersion: openchoreo.dev/v1alpha1
-kind: Trait
+kind: ClusterTrait
 metadata:
   name: observability-alert-rule
   namespace: default

--- a/samples/component-alerts/components-with-alert-rules.yaml
+++ b/samples/component-alerts/components-with-alert-rules.yaml
@@ -10,7 +10,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-application
   autoDeploy: true
 
@@ -44,7 +44,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 
@@ -77,7 +77,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/component-types/component-http-service/http-service-component.yaml
+++ b/samples/component-types/component-http-service/http-service-component.yaml
@@ -16,7 +16,7 @@ spec:
     projectName: default
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
 
 ---

--- a/samples/component-types/component-web-app/webapp-component.yaml
+++ b/samples/component-types/component-web-app/webapp-component.yaml
@@ -17,7 +17,7 @@ spec:
 
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-application
 
 ---

--- a/samples/component-types/component-with-api-management/component-with-api-management.yaml
+++ b/samples/component-types/component-with-api-management/component-with-api-management.yaml
@@ -13,7 +13,7 @@
 ---
 # API Configuration Trait - adds API management capabilities to services
 apiVersion: openchoreo.dev/v1alpha1
-kind: Trait
+kind: ClusterTrait
 metadata:
   name: api-configuration
   namespace: default
@@ -126,7 +126,7 @@ spec:
     projectName: default
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
 
   # Traits - API Configuration is added as a trait

--- a/samples/component-types/component-with-configs/component-with-configs.yaml
+++ b/samples/component-types/component-with-configs/component-with-configs.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: ComponentType
+kind: ClusterComponentType
 metadata:
   name: service-with-configs
   namespace: default
@@ -7,11 +7,11 @@ spec:
   workloadType: deployment
 
   allowedWorkflows:
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: gcp-buildpacks-builder
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: ballerina-buildpack-builder
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: dockerfile-builder
 
   allowedTraits:
@@ -280,7 +280,7 @@ spec:
     projectName: default
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service-with-configs
   autoDeploy: true
 

--- a/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+++ b/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
@@ -16,7 +16,7 @@
 ---
 # HorizontalPodAutoscaler Trait - demonstrates developer-configurable parameters with PE overrides
 apiVersion: openchoreo.dev/v1alpha1
-kind: Trait
+kind: ClusterTrait
 metadata:
   name: horizontal-pod-autoscaler
   namespace: default
@@ -85,7 +85,7 @@ spec:
 ---
 # Persistent Volume Trait - reused from component-with-traits sample
 apiVersion: openchoreo.dev/v1alpha1
-kind: Trait
+kind: ClusterTrait
 metadata:
   name: persistent-volume
   namespace: default
@@ -159,7 +159,7 @@ spec:
 # ComponentType extending the default service type structure with embedded HPA trait
 # The PE exposes autoscaling parameters through ComponentType schema, wired to the embedded HPA trait
 apiVersion: openchoreo.dev/v1alpha1
-kind: ComponentType
+kind: ClusterComponentType
 metadata:
   name: service-with-autoscaling
   namespace: default
@@ -167,11 +167,11 @@ spec:
   workloadType: deployment
 
   allowedWorkflows:
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: gcp-buildpacks-builder
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: ballerina-buildpack-builder
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: dockerfile-builder
 
   allowedTraits:
@@ -467,7 +467,7 @@ spec:
     projectName: default
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service-with-autoscaling
   autoDeploy: true
 

--- a/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
+++ b/samples/from-image/echo-websocket-service/echo-websocket-service.yaml
@@ -9,7 +9,7 @@ spec:
 
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
 
 ---

--- a/samples/from-image/go-greeter-service/greeter-service.yaml
+++ b/samples/from-image/go-greeter-service/greeter-service.yaml
@@ -9,7 +9,7 @@ spec:
 
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
 
 ---

--- a/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
+++ b/samples/from-image/issue-reporter-schedule-task/github-issue-reporter.yaml
@@ -9,7 +9,7 @@ spec:
 
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: cronjob/scheduled-task
 
   parameters:

--- a/samples/from-image/react-starter-web-app/react-starter.yaml
+++ b/samples/from-image/react-starter-web-app/react-starter.yaml
@@ -8,7 +8,7 @@ spec:
 
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-application
 
 ---

--- a/samples/gcp-microservices-demo/components/ad-component.yaml
+++ b/samples/gcp-microservices-demo/components/ad-component.yaml
@@ -9,7 +9,7 @@ spec:
 
   autoDeploy: true
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
 
 ---

--- a/samples/gcp-microservices-demo/components/cart-component.yaml
+++ b/samples/gcp-microservices-demo/components/cart-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/checkout-component.yaml
+++ b/samples/gcp-microservices-demo/components/checkout-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/currency-component.yaml
+++ b/samples/gcp-microservices-demo/components/currency-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/email-component.yaml
+++ b/samples/gcp-microservices-demo/components/email-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/frontend-component.yaml
+++ b/samples/gcp-microservices-demo/components/frontend-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-application
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/payment-component.yaml
+++ b/samples/gcp-microservices-demo/components/payment-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/productcatalog-component.yaml
+++ b/samples/gcp-microservices-demo/components/productcatalog-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/recommendation-component.yaml
+++ b/samples/gcp-microservices-demo/components/recommendation-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/redis-component.yaml
+++ b/samples/gcp-microservices-demo/components/redis-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gcp-microservices-demo/components/shipping-component.yaml
+++ b/samples/gcp-microservices-demo/components/shipping-component.yaml
@@ -8,7 +8,7 @@ spec:
     projectName: gcp-microservice-demo
 
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   autoDeploy: true
 

--- a/samples/gitops-workflows/workflows/bulk-release/bulk-gitops-release.yaml
+++ b/samples/gitops-workflows/workflows/bulk-release/bulk-gitops-release.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: bulk-gitops-release
   namespace: default

--- a/samples/ocSchema/component-traits/alert-rule-trait.yaml
+++ b/samples/ocSchema/component-traits/alert-rule-trait.yaml
@@ -1,7 +1,7 @@
 ---
 # Trait for Alert Rules - reusable across any component type
 apiVersion: openchoreo.dev/v1alpha1
-kind: Trait
+kind: ClusterTrait
 metadata:
   name: observability-alert-rule
   namespace: default

--- a/samples/ocSchema/component-traits/api-management.yaml
+++ b/samples/ocSchema/component-traits/api-management.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Trait
+kind: ClusterTrait
 metadata:
   name: api-configuration
   namespace: default

--- a/samples/ocSchema/component-types/scheduled-task.yaml
+++ b/samples/ocSchema/component-types/scheduled-task.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: ComponentType
+kind: ClusterComponentType
 metadata:
   name: scheduled-task
   namespace: default
@@ -9,9 +9,9 @@ spec:
   workloadType: cronjob
 
   allowedWorkflows:
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: google-cloud-buildpacks
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: docker
 
   allowedTraits: []

--- a/samples/ocSchema/component-types/service.yaml
+++ b/samples/ocSchema/component-types/service.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: ComponentType
+kind: ClusterComponentType
 metadata:
   name: service
   namespace: default
@@ -9,11 +9,11 @@ spec:
   workloadType: deployment
 
   allowedWorkflows:
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: google-cloud-buildpacks
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: ballerina-buildpack
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: docker
 
   allowedTraits:

--- a/samples/ocSchema/component-types/webapp.yaml
+++ b/samples/ocSchema/component-types/webapp.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: ComponentType
+kind: ClusterComponentType
 metadata:
   name: web-application
   namespace: default
@@ -9,9 +9,9 @@ spec:
   workloadType: deployment
 
   allowedWorkflows:
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: react
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: docker
 
   allowedTraits:

--- a/samples/ocSchema/component-types/worker.yaml
+++ b/samples/ocSchema/component-types/worker.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: ComponentType
+kind: ClusterComponentType
 metadata:
   name: worker
   namespace: default
@@ -9,9 +9,9 @@ spec:
   workloadType: deployment
 
   allowedWorkflows:
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: google-cloud-buildpacks
-    - kind: Workflow
+    - kind: ClusterWorkflow
       name: docker
 
   allowedTraits:

--- a/samples/ocSchema/workflows/ballerina-buildpack.yaml
+++ b/samples/ocSchema/workflows/ballerina-buildpack.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: ballerina-buildpack
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
   ttlAfterCompletion: "1d"
   parameters:

--- a/samples/ocSchema/workflows/docker.yaml
+++ b/samples/ocSchema/workflows/docker.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: docker
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
   ttlAfterCompletion: "1d"
   parameters:

--- a/samples/ocSchema/workflows/google-cloud-buildpacks-with-types.yaml
+++ b/samples/ocSchema/workflows/google-cloud-buildpacks-with-types.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: google-cloud-buildpacks
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
 
   # Template Variable Reference (processed by WorkflowRun controller):

--- a/samples/ocSchema/workflows/google-cloud-buildpacks.yaml
+++ b/samples/ocSchema/workflows/google-cloud-buildpacks.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: google-cloud-buildpacks
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
   ttlAfterCompletion: "1d"
   parameters:

--- a/samples/ocSchema/workflows/react.yaml
+++ b/samples/ocSchema/workflows/react.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: react
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
   ttlAfterCompletion: "1d"
   parameters:

--- a/samples/workflows/ci/docker.yaml
+++ b/samples/workflows/ci/docker.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: docker
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
 
   # Template Variable Reference (processed by WorkflowRun controller):

--- a/samples/workflows/ci/google-cloud-buildpacks.yaml
+++ b/samples/workflows/ci/google-cloud-buildpacks.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: google-cloud-buildpacks
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
 
   # Template Variable Reference (processed by WorkflowRun controller):

--- a/samples/workflows/ci/react.yaml
+++ b/samples/workflows/ci/react.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: react
   namespace: default
@@ -14,7 +14,7 @@ metadata:
       secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
-    kind: WorkflowPlane
+    kind: ClusterWorkflowPlane
     name: default
 
   # Template Variable Reference (processed by WorkflowRun controller):

--- a/samples/workflows/generic/github-stats-report/workflow-github-stats-report.yaml
+++ b/samples/workflows/generic/github-stats-report/workflow-github-stats-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: github-stats-report
   namespace: default

--- a/samples/workflows/generic/scm-create-repo/codecommit-create-repo.yaml
+++ b/samples/workflows/generic/scm-create-repo/codecommit-create-repo.yaml
@@ -101,7 +101,7 @@ spec:
 # Deploy this to the Control Plane cluster
 # ============================================================
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: scm-codecommit-create-repo
   namespace: default

--- a/samples/workflows/generic/scm-create-repo/github-create-repo.yaml
+++ b/samples/workflows/generic/scm-create-repo/github-create-repo.yaml
@@ -119,7 +119,7 @@ spec:
 # Deploy this to the Control Plane cluster
 # ============================================================
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workflow
+kind: ClusterWorkflow
 metadata:
   name: scm-github-create-repo
   namespace: default


### PR DESCRIPTION
fixes sample kind references from #2532

after #2532 switched default platform resources to cluster scoped kinds, some sample manifests still pointed to the namespaced kinds. that made the examples inconsistent and easy to trip over.

changes:
- switched remaining sample refs from `ComponentType`, `Trait`, `Workflow`, and `WorkflowPlane` to `ClusterComponentType`, `ClusterTrait`, `ClusterWorkflow`, and `ClusterWorkflowPlane`
- kept Argo run templates on `apiVersion: argoproj.io/v1alpha1` with `kind: Workflow` so those stay valid

tested on local workspace with ripgrep scans over `samples/**/*.yaml` and `samples/**/*.yml` to confirm no stale non cluster OpenChoreo kinds remain.

also relates to #2532
