### PR TITLE
refactor: add delete methods to PAP and remove direct k8sClient from authz svc

### DIFF
--- a/internal/authz/casbin/pap.go
+++ b/internal/authz/casbin/pap.go
@@ -430,6 +430,21 @@ func (ce *CasbinEnforcer) UpdateClusterRole(ctx context.Context, role *openchore
 	return existing, nil
 }
 
+// DeleteClusterRole deletes a cluster-scoped role by name
+func (ce *CasbinEnforcer) DeleteClusterRole(ctx context.Context, name string) error {
+	role := &openchoreov1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	if err := ce.k8sClient.Delete(ctx, role); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return authzcore.ErrRoleNotFound
+		}
+		return fmt.Errorf("failed to delete ClusterAuthzRole: %w", err)
+	}
+	ce.logger.Debug("deleted ClusterAuthzRole", "name", name)
+	return nil
+}
+
 // CreateNamespacedRole creates a new namespace-scoped role and returns the full CRD object
 func (ce *CasbinEnforcer) CreateNamespacedRole(ctx context.Context, role *openchoreov1alpha1.AuthzRole) (*openchoreov1alpha1.AuthzRole, error) {
 	if role == nil {
@@ -504,6 +519,21 @@ func (ce *CasbinEnforcer) UpdateNamespacedRole(ctx context.Context, role *opench
 		return nil, fmt.Errorf("failed to update AuthzRole: %w", err)
 	}
 	return existing, nil
+}
+
+// DeleteNamespacedRole deletes a namespace-scoped role by name and namespace
+func (ce *CasbinEnforcer) DeleteNamespacedRole(ctx context.Context, name string, namespace string) error {
+	role := &openchoreov1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	if err := ce.k8sClient.Delete(ctx, role); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return authzcore.ErrRoleNotFound
+		}
+		return fmt.Errorf("failed to delete AuthzRole: %w", err)
+	}
+	ce.logger.Debug("deleted AuthzRole", "name", name, "namespace", namespace)
+	return nil
 }
 
 // CreateClusterRoleBinding creates a new cluster-scoped role binding and returns the full CRD object
@@ -582,6 +612,21 @@ func (ce *CasbinEnforcer) UpdateClusterRoleBinding(ctx context.Context, binding 
 	return existing, nil
 }
 
+// DeleteClusterRoleBinding deletes a cluster-scoped role binding by name
+func (ce *CasbinEnforcer) DeleteClusterRoleBinding(ctx context.Context, name string) error {
+	binding := &openchoreov1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	if err := ce.k8sClient.Delete(ctx, binding); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return authzcore.ErrRoleMappingNotFound
+		}
+		return fmt.Errorf("failed to delete ClusterAuthzRoleBinding: %w", err)
+	}
+	ce.logger.Debug("deleted ClusterAuthzRoleBinding", "name", name)
+	return nil
+}
+
 // CreateNamespacedRoleBinding creates a new namespace-scoped role binding and returns the full CRD object
 func (ce *CasbinEnforcer) CreateNamespacedRoleBinding(ctx context.Context, binding *openchoreov1alpha1.AuthzRoleBinding) (*openchoreov1alpha1.AuthzRoleBinding, error) {
 	if binding == nil {
@@ -656,6 +701,21 @@ func (ce *CasbinEnforcer) UpdateNamespacedRoleBinding(ctx context.Context, bindi
 		return nil, fmt.Errorf("failed to update AuthzRoleBinding: %w", err)
 	}
 	return existing, nil
+}
+
+// DeleteNamespacedRoleBinding deletes a namespace-scoped role binding by name and namespace
+func (ce *CasbinEnforcer) DeleteNamespacedRoleBinding(ctx context.Context, name string, namespace string) error {
+	binding := &openchoreov1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	if err := ce.k8sClient.Delete(ctx, binding); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return authzcore.ErrRoleMappingNotFound
+		}
+		return fmt.Errorf("failed to delete AuthzRoleBinding: %w", err)
+	}
+	ce.logger.Debug("deleted AuthzRoleBinding", "name", name, "namespace", namespace)
+	return nil
 }
 
 // ============================================================================

