### PR TITLE
fix: correct multi-cluster setup docs and openbao context handling

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -429,6 +429,18 @@ kubectl --context k3d-openchoreo-op create configmap cluster-gateway-ca \
   --dry-run=client -o yaml | kubectl --context k3d-openchoreo-op apply -f -
 ```
 
+### OpenBao (Secret Store)
+
+Install [OpenBao](https://openbao.org/) as the secret backend on the observability plane cluster:
+
+```bash
+install/prerequisites/openbao/setup.sh --dev --seed-dev-secrets --kube-context k3d-openchoreo-op
+```
+
+This installs OpenBao in dev mode into the `openbao` namespace, configures Kubernetes auth, seeds placeholder development secrets, and creates a `ClusterSecretStore` named `default`.
+
+To use a different secret backend, skip this and create your own `ClusterSecretStore` named `default` following the [ESO provider docs](https://external-secrets.io/latest/provider/).
+
 ### Observability Plane Secrets
 
 ```bash
@@ -548,7 +560,7 @@ kubectl --context k3d-openchoreo-cp patch clusterdataplane default --type merge 
 
 # If cluster workflow plane is installed:
 kubectl --context k3d-openchoreo-cp patch clusterworkflowplane default -n default --type merge \
-  -p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
+  -p '{"spec":{"observabilityPlaneRef":{"kind":"ClusterObservabilityPlane","name":"default"}}}'
 ```
 
 ## Port Mappings

--- a/install/prerequisites/openbao/setup.sh
+++ b/install/prerequisites/openbao/setup.sh
@@ -19,7 +19,7 @@ OPENBAO_IMAGE_TAG="2.4.4"
 CLUSTER_SECRET_STORE_NAME="default"
 DEV_MODE=false
 SEED_DEV_SECRETS=false
-KUBE_CONTEXT_FLAG=""
+KUBE_CONTEXT=""
 DEV_ROOT_TOKEN="root"
 
 while [[ $# -gt 0 ]]; do
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --kube-context)
-            KUBE_CONTEXT_FLAG="--kube-context $2"
+            KUBE_CONTEXT="$2"
             shift 2
             ;;
         *)
@@ -52,7 +52,7 @@ fi
 
 # shellcheck disable=SC2086
 helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
-    ${KUBE_CONTEXT_FLAG} \
+    ${KUBE_CONTEXT:+--kube-context "$KUBE_CONTEXT"} \
     --namespace "${OPENBAO_NAMESPACE}" \
     --create-namespace \
     --version "${OPENBAO_CHART_VERSION}" \
@@ -66,14 +66,14 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
 
 echo "Waiting for OpenBao to be ready..."
 # shellcheck disable=SC2086
-kubectl ${KUBE_CONTEXT_FLAG} wait --namespace "${OPENBAO_NAMESPACE}" \
+kubectl ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} wait --namespace "${OPENBAO_NAMESPACE}" \
     --for=condition=Ready pods \
     -l app.kubernetes.io/name=openbao,component=server \
     --timeout=300s
 
 echo "Configuring OpenBao..."
 # shellcheck disable=SC2086
-kubectl ${KUBE_CONTEXT_FLAG} exec -n "${OPENBAO_NAMESPACE}" openbao-0 -- sh -c "
+kubectl ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} exec -n "${OPENBAO_NAMESPACE}" openbao-0 -- sh -c "
     export BAO_ADDR=http://127.0.0.1:8200
     export BAO_TOKEN=${DEV_ROOT_TOKEN}
 
@@ -121,7 +121,7 @@ POLICY
 
 echo "Creating ServiceAccount for ESO..."
 # shellcheck disable=SC2086
-kubectl ${KUBE_CONTEXT_FLAG} apply -f - <<EOF
+kubectl ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -131,7 +131,7 @@ EOF
 
 echo "Creating ClusterSecretStore '${CLUSTER_SECRET_STORE_NAME}'..."
 # shellcheck disable=SC2086
-kubectl ${KUBE_CONTEXT_FLAG} apply -f - <<EOF
+kubectl ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} apply -f - <<EOF
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
@@ -154,7 +154,7 @@ EOF
 if [[ "$SEED_DEV_SECRETS" == "true" ]]; then
     echo "Seeding development placeholder secrets..."
     # shellcheck disable=SC2086
-    kubectl ${KUBE_CONTEXT_FLAG} exec -n "${OPENBAO_NAMESPACE}" openbao-0 -- sh -c "
+    kubectl ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} exec -n "${OPENBAO_NAMESPACE}" openbao-0 -- sh -c "
         export BAO_ADDR=http://127.0.0.1:8200
         export BAO_TOKEN=${DEV_ROOT_TOKEN}
 


### PR DESCRIPTION
## Summary
- Fix `ObservabilityPlane` kind to `ClusterObservabilityPlane` in the workflow plane link command (multi-cluster docs)
- Add missing OpenBao setup step for the observability plane in multi-cluster docs
- Fix `openbao/setup.sh` to use `--context` for kubectl and `--kube-context` for helm when the `--kube-context` flag is passed