### PR TITLE
refactor: replace workflow annotations with label and schema extensions

### DIFF
--- a/internal/controller/annotations.go
+++ b/internal/controller/annotations.go
@@ -3,7 +3,13 @@
 
 package controller
 
-import "gopkg.in/yaml.v3"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 // This file contains the all the annotations that are used to store Choreo specific the metadata in the Kubernetes objects.
 
@@ -11,24 +17,72 @@ const (
 	AnnotationKeyDisplayName = "openchoreo.dev/display-name"
 	AnnotationKeyDescription = "openchoreo.dev/description"
 
-	// AnnotationKeyComponentWorkflowParameters maps logical parameter keys (repoUrl, branch, appPath, secretRef, commit)
-	// to dotted parameter paths within the workflow schema. Used to identify which parameters hold
-	// component build information for webhook auto-build and workflow triggering.
-	// Format: YAML multi-line block scalar with "key: value" pairs per line.
-	// Example:
-	//   openchoreo.dev/component-workflow-parameters: |
-	//     repoUrl: parameters.repository.url
-	//     branch: parameters.repository.revision.branch
-	AnnotationKeyComponentWorkflowParameters = "openchoreo.dev/component-workflow-parameters"
+	// SchemaExtensionComponentParameterRepositoryPrefix is the common prefix for all openAPIV3Schema
+	// x- extension keys that mark component repository parameter fields (set to true on the property).
+	// The suffix after the prefix is used as the role key in the map returned by ExtractComponentRepositoryPaths
+	// (e.g. "url", "branch", "commit", "app-path", "secret-ref").
+	SchemaExtensionComponentParameterRepositoryPrefix    = "x-openchoreo-component-parameter-repository-"
+	SchemaExtensionComponentParameterRepositoryURL       = SchemaExtensionComponentParameterRepositoryPrefix + "url"
+	SchemaExtensionComponentParameterRepositoryBranch    = SchemaExtensionComponentParameterRepositoryPrefix + "branch"
+	SchemaExtensionComponentParameterRepositoryCommit    = SchemaExtensionComponentParameterRepositoryPrefix + "commit"
+	SchemaExtensionComponentParameterRepositoryAppPath   = SchemaExtensionComponentParameterRepositoryPrefix + "app-path"
+	SchemaExtensionComponentParameterRepositorySecretRef = SchemaExtensionComponentParameterRepositoryPrefix + "secret-ref"
 )
 
