### PR TITLE
fix: improve component creation mcp tool

### DIFF
--- a/internal/openchoreo-api/mcphandlers/components.go
+++ b/internal/openchoreo-api/mcphandlers/components.go
@@ -75,10 +75,14 @@ func (h *MCPHandler) CreateComponent(
 			}
 			workflowParams = &runtime.RawExtension{Raw: paramsBytes}
 		}
-		component.Spec.Workflow = &openchoreov1alpha1.ComponentWorkflowConfig{
+		workflowConfig := &openchoreov1alpha1.ComponentWorkflowConfig{
 			Name:       req.Workflow.Name,
 			Parameters: workflowParams,
 		}
+		if req.Workflow.Kind != nil {
+			workflowConfig.Kind = openchoreov1alpha1.WorkflowRefKind(*req.Workflow.Kind)
+		}
+		component.Spec.Workflow = workflowConfig
 	}
 
 	created, err := h.services.ComponentService.CreateComponent(ctx, namespaceName, component)

--- a/internal/openchoreo-api/mcphandlers/transform_resources.go
+++ b/internal/openchoreo-api/mcphandlers/transform_resources.go
@@ -80,6 +80,9 @@ func componentDetail(c *openchoreov1alpha1.Component) map[string]any {
 	}
 	if c.Spec.Workflow != nil {
 		wf := map[string]any{"name": c.Spec.Workflow.Name}
+		if c.Spec.Workflow.Kind != "" {
+			wf["kind"] = string(c.Spec.Workflow.Kind)
+		}
 		if c.Spec.Workflow.Parameters != nil {
 			wf["parameters"] = rawExtensionToAny(c.Spec.Workflow.Parameters)
 		}

--- a/internal/openchoreo-api/mcphandlers/transform_test.go
+++ b/internal/openchoreo-api/mcphandlers/transform_test.go
@@ -253,6 +253,95 @@ func TestComponentSummary(t *testing.T) {
 	assertEqual(t, "latestRelease", m["latestRelease"], "v1")
 }
 
+func TestComponentDetail(t *testing.T) {
+	t.Run("workflow with kind and parameters", func(t *testing.T) {
+		paramsRaw := []byte(`{"branch":"main"}`)
+		c := &openchoreov1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-comp", Namespace: "org-ns"},
+			Spec: openchoreov1alpha1.ComponentSpec{
+				Owner:      openchoreov1alpha1.ComponentOwner{ProjectName: "my-project"},
+				AutoDeploy: true,
+				Workflow: &openchoreov1alpha1.ComponentWorkflowConfig{
+					Kind:       openchoreov1alpha1.WorkflowRefKindClusterWorkflow,
+					Name:       "go-build",
+					Parameters: &runtime.RawExtension{Raw: paramsRaw},
+				},
+			},
+		}
+
+		m := componentDetail(c)
+
+		wf, ok := m["workflow"].(map[string]any)
+		if !ok {
+			t.Fatal("expected workflow to be a map")
+		}
+		assertEqual(t, "workflow.name", wf["name"], "go-build")
+		assertEqual(t, "workflow.kind", wf["kind"], "ClusterWorkflow")
+		if wf["parameters"] == nil {
+			t.Error("expected workflow.parameters to be set")
+		}
+	})
+
+	t.Run("workflow without kind", func(t *testing.T) {
+		c := &openchoreov1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-comp", Namespace: "org-ns"},
+			Spec: openchoreov1alpha1.ComponentSpec{
+				Owner: openchoreov1alpha1.ComponentOwner{ProjectName: "my-project"},
+				Workflow: &openchoreov1alpha1.ComponentWorkflowConfig{
+					Name: "ns-build",
+				},
+			},
+		}
+
+		m := componentDetail(c)
+
+		wf, ok := m["workflow"].(map[string]any)
+		if !ok {
+			t.Fatal("expected workflow to be a map")
+		}
+		assertEqual(t, "workflow.name", wf["name"], "ns-build")
+		if _, hasKind := wf["kind"]; hasKind {
+			t.Error("kind should be omitted when empty")
+		}
+	})
+
+	t.Run("workflow kind Workflow", func(t *testing.T) {
+		c := &openchoreov1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-comp", Namespace: "org-ns"},
+			Spec: openchoreov1alpha1.ComponentSpec{
+				Owner: openchoreov1alpha1.ComponentOwner{ProjectName: "my-project"},
+				Workflow: &openchoreov1alpha1.ComponentWorkflowConfig{
+					Kind: openchoreov1alpha1.WorkflowRefKindWorkflow,
+					Name: "ns-build",
+				},
+			},
+		}
+
+		m := componentDetail(c)
+
+		wf, ok := m["workflow"].(map[string]any)
+		if !ok {
+			t.Fatal("expected workflow to be a map")
+		}
+		assertEqual(t, "workflow.kind", wf["kind"], "Workflow")
+	})
+
+	t.Run("no workflow", func(t *testing.T) {
+		c := &openchoreov1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-comp", Namespace: "org-ns"},
+			Spec: openchoreov1alpha1.ComponentSpec{
+				Owner: openchoreov1alpha1.ComponentOwner{ProjectName: "my-project"},
+			},
+		}
+
+		m := componentDetail(c)
+
+		if _, hasWf := m["workflow"]; hasWf {
+			t.Error("workflow should not be set when nil")
+		}
+	})
+}
+
 func TestEnvironmentSummary(t *testing.T) {
 	e := openchoreov1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/mcp/tools/component.go
+++ b/pkg/mcp/tools/component.go
@@ -133,8 +133,11 @@ func (t *Toolsets) RegisterCreateComponent(s *mcp.Server) {
 			},
 			"workflow": map[string]any{
 				"type": "object",
-				"description": "Optional: Component workflow configuration. Use list_workflows to discover available " +
-					"workflow names, and get_workflow_schema to inspect the parameter schema a workflow accepts.",
+				"description": "Optional: Component workflow configuration. Use list_cluster_workflows to discover " +
+					"available cluster-scoped workflow names (ClusterWorkflow kind, used with ClusterComponentType), " +
+					"or list_workflows for namespace-scoped workflows (Workflow kind). " +
+					"Use get_cluster_workflow_schema or get_workflow_schema to inspect the parameter schema. " +
+					"Set 'kind' to 'ClusterWorkflow' or 'Workflow' to match the workflow resource type.",
 			},
 		}, []string{"namespace_name", "project_name", "name", "component_type"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
@@ -186,6 +189,16 @@ func (t *Toolsets) RegisterCreateComponent(s *mcp.Server) {
 			workflow := &gen.ComponentWorkflowInput{}
 			if name, ok := args.Workflow["name"].(string); ok {
 				workflow.Name = name
+			}
+
+			// Convert kind if provided
+			if kind, ok := args.Workflow["kind"].(string); ok && kind != "" {
+				if kind != string(gen.ComponentWorkflowInputKindClusterWorkflow) &&
+					kind != string(gen.ComponentWorkflowInputKindWorkflow) {
+					return nil, nil, fmt.Errorf("invalid workflow.kind %q: must be one of [ClusterWorkflow, Workflow]", kind)
+				}
+				k := gen.ComponentWorkflowInputKind(kind)
+				workflow.Kind = &k
 			}
 
 			// Convert parameters if provided

--- a/pkg/mcp/tools/component_specs_test.go
+++ b/pkg/mcp/tools/component_specs_test.go
@@ -4,7 +4,10 @@
 package tools
 
 import (
+	"context"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -343,6 +346,69 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 				}
 			},
 		},
