### PR TITLE
chore: migrate community links from Discord to CNCF Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Whether you’re fixing a bug, improving documentation, or suggesting new featur
 
 - **[Contributor Guide](./docs/contributors/README.md)** – Learn how to get started.
 - **[Report an Issue](https://github.com/openchoreo/openchoreo/issues)** – Help us improve Choreo.
-- **[Join our Discord](https://discord.gg/asqDFC8suT)** – Be part of the community.
+- **[Join our Slack](https://cloud-native.slack.com/archives/C0ABYRG1MND)** – Be part of the community.
 
 We’re excited to have you onboard!
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -13,6 +13,6 @@ Before you start contributing, check out our guidelines:
 
 ## Need Help?
 
-If you have any questions, join our **[Discord Community](https://discord.gg/asqDFC8suT)** or open a **[GitHub Discussion](https://github.com/openchoreo/openchoreo/discussions)**.
+If you have any questions, join our **[Slack Community](https://cloud-native.slack.com/archives/C0ABYRG1MND)** or open a **[GitHub Discussion](https://github.com/openchoreo/openchoreo/discussions)**.
 
 We appreciate your contributions—thank you for making OpenChoreo better! 

--- a/docs/contributors/development-process.md
+++ b/docs/contributors/development-process.md
@@ -91,7 +91,7 @@ Each team gets together and retrospects the last sprint
 #### Key Tasks
 - Review issues in PR Sent / In Review status and try to close them off
 - Review issues still in progress and include a comment explaining why we could not finish them as planned and change the sprint to the current sprint
-- Send updates to Discord with screencast when applicable for finished tasks
+- Send updates to Slack with screencast when applicable for finished tasks
 
 ## Milestone Planning Meeting
 > *Attendees*:

--- a/samples/mcp/README.md
+++ b/samples/mcp/README.md
@@ -50,4 +50,4 @@ Deploy a complete service from source code to production using the OpenChoreo MC
 ## Getting Help
 
 - [OpenChoreo Documentation](https://openchoreo.dev/)
-- [Discord Community](https://discord.gg/asqDFC8suT)
+- [Slack Community](https://cloud-native.slack.com/archives/C0ABYRG1MND)

--- a/samples/mcp/service-deployment/step-by-step/README.md
+++ b/samples/mcp/service-deployment/step-by-step/README.md
@@ -170,4 +170,4 @@ You've successfully deployed a service using the OpenChoreo MCP server! You now 
 - Monitor component health and status
 - Manage the complete service lifecycle through natural language
 
-**Share your success** with the community on [Discord](https://discord.gg/asqDFC8suT)!
+**Share your success** with the community on [Slack](https://cloud-native.slack.com/archives/C0ABYRG1MND)!


### PR DESCRIPTION
## Purpose

Replace all Discord community references with CNCF Slack `#openchoreo` channel links following the project's move to CNCF Slack.

## Approach

- Replace Discord invite URLs with CNCF Slack channel link in README, contributor docs, and sample docs
- Update link labels from "Discord" to "Slack"

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)