-// ParseWorkflowParameterAnnotation parses the component-workflow-parameters annotation
-// from YAML format (key: value pairs) into a map.
-func ParseWorkflowParameterAnnotation(annotation string) map[string]string {
+// ExtractComponentRepositoryPaths scans an openAPIV3Schema RawExtension for boolean
+// x-openchoreo-component-parameter-repository-* extension keys
+// (e.g. "x-openchoreo-component-parameter-repository-url",
+// "x-openchoreo-component-parameter-repository-branch", "-commit", "-app-path", "-secret-ref")
+// and returns a map from the key suffix (e.g. "url", "branch", "commit", "app-path", "secret-ref")
+// to the dotted property path of the annotated field within the parameters object
+// (e.g. "repository.url", "repository.revision.branch").
+func ExtractComponentRepositoryPaths(schema *runtime.RawExtension) (map[string]string, error) {
 	result := make(map[string]string)
-	if annotation == "" {
-		return result
+	if schema == nil || schema.Raw == nil {
+		return result, nil
 	}
-	_ = yaml.Unmarshal([]byte(annotation), &result)
-	return result
+	var schemaObj map[string]interface{}
+	if err := json.Unmarshal(schema.Raw, &schemaObj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
+	}
+	if err := walkSchemaForComponentRepository(schemaObj, "", result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// walkSchemaForComponentRepository recursively walks an openAPIV3Schema properties tree,
+// collecting all fields that carry an x-openchoreo-component-parameter-repository-* extension.
+// It returns an error if the same role appears on more than one field.
+func walkSchemaForComponentRepository(schema map[string]interface{}, prefix string, result map[string]string) error {
+	for key, val := range schema {
+		if !strings.HasPrefix(key, SchemaExtensionComponentParameterRepositoryPrefix) {
+			continue
+		}
+		if enabled, ok := val.(bool); ok && enabled && prefix != "" {
+			role := strings.TrimPrefix(key, SchemaExtensionComponentParameterRepositoryPrefix)
+			if _, exists := result[role]; exists {
+				return fmt.Errorf("duplicate %s extension found at path %q (role %q already mapped to %q)", key, prefix, role, result[role])
+			}
+			result[role] = prefix
+		}
+	}
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for propName, propVal := range props {
+		propSchema, ok := propVal.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		childPath := propName
+		if prefix != "" {
+			childPath = prefix + "." + propName
+		}
+		if err := walkSchemaForComponentRepository(propSchema, childPath, result); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -14,6 +14,11 @@ const (
 	LabelKeyName            = "openchoreo.dev/name"
 	LabelKeyDataPlaneName   = "openchoreo.dev/dataplane"
 	LabelKeyWorkflowPlane   = "openchoreo.dev/workflow-plane"
+	LabelKeyWorkflowType    = "openchoreo.dev/workflow-type"
+
+	// LabelValueWorkflowTypeComponent marks a workflow as a component CI workflow,
+	// used for component builds, webhooks, and auto-build integration.
+	LabelValueWorkflowTypeComponent = "component"
 
 	LabelKeyProjectUID     = "openchoreo.dev/project-uid"
 	LabelKeyComponentUID   = "openchoreo.dev/component-uid"

--- a/internal/occ/cmd/workflow/workflow.go
+++ b/internal/occ/cmd/workflow/workflow.go
@@ -13,6 +13,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/setoverride"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
@@ -28,9 +29,6 @@ type Workflow struct{}
 func New() *Workflow {
 	return &Workflow{}
 }
-
-// workflowScopeAnnotation is the annotation key that identifies workflow scope (component or generic).
-const workflowScopeAnnotation = "openchoreo.dev/workflow-scope"
 
 // List lists all workflows in a namespace.
 func (w *Workflow) List(params ListParams) error {
@@ -253,14 +251,14 @@ func printList(items []gen.Workflow) error {
 	return w.Flush()
 }
 
-// isComponentWorkflow checks if a workflow is a component workflow by checking the workflow-scope annotation.
+// isComponentWorkflow checks if a workflow is a component workflow by checking the workflow-scope label.
 func isComponentWorkflow(wf gen.Workflow) bool {
-	if wf.Metadata.Annotations == nil {
+	if wf.Metadata.Labels == nil {
 		return false
 	}
-	scope, ok := (*wf.Metadata.Annotations)[workflowScopeAnnotation]
+	scope, ok := (*wf.Metadata.Labels)[labels.LabelKeyWorkflowType]
 	if !ok {
 		return false
 	}
-	return scope == "component"
+	return scope == labels.LabelValueWorkflowTypeComponent
 }

--- a/internal/openchoreo-api/legacyservices/webhook_service.go
+++ b/internal/openchoreo-api/legacyservices/webhook_service.go
@@ -115,7 +115,7 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 			continue
 		}
 
-		// Get repository URL, appPath, and branch from component workflow via Workflow CR annotation
+		// Get repository URL, appPath, and branch from component workflow schema extensions
 		repoURL, appPath, branch, err := s.extractRepoInfoFromComponent(ctx, comp)
 		if err != nil {
 			logger.V(1).Info("Failed to extract repo info from component",
@@ -155,13 +155,13 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 }
 
 // extractRepoInfoFromComponent extracts repository URL, appPath, and branch from a component's workflow parameters
-// by looking up the Workflow CR annotation to find the parameter paths.
+// by scanning the Workflow CR's openAPIV3Schema for x-openchoreo-component-repository extensions.
 func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp *v1alpha1.Component) (repoURL string, appPath string, branch string, err error) {
 	if comp.Spec.Workflow == nil || comp.Spec.Workflow.Name == "" {
 		return "", "", "", fmt.Errorf("component has no workflow configuration")
 	}
 
-	// Fetch the Workflow CR to get the annotation mapping
+	// Fetch the Workflow CR to get the schema
 	workflow := &v1alpha1.Workflow{}
 	if err := s.k8sClient.Get(ctx, client.ObjectKey{
 		Name:      comp.Spec.Workflow.Name,
@@ -170,14 +170,16 @@ func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp 
 		return "", "", "", fmt.Errorf("failed to get workflow %s: %w", comp.Spec.Workflow.Name, err)
 	}
 
-	// Parse the annotation that maps logical keys to parameter paths
-	annotation := workflow.Annotations[controller.AnnotationKeyComponentWorkflowParameters]
-	paramMap := controller.ParseWorkflowParameterAnnotation(annotation)
+	// Extract parameter paths from x-openchoreo-component-parameter-repository-* schema extensions
+	paramMap, err := controller.ExtractComponentRepositoryPaths(workflow.Spec.Parameters.GetRaw())
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to extract component repository paths from workflow %s schema: %w", comp.Spec.Workflow.Name, err)
+	}
 
-	// Get repoUrl path from the annotation
-	repoURLPath, ok := paramMap["repoUrl"]
+	// Get url path from schema extensions
+	repoURLPath, ok := paramMap["url"]
 	if !ok {
-		return "", "", "", fmt.Errorf("workflow %s annotation missing repoUrl mapping", comp.Spec.Workflow.Name)
+		return "", "", "", fmt.Errorf("workflow %s schema missing x-openchoreo-component-parameter-repository-url extension", comp.Spec.Workflow.Name)
 	}
 
 	repoURL, err = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, repoURLPath)
@@ -190,17 +192,16 @@ func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp 
 	}
 
 	// Get appPath (optional - not all workflows may have it)
-	if appPathPath, ok := paramMap["appPath"]; ok {
+	if appPathPath, ok := paramMap["app-path"]; ok {
 		appPath, _ = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, appPathPath)
 	}
 
-	// Get branch (optional - if not configured, all branches trigger builds).
-	// If the annotation maps a branch path but extraction fails, return an error so
-	// the component is not unintentionally treated as unscoped (all-branch).
+	// Get branch. If the component parameters don't carry a value (missing key or empty string),
+	// fall back to the schema default (e.g. "main"). An empty result means all branches trigger builds.
 	if branchPath, ok := paramMap["branch"]; ok {
-		branch, err = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, branchPath)
-		if err != nil {
-			return "", "", "", fmt.Errorf("extracting branch for component %s: %w", comp.Name, err)
+		branch, _ = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, branchPath)
+		if branch == "" {
+			branch = getSchemaFieldDefault(workflow.Spec.Parameters.GetRaw(), branchPath)
 		}
 	}
 
@@ -240,6 +241,34 @@ func getNestedStringFromRawExtension(raw *runtime.RawExtension, dottedPath strin
 		return "", fmt.Errorf("path %s: value is not a string", dottedPath)
 	}
 	return str, nil
+}
+
+// getSchemaFieldDefault navigates an openAPIV3Schema RawExtension following "properties" at each
+// segment of dottedPath (stripping a leading "parameters." prefix) and returns the "default"
+// string value of the terminal field, or "" if not present or not a string.
+func getSchemaFieldDefault(schema *runtime.RawExtension, dottedPath string) string {
+	if schema == nil || schema.Raw == nil {
+		return ""
+	}
+	path := strings.TrimPrefix(dottedPath, "parameters.")
+	var schemaObj map[string]interface{}
+	if err := json.Unmarshal(schema.Raw, &schemaObj); err != nil {
+		return ""
+	}
+	current := schemaObj
+	for _, part := range strings.Split(path, ".") {
+		props, ok := current["properties"].(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		child, ok := props[part].(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = child
+	}
+	def, _ := current["default"].(string)
+	return def
 }
 
 // setNestedValueInParameters takes a runtime.RawExtension, sets a string value at the given

--- a/internal/openchoreo-api/legacyservices/webhook_service_test.go
+++ b/internal/openchoreo-api/legacyservices/webhook_service_test.go
@@ -17,49 +17,89 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices/git"
 )
 
-func TestParseWorkflowParameterAnnotation(t *testing.T) {
+const (
+	// testSchemaURLOnly is a minimal openAPIV3Schema with only the url extension.
+	testSchemaURLOnly = `{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true}}}}}`
+	// testSchemaURLAndAppPath is a schema with url and app-path extensions.
+	testSchemaURLAndAppPath = `{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true}}},"appPath":{"type":"string","x-openchoreo-component-parameter-repository-app-path":true}}}`
+	// testSchemaURLAndBranch is a schema with url and branch extensions.
+	testSchemaURLAndBranch = `{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true},"revision":{"type":"object","properties":{"branch":{"type":"string","x-openchoreo-component-parameter-repository-branch":true}}}}}}}`
+)
+
+func TestExtractComponentRepositoryPaths(t *testing.T) {
+	makeSchema := func(jsonStr string) *runtime.RawExtension {
+		return &runtime.RawExtension{Raw: []byte(jsonStr)}
+	}
+
 	tests := []struct {
-		name       string
-		annotation string
-		want       map[string]string
+		name    string
+		schema  *runtime.RawExtension
+		want    map[string]string
+		wantErr bool
 	}{
 		{
-			name:       "empty string",
-			annotation: "",
-			want:       map[string]string{},
+			name:   "nil schema",
+			schema: nil,
+			want:   map[string]string{},
 		},
 		{
-			name:       "single key-value pair",
-			annotation: "repoUrl: parameters.repository.url\n",
-			want:       map[string]string{"repoUrl": "parameters.repository.url"},
+			name:   "nil raw bytes",
+			schema: &runtime.RawExtension{},
+			want:   map[string]string{},
 		},
 		{
-			name:       "multiple key-value pairs",
-			annotation: "repoUrl: parameters.repository.url\nbranch: parameters.repository.revision.branch\nappPath: parameters.appPath\n",
+			name:    "invalid JSON",
+			schema:  makeSchema(`not-json`),
+			wantErr: true,
+		},
+		{
+			name:   "single url extension",
+			schema: makeSchema(`{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true}}}}}`),
+			want:   map[string]string{"url": "repository.url"},
+		},
+		{
+			name:   "url and branch extensions",
+			schema: makeSchema(`{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true},"revision":{"type":"object","properties":{"branch":{"type":"string","x-openchoreo-component-parameter-repository-branch":true}}}}}}}`),
 			want: map[string]string{
-				"repoUrl": "parameters.repository.url",
-				"branch":  "parameters.repository.revision.branch",
-				"appPath": "parameters.appPath",
+				"url":    "repository.url",
+				"branch": "repository.revision.branch",
 			},
 		},
 		{
-			name:       "full annotation with all keys",
-			annotation: "repoUrl: parameters.repository.url\nbranch: parameters.repository.revision.branch\ncommit: parameters.repository.revision.commit\nappPath: parameters.repository.appPath\nsecretRef: parameters.repository.secretRef\nprojectName: parameters.scope.projectName\ncomponentName: parameters.scope.componentName\n",
+			name:   "full repository extensions",
+			schema: makeSchema(`{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true},"secretRef":{"type":"string","x-openchoreo-component-parameter-repository-secret-ref":true},"revision":{"type":"object","properties":{"branch":{"type":"string","x-openchoreo-component-parameter-repository-branch":true},"commit":{"type":"string","x-openchoreo-component-parameter-repository-commit":true}}},"appPath":{"type":"string","x-openchoreo-component-parameter-repository-app-path":true}}}}}`),
 			want: map[string]string{
-				"repoUrl":       "parameters.repository.url",
-				"branch":        "parameters.repository.revision.branch",
-				"commit":        "parameters.repository.revision.commit",
-				"appPath":       "parameters.repository.appPath",
-				"secretRef":     "parameters.repository.secretRef",
-				"projectName":   "parameters.scope.projectName",
-				"componentName": "parameters.scope.componentName",
+				"url":        "repository.url",
+				"branch":     "repository.revision.branch",
+				"commit":     "repository.revision.commit",
+				"app-path":   "repository.appPath",
+				"secret-ref": "repository.secretRef",
 			},
+		},
+		{
+			name:   "no extensions present",
+			schema: makeSchema(`{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string"}}}}}`),
+			want:   map[string]string{},
+		},
+		{
+			name:    "duplicate role returns error",
+			schema:  makeSchema(`{"type":"object","properties":{"a":{"type":"string","x-openchoreo-component-parameter-repository-url":true},"b":{"type":"string","x-openchoreo-component-parameter-repository-url":true}}}`),
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := controller.ParseWorkflowParameterAnnotation(tt.annotation)
+			got, err := controller.ExtractComponentRepositoryPaths(tt.schema)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if len(got) != len(tt.want) {
 				t.Fatalf("got %d entries, want %d: %v", len(got), len(tt.want), got)
 			}
@@ -222,7 +262,7 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "workflow missing repoUrl in annotation",
+			name: "workflow missing url extension in schema",
 			component: &v1alpha1.Component{
 				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
 				Spec: v1alpha1.ComponentSpec{
@@ -234,13 +274,17 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "wf1",
-					Namespace:   "ns1",
-					Annotations: map[string]string{controller.AnnotationKeyComponentWorkflowParameters: "branch: parameters.branch\n"},
-				},
-			},
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := `{"type":"object","properties":{"repository":{"type":"object","properties":{"revision":{"type":"object","properties":{"branch":{"type":"string","x-openchoreo-component-parameter-repository-branch":true}}}}}}}`
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
+					},
+				}
+			}(),
 			wantErr: true,
 		},
 		{
@@ -258,15 +302,17 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := testSchemaURLOnly
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
 					},
-				},
-			},
+				}
+			}(),
 			wantRepo: "https://github.com/example/repo",
 		},
 		{
@@ -285,15 +331,17 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nappPath: parameters.appPath\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := testSchemaURLAndAppPath
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
 					},
-				},
-			},
+				}
+			}(),
 			wantRepo:    "https://github.com/example/repo",
 			wantAppPath: "/src/app",
 		},
