### PR TITLE
feat: add ClusterWorkflow to occ apply resource registry

### DIFF
--- a/internal/occ/cmd/apply/registry.go
+++ b/internal/occ/cmd/apply/registry.go
@@ -161,6 +161,31 @@ func addClusterScopedResources(reg map[string]resourceEntry) {
 		},
 	}
 
+	reg["ClusterWorkflow"] = resourceEntry{
+		scope: scopeCluster,
+		get: func(ctx context.Context, c *gen.ClientWithResponses, _, name string) (int, error) {
+			r, err := c.GetClusterWorkflowWithResponse(ctx, name)
+			if err != nil {
+				return 0, err
+			}
+			return r.StatusCode(), nil
+		},
+		create: func(ctx context.Context, c *gen.ClientWithResponses, _ string, body io.Reader) (int, []byte, error) {
+			r, err := c.CreateClusterWorkflowWithBodyWithResponse(ctx, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+		update: func(ctx context.Context, c *gen.ClientWithResponses, _, name string, body io.Reader) (int, []byte, error) {
+			r, err := c.UpdateClusterWorkflowWithBodyWithResponse(ctx, name, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+	}
+
 	reg["ClusterDataPlane"] = resourceEntry{
 		scope: scopeCluster,
 		get: func(ctx context.Context, c *gen.ClientWithResponses, _, name string) (int, error) {


### PR DESCRIPTION
## Summary
- Add `ClusterWorkflow` as a cluster-scoped resource to the `occ apply` resource registry
- ClusterWorkflow had OpenAPI endpoints (create, get, update, delete) but was missing from the apply registry, preventing users from applying ClusterWorkflow resources via `occ apply`

## Test plan
- [x] Verified the package compiles successfully
- [ ] Run `occ apply` with a ClusterWorkflow YAML to verify end-to-end functionality