### PR TITLE
chore: add registry pull-through cache for local k3d development

### DIFF
--- a/install/k3d/registry-cache/README.md
+++ b/install/k3d/registry-cache/README.md
@@ -1,0 +1,106 @@
+# Registry Pull-Through Cache
+
+A Compose setup that runs local pull-through caches for container registries used by OpenChoreo.
+This speeds up repeated image pulls during local development.
+
+## How It Works
+
+Each cache is a `registry:2` instance configured as a pull-through proxy for one upstream registry.
+On first pull, the image is fetched from the upstream and cached locally. Subsequent pulls (by any
+client using the cache) are served from local disk.
+
+```mermaid
+flowchart LR
+    A[k3d node] -->|pull ghcr.io/openchoreo/controller| B[ghcr-cache :5601]
+    B -->|HIT| C[Serve from local disk]
+    B -->|MISS| D[Fetch from ghcr.io]
+    D --> E[Cache locally]
+    E --> C
+```
+
+If the caches are not running, containerd falls back to pulling directly from the upstream
+registry.
+
+## Ports
+
+| Port | Upstream        |
+|------|-----------------|
+| 5601 | ghcr.io         |
+| 5602 | docker.io       |
+| 5603 | quay.io         |
+| 5604 | cr.kgateway.dev |
+
+## Quick Start
+
+```bash
+# Start all caches
+docker compose up -d
+
+# Verify they're running
+docker compose ps
+```
+
+Then create your k3d cluster with the registry mirrors. Add this to your k3d config's
+`registries` section (or pass via `--registry-config`):
+
+```yaml
+registries:
+  config: |
+    mirrors:
+      "ghcr.io":
+        endpoint:
+          - http://host.k3d.internal:5601
+      "docker.io":
+        endpoint:
+          - http://host.k3d.internal:5602
+      "quay.io":
+        endpoint:
+          - http://host.k3d.internal:5603
+      "cr.kgateway.dev":
+        endpoint:
+          - http://host.k3d.internal:5604
+```
+
+## Browsing Cached Images
+
+```bash
+# List all cached repo:tag pairs
+./list-cached.sh
+
+# List only ghcr cache
+./list-cached.sh ghcr-cache
+```
+
+## Refreshing Mutable Tags
+
+Mutable tags like `latest-dev` get cached on first pull. If upstream publishes a new image
+under the same tag, the cache will continue serving the old version.
+
+Use the purge script to invalidate stale images:
+
+```bash
+# Purge a specific image:tag
+./purge-cache.sh openchoreo/controller:latest-dev
+
+# Purge all tags of a repo
+./purge-cache.sh openchoreo/controller
+
+# Purge all openchoreo repos
+./purge-cache.sh openchoreo/*
+
+# Purge from any registry (auto-detected)
+./purge-cache.sh external-secrets/external-secrets:v1.3.2
+
+# Purge everything from all caches
+./purge-cache.sh --all
+```
+
+## Cleanup
+
+```bash
+# Stop caches (cached data preserved in Docker volumes)
+docker compose down
+
+# Stop and clear all cached data
+docker compose down -v
+```

--- a/install/k3d/registry-cache/compose.yaml
+++ b/install/k3d/registry-cache/compose.yaml
@@ -1,0 +1,57 @@
+# Pull-through registry cache for local development
+# Caches images from upstream registries to speed up pulls during development.
+#
+# Usage:
+#   docker compose up -d          # Start all caches
+#   docker compose down           # Stop caches (data preserved)
+#   docker compose down -v        # Stop and clear cached data
+#
+# For shared office use, run on a shared machine and replace
+# "localhost" with the machine's IP in k3d registries config.
+
+services:
+  ghcr-cache:
+    image: registry:2
+    ports:
+      - "5601:5000"
+    volumes:
+      - ghcr-cache:/var/lib/registry
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://ghcr.io
+    restart: unless-stopped
+
+  dockerhub-cache:
+    image: registry:2
+    ports:
+      - "5602:5000"
+    volumes:
+      - dockerhub-cache:/var/lib/registry
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://registry-1.docker.io
+    restart: unless-stopped
+
+  quay-cache:
+    image: registry:2
+    ports:
+      - "5603:5000"
+    volumes:
+      - quay-cache:/var/lib/registry
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://quay.io
+    restart: unless-stopped
+
+  kgateway-cache:
+    image: registry:2
+    ports:
+      - "5604:5000"
+    volumes:
+      - kgateway-cache:/var/lib/registry
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://cr.kgateway.dev
+    restart: unless-stopped
+
+volumes:
+  ghcr-cache:
+  dockerhub-cache:
+  quay-cache:
+  kgateway-cache:

