### PR TITLE
feat(cli): use cluster-scoped resources in scaffold command

### DIFF
--- a/internal/occ/cmd/component/component.go
+++ b/internal/occ/cmd/component/component.go
@@ -471,8 +471,8 @@ func scaffoldComponent(params ScaffoldParams) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Fetch ComponentType schema
-	componentTypeSchemaRaw, err := apiClient.GetComponentTypeSchema(ctx, params.Namespace, componentTypeName)
+	// Fetch ClusterComponentType schema
+	componentTypeSchemaRaw, err := apiClient.GetClusterComponentTypeSchema(ctx, componentTypeName)
 	if err != nil {
 		return err
 	}
@@ -481,10 +481,10 @@ func scaffoldComponent(params ScaffoldParams) error {
 		return fmt.Errorf("invalid ComponentType schema: %w", err)
 	}
 
-	// Fetch Trait schemas if specified
+	// Fetch ClusterTrait schemas if specified
 	traitSchemas := make(map[string]*extv1.JSONSchemaProps)
 	for _, traitName := range params.Traits {
-		traitSchemaRaw, err := apiClient.GetTraitSchema(ctx, params.Namespace, traitName)
+		traitSchemaRaw, err := apiClient.GetClusterTraitSchema(ctx, traitName)
 		if err != nil {
 			return err
 		}
@@ -495,10 +495,10 @@ func scaffoldComponent(params ScaffoldParams) error {
 		traitSchemas[traitName] = traitSchema
 	}
 
-	// Fetch Workflow schema if specified
+	// Fetch ClusterWorkflow schema if specified
 	var workflowSchema *extv1.JSONSchemaProps
 	if params.WorkflowName != "" {
-		workflowSchemaRaw, err := apiClient.GetWorkflowSchema(ctx, params.Namespace, params.WorkflowName)
+		workflowSchemaRaw, err := apiClient.GetClusterWorkflowSchema(ctx, params.WorkflowName)
 		if err != nil {
 			return err
 		}

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -1311,6 +1311,51 @@ func (c *Client) GetWorkflowSchema(ctx context.Context, namespaceName, workflowN
 	return schemaResponseToRaw(resp.JSON200)
 }
 
+// GetClusterComponentTypeSchema retrieves the parameter schema for a cluster-scoped component type
+func (c *Client) GetClusterComponentTypeSchema(ctx context.Context, cctName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetClusterComponentTypeSchemaWithResponse(ctx, cctName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster component type schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("cluster component type %q not found", cctName)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+// GetClusterTraitSchema retrieves the parameter schema for a cluster-scoped trait
+func (c *Client) GetClusterTraitSchema(ctx context.Context, clusterTraitName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetClusterTraitSchemaWithResponse(ctx, clusterTraitName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster trait schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("cluster trait %q not found", clusterTraitName)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+// GetClusterWorkflowSchema retrieves the parameter schema for a cluster-scoped workflow
+func (c *Client) GetClusterWorkflowSchema(ctx context.Context, clusterWorkflowName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetClusterWorkflowSchemaWithResponse(ctx, clusterWorkflowName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster workflow schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("cluster workflow %q not found", clusterWorkflowName)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
 func schemaResponseToRaw(schema *gen.SchemaResponse) (*json.RawMessage, error) {
 	data, err := json.Marshal(schema)
 	if err != nil {

--- a/internal/scaffold/component/generator.go
+++ b/internal/scaffold/component/generator.go
@@ -325,7 +325,7 @@ func (g *Generator) generateSpec(b *YAMLBuilder, result *schemaProcessingResult)
 
 		// ComponentType
 		b.InMapping("componentType", func(b *YAMLBuilder) {
-			b.AddField("kind", "ComponentType")
+			b.AddField("kind", "ClusterComponentType")
 			b.AddField("name", fmt.Sprintf("%s/%s", g.workloadType, g.componentTypeName))
 		})
 

--- a/internal/scaffold/component/testdata/array_scaffolding_want.yaml
+++ b/internal/scaffold/component/testdata/array_scaffolding_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/basic_types_want.yaml
+++ b/internal/scaffold/component/testdata/basic_types_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/collection_shapes_want.yaml
+++ b/internal/scaffold/component/testdata/collection_shapes_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/escaping_quoting_want.yaml
+++ b/internal/scaffold/component/testdata/escaping_quoting_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/map_scaffolding_want.yaml
+++ b/internal/scaffold/component/testdata/map_scaffolding_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/minimal_comments_false_want.yaml
+++ b/internal/scaffold/component/testdata/minimal_comments_false_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/minimal_comments_true_want.yaml
+++ b/internal/scaffold/component/testdata/minimal_comments_true_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true
   parameters:

--- a/internal/scaffold/component/testdata/object_defaults_want.yaml
+++ b/internal/scaffold/component/testdata/object_defaults_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: test-project
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/service
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/validation_and_types_want.yaml
+++ b/internal/scaffold/component/testdata/validation_and_types_want.yaml
@@ -10,7 +10,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/with_traits_want.yaml
+++ b/internal/scaffold/component/testdata/with_traits_want.yaml
@@ -11,7 +11,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 

--- a/internal/scaffold/component/testdata/with_workflow_want.yaml
+++ b/internal/scaffold/component/testdata/with_workflow_want.yaml
@@ -11,7 +11,7 @@ spec:
   owner:
     projectName: online-store
   componentType:
-    kind: ComponentType
+    kind: ClusterComponentType
     name: deployment/web-app
   # autoDeploy: true # Enable automatic deployment on changes
 


### PR DESCRIPTION
## Purpose

`occ component scaffold` only resolved namespace-scoped `ComponentType`, `Trait`, and `Workflow` when fetching schemas. Since the default setup uses cluster-scoped variants (`ClusterComponentType`, `ClusterTrait`, `ClusterWorkflow`), the scaffold command failed with "not found" errors.

## Approach

- Add `GetClusterComponentTypeSchema`, `GetClusterTraitSchema`, and `GetClusterWorkflowSchema` client wrapper methods to the OCC CLI client
- Switch `scaffoldComponent()` to call cluster-scoped schema endpoints
- Update the generator to emit `kind: ClusterComponentType` in the scaffolded YAML
- Update all test fixtures to match the new output

## Related Issues

Related #2695

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)