### PR TITLE
feat: add alerts and incidents MCP tools

### DIFF
--- a/internal/observer/mcp/handlers.go
+++ b/internal/observer/mcp/handlers.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
 	"github.com/openchoreo/openchoreo/internal/observer/service"
 	"github.com/openchoreo/openchoreo/internal/observer/types"
 )
@@ -189,6 +190,68 @@ func (h *MCPHandler) QueryTraceSpans(ctx context.Context, traceID, namespace, pr
 
 func (h *MCPHandler) GetSpanDetails(ctx context.Context, traceID, spanID string) (any, error) {
 	return h.tracesService.GetSpanDetails(ctx, traceID, spanID)
+}
+
+func (h *MCPHandler) QueryAlerts(ctx context.Context, namespace, project, component, environment,
+	startTime, endTime string, limit int, sortOrder string) (any, error) {
+	limit, sortOrder, _ = setDefaults(limit, sortOrder, nil)
+	start, err := parseRFC3339Time(startTime)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start_time: %w", err)
+	}
+	end, err := parseRFC3339Time(endTime)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end_time: %w", err)
+	}
+	sortOrderTyped := gen.AlertsQueryRequestSortOrder(sortOrder)
+	req := gen.AlertsQueryRequest{
+		StartTime: start,
+		EndTime:   end,
+		Limit:     &limit,
+		SortOrder: &sortOrderTyped,
+		SearchScope: gen.ComponentSearchScope{
+			Namespace:   namespace,
+			Project:     strPtr(project),
+			Component:   strPtr(component),
+			Environment: strPtr(environment),
+		},
+	}
+	return h.alertIncidentService.QueryAlerts(ctx, req)
+}
+
+func (h *MCPHandler) QueryIncidents(ctx context.Context, namespace, project, component, environment,
+	startTime, endTime string, limit int, sortOrder string) (any, error) {
+	limit, sortOrder, _ = setDefaults(limit, sortOrder, nil)
+	start, err := parseRFC3339Time(startTime)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start_time: %w", err)
+	}
+	end, err := parseRFC3339Time(endTime)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end_time: %w", err)
+	}
+	sortOrderTyped := gen.IncidentsQueryRequestSortOrder(sortOrder)
+	req := gen.IncidentsQueryRequest{
+		StartTime: start,
+		EndTime:   end,
+		Limit:     &limit,
+		SortOrder: &sortOrderTyped,
+		SearchScope: gen.ComponentSearchScope{
+			Namespace:   namespace,
+			Project:     strPtr(project),
+			Component:   strPtr(component),
+			Environment: strPtr(environment),
+		},
+	}
+	return h.alertIncidentService.QueryIncidents(ctx, req)
+}
+
+// strPtr returns a pointer to the string, or nil if the string is empty.
+func strPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 func parseRFC3339Time(timeStr string) (time.Time, error) {

--- a/internal/observer/mcp/server.go
+++ b/internal/observer/mcp/server.go
@@ -298,6 +298,74 @@ func registerTools(s *mcpsdk.Server, handler *MCPHandler) {
 		result, err := handler.GetSpanDetails(ctx, args.TraceID, args.SpanID)
 		return handleToolResult(result, err)
 	})
