### PR TITLE
fix: handle existing release binding in deploy flow

### DIFF
--- a/internal/occ/cmd/component/component.go
+++ b/internal/occ/cmd/component/component.go
@@ -280,6 +280,28 @@ func (cp *Component) deployComponent(ctx context.Context, c *client.Client, para
 		},
 	}
 
+	// Check if a binding already exists for the lowest environment
+	existing, err := c.GetReleaseBinding(ctx, params.Namespace, bindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing != nil {
+		// Update existing binding with the new release
+		existing.Spec.ReleaseName = rb.Spec.ReleaseName
+
+		// Apply overrides if provided
+		if len(params.Set) > 0 {
+			merged, err := mergeOverridesWithBinding(existing, params.Set)
+			if err != nil {
+				return nil, fmt.Errorf("failed to merge overrides: %w", err)
+			}
+			existing = merged
+		}
+
+		return c.UpdateReleaseBinding(ctx, params.Namespace, bindingName, *existing)
+	}
+
 	// Apply overrides if provided
 	if len(params.Set) > 0 {
 		merged, err := mergeOverridesWithBinding(&rb, params.Set)
@@ -289,12 +311,7 @@ func (cp *Component) deployComponent(ctx context.Context, c *client.Client, para
 		rb = *merged
 	}
 
-	binding, err := c.CreateReleaseBinding(ctx, params.Namespace, rb)
-	if err != nil {
-		return nil, err
-	}
-
-	return binding, nil
+	return c.CreateReleaseBinding(ctx, params.Namespace, rb)
 }
 
 // promoteComponent promotes a component to the target environment


### PR DESCRIPTION
## Summary
- Fix `occ component deploy` returning 409 Conflict when re-deploying a component that already has a ReleaseBinding for the lowest environment
- The deploy flow now checks for an existing binding and updates it (with release name and overrides) instead of always attempting to create, matching the pattern already used by the promote flow

## Test plan
- [ ] Run `occ component deploy <component>` twice — second run should update the existing binding instead of failing with 409
- [ ] Run `occ component deploy <component> --set <override>` with an existing binding — overrides should be applied correctly
- [ ] Run `occ component deploy <component> --to <env>` (promote) — existing behavior unchanged