### PR TITLE
fix: remove network policy egress rules

### DIFF
--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ComponentPolicyParams holds parameters for generating per-component NetworkPolicies
-// that include both ingress (endpoint-based) and egress (isolation) rules.
+// with ingress rules based on endpoint visibility.
 type ComponentPolicyParams struct {
 	Namespace     string                                         // data plane namespace name
 	CPNamespace   string                                         // control plane namespace name
@@ -23,73 +23,11 @@ type ComponentPolicyParams struct {
 	Endpoints     map[string]openchoreov1alpha1.WorkloadEndpoint // from workload spec
 }
 
-// MakeComponentPolicies returns a unified NetworkPolicy for a component that includes
-// both ingress rules (based on declared endpoints) and egress isolation rules
-// (blocking cross-CP-namespace and cross-environment traffic).
+// MakeComponentPolicies returns a NetworkPolicy for a component with ingress rules
+// based on declared endpoint visibility. Egress is unrestricted.
 func MakeComponentPolicies(params ComponentPolicyParams) []map[string]any {
 	// Build ingress rules from endpoints
 	ingressRules := makeIngressRules(params)
-
-	// Build egress isolation rules
-	egressRules := []any{
-		// Allow egress to namespaces that are NOT OpenChoreo CP namespaces
-		// (e.g., kube-system, kube-dns, external services)
-		map[string]any{
-			"to": []any{
-				map[string]any{
-					"namespaceSelector": map[string]any{
-						"matchExpressions": []any{
-							map[string]any{
-								"key":      labels.LabelKeyNamespaceName,
-								"operator": "DoesNotExist",
-							},
-						},
-					},
-				},
-			},
-		},
-		// Allow egress to dp namespaces in the same CP namespace and same environment
-		map[string]any{
-			"to": []any{
-				map[string]any{
-					"namespaceSelector": map[string]any{
-						"matchLabels": map[string]any{
-							labels.LabelKeyNamespaceName:   params.CPNamespace,
-							labels.LabelKeyEnvironmentName: params.Environment,
-						},
-					},
-				},
-			},
-		},
-		// Allow egress to external IPs (internet).
-		// namespaceSelector rules only match in-cluster pod traffic;
-		// without an ipBlock rule, all traffic to external IPs is denied.
-		// Private/internal ranges are excluded so that cross-namespace
-		// isolation is still enforced by the namespaceSelector rules above.
-		map[string]any{
-			"to": []any{
-				map[string]any{
-					"ipBlock": map[string]any{
-						"cidr": "0.0.0.0/0",
-						"except": []any{
-							"10.0.0.0/8",
-							"172.16.0.0/12",
-							"192.168.0.0/16",
-						},
-					},
-				},
-				map[string]any{
-					"ipBlock": map[string]any{
-						"cidr": "::/0",
-						"except": []any{
-							"fc00::/7",
-							"fe80::/10",
-						},
-					},
-				},
-			},
-		},
-	}
 
 	// Generate a policy name, truncated to k8s limits
 	policyName := fmt.Sprintf("openchoreo-%s", params.ComponentName)
@@ -104,8 +42,7 @@ func MakeComponentPolicies(params ComponentPolicyParams) []map[string]any {
 		"podSelector": map[string]any{
 			"matchLabels": toAnyMap(params.PodSelectors),
 		},
-		"policyTypes": []any{"Ingress", "Egress"},
-		"egress":      egressRules,
+		"policyTypes": []any{"Ingress"},
 	}
 	if len(ingressRules) > 0 {
 		spec["ingress"] = ingressRules

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -66,30 +66,6 @@ spec:
       app: test
   policyTypes:
     - Ingress
-    - Egress
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 
 	// Also verify empty map case
@@ -137,36 +113,12 @@ spec:
       openchoreo.dev/project: my-project
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector: {}
       ports:
         - protocol: TCP
           port: 8080
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 }
 
@@ -201,7 +153,6 @@ spec:
       app: api-svc
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector: {}
@@ -216,29 +167,6 @@ spec:
       ports:
         - protocol: TCP
           port: 9090
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 }
 
@@ -273,7 +201,6 @@ spec:
       app: public-api
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector: {}
@@ -288,29 +215,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 }
 
@@ -345,7 +249,6 @@ spec:
       app: internal-svc
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector: {}
@@ -360,29 +263,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 }
 
@@ -428,7 +308,6 @@ spec:
       app: mixed-svc
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector: {}
@@ -455,29 +334,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8443
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 }
 
@@ -508,36 +364,12 @@ spec:
       app: dns-svc
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector: {}
       ports:
         - protocol: UDP
           port: 5353