+
+	// Tool 8: query_alerts
+	mcpsdk.AddTool(s, &mcpsdk.Tool{
+		Name:        "query_alerts",
+		Description: "Query fired alerts in OpenChoreo. Supports filtering by project, component, environment, and time range. Useful for investigating recent alerts and details about them.",
+		InputSchema: createSchema(map[string]any{
+			"namespace":   stringProperty("Organization namespace (required)"),
+			"project":     stringProperty("Project name to filter alerts"),
+			"component":   stringProperty("Component name to filter alerts"),
+			"environment": stringProperty("Environment name to filter alerts (e.g., 'development', 'production')"),
+			"start_time":  stringProperty("Start of time range in RFC3339 format (e.g., 2025-11-04T08:29:02.452Z)"),
+			"end_time":    stringProperty("End of time range in RFC3339 format (e.g., 2025-11-04T09:29:02.452Z)"),
+			"limit":       limitProperty(),
+			"sort_order":  sortOrderProperty(),
+		}, []string{"namespace", "start_time", "end_time"}),
+	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, args struct {
+		Namespace   string `json:"namespace"`
+		Project     string `json:"project"`
+		Component   string `json:"component"`
+		Environment string `json:"environment"`
+		StartTime   string `json:"start_time"`
+		EndTime     string `json:"end_time"`
+		Limit       int    `json:"limit"`
+		SortOrder   string `json:"sort_order"`
+	}) (*mcpsdk.CallToolResult, any, error) {
+		if err := validateComponentScope(args.Namespace, args.Project, args.Component); err != nil {
+			return nil, nil, err
+		}
+		result, err := handler.QueryAlerts(ctx,
+			args.Namespace, args.Project, args.Component, args.Environment,
+			args.StartTime, args.EndTime, args.Limit, args.SortOrder,
+		)
+		return handleToolResult(result, err)
+	})
+
+	// Tool 9: query_incidents
+	mcpsdk.AddTool(s, &mcpsdk.Tool{
+		Name:        "query_incidents",
+		Description: "Query incidents in OpenChoreo. Supports filtering by project, component, environment, and time range. Useful for tracking incident lifecycle and response status. All incidents have an accompanying alert but not the other way around.",
+		InputSchema: createSchema(map[string]any{
+			"namespace":   stringProperty("Organization namespace (required)"),
+			"project":     stringProperty("Project name to filter incidents"),
+			"component":   stringProperty("Component name to filter incidents"),
+			"environment": stringProperty("Environment name to filter incidents (e.g., 'development', 'production')"),
+			"start_time":  stringProperty("Start of time range in RFC3339 format (e.g., 2025-11-04T08:29:02.452Z)"),
+			"end_time":    stringProperty("End of time range in RFC3339 format (e.g., 2025-11-04T09:29:02.452Z)"),
+			"limit":       limitProperty(),
+			"sort_order":  sortOrderProperty(),
+		}, []string{"namespace", "start_time", "end_time"}),
+	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, args struct {
+		Namespace   string `json:"namespace"`
+		Project     string `json:"project"`
+		Component   string `json:"component"`
+		Environment string `json:"environment"`
+		StartTime   string `json:"start_time"`
+		EndTime     string `json:"end_time"`
+		Limit       int    `json:"limit"`
+		SortOrder   string `json:"sort_order"`
+	}) (*mcpsdk.CallToolResult, any, error) {
+		if err := validateComponentScope(args.Namespace, args.Project, args.Component); err != nil {
+			return nil, nil, err
+		}
+		result, err := handler.QueryIncidents(ctx,
+			args.Namespace, args.Project, args.Component, args.Environment,
+			args.StartTime, args.EndTime, args.Limit, args.SortOrder,
+		)
+		return handleToolResult(result, err)
+	})
 }
 
 // Helper functions for schema creation
