### PR TITLE
fix: occ componentrelease generate command fix

### DIFF
--- a/internal/occ/fsmode/generator/component_release.go
+++ b/internal/occ/fsmode/generator/component_release.go
@@ -13,6 +13,11 @@ import (
 	typed2 "github.com/openchoreo/openchoreo/internal/occ/fsmode/typed"
 )
 
+const (
+	traitKindTrait        = "Trait"
+	traitKindClusterTrait = "ClusterTrait"
+)
+
 // ReleaseGenerator generates ComponentRelease resources
 type ReleaseGenerator struct {
 	index *fsmode.Index
@@ -63,7 +68,7 @@ func (g *ReleaseGenerator) GenerateRelease(opts ReleaseOptions) (*unstructured.U
 
 	// 4. Fetch Traits referenced by Component
 	traitRefs := comp.GetTraitRefs()
-	traitsMap, profileTraits, err := g.buildTraitsData(traitRefs)
+	traitsList, profileTraits, err := g.buildTraitsData(traitRefs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch traits: %w", err)
 	}
@@ -83,14 +88,14 @@ func (g *ReleaseGenerator) GenerateRelease(opts ReleaseOptions) (*unstructured.U
 	}
 
 	// 6. Build ComponentRelease
-	release := g.buildRelease(releaseName, opts.Namespace, comp, ct, wl, traitsMap, profileTraits)
+	release := g.buildRelease(releaseName, opts.Namespace, comp, ct, wl, traitsList, profileTraits)
 
 	return release, nil
 }
 
-// buildTraitsData fetches traits and builds both the traits map and profile traits
+// buildTraitsData fetches traits and builds both the traits list and profile traits
 func (g *ReleaseGenerator) buildTraitsData(traitRefs []typed2.TraitRef) (
-	map[string]interface{}, // traitsMap: traitName -> full TraitSpec
+	[]interface{}, // traitsList: ComponentReleaseTrait entries with kind, name, spec
 	[]interface{}, // profileTraits: trait references for componentProfile
 	error,
 ) {
@@ -98,26 +103,51 @@ func (g *ReleaseGenerator) buildTraitsData(traitRefs []typed2.TraitRef) (
 		return nil, nil, nil
 	}
 
-	// Collect unique trait names
-	traitNames := make(map[string]bool)
+	// Collect unique traits by kind+name and fetch their specs
+	type traitKey struct{ kind, name string }
+	seen := make(map[traitKey]bool)
+	traitsList := make([]interface{}, 0, len(traitRefs))
 	for _, ref := range traitRefs {
-		traitNames[ref.Name] = true
-	}
-
-	// Fetch trait resources
-	traitsMap := make(map[string]interface{})
-	for name := range traitNames {
-		t, err := g.index.GetTypedTrait(name)
-		if err != nil {
-			return nil, nil, err
+		kind := ref.Kind
+		if kind == "" {
+			kind = traitKindTrait
 		}
-		traitsMap[name] = t.GetSpec() // Embed full TraitSpec
+
+		key := traitKey{kind: kind, name: ref.Name}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		var traitSpec map[string]interface{}
+		switch kind {
+		case traitKindTrait:
+			t, err := g.index.GetTypedTrait(ref.Name)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to look up trait %s/%s: %w", kind, ref.Name, err)
+			}
+			traitSpec = t.GetSpec()
+		case traitKindClusterTrait:
+			return nil, nil, fmt.Errorf("ClusterTrait %q lookup is not yet supported in fs-mode index", ref.Name)
+		default:
+			return nil, nil, fmt.Errorf("unsupported trait kind %q for trait %q", kind, ref.Name)
+		}
+		traitsList = append(traitsList, map[string]interface{}{
+			"kind": kind,
+			"name": ref.Name,
+			"spec": traitSpec,
+		})
 	}
 
 	// Build profile traits (references with instance params)
 	profileTraits := make([]interface{}, 0, len(traitRefs))
 	for _, ref := range traitRefs {
+		kind := ref.Kind
+		if kind == "" {
+			kind = traitKindTrait
+		}
 		traitRef := map[string]interface{}{
+			"kind":         kind,
 			"name":         ref.Name,
 			"instanceName": ref.InstanceName,
 		}
@@ -127,7 +157,7 @@ func (g *ReleaseGenerator) buildTraitsData(traitRefs []typed2.TraitRef) (
 		profileTraits = append(profileTraits, traitRef)
 	}
 
-	return traitsMap, profileTraits, nil
+	return traitsList, profileTraits, nil
 }
 
 // buildWorkloadData constructs the workload section for the ComponentRelease spec,
@@ -153,18 +183,35 @@ func (g *ReleaseGenerator) buildRelease(
 	comp *typed2.Component,
 	ct *typed2.ComponentType,
 	wl *typed2.Workload,
-	traitsMap map[string]interface{},
+	traitsList []interface{},
 	profileTraits []interface{},
 ) *unstructured.Unstructured {
+	// Build componentType.spec with workloadType, schema, and resources
+	componentTypeSpec := map[string]interface{}{
+		"workloadType": ct.WorkloadType(),
+		"resources":    ct.GetResources(),
+	}
+	if schema := ct.GetSchema(); len(schema) > 0 {
+		for k, v := range schema {
+			componentTypeSpec[k] = v
+		}
+	}
+
+	// Determine the kind from the component's componentType reference
+	ctKind := string(comp.Spec.ComponentType.Kind)
+	if ctKind == "" {
+		ctKind = "ComponentType"
+	}
+
 	spec := map[string]interface{}{
 		"owner": map[string]interface{}{
 			"componentName": comp.Name,
 			"projectName":   comp.ProjectName(),
 		},
 		"componentType": map[string]interface{}{
-			"workloadType": ct.WorkloadType(),
-			"schema":       ct.GetSchema(),
-			"resources":    ct.GetResources(),
+			"kind": ctKind,
+			"name": comp.Spec.ComponentType.Name,
+			"spec": componentTypeSpec,
 		},
 		"workload": g.buildWorkloadData(wl),
 	}
@@ -182,9 +229,9 @@ func (g *ReleaseGenerator) buildRelease(
 		spec["componentProfile"] = componentProfile
 	}
 
-	// Add traits map if present
-	if len(traitsMap) > 0 {
-		spec["traits"] = traitsMap
+	// Add traits list if present
+	if len(traitsList) > 0 {
+		spec["traits"] = traitsList
 	}
 
 	return &unstructured.Unstructured{

--- a/internal/occ/fsmode/generator/component_release_test.go
+++ b/internal/occ/fsmode/generator/component_release_test.go
@@ -4,6 +4,7 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -96,6 +97,241 @@ func addWorkload(t *testing.T, idx *index.Index, namespace, name, project, compo
 	}
 	if err := idx.Add(entry); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// addTrait adds a Trait resource entry to the index.
+func addTrait(t *testing.T, idx *index.Index, name string, spec map[string]any, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Trait",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "default",
+				},
+				"spec": spec,
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// addComponentWithTraits adds a Component with trait references to the index.
+func addComponentWithTraits(t *testing.T, idx *index.Index, namespace, name, project, componentTypeName string, traits []map[string]any, filePath string) {
+	t.Helper()
+	spec := map[string]any{
+		"owner": map[string]any{
+			"projectName": project,
+		},
+		"componentType": map[string]any{
+			"name": componentTypeName,
+			"kind": "ComponentType",
+		},
+	}
+	if len(traits) > 0 {
+		spec["traits"] = traits
+	}
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": spec,
+			},
+		},
+		FilePath: filePath,
+	}
+	if err := idx.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateRelease_ManifestShape(t *testing.T) {
+	const (
+		namespace     = "default"
+		projectName   = "myproj"
+		componentName = "my-svc"
+		releaseName   = "my-svc-release-1"
+	)
+
+	idx := index.New("/repo")
+
+	// Component with two trait refs: one explicit "Trait" kind, one with empty kind (should normalize to "Trait")
+	addComponentWithTraits(t, idx, namespace, componentName, projectName, "deployment/service",
+		[]map[string]any{
+			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-1"},
+			{"name": "logging", "instanceName": "logging-1"},
+		},
+		"/repo/projects/myproj/components/my-svc/component.yaml")
+
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+
+	addWorkload(t, idx, namespace, "my-svc-workload", projectName, componentName,
+		map[string]any{
+			"container": map[string]any{"image": "reg/my-svc:v1"},
+		},
+		"/repo/projects/myproj/components/my-svc/workload.yaml")
+
+	addTrait(t, idx, "ingress",
+		map[string]any{"creates": []any{map[string]any{"apiVersion": "networking.k8s.io/v1", "kind": "Ingress"}}},
+		"/repo/platform/traits/ingress.yaml")
+
+	addTrait(t, idx, "logging",
+		map[string]any{"creates": []any{map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}}},
+		"/repo/platform/traits/logging.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	release, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: componentName,
+		ProjectName:   projectName,
+		Namespace:     namespace,
+		ReleaseName:   releaseName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// --- Verify top-level metadata ---
+	if got := release.GetKind(); got != "ComponentRelease" {
+		t.Errorf("kind = %q, want ComponentRelease", got)
+	}
+	if got := release.GetName(); got != releaseName {
+		t.Errorf("metadata.name = %q, want %q", got, releaseName)
+	}
+	if got := release.GetNamespace(); got != namespace {
+		t.Errorf("metadata.namespace = %q, want %q", got, namespace)
+	}
+
+	// --- Verify spec.componentType ---
+	ctKind, _, _ := unstructured.NestedString(release.Object, "spec", "componentType", "kind")
+	ctName, _, _ := unstructured.NestedString(release.Object, "spec", "componentType", "name")
+	ctWorkloadType, _, _ := unstructured.NestedString(release.Object, "spec", "componentType", "spec", "workloadType")
+	if ctKind != "ComponentType" {
+		t.Errorf("spec.componentType.kind = %q, want ComponentType", ctKind)
+	}
+	if ctName != "deployment/service" {
+		t.Errorf("spec.componentType.name = %q, want deployment/service", ctName)
+	}
+	if ctWorkloadType != "deployment" {
+		t.Errorf("spec.componentType.spec.workloadType = %q, want deployment", ctWorkloadType)
+	}
+
+	// --- Verify spec.traits[] ---
+	traitsSlice, ok, _ := unstructured.NestedSlice(release.Object, "spec", "traits")
+	if !ok {
+		t.Fatal("expected spec.traits to exist")
+	}
+	if len(traitsSlice) != 2 {
+		t.Fatalf("expected 2 traits in spec.traits, got %d", len(traitsSlice))
+	}
+	for i, expected := range []struct{ kind, name string }{
+		{"Trait", "ingress"},
+		{"Trait", "logging"},
+	} {
+		traitMap, ok := traitsSlice[i].(map[string]interface{})
+		if !ok {
+			t.Fatalf("spec.traits[%d] is not a map", i)
+		}
+		if traitMap["kind"] != expected.kind {
+			t.Errorf("spec.traits[%d].kind = %v, want %q", i, traitMap["kind"], expected.kind)
+		}
+		if traitMap["name"] != expected.name {
+			t.Errorf("spec.traits[%d].name = %v, want %q", i, traitMap["name"], expected.name)
+		}
+		if traitMap["spec"] == nil {
+			t.Errorf("spec.traits[%d].spec should not be nil", i)
+		}
+	}
+
+	// --- Verify spec.componentProfile.traits[] ---
+	profileTraits, ok, _ := unstructured.NestedSlice(release.Object, "spec", "componentProfile", "traits")
+	if !ok {
+		t.Fatal("expected spec.componentProfile.traits to exist")
+	}
+	if len(profileTraits) != 2 {
+		t.Fatalf("expected 2 profile traits, got %d", len(profileTraits))
+	}
+	for i, expected := range []struct{ kind, name, instanceName string }{
+		{"Trait", "ingress", "ingress-1"},
+		{"Trait", "logging", "logging-1"},
+	} {
+		pt, ok := profileTraits[i].(map[string]interface{})
+		if !ok {
+			t.Fatalf("spec.componentProfile.traits[%d] is not a map", i)
+		}
+		if pt["kind"] != expected.kind {
+			t.Errorf("spec.componentProfile.traits[%d].kind = %v, want %q", i, pt["kind"], expected.kind)
+		}
+		if pt["name"] != expected.name {
+			t.Errorf("spec.componentProfile.traits[%d].name = %v, want %q", i, pt["name"], expected.name)
+		}
+		if pt["instanceName"] != expected.instanceName {
+			t.Errorf("spec.componentProfile.traits[%d].instanceName = %v, want %q", i, pt["instanceName"], expected.instanceName)
+		}
+	}
+
+	// --- Verify spec.owner ---
+	ownerComp, _, _ := unstructured.NestedString(release.Object, "spec", "owner", "componentName")
+	ownerProj, _, _ := unstructured.NestedString(release.Object, "spec", "owner", "projectName")
+	if ownerComp != componentName {
+		t.Errorf("spec.owner.componentName = %q, want %q", ownerComp, componentName)
+	}
+	if ownerProj != projectName {
+		t.Errorf("spec.owner.projectName = %q, want %q", ownerProj, projectName)
+	}
+}
+
+func TestGenerateRelease_ClusterTraitRefErrors(t *testing.T) {
+	const (
+		namespace     = "staging"
+		projectName   = "myproj"
+		componentName = "my-svc"
+	)
+
+	idx := index.New("/repo")
+
+	addComponentWithTraits(t, idx, namespace, componentName, projectName, "deployment/service",
+		[]map[string]any{
+			{"kind": "ClusterTrait", "name": "global-ingress", "instanceName": "gi-1"},
+		},
+		"/repo/projects/myproj/components/my-svc/component.yaml")
+
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+
+	addWorkload(t, idx, namespace, "my-svc-workload", projectName, componentName,
+		map[string]any{
+			"container": map[string]any{"image": "reg/my-svc:v1"},
+		},
+		"/repo/projects/myproj/components/my-svc/workload.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	_, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: componentName,
+		ProjectName:   projectName,
+		Namespace:     namespace,
+		ReleaseName:   "test-release",
+	})
+	if err == nil {
+		t.Fatal("expected error for ClusterTrait reference, got nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "ClusterTrait") || !strings.Contains(got, "global-ingress") {
+		t.Errorf("error should mention ClusterTrait and trait name, got: %s", got)
 	}
 }
 
@@ -294,7 +530,7 @@ func TestGenerateRelease_WorkloadWithoutEndpoints(t *testing.T) {
 	addComponent(t, idx, namespace, componentName, projectName, "deployment/worker",
 		"/repo/projects/doclet/components/worker-svc/component.yaml")
 
-	addComponentType(t, idx, "worker", "deployment",
+	addComponentType(t, idx, "worker", "statefulset",
 		"/repo/platform/component-types/worker.yaml")
 
 	addWorkload(t, idx, namespace, "worker-svc-workload", projectName, componentName,

--- a/internal/occ/fsmode/typed/component.go
+++ b/internal/occ/fsmode/typed/component.go
@@ -58,7 +58,12 @@ func (c *Component) GetTraitRefs() []TraitRef {
 
 	refs := make([]TraitRef, len(c.Spec.Traits))
 	for i, trait := range c.Spec.Traits {
+		kind := string(trait.Kind)
+		if kind == "" {
+			kind = "Trait"
+		}
 		refs[i] = TraitRef{
+			Kind:         kind,
 			Name:         trait.Name,
 			InstanceName: trait.InstanceName,
 			Parameters:   rawExtensionToMap(trait.Parameters),

--- a/internal/occ/fsmode/typed/conversion.go
+++ b/internal/occ/fsmode/typed/conversion.go
@@ -47,6 +47,7 @@ func rawExtensionToMap(raw *runtime.RawExtension) map[string]interface{} {
 // TraitRef is a convenience type for trait references
 // This mirrors the v1alpha1.ComponentTrait structure but uses map for Parameters
 type TraitRef struct {
+	Kind         string
 	Name         string
 	InstanceName string
 	Parameters   map[string]interface{}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

### Before fix

What occ componentrelease generate produced

```yaml
apiVersion: openchoreo.dev/v1alpha1
kind: ComponentRelease
metadata:
  name: document-svc-ba0e100a
  namespace: default
spec:
  owner:
    componentName: document-svc
    projectName: doclet
  componentType:
    workloadType: deployment          # ❌ wrong level
    schema:                           # ❌ wrong key name, wrong level
      parameters: {...}
      environmentConfigs: {...}
    resources:                        # ❌ wrong level
      - id: deployment
        template: {...}
  traits:                             # ❌ map keyed by name
    persistent-volume:                # ❌ raw spec, no kind/name
      creates: [...]
      patches: [...]
  componentProfile:
    traits:
      - name: persistent-volume       # ❌ missing kind
        instanceName: data-storage
        parameters: {...}
  workload: {...}
```

#### After fix

```yaml
apiVersion: openchoreo.dev/v1alpha1
kind: ComponentRelease
metadata:
  name: document-svc-ba0e100a
  namespace: default
spec:
  owner:
    componentName: document-svc
    projectName: doclet
  componentType:
    kind: ComponentType               # ✅ added (or ClusterComponentType)
    name: deployment/web-application  # ✅ added
    spec:                             # ✅ nested under spec
      workloadType: deployment
      parameters:                     # ✅ flattened from schema
        openAPIV3Schema: {...}
      environmentConfigs:             # ✅ flattened from schema
        openAPIV3Schema: {...}
      resources:
        - id: deployment
          template: {...}
  traits:                             # ✅ list of objects
    - kind: Trait                     # ✅ kind (or ClusterTrait)
      name: persistent-volume         # ✅ name
      spec:                           # ✅ spec nested properly
        creates: [...]
        patches: [...]
  componentProfile:
    traits:
      - kind: Trait                   # ✅ kind included
        name: persistent-volume
        instanceName: data-storage
        parameters: {...}
  workload: {...}
```

#### Key differences

| Field | Before | After |
|-- | -- | --|
componentType.kind | missing | ComponentType or ClusterComponentType
componentType.name | missing | e.g. deployment/web-application
componentType.spec | didn’t exist; fields at wrong level | wraps workloadType, resources, parameters, environmentConfigs
componentType.schema | nested parameters + environmentConfigs under schema key | flattened to direct parameters and environmentConfigs in spec
traits | map[name] -> rawSpec | []{ kind, name, spec }
componentProfile.traits[].kind | missing | Trait or ClusterTrait

</body></html>


## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
