### PR TITLE
fix(cli): show descriptive error for missing positional args

### DIFF
--- a/pkg/cli/cmd/authzrole/authzrole.go
+++ b/pkg/cli/cmd/authzrole/authzrole.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/authzrole"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -51,7 +52,7 @@ func newGetAuthzRoleCmd() *cobra.Command {
 		Short:   constants.GetAuthzRole.Short,
 		Long:    constants.GetAuthzRole.Long,
 		Example: constants.GetAuthzRole.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -74,7 +75,7 @@ func newDeleteAuthzRoleCmd() *cobra.Command {
 		Short:   constants.DeleteAuthzRole.Short,
 		Long:    constants.DeleteAuthzRole.Long,
 		Example: constants.DeleteAuthzRole.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/authzrolebinding/authzrolebinding.go
+++ b/pkg/cli/cmd/authzrolebinding/authzrolebinding.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/authzrolebinding"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -51,7 +52,7 @@ func newGetAuthzRoleBindingCmd() *cobra.Command {
 		Short:   constants.GetAuthzRoleBinding.Short,
 		Long:    constants.GetAuthzRoleBinding.Long,
 		Example: constants.GetAuthzRoleBinding.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -74,7 +75,7 @@ func newDeleteAuthzRoleBindingCmd() *cobra.Command {
 		Short:   constants.DeleteAuthzRoleBinding.Short,
 		Long:    constants.DeleteAuthzRoleBinding.Long,
 		Example: constants.DeleteAuthzRoleBinding.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/clusterauthzrole/clusterauthzrole.go
+++ b/pkg/cli/cmd/clusterauthzrole/clusterauthzrole.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterauthzrole"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -49,7 +50,7 @@ func newGetClusterAuthzRoleCmd() *cobra.Command {
 		Short:   constants.GetClusterAuthzRole.Short,
 		Long:    constants.GetClusterAuthzRole.Long,
 		Example: constants.GetClusterAuthzRole.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterauthzrole.New().Get(clusterauthzrole.GetParams{
@@ -67,7 +68,7 @@ func newDeleteClusterAuthzRoleCmd() *cobra.Command {
 		Short:   constants.DeleteClusterAuthzRole.Short,
 		Long:    constants.DeleteClusterAuthzRole.Long,
 		Example: constants.DeleteClusterAuthzRole.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterauthzrole.New().Delete(clusterauthzrole.DeleteParams{

--- a/pkg/cli/cmd/clusterauthzrolebinding/clusterauthzrolebinding.go
+++ b/pkg/cli/cmd/clusterauthzrolebinding/clusterauthzrolebinding.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterauthzrolebinding"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -49,7 +50,7 @@ func newGetClusterAuthzRoleBindingCmd() *cobra.Command {
 		Short:   constants.GetClusterAuthzRoleBinding.Short,
 		Long:    constants.GetClusterAuthzRoleBinding.Long,
 		Example: constants.GetClusterAuthzRoleBinding.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterauthzrolebinding.New().Get(clusterauthzrolebinding.GetParams{
@@ -67,7 +68,7 @@ func newDeleteClusterAuthzRoleBindingCmd() *cobra.Command {
 		Short:   constants.DeleteClusterAuthzRoleBinding.Short,
 		Long:    constants.DeleteClusterAuthzRoleBinding.Long,
 		Example: constants.DeleteClusterAuthzRoleBinding.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterauthzrolebinding.New().Delete(clusterauthzrolebinding.DeleteParams{

--- a/pkg/cli/cmd/clustercomponenttype/clustercomponenttype.go
+++ b/pkg/cli/cmd/clustercomponenttype/clustercomponenttype.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clustercomponenttype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetClusterComponentTypeCmd() *cobra.Command {
 		Short:   constants.GetClusterComponentType.Short,
 		Long:    constants.GetClusterComponentType.Long,
 		Example: constants.GetClusterComponentType.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clustercomponenttype.New().Get(clustercomponenttype.GetParams{
@@ -54,7 +55,7 @@ func newDeleteClusterComponentTypeCmd() *cobra.Command {
 		Short:   constants.DeleteClusterComponentType.Short,
 		Long:    constants.DeleteClusterComponentType.Long,
 		Example: constants.DeleteClusterComponentType.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clustercomponenttype.New().Delete(clustercomponenttype.DeleteParams{

--- a/pkg/cli/cmd/clusterdataplane/clusterdataplane.go
+++ b/pkg/cli/cmd/clusterdataplane/clusterdataplane.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterdataplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetClusterDataPlaneCmd() *cobra.Command {
 		Short:   constants.GetClusterDataPlane.Short,
 		Long:    constants.GetClusterDataPlane.Long,
 		Example: constants.GetClusterDataPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterdataplane.New().Get(clusterdataplane.GetParams{
@@ -54,7 +55,7 @@ func newDeleteClusterDataPlaneCmd() *cobra.Command {
 		Short:   constants.DeleteClusterDataPlane.Short,
 		Long:    constants.DeleteClusterDataPlane.Long,
 		Example: constants.DeleteClusterDataPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterdataplane.New().Delete(clusterdataplane.DeleteParams{

--- a/pkg/cli/cmd/clusterobservabilityplane/clusterobservabilityplane.go
+++ b/pkg/cli/cmd/clusterobservabilityplane/clusterobservabilityplane.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterobservabilityplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetClusterObservabilityPlaneCmd() *cobra.Command {
 		Short:   constants.GetClusterObservabilityPlane.Short,
 		Long:    constants.GetClusterObservabilityPlane.Long,
 		Example: constants.GetClusterObservabilityPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterobservabilityplane.New().Get(clusterobservabilityplane.GetParams{
@@ -54,7 +55,7 @@ func newDeleteClusterObservabilityPlaneCmd() *cobra.Command {
 		Short:   constants.DeleteClusterObservabilityPlane.Short,
 		Long:    constants.DeleteClusterObservabilityPlane.Long,
 		Example: constants.DeleteClusterObservabilityPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterobservabilityplane.New().Delete(clusterobservabilityplane.DeleteParams{

--- a/pkg/cli/cmd/clustertrait/clustertrait.go
+++ b/pkg/cli/cmd/clustertrait/clustertrait.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clustertrait"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetClusterTraitCmd() *cobra.Command {
 		Short:   constants.GetClusterTrait.Short,
 		Long:    constants.GetClusterTrait.Long,
 		Example: constants.GetClusterTrait.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clustertrait.New().Get(clustertrait.GetParams{
@@ -54,7 +55,7 @@ func newDeleteClusterTraitCmd() *cobra.Command {
 		Short:   constants.DeleteClusterTrait.Short,
 		Long:    constants.DeleteClusterTrait.Long,
 		Example: constants.DeleteClusterTrait.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clustertrait.New().Delete(clustertrait.DeleteParams{

--- a/pkg/cli/cmd/clusterworkflow/clusterworkflow.go
+++ b/pkg/cli/cmd/clusterworkflow/clusterworkflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterworkflow"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -39,7 +40,7 @@ func newGetClusterWorkflowCmd() *cobra.Command {
 		Short:   constants.GetClusterWorkflow.Short,
 		Long:    constants.GetClusterWorkflow.Long,
 		Example: constants.GetClusterWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterworkflow.New().Get(clusterworkflow.GetParams{
@@ -56,7 +57,7 @@ func newDeleteClusterWorkflowCmd() *cobra.Command {
 		Short:   constants.DeleteClusterWorkflow.Short,
 		Long:    constants.DeleteClusterWorkflow.Long,
 		Example: constants.DeleteClusterWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterworkflow.New().Delete(clusterworkflow.DeleteParams{
@@ -73,7 +74,7 @@ func newStartClusterWorkflowCmd() *cobra.Command {
 		Short:   constants.StartClusterWorkflow.Short,
 		Long:    constants.StartClusterWorkflow.Long,
 		Example: constants.StartClusterWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -97,7 +98,7 @@ func newLogsClusterWorkflowCmd() *cobra.Command {
 		Short:   constants.LogsClusterWorkflow.Short,
 		Long:    constants.LogsClusterWorkflow.Long,
 		Example: constants.LogsClusterWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/clusterworkflowplane/clusterworkflowplane.go
+++ b/pkg/cli/cmd/clusterworkflowplane/clusterworkflowplane.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterworkflowplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetClusterWorkflowPlaneCmd() *cobra.Command {
 		Short:   constants.GetClusterWorkflowPlane.Short,
 		Long:    constants.GetClusterWorkflowPlane.Long,
 		Example: constants.GetClusterWorkflowPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterworkflowplane.New().Get(clusterworkflowplane.GetParams{
@@ -54,7 +55,7 @@ func newDeleteClusterWorkflowPlaneCmd() *cobra.Command {
 		Short:   constants.DeleteClusterWorkflowPlane.Short,
 		Long:    constants.DeleteClusterWorkflowPlane.Long,
 		Example: constants.DeleteClusterWorkflowPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return clusterworkflowplane.New().Delete(clusterworkflowplane.DeleteParams{

--- a/pkg/cli/cmd/component/component.go
+++ b/pkg/cli/cmd/component/component.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/component"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -59,7 +60,7 @@ func newGetComponentCmd() *cobra.Command {
 		Short:   constants.GetComponent.Short,
 		Long:    constants.GetComponent.Long,
 		Example: constants.GetComponent.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -83,7 +84,7 @@ func newDeleteComponentCmd() *cobra.Command {
 		Short:   constants.DeleteComponent.Short,
 		Long:    constants.DeleteComponent.Long,
 		Example: constants.DeleteComponent.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -107,7 +108,7 @@ func newScaffoldComponentCmd() *cobra.Command {
 		Short:   constants.ScaffoldComponent.Short,
 		Long:    constants.ScaffoldComponent.Long,
 		Example: constants.ScaffoldComponent.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -179,7 +180,7 @@ func newDeployComponentCmd() *cobra.Command {
 		Short:   constants.DeployComponent.Short,
 		Long:    constants.DeployComponent.Long,
 		Example: constants.DeployComponent.Example,
-		Args:    cobra.ExactArgs(1), // Requires COMPONENT_NAME
+		Args:    cliargs.ExactOneArgWithUsage(), // Requires COMPONENT_NAME
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get component name from positional arg
 			componentName := args[0]
@@ -243,7 +244,7 @@ If --env is not specified, uses the lowest environment from the deployment pipel
 
   # Follow logs in real-time
   occ component logs my-component --env dev -f`,
-		Args: cobra.ExactArgs(1), // Requires COMPONENT_NAME
+		Args: cliargs.ExactOneArgWithUsage(), // Requires COMPONENT_NAME
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get component name from positional arg
 			componentName := args[0]
@@ -308,7 +309,7 @@ func newStartComponentWorkflowCmd() *cobra.Command {
 		Short:   constants.StartComponentWorkflow.Short,
 		Long:    constants.StartComponentWorkflow.Long,
 		Example: constants.StartComponentWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -359,7 +360,7 @@ func newListComponentWorkflowRunCmd() *cobra.Command {
 		Short:   constants.ListComponentWorkflowRun.Short,
 		Long:    constants.ListComponentWorkflowRun.Long,
 		Example: constants.ListComponentWorkflowRun.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -381,7 +382,7 @@ func newLogsComponentWorkflowRunCmd() *cobra.Command {
 		Short:   constants.LogsComponentWorkflowRun.Short,
 		Long:    constants.LogsComponentWorkflowRun.Long,
 		Example: constants.LogsComponentWorkflowRun.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/componentrelease/generate.go
+++ b/pkg/cli/cmd/componentrelease/generate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/componentrelease"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -159,7 +160,7 @@ func newGetCmd() *cobra.Command {
 		Short:   constants.GetComponentRelease.Short,
 		Long:    constants.GetComponentRelease.Long,
 		Example: constants.GetComponentRelease.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -179,7 +180,7 @@ func newDeleteCmd() *cobra.Command {
 		Short:   constants.DeleteComponentRelease.Short,
 		Long:    constants.DeleteComponentRelease.Long,
 		Example: constants.DeleteComponentRelease.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/componenttype/componenttype.go
+++ b/pkg/cli/cmd/componenttype/componenttype.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/componenttype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetComponentTypeCmd() *cobra.Command {
 		Short:   constants.GetComponentType.Short,
 		Long:    constants.GetComponentType.Long,
 		Example: constants.GetComponentType.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -60,7 +61,7 @@ func newDeleteComponentTypeCmd() *cobra.Command {
 		Short:   constants.DeleteComponentType.Short,
 		Long:    constants.DeleteComponentType.Long,
 		Example: constants.DeleteComponentType.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/config/config.go
+++ b/pkg/cli/cmd/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/config"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
 	"github.com/openchoreo/openchoreo/pkg/cli/flags"
@@ -73,7 +74,7 @@ func newContextAddCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 	_ = cmd.MarkFlagRequired(flags.ControlPlane.Name)
 	_ = cmd.MarkFlagRequired(flags.Credentials.Name)
 
@@ -107,7 +108,7 @@ func newContextDeleteCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }
@@ -138,7 +139,7 @@ func newContextUpdateCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }
@@ -157,7 +158,7 @@ func newContextUseCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }
@@ -196,7 +197,7 @@ func newControlPlaneAddCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 	_ = cmd.MarkFlagRequired(flags.URL.Name)
 
 	return cmd
@@ -233,7 +234,7 @@ func newControlPlaneUpdateCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }
@@ -252,7 +253,7 @@ func newControlPlaneDeleteCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }
@@ -286,7 +287,7 @@ func newCredentialsAddCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }
@@ -318,7 +319,7 @@ func newCredentialsDeleteCmd() *cobra.Command {
 		},
 	}).Build()
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cliargs.ExactOneArgWithUsage()
 
 	return cmd
 }

--- a/pkg/cli/cmd/dataplane/dataplane.go
+++ b/pkg/cli/cmd/dataplane/dataplane.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/dataplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetDataPlaneCmd() *cobra.Command {
 		Short:   constants.GetDataPlane.Short,
 		Long:    constants.GetDataPlane.Long,
 		Example: constants.GetDataPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteDataPlaneCmd() *cobra.Command {
 		Short:   constants.DeleteDataPlane.Short,
 		Long:    constants.DeleteDataPlane.Long,
 		Example: constants.DeleteDataPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/deploymentpipeline/deploymentpipeline.go
+++ b/pkg/cli/cmd/deploymentpipeline/deploymentpipeline.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/deploymentpipeline"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetDeploymentPipelineCmd() *cobra.Command {
 		Short:   constants.GetDeploymentPipeline.Short,
 		Long:    constants.GetDeploymentPipeline.Long,
 		Example: constants.GetDeploymentPipeline.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteDeploymentPipelineCmd() *cobra.Command {
 		Short:   constants.DeleteDeploymentPipeline.Short,
 		Long:    constants.DeleteDeploymentPipeline.Long,
 		Example: constants.DeleteDeploymentPipeline.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/environment/environment.go
+++ b/pkg/cli/cmd/environment/environment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/environment"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetEnvironmentCmd() *cobra.Command {
 		Short:   constants.GetEnvironment.Short,
 		Long:    constants.GetEnvironment.Long,
 		Example: constants.GetEnvironment.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteEnvironmentCmd() *cobra.Command {
 		Short:   constants.DeleteEnvironment.Short,
 		Long:    constants.DeleteEnvironment.Long,
 		Example: constants.DeleteEnvironment.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/namespace/namespace.go
+++ b/pkg/cli/cmd/namespace/namespace.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/namespace"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -48,7 +49,7 @@ func newGetNamespaceCmd() *cobra.Command {
 		Short:   constants.GetNamespace.Short,
 		Long:    constants.GetNamespace.Long,
 		Example: constants.GetNamespace.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return namespace.New().Get(args[0])
@@ -64,7 +65,7 @@ func newDeleteNamespaceCmd() *cobra.Command {
 		Short:   constants.DeleteNamespace.Short,
 		Long:    constants.DeleteNamespace.Long,
 		Example: constants.DeleteNamespace.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return namespace.New().Delete(args[0])

--- a/pkg/cli/cmd/observabilityalertsnotificationchannel/observabilityalertsnotificationchannel.go
+++ b/pkg/cli/cmd/observabilityalertsnotificationchannel/observabilityalertsnotificationchannel.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	oanc "github.com/openchoreo/openchoreo/internal/occ/cmd/observabilityalertsnotificationchannel"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetCmd() *cobra.Command {
 		Short:   constants.GetObservabilityAlertsNotificationChannel.Short,
 		Long:    constants.GetObservabilityAlertsNotificationChannel.Long,
 		Example: constants.GetObservabilityAlertsNotificationChannel.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteCmd() *cobra.Command {
 		Short:   constants.DeleteObservabilityAlertsNotificationChannel.Short,
 		Long:    constants.DeleteObservabilityAlertsNotificationChannel.Long,
 		Example: constants.DeleteObservabilityAlertsNotificationChannel.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/observabilityplane/observabilityplane.go
+++ b/pkg/cli/cmd/observabilityplane/observabilityplane.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/observabilityplane"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetObservabilityPlaneCmd() *cobra.Command {
 		Short:   constants.GetObservabilityPlane.Short,
 		Long:    constants.GetObservabilityPlane.Long,
 		Example: constants.GetObservabilityPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteObservabilityPlaneCmd() *cobra.Command {
 		Short:   constants.DeleteObservabilityPlane.Short,
 		Long:    constants.DeleteObservabilityPlane.Long,
 		Example: constants.DeleteObservabilityPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/project/project.go
+++ b/pkg/cli/cmd/project/project.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/project"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -51,7 +52,7 @@ func newGetProjectCmd() *cobra.Command {
 		Short:   constants.GetProject.Short,
 		Long:    constants.GetProject.Long,
 		Example: constants.GetProject.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -74,7 +75,7 @@ func newDeleteProjectCmd() *cobra.Command {
 		Short:   constants.DeleteProject.Short,
 		Long:    constants.DeleteProject.Long,
 		Example: constants.DeleteProject.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/releasebinding/generate.go
+++ b/pkg/cli/cmd/releasebinding/generate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/releasebinding"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -149,7 +150,7 @@ func newGetCmd() *cobra.Command {
 		Short:   constants.GetReleaseBinding.Short,
 		Long:    constants.GetReleaseBinding.Long,
 		Example: constants.GetReleaseBinding.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -169,7 +170,7 @@ func newDeleteCmd() *cobra.Command {
 		Short:   constants.DeleteReleaseBinding.Short,
 		Long:    constants.DeleteReleaseBinding.Long,
 		Example: constants.DeleteReleaseBinding.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/secretreference/secretreference.go
+++ b/pkg/cli/cmd/secretreference/secretreference.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/secretreference"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetSecretReferenceCmd() *cobra.Command {
 		Short:   constants.GetSecretReference.Short,
 		Long:    constants.GetSecretReference.Long,
 		Example: constants.GetSecretReference.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteSecretReferenceCmd() *cobra.Command {
 		Short:   constants.DeleteSecretReference.Short,
 		Long:    constants.DeleteSecretReference.Long,
 		Example: constants.DeleteSecretReference.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/trait/trait.go
+++ b/pkg/cli/cmd/trait/trait.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/trait"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -37,7 +38,7 @@ func newGetTraitCmd() *cobra.Command {
 		Short:   constants.GetTrait.Short,
 		Long:    constants.GetTrait.Long,
 		Example: constants.GetTrait.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -60,7 +61,7 @@ func newDeleteTraitCmd() *cobra.Command {
 		Short:   constants.DeleteTrait.Short,
 		Long:    constants.DeleteTrait.Long,
 		Example: constants.DeleteTrait.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/workflow/workflow.go
+++ b/pkg/cli/cmd/workflow/workflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflow"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -52,7 +53,7 @@ func newGetWorkflowCmd() *cobra.Command {
 		Short:   constants.GetWorkflow.Short,
 		Long:    constants.GetWorkflow.Long,
 		Example: constants.GetWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -74,7 +75,7 @@ func newDeleteWorkflowCmd() *cobra.Command {
 		Short:   constants.DeleteWorkflow.Short,
 		Long:    constants.DeleteWorkflow.Long,
 		Example: constants.DeleteWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -96,7 +97,7 @@ func newStartWorkflowCmd() *cobra.Command {
 		Short:   constants.StartWorkflow.Short,
 		Long:    constants.StartWorkflow.Long,
 		Example: constants.StartWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -120,7 +121,7 @@ func newLogsWorkflowCmd() *cobra.Command {
 		Short:   constants.LogsWorkflow.Short,
 		Long:    constants.LogsWorkflow.Long,
 		Example: constants.LogsWorkflow.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/workflowplane/workflowplane.go
+++ b/pkg/cli/cmd/workflowplane/workflowplane.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflowplane"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -50,7 +51,7 @@ func newGetWorkflowPlaneCmd() *cobra.Command {
 		Short:   constants.GetWorkflowPlane.Short,
 		Long:    constants.GetWorkflowPlane.Long,
 		Example: constants.GetWorkflowPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -70,7 +71,7 @@ func newDeleteWorkflowPlaneCmd() *cobra.Command {
 		Short:   constants.DeleteWorkflowPlane.Short,
 		Long:    constants.DeleteWorkflowPlane.Long,
 		Example: constants.DeleteWorkflowPlane.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/workflowrun/workflowrun.go
+++ b/pkg/cli/cmd/workflowrun/workflowrun.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/workflowrun"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -54,7 +55,7 @@ func newGetWorkflowRunCmd() *cobra.Command {
 		Short:   constants.GetWorkflowRun.Short,
 		Long:    constants.GetWorkflowRun.Long,
 		Example: constants.GetWorkflowRun.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -74,7 +75,7 @@ func newLogsWorkflowRunCmd() *cobra.Command {
 		Short:   constants.LogsWorkflowRun.Short,
 		Long:    constants.LogsWorkflowRun.Long,
 		Example: constants.LogsWorkflowRun.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/login"
 	workloadcmd "github.com/openchoreo/openchoreo/internal/occ/cmd/workload"
+	cliargs "github.com/openchoreo/openchoreo/pkg/cli/common/args"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/auth"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/builder"
 	"github.com/openchoreo/openchoreo/pkg/cli/common/constants"
@@ -84,7 +85,7 @@ func newGetWorkloadCmd() *cobra.Command {
 		Short:   constants.GetWorkload.Short,
 		Long:    constants.GetWorkload.Long,
 		Example: constants.GetWorkload.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)
@@ -104,7 +105,7 @@ func newDeleteWorkloadCmd() *cobra.Command {
 		Short:   constants.DeleteWorkload.Short,
 		Long:    constants.DeleteWorkload.Long,
 		Example: constants.DeleteWorkload.Example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cliargs.ExactOneArgWithUsage(),
 		PreRunE: auth.RequireLogin(login.NewAuthImpl()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString(flags.Namespace.Name)

--- a/pkg/cli/common/args/args.go
+++ b/pkg/cli/common/args/args.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package args
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ExactOneArgWithUsage returns a cobra positional args validator that provides a descriptive
+// error message when the required argument is missing. It extracts the argument name
+// from the command's Use field (e.g., "get [NAMESPACE_NAME]" → "NAMESPACE_NAME").
+func ExactOneArgWithUsage() cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			argName := extractArgName(cmd.Use)
+			return fmt.Errorf("required argument %s not provided\n\nUsage:\n  %s", argName, cmd.UseLine())
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("accepts 1 arg(s), received %d", len(args))
+		}
+		return nil
+	}
+}
+
+// extractArgName extracts the argument placeholder from a cobra Use string.
+// For example: "get [NAMESPACE_NAME]" → "NAMESPACE_NAME", "run WORKFLOW_NAME" → "WORKFLOW_NAME".
+func extractArgName(use string) string {
+	parts := strings.Fields(use)
+	if len(parts) > 1 {
+		arg := parts[1]
+		arg = strings.Trim(arg, "[]")
+		if arg != "" {
+			return arg
+		}
+	}
+	return "NAME"
+}

--- a/pkg/cli/common/args/args_test.go
+++ b/pkg/cli/common/args/args_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package args
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExactOneArgWithUsage(t *testing.T) {
+	tests := []struct {
+		name    string
+		use     string
+		args    []string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "no args with bracketed name",
+			use:     "get [NAMESPACE_NAME]",
+			args:    []string{},
+			wantErr: true,
+			errMsg:  "required argument NAMESPACE_NAME not provided",
+		},
+		{
+			name:    "no args with unbracketed name",
+			use:     "run WORKFLOW_NAME",
+			args:    []string{},
+			wantErr: true,
+			errMsg:  "required argument WORKFLOW_NAME not provided",
+		},
+		{
+			name:    "no args with no arg name in use",
+			use:     "scaffold",
+			args:    []string{},
+			wantErr: true,
+			errMsg:  "required argument NAME not provided",
+		},
+		{
+			name:    "one arg succeeds",
+			use:     "get [NAMESPACE_NAME]",
+			args:    []string{"my-ns"},
+			wantErr: false,
+		},
+		{
+			name:    "too many args",
+			use:     "get [NAMESPACE_NAME]",
+			args:    []string{"a", "b"},
+			wantErr: true,
+			errMsg:  "accepts 1 arg(s), received 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tt.use}
+			err := ExactOneArgWithUsage()(cmd, tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error to contain %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractArgName(t *testing.T) {
+	tests := []struct {
+		use  string
+		want string
+	}{
+		{"get [NAMESPACE_NAME]", "NAMESPACE_NAME"},
+		{"delete [PROJECT_NAME]", "PROJECT_NAME"},
+		{"run WORKFLOW_NAME", "WORKFLOW_NAME"},
+		{"scaffold COMPONENT_NAME", "COMPONENT_NAME"},
+		{"list", "NAME"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.use, func(t *testing.T) {
+			got := extractArgName(tt.use)
+			if got != tt.want {
+				t.Errorf("extractArgName(%q) = %q, want %q", tt.use, got, tt.want)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -1220,7 +1220,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigContextAdd holds usage and help texts for "config context add" command.
 	ConfigContextAdd = Command{
-		Use:   "add",
+		Use:   "add [CONTEXT_NAME]",
 		Short: "Add a new configuration context",
 		Long:  "Add a new configuration context with control plane and credentials references.",
 		Example: fmt.Sprintf(`  # Add a new context with control plane and credentials
@@ -1239,7 +1239,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigContextDelete holds usage and help texts for "config context delete" command.
 	ConfigContextDelete = Command{
-		Use:   "delete",
+		Use:   "delete [CONTEXT_NAME]",
 		Short: "Delete a configuration context",
 		Long:  "Delete a configuration context by name.",
 		Example: fmt.Sprintf(`  # Delete a configuration context
@@ -1248,7 +1248,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigContextUpdate holds usage and help texts for "config context update" command.
 	ConfigContextUpdate = Command{
-		Use:   "update",
+		Use:   "update [CONTEXT_NAME]",
 		Short: "Update an existing configuration context",
 		Long:  "Update fields of an existing configuration context.",
 		Example: fmt.Sprintf(`  # Update the namespace and project for a context
@@ -1258,7 +1258,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigContextUse holds usage and help texts for "config context use" command.
 	ConfigContextUse = Command{
-		Use:   "use",
+		Use:   "use [CONTEXT_NAME]",
 		Short: "Switch to a configuration context",
 		Long:  "Set the active context, so subsequent commands automatically use its stored values when flags are omitted.",
 		Example: fmt.Sprintf(`  # Switch to the configuration context named my-context
@@ -1274,7 +1274,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigControlPlaneAdd holds usage and help texts for "config controlplane add" command.
 	ConfigControlPlaneAdd = Command{
-		Use:   "add",
+		Use:   "add [CONTROLPLANE_NAME]",
 		Short: "Add a new control plane configuration",
 		Long:  "Add a new control plane configuration with a URL.",
 		Example: fmt.Sprintf(`  # Add a control plane
@@ -1292,7 +1292,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigControlPlaneUpdate holds usage and help texts for "config controlplane update" command.
 	ConfigControlPlaneUpdate = Command{
-		Use:   "update",
+		Use:   "update [CONTROLPLANE_NAME]",
 		Short: "Update a control plane configuration",
 		Long:  "Update the URL of an existing control plane configuration.",
 		Example: fmt.Sprintf(`  # Update a control plane URL
@@ -1301,7 +1301,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigControlPlaneDelete holds usage and help texts for "config controlplane delete" command.
 	ConfigControlPlaneDelete = Command{
-		Use:   "delete",
+		Use:   "delete [CONTROLPLANE_NAME]",
 		Short: "Delete a control plane configuration",
 		Long:  "Delete a control plane configuration by name.",
 		Example: fmt.Sprintf(`  # Delete a control plane
@@ -1317,7 +1317,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigCredentialsAdd holds usage and help texts for "config credentials add" command.
 	ConfigCredentialsAdd = Command{
-		Use:   "add",
+		Use:   "add [CREDENTIALS_NAME]",
 		Short: "Add a new credentials configuration",
 		Long:  "Add a new credentials configuration entry.",
 		Example: fmt.Sprintf(`  # Add credentials
@@ -1335,7 +1335,7 @@ Use --workflowrun to specify a particular run.`,
 
 	// ConfigCredentialsDelete holds usage and help texts for "config credentials delete" command.
 	ConfigCredentialsDelete = Command{
-		Use:   "delete",
+		Use:   "delete [CREDENTIALS_NAME]",
 		Short: "Delete a credentials configuration",
 		Long:  "Delete a credentials configuration by name.",
 		Example: fmt.Sprintf(`  # Delete credentials


### PR DESCRIPTION
## Purpose

All `occ` commands requiring a positional argument show a generic `Error: accepts 1 arg(s), received 0` when invoked without the argument. This gives users no indication of what argument is expected.

## Approach

- Add `ExactOneArgWithUsage()` validator in `pkg/cli/common/args` that extracts the arg name from the command's `Use` field and shows a descriptive error with usage
- Replace all 72 occurrences of `cobra.ExactArgs(1)` across 28 command files with the new validator
- Add arg name placeholders to 9 config command `Use` fields that were missing them (e.g., `"add"` → `"add [CONTEXT_NAME]"`)

**Before:**
```
Error: accepts 1 arg(s), received 0
```

**After:**
```
Error: required argument NAMESPACE_NAME not provided

Usage:
  occ namespace get [NAMESPACE_NAME] [flags]
```

## Related Issues

Closes #2779

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)