### PR TITLE
fix: update missed Release to RenderedRelease references

### DIFF
--- a/docs/crds/README.md
+++ b/docs/crds/README.md
@@ -4,4 +4,4 @@ This directory contains design documentation for OpenChoreo's Custom Resource De
 
 ## List of CRDs
 
-- [**Release**](release.md) - Applies component-specific resources to the dataplane that are generated via bindings
+- [**RenderedRelease**](renderedrelease.md) - Applies component-specific resources to the dataplane that are generated via bindings

--- a/install/quick-start/build-deploy-greeter.sh
+++ b/install/quick-start/build-deploy-greeter.sh
@@ -210,7 +210,7 @@ done
 log_info "Waiting for Deployment to be available..."
 elapsed=0
 while true; do
-    DEPLOYMENT_AVAILABLE=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="Deployment") | .status.conditions[]? | select(.type=="Available" and .reason=="MinimumReplicasAvailable") | .status' || echo "")
+    DEPLOYMENT_AVAILABLE=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="Deployment") | .status.conditions[]? | select(.type=="Available" and .reason=="MinimumReplicasAvailable") | .status' || echo "")
 
     if [[ "$DEPLOYMENT_AVAILABLE" == "True" ]]; then
         log_success "Deployment is available"
@@ -230,7 +230,7 @@ done
 log_info "Waiting for HTTPRoute to be ready..."
 elapsed=0
 while true; do
-    ROUTE_ACCEPTED=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="HTTPRoute") | .status.parents[]?.conditions[]? | select(.type=="Accepted") | .status' || echo "")
+    ROUTE_ACCEPTED=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="HTTPRoute") | .status.parents[]?.conditions[]? | select(.type=="Accepted") | .status' || echo "")
 
     if [[ "$ROUTE_ACCEPTED" == "True" ]]; then
         log_success "HTTPRoute is ready"
@@ -247,8 +247,8 @@ while true; do
 done
 
 # Get the public URL from HTTPRoute
-HOSTNAME=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.hostnames[0]' || echo "")
-PATH_PREFIX=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.rules[0].matches[0].path.value' || echo "")
+HOSTNAME=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.hostnames[0]' || echo "")
+PATH_PREFIX=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.rules[0].matches[0].path.value' || echo "")
 
 if [[ -z "$HOSTNAME" ]] || [[ "$HOSTNAME" == "null" ]]; then
     log_error "Failed to retrieve hostname from HTTPRoute"

--- a/install/quick-start/deploy-gcp-demo.sh
+++ b/install/quick-start/deploy-gcp-demo.sh
@@ -136,10 +136,10 @@ log_info "Waiting for all Deployments to be available..."
 elapsed=0
 while true; do
     # Count total releases for this project
-    total_releases=$(kubectl get release -n "$NAMESPACE" -o json 2>/dev/null | jq -r "[.items[] | select(.metadata.labels.\"openchoreo.dev/project\" == \"$PROJECT_NAME\")] | length" || echo "0")
+    total_releases=$(kubectl get renderedrelease -n "$NAMESPACE" -o json 2>/dev/null | jq -r "[.items[] | select(.metadata.labels.\"openchoreo.dev/project\" == \"$PROJECT_NAME\")] | length" || echo "0")
 
     # Count releases with healthy deployments
-    available=$(kubectl get release -n "$NAMESPACE" -o json 2>/dev/null | jq -r "[.items[] | select(.metadata.labels.\"openchoreo.dev/project\" == \"$PROJECT_NAME\") | select(.status.resources[]? | select(.kind==\"Deployment\" and .healthStatus==\"Healthy\"))] | length" || echo "0")
+    available=$(kubectl get renderedrelease -n "$NAMESPACE" -o json 2>/dev/null | jq -r "[.items[] | select(.metadata.labels.\"openchoreo.dev/project\" == \"$PROJECT_NAME\") | select(.status.resources[]? | select(.kind==\"Deployment\" and .healthStatus==\"Healthy\"))] | length" || echo "0")
 
     if [[ "$total_releases" -gt 0 ]] && [[ "$available" -eq "$total_releases" ]]; then
         log_success "All $total_releases Deployments are available"
@@ -162,7 +162,7 @@ done
 
 # Get the frontend URL
 FRONTEND_DEPLOYMENT="frontend${DEPLOYMENT_NAME_SUFFIX}"
