### PR TITLE
feat: add configurable auth, refine remediation model, and bump deps

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/deployment.yaml
@@ -2,6 +2,9 @@
 {{- if not .Values.rca.secretName }}
 {{- fail "rca.secretName is required when rca is enabled. Create a Secret with keys matching the RCA agent's expected env vars (RCA_LLM_API_KEY, OAUTH_CLIENT_SECRET, and optionally SQL_BACKEND_URI), then set rca.secretName." }}
 {{- end }}
+{{- if not .Values.rca.observerApiUrl }}
+{{- fail "rca.observerApiUrl is required when rca is enabled. Set it to the Observer API base URL (e.g. http://observer:8080)." }}
+{{- end }}
 {{- if and (eq .Values.rca.reportBackend "sqlite") (gt (.Values.rca.replicas | int) 1) }}
 {{- fail "rca.replicas must be 1 when using sqlite backend (ReadWriteOnce PVC). Set rca.replicas=1 or use reportBackend=postgresql." }}
 {{- end }}
@@ -21,6 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ai-rca-agent/rca-agent-config.yaml") . | sha256sum }}
+        checksum/observer-auth-config: {{ include (print $.Template.BasePath "/observer/observer-auth-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" .Values.rca.name) | nindent 8 }}
     spec:
@@ -67,8 +71,11 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
 
-        {{- if eq .Values.rca.reportBackend "sqlite" }}
         volumeMounts:
+        - name: auth-config
+          mountPath: /etc/openchoreo
+          readOnly: true
+        {{- if eq .Values.rca.reportBackend "sqlite" }}
         - name: data
           mountPath: /app/data
         {{- end }}
@@ -78,8 +85,11 @@ spec:
           readOnlyRootFilesystem: false
           runAsNonRoot: true
           runAsUser: 12000
-      {{- if eq .Values.rca.reportBackend "sqlite" }}
       volumes:
+      - name: auth-config
+        configMap:
+          name: observer-auth-config
+      {{- if eq .Values.rca.reportBackend "sqlite" }}
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.rca.name }}-data

--- a/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/http-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/http-route.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   parentRefs:
   - name: gateway-default
-    sectionName: http
   {{- with .Values.rca.http.hostnames }}
   hostnames:
     {{- range . }}

--- a/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/rca-agent-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/rca-agent-config.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" .Values.rca.name) | nindent 4 }}
 data:
-  OBSERVER_MCP_URL: {{ .Values.rca.observerMcpUrl | default "http://observer:8080/mcp" | quote }}
-  CONTROL_PLANE_URL: {{ .Values.rca.controlPlaneUrl | quote }}
+  OBSERVER_API_URL: {{ .Values.rca.observerApiUrl | quote }}
+  OPENCHOREO_API_URL: {{ .Values.rca.openchoreoApiUrl | quote }}
   AUTHZ_TIMEOUT_SECONDS: {{ .Values.rca.authz.timeoutSeconds | quote }}
   RCA_MODEL_NAME: {{ .Values.rca.llm.modelName | quote }}
   REPORT_BACKEND: {{ .Values.rca.reportBackend | quote }}
@@ -18,6 +18,7 @@ data:
   JWT_JWKS_URL: {{ .Values.security.oidc.jwksUrl | quote }}
   JWT_ISSUER: {{ .Values.security.oidc.issuer | quote }}
   JWT_AUDIENCE: {{ .Values.security.jwt.audience | quote }}
+  AUTH_CONFIG_PATH: /etc/openchoreo/auth-config.yaml
   LOG_LEVEL: {{ .Values.rca.logLevel | quote }}
   REMED_AGENT: {{ .Values.rca.remedAgent | quote }}
   {{- if .Values.rca.cors.allowedOrigins }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -3629,12 +3629,6 @@
           "title": "authz",
           "type": "object"
         },
-        "controlPlaneUrl": {
-          "default": "http://api.openchoreo.localhost:8080",
-          "description": "Control plane API base URL used by rca-agent",
-          "title": "controlPlaneUrl",
-          "type": "string"
-        },
         "cors": {
           "additionalProperties": false,
           "description": "CORS configuration for the RCA agent",
@@ -3774,10 +3768,16 @@
           "title": "oauth",
           "type": "object"
         },