@@ -312,15 +360,17 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := testSchemaURLOnly
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
 					},
-				},
-			},
+				}
+			}(),
 			wantErr: true,
 		},
 		{
@@ -334,15 +384,17 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := testSchemaURLOnly
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
 					},
-				},
-			},
+				}
+			}(),
 			wantErr: true,
 		},
 		{
@@ -360,20 +412,22 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nappPath: parameters.appPath\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := testSchemaURLAndAppPath
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
 					},
-				},
-			},
+				}
+			}(),
 			wantRepo:    "https://github.com/example/repo",
 			wantAppPath: "",
 		},
 		{
-			name: "branch path configured but missing from parameters is an error",
+			name: "branch missing from parameters and no schema default yields empty branch (all branches trigger)",
 			component: &v1alpha1.Component{
 				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
 				Spec: v1alpha1.ComponentSpec{
@@ -387,16 +441,49 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nbranch: parameters.repository.revision.branch\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := testSchemaURLAndBranch
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
+					},
+				}
+			}(),
+			wantRepo:   "https://github.com/example/repo",
+			wantBranch: "",
+		},
+		{
+			name: "branch missing from parameters falls back to schema default",
+			component: &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec: v1alpha1.ComponentSpec{
+					Workflow: &v1alpha1.WorkflowRunConfig{
+						Name: "wf1",
+						Parameters: makeRaw(map[string]interface{}{
+							"repository": map[string]interface{}{
+								"url": "https://github.com/example/repo",
+							},
+						}),
 					},
 				},
 			},
