### PR TITLE
fix: disable fluent-bit by default and enable after observability plane setup

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -515,17 +515,6 @@ helm upgrade --install openchoreo-observability-plane install/helm/openchoreo-ob
 
 Install the required logs, metrics and tracing modules. Refer https://openchoreo.dev/modules for more details
 
-Enable Fluent Bit for log collection:
-
-```bash
-helm upgrade openchoreo-observability-plane install/helm/openchoreo-observability-plane \
-  --kube-context k3d-openchoreo-op \
-  --namespace openchoreo-observability-plane \
-  --reuse-values \
-  --set observability-logs-opensearch.fluent-bit.enabled=true \
-  --timeout 10m
-```
-
 ```bash
 kubectl --context k3d-openchoreo-op wait -n openchoreo-observability-plane \
   --for=condition=available --timeout=600s deployment --all
@@ -561,6 +550,28 @@ kubectl --context k3d-openchoreo-cp patch clusterdataplane default --type merge 
 # If cluster workflow plane is installed:
 kubectl --context k3d-openchoreo-cp patch clusterworkflowplane default -n default --type merge \
   -p '{"spec":{"observabilityPlaneRef":{"kind":"ClusterObservabilityPlane","name":"default"}}}'
+```
+
+### Enable logs collection in the data plane
+
+```bash
+helm upgrade openchoreo-data-plane install/helm/openchoreo-data-plane \
+  --kube-context k3d-openchoreo-dp \
+  --namespace openchoreo-data-plane \
+  --reuse-values \
+  --set fluent-bit.enabled=true \
+  --timeout 10m
+```
+
+### Enable logs collection in the workflow plane (optional)
+
+```bash
+helm upgrade openchoreo-workflow-plane install/helm/openchoreo-workflow-plane \
+  --kube-context k3d-openchoreo-wp \
+  --namespace openchoreo-workflow-plane \
+  --reuse-values \
+  --set fluent-bit.enabled=true \
+  --timeout 10m
 ```
 
 ## Port Mappings

--- a/install/k3d/multi-cluster/values-dp.yaml
+++ b/install/k3d/multi-cluster/values-dp.yaml
@@ -10,7 +10,7 @@ gateway:
     enabled: false
 
 fluent-bit:
-  enabled: true
+  enabled: false
   envFrom: []
   env:
     - name: OPENSEARCH_HOST

--- a/install/k3d/multi-cluster/values-wp.yaml
+++ b/install/k3d/multi-cluster/values-wp.yaml
@@ -12,7 +12,7 @@ argo-workflows:
       - server
 
 fluent-bit:
-  enabled: true
+  enabled: false
   envFrom: []
   env:
     - name: OPENSEARCH_HOST


### PR DESCRIPTION
## Summary
- Disable fluent-bit by default in multi-cluster data plane and workflow plane values
- Move fluent-bit enable steps to after observability plane is fully set up, so logs aren't published before the OpenSearch index template is created