### PR TITLE
fix: propagate workflow kind from component in TriggerWorkflowRun

### DIFF
--- a/internal/openchoreo-api/mcphandlers/components.go
+++ b/internal/openchoreo-api/mcphandlers/components.go
@@ -584,6 +584,7 @@ func (h *MCPHandler) TriggerWorkflowRun(
 		},
 		Spec: openchoreov1alpha1.WorkflowRunSpec{
 			Workflow: openchoreov1alpha1.WorkflowRunConfig{
+				Kind:       component.Spec.Workflow.Kind,
 				Name:       component.Spec.Workflow.Name,
 				Parameters: parameters,
 			},


### PR DESCRIPTION
## Summary
- Propagate `component.Spec.Workflow.Kind` into the `WorkflowRunConfig` when triggering a workflow run via MCP, so the service layer resolves the correct workflow type