-        "observerMcpUrl": {
+        "observerApiUrl": {
           "default": "",
-          "description": "Observer MCP endpoint URL",
-          "title": "observerMcpUrl",
+          "description": "Observer API base URL",
+          "title": "observerApiUrl",
+          "type": "string"
+        },
+        "openchoreoApiUrl": {
+          "default": "http://api.openchoreo.localhost:8080",
+          "description": "OpenChoreo API base URL used by rca-agent",
+          "title": "openchoreoApiUrl",
           "type": "string"
         },
         "remedAgent": {

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -3141,17 +3141,17 @@ rca:
 
   # @schema
   # type: string
-  # description: Observer MCP endpoint URL
+  # description: Observer API base URL
   # default: ""
   # @schema
-  observerMcpUrl: ""
+  observerApiUrl: ""
 
   # @schema
   # type: string
-  # description: Control plane API base URL used by rca-agent
+  # description: OpenChoreo API base URL used by rca-agent
   # default: "http://api.openchoreo.localhost:8080"
   # @schema
-  controlPlaneUrl: "http://api.openchoreo.localhost:8080"
+  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
 
   # @schema
   # type: string

--- a/rca-agent/Dockerfile
+++ b/rca-agent/Dockerfile
@@ -52,4 +52,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app"
 USER 12000
 
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/rca-agent/auth-config.yaml
+++ b/rca-agent/auth-config.yaml
@@ -1,0 +1,18 @@
+auth:
+  subject_types:
+    - type: "user"
+      display_name: "User"
+      priority: 1
+      auth_mechanisms:
+        - type: "jwt"
+          entitlement:
+            claim: "groups"
+            display_name: "User Group"
+    - type: "service_account"
+      display_name: "Service Account"
+      priority: 2
+      auth_mechanisms:
+        - type: "jwt"
+          entitlement:
+            claim: "sub"
+            display_name: "Client ID"

--- a/rca-agent/openapi.yaml
+++ b/rca-agent/openapi.yaml
@@ -248,10 +248,10 @@ paths:
     put:
       tags:
         - RCA Reports
-      summary: Update report state (mark actions as applied)
+      summary: Update action statuses
       description: |
-        Marks the specified remediation actions as `applied` in the stored report.
-        Called by the frontend after successfully applying fixes client-side.
+        Updates the status of specific remediation actions in the stored report.
+        Accepts indices to mark as `applied` or `dismissed`.
       operationId: updateReport
       parameters:
         - name: report_id
@@ -267,7 +267,7 @@ paths:
               $ref: '#/components/schemas/ReportUpdateRequest'
       responses:
         '200':
-          description: Report updated successfully
+          description: Actions updated successfully
           content:
             application/json:
               schema:
@@ -582,17 +582,7 @@ components:
 
     ReportAlertContext:
       type: object
-      required:
-        [
-          alert_id,
-          alert_name,
-          triggered_at,
-          trigger_value,
-          condition,
-          component,
-          project,
-          environment,
-        ]
+      required: [alert_id, alert_name, triggered_at, trigger_value, condition, component, project, environment]
       properties:
         alert_id:
           type: string
@@ -672,13 +662,7 @@ components:
           enum: [no_root_cause_identified]
         outcome:
           type: string
-          enum:
-            [
-              no_anomaly_detected,
-              insufficient_data,
-              transient,
-              external_dependency,
-            ]
+          enum: [no_anomaly_detected, insufficient_data, transient, external_dependency]
         explanation:
           type: string
         recommendations:
@@ -852,20 +836,18 @@ components:
 
     RecommendedAction:
       type: object
-      required: [description]
+      required: [description, status]
       allOf:
         - $ref: '#/components/schemas/Action'
         - type: object
           properties:
             status:
               type: string
-              enum: [suggested, revised, applied]
+              enum: [suggested, revised, applied, dismissed]
               default: suggested
-            changes:
-              type: array
-              default: []
-              items:
-                $ref: '#/components/schemas/ResourceChange'
+            change:
+              nullable: true
+              $ref: '#/components/schemas/ResourceChange'
 
     ResourceChange:
       type: object
@@ -873,23 +855,19 @@ components:
       properties:
         release_binding:
           type: string
-          description: Name of the ReleaseBinding to modify
         env:
           type: array
           default: []
-          description: Environment variable changes, identified by key name
           items:
             $ref: '#/components/schemas/EnvVarChange'
         files:
           type: array
           default: []
-          description: File mount changes, identified by key name
           items:
             $ref: '#/components/schemas/FileChange'
         fields:
           type: array
           default: []
-          description: Field-level changes for non-array paths (trait overrides, componentType overrides)
           items:
             $ref: '#/components/schemas/FieldChange'
 
@@ -899,24 +877,19 @@ components:
       properties:
         key:
           type: string
-          description: "Environment variable name (e.g. POSTGRES_DSN)"
         value:
           type: string
-          description: New value for the environment variable
 
     FileChange:
       type: object
-      required: [key]
+      required: [key, mount_path, value]
       properties:
         key:
           type: string
-          description: "File key (e.g. config.yaml)"
-        value:
-          type: string
-          description: New file content
         mount_path:
           type: string
-          description: "New mount path (e.g. /app/)"
+        value:
+          type: string
 
     FieldChange:
       type: object
@@ -924,25 +897,25 @@ components:
       properties:
         json_pointer:
           type: string
-          description: "RFC 6901 JSON Pointer for non-array fields. Example: /spec/traitEnvironmentConfigs/my-trait/enabled"
         value:
-          description: Value to set at the JSON Pointer location
           oneOf:
             - type: string
             - type: number
             - type: boolean
-            - type: object
-            - type: array
 
     ReportUpdateRequest:
       type: object
-      required: [appliedIndices]
       properties:
         appliedIndices:
           type: array
+          default: []
           items:
             type: integer
-          description: Indices of the recommended actions to mark as applied
+        dismissedIndices:
+          type: array
+          default: []
+          items:
+            type: integer
 
   securitySchemes:
     bearerAuth:

--- a/rca-agent/pyproject.toml
+++ b/rca-agent/pyproject.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 description = "Add your description here"
 requires-python = ">=3.14"
 dependencies = [
-    "authlib>=1.4.0",
-    "fastapi>=0.121.1",
+    "authlib>=1.6.8",
+    "fastapi>=0.133.1",
     "httpx>=0.23.0",
     "jinja2>=3.1.0",
     "langchain>=1.0.5",
-    "langchain-anthropic>=1.3.1",
     "langchain-mcp-adapters>=0.2.1",
-    "langchain-openai>=1.1.7",
+    "langchain-openai>=1.1.10",
     "numpy>=2.4.1",
     "aiosqlite>=0.20.0",
     "asyncpg>=0.30.0",
     "sqlalchemy[asyncio]>=2.0.0",
     "pyjwt[crypto]>=2.8.0",
-    "uvicorn>=0.38.0",
+    "pyyaml>=6.0.0",
+    "uvicorn>=0.41.0",
 ]
 
 [tool.uv]

--- a/rca-agent/src/api/report_routes.py
+++ b/rca-agent/src/api/report_routes.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import ConfigDict, Field
 
-from src.auth import require_authn, require_reports_authz
+from src.auth import require_authn, require_reports_authz, require_reports_update_authz
 from src.auth.authz_models import SubjectContext
 from src.clients import get_report_backend
 from src.helpers import resolve_project_scope, validate_time_range
@@ -46,7 +46,7 @@ class RCAReportDetailed(BaseModel):
 
 
 @router.get(
-    "/",
+    "",
     response_model=RCAReportsResponse,
     response_model_by_alias=True,
 )
@@ -113,7 +113,8 @@ async def get_rca_report(
 
 
 class ReportUpdateRequest(BaseModel):
-    applied_indices: list[int] = Field(alias="appliedIndices")
+    applied_indices: list[int] = Field(default_factory=list, alias="appliedIndices")
+    dismissed_indices: list[int] = Field(default_factory=list, alias="dismissedIndices")
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -122,21 +123,38 @@ async def update_report(
     report_id: str,
     body: ReportUpdateRequest,
     _auth: Annotated[SubjectContext, Depends(require_authn)],
-    _authz: Annotated[SubjectContext, Depends(require_reports_authz)],
+    _authz: Annotated[SubjectContext, Depends(require_reports_update_authz)],
 ):
+    overlap = set(body.applied_indices) & set(body.dismissed_indices)
+    if overlap:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Indices cannot appear in both appliedIndices and dismissedIndices: {sorted(overlap)}",
+        )
+
     logger.info(
-        "Updating report %s: marking actions %s as applied", report_id, body.applied_indices
+        "Updating report %s: applied=%s dismissed=%s",
+        report_id,
+        body.applied_indices,
+        body.dismissed_indices,
     )
-    await _mark_actions_applied(report_id, set(body.applied_indices))
+    await _update_action_statuses(
+        report_id,
+        applied=set(body.applied_indices),
+        dismissed=set(body.dismissed_indices),
+    )
     return {"status": "ok"}
 
 
-async def _mark_actions_applied(report_id: str, applied_indices: set[int]) -> None:
+async def _update_action_statuses(
+    report_id: str,
+    applied: set[int],
+    dismissed: set[int],
+) -> None:
     report_backend = get_report_backend()
     stored = await report_backend.get_rca_report(report_id)
     if not stored:
-        logger.warning("Cannot update action statuses: report %s not found", report_id)
-        return
+        raise HTTPException(status_code=404, detail="Report not found")
 
     actions = (
         stored.get("report", {})
@@ -147,8 +165,12 @@ async def _mark_actions_applied(report_id: str, applied_indices: set[int]) -> No
 
     changed = False
     for i, action in enumerate(actions):
-        if i in applied_indices and action.get("status") == "revised":
+        current = action.get("status")
+        if i in applied and current == "revised":
             action["status"] = "applied"
+            changed = True
+        elif i in dismissed and current in ("revised", "suggested"):
+            action["status"] = "dismissed"
             changed = True
 
     if changed:

--- a/rca-agent/src/auth/__init__.py
+++ b/rca-agent/src/auth/__init__.py
@@ -10,7 +10,12 @@ from src.auth.authz_models import (
     SubjectContext,
 )
 from src.auth.bearer import BearerTokenAuth
-from src.auth.dependencies import require_authn, require_chat_authz, require_reports_authz
+from src.auth.dependencies import (
+    require_authn,
+    require_chat_authz,
+    require_reports_authz,
+    require_reports_update_authz,
+)
 from src.auth.jwt import JWTValidationError, JWTValidator, get_jwt_validator
 from src.auth.oauth_client import check_oauth2_connection, get_oauth2_auth
 
@@ -34,4 +39,5 @@ __all__ = [
     "require_authn",
     "require_chat_authz",
     "require_reports_authz",
+    "require_reports_update_authz",
 ]

--- a/rca-agent/src/auth/dependencies.py
+++ b/rca-agent/src/auth/dependencies.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from pathlib import Path
 from typing import Annotated, Any
 
+import yaml
 from fastapi import Depends, HTTPException, Request
 
 from src.auth.authz_client import AuthzClient
@@ -19,6 +21,50 @@ from src.config import settings
 logger = logging.getLogger(__name__)
 
 _authz_client: AuthzClient | None = None
+_auth_config: dict[str, Any] | None = None
+
+
+def _load_auth_config() -> dict[str, Any]:
+    global _auth_config
+    if _auth_config is not None:
+        return _auth_config
+
+    config_path = settings.auth_config_path
+    if not config_path or not Path(config_path).is_file():
+        logger.warning("Auth config not found at %s, using defaults", config_path)
+        _auth_config = {}
+        return _auth_config
+
+    with open(config_path) as f:
+        _auth_config = yaml.safe_load(f) or {}
+
+    logger.info("Loaded auth config from %s", config_path)
+    return _auth_config
+
+
+def _get_subject_types() -> list[dict[str, Any]]:
+    config = _load_auth_config()
+    types = list(config.get("auth", {}).get("subject_types", []))
+    types.sort(key=lambda t: t.get("priority", 0))
+    return types
+
+
+def _get_jwt_claim(subject_type_config: dict[str, Any]) -> str | None:
+    for mech in subject_type_config.get("auth_mechanisms", []):
+        if mech.get("type") == "jwt":
+            return mech.get("entitlement", {}).get("claim")
+    return None
+
+
+def _extract_entitlements(claims: dict[str, Any], claim: str) -> list[str] | None:
+    if claim not in claims:
+        return None
+    value = claims[claim]
+    if isinstance(value, list):
+        return [str(v) for v in value if v]
+    if value:
+        return [str(value)]
+    return []
 
 
 def get_authz_client() -> AuthzClient:
@@ -45,26 +91,25 @@ def extract_bearer_token(request: Request) -> str | None:
 
 
 def extract_subject_context_from_claims(claims: dict[str, Any]) -> SubjectContext:
-    # Service account: has client_id but no sub
-    if "client_id" in claims and "sub" not in claims:
-        subject_type = "service"
-        entitlement_claim = "client_id"
-        entitlement_values = [claims.get("client_id", "")]
-    else:
-        # Regular user
-        subject_type = "user"
-        if "groups" in claims:
-            entitlement_claim = "groups"
-            groups = claims.get("groups", [])
-            entitlement_values = groups if isinstance(groups, list) else [groups]
-        else:
-            entitlement_claim = "sub"
-            entitlement_values = [claims.get("sub", "")]
+    for st in _get_subject_types():
+        claim = _get_jwt_claim(st)
+        if claim is None:
+            continue
+        entitlements = _extract_entitlements(claims, claim)
+        if entitlements is None:
+            continue
+        return SubjectContext(
+            type=st.get("type", "unknown"),
+            entitlementClaim=claim,
+            entitlementValues=entitlements,
+        )
 
+    # Fallback when no config matches
+    sub = claims.get("sub", "")
     return SubjectContext(
-        type=subject_type,
-        entitlementClaim=entitlement_claim,
-        entitlementValues=entitlement_values,
+        type="user",
+        entitlementClaim="sub",
+        entitlementValues=[sub] if sub else [],
     )
 
 
@@ -188,4 +233,7 @@ class ReportAuthorizationChecker(AuthorizationChecker):
 require_chat_authz = AuthorizationChecker(action="rcareport:view", resource_type="rcareport")
 require_reports_authz = ReportAuthorizationChecker(
     action="rcareport:view", resource_type="rcareport"
+)
+require_reports_update_authz = ReportAuthorizationChecker(
+    action="rcareport:update", resource_type="rcareport"
 )

--- a/rca-agent/src/clients/openchoreo_api.py
+++ b/rca-agent/src/clients/openchoreo_api.py
@@ -10,7 +10,7 @@ from src.config import settings
 
 logger = logging.getLogger(__name__)
 
-_API_BASE = f"{settings.control_plane_url.rstrip('/')}/api/v1"
+_API_BASE = f"{settings.openchoreo_api_url.rstrip('/')}/api/v1"
 
 
 _HEADERS = {"X-Use-OpenAPI": "true"}

--- a/rca-agent/src/config.py
+++ b/rca-agent/src/config.py
@@ -18,12 +18,16 @@ class Settings(BaseSettings):
     rca_model_name: str = ""
     rca_llm_api_key: str = ""
 
-    observer_mcp_url: str = "http://observer:8080/mcp"
-    control_plane_url: str = "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
+    observer_api_url: str = "http://observer:8080"
+    openchoreo_api_url: str = "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
+
+    @property
+    def observer_mcp_url(self) -> str:
+        return f"{self.observer_api_url.rstrip('/')}/mcp"
 
     @property
     def openchoreo_mcp_url(self) -> str:
-        return f"{self.control_plane_url.rstrip('/')}/mcp"
+        return f"{self.openchoreo_api_url.rstrip('/')}/mcp"
 
     report_backend: str = "sqlite"
     sql_backend_uri: str = ""
@@ -36,10 +40,11 @@ class Settings(BaseSettings):
     jwt_audience: str = ""
     jwt_jwks_refresh_interval: int = 3600
     authz_timeout_seconds: int = 30
+    auth_config_path: str = "auth-config.yaml"
 
     @property
     def authz_service_url(self) -> str:
-        return self.control_plane_url.rstrip("/")
+        return self.openchoreo_api_url.rstrip("/")
 
     max_concurrent_analyses: int = 5
     analysis_timeout_seconds: int = 1500

--- a/rca-agent/src/logging_config.py
+++ b/rca-agent/src/logging_config.py
@@ -44,6 +44,7 @@ def setup_logging():
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("mcp.client.streamable_http").setLevel(logging.WARNING)
+    logging.getLogger("aiosqlite").setLevel(logging.WARNING)
 
     # Control OpenAI client log level
     if settings.openai_debug_logs:

--- a/rca-agent/src/main.py
+++ b/rca-agent/src/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 
 from src.api import agent_router, report_router
 from src.auth import check_oauth2_connection, get_oauth2_auth
+from src.auth.dependencies import _load_auth_config
 from src.clients import MCPClient, get_model, get_report_backend
 from src.config import settings
 from src.logging_config import setup_logging
@@ -49,6 +50,14 @@ async def lifespan(_app: FastAPI):
         logger.error("OAuth2 initialization failed: %s", e)
         raise RuntimeError(f"OAuth2 initialization failed: {e}") from e
 
+    logger.info("Loading auth config...")
+    try:
+        _load_auth_config()
+        logger.info("Auth config loaded successfully")
+    except Exception as e:
+        logger.error("Auth config loading failed: %s", e)
+        raise RuntimeError(f"Auth config loading failed: {e}") from e
+
     logger.info("Testing MCP connections...")
     try:
         mcp_client = MCPClient(auth=get_oauth2_auth())
@@ -64,7 +73,7 @@ async def lifespan(_app: FastAPI):
     await report_backend.close()
 
 
-app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
+app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None, strict_content_type=False)
 
 # Configure CORS if allowed origins are specified
 if settings.cors_allowed_origins:

--- a/rca-agent/src/models/remediation_result.py
+++ b/rca-agent/src/models/remediation_result.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import StrEnum
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -11,6 +10,7 @@ class ActionStatus(StrEnum):
     SUGGESTED = "suggested"
     REVISED = "revised"
     APPLIED = "applied"
+    DISMISSED = "dismissed"
 
 
 class EnvVarChange(BaseModel):
@@ -21,17 +21,17 @@ class EnvVarChange(BaseModel):
 
 
 class FileChange(BaseModel):
-    """A single file mount change, identified by key name"""
+    """A content-only change to an existing file mount, identified by key + mountPath"""
 
     model_config = ConfigDict(populate_by_name=True)
 
-    key: str = Field(..., description="File key (e.g. 'config.yaml')")
-    value: str | None = Field(default=None, description="New file content")
-    mount_path: str | None = Field(
-        default=None,
+    key: str = Field(..., description="File key of the existing mount (e.g. 'config.yaml')")
+    mount_path: str = Field(
+        ...,
         alias="mountPath",
-        description="New mount path (e.g. '/app/')",
+        description="Mount path that identifies the file mount (e.g. '/app/frontend/'). Must match an existing mount.",
     )
+    value: str = Field(..., description="New file content")
 
 
 class FieldChange(BaseModel):
@@ -48,7 +48,13 @@ class FieldChange(BaseModel):
             "'/spec/traitEnvironmentConfigs/my-trait/enabled'"
         ),
     )
-    value: Any = Field(..., description="Value to set at the JSON Pointer location")
+    value: str | int | float | bool = Field(
+        ...,
+        description=(
+            "Scalar value to set at the JSON Pointer location. "
+            "For nested objects, flatten into separate FieldChange entries with leaf-level pointers."
+        ),
+    )
 
 
 class ResourceChange(BaseModel):
@@ -64,7 +70,7 @@ class ResourceChange(BaseModel):
     )
     files: list[FileChange] = Field(
         default_factory=list,
-        description="File mount changes, identified by key. Updates existing files or appends new ones.",
+        description="File content changes for existing mounts, identified by key + mountPath. Only the content (value) is changed.",
     )
     fields: list[FieldChange] = Field(
         default_factory=list,
@@ -84,9 +90,9 @@ class RemediationAction(BaseModel):
         ...,
         description="'suggested' if kept as-is, 'revised' if translated into concrete OpenChoreo guidance",
     )
