### PR TITLE
fix: add clusterroles RBAC and fix ClusterTrait kind in embedded traits sample

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -56,6 +56,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs: ["*"]
 # Autoscaling
 - apiGroups: ["autoscaling"]

--- a/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+++ b/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
@@ -479,7 +479,8 @@ spec:
 
   # Developer can add allowed traits (but NOT HPA - it's embedded)
   traits:
-    - name: persistent-volume
+    - kind: ClusterTrait
+      name: persistent-volume
       instanceName: data-storage
       parameters:
         volumeName: app-data


### PR DESCRIPTION
## Purpose
 - **fix(helm):** Add `clusterroles` and `clusterrolebindings` to the `cluster-agent-dataplane` ClusterRole. The `renderedrelease` controller lists these resource types as part of its orphaned-resource safety net (`wellKnownGVKs`), but the ClusterRole only granted access to namespaced `roles`/`rolebindings`, causing repeated `forbidden` errors in the controller logs.

  - **fix(sample):** Add `kind: ClusterTrait` to the `persistent-volume` trait reference in the `component-with-embedded-traits` sample. `ComponentTrait.kind` defaults to `Trait` (namespace-scoped) when omitted, which fails `allowedTraits` validation because `ClusterComponentType.allowedTraits` entries carry kind
   `ClusterTrait` — the exact-match check `Trait:persistent-volume ≠ ClusterTrait:persistent-volume` caused the Component to remain in `InvalidConfiguration`, blocking ComponentRelease and ReleaseBinding creation.