+	}
+}
+
+// TestCreateComponentWorkflowKindValidation tests that invalid workflow.kind values are rejected
+// before forwarding to the API, while valid values ("ClusterWorkflow", "Workflow") pass through.
+func TestCreateComponentWorkflowKindValidation(t *testing.T) {
+	clientSession, mockHandler := setupTestServer(t)
+	defer clientSession.Close()
+
+	ctx := context.Background()
+
+	baseArgs := map[string]any{
+		"namespace_name": testNamespaceName,
+		"project_name":   testProjectName,
+		"name":           "new-component",
+		"component_type": "WebApplication",
+	}
+
+	copyArgs := func(extra map[string]any) map[string]any {
+		out := make(map[string]any, len(baseArgs)+len(extra))
+		for k, v := range baseArgs {
+			out[k] = v
+		}
+		for k, v := range extra {
+			out[k] = v
+		}
+		return out
+	}
+
+	t.Run("invalid kind returns error", func(t *testing.T) {
+		mockHandler.calls = make(map[string][]interface{})
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "create_component",
+			Arguments: copyArgs(map[string]any{"workflow": map[string]any{"name": "wf", "kind": "BadKind"}}),
+		})
+		if err != nil {
+			t.Fatalf("unexpected protocol error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected IsError=true for invalid workflow.kind")
+		}
+		if _, called := mockHandler.calls["CreateComponent"]; called {
+			t.Error("CreateComponent must not be called when workflow.kind is invalid")
+		}
+	})
+
+	for _, validKind := range []string{"ClusterWorkflow", "Workflow"} {
+		t.Run(validKind+"_kind_is_valid", func(t *testing.T) {
+			mockHandler.calls = make(map[string][]interface{})
+			result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "create_component",
+				Arguments: copyArgs(map[string]any{"workflow": map[string]any{"name": "wf", "kind": validKind}}),
+			})
+			if err != nil {
+				t.Fatalf("unexpected protocol error: %v", err)
+			}
+			if result.IsError {
+				t.Errorf("expected IsError=false for valid workflow.kind %q", validKind)
+			}
+			if _, called := mockHandler.calls["CreateComponent"]; !called {
+				t.Errorf("CreateComponent must be called for valid workflow.kind %q", validKind)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR fixes the component_create MCP tool issue where the repo doesn't contain a workload file.