-    changes: list[ResourceChange] = Field(
-        default_factory=list,
-        description="Specific field changes to make. Empty when status is 'suggested'",
+    change: ResourceChange | None = Field(
+        default=None,
+        description="The specific changes to apply to a single ReleaseBinding. None when status is 'suggested'",
     )
 
 

--- a/rca-agent/src/templates/prompts/remed_agent_prompt.j2
+++ b/rca-agent/src/templates/prompts/remed_agent_prompt.j2
@@ -1,33 +1,37 @@
 You are an expert in OpenChoreo. You receive a completed Root Cause Analysis (RCA) report and translate its generic recommendations into concrete, OpenChoreo-specific remediation actions.
 
-{% if scope %}
-All your tool calls and recommendations should be scoped to namespace `{{ scope.namespace }}`, project `{{ scope.project }}` (`{{ scope.project_uid }}`), and environment `{{ scope.environment }}` (`{{ scope.environment_uid }}`).
-{% endif %}
+All your tool calls and recommendations should be STRICTLY scoped to namespace `{{ scope.namespace }}`, project `{{ scope.project }}`, and environment `{{ scope.environment }}`.
 
 ## OPENCHOREO PLATFORM MODEL
 
-A **Namespace** contains **Projects** and **Environments**. A Project is an isolated runtime boundary (called a "Cell").
+A **Namespace** contains **Projects** and **Environments**. A Project is an isolated runtime boundary.
 
-Inside a Project, you define **Components**. Each Component references a **ComponentType** that determines its workload shape. If building from an image, you also define a **Workload** that specifies the runtime contract (containers, endpoints, env vars, connections). If building from source, the Workload is generated automatically. You can also attach **Traits** to a Component — composable add-ons that must be allowed by the ComponentType.
+Inside a Project, you define **Components**. Each Component references a **ComponentType** that determines its workload shape, declares parameters (port, resources, etc.), and optionally attaches **Traits**. If building from an image, you also define a **Workload** that specifies the runtime contract (container image, env vars, files, endpoints, dependencies). If building from source, the Workload is generated automatically.
 
-All of this is snapshotted into a **ComponentRelease**. A **ReleaseBinding** then binds that release to a specific Environment with environment-specific overrides and renders it into concrete Kubernetes manifests. The ReleaseBinding `spec` contains override sections — call `list_release_bindings` to see the current structure.
+All of this is snapshotted into a **ComponentRelease**. A **ReleaseBinding** then binds that ComponentRelease to a specific Environment with environment-specific overrides and renders it into concrete Kubernetes manifests. The ReleaseBinding `spec` contains override sections per environment — call `list_release_bindings` to see the current structure.
 
 Namespace > Project > Component > ComponentRelease > ReleaseBinding (per Environment)
 
+Since you operate on the environment level, your suggestions are solely on updating ReleaseBindings. You may keep the other suggestions from the RCA report as is
+
 ### Key Resources
 
-**Component** (`openchoreo.dev/v1alpha1/Component`): The fundamental deployable unit. References a ComponentType (e.g. `deployment/service`) and optionally attaches Traits.
+**Component** (`openchoreo.dev/v1alpha1/Component`): The fundamental deployable unit. References a ComponentType (e.g. `deployment/service`), declares `spec.parameters` (port, replicas, resources, etc.), and optionally attaches Traits inline via `spec.traits`.
 
-**Workload** (`openchoreo.dev/v1alpha1/Workload`): Defines the runtime contract — containers (image, env vars, files), endpoints (HTTP, gRPC, TCP, Websocket with visibility scope), and connections to other services.
+**Workload** (`openchoreo.dev/v1alpha1/Workload`): Defines the runtime contract for a single container:
+- `spec.container` — image, env vars (`{key, value}` list), and files
+- `spec.endpoints` — a map keyed by endpoint name (e.g. `{"http": {port, type, visibility}}`)
+- `spec.dependencies.endpoints` — connections to other components with `envBindings`
 
 **ReleaseBinding** (`openchoreo.dev/v1alpha1/ReleaseBinding`): Binds a component to a specific environment with overrides. This is the primary surface for environment-specific tuning:
-- `spec.componentTypeEnvironmentConfigs` — overrides for fields defined by the ComponentType, applied per environment
-- `spec.workloadOverrides` — per-container env vars and files
-- `spec.traitEnvironmentConfigs` — per-trait-instance overrides
+- `spec.componentTypeEnvironmentConfigs` — overrides for fields defined by the ComponentType (the available fields are **dynamic** and vary per ComponentType — always check the schema)
+- `spec.workloadOverrides.container.env` — env var overrides (`{key, value}` list)
+- `spec.workloadOverrides.container.files` — file mount overrides (`{key, value, mountPath}` list)
+- `spec.traitEnvironmentConfigs` — per-trait-instance overrides, keyed by trait instance name
 
-**ComponentType** (`openchoreo.dev/v1alpha1/ComponentType`): Platform-defined template that determines the workload shape. Component types are extensible — anyone can define new ones.
+**ComponentType** (`openchoreo.dev/v1alpha1/ComponentType`): Platform-defined template that determines the workload shape and which fields are overridable per environment. The set of configurable fields is **dynamic** — different ComponentTypes expose different fields. Always call `get_component_release_schema` to discover available fields.
 
-**Trait** (`openchoreo.dev/v1alpha1/Trait`): Composable capabilities attached to components. Traits are extensible — anyone can define new ones.
+**Trait** (`openchoreo.dev/v1alpha1/Trait`): Composable capabilities attached to components. Traits are extensible — anyone can define new ones. Traits are declared inline in the Component's `spec.traits` array.
 
 ## OBJECTIVES
 
@@ -45,35 +49,39 @@ You are NOT required to map RCA actions 1:1. Think holistically:
 
 ### Action statuses
 
-- `revised`: You translated one or more RCA recommendations into concrete changes. Each entry in `changes` targets **one ReleaseBinding** and contains all updates for it:
+- `revised`: You translated one or more RCA recommendations into a concrete change targeting **exactly one ReleaseBinding**. The `change` object contains:
   - `release_binding`: the ReleaseBinding name (e.g. "api-service-development")
   - `env`: a list of `{key, value}` pairs for environment variable changes. Reference env vars **by key name**, not by array index. If the key already exists in the binding's env array it will be updated; otherwise it will be appended.
-  - `files`: a list of `{key, value?, mount_path?}` pairs for file mount changes. Reference files **by key name**, not by array index. Only include the fields you want to change (`value`, `mount_path`, or both). If the key already exists it will be updated; otherwise it will be appended.
-  - `fields`: a list of `{json_pointer, value}` pairs for non-array changes (trait overrides, componentType overrides, etc.). Use RFC 6901 JSON Pointers starting with `/spec/`.
+  - `files`: a list of `{key, mount_path, value}` entries for updating the content of **existing** file mounts only. `key` + `mount_path` together identify the file mount — both must match an existing mount from `list_release_bindings`. Only the `value` (file content) is changed; you cannot add new mounts or change the mount path.
+  - `fields`: a list of `{json_pointer, value}` pairs for non-array changes (trait overrides, componentType overrides, etc.). Use RFC 6901 JSON Pointers starting with `/spec/`. **Only use field paths that exist in the schema returned by `get_component_release_schema`** — the available fields are dynamic and vary per ComponentType and Trait.
 
-  **Use `env` for env var changes, `files` for file mount changes, and `fields` only for non-array paths** (trait overrides, componentType overrides). Never use `fields` with array indices.
+  **Each revised action targets exactly one ReleaseBinding.** If you need to change multiple bindings, create separate actions for each.
+
+  **Use `env` for env var changes, `files` for existing file mount content changes, and `fields` only for non-array paths** (trait overrides, componentType overrides). Never use `fields` with array indices.
+
+  **`fields` values must be scalars** (string, number, or boolean). For nested objects, flatten them into separate entries with leaf-level JSON Pointers.
 
   WRONG — do not use fields with array indices for env vars:
-    {"release_binding": "svc-a-development", "fields": [{"json_pointer": "/spec/workloadOverrides/container/env/0/value", "value": "new-value"}]}
+    {"change": {"release_binding": "svc-a-development", "fields": [{"json_pointer": "/spec/workloadOverrides/container/env/0/value", "value": "new-value"}]}}
   RIGHT — use env with key-based access:
-    {"release_binding": "svc-a-development", "env": [{"key": "MY_VAR", "value": "new-value"}]}
+    {"change": {"release_binding": "svc-a-development", "env": [{"key": "MY_VAR", "value": "new-value"}]}}
 
-  **Group all changes for the same ReleaseBinding into one `changes` entry. Never repeat a `release_binding` within the same action.**
+  WRONG — do not put JSON objects or stringified JSON as a field value:
+    {"change": {"release_binding": "svc-a-development", "fields": [{"json_pointer": "/spec/componentTypeEnvironmentConfigs/resources", "value": "{\"requests\": {\"cpu\": \"100m\"}}"}]}}
+  RIGHT — flatten nested objects into leaf-level pointers:
+    {"change": {"release_binding": "svc-a-development", "fields": [{"json_pointer": "/spec/componentTypeEnvironmentConfigs/resources/requests/cpu", "value": "100m"}, {"json_pointer": "/spec/componentTypeEnvironmentConfigs/resources/requests/memory", "value": "256Mi"}]}}
 
-  Example — update and add env vars on the same binding:
-    {"release_binding": "svc-a-development", "env": [{"key": "DB_HOST", "value": "db.example.com"}, {"key": "NEW_VAR", "value": "some-value"}]}
+  Example — update and add env vars on a binding:
+    {"change": {"release_binding": "svc-a-development", "env": [{"key": "DB_HOST", "value": "db.example.com"}, {"key": "NEW_VAR", "value": "some-value"}]}}
 
-  Example — update a mounted file's content:
-    {"release_binding": "svc-a-development", "files": [{"key": "config.yaml", "value": "host: db.example.com\nport: 5432"}]}
+  Example — update an existing file mount's content:
+    {"change": {"release_binding": "svc-a-development", "files": [{"key": "config.yaml", "mount_path": "/app/config/", "value": "host: db.example.com\nport: 5432"}]}}
 
   Example — update a trait field:
-    {"release_binding": "svc-b-development", "fields": [{"json_pointer": "/spec/traitEnvironmentConfigs/my-alert/enabled", "value": false}]}
+    {"change": {"release_binding": "svc-b-development", "fields": [{"json_pointer": "/spec/traitEnvironmentConfigs/my-alert/enabled", "value": false}]}}
 
-  Example — mixed changes across two bindings in one action:
-    "changes": [
-      {"release_binding": "svc-a-development", "env": [{"key": "DB_HOST", "value": "db.example.com"}], "fields": [{"json_pointer": "/spec/componentTypeEnvironmentConfigs/replicas", "value": 2}]},
-      {"release_binding": "svc-b-development", "env": [{"key": "UPSTREAM_URL", "value": "http://svc-a:8080"}]}
-    ]
+  Example — mixed env and field changes on the same binding:
+    {"change": {"release_binding": "svc-a-development", "env": [{"key": "DB_HOST", "value": "db.example.com"}], "fields": [{"json_pointer": "/spec/componentTypeEnvironmentConfigs/replicas", "value": 2}]}}
 
 - `suggested`: The action cannot be expressed as an OpenChoreo resource change, or is already specific enough. Keep the original description as-is.
 
@@ -88,11 +96,12 @@ You are NOT required to map RCA actions 1:1. Think holistically:
 - Do not attempt to execute or apply any actions — your role is to revise recommendations only
 - Always reference the specific OpenChoreo resource (kind, name) when revising actions
 - Before producing any `revised` action, investigate the current state using the available tools to ensure changes target valid resources and fields
+- Always call `get_component_release_schema` before using `fields` — the available override fields are dynamic per ComponentType and Trait. Do not assume any specific fields exist
 
 ## TOOL GUIDELINES
 
-- `list_release_bindings`: Returns the current binding spec with all environment-specific overrides (env vars, files, trait overrides, componentType overrides).
-- `get_component_workloads`: Returns the base workload spec as defined by the developer (containers, env vars, files, endpoints).
-- `get_component_release_schema`: Returns the JSON Schema describing configurable fields for componentType and trait overrides.
-- `list_component_traits`: Lists traits attached to a component with their base parameter values.
+- `list_release_bindings`: Returns the current binding spec including `workloadOverrides.container.env`, `workloadOverrides.container.files`, `componentTypeEnvironmentConfigs`, and `traitEnvironmentConfigs`.
+- `get_component_workloads`: Returns the base workload spec — single `container` (image, env vars, files), `endpoints` (map keyed by name), and `dependencies.endpoints` (connections with envBindings).
+- `get_component_release_schema`: Returns the JSON Schema for overridable fields. **Call this before producing any `revised` action with `fields`** — the schema is dynamic and varies per ComponentType and Trait. It has two top-level sections: `componentTypeEnvironmentConfigs` and `traitEnvironmentConfigs`.
+- `list_component_traits`: Returns traits from the Component's inline `spec.traits` array with their base parameter values.
 - `list_components`: Lists components in a project.

--- a/rca-agent/uv.lock
+++ b/rca-agent/uv.lock
@@ -36,25 +36,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.79.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/b1/91aea3f8fd180d01d133d931a167a78a3737b3fd39ccef2ae8d6619c24fd/anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871", size = 509825, upload-time = "2026-02-07T18:06:18.388Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/b2/cc0b8e874a18d7da50b0fda8c99e4ac123f23bf47b471827c5f6f3e4a767/anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf", size = 405918, upload-time = "2026-02-07T18:06:20.246Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -102,14 +83,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.7"
+version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/dc/ed1681bf1339dd6ea1ce56136bad4baabc6f7ad466e375810702b0237047/authlib-1.6.7.tar.gz", hash = "sha256:dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b", size = 164950, upload-time = "2026-02-06T14:04:14.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/00/3ed12264094ec91f534fae429945efbaa9f8c666f3aa7061cc3b2a26a0cd/authlib-1.6.7-py2.py3-none-any.whl", hash = "sha256:c637340d9a02789d2efa1d003a7437d10d3e565237bcb5fcbc6c134c7b95bab0", size = 244115, upload-time = "2026-02-06T14:04:12.141Z" },
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
 ]
 
 [[package]]