--- a/internal/authz/casbin/pap_test.go
+++ b/internal/authz/casbin/pap_test.go
@@ -1131,6 +1131,40 @@ func TestCasbinEnforcer_UpdateClusterRole(t *testing.T) {
 	})
 }
 
+// TestCasbinEnforcer_DeleteClusterRole tests deleting cluster-scoped roles
+func TestCasbinEnforcer_DeleteClusterRole(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+
+	t.Run("delete existing cluster role", func(t *testing.T) {
+		role := &openchoreov1alpha1.ClusterAuthzRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete-cr"},
+			Spec:       openchoreov1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+		}
+		if err := enforcer.k8sClient.Create(ctx, role); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		if err := enforcer.DeleteClusterRole(ctx, "delete-cr"); err != nil {
+			t.Fatalf("DeleteClusterRole() error = %v", err)
+		}
+
+		// Verify the CRD is gone
+		var crd openchoreov1alpha1.ClusterAuthzRole
+		err := enforcer.k8sClient.Get(ctx, client.ObjectKey{Name: "delete-cr"}, &crd)
+		if !k8serrors.IsNotFound(err) {
+			t.Errorf("expected NotFound after delete, got err = %v", err)
+		}
+	})
+
+	t.Run("delete non-existent cluster role", func(t *testing.T) {
+		err := enforcer.DeleteClusterRole(ctx, "non-existent-cr")
+		if !errors.Is(err, authzcore.ErrRoleNotFound) {
+			t.Errorf("DeleteClusterRole() error = %v, want ErrRoleNotFound", err)
+		}
+	})
+}
+
 // TestCasbinEnforcer_CreateNamespacedRole tests creating namespace-scoped roles
 func TestCasbinEnforcer_CreateNamespacedRole(t *testing.T) {
 	enforcer := setupTestEnforcer(t)
@@ -1310,6 +1344,56 @@ func TestCasbinEnforcer_UpdateNamespacedRole(t *testing.T) {
 		_, err := enforcer.UpdateNamespacedRole(ctx, nil)
 		if !errors.Is(err, authzcore.ErrInvalidRequest) {
 			t.Errorf("error = %v, want ErrInvalidRequest", err)
+		}
+	})
+}
+
+// TestCasbinEnforcer_DeleteNamespacedRole tests deleting namespace-scoped roles
+func TestCasbinEnforcer_DeleteNamespacedRole(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	const testNs = "acme"
+
+	t.Run("delete existing namespaced role", func(t *testing.T) {
+		role := &openchoreov1alpha1.AuthzRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete-ns-role", Namespace: testNs},
+			Spec:       openchoreov1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+		}
+		if err := enforcer.k8sClient.Create(ctx, role); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		if err := enforcer.DeleteNamespacedRole(ctx, "delete-ns-role", testNs); err != nil {
+			t.Fatalf("DeleteNamespacedRole() error = %v", err)
+		}
+
+		// Verify the CRD is gone
+		var crd openchoreov1alpha1.AuthzRole
+		err := enforcer.k8sClient.Get(ctx, client.ObjectKey{Name: "delete-ns-role", Namespace: testNs}, &crd)
+		if !k8serrors.IsNotFound(err) {
+			t.Errorf("expected NotFound after delete, got err = %v", err)
+		}
+	})
+
+	t.Run("delete non-existent namespaced role", func(t *testing.T) {
+		err := enforcer.DeleteNamespacedRole(ctx, "non-existent", testNs)
+		if !errors.Is(err, authzcore.ErrRoleNotFound) {
+			t.Errorf("DeleteNamespacedRole() error = %v, want ErrRoleNotFound", err)
+		}
+	})
+
+	t.Run("delete namespaced role wrong namespace", func(t *testing.T) {
+		role := &openchoreov1alpha1.AuthzRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete-wrong-ns", Namespace: testNs},
+			Spec:       openchoreov1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+		}
+		if err := enforcer.k8sClient.Create(ctx, role); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		err := enforcer.DeleteNamespacedRole(ctx, "delete-wrong-ns", "wrong-ns")
+		if !errors.Is(err, authzcore.ErrRoleNotFound) {
+			t.Errorf("DeleteNamespacedRole() error = %v, want ErrRoleNotFound", err)
 		}
 	})
 }
