### PR TITLE
fix: correct nginx endpoint port in component-with-configs sample

### DIFF
--- a/samples/component-types/component-with-configs/component-with-configs.yaml
+++ b/samples/component-types/component-with-configs/component-with-configs.yaml
@@ -297,7 +297,7 @@ spec:
   endpoints:
     http:
       type: HTTP
-      port: 8080
+      port: 80
       visibility: [external]
 
   container:


### PR DESCRIPTION
## Purpose

The component-with-configs sample uses port 8080 for the nginx endpoint, but nginx listens on port 80 by default. This causes the Service to route traffic to port 8080 where nothing is listening.

## Approach

- Change endpoint port from 8080 to 80 to match nginx default

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)