### PR TITLE
fix(api): remove component validation from update path

### DIFF
--- a/internal/openchoreo-api/services/releasebinding/service.go
+++ b/internal/openchoreo-api/services/releasebinding/service.go
@@ -104,11 +104,6 @@ func (s *releaseBindingService) UpdateReleaseBinding(ctx context.Context, namesp
 		return nil, fmt.Errorf("failed to get release binding: %w", err)
 	}
 
-	// Validate that the referenced component exists
-	if err := s.validateComponentExists(ctx, namespaceName, rb.Spec.Owner.ComponentName); err != nil {
-		return nil, err
-	}
-
 	// Clear status from user input — status is server-managed
 	rb.Status = openchoreov1alpha1.ReleaseBindingStatus{}
 

--- a/internal/openchoreo-api/services/workload/service.go
+++ b/internal/openchoreo-api/services/workload/service.go
@@ -105,11 +105,6 @@ func (s *workloadService) UpdateWorkload(ctx context.Context, namespaceName stri
 		return nil, fmt.Errorf("failed to get workload: %w", err)
 	}
 
-	// Validate that the referenced component exists
-	if err := s.validateComponentExists(ctx, namespaceName, w.Spec.Owner.ComponentName); err != nil {
-		return nil, err
-	}
-
 	// Clear status from user input — status is server-managed
 	w.Status = openchoreov1alpha1.WorkloadStatus{}
 


### PR DESCRIPTION
## Summary

- Remove `validateComponentExists` from the update path in workload and releasebinding services
- The `owner` field is immutable (K8s XValidation `self == oldSelf`), so validating the component on update was causing a 500 when the owner was changed instead of letting the immutability check return a proper 400

Fixes #2629

## Test plan

- [x] Update workload with changed owner → returns 400 `spec.owner is immutable`
- [x] Update workload with same owner (image change) → returns 200