@@ -263,27 +244,19 @@ wheels = [
 ]
 
 [[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
-
-[[package]]
 name = "fastapi"
-version = "0.121.1"
+version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/a4/29e1b861fc9017488ed02ff1052feffa40940cb355ed632a8845df84ce84/fastapi-0.121.1.tar.gz", hash = "sha256:b6dba0538fd15dab6fe4d3e5493c3957d8a9e1e9257f56446b5859af66f32441", size = 342523, upload-time = "2025-11-08T21:48:14.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fd/2e6f7d706899cc08690c5f6641e2ffbfffe019e8f16ce77104caa5730910/fastapi-0.121.1-py3-none-any.whl", hash = "sha256:2c5c7028bc3a58d8f5f09aecd3fd88a000ccc0c5ad627693264181a3c33aa1fc", size = 109192, upload-time = "2025-11-08T21:48:12.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -474,20 +447,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langchain-anthropic"
-version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anthropic" },
-    { name = "langchain-core" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/48/cf217b3836099220737ff1f8fd07a554993080dfc9c0b4dd4af16ccb0604/langchain_anthropic-1.3.3.tar.gz", hash = "sha256:37198413c9bde5a9e9829f13c7b9ed4870d7085e7fba9fd803ef4d98ef8ea220", size = 686916, upload-time = "2026-02-10T21:02:28.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/f1/cf56d47964b6fe080cdc54c3e32bc05e560927d549b2634b39d14aaf6e05/langchain_anthropic-1.3.3-py3-none-any.whl", hash = "sha256:8008ce5fb680268681673e09f93a9ac08eba9e304477101e5e138f06b5cd8710", size = 46831, upload-time = "2026-02-10T21:02:27.386Z" },
-]
-
-[[package]]
 name = "langchain-core"
 version = "1.2.15"
 source = { registry = "https://pypi.org/simple" }
@@ -522,16 +481,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.9"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/ae/1dbeb49ab8f098f78ec52e21627e705e5d7c684dc8826c2c34cc2746233a/langchain_openai-1.1.9.tar.gz", hash = "sha256:fdee25dcf4b0685d8e2f59856f4d5405431ef9e04ab53afe19e2e8360fed8234", size = 1004828, upload-time = "2026-02-10T21:03:21.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/0f/01147f842499338ae3b0dd0a351fb83006d9ed623cf3a999bd68ba5bbe2d/langchain_openai-1.1.10.tar.gz", hash = "sha256:ca6fae7cf19425acc81814efed59c7d205ec9a1f284fd1d08aae9bda85d6501b", size = 1059755, upload-time = "2026-02-17T18:03:44.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a1/8a20d19f69d022c10d34afa42d972cc50f971b880d0eb4a828cf3dd824a8/langchain_openai-1.1.9-py3-none-any.whl", hash = "sha256:ca2482b136c45fb67c0db84a9817de675e0eb8fb2203a33914c1b7a96f273940", size = 85769, upload-time = "2026-02-10T21:03:20.333Z" },
+    { url = "https://files.pythonhosted.org/packages/72/17/3785cbcdc81c451179247e4176d2697879cb4f45ab2c59d949ca574e072d/langchain_openai-1.1.10-py3-none-any.whl", hash = "sha256:d91b2c09e9fbc70f7af45345d3aa477744962d41c73a029beb46b4f83b824827", size = 87205, upload-time = "2026-02-17T18:03:43.502Z" },
 ]
 
 [[package]]