@@ -2175,6 +2259,108 @@ func TestCasbinEnforcer_UpdateNamespacedRoleBinding(t *testing.T) {
 		_, err := enforcer.UpdateNamespacedRoleBinding(ctx, nil)
 		if !errors.Is(err, authzcore.ErrInvalidRequest) {
 			t.Errorf("error = %v, want ErrInvalidRequest", err)
+		}
+	})
+}
+
+// TestCasbinEnforcer_DeleteClusterRoleBinding tests deleting cluster-scoped role bindings
+func TestCasbinEnforcer_DeleteClusterRoleBinding(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+
+	t.Run("delete existing cluster role binding", func(t *testing.T) {
+		binding := &openchoreov1alpha1.ClusterAuthzRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete-crb"},
+			Spec: openchoreov1alpha1.ClusterAuthzRoleBindingSpec{
+				Entitlement: openchoreov1alpha1.EntitlementClaim{Claim: testClaimGroups, Value: "ops"},
+				RoleMappings: []openchoreov1alpha1.ClusterRoleMapping{{
+					RoleRef: openchoreov1alpha1.RoleRef{Kind: openchoreov1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+				}},
+				Effect: openchoreov1alpha1.EffectAllow,
+			},
+		}
+		if err := enforcer.k8sClient.Create(ctx, binding); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		if err := enforcer.DeleteClusterRoleBinding(ctx, "delete-crb"); err != nil {
+			t.Fatalf("DeleteClusterRoleBinding() error = %v", err)
+		}
+
+		// Verify the CRD is gone
+		var crd openchoreov1alpha1.ClusterAuthzRoleBinding
+		err := enforcer.k8sClient.Get(ctx, client.ObjectKey{Name: "delete-crb"}, &crd)
+		if !k8serrors.IsNotFound(err) {
+			t.Errorf("expected NotFound after delete, got err = %v", err)
+		}
+	})
+
+	t.Run("delete non-existent cluster role binding", func(t *testing.T) {
+		err := enforcer.DeleteClusterRoleBinding(ctx, "non-existent-crb")
+		if !errors.Is(err, authzcore.ErrRoleMappingNotFound) {
+			t.Errorf("DeleteClusterRoleBinding() error = %v, want ErrRoleMappingNotFound", err)
+		}
+	})
+}
+
+// TestCasbinEnforcer_DeleteNamespacedRoleBinding tests deleting namespace-scoped role bindings
+func TestCasbinEnforcer_DeleteNamespacedRoleBinding(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	const testNs = "acme"
+
+	t.Run("delete existing namespaced role binding", func(t *testing.T) {
+		binding := &openchoreov1alpha1.AuthzRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete-rb", Namespace: testNs},
+			Spec: openchoreov1alpha1.AuthzRoleBindingSpec{
+				Entitlement: openchoreov1alpha1.EntitlementClaim{Claim: testClaimGroups, Value: "devs"},
+				RoleMappings: []openchoreov1alpha1.RoleMapping{{
+					RoleRef: openchoreov1alpha1.RoleRef{Kind: openchoreov1alpha1.RoleRefKindAuthzRole, Name: "dev-role"},
+				}},
+				Effect: openchoreov1alpha1.EffectAllow,
+			},
+		}
+		if err := enforcer.k8sClient.Create(ctx, binding); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		if err := enforcer.DeleteNamespacedRoleBinding(ctx, "delete-rb", testNs); err != nil {
+			t.Fatalf("DeleteNamespacedRoleBinding() error = %v", err)
+		}
+
+		// Verify the CRD is gone
+		var crd openchoreov1alpha1.AuthzRoleBinding
+		err := enforcer.k8sClient.Get(ctx, client.ObjectKey{Name: "delete-rb", Namespace: testNs}, &crd)
+		if !k8serrors.IsNotFound(err) {
+			t.Errorf("expected NotFound after delete, got err = %v", err)
+		}
+	})
+
+	t.Run("delete non-existent namespaced role binding", func(t *testing.T) {
+		err := enforcer.DeleteNamespacedRoleBinding(ctx, "non-existent-rb", testNs)
+		if !errors.Is(err, authzcore.ErrRoleMappingNotFound) {
+			t.Errorf("DeleteNamespacedRoleBinding() error = %v, want ErrRoleMappingNotFound", err)
+		}
+	})
+
+	t.Run("delete namespaced role binding wrong namespace", func(t *testing.T) {
+		binding := &openchoreov1alpha1.AuthzRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete-wrong-ns-rb", Namespace: testNs},
+			Spec: openchoreov1alpha1.AuthzRoleBindingSpec{
+				Entitlement: openchoreov1alpha1.EntitlementClaim{Claim: testClaimGroups, Value: "devs"},
+				RoleMappings: []openchoreov1alpha1.RoleMapping{{
+					RoleRef: openchoreov1alpha1.RoleRef{Kind: openchoreov1alpha1.RoleRefKindAuthzRole, Name: "dev-role"},
+				}},
+				Effect: openchoreov1alpha1.EffectAllow,
+			},
+		}
+		if err := enforcer.k8sClient.Create(ctx, binding); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		err := enforcer.DeleteNamespacedRoleBinding(ctx, "delete-wrong-ns-rb", "wrong-ns")
+		if !errors.Is(err, authzcore.ErrRoleMappingNotFound) {
+			t.Errorf("DeleteNamespacedRoleBinding() error = %v, want ErrRoleMappingNotFound", err)
 		}
 	})
 }

