### PR TITLE
fix: update thunder login page design for openchoreo clients

### DIFF
--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -58,6 +58,609 @@ setup:
 
 bootstrap:
   scripts:
+    49-openchoreo-theme.sh: |
+      #!/bin/bash
+      set -e
+
+      THUNDER_URL="http://localhost:8090"
+
+      log_info "Checking if theme 'OpenChoreo' already exists..."
+      existing_themes=$(curl -s --fail-with-body --max-time 10 "${THUNDER_URL}/design/themes")
+
+      if echo "$existing_themes" | grep -qE '"displayName"[[:space:]]*:[[:space:]]*"OpenChoreo"'; then
+        log_info "Theme 'OpenChoreo' already exists, skipping creation"
+      else
+        log_info "Creating theme 'OpenChoreo'..."
+        THEME_PAYLOAD=$(cat <<'THEME_EOF'
+      {
+          "displayName": "OpenChoreo",
+          "theme": {
+              "defaultColorScheme": "light",
+              "direction": "ltr",
+              "shape": {
+                  "borderRadius": 8
+              },
+              "typography": {
+                  "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+                  "fontWeightRegular": 400,
+                  "fontSize": 14,
+                  "h1": {
+                      "fontSize": "2.533rem",
+                      "fontWeight": 700,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.167
+                  },
+                  "h2": {
+                      "fontSize": "1.867rem",
+                      "fontWeight": 700,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.2
+                  },
+                  "h3": {
+                      "fontSize": "1.333rem",
+                      "fontWeight": 600,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.167
+                  },
+                  "h4": {
+                      "fontSize": "1.067rem",
+                      "fontWeight": 600,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.235
+                  },
+                  "h5": {
+                      "fontSize": "0.933rem",
+                      "fontWeight": 600,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.334
+                  },
+                  "h6": {
+                      "fontSize": "0.867rem",
+                      "fontWeight": 600,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.6
+                  },
+                  "subtitle1": {
+                      "fontSize": "1.067rem",
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "fontWeight": 400,
+                      "lineHeight": 1.75
+                  },
+                  "subtitle2": {
+                      "fontSize": "0.933rem",
+                      "fontWeight": 500,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.57
+                  },
+                  "body1": {
+                      "fontSize": "0.933rem",
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "fontWeight": 400,
+                      "lineHeight": 1.6
+                  },
+                  "body2": {
+                      "fontSize": "0.867rem",
+                      "fontWeight": 400,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.5
+                  },
+                  "button": {
+                      "fontSize": "0.933rem",
+                      "fontWeight": 500,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.75,
+                      "textTransform": "none"
+                  },
+                  "caption": {
+                      "fontSize": "0.733rem",
+                      "fontWeight": 400,
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "lineHeight": 1.66
+                  },
+                  "htmlFontSize": 15,
+                  "fontWeightLight": 300,
+                  "fontWeightMedium": 500,
+                  "fontWeightBold": 700,
+                  "overline": {
+                      "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif",
+                      "fontWeight": 400,
+                      "fontSize": "0.733rem",
+                      "lineHeight": 2.66,
+                      "textTransform": "uppercase"
+                  },
+                  "inherit": {
+                      "fontFamily": "inherit",
+                      "fontWeight": "inherit",
+                      "fontSize": "inherit",
+                      "lineHeight": "inherit",
+                      "letterSpacing": "inherit"
+                  }
+              },
+              "border": {
+                  "width": "1px",
+                  "style": "solid"
+              },
+              "colorSchemes": {
+                  "light": {
+                      "palette": {
+                          "mode": "light",
+                          "primary": {
+                              "main": "#6c7fd8",
+                              "light": "#f0f1fb",
+                              "dark": "#5568c4",
+                              "contrastText": "#ffffff",
+                              "mainChannel": "108 127 216",
+                              "lightChannel": "240 241 251",
+                              "darkChannel": "85 104 196",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "secondary": {
+                              "main": "#6b7280",
+                              "contrastText": "#ffffff",
+                              "light": "#fafbfc",
+                              "dark": "#374151",
+                              "mainChannel": "107 114 128",
+                              "lightChannel": "250 251 252",
+                              "darkChannel": "55 65 81",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "background": {
+                              "default": "#f9fafb",
+                              "paper": "#ffffff",
+                              "defaultChannel": "249 250 251",
+                              "paperChannel": "255 255 255"
+                          },
+                          "common": {
+                              "black": "#111827",
+                              "white": "#fff",
+                              "background": "#fff",
+                              "onBackground": "#111827",
+                              "backgroundChannel": "255 255 255",
+                              "onBackgroundChannel": "17 24 39"
+                          },
+                          "error": {
+                              "main": "#ef4444",
+                              "light": "#fef2f2",
+                              "dark": "#dc2626",
+                              "contrastText": "#fff",
+                              "mainChannel": "239 68 68",
+                              "lightChannel": "254 242 242",
+                              "darkChannel": "220 38 38",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "warning": {
+                              "main": "#f59e0b",
+                              "light": "#fff5eb",
+                              "dark": "#d97706",
+                              "contrastText": "#fff",
+                              "mainChannel": "245 158 11",
+                              "lightChannel": "255 245 235",
+                              "darkChannel": "217 119 6",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "info": {
+                              "main": "#6c7fd8",
+                              "light": "#f0f1fb",
+                              "dark": "#5568c4",
+                              "contrastText": "#fff",
+                              "mainChannel": "108 127 216",
+                              "lightChannel": "240 241 251",
+                              "darkChannel": "85 104 196",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "success": {
+                              "main": "#10b981",
+                              "light": "#f0fdf4",
+                              "dark": "#059669",
+                              "contrastText": "#fff",
+                              "mainChannel": "16 185 129",
+                              "lightChannel": "240 253 244",
+                              "darkChannel": "5 150 105",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "grey": {
+                              "50": "#f9fafb",
+                              "100": "#f3f4f6",
+                              "200": "#e5e7eb",
+                              "300": "#d1d5db",
+                              "400": "#9ca3af",
+                              "500": "#6b7280",
+                              "600": "#4b5563",
+                              "700": "#374151",
+                              "800": "#1f2937",
+                              "900": "#111827",
+                              "A100": "#f3f4f6",
+                              "A200": "#e5e7eb",
+                              "A400": "#9ca3af",
+                              "A700": "#374151"
+                          },
+                          "contrastThreshold": 3,
+                          "tonalOffset": 0.2,
+                          "text": {
+                              "primary": "#111827",
+                              "secondary": "#4b5563",
+                              "disabled": "rgba(17, 24, 39, 0.38)",
+                              "primaryChannel": "17 24 39",
+                              "secondaryChannel": "75 85 99"
+                          },
+                          "divider": "#e5e7eb",
+                          "action": {
+                              "active": "rgba(17, 24, 39, 0.54)",
+                              "hover": "rgba(108, 127, 216, 0.04)",
+                              "hoverOpacity": 0.04,
+                              "selected": "rgba(108, 127, 216, 0.08)",
+                              "selectedOpacity": 0.08,
+                              "disabled": "rgba(17, 24, 39, 0.26)",
+                              "disabledBackground": "rgba(17, 24, 39, 0.12)",
+                              "disabledOpacity": 0.38,
+                              "focus": "rgba(108, 127, 216, 0.12)",
+                              "focusOpacity": 0.12,
+                              "activatedOpacity": 0.12,
+                              "activeChannel": "17 24 39",
+                              "selectedChannel": "108 127 216"
+                          },
+                          "Alert": {
+                              "errorColor": "rgb(220, 38, 38)",
+                              "infoColor": "rgb(85, 104, 196)",
+                              "successColor": "rgb(5, 150, 105)",
+                              "warningColor": "rgb(217, 119, 6)",
+                              "errorFilledBg": "var(--oxygen-palette-error-main, #ef4444)",
+                              "infoFilledBg": "var(--oxygen-palette-info-main, #6c7fd8)",
+                              "successFilledBg": "var(--oxygen-palette-success-main, #10b981)",
+                              "warningFilledBg": "var(--oxygen-palette-warning-main, #f59e0b)",
+                              "errorFilledColor": "#fff",
+                              "infoFilledColor": "#fff",
+                              "successFilledColor": "#fff",
+                              "warningFilledColor": "#fff",
+                              "errorStandardBg": "#fef2f2",
+                              "infoStandardBg": "#f0f1fb",
+                              "successStandardBg": "#f0fdf4",
+                              "warningStandardBg": "#fff5eb",
+                              "errorIconColor": "var(--oxygen-palette-error-main, #ef4444)",
+                              "infoIconColor": "var(--oxygen-palette-info-main, #6c7fd8)",
+                              "successIconColor": "var(--oxygen-palette-success-main, #10b981)",
+                              "warningIconColor": "var(--oxygen-palette-warning-main, #f59e0b)"
+                          },
+                          "AppBar": {
+                              "defaultBg": "var(--oxygen-palette-grey-100, #f3f4f6)"
+                          },
+                          "Avatar": {
+                              "defaultBg": "var(--oxygen-palette-grey-400, #9ca3af)"
+                          },
+                          "Button": {
+                              "inheritContainedBg": "var(--oxygen-palette-grey-300, #d1d5db)",
+                              "inheritContainedHoverBg": "var(--oxygen-palette-grey-A100, #f3f4f6)"
+                          },
+                          "Chip": {
+                              "defaultBorder": "var(--oxygen-palette-grey-400, #9ca3af)",
+                              "defaultAvatarColor": "var(--oxygen-palette-grey-700, #374151)",
+                              "defaultIconColor": "var(--oxygen-palette-grey-700, #374151)"
+                          },
+                          "FilledInput": {
+                              "bg": "rgba(17, 24, 39, 0.06)",
+                              "hoverBg": "rgba(17, 24, 39, 0.09)",
+                              "disabledBg": "rgba(17, 24, 39, 0.12)"
+                          },
+                          "LinearProgress": {
+                              "primaryBg": "rgb(240, 241, 251)",
+                              "secondaryBg": "rgb(250, 251, 252)",
+                              "errorBg": "rgb(254, 242, 242)",
+                              "infoBg": "rgb(240, 241, 251)",
+                              "successBg": "rgb(240, 253, 244)",
+                              "warningBg": "rgb(255, 245, 235)"
+                          },
+                          "Skeleton": {
+                              "bg": "rgba(var(--oxygen-palette-text-primaryChannel, undefined) / 0.11)"
+                          },
+                          "Slider": {
+                              "primaryTrack": "rgb(240, 241, 251)",
+                              "secondaryTrack": "rgb(250, 251, 252)",
+                              "errorTrack": "rgb(254, 242, 242)",
+                              "infoTrack": "rgb(240, 241, 251)",
+                              "successTrack": "rgb(240, 253, 244)",
+                              "warningTrack": "rgb(255, 245, 235)"
+                          },
+                          "SnackbarContent": {
+                              "bg": "#1f2937",
+                              "color": "#fff"
+                          },
+                          "SpeedDialAction": {
+                              "fabHoverBg": "#e5e7eb"
+                          },
+                          "StepConnector": {
+                              "border": "var(--oxygen-palette-grey-400, #9ca3af)"
+                          },
+                          "StepContent": {
+                              "border": "var(--oxygen-palette-grey-400, #9ca3af)"
+                          },
+                          "Switch": {
+                              "defaultColor": "var(--oxygen-palette-common-white, #fff)",
+                              "defaultDisabledColor": "var(--oxygen-palette-grey-100, #f3f4f6)",
+                              "primaryDisabledColor": "rgb(240, 241, 251)",
+                              "secondaryDisabledColor": "rgb(250, 251, 252)",
+                              "errorDisabledColor": "rgb(254, 242, 242)",
+                              "infoDisabledColor": "rgb(240, 241, 251)",
+                              "successDisabledColor": "rgb(240, 253, 244)",
+                              "warningDisabledColor": "rgb(255, 245, 235)"
+                          },
+                          "TableCell": {
+                              "border": "#e5e7eb"
+                          },
+                          "Tooltip": {
+                              "bg": "rgba(55, 65, 81, 0.92)"
+                          },
+                          "dividerChannel": "17 24 39"
+                      },
+                      "opacity": {
+                          "inputPlaceholder": 0.42,
+                          "inputUnderline": 0.42,
+                          "switchTrackDisabled": 0.12,
+                          "switchTrack": 0.38
+                      },
+                      "overlays": []
+                  },
+                  "dark": {
+                      "palette": {
+                          "common": {
+                              "black": "#000",
+                              "white": "#fff",
+                              "background": "#000",
+                              "onBackground": "#fff",
+                              "backgroundChannel": "0 0 0",
+                              "onBackgroundChannel": "255 255 255"
+                          },
+                          "mode": "dark",
+                          "primary": {
+                              "main": "#6c7fd8",
+                              "light": "#f0f1fb",
+                              "dark": "#5568c4",
+                              "contrastText": "#ffffff",
+                              "mainChannel": "108 127 216",
+                              "lightChannel": "240 241 251",
+                              "darkChannel": "85 104 196",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "secondary": {
+                              "main": "#9ca3af",
+                              "contrastText": "#111827",
+                              "light": "#d1d5db",
+                              "dark": "#6b7280",
+                              "mainChannel": "156 163 175",
+                              "lightChannel": "209 213 219",
+                              "darkChannel": "107 114 128",
+                              "contrastTextChannel": "17 24 39"
+                          },
+                          "error": {
+                              "main": "#f87171",
+                              "light": "#fca5a5",
+                              "dark": "#ef4444",
+                              "contrastText": "#fff",
+                              "mainChannel": "248 113 113",
+                              "lightChannel": "252 165 165",
+                              "darkChannel": "239 68 68",
+                              "contrastTextChannel": "255 255 255"
+                          },
+                          "warning": {
+                              "main": "#fbbf24",
+                              "light": "#fcd34d",
+                              "dark": "#f59e0b",
+                              "contrastText": "rgba(0, 0, 0, 0.87)",
+                              "mainChannel": "251 191 36",
+                              "lightChannel": "252 211 77",
+                              "darkChannel": "245 158 11",
+                              "contrastTextChannel": "0 0 0"
+                          },
+                          "info": {
+                              "main": "#818cf8",
+                              "light": "#a5b4fc",
+                              "dark": "#6c7fd8",
+                              "contrastText": "rgba(0, 0, 0, 0.87)",
+                              "mainChannel": "129 140 248",
+                              "lightChannel": "165 180 252",
+                              "darkChannel": "108 127 216",
+                              "contrastTextChannel": "0 0 0"
+                          },
+                          "success": {
+                              "main": "#34d399",
+                              "light": "#6ee7b7",
+                              "dark": "#10b981",
+                              "contrastText": "rgba(0, 0, 0, 0.87)",
+                              "mainChannel": "52 211 153",
+                              "lightChannel": "110 231 183",
+                              "darkChannel": "16 185 129",
+                              "contrastTextChannel": "0 0 0"
+                          },
+                          "grey": {
+                              "50": "#f9fafb",
+                              "100": "#f3f4f6",
+                              "200": "#e5e7eb",
+                              "300": "#d1d5db",
+                              "400": "#9ca3af",
+                              "500": "#6b7280",
+                              "600": "#4b5563",
+                              "700": "#374151",
+                              "800": "#1f2937",
+                              "900": "#111827",
+                              "A100": "#f3f4f6",
+                              "A200": "#e5e7eb",
+                              "A400": "#9ca3af",
+                              "A700": "#374151"
+                          },
+                          "contrastThreshold": 3,
+                          "tonalOffset": 0.2,
+                          "text": {
+                              "primary": "#fff",
+                              "secondary": "rgba(255, 255, 255, 0.7)",
+                              "disabled": "rgba(255, 255, 255, 0.5)",
+                              "icon": "rgba(255, 255, 255, 0.5)",
+                              "primaryChannel": "255 255 255",
+                              "secondaryChannel": "255 255 255"
+                          },
+                          "divider": "rgba(255, 255, 255, 0.12)",
+                          "background": {
+                              "paper": "#1f2937",
+                              "default": "#111827",
+                              "defaultChannel": "17 24 39",
+                              "paperChannel": "31 41 55"
+                          },
+                          "action": {
+                              "active": "#fff",
+                              "hover": "rgba(108, 127, 216, 0.08)",
+                              "hoverOpacity": 0.08,
+                              "selected": "rgba(108, 127, 216, 0.16)",
+                              "selectedOpacity": 0.16,
+                              "disabled": "rgba(255, 255, 255, 0.3)",
+                              "disabledBackground": "rgba(255, 255, 255, 0.12)",
+                              "disabledOpacity": 0.38,
+                              "focus": "rgba(255, 255, 255, 0.12)",
+                              "focusOpacity": 0.12,
+                              "activatedOpacity": 0.24,
+                              "activeChannel": "255 255 255",
+                              "selectedChannel": "108 127 216"
+                          },
+                          "Alert": {
+                              "errorColor": "rgb(252, 165, 165)",
+                              "infoColor": "rgb(165, 180, 252)",
+                              "successColor": "rgb(110, 231, 183)",
+                              "warningColor": "rgb(252, 211, 77)",
+                              "errorFilledBg": "var(--oxygen-palette-error-dark, #ef4444)",
+                              "infoFilledBg": "var(--oxygen-palette-info-dark, #6c7fd8)",
+                              "successFilledBg": "var(--oxygen-palette-success-dark, #10b981)",
+                              "warningFilledBg": "var(--oxygen-palette-warning-dark, #f59e0b)",
+                              "errorFilledColor": "#fff",
+                              "infoFilledColor": "#fff",
+                              "successFilledColor": "#fff",
+                              "warningFilledColor": "rgba(0, 0, 0, 0.87)",
+                              "errorStandardBg": "rgb(31, 15, 15)",
+                              "infoStandardBg": "rgb(15, 19, 35)",
+                              "successStandardBg": "rgb(10, 25, 20)",
+                              "warningStandardBg": "rgb(25, 18, 7)",
+                              "errorIconColor": "var(--oxygen-palette-error-main, #f87171)",
+                              "infoIconColor": "var(--oxygen-palette-info-main, #818cf8)",
+                              "successIconColor": "var(--oxygen-palette-success-main, #34d399)",
+                              "warningIconColor": "var(--oxygen-palette-warning-main, #fbbf24)"
+                          },
+                          "AppBar": {
+                              "defaultBg": "var(--oxygen-palette-grey-900, #111827)",
+                              "darkBg": "var(--oxygen-palette-background-paper, #1f2937)",
+                              "darkColor": "var(--oxygen-palette-text-primary, #fff)"
+                          },
+                          "Avatar": {
+                              "defaultBg": "var(--oxygen-palette-grey-600, #4b5563)"
+                          },
+                          "Button": {
+                              "inheritContainedBg": "var(--oxygen-palette-grey-800, #1f2937)",
+                              "inheritContainedHoverBg": "var(--oxygen-palette-grey-700, #374151)"
+                          },
+                          "Chip": {
+                              "defaultBorder": "var(--oxygen-palette-grey-700, #374151)",
+                              "defaultAvatarColor": "var(--oxygen-palette-grey-300, #d1d5db)",
+                              "defaultIconColor": "var(--oxygen-palette-grey-300, #d1d5db)"
+                          },
+                          "FilledInput": {
+                              "bg": "rgba(255, 255, 255, 0.09)",
+                              "hoverBg": "rgba(255, 255, 255, 0.13)",
+                              "disabledBg": "rgba(255, 255, 255, 0.12)"
+                          },
+                          "LinearProgress": {
+                              "primaryBg": "rgb(55, 65, 81)",
+                              "secondaryBg": "rgb(75, 85, 99)",
+                              "errorBg": "rgb(69, 26, 26)",
+                              "infoBg": "rgb(40, 46, 80)",
+                              "successBg": "rgb(20, 55, 44)",
+                              "warningBg": "rgb(77, 56, 16)"
+                          },
+                          "Skeleton": {
+                              "bg": "rgba(var(--oxygen-palette-text-primaryChannel, undefined) / 0.13)"
+                          },
+                          "Slider": {
+                              "primaryTrack": "rgb(55, 65, 81)",
+                              "secondaryTrack": "rgb(75, 85, 99)",
+                              "errorTrack": "rgb(69, 26, 26)",
+                              "infoTrack": "rgb(40, 46, 80)",
+                              "successTrack": "rgb(20, 55, 44)",
+                              "warningTrack": "rgb(77, 56, 16)"
+                          },
+                          "SnackbarContent": {
+                              "bg": "rgb(240, 241, 251)",
+                              "color": "rgba(0, 0, 0, 0.87)"
+                          },
+                          "SpeedDialAction": {
+                              "fabHoverBg": "rgb(55, 65, 81)"
+                          },
+                          "StepConnector": {
+                              "border": "var(--oxygen-palette-grey-600, #4b5563)"
+                          },
+                          "StepContent": {
+                              "border": "var(--oxygen-palette-grey-600, #4b5563)"
+                          },
+                          "Switch": {
+                              "defaultColor": "var(--oxygen-palette-grey-300, #d1d5db)",
+                              "defaultDisabledColor": "var(--oxygen-palette-grey-600, #4b5563)",
+                              "primaryDisabledColor": "rgb(55, 65, 81)",
+                              "secondaryDisabledColor": "rgb(75, 85, 99)",
+                              "errorDisabledColor": "rgb(69, 26, 26)",
+                              "infoDisabledColor": "rgb(40, 46, 80)",
+                              "successDisabledColor": "rgb(20, 55, 44)",
+                              "warningDisabledColor": "rgb(77, 56, 16)"
+                          },
+                          "TableCell": {
+                              "border": "rgba(55, 65, 81, 1)"
+                          },
+                          "Tooltip": {
+                              "bg": "rgba(17, 24, 39, 0.92)"
+                          },
+                          "dividerChannel": "255 255 255"
+                      },
+                      "opacity": {
+                          "inputPlaceholder": 0.5,
+                          "inputUnderline": 0.7,
+                          "switchTrackDisabled": 0.2,
+                          "switchTrack": 0.3
+                      },
+                      "overlays": [
+                          "none",
+                          "linear-gradient(rgba(255 255 255 / 0.051), rgba(255 255 255 / 0.051))",
+                          "linear-gradient(rgba(255 255 255 / 0.069), rgba(255 255 255 / 0.069))",
+                          "linear-gradient(rgba(255 255 255 / 0.082), rgba(255 255 255 / 0.082))",
+                          "linear-gradient(rgba(255 255 255 / 0.092), rgba(255 255 255 / 0.092))",
+                          "linear-gradient(rgba(255 255 255 / 0.101), rgba(255 255 255 / 0.101))",
+                          "linear-gradient(rgba(255 255 255 / 0.108), rgba(255 255 255 / 0.108))",
+                          "linear-gradient(rgba(255 255 255 / 0.114), rgba(255 255 255 / 0.114))",
+                          "linear-gradient(rgba(255 255 255 / 0.119), rgba(255 255 255 / 0.119))",
+                          "linear-gradient(rgba(255 255 255 / 0.124), rgba(255 255 255 / 0.124))",
+                          "linear-gradient(rgba(255 255 255 / 0.128), rgba(255 255 255 / 0.128))",
+                          "linear-gradient(rgba(255 255 255 / 0.132), rgba(255 255 255 / 0.132))",
+                          "linear-gradient(rgba(255 255 255 / 0.135), rgba(255 255 255 / 0.135))",
+                          "linear-gradient(rgba(255 255 255 / 0.139), rgba(255 255 255 / 0.139))",
+                          "linear-gradient(rgba(255 255 255 / 0.142), rgba(255 255 255 / 0.142))",
+                          "linear-gradient(rgba(255 255 255 / 0.145), rgba(255 255 255 / 0.145))",
+                          "linear-gradient(rgba(255 255 255 / 0.147), rgba(255 255 255 / 0.147))",
+                          "linear-gradient(rgba(255 255 255 / 0.15), rgba(255 255 255 / 0.15))",
+                          "linear-gradient(rgba(255 255 255 / 0.152), rgba(255 255 255 / 0.152))",
+                          "linear-gradient(rgba(255 255 255 / 0.155), rgba(255 255 255 / 0.155))",
+                          "linear-gradient(rgba(255 255 255 / 0.157), rgba(255 255 255 / 0.157))",
+                          "linear-gradient(rgba(255 255 255 / 0.159), rgba(255 255 255 / 0.159))",
+                          "linear-gradient(rgba(255 255 255 / 0.161), rgba(255 255 255 / 0.161))",
+                          "linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))",
+                          "linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))"
+                      ]
+                  }
+              }
+          }
+      }
+      THEME_EOF
+        )
+        curl --location "${THUNDER_URL}/design/themes" \
+          --header 'Content-Type: application/json' \
+          --data "$THEME_PAYLOAD" \
+          --fail-with-body \
+          --max-time 30 \
+          --retry 3 \
+          --retry-delay 5
+        log_info "Theme 'OpenChoreo' created successfully"
+      fi
+
     50-user-schema-and-users.sh: |
       #!/bin/bash
       set -e
@@ -234,6 +837,25 @@ bootstrap:
 
       THUNDER_URL="http://localhost:8090"
 
+      log_info "Looking up OpenChoreo theme ID..."
+      existing_themes=$(curl -s --fail-with-body --max-time 10 "${THUNDER_URL}/design/themes")
+      THEME_ID=""
+      if echo "$existing_themes" | grep -qE '"displayName"[[:space:]]*:[[:space:]]*"OpenChoreo"'; then
+        THEME_ID=$(echo "$existing_themes" | tr '\n' ' ' | sed 's/},/}\n/g' | grep -E '"displayName"[[:space:]]*:[[:space:]]*"OpenChoreo"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+        if [ -n "$THEME_ID" ]; then
+          log_info "Found OpenChoreo theme ID: $THEME_ID"
+        else
+          log_info "Warning: OpenChoreo theme found but could not extract ID, proceeding without theme_id"
+        fi
+      else
+        log_info "Warning: OpenChoreo theme not found, proceeding without theme_id"
+      fi
+
+      THEME_FIELD=""
+      if [ -n "$THEME_ID" ]; then
+        THEME_FIELD=',"theme_id":"'"${THEME_ID}"'"'
+      fi
+
       log_info "Checking if application 'Backstage' already exists..."
       existing_apps=$(curl -s --max-time 10 "${THUNDER_URL}/applications")
 
@@ -242,6 +864,7 @@ bootstrap:
       APP_PAYLOAD='{
         "name": "Backstage",
         "description": "OpenChoreo Backstage Portal",
+        "logo_url": "https://cdn.statically.io/gh/openchoreo/openchoreo.github.io@main/static/img/openchoreo-logo.png",
         "allowed_user_types": ["openchoreo-user"],
         "assertion": {
           "validity_period": 3600
@@ -302,7 +925,7 @@ bootstrap:
               }
             }
           }
-        ]
+        ]'${THEME_FIELD}'
       }'
 
       if [ -n "$app_id" ]; then
@@ -455,6 +1078,25 @@ bootstrap:
 
       THUNDER_URL="http://localhost:8090"
 
+      log_info "Looking up OpenChoreo theme ID..."
+      existing_themes=$(curl -s --fail-with-body --max-time 10 "${THUNDER_URL}/design/themes")
+      THEME_ID=""
+      if echo "$existing_themes" | grep -qE '"displayName"[[:space:]]*:[[:space:]]*"OpenChoreo"'; then
+        THEME_ID=$(echo "$existing_themes" | tr '\n' ' ' | sed 's/},/}\n/g' | grep -E '"displayName"[[:space:]]*:[[:space:]]*"OpenChoreo"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+        if [ -n "$THEME_ID" ]; then
+          log_info "Found OpenChoreo theme ID: $THEME_ID"
+        else
+          log_info "Warning: OpenChoreo theme found but could not extract ID, proceeding without theme_id"
+        fi
+      else
+        log_info "Warning: OpenChoreo theme not found, proceeding without theme_id"
+      fi
+
+      THEME_FIELD=""
+      if [ -n "$THEME_ID" ]; then
+        THEME_FIELD=',"theme_id":"'"${THEME_ID}"'"'
+      fi
+
       log_info "Checking if application 'OpenChoreo CLI' already exists..."
       existing_apps=$(curl -s --max-time 10 "${THUNDER_URL}/applications")
 
@@ -463,6 +1105,7 @@ bootstrap:
       APP_PAYLOAD='{
         "name": "OpenChoreo CLI",
         "description": "OpenChoreo CLI Default Application",
+        "logo_url": "https://cdn.statically.io/gh/openchoreo/openchoreo.github.io@main/static/img/openchoreo-logo.png",
         "allowed_user_types": ["openchoreo-user"],
         "assertion": {
           "validity_period": 3600
@@ -521,7 +1164,7 @@ bootstrap:
               }
             }
           }
-        ]
+        ]'${THEME_FIELD}'
       }'
 
       if [ -n "$app_id" ]; then


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2788