-			wantErr: true,
+			workflow: func() *v1alpha1.Workflow {
+				// Schema has a default of "main" for branch
+				schemaJSON := `{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true},"revision":{"type":"object","properties":{"branch":{"type":"string","default":"main","x-openchoreo-component-parameter-repository-branch":true}}}}}}}`
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
+					},
+				}
+			}(),
+			wantRepo:   "https://github.com/example/repo",
+			wantBranch: "main",
 		},
 		{
 			name: "extracts repoUrl, appPath, and branch",
@@ -417,15 +504,17 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 					},
 				},
 			},
-			workflow: &v1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "wf1",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nappPath: parameters.appPath\nbranch: parameters.repository.revision.branch\n",
+			workflow: func() *v1alpha1.Workflow {
+				schemaJSON := `{"type":"object","properties":{"repository":{"type":"object","properties":{"url":{"type":"string","x-openchoreo-component-parameter-repository-url":true},"revision":{"type":"object","properties":{"branch":{"type":"string","x-openchoreo-component-parameter-repository-branch":true}}}}},"appPath":{"type":"string","x-openchoreo-component-parameter-repository-app-path":true}}}`
+				return &v1alpha1.Workflow{
+					ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+					Spec: v1alpha1.WorkflowSpec{
+						Parameters: &v1alpha1.SchemaSection{
+							OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
+						},
 					},
-				},
-			},
+				}
+			}(),
 			wantRepo:    "https://github.com/example/repo",
 			wantAppPath: "/src/app",
 			wantBranch:  "main",