@@ -694,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.8.0"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -706,9 +665,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/0c/b9321e12f89e236f5e9a46346c30fb801818e22ba33b798a5aca84be895c/openai-2.8.0.tar.gz", hash = "sha256:4851908f6d6fcacbd47ba659c5ac084f7725b752b6bfa1e948b6fbfc111a6bad", size = 602412, upload-time = "2025-11-13T18:15:25.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/91/2a06c4e9597c338cac1e5e5a8dd6f29e1836fc229c4c523529dca387fda8/openai-2.26.0.tar.gz", hash = "sha256:b41f37c140ae0034a6e92b0c509376d907f3a66109935fba2c1b471a7c05a8fb", size = 666702, upload-time = "2026-03-05T23:17:35.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/e1/0a6560bab7fb7b5a88d35a505b859c6d969cb2fa2681b568eb5d95019dec/openai-2.8.0-py3-none-any.whl", hash = "sha256:ba975e347f6add2fe13529ccb94d54a578280e960765e5224c34b08d7e029ddf", size = 1022692, upload-time = "2025-11-13T18:15:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2e/3f73e8ca53718952222cacd0cf7eecc9db439d020f0c1fe7ae717e4e199a/openai-2.26.0-py3-none-any.whl", hash = "sha256:6151bf8f83802f036117f06cc8a57b3a4da60da9926826cc96747888b57f394f", size = 1136409, upload-time = "2026-03-05T23:17:34.072Z" },
 ]
 
 [[package]]
