### PR TITLE
fix(controller): always set ReleaseBinding Ready condition and detect CrashLoopBackOff

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -101,6 +101,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 
 	// Deferred status update
 	defer func() {
+		// Always update the aggregated Ready condition based on current sub-conditions.
+		// This ensures Ready is present on every reconciliation regardless of code path.
+		r.setReadyCondition(releaseBinding)
+
 		// Skip update if nothing changed
 		if apiequality.Semantic.DeepEqual(old.Status, releaseBinding.Status) {
 			return
@@ -603,7 +607,6 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 	connectionsResolved := allConnectionsResolved(releaseBinding, snapshotWorkload.Spec.GetDependencyEndpoints())
 	setConnectionsCondition(releaseBinding, connectionsResolved)
 	if !connectionsResolved {
-		r.setReadyCondition(releaseBinding)
 		logger.Info("Connections not yet resolved, waiting for provider endpoint changes",
 			"pending", len(releaseBinding.Status.PendingConnections),
 			"resolved", len(releaseBinding.Status.ResolvedConnections))
@@ -621,7 +624,6 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 		applyCond.ObservedGeneration == dataPlaneRelease.Generation {
 		controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
 			ReasonResourceApplyFailed, applyCond.Message)
-		r.setReadyCondition(releaseBinding)
 		return ctrl.Result{}, nil
 	}
 
@@ -641,9 +643,6 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 	if err := r.setResourcesReadyStatus(ctx, releaseBinding, dataPlaneRelease, component); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set resources ready status: %w", err)
 	}
-
-	// Set overall Ready condition based on ReleaseSynced and ResourcesReady
-	r.setReadyCondition(releaseBinding)
 
 	return ctrl.Result{}, nil
 }
@@ -717,8 +716,6 @@ func (r *Reconciler) handleUndeploy(ctx context.Context,
 			ReasonResourcesUndeployed, "Resources being undeployed")
 		controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
 			ReasonResourcesUndeployed, "Resources being undeployed")
-		controller.MarkFalseCondition(releaseBinding, ConditionReady,
-			ReasonResourcesUndeployed, "Resources being undeployed")
 		return ctrl.Result{}, nil
 	}
 
@@ -727,8 +724,6 @@ func (r *Reconciler) handleUndeploy(ctx context.Context,
 		controller.MarkFalseCondition(releaseBinding, ConditionReleaseSynced,
 			ReasonResourcesUndeployed, "Resources undeployed")
 		controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
-			ReasonResourcesUndeployed, "Resources undeployed")
-		controller.MarkFalseCondition(releaseBinding, ConditionReady,
 			ReasonResourcesUndeployed, "Resources undeployed")
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -214,18 +214,7 @@ func getDeploymentHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.Hea
 	unavailableReplicas := deployment.Status.UnavailableReplicas
 
 	// Extract deployment conditions
-	var availableCond, progressingCond, replicaFailCond *appsv1.DeploymentCondition
-	for i := range deployment.Status.Conditions {
-		c := &deployment.Status.Conditions[i]
-		switch c.Type {
-		case appsv1.DeploymentAvailable:
-			availableCond = c
-		case appsv1.DeploymentProgressing:
-			progressingCond = c
-		case appsv1.DeploymentReplicaFailure:
-			replicaFailCond = c
-		}
-	}
+	availableCond, progressingCond, replicaFailCond := extractDeploymentConditions(deployment.Status.Conditions)
 
 	// Progress deadline or replica failure -> Degraded
 	if progressingCond != nil && progressingCond.Reason == "ProgressDeadlineExceeded" {
@@ -235,14 +224,19 @@ func getDeploymentHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.Hea
 		return openchoreov1alpha1.HealthStatusDegraded, nil
 	}
 
-	// All pods on new revision but none are available yet -> Degraded
-	// Check if deployment is still progressing normally before marking as degraded
+	// All pods on new revision but none are available yet -> check if rollout is still in progress
 	if desiredReplicas == updatedReplicas && availableReplicas == 0 && desiredReplicas > 0 {
-		// If Progressing condition is True, pods are still starting up
 		if progressingCond != nil && progressingCond.Status == corev1.ConditionTrue {
+			// "NewReplicaSetAvailable" means the rollout completed (new ReplicaSet was created
+			// and scaled up). If pods are still not available after rollout completion, it
+			// indicates a runtime failure (e.g., CrashLoopBackOff, failing readiness probes).
+			if progressingCond.Reason == "NewReplicaSetAvailable" {
+				return openchoreov1alpha1.HealthStatusDegraded, nil
+			}
+			// Other reasons (e.g., "ReplicaSetUpdated") mean pods are still being created
 			return openchoreov1alpha1.HealthStatusProgressing, nil
 		}
-		// Only mark as degraded if progressing is False or unknown
+		// Progressing is False or unknown -> degraded
 		return openchoreov1alpha1.HealthStatusDegraded, nil
 	}
 
@@ -267,6 +261,21 @@ func getDeploymentHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.Hea
 	// - Not all replicas are available
 	// - Some replicas are unavailable
 	return openchoreov1alpha1.HealthStatusProgressing, nil
+}
+
+func extractDeploymentConditions(conditions []appsv1.DeploymentCondition) (available, progressing, replicaFailure *appsv1.DeploymentCondition) {
+	for i := range conditions {
+		c := &conditions[i]
+		switch c.Type {
+		case appsv1.DeploymentAvailable:
+			available = c
+		case appsv1.DeploymentProgressing:
+			progressing = c
+		case appsv1.DeploymentReplicaFailure:
+			replicaFailure = c
+		}
+	}
+	return available, progressing, replicaFailure
 }
 
 // TODO: Check the statefulset health tracking and update logic

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -559,6 +559,38 @@ func TestGetDeploymentHealth(t *testing.T) {
 			want: openchoreov1alpha1.HealthStatusProgressing,
 		},
 		{
+			name: "rollout complete (NewReplicaSetAvailable) but no pods available is Degraded",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  0,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			want: openchoreov1alpha1.HealthStatusDegraded,
+		},
+		{
+			name: "replica set still updating (ReplicaSetUpdated) with no pods available is Progressing",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  0,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "ReplicaSetUpdated"},
+					},
+				},
+			},
+			want: openchoreov1alpha1.HealthStatusProgressing,
+		},
+		{
 			name: "all pods on new revision but none available, progressing condition false is Degraded",
 			deployment: appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
@@ -569,6 +601,22 @@ func TestGetDeploymentHealth(t *testing.T) {
 					AvailableReplicas:  0,
 					Conditions: []appsv1.DeploymentCondition{
 						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			want: openchoreov1alpha1.HealthStatusDegraded,
+		},
+		{
+			name: "all pods on new revision but none available, progressing condition unknown is Degraded",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  0,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionUnknown},
 					},
 				},
 			},


### PR DESCRIPTION
## Purpose

### Summary

- Ensure the ReleaseBinding `Ready` condition is always present by moving `setReadyCondition()` into the deferred status update block
- Fix Deployment health check to immediately detect CrashLoopBackOff as `Degraded` when the rollout has already completed (`Progressing: True / NewReplicaSetAvailable`)

### Testing

See the details on : https://github.com/openchoreo/openchoreo/issues/2697#issuecomment-4059832434

## Related Issues
fixes: https://github.com/openchoreo/openchoreo/issues/2697

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
