### PR TITLE
fix: add missing helm values for quick start observability MCP server

### DIFF
--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -26,6 +26,8 @@ observer:
     - observer.openchoreo.localhost
   openSearchSecretName: opensearch-admin-credentials
   extraEnvs:
+    - name: OBSERVER_BASE_URL
+      value: "http://observer.openchoreo.localhost:11080"
     - name: OPENSEARCH_ADDRESS
       value: "https://opensearch:9200"
     - name: PROMETHEUS_ADDRESS
@@ -50,3 +52,4 @@ gateway:
 security:
   oidc:
     jwksUrl: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/jwks"
+    authServerBaseUrl: "http://thunder.openchoreo.localhost:8080"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The quickstart openchoreo installation's observability MCP server auth is not working properly. This PR fixes it by adding the wellknown endpoint's configs

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2635

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