@@ -910,11 +869,11 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "langchain" },
-    { name = "langchain-anthropic" },
     { name = "langchain-mcp-adapters" },
     { name = "langchain-openai" },
     { name = "numpy" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn" },
 ]
@@ -923,18 +882,18 @@ dependencies = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
-    { name = "authlib", specifier = ">=1.4.0" },
-    { name = "fastapi", specifier = ">=0.121.1" },
+    { name = "authlib", specifier = ">=1.6.8" },
+    { name = "fastapi", specifier = ">=0.133.1" },
     { name = "httpx", specifier = ">=0.23.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "langchain", specifier = ">=1.0.5" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1" },
     { name = "langchain-mcp-adapters", specifier = ">=0.2.1" },
-    { name = "langchain-openai", specifier = ">=1.1.7" },
+    { name = "langchain-openai", specifier = ">=1.1.10" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
-    { name = "uvicorn", specifier = ">=0.38.0" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 
 [[package]]
@@ -1215,15 +1174,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add external `auth-config.yaml` for configurable JWT entitlement claims
- Change `RemediationAction` from multi-binding `changes` list to single `change` per action
- Restrict `FieldChange` values to scalars only (no nested objects/arrays)
- Add proxy header support to uvicorn CMD
- Remove `langchain-anthropic` dependency
- Bump `fastapi`, `authlib`, `uvicorn`, and `langchain-openai` versions
- Improve remediation agent prompt with clearer examples and constraints