### PR TITLE
feat: add clusterworkflowplane list, get, and delete CLI commands

### DIFF
--- a/internal/occ/cmd/clusterworkflowplane/clusterworkflowplane.go
+++ b/internal/occ/cmd/clusterworkflowplane/clusterworkflowplane.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterworkflowplane
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ClusterWorkflowPlane implements cluster workflow plane operations
+type ClusterWorkflowPlane struct{}
+
+// New creates a new cluster workflow plane implementation
+func New() *ClusterWorkflowPlane {
+	return &ClusterWorkflowPlane{}
+}
+
+// List lists all cluster-scoped workflow planes
+func (c *ClusterWorkflowPlane) List() error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ClusterWorkflowPlane, string, error) {
+		p := &gen.ListClusterWorkflowPlanesParams{}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := cl.ListClusterWorkflowPlanes(ctx, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+	return printList(items)
+}
+
+// Get retrieves a single cluster workflow plane and outputs it as YAML
+func (c *ClusterWorkflowPlane) Get(params GetParams) error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	result, err := cl.GetClusterWorkflowPlane(ctx, params.ClusterWorkflowPlaneName)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cluster workflow plane to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete deletes a single cluster workflow plane
+func (c *ClusterWorkflowPlane) Delete(params DeleteParams) error {
+	ctx := context.Background()
+
+	cl, err := client.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := cl.DeleteClusterWorkflowPlane(ctx, params.ClusterWorkflowPlaneName); err != nil {
+		return err
+	}
+
+	fmt.Printf("ClusterWorkflowPlane '%s' deleted\n", params.ClusterWorkflowPlaneName)
+	return nil
+}
+
+func printList(items []gen.ClusterWorkflowPlane) error {
+	if len(items) == 0 {
+		fmt.Println("No cluster workflow planes found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tAGE")
+
+	for _, cwp := range items {
+		age := ""
+		if cwp.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*cwp.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\n",
+			cwp.Metadata.Name,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/clusterworkflowplane/params.go
+++ b/internal/occ/cmd/clusterworkflowplane/params.go
@@ -1,0 +1,14 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterworkflowplane
+
+// GetParams defines parameters for getting a single cluster workflow plane
+type GetParams struct {
+	ClusterWorkflowPlaneName string
+}
+
+// DeleteParams defines parameters for deleting a single cluster workflow plane
+type DeleteParams struct {
+	ClusterWorkflowPlaneName string
+}

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -1200,6 +1200,33 @@ func (c *Client) GetClusterWorkflowPlane(ctx context.Context, clusterWorkflowPla
 	return resp.JSON200, nil
 }
 
+// ListClusterWorkflowPlanes retrieves all cluster-scoped workflow planes
+func (c *Client) ListClusterWorkflowPlanes(ctx context.Context, params *gen.ListClusterWorkflowPlanesParams) (*gen.ClusterWorkflowPlaneList, error) {
+	if params == nil {
+		params = &gen.ListClusterWorkflowPlanesParams{}
+	}
+	resp, err := c.client.ListClusterWorkflowPlanesWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster workflow planes: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteClusterWorkflowPlane deletes a cluster workflow plane
+func (c *Client) DeleteClusterWorkflowPlane(ctx context.Context, clusterWorkflowPlaneName string) error {
+	resp, err := c.client.DeleteClusterWorkflowPlaneWithResponse(ctx, clusterWorkflowPlaneName)
+	if err != nil {
+		return fmt.Errorf("failed to delete cluster workflow plane: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return nil
+}
+
 // ListClusterObservabilityPlanes retrieves all cluster-scoped observability planes
 func (c *Client) ListClusterObservabilityPlanes(ctx context.Context, params *gen.ListClusterObservabilityPlanesParams) (*gen.ClusterObservabilityPlaneList, error) {
 	if params == nil {

--- a/pkg/cli/cmd/clusterworkflowplane/clusterworkflowplane.go
+++ b/pkg/cli/cmd/clusterworkflowplane/clusterworkflowplane.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterworkflowplane
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterworkflowplane"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
+	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
+	"github.com/openchoreo/openchoreo/pkg/cli/flags"
+)
+
+func NewClusterWorkflowPlaneCmd() *cobra.Command {
+	clusterWorkflowPlaneCmd := &cobra.Command{
+		Use:     constants.ClusterWorkflowPlane.Use,
+		Aliases: constants.ClusterWorkflowPlane.Aliases,
+		Short:   constants.ClusterWorkflowPlane.Short,
+		Long:    constants.ClusterWorkflowPlane.Long,
+	}
+
+	clusterWorkflowPlaneCmd.AddCommand(
+		newListClusterWorkflowPlaneCmd(),
+		newGetClusterWorkflowPlaneCmd(),
+		newDeleteClusterWorkflowPlaneCmd(),
+	)
+
+	return clusterWorkflowPlaneCmd
+}
+
+func newGetClusterWorkflowPlaneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.GetClusterWorkflowPlane.Use,
+		Short:   constants.GetClusterWorkflowPlane.Short,
+		Long:    constants.GetClusterWorkflowPlane.Long,
+		Example: constants.GetClusterWorkflowPlane.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return clusterworkflowplane.New().Get(clusterworkflowplane.GetParams{
+				ClusterWorkflowPlaneName: args[0],
+			})
+		},
+	}
+	return cmd
+}
+
+func newDeleteClusterWorkflowPlaneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     constants.DeleteClusterWorkflowPlane.Use,
+		Short:   constants.DeleteClusterWorkflowPlane.Short,
+		Long:    constants.DeleteClusterWorkflowPlane.Long,
+		Example: constants.DeleteClusterWorkflowPlane.Example,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return clusterworkflowplane.New().Delete(clusterworkflowplane.DeleteParams{
+				ClusterWorkflowPlaneName: args[0],
+			})
+		},
+	}
+	return cmd
+}
+
+func newListClusterWorkflowPlaneCmd() *cobra.Command {
+	return (&builder.CommandBuilder{
+		Command: constants.ListClusterWorkflowPlane,
+		Flags:   []flags.Flag{},
+		RunE: func(fg *builder.FlagGetter) error {
+			return clusterworkflowplane.New().List()
+		},
+		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
+	}).Build()
+}

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -685,6 +685,37 @@ This command allows you to:
   occ clusterobservabilityplane delete default`,
 	}
 
+	ClusterWorkflowPlane = Command{
+		Use:     "clusterworkflowplane",
+		Aliases: []string{"clusterworkflowplanes", "cwp"},
+		Short:   "Manage cluster workflow planes",
+		Long:    `Manage cluster-scoped workflow planes for OpenChoreo.`,
+	}
+
+	ListClusterWorkflowPlane = Command{
+		Use:   "list",
+		Short: "List cluster workflow planes",
+		Long:  `List all cluster-scoped workflow planes available across the cluster.`,
+		Example: `  # List all cluster workflow planes
+  occ clusterworkflowplane list`,
+	}
+
+	GetClusterWorkflowPlane = Command{
+		Use:   "get [CLUSTER_WORKFLOW_PLANE_NAME]",
+		Short: "Get a cluster workflow plane",
+		Long:  `Get a cluster workflow plane and display its details in YAML format.`,
+		Example: `  # Get a cluster workflow plane
+  occ clusterworkflowplane get default`,
+	}
+
+	DeleteClusterWorkflowPlane = Command{
+		Use:   "delete [CLUSTER_WORKFLOW_PLANE_NAME]",
+		Short: "Delete a cluster workflow plane",
+		Long:  `Delete a cluster workflow plane by name.`,
+		Example: `  # Delete a cluster workflow plane
+  occ clusterworkflowplane delete default`,
+	}
+
 	ClusterTrait = Command{
 		Use:     "clustertrait",
 		Aliases: []string{"clustertraits"},

--- a/pkg/cli/core/root/root.go
+++ b/pkg/cli/core/root/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clusterobservabilityplane"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clustertrait"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clusterworkflow"
+	"github.com/openchoreo/openchoreo/pkg/cli/cmd/clusterworkflowplane"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/component"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/componentrelease"
 	"github.com/openchoreo/openchoreo/pkg/cli/cmd/componenttype"
@@ -70,6 +71,7 @@ func BuildRootCmd(config *config.CLIConfig, impl api.CommandImplementationInterf
 		clustercomponenttype.NewClusterComponentTypeCmd(),
 		clusterdataplane.NewClusterDataPlaneCmd(),
 		clusterobservabilityplane.NewClusterObservabilityPlaneCmd(),
+		clusterworkflowplane.NewClusterWorkflowPlaneCmd(),
 		trait.NewTraitCmd(),
 		clustertrait.NewClusterTraitCmd(),
 		clusterworkflow.NewClusterWorkflowCmd(),


### PR DESCRIPTION
## Summary
- Add `list`, `get`, and `delete` subcommands for the `clusterworkflowplane` CLI resource
- Add `ListClusterWorkflowPlanes` and `DeleteClusterWorkflowPlane` client wrapper methods
- Register command constants and wire up the root command with aliases (`clusterworkflowplanes`, `cwp`)

## Test plan
- [x] `occ clusterworkflowplane list` — shows help and runs correctly
- [x] `occ clusterworkflowplane get <name>` — shows help and accepts 1 arg
- [x] `occ clusterworkflowplane delete <name>` — shows help and accepts 1 arg
- [x] `occ cwp` alias works
- [x] `go build ./cmd/occ/` compiles successfully