### PR TITLE
feat(cli): support mixed-scope resources in occ scaffold

### DIFF
--- a/internal/observer/api/logsadapterclientgen/client.gen.go
+++ b/internal/observer/api/logsadapterclientgen/client.gen.go
@@ -18,10 +18,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-const (
-	BearerAuthScopes = "BearerAuth.Scopes"
-)
-
 // Defines values for AlertRuleRequestConditionOperator.
 const (
 	AlertRuleRequestConditionOperatorEq  AlertRuleRequestConditionOperator = "eq"

--- a/internal/occ/cmd/component/component.go
+++ b/internal/occ/cmd/component/component.go
@@ -440,109 +440,73 @@ func findSourceEnvironment(pipeline *gen.DeploymentPipeline, targetEnv string) (
 	return "", fmt.Errorf("no promotion path found for target environment '%s'", targetEnv)
 }
 
+// scaffoldResolution holds the resolved scope information for scaffold parameters.
+type scaffoldResolution struct {
+	workloadType       string
+	componentTypeName  string
+	traitNames         []string
+	traitKinds         map[string]string // trait name -> kind
+	workflowName       string
+	componentTypeKind  string
+	workflowKind       string
+	useClusterCT       bool
+	useClusterWorkflow bool
+}
+
 func scaffoldComponent(params ScaffoldParams) error {
-	// Validate required parameters
-	if params.ComponentName == "" {
-		return fmt.Errorf("component name is required")
-	}
-	if params.ComponentType == "" {
-		return fmt.Errorf("component type is required (--type)")
-	}
-	if params.Namespace == "" {
-		return fmt.Errorf("namespace is required (--namespace or set via context)")
-	}
-	if params.ProjectName == "" {
-		return fmt.Errorf("project is required (--project or set via context)")
+	if err := validateScaffoldParams(params); err != nil {
+		return err
 	}
 
-	// Parse component type (format: workloadType/componentTypeName)
-	workloadType, componentTypeName, err := parseComponentType(params.ComponentType)
+	res, err := resolveScaffoldScope(params)
 	if err != nil {
 		return err
 	}
 
-	// Create API client
 	apiClient, err := client.NewClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	// Create context with timeout for all API requests (ComponentType, Traits, Workflow)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Fetch ClusterComponentType schema
-	componentTypeSchemaRaw, err := apiClient.GetClusterComponentTypeSchema(ctx, componentTypeName)
+	componentTypeSchema, traitSchemas, workflowSchema, err := fetchScaffoldSchemas(ctx, apiClient, params.Namespace, res)
 	if err != nil {
 		return err
 	}
-	componentTypeSchema, err := unmarshalSchema(componentTypeSchemaRaw)
-	if err != nil {
-		return fmt.Errorf("invalid ComponentType schema: %w", err)
-	}
 
-	// Fetch ClusterTrait schemas if specified
-	traitSchemas := make(map[string]*extv1.JSONSchemaProps)
-	for _, traitName := range params.Traits {
-		traitSchemaRaw, err := apiClient.GetClusterTraitSchema(ctx, traitName)
-		if err != nil {
-			return err
-		}
-		traitSchema, err := unmarshalSchema(traitSchemaRaw)
-		if err != nil {
-			return fmt.Errorf("invalid Trait schema for %q: %w", traitName, err)
-		}
-		traitSchemas[traitName] = traitSchema
-	}
-
-	// Fetch ClusterWorkflow schema if specified
-	var workflowSchema *extv1.JSONSchemaProps
-	if params.WorkflowName != "" {
-		workflowSchemaRaw, err := apiClient.GetClusterWorkflowSchema(ctx, params.WorkflowName)
-		if err != nil {
-			return err
-		}
-		workflowSchema, err = unmarshalSchema(workflowSchemaRaw)
-		if err != nil {
-			return fmt.Errorf("invalid Workflow schema: %w", err)
-		}
-	}
-
-	// Create generator options
-	// Default behavior: include all comments and optional fields
-	// --skip-comments disables both structural comments and field descriptions
-	// --skip-optional disables optional fields without defaults
 	opts := &scaffold.Options{
 		ComponentName:             params.ComponentName,
-		Namespace:                 params.Namespace, // namespace name = k8s namespace
+		Namespace:                 params.Namespace,
 		ProjectName:               params.ProjectName,
 		IncludeAllFields:          !params.SkipOptional,
 		IncludeFieldDescriptions:  !params.SkipComments,
 		IncludeStructuralComments: !params.SkipComments,
-		IncludeWorkflow:           params.WorkflowName != "",
+		IncludeWorkflow:           res.workflowName != "",
 	}
 
-	// Create generator from schemas
+	kindOpts := &scaffold.KindOptions{
+		ComponentTypeKind: res.componentTypeKind,
+		TraitKinds:        res.traitKinds,
+		WorkflowKind:      res.workflowKind,
+	}
+
 	generator, err := scaffold.NewGeneratorFromSchemas(
-		componentTypeName,
-		workloadType,
-		componentTypeSchema,
-		traitSchemas,
-		params.WorkflowName,
-		workflowSchema,
-		opts,
+		res.componentTypeName, res.workloadType,
+		componentTypeSchema, traitSchemas,
+		res.workflowName, workflowSchema,
+		opts, kindOpts,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create generator: %w", err)
 	}
 
-	// Generate YAML
 	yamlContent, err := generator.Generate()
 	if err != nil {
 		return fmt.Errorf("failed to generate Component YAML: %w", err)
 	}
 
-	// Output
 	if params.OutputPath != "" {
 		if err := os.WriteFile(params.OutputPath, []byte(yamlContent), 0600); err != nil {
 			return fmt.Errorf("failed to write output file %s: %w", params.OutputPath, err)
@@ -555,15 +519,144 @@ func scaffoldComponent(params ScaffoldParams) error {
 	return nil
 }
 
+func validateScaffoldParams(params ScaffoldParams) error {
+	if params.ComponentName == "" {
+		return fmt.Errorf("component name is required")
+	}
+	if params.Namespace == "" {
+		return fmt.Errorf("namespace is required (--namespace or set via context)")
+	}
+	if params.ProjectName == "" {
+		return fmt.Errorf("project is required (--project or set via context)")
+	}
+	if params.ComponentType != "" && params.ClusterComponentType != "" {
+		return fmt.Errorf("--componenttype and --clustercomponenttype are mutually exclusive")
+	}
+	if params.ComponentType == "" && params.ClusterComponentType == "" {
+		return fmt.Errorf("one of --componenttype or --clustercomponenttype is required")
+	}
+	if params.WorkflowName != "" && params.ClusterWorkflowName != "" {
+		return fmt.Errorf("--workflow and --clusterworkflow are mutually exclusive")
+	}
+	return nil
+}
+
+func resolveScaffoldScope(params ScaffoldParams) (*scaffoldResolution, error) {
+	res := &scaffoldResolution{
+		useClusterCT:       params.ClusterComponentType != "",
+		useClusterWorkflow: params.ClusterWorkflowName != "",
+	}
+
+	componentTypeStr := params.ComponentType
+	if res.useClusterCT {
+		componentTypeStr = params.ClusterComponentType
+	}
+
+	var err error
+	res.workloadType, res.componentTypeName, err = parseComponentType(componentTypeStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge namespace-scoped and cluster-scoped traits, tracking each trait's kind
+	res.traitKinds = make(map[string]string)
+	for _, name := range params.Traits {
+		res.traitNames = append(res.traitNames, name)
+		res.traitKinds[name] = "Trait"
+	}
+	for _, name := range params.ClusterTraits {
+		res.traitNames = append(res.traitNames, name)
+		res.traitKinds[name] = "ClusterTrait"
+	}
+
+	res.workflowName = params.WorkflowName
+	if res.useClusterWorkflow {
+		res.workflowName = params.ClusterWorkflowName
+	}
+
+	res.componentTypeKind = "ComponentType"
+	if res.useClusterCT {
+		res.componentTypeKind = "ClusterComponentType"
+	}
+	res.workflowKind = "Workflow"
+	if res.useClusterWorkflow {
+		res.workflowKind = "ClusterWorkflow"
+	}
+
+	return res, nil
+}
+
+func fetchScaffoldSchemas(
+	ctx context.Context,
+	apiClient *client.Client,
+	namespace string,
+	res *scaffoldResolution,
+) (*extv1.JSONSchemaProps, map[string]*extv1.JSONSchemaProps, *extv1.JSONSchemaProps, error) {
+	// Fetch ComponentType schema
+	var componentTypeSchemaRaw *json.RawMessage
+	var err error
+	if res.useClusterCT {
+		componentTypeSchemaRaw, err = apiClient.GetClusterComponentTypeSchema(ctx, res.componentTypeName)
+	} else {
+		componentTypeSchemaRaw, err = apiClient.GetComponentTypeSchema(ctx, namespace, res.componentTypeName)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	componentTypeSchema, err := unmarshalSchema(componentTypeSchemaRaw)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("invalid ComponentType schema: %w", err)
+	}
+
+	// Fetch Trait schemas (each trait resolved by its own kind)
+	traitSchemas := make(map[string]*extv1.JSONSchemaProps)
+	for _, traitName := range res.traitNames {
+		var traitSchemaRaw *json.RawMessage
+		if res.traitKinds[traitName] == "ClusterTrait" {
+			traitSchemaRaw, err = apiClient.GetClusterTraitSchema(ctx, traitName)
+		} else {
+			traitSchemaRaw, err = apiClient.GetTraitSchema(ctx, namespace, traitName)
+		}
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		traitSchema, err := unmarshalSchema(traitSchemaRaw)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid Trait schema for %q: %w", traitName, err)
+		}
+		traitSchemas[traitName] = traitSchema
+	}
+
+	// Fetch Workflow schema
+	var workflowSchema *extv1.JSONSchemaProps
+	if res.workflowName != "" {
+		var workflowSchemaRaw *json.RawMessage
+		if res.useClusterWorkflow {
+			workflowSchemaRaw, err = apiClient.GetClusterWorkflowSchema(ctx, res.workflowName)
+		} else {
+			workflowSchemaRaw, err = apiClient.GetWorkflowSchema(ctx, namespace, res.workflowName)
+		}
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		workflowSchema, err = unmarshalSchema(workflowSchemaRaw)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid Workflow schema: %w", err)
+		}
+	}
+
+	return componentTypeSchema, traitSchemas, workflowSchema, nil
+}
+
 // parseComponentType parses "workloadType/componentTypeName" format
 func parseComponentType(typeStr string) (workloadType, componentTypeName string, err error) {
 	if typeStr == "" {
-		return "", "", fmt.Errorf("--type is required (format: workloadType/componentTypeName, e.g., deployment/web-app)")
+		return "", "", fmt.Errorf("component type is required (format: workloadType/componentTypeName, e.g., deployment/web-app)")
 	}
 
 	parts := strings.SplitN(typeStr, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("invalid --type format: expected 'workloadType/componentTypeName' (e.g., deployment/web-app), got %q", typeStr)
+		return "", "", fmt.Errorf("invalid component type format: expected 'workloadType/componentTypeName' (e.g., deployment/web-app), got %q", typeStr)
 	}
 
 	return parts[0], parts[1], nil

--- a/internal/occ/cmd/component/params.go
+++ b/internal/occ/cmd/component/params.go
@@ -13,15 +13,18 @@ func (p ListParams) GetNamespace() string { return p.Namespace }
 
 // ScaffoldParams defines parameters for scaffolding a component
 type ScaffoldParams struct {
-	ComponentName string
-	ComponentType string   // format: workloadType/componentTypeName
-	Traits        []string // trait names
-	WorkflowName  string
-	Namespace     string
-	ProjectName   string
-	OutputPath    string
-	SkipComments  bool // skip structural comments and field descriptions
-	SkipOptional  bool // skip optional fields without defaults
+	ComponentName        string
+	ComponentType        string   // namespace-scoped, format: workloadType/componentTypeName
+	ClusterComponentType string   // cluster-scoped, format: workloadType/componentTypeName
+	Traits               []string // namespace-scoped trait names
+	ClusterTraits        []string // cluster-scoped trait names
+	WorkflowName         string   // namespace-scoped workflow name
+	ClusterWorkflowName  string   // cluster-scoped workflow name
+	Namespace            string
+	ProjectName          string
+	OutputPath           string
+	SkipComments         bool // skip structural comments and field descriptions
+	SkipOptional         bool // skip optional fields without defaults
 }
 
 // DeployParams defines parameters for deploying or promoting a component

--- a/internal/scaffold/component/generator.go
+++ b/internal/scaffold/component/generator.go
@@ -172,11 +172,14 @@ type Options struct {
 type Generator struct {
 	componentTypeName string
 	workloadType      string
+	componentTypeKind string
 	componentSchema   *extv1.JSONSchemaProps
 
 	traitSchemas map[string]*extv1.JSONSchemaProps
+	traitKinds   map[string]string // trait name -> kind ("Trait" or "ClusterTrait")
 
 	workflowName   string
+	workflowKind   string
 	workflowSchema *extv1.JSONSchemaProps
 
 	opts     *Options
@@ -226,7 +229,19 @@ func NewGenerator(
 		workflowName,
 		workflowSchema,
 		opts,
+		nil,
 	)
+}
+
+// KindOptions configures the Kubernetes resource kinds for generated references.
+type KindOptions struct {
+	// ComponentTypeKind is the kind for the componentType reference (e.g., "ClusterComponentType" or "ComponentType")
+	ComponentTypeKind string
+	// TraitKinds maps each trait name to its kind ("Trait" or "ClusterTrait").
+	// Traits not present in this map default to "ClusterTrait".
+	TraitKinds map[string]string
+	// WorkflowKind is the kind for the workflow reference (e.g., "ClusterWorkflow" or "Workflow")
+	WorkflowKind string
 }
 
 // NewGeneratorFromSchemas creates a new generator instance directly from JSON schemas.
@@ -240,6 +255,7 @@ func NewGeneratorFromSchemas(
 	workflowName string,
 	workflowSchema *extv1.JSONSchemaProps,
 	opts *Options,
+	kindOpts *KindOptions,
 ) (*Generator, error) {
 	if opts == nil {
 		opts = &Options{}
@@ -249,12 +265,33 @@ func NewGeneratorFromSchemas(
 		traitSchemas = make(map[string]*extv1.JSONSchemaProps)
 	}
 
+	componentTypeKind := "ClusterComponentType"
+	workflowKind := "ClusterWorkflow"
+	traitKinds := make(map[string]string, len(traitSchemas))
+	for name := range traitSchemas {
+		traitKinds[name] = "ClusterTrait"
+	}
+	if kindOpts != nil {
+		if kindOpts.ComponentTypeKind != "" {
+			componentTypeKind = kindOpts.ComponentTypeKind
+		}
+		for name, kind := range kindOpts.TraitKinds {
+			traitKinds[name] = kind
+		}
+		if kindOpts.WorkflowKind != "" {
+			workflowKind = kindOpts.WorkflowKind
+		}
+	}
+
 	return &Generator{
 		componentTypeName: componentTypeName,
 		workloadType:      workloadType,
+		componentTypeKind: componentTypeKind,
 		componentSchema:   componentSchema,
 		traitSchemas:      traitSchemas,
+		traitKinds:        traitKinds,
 		workflowName:      workflowName,
+		workflowKind:      workflowKind,
 		workflowSchema:    workflowSchema,
 		opts:              opts,
 		renderer:          NewFieldRenderer(opts.IncludeFieldDescriptions, opts.IncludeAllFields, opts.IncludeStructuralComments),
@@ -325,7 +362,7 @@ func (g *Generator) generateSpec(b *YAMLBuilder, result *schemaProcessingResult)
 
 		// ComponentType
 		b.InMapping("componentType", func(b *YAMLBuilder) {
-			b.AddField("kind", "ClusterComponentType")
+			b.AddField("kind", g.componentTypeKind)
 			b.AddField("name", fmt.Sprintf("%s/%s", g.workloadType, g.componentTypeName))
 		})
 
@@ -403,6 +440,9 @@ func (g *Generator) generateTraits(b *YAMLBuilder) error {
 			commentedNodes: b.commentedNodes,
 		}
 
+		// Add kind field
+		traitBuilder.AddField("kind", g.traitKinds[traitName])
+
 		// Add name field
 		var nameOpts []FieldOption
 		if g.opts.IncludeStructuralComments {
@@ -445,6 +485,9 @@ func (g *Generator) generateWorkflow(b *YAMLBuilder) error {
 		sectionOpts = append(sectionOpts, WithHeadComment(CommentWorkflowSection))
 	}
 	b.InMapping("workflow", func(b *YAMLBuilder) {
+		// Add kind field
+		b.AddField("kind", g.workflowKind)
+
 		// Add name field
 		var nameOpts []FieldOption
 		if g.opts.IncludeStructuralComments {

--- a/internal/scaffold/component/testdata/with_traits_want.yaml
+++ b/internal/scaffold/component/testdata/with_traits_want.yaml
@@ -21,17 +21,20 @@ spec:
 
   # Traits augment the component with additional capabilities
   traits:
-    - name: logging # Trait resource name
+    - kind: ClusterTrait
+      name: logging # Trait resource name
       instanceName: app-logging # Unique instance name within this Component
       # Parameters for logging trait
       parameters:
         # level: info # also: info, warn, error
-    - name: networking # Trait resource name
+    - kind: ClusterTrait
+      name: networking # Trait resource name
       instanceName: app-networking # Unique instance name within this Component
       # Parameters for networking trait
       parameters:
         ingress: <TODO_INGRESS> # Enable ingress
-    - name: storage # Trait resource name
+    - kind: ClusterTrait
+      name: storage # Trait resource name
       instanceName: app-storage # Unique instance name within this Component
       # Parameters for storage trait
       parameters:

--- a/internal/scaffold/component/testdata/with_workflow_want.yaml
+++ b/internal/scaffold/component/testdata/with_workflow_want.yaml
@@ -21,6 +21,7 @@ spec:
 
   # Workflow configuration for building this component
   workflow:
+    kind: ClusterWorkflow
     name: docker-build # Workflow to use for builds
     parameters:
       buildArgs: # Build arguments

--- a/pkg/cli/cmd/component/component.go
+++ b/pkg/cli/cmd/component/component.go
@@ -110,46 +110,41 @@ func newScaffoldComponentCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Parse traits from comma-separated string
-			traitsStr, _ := cmd.Flags().GetString(flags.Traits.Name)
-			var traits []string
-			if traitsStr != "" {
-				parts := strings.Split(traitsStr, ",")
-				for _, part := range parts {
-					trimmed := strings.TrimSpace(part)
-					if trimmed != "" {
-						traits = append(traits, trimmed)
-					}
-				}
-			}
-
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
 			project, _ := cmd.Flags().GetString(flags.Project.Name)
 			componentType, _ := cmd.Flags().GetString(flags.ScaffoldType.Name)
+			clusterComponentType, _ := cmd.Flags().GetString(flags.ClusterComponentType.Name)
 			workflow, _ := cmd.Flags().GetString(flags.Workflow.Name)
+			clusterWorkflow, _ := cmd.Flags().GetString(flags.ClusterWorkflow.Name)
 			outputFile, _ := cmd.Flags().GetString(flags.OutputFile.Name)
 			skipComments, _ := cmd.Flags().GetBool(flags.SkipComments.Name)
 			skipOptional, _ := cmd.Flags().GetBool(flags.SkipOptional.Name)
 
 			compImpl := component.New()
 			return compImpl.Scaffold(component.ScaffoldParams{
-				ComponentName: args[0],
-				ComponentType: componentType,
-				Traits:        traits,
-				WorkflowName:  workflow,
-				Namespace:     namespace,
-				ProjectName:   project,
-				OutputPath:    outputFile,
-				SkipComments:  skipComments,
-				SkipOptional:  skipOptional,
+				ComponentName:        args[0],
+				ComponentType:        componentType,
+				ClusterComponentType: clusterComponentType,
+				Traits:               parseCSV(cmd, flags.Traits.Name),
+				ClusterTraits:        parseCSV(cmd, flags.ClusterTraits.Name),
+				WorkflowName:         workflow,
+				ClusterWorkflowName:  clusterWorkflow,
+				Namespace:            namespace,
+				ProjectName:          project,
+				OutputPath:           outputFile,
+				SkipComments:         skipComments,
+				SkipOptional:         skipOptional,
 			})
 		},
 	}
 
 	flags.AddFlags(cmd,
 		flags.ScaffoldType,
+		flags.ClusterComponentType,
 		flags.Traits,
+		flags.ClusterTraits,
 		flags.Workflow,
+		flags.ClusterWorkflow,
 		flags.Project,
 		flags.Namespace,
 		flags.OutputFile,
@@ -158,6 +153,23 @@ func newScaffoldComponentCmd() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// parseCSV parses a comma-separated flag value into a trimmed, non-empty string slice.
+func parseCSV(cmd *cobra.Command, flagName string) []string {
+	val, _ := cmd.Flags().GetString(flagName)
+	if val == "" {
+		return nil
+	}
+	parts := strings.Split(val, ",")
+	var result []string
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 //nolint:dupl // deploy and logs commands follow the same pattern but are distinct

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -149,7 +149,7 @@ Examples:
 
 Examples:
   # Scaffold a component from a ComponentType
-  %[1]s scaffold component my-app --type deployment/web-app`, messages.DefaultCLIName),
+  %[1]s scaffold component my-app --componenttype deployment/web-app`, messages.DefaultCLIName),
 	}
 
 	ScaffoldComponent = Command{
@@ -161,20 +161,27 @@ The command fetches the ComponentType and any specified Traits from the cluster,
 applies default values, and generates a YAML file with required fields as
 placeholders and optional fields as commented examples.
 
+Use --type/--traits/--workflow for namespace-scoped resources, or
+--clustercomponenttype/--clustertraits/--clusterworkflow for cluster-scoped resources.
+Each pair is mutually exclusive.
+
 The --namespace and --project flags can be omitted if set in the current context.
 
 Examples:
-  # Scaffold a basic component
-  %[1]s component scaffold my-app --type deployment/web-app
+  # Scaffold using a cluster-scoped ClusterComponentType
+  %[1]s component scaffold my-app --clustercomponenttype deployment/web-app
 
-  # Scaffold with traits
-  %[1]s component scaffold my-app --type deployment/web-app --traits storage,ingress
+  # Scaffold using a namespace-scoped ComponentType
+  %[1]s component scaffold my-app --componenttype deployment/web-app
 
-  # Scaffold with workflow
-  %[1]s component scaffold my-app --type deployment/web-app --workflow docker-build
+  # Scaffold with cluster-scoped traits
+  %[1]s component scaffold my-app --clustercomponenttype deployment/web-app --clustertraits storage,ingress
+
+  # Scaffold with cluster-scoped workflow
+  %[1]s component scaffold my-app --clustercomponenttype deployment/web-app --clusterworkflow docker-build
 
   # Output to file
-  %[1]s component scaffold my-app --type deployment/web-app -o my-app.yaml`, messages.DefaultCLIName),
+  %[1]s component scaffold my-app --clustercomponenttype deployment/web-app -o my-app.yaml`, messages.DefaultCLIName),
 	}
 
 	ListNamespace = Command{

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -277,18 +277,33 @@ var (
 	// Scaffold-specific flags
 
 	ScaffoldType = Flag{
-		Name:  "type",
-		Usage: "Component type in format workloadType/componentTypeName (e.g., deployment/web-app)",
+		Name:  "componenttype",
+		Usage: "Namespace-scoped component type in format workloadType/componentTypeName (e.g., deployment/web-app)",
 	}
 
 	Traits = Flag{
 		Name:  "traits",
-		Usage: "Comma-separated list of trait names to include",
+		Usage: "Comma-separated list of namespace-scoped Trait names to include",
+	}
+
+	ClusterTraits = Flag{
+		Name:  "clustertraits",
+		Usage: "Comma-separated list of cluster-scoped ClusterTrait names to include",
 	}
 
 	Workflow = Flag{
 		Name:  "workflow",
-		Usage: "Workflow name",
+		Usage: "Namespace-scoped Workflow name",
+	}
+
+	ClusterWorkflow = Flag{
+		Name:  "clusterworkflow",
+		Usage: "Cluster-scoped ClusterWorkflow name",
+	}
+
+	ClusterComponentType = Flag{
+		Name:  "clustercomponenttype",
+		Usage: "Cluster-scoped component type in format workloadType/componentTypeName (e.g., deployment/web-app)",
 	}
 
 	SkipComments = Flag{


### PR DESCRIPTION
## Purpose

`occ component scaffold` previously only resolved cluster-scoped resources (`ClusterComponentType`, `ClusterTrait`, `ClusterWorkflow`). This PR adds support for namespace-scoped variants and allows mixing both scopes in a single scaffold command.

Closes #2695

## Approach

- Add new flags `--clustercomponenttype`, `--clustertraits`, `--clusterworkflow` for cluster-scoped resources
- Rename `--type` to `--componenttype` for namespace-scoped ComponentType (consistent with other resource flags)
- `--componenttype` / `--clustercomponenttype` are mutually exclusive (one required)
- `--workflow` / `--clusterworkflow` are mutually exclusive
- `--traits` and `--clustertraits` can be used together — each trait independently tracks its kind
- Generator now emits `kind` field for componentType, traits, and workflow in the generated YAML
- Per-trait kind tracking via `KindOptions.TraitKinds` map so mixed `Trait` + `ClusterTrait` works
- Refactor `scaffoldComponent()` into `validateScaffoldParams()`, `resolveScaffoldScope()`, and `fetchScaffoldSchemas()` to fix cyclomatic complexity lint

## Related Issues

Closes #2695

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)