### PR TITLE
feat: add run and logs commands to clusterworkflow CLI

### DIFF
--- a/internal/occ/cmd/clusterworkflow/clusterworkflow.go
+++ b/internal/occ/cmd/clusterworkflow/clusterworkflow.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflow"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflowrun"
 	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
@@ -94,6 +96,49 @@ func (c *ClusterWorkflow) Delete(params DeleteParams) error {
 
 	fmt.Printf("ClusterWorkflow '%s' deleted\n", params.ClusterWorkflowName)
 	return nil
+}
+
+// StartRun starts a cluster workflow run in the given namespace.
+func (c *ClusterWorkflow) StartRun(params StartRunParams) error {
+	if params.Namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if params.WorkflowName == "" {
+		return fmt.Errorf("cluster workflow name is required")
+	}
+
+	return workflow.New().StartRun(workflow.StartRunParams{
+		Namespace:    params.Namespace,
+		WorkflowName: params.WorkflowName,
+		WorkflowKind: "ClusterWorkflow",
+		Set:          params.Set,
+	})
+}
+
+// Logs fetches and displays logs for a cluster workflow.
+func (c *ClusterWorkflow) Logs(params LogsParams) error {
+	if params.Namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if params.WorkflowName == "" {
+		return fmt.Errorf("cluster workflow name is required")
+	}
+
+	runName := params.RunName
+	if runName == "" {
+		var err error
+		runName, err = workflow.ResolveLatestRun(params.Namespace, params.WorkflowName, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return workflowrun.New().Logs(workflowrun.LogsParams{
+		Namespace:       params.Namespace,
+		WorkflowRunName: runName,
+		Follow:          params.Follow,
+		Since:           params.Since,
+	})
 }
 
 func printList(items []gen.ClusterWorkflow) error {

--- a/internal/occ/cmd/clusterworkflow/params.go
+++ b/internal/occ/cmd/clusterworkflow/params.go
@@ -12,3 +12,22 @@ type GetParams struct {
 type DeleteParams struct {
 	ClusterWorkflowName string
 }
+
+// StartRunParams defines parameters for starting a cluster workflow run
+type StartRunParams struct {
+	Namespace    string
+	WorkflowName string
+	Set          []string // --set overrides applied on top of Parameters
+}
+
+// LogsParams defines parameters for getting cluster workflow logs
+type LogsParams struct {
+	Namespace    string
+	WorkflowName string
+	RunName      string // optional --workflowrun flag; defaults to latest
+	Follow       bool
+	Since        string
+}
+
+func (p LogsParams) GetNamespace() string    { return p.Namespace }
+func (p LogsParams) GetWorkflowName() string { return p.WorkflowName }

--- a/pkg/cli/cmd/clusterworkflow/clusterworkflow.go
+++ b/pkg/cli/cmd/clusterworkflow/clusterworkflow.go
@@ -26,6 +26,8 @@ func NewClusterWorkflowCmd() *cobra.Command {
 		newListClusterWorkflowCmd(),
 		newGetClusterWorkflowCmd(),
 		newDeleteClusterWorkflowCmd(),
+		newStartClusterWorkflowCmd(),
+		newLogsClusterWorkflowCmd(),
 	)
 
 	return clusterWorkflowCmd
@@ -62,6 +64,58 @@ func newDeleteClusterWorkflowCmd() *cobra.Command {
 			})
 		},
 	}
+	return cmd
+}
+
+func newStartClusterWorkflowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.StartClusterWorkflow.Use,
+		Short:   constants.StartClusterWorkflow.Short,
+		Long:    constants.StartClusterWorkflow.Long,
+		Example: constants.StartClusterWorkflow.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+			set, _ := cmd.Flags().GetStringArray(flags.Set.Name)
+			return clusterworkflow.New().StartRun(clusterworkflow.StartRunParams{
+				Namespace:    namespace,
+				WorkflowName: args[0],
+				Set:          set,
+			})
+		},
+	}
+
+	flags.AddFlags(cmd, flags.Namespace, flags.Set)
+
+	return cmd
+}
+
+func newLogsClusterWorkflowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.LogsClusterWorkflow.Use,
+		Short:   constants.LogsClusterWorkflow.Short,
+		Long:    constants.LogsClusterWorkflow.Long,
+		Example: constants.LogsClusterWorkflow.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
+			follow, _ := cmd.Flags().GetBool(flags.Follow.Name)
+			since, _ := cmd.Flags().GetString(flags.Since.Name)
+			run, _ := cmd.Flags().GetString(flags.WorkflowRun.Name)
+			return clusterworkflow.New().Logs(clusterworkflow.LogsParams{
+				Namespace:    namespace,
+				WorkflowName: args[0],
+				RunName:      run,
+				Follow:       follow,
+				Since:        since,
+			})
+		},
+	}
+
+	flags.AddFlags(cmd, flags.Namespace, flags.Follow, flags.Since, flags.WorkflowRun)
+
 	return cmd
 }
 

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -685,6 +685,34 @@ This command allows you to:
   occ clusterworkflow delete build-go`,
 	}
 
+	StartClusterWorkflow = Command{
+		Use:   "run CLUSTER_WORKFLOW_NAME",
+		Short: "Run a cluster workflow",
+		Long: `Run a new cluster workflow with optional parameters.
+Requires --namespace to specify where the workflow run will be created.`,
+		Example: fmt.Sprintf(`  # Run a cluster workflow
+  %[1]s clusterworkflow run dockerfile-builder --namespace acme-corp
+
+  # Run with parameters
+  %[1]s clusterworkflow run dockerfile-builder --namespace acme-corp \
+    --set spec.workflow.parameters.repository.url=https://github.com/example/repo`, messages.DefaultCLIName),
+	}
+
+	LogsClusterWorkflow = Command{
+		Use:   "logs CLUSTER_WORKFLOW_NAME",
+		Short: "Get logs for a cluster workflow",
+		Long: `Get logs for a cluster workflow by finding the latest workflow run.
+Use --workflowrun to specify a particular workflow run instead of the latest.`,
+		Example: fmt.Sprintf(`  # Get logs for the latest run of a cluster workflow
+  %[1]s clusterworkflow logs dockerfile-builder --namespace acme-corp
+
+  # Get logs for a specific run
+  %[1]s clusterworkflow logs dockerfile-builder --namespace acme-corp --workflowrun my-run
+
+  # Follow logs
+  %[1]s clusterworkflow logs dockerfile-builder --namespace acme-corp -f`, messages.DefaultCLIName),
+	}
+
 	ListWorkflow = Command{
 		Use:   "list",
 		Short: "List workflows",


### PR DESCRIPTION
## Summary
- Add `run` and `logs` subcommands to `occ clusterworkflow`
- Reuses existing namespace-scoped WorkflowRun API with `Kind: ClusterWorkflow` — no new API endpoints needed
- `run` delegates to `workflow.StartRun()` with `WorkflowKind: "ClusterWorkflow"`
- `logs` delegates to `workflowrun.Logs()` after resolving the latest run via `workflow.ResolveLatestRun()`

## Test plan
- [x] `occ clusterworkflow run dockerfile-builder --namespace default --set ...` creates a WorkflowRun and Argo workflow is created
- [x] `occ clusterworkflow --help` shows `run` and `logs` subcommands
- [x] Existing tests pass (`go test ./internal/occ/cmd/clusterworkflow/... ./pkg/cli/cmd/clusterworkflow/...`)
- [ ] Verify `occ clusterworkflow logs` retrieves logs from a completed run