--- a/install/k3d/registry-cache/list-cached.sh
+++ b/install/k3d/registry-cache/list-cached.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# List cached images across all registry caches.
+#
+# Usage:
+#   ./list-cached.sh             # List all cached repo:tag pairs
+#   ./list-cached.sh ghcr-cache  # List only ghcr cache
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/compose.yaml"
+REPO_BASE="/var/lib/registry/docker/registry/v2/repositories"
+
+SERVICES=("ghcr-cache" "dockerhub-cache" "quay-cache" "kgateway-cache")
+UPSTREAMS=("ghcr.io" "docker.io" "quay.io" "cr.kgateway.dev")
+
+# Filter to a specific service if provided
+if [[ -n "$1" ]]; then
+  SERVICES=("$1")
+  case "$1" in
+    ghcr-cache)      UPSTREAMS=("ghcr.io") ;;
+    dockerhub-cache) UPSTREAMS=("docker.io") ;;
+    quay-cache)      UPSTREAMS=("quay.io") ;;
+    kgateway-cache)  UPSTREAMS=("cr.kgateway.dev") ;;
+    *)
+      echo "Unknown service: $1"
+      echo "Available: ghcr-cache, dockerhub-cache, quay-cache, kgateway-cache"
+      exit 1
+      ;;
+  esac
+fi
+
+for i in "${!SERVICES[@]}"; do
+  service="${SERVICES[$i]}"
+  upstream="${UPSTREAMS[$i]}"
+
+  tags=$(docker compose -f "$COMPOSE_FILE" exec -T "$service" \
+    find "$REPO_BASE" -name "link" -path "*/_manifests/tags/*/current/*" 2>/dev/null \
+    | sed 's|.*/repositories/||;s|/_manifests/tags/|:|;s|/current/link||' \
+    | sort) || true
+
+  if [[ -n "$tags" ]]; then
+    echo "=== ${upstream} ==="
+    echo "$tags"
+    echo ""
+  fi
+done

