### PR TITLE
fix: update authz mappings in Helm values for quick-start

### DIFF
--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -10,12 +10,11 @@ openchoreoApi:
     security:
       authorization:
         bootstrap:
-          # Helm replaces lists so all mappings must be specified here.
-          # The chart defaults provide the first 3; quick-start adds the CLI binding.
+          # Includes admin, developer, platform-engineer bindings from base values,
+          # all system bindings, and the quick-start CLI admin binding.
           mappings:
             - name: admin-binding
               kind: ClusterAuthzRoleBinding
-              system: true
               roleMappings:
                 - roleRef:
                     name: admin
@@ -23,6 +22,26 @@ openchoreoApi:
               entitlement:
                 claim: groups
                 value: admins
+              effect: allow
+            - name: developer-binding
+              kind: ClusterAuthzRoleBinding
+              roleMappings:
+                - roleRef:
+                    name: developer
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: groups
+                value: developers
+              effect: allow
+            - name: platform-engineer-binding
+              kind: ClusterAuthzRoleBinding
+              roleMappings:
+                - roleRef:
+                    name: platform-engineer
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: groups
+                value: platform-engineers
               effect: allow
             - name: backstage-catalog-reader-binding
               kind: ClusterAuthzRoleBinding
@@ -46,16 +65,6 @@ openchoreoApi:
                 claim: sub
                 value: openchoreo-rca-agent
               effect: allow
-            - name: quickstart-cli-admin-binding
-              kind: ClusterAuthzRoleBinding
-              roleMappings:
-                - roleRef:
-                    name: admin
-                    kind: ClusterAuthzRole
-              entitlement:
-                claim: sub
-                value: openchoreo-cli-quickstart
-              effect: allow
             - name: workload-publisher-binding
               kind: ClusterAuthzRoleBinding
               system: true
@@ -77,6 +86,26 @@ openchoreoApi:
               entitlement:
                 claim: sub
                 value: openchoreo-observer-resource-reader-client
+              effect: allow
+            - name: mcp-tryout-client-binding
+              kind: ClusterAuthzRoleBinding
+              roleMappings:
+                - roleRef:
+                    name: admin
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: service_mcp_client
+              effect: allow
+            - name: quickstart-cli-admin-binding
+              kind: ClusterAuthzRoleBinding
+              roleMappings:
+                - roleRef:
+                    name: admin
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-cli-quickstart
               effect: allow
 
 backstage:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pr is to sync quick start authz binding with base authz bindings in the helm cp values
 
 **Missing in quickstart (present in base):**                                                                                      
  - sre-binding — intentionally excluded per your request                                                                       
                                                                                                                                
 **Additional in quickstart (not in base):**                                                                                       
  - quickstart-cli-admin-binding — quickstart-specific, grants CLI service account admin access
                                                                                                                                
**Identical between both:**                                                                                                       
  All other 8 bindings match exactly — admin-binding, developer-binding, platform-engineer-binding,
  backstage-catalog-reader-binding, rca-agent-binding, workload-publisher-binding, observer-resource-reader-binding,            
  mcp-tryout-client-binding.    

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
