### PR TITLE
fix: update quick-start helpers to use ClusterWorkflowPlane

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -811,7 +811,7 @@ DPEOF
 
 # Extract cluster-agent CA and create ClusterWorkflowPlane CR
 create_workflowplane_resource() {
-    log_info "Creating Cluster WorkflowPlane resource..."
+    log_info "Creating Cluster Workflow Plane resource..."
 
     # Wait for cluster-agent-tls secret
     local max_attempts=60
@@ -844,7 +844,7 @@ $(echo "$agent_ca" | sed 's/^/        /')
     name: default
 BPEOF
 
-    log_success "WorkflowPlane resource created"
+    log_success "Cluster Workflow Plane resource created"
 }
 
 # Extract cluster-agent CA and create ClusterObservabilityPlane CR


### PR DESCRIPTION
## Summary
- Update quick-start `.helpers.sh` to reference `ClusterWorkflowPlane` instead of the old `WorkflowPlane` resource name
- Fix `kubectl patch` command to target `clusterworkflowplane` instead of `workflowplane`
- Update log messages and comments to reflect the renamed resource

## Test plan
- [ ] Run quick-start install with `ENABLE_WORKFLOW_PLANE=true` and verify the workflow plane resource is created and patched correctly