### PR TITLE
fix: fix workflow plane creation in quickstart

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -830,7 +830,7 @@ create_workflowplane_resource() {
 
     kubectl apply -f - >/dev/null <<BPEOF
 apiVersion: openchoreo.dev/v1alpha1
-kind: WorkflowPlane
+kind: ClusterWorkflowPlane
 metadata:
   name: default
   namespace: default

--- a/internal/controller/workflowrun/controller_conditions.go
+++ b/internal/controller/workflowrun/controller_conditions.go
@@ -102,7 +102,7 @@ func setWorkflowPlaneNotFoundCondition(workflowRun *openchoreov1alpha1.WorkflowR
 		Type:               string(ConditionWorkflowCompleted),
 		Status:             metav1.ConditionFalse,
 		Reason:             string(ReasonWorkflowPlaneNotFound),
-		Message:            "No workflow plane found for the project associated with this workflow run",
+		Message:            "No workflow plane found for the workflow associated with this workflow run",
 		ObservedGeneration: workflowRun.Generation,
 	})
 }


### PR DESCRIPTION
## Summary
- Fix quick-start helper to use `ClusterWorkflowPlane` instead of `WorkflowPlane` kind, which was causing "No workflow plane found" errors during builds
- Fix workflow plane not found condition message to reference "workflow" instead of "project"

## Test plan
- [ ] Verify quick-start build-deploy-greeter flow succeeds without workflow plane errors