### PR TITLE
feat: enhance workflow plane client handling with fallback mechanism

### DIFF
--- a/internal/controller/reference.go
+++ b/internal/controller/reference.go
@@ -544,11 +544,18 @@ func (r *WorkflowResult) GetWorkflowSpec() openchoreov1alpha1.WorkflowSpec {
 			ExternalRefs:       r.ClusterWorkflow.Spec.ExternalRefs,
 			TTLAfterCompletion: r.ClusterWorkflow.Spec.TTLAfterCompletion,
 		}
-		// WorkflowPlaneRef is always set by CRD defaulting
+		// Map ClusterWorkflowPlaneRef to WorkflowPlaneRef, defaulting to ClusterWorkflowPlane "default"
+		// when the field is omitted (CRD defaulting webhook may not have run).
 		if r.ClusterWorkflow.Spec.WorkflowPlaneRef != nil {
 			spec.WorkflowPlaneRef = &openchoreov1alpha1.WorkflowPlaneRef{
 				Kind: openchoreov1alpha1.WorkflowPlaneRefKind(r.ClusterWorkflow.Spec.WorkflowPlaneRef.Kind),
 				Name: r.ClusterWorkflow.Spec.WorkflowPlaneRef.Name,
+			}
+		} else {
+			// Default to the cluster-scoped WorkflowPlane named "default"
+			spec.WorkflowPlaneRef = &openchoreov1alpha1.WorkflowPlaneRef{
+				Kind: openchoreov1alpha1.WorkflowPlaneRefKindClusterWorkflowPlane,
+				Name: DefaultPlaneName,
 			}
 		}
 		return spec