--- a/install/k3d/registry-cache/purge-cache.sh
+++ b/install/k3d/registry-cache/purge-cache.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Purge cached images from the registry caches.
+#
+# Usage:
+#   ./purge-cache.sh external-secrets/external-secrets:v1.3.2   # Purge a specific image:tag
+#   ./purge-cache.sh openchoreo/controller                      # Purge all tags of a repo
+#   ./purge-cache.sh openchoreo/*                               # Purge all openchoreo repos
+#   ./purge-cache.sh --all                                      # Purge everything from all caches
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/compose.yaml"
+REPO_BASE="/var/lib/registry/docker/registry/v2/repositories"
+
+ALL_SERVICES="ghcr-cache dockerhub-cache quay-cache kgateway-cache"
+
+compose_exec() {
+  local service="$1"
+  shift
+  docker compose -f "$COMPOSE_FILE" exec -T "$service" "$@"
+}
+
+gc() {
+  local service="$1"
+  compose_exec "$service" registry garbage-collect /etc/docker/registry/config.yml --delete-untagged 2>/dev/null || true
+}
+
+usage() {
+  cat <<EOF
+Usage: $0 <image-ref> [<image-ref>...]
+
+Purge cached images so the next pull fetches fresh from upstream.
+
+Arguments:
+  <repo>:<tag>      Purge a specific tag (e.g., openchoreo/controller:latest-dev)
+  <repo>            Purge all tags of a repo (e.g., openchoreo/controller)
+  <org>/*           Purge all repos under an org (e.g., openchoreo/*)
+  --all             Purge everything from all caches
+
+The image is automatically found and purged from whichever cache contains it.
+
+Examples:
+  $0 openchoreo/controller:latest-dev
+  $0 openchoreo/*
+  $0 external-secrets/external-secrets:v1.3.2
+  $0 jetstack/cert-manager-controller:v1.19.2
+  $0 --all
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+# Handle --all
+if [[ "$1" == "--all" ]]; then
+  for svc in $ALL_SERVICES; do
+    echo "Purging all cached images from ${svc}..."
+    compose_exec "$svc" sh -c "rm -rf ${REPO_BASE}/*" 2>/dev/null || true
+    gc "$svc"
+  done
+  echo "Done."
+  exit 0
+fi
+
+# Track which services need garbage collection
+gc_services=""
+
+for ref in "$@"; do
+  # Split into repo and tag
+  if [[ "$ref" == *:* ]]; then
+    repo="${ref%%:*}"
+    tag="${ref#*:}"
+  else
+    repo="$ref"
+    tag=""
+  fi
+
+  # Handle wildcard (e.g., openchoreo/*)
+  if [[ "$repo" == *'/*' ]]; then
+    org="${repo%/*}"
+    found=false
+    for svc in $ALL_SERVICES; do
+      if compose_exec "$svc" test -d "${REPO_BASE}/${org}" 2>/dev/null; then
+        compose_exec "$svc" rm -rf "${REPO_BASE}/${org}"
+        echo "Purged ${org}/* from ${svc}"
+        gc_services="${gc_services} ${svc}"
+        found=true
+      fi
+    done
+    if [[ "$found" == "false" ]]; then
+      echo "Not cached: ${org}/*"
+    fi
+    continue
+  fi
+
+  found=false
+  for svc in $ALL_SERVICES; do
+    if [[ -z "$tag" ]]; then
+      # Purge entire repo
+      if compose_exec "$svc" test -d "${REPO_BASE}/${repo}" 2>/dev/null; then
+        compose_exec "$svc" rm -rf "${REPO_BASE}/${repo}"
+        echo "Purged ${repo} from ${svc}"
+        gc_services="${gc_services} ${svc}"
+        found=true
+        break
+      fi
+    else
+      # Purge specific tag
+      tag_path="${REPO_BASE}/${repo}/_manifests/tags/${tag}"
+      if compose_exec "$svc" test -d "$tag_path" 2>/dev/null; then
+        compose_exec "$svc" rm -rf "$tag_path"
+        echo "Purged ${repo}:${tag} from ${svc}"
+        gc_services="${gc_services} ${svc}"
+        found=true
+        break
+      fi
+    fi
+  done
+
+  if [[ "$found" == "false" ]]; then
+    echo "Not cached: ${ref}"
+  fi
+done
+
+# Run garbage collection on affected caches (deduplicated)
+for svc in $(echo "$gc_services" | tr ' ' '\n' | sort -u); do
+  [[ -z "$svc" ]] && continue
+  echo "Running garbage collection on ${svc}..."
+  gc "$svc"
+done
+
+echo "Done."


### PR DESCRIPTION
## Purpose

Add registry pull-through caches for local k3d development to speed up image pulls and reduce external registry rate-limiting issues.

## Approach

- Add `compose.yaml` with pull-through cache services for ghcr.io, docker.io, quay.io, and cr.kgateway.dev
- Add `list-cached.sh` script to browse cached repo:tag pairs across all caches
- Add `purge-cache.sh` script to invalidate cached images by repo, tag, or org wildcard
- Add README with setup instructions and k3d registries mirror configuration

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)