-  egress:
-    - to:
-        - namespaceSelector:
-            matchExpressions:
-              - key: openchoreo.dev/namespace
-                operator: DoesNotExist
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              openchoreo.dev/namespace: cp-ns
-              openchoreo.dev/environment: development
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-        - ipBlock:
-            cidr: "::/0"
-            except:
-              - fc00::/7
-              - fe80::/10
 `)
 }
 

--- a/test/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/test/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -435,30 +435,6 @@ var _ = Describe("NetworkPolicy Enforcement", Ordered, func() {
 		}, 2*time.Minute, 2*time.Second).Should(Succeed(),
 			"per-component NetworkPolicies not found in beta/proj1/dev dp namespace")
 
-		By("deploying unprotected pods into data plane namespaces for egress isolation testing")
-		// These pods have no NetworkPolicy selecting them, so all ingress is allowed.
-		// They isolate egress denial: blocked traffic proves the source's egress policy works.
-		for _, tc := range []struct{ ns, name string }{
-			{dpBetaProj1Dev, "unprotected-echo"},
-			{dpAcmeProj1Stg, "unprotected-echo"},
-		} {
-			output, err = framework.KubectlApplyLiteral(kubeContext, unprotectedPodYAML(tc.ns, tc.name))
-			Expect(err).NotTo(HaveOccurred(), "failed to create unprotected pod in %s: %s", tc.ns, output)
-		}
-
-		By("waiting for unprotected pods to be Running")
-		for _, ns := range []string{dpBetaProj1Dev, dpAcmeProj1Stg} {
-			Eventually(func(g Gomega) {
-				out, err := framework.Kubectl(kubeContext,
-					"get", "pod", "-n", ns, "-l", "app=unprotected-echo",
-					"--field-selector=status.phase=Running",
-					"-o", "jsonpath={.items[0].metadata.name}")
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(out).NotTo(BeEmpty())
-			}, 2*time.Minute, 2*time.Second).Should(Succeed(),
-				"unprotected-echo pod not running in %s", ns)
-		}
-
 		By("waiting until policy enforcement is observed on a blocked path")
 		assertSourcePodReady(dpAcmeProj2Dev, "openchoreo.dev/component=client-b", "main")
 		assertDNSResolution(dpAcmeProj2Dev, "openchoreo.dev/component=client-b", "main", fqdn("comp-b", dpAcmeProj1Dev))
@@ -610,26 +586,6 @@ var _ = Describe("NetworkPolicy Enforcement", Ordered, func() {
 			targetPort:  8080,
 			expectAllow: true,
 		},
-		{
-			name:        "egress isolation blocks cross-OC-namespace traffic to unprotected target",
-			intent:      "unprotected-echo in beta has no ingress policy, so only the source's egress isolation can block this path.",
-			sourceNS:    func() string { return dpAcmeProj1Dev },
-			sourceLabel: "openchoreo.dev/component=client-a",
-			sourceCtr:   "main",
-			targetHost:  func() string { return fqdn("unprotected-echo", dpBetaProj1Dev) },
-			targetPort:  8080,
-			expectAllow: false,
-		},
-		{
-			name:        "egress isolation blocks cross-environment traffic to unprotected target",
-			intent:      "unprotected-echo in staging has no ingress policy, so only the source's egress isolation can block this path.",
-			sourceNS:    func() string { return dpAcmeProj1Dev },
-			sourceLabel: "openchoreo.dev/component=client-a",
-			sourceCtr:   "main",
-			targetHost:  func() string { return fqdn("unprotected-echo", dpAcmeProj1Stg) },
-			targetPort:  8080,
-			expectAllow: false,
-		},
 	}
 
 	for _, scenario := range scenarios {
@@ -671,35 +627,6 @@ var _ = Describe("NetworkPolicy Enforcement", Ordered, func() {
 		}, 30*time.Second, 2*time.Second).Should(Succeed(), "DNS resolution failed")
 	})
 
-	It("allows external DNS resolution", func() {
-		By("pods should resolve external domain names while egress policies are in place")
-		Eventually(func() error {
-			_, err := framework.KubectlExecByLabel(
-				kubeContext,
-				dpAcmeProj1Dev,
-				"openchoreo.dev/component=client-a",
-				"main",
-				"nslookup", "www.google.com",
-			)
-			return err
-		}, 30*time.Second, 2*time.Second).Should(Succeed(), "external DNS resolution failed")
-	})
-
-	It("allows internet egress from data plane pods", func() {
-		By("pods should reach external internet endpoints; egress policies must not block outbound internet access")
-		assertSourcePodReady(dpAcmeProj1Dev, "openchoreo.dev/component=client-a", "main")
-		Eventually(func() error {
-			_, err := framework.KubectlExecByLabel(
-				kubeContext,
-				dpAcmeProj1Dev,
-				"openchoreo.dev/component=client-a",
-				"main",
-				"wget", "-q", "-O", "/dev/null", "--timeout=5", "http://connectivitycheck.gstatic.com/generate_204",
-			)
-			return err
-		}, 30*time.Second, 2*time.Second).Should(Succeed(),
-			"expected internet egress to be allowed from data plane pods")
-	})
 
 
 })


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Egress rules had only namespace selectors. internet access from pods is blocked on k3d setup. Allowing all cidrs is also not an option as it bypass namespace selectors (Can block private ip ranges, but not a proper solution). Therefore removing egress rules until we can properly figure out how to allow egress while restricting traffic within cluster and how to manage same behaviour across CNIs etc.
> endpoint visibilities will continue to work as expected due to ingress rules.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2163

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
