### PR TITLE
fix: bump thunder version to 0.26.0

### DIFF
--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -34,7 +34,7 @@ configuration:
     scheme: "http"
 
   database:
-    identity:
+    config:
       type: sqlite
       sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
     runtime:

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -68,7 +68,7 @@ helm upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
   --kube-context k3d-openchoreo-cp \
   --namespace thunder \
   --create-namespace \
-  --version 0.24.0 \
+  --version 0.26.0 \
   --values install/k3d/common/values-thunder.yaml
 ```
 

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -85,7 +85,7 @@ Bootstrap scripts auto-configure the org, users, groups, and OAuth apps on first
 helm upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
   --namespace thunder \
   --create-namespace \
-  --version 0.24.0 \
+  --version 0.26.0 \
   --values install/k3d/common/values-thunder.yaml
 ```
 

--- a/install/quick-start/.config.sh
+++ b/install/quick-start/.config.sh
@@ -29,4 +29,4 @@ ESO_REPO="oci://ghcr.io/external-secrets/charts"
 KGATEWAY_VERSION="v2.2.1"
 
 # Thunder configuration
-THUNDER_VERSION="0.24.0"
+THUNDER_VERSION="0.26.0"

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -30,7 +30,7 @@ GATEWAY_API_VERSION    ?= v1.4.1
 CERT_MANAGER_VERSION   ?= v1.19.2
 ESO_VERSION            ?= 1.3.2
 KGATEWAY_VERSION       ?= v2.1.1
-THUNDER_VERSION        ?= 0.24.0
+THUNDER_VERSION        ?= 0.26.0
 
 # Helm chart references: local chart dirs or OCI registry
 ifeq ($(E2E_HELM_SOURCE),oci)


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2583

This pull request updates the Thunder component version across multiple configuration files and makes a minor change to the database configuration structure. The main goal is to ensure consistency in the Thunder version used throughout the project and improve clarity in configuration naming.

Thunder version update:

* Updated the `THUNDER_VERSION` variable from `0.24.0` to `0.26.0` in `.config.sh`, `e2e.mk`, and Helm command references in both `multi-cluster/README.md` and `single-cluster/README.md` to ensure the latest version is used across all environments. [[1]](diffhunk://#diff-081046352a184781354bfe4f231f7927a7c25fc93a3265e46db001457688a858L32-R32) [[2]](diffhunk://#diff-8a117bbc6863d3e4a11c6c059178d5dc78b0376e9696c25253d99a4a7b62ef7eL33-R33) [[3]](diffhunk://#diff-c274cd4f3f8de8434acc449281ffd0045c7e544f095d87185c0a97353581edc0L71-R71) [[4]](diffhunk://#diff-0c0ca444a315238a047afe983167f3482345dbe2eaee8edb95e4d8f35cf3aff0L88-R88)

Configuration structure improvement:

* Renamed the `identity` key to `config` under the `database` section in `values-thunder.yaml` for improved clarity and maintainability.