--- a/internal/authz/core/interface.go
+++ b/internal/authz/core/interface.go
@@ -73,6 +73,8 @@ type PAP interface {
 	ListClusterRoles(ctx context.Context, limit int, cursor string) (*PaginatedList[openchoreov1alpha1.ClusterAuthzRole], error)
 	// UpdateClusterRole updates a cluster-scoped role and returns the updated CRD object
 	UpdateClusterRole(ctx context.Context, role *openchoreov1alpha1.ClusterAuthzRole) (*openchoreov1alpha1.ClusterAuthzRole, error)
+	// DeleteClusterRole deletes a cluster-scoped role by name
+	DeleteClusterRole(ctx context.Context, name string) error
 
 	// Roles - Namespace scoped
 
@@ -84,6 +86,8 @@ type PAP interface {
 	ListNamespacedRoles(ctx context.Context, namespace string, limit int, cursor string) (*PaginatedList[openchoreov1alpha1.AuthzRole], error)
 	// UpdateNamespacedRole updates a namespace-scoped role and returns the updated CRD object
 	UpdateNamespacedRole(ctx context.Context, role *openchoreov1alpha1.AuthzRole) (*openchoreov1alpha1.AuthzRole, error)
+	// DeleteNamespacedRole deletes a namespace-scoped role by name and namespace
+	DeleteNamespacedRole(ctx context.Context, name string, namespace string) error
 
 	// Bindings - Cluster scoped
 
@@ -95,6 +99,8 @@ type PAP interface {
 	ListClusterRoleBindings(ctx context.Context, limit int, cursor string) (*PaginatedList[openchoreov1alpha1.ClusterAuthzRoleBinding], error)
 	// UpdateClusterRoleBinding updates a cluster-scoped role binding and returns the updated CRD object
 	UpdateClusterRoleBinding(ctx context.Context, binding *openchoreov1alpha1.ClusterAuthzRoleBinding) (*openchoreov1alpha1.ClusterAuthzRoleBinding, error)
+	// DeleteClusterRoleBinding deletes a cluster-scoped role binding by name
+	DeleteClusterRoleBinding(ctx context.Context, name string) error
 
 	// Bindings - Namespace scoped
 
@@ -106,4 +112,6 @@ type PAP interface {
 	ListNamespacedRoleBindings(ctx context.Context, namespace string, limit int, cursor string) (*PaginatedList[openchoreov1alpha1.AuthzRoleBinding], error)
 	// UpdateNamespacedRoleBinding updates a namespace-scoped role binding and returns the updated CRD object
 	UpdateNamespacedRoleBinding(ctx context.Context, binding *openchoreov1alpha1.AuthzRoleBinding) (*openchoreov1alpha1.AuthzRoleBinding, error)
+	// DeleteNamespacedRoleBinding deletes a namespace-scoped role binding by name and namespace
+	DeleteNamespacedRoleBinding(ctx context.Context, name string, namespace string) error
 }

--- a/internal/authz/disabled_authorizer.go
+++ b/internal/authz/disabled_authorizer.go
@@ -159,6 +159,10 @@ func (da *DisabledAuthorizer) UpdateClusterRole(ctx context.Context, role *openc
 	return nil, authz.ErrAuthzDisabled
 }
 
+func (da *DisabledAuthorizer) DeleteClusterRole(ctx context.Context, name string) error {
+	return authz.ErrAuthzDisabled
+}
+
 func (da *DisabledAuthorizer) CreateNamespacedRole(ctx context.Context, role *openchoreov1alpha1.AuthzRole) (*openchoreov1alpha1.AuthzRole, error) {
 	return nil, authz.ErrAuthzDisabled
 }
@@ -173,6 +177,10 @@ func (da *DisabledAuthorizer) ListNamespacedRoles(ctx context.Context, namespace
 
 func (da *DisabledAuthorizer) UpdateNamespacedRole(ctx context.Context, role *openchoreov1alpha1.AuthzRole) (*openchoreov1alpha1.AuthzRole, error) {
 	return nil, authz.ErrAuthzDisabled
+}
+
+func (da *DisabledAuthorizer) DeleteNamespacedRole(ctx context.Context, name string, namespace string) error {
+	return authz.ErrAuthzDisabled
 }
 
 func (da *DisabledAuthorizer) CreateClusterRoleBinding(ctx context.Context, binding *openchoreov1alpha1.ClusterAuthzRoleBinding) (*openchoreov1alpha1.ClusterAuthzRoleBinding, error) {
@@ -191,6 +199,10 @@ func (da *DisabledAuthorizer) UpdateClusterRoleBinding(ctx context.Context, bind
 	return nil, authz.ErrAuthzDisabled
 }
 
+func (da *DisabledAuthorizer) DeleteClusterRoleBinding(ctx context.Context, name string) error {
+	return authz.ErrAuthzDisabled
+}
+
 func (da *DisabledAuthorizer) CreateNamespacedRoleBinding(ctx context.Context, binding *openchoreov1alpha1.AuthzRoleBinding) (*openchoreov1alpha1.AuthzRoleBinding, error) {
 	return nil, authz.ErrAuthzDisabled
 }
@@ -205,6 +217,10 @@ func (da *DisabledAuthorizer) ListNamespacedRoleBindings(ctx context.Context, na
 
 func (da *DisabledAuthorizer) UpdateNamespacedRoleBinding(ctx context.Context, binding *openchoreov1alpha1.AuthzRoleBinding) (*openchoreov1alpha1.AuthzRoleBinding, error) {
 	return nil, authz.ErrAuthzDisabled
+}
+
+func (da *DisabledAuthorizer) DeleteNamespacedRoleBinding(ctx context.Context, name string, namespace string) error {
+	return authz.ErrAuthzDisabled
 }
 
 // These var declarations enforce at compile-time that DisabledAuthorizer

--- a/internal/authz/disabled_authorizer_test.go
+++ b/internal/authz/disabled_authorizer_test.go
@@ -218,3 +218,43 @@ func TestDisabledAuthorizer_ListActions(t *testing.T) {
 		t.Errorf("expected nil actions, got %v", actions)
 	}
 }
+
+// TestDisabledAuthorizer_DeleteClusterRole verifies PAP methods return ErrAuthzDisabled
+func TestDisabledAuthorizer_DeleteClusterRole(t *testing.T) {
+	ctx := context.Background()
+
+	err := disabledAuthorizer.DeleteClusterRole(ctx, "test-role")
+	if !errors.Is(err, authzcore.ErrAuthzDisabled) {
+		t.Errorf("expected ErrAuthzDisabled, got %v", err)
+	}
+}
+
+// TestDisabledAuthorizer_DeleteNamespacedRole verifies PAP methods return ErrAuthzDisabled
+func TestDisabledAuthorizer_DeleteNamespacedRole(t *testing.T) {
+	ctx := context.Background()
+
+	err := disabledAuthorizer.DeleteNamespacedRole(ctx, "test-role", "test-ns")
+	if !errors.Is(err, authzcore.ErrAuthzDisabled) {
+		t.Errorf("expected ErrAuthzDisabled, got %v", err)
+	}
+}
+
+// TestDisabledAuthorizer_DeleteClusterRoleBinding verifies PAP methods return ErrAuthzDisabled
+func TestDisabledAuthorizer_DeleteClusterRoleBinding(t *testing.T) {
+	ctx := context.Background()
+
+	err := disabledAuthorizer.DeleteClusterRoleBinding(ctx, "test-binding")
+	if !errors.Is(err, authzcore.ErrAuthzDisabled) {
+		t.Errorf("expected ErrAuthzDisabled, got %v", err)
+	}
+}
+
+// TestDisabledAuthorizer_DeleteNamespacedRoleBinding verifies PAP methods return ErrAuthzDisabled
+func TestDisabledAuthorizer_DeleteNamespacedRoleBinding(t *testing.T) {
+	ctx := context.Background()
+
+	err := disabledAuthorizer.DeleteNamespacedRoleBinding(ctx, "test-binding", "test-ns")
+	if !errors.Is(err, authzcore.ErrAuthzDisabled) {
+		t.Errorf("expected ErrAuthzDisabled, got %v", err)
+	}
+}

--- a/internal/observer/api/logsadapterclientgen/client.gen.go
+++ b/internal/observer/api/logsadapterclientgen/client.gen.go
@@ -18,10 +18,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-const (
-	BearerAuthScopes = "BearerAuth.Scopes"
-)
-
 // Defines values for AlertRuleRequestConditionOperator.
 const (
 	AlertRuleRequestConditionOperatorEq  AlertRuleRequestConditionOperator = "eq"

--- a/internal/openchoreo-api/services/authz/service.go
+++ b/internal/openchoreo-api/services/authz/service.go
@@ -10,7 +10,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
@@ -19,10 +18,9 @@ import (
 
 // authzService handles authz CRUD operations without authorization checks.
 type authzService struct {
-	pap       authzcore.PAP
-	pdp       authzcore.PDP
-	k8sClient client.Client
-	logger    *slog.Logger
+	pap    authzcore.PAP
+	pdp    authzcore.PDP
+	logger *slog.Logger
 }
 
 var _ Service = (*authzService)(nil)
@@ -48,12 +46,11 @@ var authzRoleBindingTypeMeta = metav1.TypeMeta{
 }
 
 // NewService creates a new authz service without authorization checks.
-func NewService(pap authzcore.PAP, pdp authzcore.PDP, k8sClient client.Client, logger *slog.Logger) Service {
+func NewService(pap authzcore.PAP, pdp authzcore.PDP, logger *slog.Logger) Service {
 	return &authzService{
-		pap:       pap,
-		pdp:       pdp,
-		k8sClient: k8sClient,
-		logger:    logger,
+		pap:    pap,
+		pdp:    pdp,
+		logger: logger,
 	}
 }
 
@@ -118,16 +115,7 @@ func (s *authzService) UpdateClusterRole(ctx context.Context, role *openchoreov1
 
 func (s *authzService) DeleteClusterRole(ctx context.Context, name string) error {
 	s.logger.Debug("Deleting cluster role", "name", name)
-	role := &openchoreov1alpha1.ClusterAuthzRole{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
-	if err := s.k8sClient.Delete(ctx, role); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrRoleNotFound
-		}
-		return fmt.Errorf("failed to delete cluster role: %w", err)
-	}
-	return nil
+	return s.pap.DeleteClusterRole(ctx, name)
 }
 
 // --- Namespace Roles ---
@@ -193,16 +181,7 @@ func (s *authzService) UpdateNamespaceRole(ctx context.Context, namespace string
 
 func (s *authzService) DeleteNamespaceRole(ctx context.Context, namespace, name string) error {
 	s.logger.Debug("Deleting namespace role", "namespace", namespace, "name", name)
-	role := &openchoreov1alpha1.AuthzRole{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-	}
-	if err := s.k8sClient.Delete(ctx, role); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrRoleNotFound
-		}
-		return fmt.Errorf("failed to delete namespace role: %w", err)
-	}
-	return nil
+	return s.pap.DeleteNamespacedRole(ctx, name, namespace)
 }
 
 // --- Cluster Role Bindings ---
@@ -266,16 +245,7 @@ func (s *authzService) UpdateClusterRoleBinding(ctx context.Context, binding *op
 
 func (s *authzService) DeleteClusterRoleBinding(ctx context.Context, name string) error {
 	s.logger.Debug("Deleting cluster role binding", "name", name)
-	binding := &openchoreov1alpha1.ClusterAuthzRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
-	if err := s.k8sClient.Delete(ctx, binding); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrRoleBindingNotFound
-		}
-		return fmt.Errorf("failed to delete cluster role binding: %w", err)
-	}
-	return nil
+	return s.pap.DeleteClusterRoleBinding(ctx, name)
 }
 
 // --- Namespace Role Bindings ---
@@ -341,16 +311,7 @@ func (s *authzService) UpdateNamespaceRoleBinding(ctx context.Context, namespace
 
 func (s *authzService) DeleteNamespaceRoleBinding(ctx context.Context, namespace, name string) error {
 	s.logger.Debug("Deleting namespace role binding", "namespace", namespace, "name", name)
-	binding := &openchoreov1alpha1.AuthzRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-	}
-	if err := s.k8sClient.Delete(ctx, binding); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return ErrRoleBindingNotFound
-		}
-		return fmt.Errorf("failed to delete namespace role binding: %w", err)
-	}
-	return nil
+	return s.pap.DeleteNamespacedRoleBinding(ctx, name, namespace)
 }
 
 // --- Evaluation & Profile ---

--- a/internal/openchoreo-api/services/authz/service_authz.go
+++ b/internal/openchoreo-api/services/authz/service_authz.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"log/slog"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
@@ -50,9 +48,9 @@ type authzServiceWithAuthz struct {
 var _ Service = (*authzServiceWithAuthz)(nil)
 
 // NewServiceWithAuthz creates an authz service with authorization checks.
-func NewServiceWithAuthz(pap authzcore.PAP, pdp authzcore.PDP, k8sClient client.Client, logger *slog.Logger) Service {
+func NewServiceWithAuthz(pap authzcore.PAP, pdp authzcore.PDP, logger *slog.Logger) Service {
 	return &authzServiceWithAuthz{
-		internal: NewService(pap, pdp, k8sClient, logger),
+		internal: NewService(pap, pdp, logger),
 		authz:    services.NewAuthzChecker(pdp, logger),
 	}
 }

--- a/internal/openchoreo-api/services/handlerservices/services.go
+++ b/internal/openchoreo-api/services/handlerservices/services.go
@@ -75,7 +75,7 @@ type Services struct {
 func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, wpClientMgr *kubernetesClient.KubeMultiClientManager, gatewayURL string, logger *slog.Logger, gwClient *gatewayClient.Client, webhookProcessor autobuildsvc.WebhookProcessor) *Services {
 	return &Services{
 		AutoBuildService:                              autobuildsvc.NewService(k8sClient, webhookProcessor, logger.With("component", "autobuild-service")),
-		AuthzService:                                  authzsvc.NewServiceWithAuthz(pap, pdp, k8sClient, logger.With("component", "authz-service")),
+		AuthzService:                                  authzsvc.NewServiceWithAuthz(pap, pdp, logger.With("component", "authz-service")),
 		ProjectService:                                projectsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "project-service")),
 		WorkflowPlaneService:                          workflowplanesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "workflowplane-service")),
 		ClusterWorkflowPlaneService:                   clusterworkflowplanesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "clusterworkflowplane-service")),


### PR DESCRIPTION


<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose


Here's a PR description:

---

## Summary

The authz service layer (`internal/openchoreo-api/services/authz/service.go`) had an inconsistency: Create, Get, List, and Update operations for all 4 resource types (ClusterAuthzRole, AuthzRole, ClusterAuthzRoleBinding, AuthzRoleBinding) were routed through the PAP interface, but **Delete operations bypassed PAP and went directly to `k8sClient.Delete`**. This was the only reason the authz service held a `k8sClient` reference.

This PR:
- Adds 4 delete methods (`DeleteClusterRole`, `DeleteNamespacedRole`, `DeleteClusterRoleBinding`, `DeleteNamespacedRoleBinding`) to the PAP interface
- Implements them in `CasbinEnforcer` and `DisabledAuthorizer`
- Routes the authz service delete operations through PAP, matching the pattern used by all other CRUD operations
- Removes the now-unnecessary `k8sClient` field from `authzService` and the `client.Client` parameter from `NewService` / `NewServiceWithAuthz`
- Adds tests for all new PAP delete methods and disabled authorizer stubs


🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
