### PR TITLE
fix: let transport handle k8s auth token refresh in cluster-agent

### DIFF
--- a/internal/cluster-agent/router.go
+++ b/internal/cluster-agent/router.go
@@ -169,13 +169,9 @@ func createK8sRoute(config *rest.Config) (*Route, error) {
 	}
 
 	return &Route{
-		Name:     "k8s",
-		Backend:  "kubernetes",
-		Endpoint: config.Host,
-		Auth: AuthConfig{
-			Type:  "serviceaccount",
-			Token: config.BearerToken,
-		},
+		Name:      "k8s",
+		Backend:   "kubernetes",
+		Endpoint:  config.Host,
 		Transport: transport,
 	}, nil
 }


### PR DESCRIPTION
## Purpose

The k8s route was capturing the ServiceAccount token once at startup via config.BearerToken and storing it as a static string. This bypassed the token refresh mechanism built into `rest.TransportFor()`, which re-reads the projected token file on each request. On clusters with bound ServiceAccount tokens (e.g., AKS), the static token expired after ~1 hour, causing all proxied k8s API requests to return 401.

Remove the static Auth config from the k8s route so the transport's built-in token management handles authentication automatically.

## Summary

- Fixed 401 Unauthorized errors from cluster-agent after running for ~1 hour on clusters with bound ServiceAccount tokens (e.g., AKS)
- The root cause was `createK8sRoute()` capturing `config.BearerToken` as a static string at startup and manually setting it on every request via `applyAuth()`, bypassing the token refresh mechanism already built into the transport created by `rest.TransportFor()`
- Removed the `Auth` config from the k8s route, allowing the transport to handle ServiceAccount token authentication and automatic refresh from the projected token file

**Additional Note:** This was working in k3d (k3s) because the token issues in k3d cluster is having a 1 year expiry time.



## Approach
> Summarize the solution and implementation details.

## Related Issues
fixes : https://github.com/openchoreo/openchoreo/issues/2723

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