@@ -324,6 +392,13 @@ func limitLogsProperty() map[string]any {
 }
 
 func limitTraceSpansProperty() map[string]any {
+	return map[string]any{
+		"type":        "number",
+		"description": "Maximum number of entries to return. Default: 100",
+	}
+}
+
+func limitProperty() map[string]any {
 	return map[string]any{
 		"type":        "number",
 		"description": "Maximum number of entries to return. Default: 100",

--- a/internal/observer/mcp/server_test.go
+++ b/internal/observer/mcp/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
 	"github.com/openchoreo/openchoreo/internal/observer/service"
 	"github.com/openchoreo/openchoreo/internal/observer/types"
 )
@@ -29,6 +30,7 @@ const (
 	testEndTime     = "2025-01-01T23:59:59Z"
 	testTraceID     = "trace-abc123"
 	testSpanID      = "span-def456"
+	sortOrderAsc    = "asc"
 	sortOrderDesc   = "desc"
 )
 
@@ -184,19 +186,76 @@ func (m *MockTracesQuerier) reset() {
 	m.spanDetailsSpanIDs = nil
 }
 
+type MockAlertIncidentService struct {
+	alertsRequests    []gen.AlertsQueryRequest
+	incidentsRequests []gen.IncidentsQueryRequest
+	alertsResponse    *gen.AlertsQueryResponse
+	incidentsResponse *gen.IncidentsQueryResponse
+	queryAlertsErr    error
+	queryIncidentsErr error
+}
+
+func NewMockAlertIncidentService() *MockAlertIncidentService {
+	return &MockAlertIncidentService{
+		alertsResponse:    &gen.AlertsQueryResponse{},
+		incidentsResponse: &gen.IncidentsQueryResponse{},
+	}
+}
+
+func (m *MockAlertIncidentService) QueryAlerts(_ context.Context, req gen.AlertsQueryRequest) (*gen.AlertsQueryResponse, error) {
+	m.alertsRequests = append(m.alertsRequests, req)
+	if m.queryAlertsErr != nil {
+		return nil, m.queryAlertsErr
+	}
+	return m.alertsResponse, nil
+}
+
+func (m *MockAlertIncidentService) QueryIncidents(_ context.Context, req gen.IncidentsQueryRequest) (*gen.IncidentsQueryResponse, error) {
+	m.incidentsRequests = append(m.incidentsRequests, req)
+	if m.queryIncidentsErr != nil {
+		return nil, m.queryIncidentsErr
+	}
+	return m.incidentsResponse, nil
+}
+
+func (m *MockAlertIncidentService) UpdateIncident(_ context.Context, _ string, _ gen.IncidentPutRequest) (*gen.IncidentPutResponse, error) {
+	return &gen.IncidentPutResponse{}, nil
+}
+
+func (m *MockAlertIncidentService) lastAlertsRequest() *gen.AlertsQueryRequest {
+	if len(m.alertsRequests) == 0 {
+		return nil
+	}
+	return &m.alertsRequests[len(m.alertsRequests)-1]
+}
+
+func (m *MockAlertIncidentService) lastIncidentsRequest() *gen.IncidentsQueryRequest {
+	if len(m.incidentsRequests) == 0 {
+		return nil
+	}
+	return &m.incidentsRequests[len(m.incidentsRequests)-1]
+}
+
+func (m *MockAlertIncidentService) reset() {
+	m.alertsRequests = nil
+	m.incidentsRequests = nil
+}
+
 // ---- Test harness ----
 
 type testServices struct {
-	logs    *MockLogsQuerier
-	metrics *MockMetricsQuerier
-	traces  *MockTracesQuerier
+	logs            *MockLogsQuerier
+	metrics         *MockMetricsQuerier
+	traces          *MockTracesQuerier
+	alertsIncidents *MockAlertIncidentService
 }
 
 func newTestServices() *testServices {
 	return &testServices{
-		logs:    NewMockLogsQuerier(),
-		metrics: NewMockMetricsQuerier(),
-		traces:  NewMockTracesQuerier(),
+		logs:            NewMockLogsQuerier(),
+		metrics:         NewMockMetricsQuerier(),
+		traces:          NewMockTracesQuerier(),
+		alertsIncidents: NewMockAlertIncidentService(),
 	}
 }
 
@@ -204,6 +263,7 @@ func (s *testServices) resetAll() {
 	s.logs.reset()
 	s.metrics.reset()
 	s.traces.reset()
+	s.alertsIncidents.reset()
 }
 
 func buildMCPHandler(svcs *testServices) (*MCPHandler, error) {
@@ -212,8 +272,7 @@ func buildMCPHandler(svcs *testServices) (*MCPHandler, error) {
 	if err != nil {
 		return nil, err
 	}
-	alertSvc := service.NewAlertService(nil, nil, nil, nil, nil, nil, logger, "", false, nil, nil)
-	return NewMCPHandler(healthSvc, svcs.logs, svcs.metrics, alertSvc, svcs.traces, logger)
+	return NewMCPHandler(healthSvc, svcs.logs, svcs.metrics, svcs.alertsIncidents, svcs.traces, logger)
 }
 
 func setupTestServer(t *testing.T) (*mcpsdk.ClientSession, *testServices) {
@@ -287,7 +346,7 @@ var allToolSpecs = []toolTestSpec{
 			"search_phrase": "error",
 			"log_levels":    []any{"ERROR", "WARN"},
 			"limit":         50,
-			"sort_order":    "asc",
+			"sort_order":    sortOrderAsc,
 		},
 		validateCall: func(t *testing.T, svcs *testServices) {
 			t.Helper()
@@ -326,7 +385,7 @@ var allToolSpecs = []toolTestSpec{
 			if req.Limit != 50 {
 				t.Errorf("Expected limit 50, got %d", req.Limit)
 			}
-			if req.SortOrder != "asc" {
+			if req.SortOrder != sortOrderAsc {
 				t.Errorf("Expected sort_order 'asc', got %q", req.SortOrder)
 			}
 		},
@@ -474,7 +533,7 @@ var allToolSpecs = []toolTestSpec{
 			"start_time":  testStartTime,
 			"end_time":    testEndTime,
 			"limit":       25,
-			"sort_order":  "asc",
+			"sort_order":  sortOrderAsc,
 		},
 		validateCall: func(t *testing.T, svcs *testServices) {
 			t.Helper()
@@ -505,7 +564,7 @@ var allToolSpecs = []toolTestSpec{
 			if req.Limit != 25 {
 				t.Errorf("Expected limit 25, got %d", req.Limit)
 			}
-			if req.SortOrder != "asc" {
+			if req.SortOrder != sortOrderAsc {
 				t.Errorf("Expected sort 'asc', got %q", req.SortOrder)
 			}
 		},
@@ -575,6 +634,106 @@ var allToolSpecs = []toolTestSpec{
 			}
 		},
 	},
+	{
+		name:                "query_alerts",
+		descriptionKeywords: []string{"alert"},
+		descriptionMinLen:   20,
+		requiredParams:      []string{"namespace", "start_time", "end_time"},
+		optionalParams:      []string{"project", "component", "environment", "limit", "sort_order"},
+		testArgs: map[string]any{
+			"namespace":   testNamespace,
+			"project":     testProject,
+			"component":   testComponent,
+			"environment": testEnvironment,
+			"start_time":  testStartTime,
+			"end_time":    testEndTime,
+			"limit":       50,
+			"sort_order":  sortOrderAsc,
+		},
+		validateCall: func(t *testing.T, svcs *testServices) {
+			t.Helper()
+			req := svcs.alertsIncidents.lastAlertsRequest()
+			if req == nil {
+				t.Fatal("Expected QueryAlerts to be called")
+			}
+			if req.SearchScope.Namespace != testNamespace {
+				t.Errorf("Expected namespace %q, got %q", testNamespace, req.SearchScope.Namespace)
+			}
+			if req.SearchScope.Project == nil || *req.SearchScope.Project != testProject {
+				t.Errorf("Expected project %q, got %v", testProject, req.SearchScope.Project)
+			}
+			if req.SearchScope.Component == nil || *req.SearchScope.Component != testComponent {
+				t.Errorf("Expected component %q, got %v", testComponent, req.SearchScope.Component)
+			}
+			if req.SearchScope.Environment == nil || *req.SearchScope.Environment != testEnvironment {
+				t.Errorf("Expected environment %q, got %v", testEnvironment, req.SearchScope.Environment)
+			}
+			expectedStart, _ := time.Parse(time.RFC3339, testStartTime)
+			if !req.StartTime.Equal(expectedStart) {
+				t.Errorf("Expected start_time %v, got %v", expectedStart, req.StartTime)
+			}
+			expectedEnd, _ := time.Parse(time.RFC3339, testEndTime)
+			if !req.EndTime.Equal(expectedEnd) {
+				t.Errorf("Expected end_time %v, got %v", expectedEnd, req.EndTime)
+			}
+			if req.Limit == nil || *req.Limit != 50 {
+				t.Errorf("Expected limit 50, got %v", req.Limit)
+			}
+			if req.SortOrder == nil || string(*req.SortOrder) != sortOrderAsc {
+				t.Errorf("Expected sort_order 'asc', got %v", req.SortOrder)
+			}
+		},
+	},
+	{
+		name:                "query_incidents",
+		descriptionKeywords: []string{"incident"},
+		descriptionMinLen:   20,
+		requiredParams:      []string{"namespace", "start_time", "end_time"},
+		optionalParams:      []string{"project", "component", "environment", "limit", "sort_order"},
+		testArgs: map[string]any{
+			"namespace":   testNamespace,
+			"project":     testProject,
+			"component":   testComponent,
+			"environment": testEnvironment,
+			"start_time":  testStartTime,
+			"end_time":    testEndTime,
+			"limit":       25,
+			"sort_order":  sortOrderDesc,
+		},
+		validateCall: func(t *testing.T, svcs *testServices) {
+			t.Helper()
+			req := svcs.alertsIncidents.lastIncidentsRequest()
+			if req == nil {
+				t.Fatal("Expected QueryIncidents to be called")
+			}
+			if req.SearchScope.Namespace != testNamespace {
+				t.Errorf("Expected namespace %q, got %q", testNamespace, req.SearchScope.Namespace)
+			}
+			if req.SearchScope.Project == nil || *req.SearchScope.Project != testProject {
+				t.Errorf("Expected project %q, got %v", testProject, req.SearchScope.Project)
+			}
+			if req.SearchScope.Component == nil || *req.SearchScope.Component != testComponent {
+				t.Errorf("Expected component %q, got %v", testComponent, req.SearchScope.Component)
+			}
+			if req.SearchScope.Environment == nil || *req.SearchScope.Environment != testEnvironment {
+				t.Errorf("Expected environment %q, got %v", testEnvironment, req.SearchScope.Environment)
+			}
+			expectedStart, _ := time.Parse(time.RFC3339, testStartTime)
+			if !req.StartTime.Equal(expectedStart) {
+				t.Errorf("Expected start_time %v, got %v", expectedStart, req.StartTime)
+			}
+			expectedEnd, _ := time.Parse(time.RFC3339, testEndTime)
+			if !req.EndTime.Equal(expectedEnd) {
+				t.Errorf("Expected end_time %v, got %v", expectedEnd, req.EndTime)
+			}
+			if req.Limit == nil || *req.Limit != 25 {
+				t.Errorf("Expected limit 25, got %v", req.Limit)
+			}
+			if req.SortOrder == nil || string(*req.SortOrder) != sortOrderDesc {
+				t.Errorf("Expected sort_order %q, got %v", sortOrderDesc, req.SortOrder)
+			}
+		},
+	},
 }
 
 // ---- Tests ----
@@ -583,7 +742,7 @@ var allToolSpecs = []toolTestSpec{
 func TestNewMCPHandlerValidation(t *testing.T) {
 	logger := slog.Default()
 	healthSvc, _ := service.NewHealthService(logger)
-	alertSvc := service.NewAlertService(nil, nil, nil, nil, nil, nil, logger, "", false, nil, nil)
+	alertIncidentSvc := NewMockAlertIncidentService()
 	logs := NewMockLogsQuerier()
 	metrics := NewMockMetricsQuerier()
 	traces := NewMockTracesQuerier()
@@ -597,12 +756,12 @@ func TestNewMCPHandlerValidation(t *testing.T) {
 		traces               service.TracesQuerier
 		log                  *slog.Logger
 	}{
-		{"nil healthService", nil, logs, metrics, alertSvc, traces, logger},
-		{"nil logsService", healthSvc, nil, metrics, alertSvc, traces, logger},
-		{"nil metricsService", healthSvc, logs, nil, alertSvc, traces, logger},
+		{"nil healthService", nil, logs, metrics, alertIncidentSvc, traces, logger},
+		{"nil logsService", healthSvc, nil, metrics, alertIncidentSvc, traces, logger},
+		{"nil metricsService", healthSvc, logs, nil, alertIncidentSvc, traces, logger},
 		{"nil alertIncidentService", healthSvc, logs, metrics, nil, traces, logger},
-		{"nil tracesService", healthSvc, logs, metrics, alertSvc, nil, logger},
-		{"nil logger", healthSvc, logs, metrics, alertSvc, traces, nil},
+		{"nil tracesService", healthSvc, logs, metrics, alertIncidentSvc, nil, logger},
+		{"nil logger", healthSvc, logs, metrics, alertIncidentSvc, traces, nil},
 	}
 
 	for _, tt := range tests {
@@ -1083,6 +1242,46 @@ func TestHandlerErrorPropagation(t *testing.T) {
 			setupErr: func(s *testServices) { s.traces.spanDetailsErr = errors.New("span not found") },
 		},
 		{
+			name:     "alerts_service_error",
+			toolName: "query_alerts",
+			args: map[string]any{
+				"namespace":  testNamespace,
+				"start_time": testStartTime,
+				"end_time":   testEndTime,
+			},
+			setupErr: func(s *testServices) { s.alertsIncidents.queryAlertsErr = errors.New("alert store unavailable") },
+		},
+		{
+			name:     "incidents_service_error",
+			toolName: "query_incidents",
+			args: map[string]any{
+				"namespace":  testNamespace,
+				"start_time": testStartTime,
+				"end_time":   testEndTime,
+			},
+			setupErr: func(s *testServices) { s.alertsIncidents.queryIncidentsErr = errors.New("incident store unavailable") },
+		},
+		{
+			name:     "alerts_invalid_start_time",
+			toolName: "query_alerts",
+			args: map[string]any{
+				"namespace":  testNamespace,
+				"start_time": "not-a-time",
+				"end_time":   testEndTime,
+			},
+			setupErr: func(s *testServices) {},
+		},
+		{
+			name:     "incidents_invalid_end_time",
+			toolName: "query_incidents",
+			args: map[string]any{
+				"namespace":  testNamespace,
+				"start_time": testStartTime,
+				"end_time":   "bad-time-format",
+			},
+			setupErr: func(s *testServices) {},
+		},
+		{
 			name:     "traces_invalid_start_time",
 			toolName: "query_traces",
 			args: map[string]any{
@@ -1235,6 +1434,48 @@ func TestOptionalParametersDefaults(t *testing.T) {
 				}
 				if req.SortOrder != sortOrderDesc {
 					t.Errorf("Expected default sort %q, got %q", sortOrderDesc, req.SortOrder)
+				}
+			},
+		},
+		{
+			name:     "alerts_default_limit_and_sort",
+			toolName: "query_alerts",
+			args: map[string]any{
+				"namespace":  testNamespace,
+				"start_time": testStartTime,
+				"end_time":   testEndTime,
+			},
+			validateCall: func(t *testing.T, svcs *testServices) {
+				req := svcs.alertsIncidents.lastAlertsRequest()
+				if req == nil {
+					t.Fatal("Expected QueryAlerts to be called")
+				}
+				if req.Limit == nil || *req.Limit != 100 {
+					t.Errorf("Expected default limit 100, got %v", req.Limit)
+				}
+				if req.SortOrder == nil || string(*req.SortOrder) != sortOrderDesc {
+					t.Errorf("Expected default sort %q, got %v", sortOrderDesc, req.SortOrder)
+				}
+			},
+		},
+		{
+			name:     "incidents_default_limit_and_sort",
+			toolName: "query_incidents",
+			args: map[string]any{
+				"namespace":  testNamespace,
+				"start_time": testStartTime,
+				"end_time":   testEndTime,
+			},
+			validateCall: func(t *testing.T, svcs *testServices) {
+				req := svcs.alertsIncidents.lastIncidentsRequest()
+				if req == nil {
+					t.Fatal("Expected QueryIncidents to be called")
+				}
+				if req.Limit == nil || *req.Limit != 100 {
+					t.Errorf("Expected default limit 100, got %v", req.Limit)
+				}
+				if req.SortOrder == nil || string(*req.SortOrder) != sortOrderDesc {
+					t.Errorf("Expected default sort %q, got %v", sortOrderDesc, req.SortOrder)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- Add `query_alerts` and `query_incidents` tools to the MCP server
- Enable AI agents to query fired alerts and incident lifecycle for components
- Include tests for parameter wiring, error propagation, and defaults

#2741
