### PR TITLE
fix: pass workflow kind when starting component workflow run

### DIFF
--- a/internal/occ/cmd/component/component.go
+++ b/internal/occ/cmd/component/component.go
@@ -102,9 +102,15 @@ func (cp *Component) StartWorkflow(params StartWorkflowParams) error {
 		baseParams = *wfConfig.Parameters
 	}
 
+	var workflowKind string
+	if wfConfig.Kind != nil {
+		workflowKind = string(*wfConfig.Kind)
+	}
+
 	return workflow.New().StartRun(workflow.StartRunParams{
 		Namespace:    params.Namespace,
 		WorkflowName: wfConfig.Name,
+		WorkflowKind: workflowKind,
 		RunName:      fmt.Sprintf("%s-build-%d", params.ComponentName, time.Now().Unix()),
 		Parameters:   baseParams,
 		Set:          params.Set,

--- a/internal/occ/cmd/workflow/params.go
+++ b/internal/occ/cmd/workflow/params.go
@@ -42,6 +42,7 @@ func (p DeleteParams) GetWorkflowName() string { return p.WorkflowName }
 type StartRunParams struct {
 	Namespace    string
 	WorkflowName string
+	WorkflowKind string                 // optional; "ClusterWorkflow" or "Workflow" (defaults to "Workflow")
 	RunName      string                 // optional; auto-generated if empty
 	Parameters   map[string]interface{} // base parameters (e.g., from component workflow config)
 	Set          []string               // --set overrides applied on top of Parameters

--- a/internal/occ/cmd/workflow/workflow.go
+++ b/internal/occ/cmd/workflow/workflow.go
@@ -148,6 +148,11 @@ func (w *Workflow) StartRun(params StartRunParams) error {
 	if len(params.Labels) > 0 {
 		labels = &params.Labels
 	}
+	var workflowKind *gen.WorkflowRunConfigKind
+	if params.WorkflowKind != "" {
+		k := gen.WorkflowRunConfigKind(params.WorkflowKind)
+		workflowKind = &k
+	}
 	req := gen.WorkflowRun{
 		Metadata: gen.ObjectMeta{
 			Name:      runName,
@@ -156,6 +161,7 @@ func (w *Workflow) StartRun(params StartRunParams) error {
 		},
 		Spec: &gen.WorkflowRunSpec{
 			Workflow: gen.WorkflowRunConfig{
+				Kind:       workflowKind,
 				Name:       params.WorkflowName,
 				Parameters: baseParams,
 			},


### PR DESCRIPTION
## Summary
- Fix `occ component workflow run` returning 404 for components referencing `ClusterWorkflow` resources
- Pass the workflow `Kind` (e.g., `ClusterWorkflow`) from the component's workflow config through to the `WorkflowRun` creation request
- Without the Kind field, the server defaults to looking for a namespace-scoped `Workflow` which doesn't exist for cluster-scoped workflows

## Test plan
- [x] Verified `occ component workflow run greeting-service` succeeds for a component using `ClusterWorkflow` (previously returned 404)
- [ ] Verify `occ component workflow run` still works for components using namespace-scoped `Workflow`
- [ ] Verify `occ workflow run start` (direct workflow run) is unaffected