--- a/internal/controller/reference_test.go
+++ b/internal/controller/reference_test.go
@@ -1329,8 +1329,9 @@ func TestWorkflowResult_GetWorkflowSpec_FromClusterWorkflow(t *testing.T) {
 }
 
 func TestWorkflowResult_GetWorkflowSpec_FromClusterWorkflow_NilWorkflowPlaneRef(t *testing.T) {
-	// With CRD defaulting, WorkflowPlaneRef should always be set.
-	// When nil (e.g., legacy resources), GetWorkflowSpec returns nil WorkflowPlaneRef.
+	// When ClusterWorkflow omits WorkflowPlaneRef (e.g., legacy or before defaulting webhook),
+	// GetWorkflowSpec defaults to ClusterWorkflowPlane "default" so ResolveWorkflowPlane
+	// always receives a non-nil ref.
 	result := &WorkflowResult{
 		ClusterWorkflow: &openchoreov1alpha1.ClusterWorkflow{
 			ObjectMeta: metav1.ObjectMeta{Name: "cwf-no-wp"},
@@ -1342,7 +1343,9 @@ func TestWorkflowResult_GetWorkflowSpec_FromClusterWorkflow_NilWorkflowPlaneRef(
 
 	spec := result.GetWorkflowSpec()
 	assert.Equal(t, "1h", spec.TTLAfterCompletion)
-	assert.Nil(t, spec.WorkflowPlaneRef, "nil ClusterWorkflow WorkflowPlaneRef should remain nil")
+	require.NotNil(t, spec.WorkflowPlaneRef)
+	assert.Equal(t, openchoreov1alpha1.WorkflowPlaneRefKindClusterWorkflowPlane, spec.WorkflowPlaneRef.Kind)
+	assert.Equal(t, "default", spec.WorkflowPlaneRef.Name)
 }
 
 func TestWorkflowResult_GetWorkflowSpec_Empty(t *testing.T) {

--- a/internal/openchoreo-api/legacyservices/workflowplane_service.go
+++ b/internal/openchoreo-api/legacyservices/workflowplane_service.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"log/slog"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -20,6 +22,18 @@ import (
 	argoproj "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes/types/argoproj.io/workflow/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 )
+
+// workflowPlaneClient bundles a workflow plane k8s client with the identity
+// information required to route gateway calls (pod logs, events) to the
+// correct agent proxy URL. For namespace-scoped WorkflowPlanes the
+// planeNamespace is the CR namespace; for cluster-scoped ClusterWorkflowPlanes
+// it is "_cluster".
+type workflowPlaneClient struct {
+	client         client.Client
+	planeID        string
+	planeNamespace string
+	planeName      string
+}
 
 // WorkflowPlaneService handles workflow plane-related business logic
 type WorkflowPlaneService struct {
@@ -52,7 +66,8 @@ func (s *WorkflowPlaneService) getWorkflowPlane(ctx context.Context, namespaceNa
 	// Check if any workflow planes exist
 	if len(workflowPlanes.Items) == 0 {
 		s.logger.Warn("No workflow planes found", "namespace", namespaceName)
-		return nil, fmt.Errorf("no workflow planes found for namespace: %s", namespaceName)
+		// Treat absence of any WorkflowPlane in the namespace as a Kubernetes-style NotFound error
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "workflowplanes"}, namespaceName)
 	}
 
 	// Return the first workflow plane (0th index)
@@ -77,6 +92,103 @@ func (s *WorkflowPlaneService) GetWorkflowPlane(ctx context.Context, namespaceNa
 	}
 
 	return workflowPlane, nil
+}
+
+// getClusterWorkflowPlane retrieves the default-named ClusterWorkflowPlane (cluster-scoped) without auth checks.
+func (s *WorkflowPlaneService) getClusterWorkflowPlane(ctx context.Context) (*openchoreov1alpha1.ClusterWorkflowPlane, error) {
+	var list openchoreov1alpha1.ClusterWorkflowPlaneList
+	if err := s.k8sClient.List(ctx, &list); err != nil {
+		s.logger.Error("Failed to list cluster workflow planes", "error", err)
+		return nil, fmt.Errorf("failed to list cluster workflow planes: %w", err)
+	}
+	if len(list.Items) == 0 {
+		s.logger.Warn("No cluster workflow planes found")
+		return nil, fmt.Errorf("no cluster workflow planes found")
+	}
+	// Prefer the default-named plane if present to avoid relying on list ordering.
+	for i := range list.Items {
+		if list.Items[i].Name == controller.DefaultPlaneName {
+			cwp := &list.Items[i]
+			s.logger.Debug("Found default-named cluster workflow plane", "name", cwp.Name)
+			return cwp, nil
+		}
+	}
+
+	// No default-named plane found; return the first item.
+	s.logger.Warn(
+		"No default-named cluster workflow plane found, falling back to first item",
+		"defaultName", controller.DefaultPlaneName,
+		"count", len(list.Items),
+	)
+	cwp := &list.Items[0]
+	s.logger.Debug("Falling back to first cluster workflow plane", "name", cwp.Name)
+	return cwp, nil
+}
+
+// GetClusterWorkflowPlaneClient creates and returns a Kubernetes client for the cluster workflow plane.
+func (s *WorkflowPlaneService) GetClusterWorkflowPlaneClient(ctx context.Context, gatewayURL string) (client.Client, error) {
+	cwp, err := s.getClusterWorkflowPlane(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster workflow plane: %w", err)
+	}
+	c, err := kubernetesClient.GetK8sClientFromClusterWorkflowPlane(s.wpClientMgr, cwp, gatewayURL)
+	if err != nil {
+		s.logger.Error("Failed to create cluster workflow plane client", "error", err)
+		return nil, fmt.Errorf("failed to create cluster workflow plane client: %w", err)
+	}
+	s.logger.Debug("Created cluster workflow plane client", "cluster", cwp.Name)
+	return c, nil
+}
+
+// getWorkflowPlaneClientWithFallback tries to get a namespace-scoped WorkflowPlane client first,
+// falling back to the cluster-scoped ClusterWorkflowPlane when none exists. Returns a
+// workflowPlaneClient struct with the client and plane identity needed for gateway calls.
+func (s *WorkflowPlaneService) getWorkflowPlaneClientWithFallback(ctx context.Context, namespaceName string, gatewayURL string) (*workflowPlaneClient, error) {
+	// Try namespace-scoped WorkflowPlane first
+	wp, err := s.getWorkflowPlane(ctx, namespaceName)
+	if err == nil {
+		planeID := wp.Spec.PlaneID
+		if planeID == "" {
+			planeID = wp.Name
+		}
+		c, err := kubernetesClient.GetK8sClientFromWorkflowPlane(s.wpClientMgr, wp, gatewayURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create workflow plane client: %w", err)
+		}
+		return &workflowPlaneClient{
+			client:         c,
+			planeID:        planeID,
+			planeNamespace: wp.Namespace,
+			planeName:      wp.Name,
+		}, nil
+	}
+
+	// Only fall back to the cluster-scoped plane when the namespace-scoped plane is actually not found.
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get namespace workflow plane: %w", err)
+	}
+
+	s.logger.Debug("No namespace-scoped workflow plane, falling back to cluster workflow plane", "namespace", namespaceName, "error", err)
+
+	// Fall back to cluster-scoped ClusterWorkflowPlane
+	cwp, err := s.getClusterWorkflowPlane(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get any workflow plane for namespace %s: %w", namespaceName, err)
+	}
+	planeID := cwp.Spec.PlaneID
+	if planeID == "" {
+		planeID = cwp.Name
+	}
+	c, err := kubernetesClient.GetK8sClientFromClusterWorkflowPlane(s.wpClientMgr, cwp, gatewayURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cluster workflow plane client: %w", err)
+	}
+	return &workflowPlaneClient{
+		client:         c,
+		planeID:        planeID,
+		planeNamespace: "_cluster",
+		planeName:      cwp.Name,
+	}, nil
 }
 
 // GetWorkflowPlaneClient creates and returns a Kubernetes client for the workflow plane cluster
@@ -189,14 +301,14 @@ func (s *WorkflowPlaneService) ArgoWorkflowExists(
 		return false
 	}
 
-	wpClient, err := s.GetWorkflowPlaneClient(ctx, namespaceName, gatewayURL)
+	wpc, err := s.getWorkflowPlaneClientWithFallback(ctx, namespaceName, gatewayURL)
 	if err != nil {
 		s.logger.Debug("Failed to get workflow plane client for workflow existence check", "error", err)
 		return false
 	}
 
 	var argoWorkflow argoproj.Workflow
-	if err := wpClient.Get(ctx, types.NamespacedName{
+	if err := wpc.client.Get(ctx, types.NamespacedName{
 		Name:      runReference.Name,
 		Namespace: runReference.Namespace,
 	}, &argoWorkflow); err != nil {

--- a/internal/openchoreo-api/legacyservices/workflowrun_service.go
+++ b/internal/openchoreo-api/legacyservices/workflowrun_service.go
@@ -459,8 +459,8 @@ func (s *WorkflowRunService) getArgoWorkflowRunLogs(
 	logger := s.logger.With("namespace", namespaceName, "runReference", runReference, "step", stepName, "sinceSeconds", sinceSeconds)
 	logger.Debug("Getting Argo workflow run logs")
 
-	// Get workflow plane client
-	wpClient, err := s.workflowPlaneService.GetWorkflowPlaneClient(ctx, namespaceName, gatewayURL)
+	// Get workflow plane client (with fallback to cluster-scoped)
+	wpc, err := s.workflowPlaneService.getWorkflowPlaneClientWithFallback(ctx, namespaceName, gatewayURL)
 	if err != nil {
 		logger.Error("Failed to get workflow plane client", "error", err)
 		return nil, fmt.Errorf("failed to get workflow plane client: %w", err)
@@ -468,7 +468,7 @@ func (s *WorkflowRunService) getArgoWorkflowRunLogs(
 
 	// Get Argo Workflow from workflow plane
 	var argoWorkflow argoproj.Workflow
-	if err := wpClient.Get(ctx, types.NamespacedName{
+	if err := wpc.client.Get(ctx, types.NamespacedName{
 		Name:      runReference.Name,
 		Namespace: runReference.Namespace,
 	}, &argoWorkflow); err != nil {
@@ -481,22 +481,15 @@ func (s *WorkflowRunService) getArgoWorkflowRunLogs(
 	}
 
 	// Get pods for the workflow/step
-	pods, err := s.getArgoWorkflowPodsForLogs(ctx, wpClient, &argoWorkflow, stepName)
+	pods, err := s.getArgoWorkflowPodsForLogs(ctx, wpc.client, &argoWorkflow, stepName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get workflow pods: %w", err)
-	}
-
-	// Get workflow plane resource
-	workflowPlane, err := s.workflowPlaneService.GetWorkflowPlane(ctx, namespaceName)
-	if err != nil {
-		logger.Error("Failed to get workflow plane", "error", err)
-		return nil, fmt.Errorf("failed to get workflow plane: %w", err)
 	}
 
 	// Get logs from pods and convert to structured format
 	allLogEntries := make([]models.WorkflowRunLogEntry, 0)
 	for _, pod := range pods {
-		podLogs, err := s.getArgoWorkflowPodLogs(ctx, workflowPlane, &pod, sinceSeconds)
+		podLogs, err := s.getArgoWorkflowPodLogs(ctx, wpc, &pod, sinceSeconds)
 		if err != nil {
 			logger.Warn("Failed to get logs from pod", "pod", pod.Name, "error", err)
 			return nil, fmt.Errorf("failed to get logs from pod: %w", err)
@@ -581,7 +574,7 @@ func (s *WorkflowRunService) getArgoWorkflowPodsForLogs(ctx context.Context, wpC
 }
 
 // getArgoWorkflowPodLogs retrieves logs from an Argo Workflow pod using the gateway client
-func (s *WorkflowRunService) getArgoWorkflowPodLogs(ctx context.Context, workflowPlane *openchoreov1alpha1.WorkflowPlane, pod *corev1.Pod, sinceSeconds *int64) (string, error) {
+func (s *WorkflowRunService) getArgoWorkflowPodLogs(ctx context.Context, wpc *workflowPlaneClient, pod *corev1.Pod, sinceSeconds *int64) (string, error) {
 	if s.gwClient == nil {
 		return "", fmt.Errorf("gateway client is not configured")
 	}
@@ -607,7 +600,7 @@ func (s *WorkflowRunService) getArgoWorkflowPodLogs(ctx context.Context, workflo
 			allLogs.WriteString("\n---\n")
 		}
 
-		logs, err := s.gwClient.GetPodLogsFromPlane(ctx, "workflowplane", workflowPlane.Spec.PlaneID, workflowPlane.Namespace, workflowPlane.Name,
+		logs, err := s.gwClient.GetPodLogsFromPlane(ctx, "workflowplane", wpc.planeID, wpc.planeNamespace, wpc.planeName,
 			&gatewayClient.PodReference{
 				Namespace: pod.Namespace,
 				Name:      pod.Name,
@@ -674,8 +667,8 @@ func (s *WorkflowRunService) getArgoWorkflowRunEvents(
 	logger := s.logger.With("namespace", namespaceName, "runReference", runReference, "step", stepName)
 	logger.Debug("Getting Argo workflow run events")
 
-	// Get workflow plane client
-	wpClient, err := s.workflowPlaneService.GetWorkflowPlaneClient(ctx, namespaceName, gatewayURL)
+	// Get workflow plane client (with fallback to cluster-scoped)
+	wpc, err := s.workflowPlaneService.getWorkflowPlaneClientWithFallback(ctx, namespaceName, gatewayURL)
 	if err != nil {
 		logger.Error("Failed to get workflow plane client", "error", err)
 		return nil, fmt.Errorf("failed to get workflow plane client: %w", err)
@@ -683,7 +676,7 @@ func (s *WorkflowRunService) getArgoWorkflowRunEvents(
 
 	// Get Argo Workflow from workflow plane
 	var argoWorkflow argoproj.Workflow
-	if err := wpClient.Get(ctx, types.NamespacedName{
+	if err := wpc.client.Get(ctx, types.NamespacedName{
 		Name:      runReference.Name,
 		Namespace: runReference.Namespace,
 	}, &argoWorkflow); err != nil {
@@ -696,22 +689,15 @@ func (s *WorkflowRunService) getArgoWorkflowRunEvents(
 	}
 
 	// Get pods for the workflow/step
-	pods, err := s.getArgoWorkflowPods(ctx, wpClient, &argoWorkflow, stepName)
+	pods, err := s.getArgoWorkflowPods(ctx, wpc.client, &argoWorkflow, stepName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get workflow pods: %w", err)
-	}
-
-	// Get workflow plane resource
-	workflowPlane, err := s.workflowPlaneService.GetWorkflowPlane(ctx, namespaceName)
-	if err != nil {
-		logger.Error("Failed to get workflow plane", "error", err)
-		return nil, fmt.Errorf("failed to get workflow plane: %w", err)
 	}
 
 	// Get events from pods and convert to structured format
 	allEventEntries := make([]models.WorkflowRunEventEntry, 0)
 	for _, pod := range pods {
-		podEvents, err := s.getArgoWorkflowPodEvents(ctx, workflowPlane, &pod)
+		podEvents, err := s.getArgoWorkflowPodEvents(ctx, wpc, &pod)
 		if err != nil {
 			logger.Warn("Failed to get events from pod", "pod", pod.Name, "error", err)
 			// Continue with other pods instead of failing completely
@@ -755,12 +741,12 @@ func (s *WorkflowRunService) getArgoWorkflowPods(ctx context.Context, wpClient c
 }
 
 // getArgoWorkflowPodEvents retrieves events for a pod using the gateway client
-func (s *WorkflowRunService) getArgoWorkflowPodEvents(ctx context.Context, workflowPlane *openchoreov1alpha1.WorkflowPlane, pod *corev1.Pod) (*corev1.EventList, error) {
+func (s *WorkflowRunService) getArgoWorkflowPodEvents(ctx context.Context, wpc *workflowPlaneClient, pod *corev1.Pod) (*corev1.EventList, error) {
 	if s.gwClient == nil {
 		return nil, fmt.Errorf("gateway client is not configured")
 	}
 
-	body, err := s.gwClient.GetPodEventsFromPlane(ctx, "workflowplane", workflowPlane.Spec.PlaneID, workflowPlane.Namespace, workflowPlane.Name,
+	body, err := s.gwClient.GetPodEventsFromPlane(ctx, "workflowplane", wpc.planeID, wpc.planeNamespace, wpc.planeName,
 		&gatewayClient.PodReference{
 			Namespace: pod.Namespace,
 			Name:      pod.Name,

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -381,10 +381,13 @@ func (s *workflowRunService) resolveWorkflowPlane(ctx context.Context, namespace
 		return workflowPlaneResult.WorkflowPlane, nil
 	}
 	if workflowPlaneResult.ClusterWorkflowPlane != nil {
-		// Build a facade WorkflowPlane from ClusterWorkflowPlane for the gateway client
+		// Build a facade WorkflowPlane from ClusterWorkflowPlane for the gateway client.
+		// Namespace must be "_cluster" for cluster-scoped planes so the gateway proxy
+		// constructs the correct URL path segment.
 		return &openchoreov1alpha1.WorkflowPlane{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: workflowPlaneResult.ClusterWorkflowPlane.Name,
+				Name:      workflowPlaneResult.ClusterWorkflowPlane.Name,
+				Namespace: "_cluster",
 			},
 			Spec: openchoreov1alpha1.WorkflowPlaneSpec{
 				PlaneID: workflowPlaneResult.ClusterWorkflowPlane.Spec.PlaneID,


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

This pull request enhances the workflow plane client logic to robustly support both namespace-scoped and cluster-scoped workflow planes, improving fallback behavior and ensuring correct routing for gateway calls (such as logs and events). The main changes introduce a new `workflowPlaneClient` struct to encapsulate both client and identity information, refactor service methods to use this abstraction, and ensure that cluster-scoped planes are correctly handled when namespace-scoped planes are unavailable.

Key changes include:

**Workflow Plane Client Abstraction and Fallback Logic:**
- Introduced the `workflowPlaneClient` struct to bundle the Kubernetes client with plane identity details (plane ID, namespace, and name), supporting both namespace and cluster-scoped workflow planes.
- Added `getWorkflowPlaneClientWithFallback`, which attempts to retrieve a namespace-scoped workflow plane client, falling back to a cluster-scoped plane if necessary. This ensures workflows can always be executed even if a namespace-scoped plane is missing.

**Service Method Refactoring:**
- Updated methods in `WorkflowPlaneService` and `WorkflowRunService` to use the new `workflowPlaneClient` abstraction and fallback logic, replacing direct calls to the old client retrieval methods. This affects log and event retrieval, as well as workflow existence checks. [[1]](diffhunk://#diff-084227396c48d24c30ffdab245a2f002acb7bc7d8c0c3767bf99445187286f8eL192-R287) [[2]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L462-R471) [[3]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L484-R492) [[4]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L584-R577) [[5]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L610-R603) [[6]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L677-R679) [[7]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L699-R700) [[8]](diffhunk://#diff-696c674e568d2cce7cb49370beda9bd9799298c904dd8732444b5ca29c220966L758-R749)

**Correct Namespace Handling for Cluster-Scoped Planes:**
- Ensured that when constructing a facade `WorkflowPlane` from a `ClusterWorkflowPlane`, the namespace is set to `"_cluster"` so that the gateway proxy generates the correct URL path.

**Defaulting and Spec Handling:**
- Improved the logic in `GetWorkflowSpec` to explicitly default to the cluster-scoped workflow plane named `"default"` if the `WorkflowPlaneRef` is not set, handling cases where the CRD defaulting webhook may not have run.

These changes collectively make workflow execution and log/event retrieval more robust and reliable across different workflow plane scopes.

## Approach
- Implemented a fallback mechanism in the WorkflowPlaneService to retrieve a cluster-scoped WorkflowPlane when a namespace-scoped one is unavailable.
- Updated related methods in WorkflowRunService to utilize the new fallback client, ensuring robust access to workflow resources.
- Added default handling for WorkflowPlaneRef in GetWorkflowSpec to default to a cluster-scoped WorkflowPlane named "default" when omitted.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/2562

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
