### PR TITLE
feat: enable platform engineer mcp toolset by default

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1517,6 +1517,7 @@ openchoreoApi:
         - "component"
         - "deployment"
         - "build"
+        - "pe"
     # @schema
     # type: object
     # description: Logging configuration


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR enables platform engineer mcp toolset by default

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2746