### PR TITLE
fix: mark user-type attributes as required attributes

### DIFF
--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -116,20 +116,23 @@ bootstrap:
               },
               \"password\": {
                 \"type\": \"string\",
-                \"required\": false,
+                \"required\": true,
                 \"credential\": true,
                 \"displayName\": \"Password\"
               },
               \"given_name\": {
                 \"type\": \"string\",
+                \"required\": true,
                 \"displayName\": \"First Name\"
               },
               \"family_name\": {
                 \"type\": \"string\",
+                \"required\": true,
                 \"displayName\": \"Last Name\"
               },
               \"email\": {
                 \"type\": \"string\",
+                \"required\": true,
                 \"unique\": true,
                 \"displayName\": \"Email\"
               }


### PR DESCRIPTION
This pull request updates the user bootstrap schema in `install/k3d/common/values-thunder.yaml` to require more user information during setup. The most important change is that several fields are now mandatory.

User schema changes:

* Made the `password`, `given_name` (First Name), `family_name` (Last Name), and `email` fields required in the bootstrap configuration.