This pull request enhances the bootstrap process for Thunder by introducing a custom "OpenChoreo" theme and integrating it with the default applications. The changes ensure that the theme is created if it doesn't already exist, and then both the "Backstage" and "OpenChoreo CLI" applications are updated to use this theme and display the OpenChoreo logo.

Theme creation and integration:

* Added a new bootstrap script (`49-openchoreo-theme.sh`) to create the "OpenChoreo" theme in Thunder if it doesn't already exist, including detailed theme configuration for both light and dark modes.
* Updated application bootstrap scripts to look up the "OpenChoreo" theme ID and associate it with the "Backstage" and "OpenChoreo CLI" applications via the `theme_id` field. [[1]](diffhunk://#diff-c4b907e368465b200ecb1826632157f721c53fed4c50e22961d0389909598695R291-R300) [[2]](diffhunk://#diff-c4b907e368465b200ecb1826632157f721c53fed4c50e22961d0389909598695L302-R371) [[3]](diffhunk://#diff-c4b907e368465b200ecb1826632157f721c53fed4c50e22961d0389909598695R524-R533) [[4]](diffhunk://#diff-c4b907e368465b200ecb1826632157f721c53fed4c50e22961d0389909598695L521-R602)

Branding improvements:

* Added the OpenChoreo logo URL to both the "Backstage" and "OpenChoreo CLI" application payloads for improved branding. [[1]](diffhunk://#diff-c4b907e368465b200ecb1826632157f721c53fed4c50e22961d0389909598695R309) [[2]](diffhunk://#diff-c4b907e368465b200ecb1826632157f721c53fed4c50e22961d0389909598695R542)