-HOSTNAME=$(kubectl get release "$FRONTEND_DEPLOYMENT" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.hostnames[0]' || echo "")
+HOSTNAME=$(kubectl get renderedrelease "$FRONTEND_DEPLOYMENT" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.hostnames[0]' || echo "")
 
 echo ""
 log_success "GCP Microservices Demo is ready!"
@@ -187,7 +187,7 @@ if [[ -n "$HOSTNAME" ]] && [[ "$HOSTNAME" != "null" ]]; then
     echo "   Open this URL in your browser to explore the microservices demo."
 else
     log_warning "Could not retrieve frontend URL"
-    log_info "You can find the URL with: kubectl get release $FRONTEND_DEPLOYMENT -n $NAMESPACE -o yaml"
+    log_info "You can find the URL with: kubectl get renderedrelease $FRONTEND_DEPLOYMENT -n $NAMESPACE -o yaml"
 fi
 
 echo ""

--- a/install/quick-start/deploy-react-starter.sh
+++ b/install/quick-start/deploy-react-starter.sh
@@ -119,7 +119,7 @@ done
 log_info "Waiting for Deployment to be available..."
 elapsed=0
 while true; do
-    DEPLOYMENT_AVAILABLE=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="Deployment") | .status.conditions[]? | select(.type=="Available" and .reason=="MinimumReplicasAvailable") | .status' || echo "")
+    DEPLOYMENT_AVAILABLE=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="Deployment") | .status.conditions[]? | select(.type=="Available" and .reason=="MinimumReplicasAvailable") | .status' || echo "")
 
     if [[ "$DEPLOYMENT_AVAILABLE" == "True" ]]; then
         log_success "Deployment is available"
@@ -139,7 +139,7 @@ done
 log_info "Waiting for HTTPRoute to be ready..."
 elapsed=0
 while true; do
-    ROUTE_ACCEPTED=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="HTTPRoute") | .status.parents[]?.conditions[]? | select(.type=="Accepted") | .status' || echo "")
+    ROUTE_ACCEPTED=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.status.resources[]? | select(.kind=="HTTPRoute") | .status.parents[]?.conditions[]? | select(.type=="Accepted") | .status' || echo "")
 
     if [[ "$ROUTE_ACCEPTED" == "True" ]]; then
         log_success "HTTPRoute is ready"
@@ -156,7 +156,7 @@ while true; do
 done
 
 # Get the public URL from HTTPRoute
-HOSTNAME=$(kubectl get release "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.hostnames[0]' || echo "")
+HOSTNAME=$(kubectl get renderedrelease "$RELEASE_BINDING_NAME" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.spec.resources[]? | select(.id | startswith("httproute-")) | .object.spec.hostnames[0]' || echo "")
 
 if [[ -z "$HOSTNAME" ]] || [[ "$HOSTNAME" == "null" ]]; then
     log_error "Failed to retrieve hostname from HTTPRoute"

--- a/internal/openchoreo-api/api/handlers/releasebinding_k8sresources.go
+++ b/internal/openchoreo-api/api/handlers/releasebinding_k8sresources.go
@@ -136,7 +136,7 @@ func (h *Handler) handleK8sResourceTreeError(err error) (gen.GetReleaseBindingK8
 		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
 	}
 	if errors.Is(err, k8sresourcessvc.ErrRenderedReleaseNotFound) {
-		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("Release")}, nil
+		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("RenderedRelease")}, nil
 	}
 	if errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound) {
 		return gen.GetReleaseBindingK8sResourceTree404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
@@ -153,7 +153,7 @@ func (h *Handler) handleK8sResourceEventsError(err error) (gen.GetReleaseBinding
 		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
 	}
 	if errors.Is(err, k8sresourcessvc.ErrRenderedReleaseNotFound) {
-		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("Release")}, nil
+		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("RenderedRelease")}, nil
 	}
 	if errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound) {
 		return gen.GetReleaseBindingK8sResourceEvents404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
@@ -173,7 +173,7 @@ func (h *Handler) handleK8sResourceLogsError(err error) (gen.GetReleaseBindingK8
 		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
 	}
 	if errors.Is(err, k8sresourcessvc.ErrRenderedReleaseNotFound) {
-		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("Release")}, nil
+		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("RenderedRelease")}, nil
 	}
 	if errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound) {
 		return gen.GetReleaseBindingK8sResourceLogs404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -366,7 +366,7 @@ e2e.diagnostics: ## Collect logs, events, and resource dumps from all namespaces
 		done; \
 	done
 	@$(E2E_KUBECTL) get clusterdataplane,workflowplane,observabilityplane -n default -o yaml > $(E2E_DIAGNOSTICS_DIR)/plane-resources.yaml 2>&1 || true
-	@$(E2E_KUBECTL) get component,componentrelease,releasebinding,release -A -o yaml > $(E2E_DIAGNOSTICS_DIR)/release-chain.yaml 2>&1 || true
+	@$(E2E_KUBECTL) get component,componentrelease,releasebinding,renderedrelease -A -o yaml > $(E2E_DIAGNOSTICS_DIR)/release-chain.yaml 2>&1 || true
 	@$(call log_success, Diagnostics collected to $(E2E_DIAGNOSTICS_DIR))
 
 .PHONY: e2e.down


### PR DESCRIPTION
## Summary
- Fix `kubectl get release` commands in quickstart scripts to use `kubectl get renderedrelease` after the CRD rename
- Fix `notFound("Release")` API error messages to `notFound("RenderedRelease")` in k8s resource handlers
- Fix e2e diagnostics makefile target to use `renderedrelease` resource name
- Fix CRD docs README link to point to `renderedrelease.md`

## Test plan
- [ ] Verify quickstart scripts (`build-deploy-greeter.sh`, `deploy-gcp-demo.sh`, `deploy-react-starter.sh`) work with the renamed CRD
- [ ] Verify API 404 responses show correct resource name "RenderedRelease"
- [ ] Verify `make e2e.diagnostics` collects renderedrelease resources