@@ -489,27 +578,27 @@ func makeAutoBuildComponent(name, ns, workflowName, repoURL, branch string, make
 	}
 }
 
-// makeWorkflowWithBranch returns a Workflow CR whose annotation maps repoUrl and branch.
+// makeWorkflowWithBranch returns a Workflow CR whose schema marks url and branch with x-openchoreo-component-repository extensions.
 func makeWorkflowWithBranch(name, ns string) *v1alpha1.Workflow {
+	schemaJSON := testSchemaURLAndBranch
 	return &v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-			Annotations: map[string]string{
-				controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\nbranch: parameters.repository.revision.branch\n",
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1alpha1.WorkflowSpec{
+			Parameters: &v1alpha1.SchemaSection{
+				OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
 			},
 		},
 	}
 }
 
-// makeWorkflowNoBranch returns a Workflow CR whose annotation does NOT map branch.
+// makeWorkflowNoBranch returns a Workflow CR whose schema marks only url with x-openchoreo-component-repository extension (no branch).
 func makeWorkflowNoBranch(name, ns string) *v1alpha1.Workflow {
+	schemaJSON := testSchemaURLOnly
 	return &v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-			Annotations: map[string]string{
-				controller.AnnotationKeyComponentWorkflowParameters: "repoUrl: parameters.repository.url\n",
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1alpha1.WorkflowSpec{
+			Parameters: &v1alpha1.SchemaSection{
+				OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(schemaJSON)},
 			},
 		},
 	}
@@ -579,7 +668,7 @@ func TestWebhookBranchFilter_NoConfiguredBranch(t *testing.T) {
 	}
 
 	scheme := newTestScheme(t)
