### PR TITLE
fix: handle ClusterWorkflow in auto-build webhook component lookup

### DIFF
--- a/internal/openchoreo-api/legacyservices/services.go
+++ b/internal/openchoreo-api/legacyservices/services.go
@@ -79,7 +79,7 @@ func NewServices(k8sClient client.Client, k8sClientMgr *kubernetesClient.KubeMul
 	workflowRunService := NewWorkflowRunService(k8sClient, logger.With("service", "workflowrun"), authzPDP, workflowPlaneService, gwClient)
 
 	// Create webhook service (handles all git providers)
-	webhookService := NewWebhookService(k8sClient, workflowRunService)
+	webhookService := NewWebhookService(k8sClient, workflowRunService, logger.With("service", "webhook"))
 
 	// Create Schema service
 	schemaService := NewSchemaService(k8sClient, logger.With("service", "schema"))

--- a/internal/openchoreo-api/legacyservices/webhook_service.go
+++ b/internal/openchoreo-api/legacyservices/webhook_service.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/controller"
@@ -22,28 +22,28 @@ import (
 type WebhookService struct {
 	k8sClient       client.Client
 	workflowService *WorkflowRunService
+	logger          *slog.Logger
 }
 
 // NewWebhookService creates a new WebhookService
-func NewWebhookService(k8sClient client.Client, workflowService *WorkflowRunService) *WebhookService {
+func NewWebhookService(k8sClient client.Client, workflowService *WorkflowRunService, logger *slog.Logger) *WebhookService {
 	return &WebhookService{
 		k8sClient:       k8sClient,
 		workflowService: workflowService,
+		logger:          logger,
 	}
 }
 
 // ProcessWebhook processes an incoming webhook payload from any git provider
 func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provider, payload []byte) ([]string, error) {
-	logger := log.FromContext(ctx)
-
 	// Parse payload using the provider
 	event, err := provider.ParseWebhookPayload(payload)
 	if err != nil {
-		logger.Error(err, "Failed to parse webhook payload")
+		s.logger.Error("Failed to parse webhook payload", "error", err)
 		return nil, fmt.Errorf("failed to parse webhook payload: %w", err)
 	}
 
-	logger.Info("Processing webhook event",
+	s.logger.Info("Processing webhook event",
 		"provider", event.Provider,
 		"repository", event.RepositoryURL,
 		"branch", event.Branch,
@@ -53,11 +53,11 @@ func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provid
 	// Find affected components
 	affectedComponents, err := s.findAffectedComponents(ctx, event)
 	if err != nil {
-		logger.Error(err, "Failed to find affected components")
+		s.logger.Error("Failed to find affected components", "error", err)
 		return nil, fmt.Errorf("failed to find affected components: %w", err)
 	}
 
-	logger.Info("Found affected components", "count", len(affectedComponents))
+	s.logger.Info("Found affected components", "count", len(affectedComponents))
 
 	// Trigger builds for affected components
 	triggeredComponents := make([]string, 0)
@@ -66,7 +66,7 @@ func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provid
 		projectName := comp.Spec.Owner.ProjectName
 		componentName := comp.Name
 
-		logger.Info("Triggering build for component",
+		s.logger.Info("Triggering build for component",
 			"namespace", namespaceName,
 			"project", projectName,
 			"component", componentName,
@@ -81,7 +81,8 @@ func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provid
 		)
 		if err != nil {
 			// Log error but continue processing other components
-			logger.Error(err, "Failed to trigger build for component",
+			s.logger.Error("Failed to trigger build for component",
+				"error", err,
 				"component", componentName)
 			continue
 		}
@@ -89,7 +90,7 @@ func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provid
 		triggeredComponents = append(triggeredComponents, fmt.Sprintf("%s/%s", comp.Namespace, componentName))
 	}
 
-	logger.Info("Webhook processing completed",
+	s.logger.Info("Webhook processing completed",
 		"affectedComponents", len(affectedComponents),
 		"triggeredBuilds", len(triggeredComponents))
 
@@ -98,8 +99,6 @@ func (s *WebhookService) ProcessWebhook(ctx context.Context, provider git.Provid
 
 // findAffectedComponents finds all components that should be built based on the webhook event
 func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.WebhookEvent) ([]*v1alpha1.Component, error) {
-	logger := log.FromContext(ctx)
-
 	// List all components
 	componentList := &v1alpha1.ComponentList{}
 	if err := s.k8sClient.List(ctx, componentList); err != nil {
@@ -118,7 +117,7 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 		// Get repository URL, appPath, and branch from component workflow schema extensions
 		repoURL, appPath, branch, err := s.extractRepoInfoFromComponent(ctx, comp)
 		if err != nil {
-			logger.V(1).Info("Failed to extract repo info from component",
+			s.logger.Info("Skipping component: failed to extract repo info",
 				"component", comp.Name,
 				"error", err)
 			continue
@@ -126,13 +125,17 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 
 		// Check if component's repository matches the webhook repository
 		if !s.matchesRepository(repoURL, event.RepositoryURL) {
+			s.logger.Info("Skipping component: repository mismatch",
+				"component", comp.Name,
+				"componentRepo", repoURL,
+				"webhookRepo", event.RepositoryURL)
 			continue
 		}
 
 		// Check if the webhook branch matches the component's configured branch.
 		// If the component has no branch configured, all branches trigger builds.
 		if branch != "" && branch != event.Branch {
-			logger.V(1).Info("Skipping component: branch mismatch",
+			s.logger.Info("Skipping component: branch mismatch",
 				"component", comp.Name,
 				"componentBranch", branch,
 				"webhookBranch", event.Branch)
@@ -142,12 +145,17 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 		// Check if modified paths affect this component
 		// If no modified paths (e.g., Bitbucket), trigger all components for the repo
 		if len(event.ModifiedPaths) == 0 || s.isComponentAffected(appPath, event.ModifiedPaths) {
-			logger.Info("Component is affected by webhook event",
+			s.logger.Info("Component is affected by webhook event",
 				"component", comp.Name,
 				"appPath", appPath,
 				"branch", branch,
 				"modifiedPaths", len(event.ModifiedPaths))
 			affected = append(affected, comp)
+		} else {
+			s.logger.Info("Skipping component: no modified paths match app path",
+				"component", comp.Name,
+				"appPath", appPath,
+				"modifiedPaths", event.ModifiedPaths)
 		}
 	}
 
@@ -155,23 +163,35 @@ func (s *WebhookService) findAffectedComponents(ctx context.Context, event *git.
 }
 
 // extractRepoInfoFromComponent extracts repository URL, appPath, and branch from a component's workflow parameters
-// by scanning the Workflow CR's openAPIV3Schema for x-openchoreo-component-repository extensions.
+// by scanning the Workflow or ClusterWorkflow CR's openAPIV3Schema for x-openchoreo-component-repository extensions.
 func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp *v1alpha1.Component) (repoURL string, appPath string, branch string, err error) {
 	if comp.Spec.Workflow == nil || comp.Spec.Workflow.Name == "" {
 		return "", "", "", fmt.Errorf("component has no workflow configuration")
 	}
 
-	// Fetch the Workflow CR to get the schema
-	workflow := &v1alpha1.Workflow{}
-	if err := s.k8sClient.Get(ctx, client.ObjectKey{
-		Name:      comp.Spec.Workflow.Name,
-		Namespace: comp.Namespace,
-	}, workflow); err != nil {
-		return "", "", "", fmt.Errorf("failed to get workflow %s: %w", comp.Spec.Workflow.Name, err)
+	// Fetch the Workflow or ClusterWorkflow CR to get the schema
+	var parametersSchema *v1alpha1.SchemaSection
+	if comp.Spec.Workflow.Kind == v1alpha1.WorkflowRefKindClusterWorkflow {
+		cw := &v1alpha1.ClusterWorkflow{}
+		if err := s.k8sClient.Get(ctx, client.ObjectKey{
+			Name: comp.Spec.Workflow.Name,
+		}, cw); err != nil {
+			return "", "", "", fmt.Errorf("failed to get ClusterWorkflow %s: %w", comp.Spec.Workflow.Name, err)
+		}
+		parametersSchema = cw.Spec.Parameters
+	} else {
+		workflow := &v1alpha1.Workflow{}
+		if err := s.k8sClient.Get(ctx, client.ObjectKey{
+			Name:      comp.Spec.Workflow.Name,
+			Namespace: comp.Namespace,
+		}, workflow); err != nil {
+			return "", "", "", fmt.Errorf("failed to get workflow %s: %w", comp.Spec.Workflow.Name, err)
+		}
+		parametersSchema = workflow.Spec.Parameters
 	}
 
 	// Extract parameter paths from x-openchoreo-component-parameter-repository-* schema extensions
-	paramMap, err := controller.ExtractComponentRepositoryPaths(workflow.Spec.Parameters.GetRaw())
+	paramMap, err := controller.ExtractComponentRepositoryPaths(parametersSchema.GetRaw())
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to extract component repository paths from workflow %s schema: %w", comp.Spec.Workflow.Name, err)
 	}
@@ -201,7 +221,7 @@ func (s *WebhookService) extractRepoInfoFromComponent(ctx context.Context, comp 
 	if branchPath, ok := paramMap["branch"]; ok {
 		branch, _ = getNestedStringFromRawExtension(comp.Spec.Workflow.Parameters, branchPath)
 		if branch == "" {
-			branch = getSchemaFieldDefault(workflow.Spec.Parameters.GetRaw(), branchPath)
+			branch = getSchemaFieldDefault(parametersSchema.GetRaw(), branchPath)
 		}
 	}
 

--- a/internal/openchoreo-api/legacyservices/webhook_service_test.go
+++ b/internal/openchoreo-api/legacyservices/webhook_service_test.go
@@ -6,6 +6,8 @@ package legacyservices
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +18,11 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/legacyservices/git"
 )
+
+// discardLogger returns a slog.Logger that discards all output, for use in tests.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 const (
 	// testSchemaURLOnly is a minimal openAPIV3Schema with only the url extension.
@@ -235,13 +242,14 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 	scheme := newTestScheme(t)
 
 	tests := []struct {
-		name        string
-		component   *v1alpha1.Component
-		workflow    *v1alpha1.Workflow
-		wantRepo    string
-		wantAppPath string
-		wantBranch  string
-		wantErr     bool
+		name            string
+		component       *v1alpha1.Component
+		workflow        *v1alpha1.Workflow
+		clusterWorkflow *v1alpha1.ClusterWorkflow
+		wantRepo        string
+		wantAppPath     string
+		wantBranch      string
+		wantErr         bool
 	}{
 		{
 			name: "no workflow config on component",
@@ -519,6 +527,77 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 			wantAppPath: "/src/app",
 			wantBranch:  "main",
 		},
+		{
+			name: "ClusterWorkflow kind: extracts repoUrl from cluster-scoped workflow",
+			component: &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec: v1alpha1.ComponentSpec{
+					Workflow: &v1alpha1.ComponentWorkflowConfig{
+						Kind: v1alpha1.WorkflowRefKindClusterWorkflow,
+						Name: "cwf1",
+						Parameters: makeRaw(map[string]interface{}{
+							"repository": map[string]interface{}{
+								"url": "https://github.com/example/repo",
+							},
+						}),
+					},
+				},
+			},
+			clusterWorkflow: &v1alpha1.ClusterWorkflow{
+				ObjectMeta: metav1.ObjectMeta{Name: "cwf1"},
+				Spec: v1alpha1.ClusterWorkflowSpec{
+					Parameters: &v1alpha1.SchemaSection{
+						OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(testSchemaURLOnly)},
+					},
+				},
+			},
+			wantRepo: "https://github.com/example/repo",
+		},
+		{
+			name: "Workflow kind explicit: extracts repoUrl from namespace-scoped workflow",
+			component: &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec: v1alpha1.ComponentSpec{
+					Workflow: &v1alpha1.ComponentWorkflowConfig{
+						Kind: v1alpha1.WorkflowRefKindWorkflow,
+						Name: "wf1",
+						Parameters: makeRaw(map[string]interface{}{
+							"repository": map[string]interface{}{
+								"url": "https://github.com/example/repo",
+							},
+						}),
+					},
+				},
+			},
+			workflow: &v1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{Name: "wf1", Namespace: "ns1"},
+				Spec: v1alpha1.WorkflowSpec{
+					Parameters: &v1alpha1.SchemaSection{
+						OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(testSchemaURLOnly)},
+					},
+				},
+			},
+			wantRepo: "https://github.com/example/repo",
+		},
+		{
+			name: "ClusterWorkflow not found returns wrapped error",
+			component: &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec: v1alpha1.ComponentSpec{
+					Workflow: &v1alpha1.ComponentWorkflowConfig{
+						Kind: v1alpha1.WorkflowRefKindClusterWorkflow,
+						Name: "nonexistent-cwf",
+						Parameters: makeRaw(map[string]interface{}{
+							"repository": map[string]interface{}{
+								"url": "https://github.com/example/repo",
+							},
+						}),
+					},
+				},
+			},
+			// no clusterWorkflow registered → fake client returns not-found
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -527,9 +606,12 @@ func TestExtractRepoInfoFromComponent(t *testing.T) {
 			if tt.workflow != nil {
 				builder = builder.WithObjects(tt.workflow)
 			}
+			if tt.clusterWorkflow != nil {
+				builder = builder.WithObjects(tt.clusterWorkflow)
+			}
 			k8sClient := builder.Build()
 
-			svc := &WebhookService{k8sClient: k8sClient}
+			svc := &WebhookService{k8sClient: k8sClient, logger: discardLogger()}
 
 			gotRepo, gotAppPath, gotBranch, err := svc.extractRepoInfoFromComponent(context.Background(), tt.component)
 			if tt.wantErr {
@@ -615,7 +697,7 @@ func TestWebhookBranchFilter_Match(t *testing.T) {
 	workflow := makeWorkflowWithBranch("wf1", "ns1")
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp, workflow).Build()
-	svc := &WebhookService{k8sClient: k8sClient}
+	svc := &WebhookService{k8sClient: k8sClient, logger: discardLogger()}
 
 	event := &git.WebhookEvent{
 		RepositoryURL: "https://github.com/example/repo",
@@ -645,7 +727,7 @@ func TestWebhookBranchFilter_Mismatch(t *testing.T) {
 	workflow := makeWorkflowWithBranch("wf1", "ns1")
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp, workflow).Build()
-	svc := &WebhookService{k8sClient: k8sClient}
+	svc := &WebhookService{k8sClient: k8sClient, logger: discardLogger()}
 
 	event := &git.WebhookEvent{
 		RepositoryURL: "https://github.com/example/repo",
@@ -688,7 +770,7 @@ func TestWebhookBranchFilter_NoConfiguredBranch(t *testing.T) {
 	workflow := makeWorkflowNoBranch("wf1", "ns1")
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp, workflow).Build()
-	svc := &WebhookService{k8sClient: k8sClient}
+	svc := &WebhookService{k8sClient: k8sClient, logger: discardLogger()}
 
 	for _, pushBranch := range []string{"main", "feature/foo", "release/v1"} {
 		t.Run(pushBranch, func(t *testing.T) {

--- a/internal/openchoreo-api/legacyservices/workflowrun_service.go
+++ b/internal/openchoreo-api/legacyservices/workflowrun_service.go
@@ -798,18 +798,31 @@ func (s *WorkflowRunService) triggerWorkflowInternal(ctx context.Context, namesp
 		return nil, fmt.Errorf("component %s does not have a workflow configured", componentName)
 	}
 
-	// Fetch the Workflow CR to get the schema
-	workflow := &openchoreov1alpha1.Workflow{}
-	if err := s.k8sClient.Get(ctx, client.ObjectKey{
-		Name:      component.Spec.Workflow.Name,
-		Namespace: namespaceName,
-	}, workflow); err != nil {
-		s.logger.Error("Failed to get workflow", "error", err, "workflow", component.Spec.Workflow.Name)
-		return nil, fmt.Errorf("failed to get workflow %s: %w", component.Spec.Workflow.Name, err)
+	// Fetch the Workflow or ClusterWorkflow CR to get the schema
+	var workflowParameters *openchoreov1alpha1.SchemaSection
+	if component.Spec.Workflow.Kind == openchoreov1alpha1.WorkflowRefKindClusterWorkflow {
+		cw := &openchoreov1alpha1.ClusterWorkflow{}
+		if err := s.k8sClient.Get(ctx, client.ObjectKey{
+			Name: component.Spec.Workflow.Name,
+		}, cw); err != nil {
+			s.logger.Error("Failed to get ClusterWorkflow", "error", err, "workflow", component.Spec.Workflow.Name)
+			return nil, fmt.Errorf("failed to get ClusterWorkflow %s: %w", component.Spec.Workflow.Name, err)
+		}
+		workflowParameters = cw.Spec.Parameters
+	} else {
+		workflow := &openchoreov1alpha1.Workflow{}
+		if err := s.k8sClient.Get(ctx, client.ObjectKey{
+			Name:      component.Spec.Workflow.Name,
+			Namespace: namespaceName,
+		}, workflow); err != nil {
+			s.logger.Error("Failed to get workflow", "error", err, "workflow", component.Spec.Workflow.Name)
+			return nil, fmt.Errorf("failed to get workflow %s: %w", component.Spec.Workflow.Name, err)
+		}
+		workflowParameters = workflow.Spec.Parameters
 	}
 
 	// Extract parameter paths from x-openchoreo-component-repository schema extensions
-	paramMap, err := controller.ExtractComponentRepositoryPaths(workflow.Spec.Parameters.GetRaw())
+	paramMap, err := controller.ExtractComponentRepositoryPaths(workflowParameters.GetRaw())
 	if err != nil {
 		s.logger.Error("Failed to extract component repository paths from workflow schema", "error", err, "workflow", component.Spec.Workflow.Name)
 		return nil, fmt.Errorf("failed to extract component repository paths from workflow %s schema: %w", component.Spec.Workflow.Name, err)


### PR DESCRIPTION
## Purpose
- `extractRepoInfoFromComponent` in `webhook_service.go` always fetched a namespace-scoped `Workflow` CR regardless of the component's workflow kind, causing the lookup to fail silently for components referencing a `ClusterWorkflow`
- Affected components were excluded from `affectedComponents`, resulting in the webhook returning HTTP 200 with zero builds triggered
- Fixed by checking `comp.Spec.Workflow.Kind` and fetching either a `ClusterWorkflow` (cluster-scoped) or `Workflow` (namespace-scoped) accordingly