-	// Component has a branch value in parameters but the Workflow annotation does NOT map "branch",
+	// Component has a branch value in parameters but the Workflow schema extension does NOT mark "branch",
 	// so no branch filtering should occur and any push branch triggers a build.
 	autoBuild := true
 	comp := &v1alpha1.Component{

--- a/internal/openchoreo-api/legacyservices/workflowrun_service.go
+++ b/internal/openchoreo-api/legacyservices/workflowrun_service.go
@@ -812,7 +812,7 @@ func (s *WorkflowRunService) triggerWorkflowInternal(ctx context.Context, namesp
 		return nil, fmt.Errorf("component %s does not have a workflow configured", componentName)
 	}
 
-	// Fetch the Workflow CR to get the annotation mapping
+	// Fetch the Workflow CR to get the schema
 	workflow := &openchoreov1alpha1.Workflow{}
 	if err := s.k8sClient.Get(ctx, client.ObjectKey{
 		Name:      component.Spec.Workflow.Name,
@@ -822,16 +822,26 @@ func (s *WorkflowRunService) triggerWorkflowInternal(ctx context.Context, namesp
 		return nil, fmt.Errorf("failed to get workflow %s: %w", component.Spec.Workflow.Name, err)
 	}
 
-	// Parse the annotation that maps logical keys to parameter paths
-	annotation := workflow.Annotations[controller.AnnotationKeyComponentWorkflowParameters]
-	paramMap := controller.ParseWorkflowParameterAnnotation(annotation)
+	// Extract parameter paths from x-openchoreo-component-repository schema extensions
+	paramMap, err := controller.ExtractComponentRepositoryPaths(workflow.Spec.Parameters.GetRaw())
+	if err != nil {
+		s.logger.Error("Failed to extract component repository paths from workflow schema", "error", err, "workflow", component.Spec.Workflow.Name)
+		return nil, fmt.Errorf("failed to extract component repository paths from workflow %s schema: %w", component.Spec.Workflow.Name, err)
+	}
 
-	// Validate that repoUrl is configured in the component parameters
-	if repoURLPath, ok := paramMap["repoUrl"]; ok {
+	// Validate that repoUrl is configured in the component parameters.
+	// Component-labeled workflows may omit the x-openchoreo-component-parameter-repository-url
+	// extension (e.g. generic component workflows that don't require a repository). URL validation
+	// is skipped in that case and a WorkflowRun is still created with the existing parameters.
+	if repoURLPath, ok := paramMap["url"]; ok {
 		repoURL, err := getNestedStringFromRawExtension(component.Spec.Workflow.Parameters, repoURLPath)
-		if err != nil || repoURL == "" {
-			s.logger.Error("Component workflow does not have repository URL configured", "component", componentName)
-			return nil, fmt.Errorf("component %s workflow does not have repository URL configured", componentName)
+		if err != nil {
+			s.logger.Error("Failed to read repository URL from component parameters", "error", err, "path", repoURLPath, "component", componentName)
+			return nil, fmt.Errorf("failed to read repository URL for component %s at path %s: %w", componentName, repoURLPath, err)
+		}
+		if repoURL == "" {
+			s.logger.Error("Repository URL is empty in component parameters", "component", componentName)
+			return nil, fmt.Errorf("component %s has an empty repository URL configured", componentName)
 		}
 	}
 
@@ -859,13 +869,12 @@ func (s *WorkflowRunService) triggerWorkflowInternal(ctx context.Context, namesp
 		}
 	}
 
-	// Generate a unique workflow run name with short UUID
-	uuid, err := generateShortUUID()
+	// Generate a unique workflow run name, applying the same length/truncation guard as other run names
+	workflowRunName, err := s.generateWorkflowRunName(componentName)
 	if err != nil {
-		s.logger.Error("Failed to generate UUID", "error", err)
-		return nil, fmt.Errorf("failed to generate UUID: %w", err)
+		s.logger.Error("Failed to generate workflow run name", "error", err)
+		return nil, fmt.Errorf("failed to generate workflow run name: %w", err)
 	}
-	workflowRunName := fmt.Sprintf("%s-workflow-%s", componentName, uuid)
 
 	// Create the WorkflowRun CR (using the unified Workflow/WorkflowRun model)
 	workflowRun := &openchoreov1alpha1.WorkflowRun{
@@ -914,13 +923,4 @@ func (s *WorkflowRunService) triggerWorkflowInternal(ctx context.Context, namesp
 		CreatedAt:     workflowRun.CreationTimestamp.Time,
 		Image:         "",
 	}, nil
-}
-
-// generateShortUUID generates a short 8-character UUID for workflow naming.
-func generateShortUUID() (string, error) {
-	bytes := make([]byte, 4) // 4 bytes = 8 hex characters
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
 }

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -962,15 +962,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: paketo-buildpacks-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Supports building Java, Node.js, Python, Go, .NET, Ruby, PHP, and more. See https://paketo.io/docs/"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -993,10 +988,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for private repository Git credentials (optional for public repos)"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -1005,14 +1002,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest commit on branch)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         buildEnv:
           type: array
           default: []
@@ -1176,15 +1176,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: gcp-buildpacks-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Supports building Go, Java, Node.js, Python, and .NET applications. See https://cloud.google.com/docs/buildpacks/overview"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -1205,10 +1200,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for Git credentials"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -1217,14 +1214,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         buildEnv:
           type: array
           default: []
@@ -1384,15 +1384,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: ballerina-buildpack-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Workflow for building applications written in Ballerina"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -1413,10 +1408,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for Git credentials"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -1425,14 +1422,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the Ballerina application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         buildEnv:
           type: array
           default: []
@@ -1594,15 +1594,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: dockerfile-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Build with a provided Dockerfile/Containerfile/Podmanfile"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -1623,10 +1618,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for Git credentials"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -1635,14 +1632,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         docker:
           type: object
           default: {}

--- a/samples/getting-started/workflows/ballerina-buildpack-builder.yaml
+++ b/samples/getting-started/workflows/ballerina-buildpack-builder.yaml
@@ -2,15 +2,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: ballerina-buildpack-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Workflow for building applications written in Ballerina"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -31,10 +26,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for Git credentials"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -43,14 +40,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the Ballerina application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         buildEnv:
           type: array
           default: []

--- a/samples/getting-started/workflows/dockerfile-builder.yaml
+++ b/samples/getting-started/workflows/dockerfile-builder.yaml
@@ -2,15 +2,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: dockerfile-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Build with a provided Dockerfile/Containerfile/Podmanfile"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -31,10 +26,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for Git credentials"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -43,14 +40,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         docker:
           type: object
           default: {}

--- a/samples/getting-started/workflows/gcp-buildpacks-builder.yaml
+++ b/samples/getting-started/workflows/gcp-buildpacks-builder.yaml
@@ -2,15 +2,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: gcp-buildpacks-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Supports building Go, Java, Node.js, Python, and .NET applications. See https://cloud.google.com/docs/buildpacks/overview"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -31,10 +26,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for Git credentials"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -43,14 +40,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         buildEnv:
           type: array
           default: []

--- a/samples/getting-started/workflows/paketo-buildpacks-builder.yaml
+++ b/samples/getting-started/workflows/paketo-buildpacks-builder.yaml
@@ -2,15 +2,10 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterWorkflow
 metadata:
   name: paketo-buildpacks-builder
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Supports building Java, Node.js, Python, Go, .NET, Ruby, PHP, and more. See https://paketo.io/docs/"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -33,10 +28,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for private repository Git credentials (optional for public repos)"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -45,14 +42,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest commit on branch)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         buildEnv:
           type: array
           default: []

--- a/samples/ocSchema/workflows/ballerina-buildpack.yaml
+++ b/samples/ocSchema/workflows/ballerina-buildpack.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Ballerina build workflow for containerized builds using Ballerina Buildpack"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane

--- a/samples/ocSchema/workflows/docker.yaml
+++ b/samples/ocSchema/workflows/docker.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Docker build workflow for containerized builds using Dockerfile"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane

--- a/samples/ocSchema/workflows/google-cloud-buildpacks-with-types.yaml
+++ b/samples/ocSchema/workflows/google-cloud-buildpacks-with-types.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Google Cloud Buildpacks workflow for auto-detecting and building applications without Dockerfiles"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane

--- a/samples/ocSchema/workflows/google-cloud-buildpacks.yaml
+++ b/samples/ocSchema/workflows/google-cloud-buildpacks.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Google Cloud Buildpacks workflow for containerized builds"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane

--- a/samples/ocSchema/workflows/react.yaml
+++ b/samples/ocSchema/workflows/react.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: default
   annotations:
     openchoreo.dev/description: "Build workflow for React web applications"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane

--- a/samples/workflows/README.md
+++ b/samples/workflows/README.md
@@ -41,4 +41,4 @@ See [`generic/README.md`](./generic/README.md) for details.
 | **Parameters** | Includes `repository` (url, branch, appPath) | Domain-specific (no git-clone structure) |
 | **Triggered by** | Webhooks, API, `WorkflowRun` | `WorkflowRun` (manual or event-driven) |
 | **Typical steps** | Clone → Build → Push image | Fetch data → Transform → Report / any pipeline |
-| **Annotation** | `openchoreo.dev/workflow-scope: component` | No scope annotation |
+| **Label** | `openchoreo.dev/workflow-type: component` | None |

--- a/samples/workflows/ci/README.md
+++ b/samples/workflows/ci/README.md
@@ -36,7 +36,7 @@ In OpenChoreo, a CI **Workflow** is a Custom Resource that:
 4. **Templates Argo Workflows** - Generates the actual Argo Workflow resources that execute in the Workflow Plane
 5. **Enforces governance** - Platform Engineers control hardcoded parameters (registry URLs, timeouts, security settings)
 
-CI Workflows carry the annotation `openchoreo.dev/workflow-scope: component` and the `openchoreo.dev/component-workflow-parameters` annotation that maps repository fields for webhook and auto-build integration.
+CI Workflows carry the label `openchoreo.dev/workflow-type: component` and use `x-openchoreo-component-parameter-repository-*` schema extensions to mark repository fields for webhook and auto-build integration.
 
 ## How CI Workflows Work
 
@@ -350,15 +350,30 @@ parameters:
     appPath: string            # Path to application code in repository
 ```
 
-The `component-workflow-parameters` annotation maps these fields for webhook and auto-build integration:
+Fields used for webhook and auto-build integration are marked directly in the `openAPIV3Schema` using `x-openchoreo-component-parameter-repository-*` boolean extensions:
 ```yaml
-annotations:
-  openchoreo.dev/component-workflow-parameters: |
-    repoUrl: parameters.repository.url
-    branch: parameters.repository.revision.branch
-    commit: parameters.repository.revision.commit
-    appPath: parameters.repository.appPath
-    secretRef: parameters.repository.secretRef
+parameters:
+  openAPIV3Schema:
+    properties:
+      repository:
+        properties:
+          url:
+            type: string
+            x-openchoreo-component-parameter-repository-url: true
+          secretRef:
+            type: string
+            x-openchoreo-component-parameter-repository-secret-ref: true
+          revision:
+            properties:
+              branch:
+                type: string
+                x-openchoreo-component-parameter-repository-branch: true
+              commit:
+                type: string
+                x-openchoreo-component-parameter-repository-commit: true
+          appPath:
+            type: string
+            x-openchoreo-component-parameter-repository-app-path: true
 ```
 
 ### Developer Parameters (Complete Freedom)

--- a/samples/workflows/ci/docker.yaml
+++ b/samples/workflows/ci/docker.yaml
@@ -3,15 +3,10 @@ kind: ClusterWorkflow
 metadata:
   name: docker
   namespace: default
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Docker build workflow for containerized applications using Dockerfile"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -47,10 +42,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for private repository Git credentials (optional for public repos)"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -59,14 +56,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest commit on branch)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         docker:
           type: object
           default: {}

--- a/samples/workflows/ci/google-cloud-buildpacks.yaml
+++ b/samples/workflows/ci/google-cloud-buildpacks.yaml
@@ -3,15 +3,10 @@ kind: ClusterWorkflow
 metadata:
   name: google-cloud-buildpacks
   namespace: default
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Google Cloud Buildpacks workflow for auto-detecting and building applications without Dockerfiles"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -83,10 +78,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for private repository Git credentials (optional for public repos)"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -95,14 +92,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest commit on branch)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         version:
           type: integer
           default: 1

--- a/samples/workflows/ci/react.yaml
+++ b/samples/workflows/ci/react.yaml
@@ -3,15 +3,10 @@ kind: ClusterWorkflow
 metadata:
   name: react
   namespace: default
+  labels:
+    openchoreo.dev/workflow-type: "component"
   annotations:
     openchoreo.dev/description: "Build workflow for React web applications"
-    openchoreo.dev/workflow-scope: "component"
-    openchoreo.dev/component-workflow-parameters: |
-      repoUrl: parameters.repository.url
-      branch: parameters.repository.revision.branch
-      commit: parameters.repository.revision.commit
-      appPath: parameters.repository.appPath
-      secretRef: parameters.repository.secretRef
 spec:
   workflowPlaneRef:
     kind: ClusterWorkflowPlane
@@ -47,10 +42,12 @@ spec:
             url:
               type: string
               description: "Git repository URL"
+              x-openchoreo-component-parameter-repository-url: true
             secretRef:
               type: string
               default: ""
               description: "Secret reference name for private repository Git credentials (optional for public repos)"
+              x-openchoreo-component-parameter-repository-secret-ref: true
             revision:
               type: object
               default: {}
@@ -59,14 +56,17 @@ spec:
                   type: string
                   default: main
                   description: "Git branch to checkout"
+                  x-openchoreo-component-parameter-repository-branch: true
                 commit:
                   type: string
                   default: ""
                   description: "Git commit SHA or reference (optional, defaults to latest commit on branch)"
+                  x-openchoreo-component-parameter-repository-commit: true
             appPath:
               type: string
               default: "."
               description: "Path to the React application directory within the repository"
+              x-openchoreo-component-parameter-repository-app-path: true
         nodeVersion:
           type: string
           default: "18"

--- a/samples/workflows/generic/README.md
+++ b/samples/workflows/generic/README.md
@@ -23,7 +23,7 @@ This directory contains Generic Workflow definitions — workflows that run inde
 |--|---|---|
 | **Linked to Component?** | Yes | No |
 | **Parameter schema** | Requires `repository` (url, branch, appPath) | Domain-specific; no git-clone structure |
-| **Annotation** | `openchoreo.dev/workflow-scope: component` | None |
+| **Label** | `openchoreo.dev/workflow-type: component` | None |
 | **Triggered by** | Webhooks, API, Component build, `WorkflowRun` | `WorkflowRun` (manual, scheduled, or event-driven) |
 | **Typical outcome** | Container image pushed to registry | Report, transformed data, test results, etc. |
 


### PR DESCRIPTION
## Related Issue
- Fix https://github.com/openchoreo/openchoreo/issues/2563

## Summary                                            
 Previously, component CI workflows used two annotations

  1. openchoreo.dev/workflow-scope: "component" — annotation on the ClusterWorkflow CR to mark it as a component workflow
  2. openchoreo.dev/component-workflow-parameters — annotation that mapped logical keys (repoUrl, branch, commit, appPath, secretRef) to dotted parameter paths (e.g parameters.repository.revision.branch)

## What changed
1. Workflow type is now a label, not an annotation

 - openchoreo.dev/workflow-scope: "component" (annotation) → openchoreo.dev/workflow-type: "component" (label)
 - Labels are selectable and queryable via the Kubernetes API; an annotation was the wrong primitive for metadata that identifies workflow kind.

 2. Parameter mapping is now inline schema extensions, not a separate annotation

The openchoreo.dev/component-workflow-parameters annotation is removed. Parameter fields are now self-describing via boolean openAPIV3Schema extensions placed directly on the relevant
  properties:

```openapi
  url:
    type: string
    x-openchoreo-component-parameter-repository-url: true
  revision:
    properties:
      branch:
        type: string
        default: main
        x-openchoreo-component-parameter-repository-branch: true
      commit:
        type: string
        x-openchoreo-component-parameter-repository-commit: true
  appPath:
    type: string
    x-openchoreo-component-parameter-repository-app-path: true
  secretRef:
    type: string
    x-openchoreo-component-parameter-repository-secret-ref: true
```