### PR TITLE
test: add pipeline component tests and migrate test schemas to OpenAPIv3

### DIFF
--- a/internal/pipeline/component/context/builder_test.go
+++ b/internal/pipeline/component/context/builder_test.go
@@ -46,8 +46,13 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      replicas: "integer | default=1"
-      image: "string"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
+        image:
+          type: string
 `,
 			envSettingsYAML: `
 apiVersion: choreo.dev/v1alpha1
@@ -124,10 +129,18 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      cpu: "string | default=100m"
+      type: object
+      properties:
+        cpu:
+          type: string
+          default: 100m
   environmentConfigs:
     openAPIV3Schema:
-      replicas: "integer | default=1"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
 `,
 			envSettingsYAML: `
 apiVersion: choreo.dev/v1alpha1
@@ -388,7 +401,10 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      database: "string"
+      type: object
+      properties:
+        database:
+          type: string
 `,
 			componentYAML: `
 apiVersion: choreo.dev/v1alpha1
@@ -478,10 +494,17 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      database: "string"
+      type: object
+      properties:
+        database:
+          type: string
   environmentConfigs:
     openAPIV3Schema:
-      size: "string | default=small"
+      type: object
+      properties:
+        size:
+          type: string
+          default: small
 `,
 			componentYAML: `
 apiVersion: choreo.dev/v1alpha1

--- a/internal/pipeline/component/context/component_test.go
+++ b/internal/pipeline/component/context/component_test.go
@@ -1,0 +1,789 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// validMetadata returns a MetadataContext that satisfies all "required" validation tags.
+func validMetadata() MetadataContext {
+	return MetadataContext{
+		Name:               "comp-dev-12345678",
+		Namespace:          "dp-ns",
+		ComponentName:      "comp",
+		ComponentUID:       "uid-comp",
+		ComponentNamespace: "cp-ns",
+		ProjectName:        "proj",
+		ProjectUID:         "uid-proj",
+		DataPlaneName:      "dp",
+		DataPlaneUID:       "uid-dp",
+		EnvironmentName:    "dev",
+		EnvironmentUID:     "uid-env",
+		Labels:             map[string]string{},
+		Annotations:        map[string]string{},
+		PodSelectors:       map[string]string{"app": "comp"},
+	}
+}
+
+// minimalDataPlane returns a DataPlane with no optional fields.
+func minimalDataPlane() *v1alpha1.DataPlane {
+	return &v1alpha1.DataPlane{
+		Spec: v1alpha1.DataPlaneSpec{},
+	}
+}
+
+// minimalEnvironment returns an Environment with no gateway config.
+func minimalEnvironment() *v1alpha1.Environment {
+	return &v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{},
+	}
+}
+
+// openAPIV3Schema builds a SchemaSection from a proper OpenAPI v3 schema map.
+// Example: openAPIV3Schema(map[string]any{"type": "object", "properties": map[string]any{...}})
+func openAPIV3Schema(schema map[string]any) *v1alpha1.SchemaSection {
+	raw, _ := json.Marshal(schema)
+	return &v1alpha1.SchemaSection{
+		OpenAPIV3Schema: &runtime.RawExtension{Raw: raw},
+	}
+}
+
+// integerPropSchema returns an OpenAPI v3 property schema for an integer field.
+func integerPropSchema(opts ...any) map[string]any {
+	prop := map[string]any{"type": "integer"}
+	if len(opts) > 0 {
+		prop["default"] = opts[0]
+	}
+	return prop
+}
+
+// stringPropSchema returns an OpenAPI v3 property schema for a string field.
+func stringPropSchema(opts ...any) map[string]any {
+	prop := map[string]any{"type": "string"}
+	if len(opts) > 0 {
+		prop["default"] = opts[0]
+	}
+	return prop
+}
+
+// objectSchema wraps properties into a full OpenAPI v3 object schema.
+func objectSchema(properties map[string]any) map[string]any {
+	return map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+}
+
+// rawParams builds a *runtime.RawExtension from a map.
+func rawParams(m map[string]any) *runtime.RawExtension {
+	raw, _ := json.Marshal(m)
+	return &runtime.RawExtension{Raw: raw}
+}
+
+// --- BuildComponentContext validation tests ---
+
+func TestBuildComponentContext_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *ComponentContextInput
+	}{
+		{
+			name: "nil Component",
+			input: &ComponentContextInput{
+				Component:     nil,
+				ComponentType: &v1alpha1.ComponentType{},
+				DataPlane:     minimalDataPlane(),
+				Environment:   minimalEnvironment(),
+				Metadata:      validMetadata(),
+			},
+		},
+		{
+			name: "nil ComponentType",
+			input: &ComponentContextInput{
+				Component:     &v1alpha1.Component{},
+				ComponentType: nil,
+				DataPlane:     minimalDataPlane(),
+				Environment:   minimalEnvironment(),
+				Metadata:      validMetadata(),
+			},
+		},
+		{
+			name: "nil DataPlane",
+			input: &ComponentContextInput{
+				Component:     &v1alpha1.Component{},
+				ComponentType: &v1alpha1.ComponentType{},
+				DataPlane:     nil,
+				Environment:   minimalEnvironment(),
+				Metadata:      validMetadata(),
+			},
+		},
+		{
+			name: "nil Environment",
+			input: &ComponentContextInput{
+				Component:     &v1alpha1.Component{},
+				ComponentType: &v1alpha1.ComponentType{},
+				DataPlane:     minimalDataPlane(),
+				Environment:   nil,
+				Metadata:      validMetadata(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := BuildComponentContext(tt.input)
+			require.Error(t, err)
+			assert.Nil(t, ctx)
+			assert.Contains(t, err.Error(), "validation failed")
+		})
+	}
+}
+
+func TestBuildComponentContext_NilMetadataMaps(t *testing.T) {
+	input := &ComponentContextInput{
+		Component:     &v1alpha1.Component{},
+		ComponentType: &v1alpha1.ComponentType{},
+		DataPlane:     minimalDataPlane(),
+		Environment:   minimalEnvironment(),
+		Metadata: MetadataContext{
+			Name:               "comp-dev-12345678",
+			Namespace:          "dp-ns",
+			ComponentName:      "comp",
+			ComponentUID:       "uid-comp",
+			ComponentNamespace: "cp-ns",
+			ProjectName:        "proj",
+			ProjectUID:         "uid-proj",
+			DataPlaneName:      "dp",
+			DataPlaneUID:       "uid-dp",
+			EnvironmentName:    "dev",
+			EnvironmentUID:     "uid-env",
+			Labels:             nil,
+			Annotations:        nil,
+			PodSelectors:       map[string]string{"app": "comp"},
+		},
+	}
+
+	// The validator will reject nil Labels/Annotations because they have `validate:"required"`.
+	// We need to check that the validation accepts them or that after passing they get initialized.
+	// Since PodSelectors has `validate:"required,min=1"` and Labels/Annotations have `validate:"required"`,
+	// nil maps should fail validation.
+	_, err := BuildComponentContext(input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation failed")
+
+	// Now test with empty maps (which pass validation) — verify they remain initialized
+	input.Metadata.Labels = map[string]string{}
+	input.Metadata.Annotations = map[string]string{}
+	ctx, err := BuildComponentContext(input)
+	require.NoError(t, err)
+	assert.NotNil(t, ctx.Metadata.Labels)
+	assert.NotNil(t, ctx.Metadata.Annotations)
+	assert.NotNil(t, ctx.Metadata.PodSelectors)
+}
+
+// --- processComponentParameters tests ---
+
+func TestProcessComponentParameters_InvalidSchema(t *testing.T) {
+	input := &ComponentContextInput{
+		Component: &v1alpha1.Component{},
+		ComponentType: &v1alpha1.ComponentType{
+			Spec: v1alpha1.ComponentTypeSpec{
+				Parameters: &v1alpha1.SchemaSection{
+					OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(`{"type": "object", "properties": "invalid"}`)},
+				},
+			},
+		},
+		DataPlane:   minimalDataPlane(),
+		Environment: minimalEnvironment(),
+		Metadata:    validMetadata(),
+	}
+
+	ctx, err := BuildComponentContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "schema")
+}
+
+func TestProcessComponentParameters_InvalidJSON(t *testing.T) {
+	input := &ComponentContextInput{
+		Component: &v1alpha1.Component{
+			Spec: v1alpha1.ComponentSpec{
+				Parameters: &runtime.RawExtension{Raw: []byte(`{invalid json}`)},
+			},
+		},
+		ComponentType: &v1alpha1.ComponentType{
+			Spec: v1alpha1.ComponentTypeSpec{
+				Parameters: openAPIV3Schema(objectSchema(map[string]any{
+					"replicas": integerPropSchema(),
+				})),
+			},
+		},
+		DataPlane:   minimalDataPlane(),
+		Environment: minimalEnvironment(),
+		Metadata:    validMetadata(),
+	}
+
+	ctx, err := BuildComponentContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "parameters")
+}
+
+func TestProcessComponentParameters_ValidationFailure(t *testing.T) {
+	// Schema expects integer, but we provide a string value
+	input := &ComponentContextInput{
+		Component: &v1alpha1.Component{
+			Spec: v1alpha1.ComponentSpec{
+				Parameters: rawParams(map[string]any{"replicas": "not-an-integer"}),
+			},
+		},
+		ComponentType: &v1alpha1.ComponentType{
+			Spec: v1alpha1.ComponentTypeSpec{
+				Parameters: openAPIV3Schema(objectSchema(map[string]any{
+					"replicas": integerPropSchema(),
+				})),
+			},
+		},
+		DataPlane:   minimalDataPlane(),
+		Environment: minimalEnvironment(),
+		Metadata:    validMetadata(),
+	}
+
+	ctx, err := BuildComponentContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "validation failed")
+}
+
+func TestProcessComponentParameters_NoSchema(t *testing.T) {
+	input := &ComponentContextInput{
+		Component:     &v1alpha1.Component{},
+		ComponentType: &v1alpha1.ComponentType{},
+		DataPlane:     minimalDataPlane(),
+		Environment:   minimalEnvironment(),
+		Metadata:      validMetadata(),
+	}
+
+	ctx, err := BuildComponentContext(input)
+	require.NoError(t, err)
+	assert.Empty(t, ctx.Parameters)
+	assert.Empty(t, ctx.EnvironmentConfigs)
+}
+
+func TestProcessComponentParameters_PruneAndDefault(t *testing.T) {
+	// Schema defines "replicas" (integer, default=1), "image" (string), and "protocol" (string, default="TCP").
+	// Component provides "image" and "extra" but omits "replicas" and "protocol" — those should get defaults.
+	input := &ComponentContextInput{
+		Component: &v1alpha1.Component{
+			Spec: v1alpha1.ComponentSpec{
+				Parameters: rawParams(map[string]any{
+					"image": "myapp:v1",
+					"extra": "should-be-pruned",
+				}),
+			},
+		},
+		ComponentType: &v1alpha1.ComponentType{
+			Spec: v1alpha1.ComponentTypeSpec{
+				Parameters: openAPIV3Schema(objectSchema(map[string]any{
+					"replicas": integerPropSchema(1),
+					"image":    stringPropSchema(),
+					"protocol": stringPropSchema("TCP"),
+				})),
+			},
+		},
+		DataPlane:   minimalDataPlane(),
+		Environment: minimalEnvironment(),
+		Metadata:    validMetadata(),
+	}
+
+	ctx, err := BuildComponentContext(input)
+	require.NoError(t, err)
+	// extra key should be pruned
+	_, hasExtra := ctx.Parameters["extra"]
+	assert.False(t, hasExtra, "extra key should be pruned")
+	// provided values should remain
+	assert.Equal(t, "myapp:v1", ctx.Parameters["image"])
+	// omitted fields should get schema defaults
+	assert.Equal(t, int64(1), ctx.Parameters["replicas"])
+	assert.Equal(t, "TCP", ctx.Parameters["protocol"])
+}
+
+// --- extractDataPlaneData tests ---
+
+func TestExtractDataPlaneData_Full(t *testing.T) {
+	dp := &v1alpha1.DataPlane{
+		Spec: v1alpha1.DataPlaneSpec{
+			SecretStoreRef: &v1alpha1.SecretStoreRef{
+				Name: "my-secret-store",
+			},
+			ObservabilityPlaneRef: &v1alpha1.ObservabilityPlaneRef{
+				Kind: v1alpha1.ObservabilityPlaneRefKindClusterObservabilityPlane,
+				Name: "cluster-obs",
+			},
+			Gateway: v1alpha1.GatewaySpec{
+				Ingress: &v1alpha1.GatewayNetworkSpec{
+					External: &v1alpha1.GatewayEndpointSpec{
+						Name:      "ext-gw",
+						Namespace: "gw-ns",
+						HTTPS: &v1alpha1.GatewayListenerSpec{
+							ListenerName: "https",
+							Port:         443,
+							Host:         "api.example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data := extractDataPlaneData(dp)
+	assert.Equal(t, "my-secret-store", data.SecretStore)
+	require.NotNil(t, data.ObservabilityPlaneRef)
+	assert.Equal(t, "ClusterObservabilityPlane", data.ObservabilityPlaneRef.Kind)
+	assert.Equal(t, "cluster-obs", data.ObservabilityPlaneRef.Name)
+	require.NotNil(t, data.Gateway)
+	require.NotNil(t, data.Gateway.Ingress)
+	require.NotNil(t, data.Gateway.Ingress.External)
+	assert.Equal(t, "ext-gw", data.Gateway.Ingress.External.Name)
+	require.NotNil(t, data.Gateway.Ingress.External.HTTPS)
+	assert.Equal(t, "api.example.com", data.Gateway.Ingress.External.HTTPS.Host)
+	assert.Equal(t, int32(443), data.Gateway.Ingress.External.HTTPS.Port)
+}
+
+func TestExtractDataPlaneData_Minimal(t *testing.T) {
+	dp := minimalDataPlane()
+	data := extractDataPlaneData(dp)
+	assert.Empty(t, data.SecretStore)
+	assert.Nil(t, data.ObservabilityPlaneRef)
+	assert.Nil(t, data.Gateway)
+}
+
+// --- toGatewayData tests ---
+
+func TestToGatewayData_Full(t *testing.T) {
+	gw := &v1alpha1.GatewaySpec{
+		Ingress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      "ingress-gw",
+				Namespace: "gw-ns",
+			},
+		},
+		Egress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      "egress-gw",
+				Namespace: "gw-ns",
+			},
+		},
+	}
+
+	data := toGatewayData(gw)
+	require.NotNil(t, data)
+	require.NotNil(t, data.Ingress)
+	require.NotNil(t, data.Ingress.External)
+	assert.Equal(t, "ingress-gw", data.Ingress.External.Name)
+	require.NotNil(t, data.Egress)
+	require.NotNil(t, data.Egress.External)
+	assert.Equal(t, "egress-gw", data.Egress.External.Name)
+}
+
+func TestToGatewayData_NilInput(t *testing.T) {
+	data := toGatewayData(nil)
+	assert.Nil(t, data)
+}
+
+func TestToGatewayData_EmptySpec(t *testing.T) {
+	// GatewaySpec with neither Ingress nor Egress should return nil
+	gw := &v1alpha1.GatewaySpec{}
+	data := toGatewayData(gw)
+	assert.Nil(t, data)
+}
+
+// --- toGatewayNetworkData tests ---
+
+func TestToGatewayNetworkData_Full(t *testing.T) {
+	network := &v1alpha1.GatewayNetworkSpec{
+		External: &v1alpha1.GatewayEndpointSpec{
+			Name:      "ext-gw",
+			Namespace: "gw-ns",
+		},
+		Internal: &v1alpha1.GatewayEndpointSpec{
+			Name:      "int-gw",
+			Namespace: "gw-ns",
+		},
+	}
+
+	data := toGatewayNetworkData(network)
+	require.NotNil(t, data)
+	require.NotNil(t, data.External)
+	assert.Equal(t, "ext-gw", data.External.Name)
+	require.NotNil(t, data.Internal)
+	assert.Equal(t, "int-gw", data.Internal.Name)
+}
+
+func TestToGatewayNetworkData_Nil(t *testing.T) {
+	data := toGatewayNetworkData(nil)
+	assert.Nil(t, data)
+}
+
+// --- toGatewayEndpointData tests ---
+
+func TestToGatewayEndpointData_Full(t *testing.T) {
+	ep := &v1alpha1.GatewayEndpointSpec{
+		Name:      "gw",
+		Namespace: "gw-ns",
+		HTTP: &v1alpha1.GatewayListenerSpec{
+			ListenerName: "http-listener",
+			Port:         80,
+			Host:         "http.example.com",
+		},
+		HTTPS: &v1alpha1.GatewayListenerSpec{
+			ListenerName: "https-listener",
+			Port:         443,
+			Host:         "https.example.com",
+		},
+		TLS: &v1alpha1.GatewayListenerSpec{
+			ListenerName: "tls-listener",
+			Port:         8443,
+			Host:         "tls.example.com",
+		},
+	}
+
+	data := toGatewayEndpointData(ep)
+	require.NotNil(t, data)
+	assert.Equal(t, "gw", data.Name)
+	assert.Equal(t, "gw-ns", data.Namespace)
+
+	require.NotNil(t, data.HTTP)
+	assert.Equal(t, "http-listener", data.HTTP.ListenerName)
+	assert.Equal(t, int32(80), data.HTTP.Port)
+	assert.Equal(t, "http.example.com", data.HTTP.Host)
+
+	require.NotNil(t, data.HTTPS)
+	assert.Equal(t, "https-listener", data.HTTPS.ListenerName)
+	assert.Equal(t, int32(443), data.HTTPS.Port)
+	assert.Equal(t, "https.example.com", data.HTTPS.Host)
+
+	require.NotNil(t, data.TLS)
+	assert.Equal(t, "tls-listener", data.TLS.ListenerName)
+	assert.Equal(t, int32(8443), data.TLS.Port)
+	assert.Equal(t, "tls.example.com", data.TLS.Host)
+}
+
+func TestToGatewayEndpointData_Nil(t *testing.T) {
+	data := toGatewayEndpointData(nil)
+	assert.Nil(t, data)
+}
+
+func TestToGatewayEndpointData_PartialListeners(t *testing.T) {
+	// Only HTTP listener set, HTTPS and TLS are nil
+	ep := &v1alpha1.GatewayEndpointSpec{
+		Name:      "gw",
+		Namespace: "gw-ns",
+		HTTP: &v1alpha1.GatewayListenerSpec{
+			ListenerName: "http",
+			Port:         80,
+			Host:         "api.example.com",
+		},
+	}
+
+	data := toGatewayEndpointData(ep)
+	require.NotNil(t, data)
+	require.NotNil(t, data.HTTP)
+	assert.Equal(t, int32(80), data.HTTP.Port)
+	assert.Nil(t, data.HTTPS)
+	assert.Nil(t, data.TLS)
+}
+
+// --- extractEnvironmentData / mergeGatewayData tests ---
+
+func TestExtractEnvironmentData_GatewayMerge(t *testing.T) {
+	// Environment overrides dp ingress external; dp provides ingress internal as fallback
+	dp := &v1alpha1.DataPlane{
+		Spec: v1alpha1.DataPlaneSpec{
+			Gateway: v1alpha1.GatewaySpec{
+				Ingress: &v1alpha1.GatewayNetworkSpec{
+					External: &v1alpha1.GatewayEndpointSpec{
+						Name:      "dp-ext-gw",
+						Namespace: "dp-ns",
+						HTTPS: &v1alpha1.GatewayListenerSpec{
+							ListenerName: "dp-https",
+							Port:         443,
+							Host:         "dp.example.com",
+						},
+					},
+					Internal: &v1alpha1.GatewayEndpointSpec{
+						Name:      "dp-int-gw",
+						Namespace: "dp-ns",
+						HTTP: &v1alpha1.GatewayListenerSpec{
+							ListenerName: "dp-http",
+							Port:         80,
+							Host:         "internal.dp.example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	env := &v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			Gateway: v1alpha1.GatewaySpec{
+				Ingress: &v1alpha1.GatewayNetworkSpec{
+					External: &v1alpha1.GatewayEndpointSpec{
+						Name:      "env-ext-gw",
+						Namespace: "env-ns",
+						HTTPS: &v1alpha1.GatewayListenerSpec{
+							ListenerName: "env-https",
+							Port:         443,
+							Host:         "env.example.com",
+						},
+					},
+					// Internal not set in env -> should fall back to dp
+				},
+			},
+		},
+	}
+
+	data := extractEnvironmentData(env, dp, "slack-channel")
+	require.NotNil(t, data.Gateway)
+	require.NotNil(t, data.Gateway.Ingress)
+
+	// External should come from env (env wins)
+	require.NotNil(t, data.Gateway.Ingress.External)
+	assert.Equal(t, "env-ext-gw", data.Gateway.Ingress.External.Name)
+	assert.Equal(t, "env.example.com", data.Gateway.Ingress.External.HTTPS.Host)
+
+	// Internal should fall back to dp
+	require.NotNil(t, data.Gateway.Ingress.Internal)
+	assert.Equal(t, "dp-int-gw", data.Gateway.Ingress.Internal.Name)
+
+	assert.Equal(t, "slack-channel", data.DefaultNotificationChannel)
+}
+
+func TestMergeGatewayData_BothNil(t *testing.T) {
+	data := mergeGatewayData(nil, nil)
+	assert.Nil(t, data)
+}
+
+// --- mergeGatewayNetworkData tests ---
+
+func TestMergeGatewayNetworkData_Fallback(t *testing.T) {
+	envNetwork := &v1alpha1.GatewayNetworkSpec{
+		External: &v1alpha1.GatewayEndpointSpec{
+			Name:      "env-ext",
+			Namespace: "env-ns",
+		},
+	}
+	dpNetwork := &v1alpha1.GatewayNetworkSpec{
+		Internal: &v1alpha1.GatewayEndpointSpec{
+			Name:      "dp-int",
+			Namespace: "dp-ns",
+		},
+	}
+
+	data := mergeGatewayNetworkData(envNetwork, dpNetwork)
+	require.NotNil(t, data)
+	require.NotNil(t, data.External)
+	assert.Equal(t, "env-ext", data.External.Name)
+	require.NotNil(t, data.Internal)
+	assert.Equal(t, "dp-int", data.Internal.Name)
+}
+
+func TestMergeGatewayNetworkData_BothNil(t *testing.T) {
+	data := mergeGatewayNetworkData(nil, nil)
+	assert.Nil(t, data)
+}
+
+func TestMergeGatewayNetworkData_EnvWins(t *testing.T) {
+	envNetwork := &v1alpha1.GatewayNetworkSpec{
+		External: &v1alpha1.GatewayEndpointSpec{
+			Name:      "env-ext",
+			Namespace: "env-ns",
+		},
+	}
+	dpNetwork := &v1alpha1.GatewayNetworkSpec{
+		External: &v1alpha1.GatewayEndpointSpec{
+			Name:      "dp-ext",
+			Namespace: "dp-ns",
+		},
+	}
+
+	data := mergeGatewayNetworkData(envNetwork, dpNetwork)
+	require.NotNil(t, data)
+	require.NotNil(t, data.External)
+	// env external should take precedence over dp external
+	assert.Equal(t, "env-ext", data.External.Name)
+	assert.Equal(t, "env-ns", data.External.Namespace)
+}
+
+// --- ExtractWorkloadData tests ---
+
+func TestExtractWorkloadData_WithEndpoints(t *testing.T) {
+	workload := &v1alpha1.Workload{
+		Spec: v1alpha1.WorkloadSpec{
+			WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+				Container: v1alpha1.Container{
+					Image:   "myapp:v1",
+					Command: []string{"/bin/app"},
+					Args:    []string{"--port=8080"},
+				},
+				Endpoints: map[string]v1alpha1.WorkloadEndpoint{
+					"http-ep": {
+						DisplayName: "HTTP Endpoint",
+						Type:        v1alpha1.EndpointTypeHTTP,
+						Port:        8080,
+						TargetPort:  9090,
+						BasePath:    "/api",
+						Visibility:  []v1alpha1.EndpointVisibility{v1alpha1.EndpointVisibilityExternal, v1alpha1.EndpointVisibilityProject},
+						Schema: &v1alpha1.Schema{
+							Type:    "openapi",
+							Content: "spec-content",
+						},
+					},
+					"grpc-ep": {
+						Type:       v1alpha1.EndpointTypeGRPC,
+						Port:       9090,
+						Visibility: []v1alpha1.EndpointVisibility{v1alpha1.EndpointVisibilityNamespace},
+					},
+				},
+			},
+		},
+	}
+
+	data := ExtractWorkloadData(workload)
+
+	// Container
+	assert.Equal(t, "myapp:v1", data.Container.Image)
+	assert.Equal(t, []string{"/bin/app"}, data.Container.Command)
+	assert.Equal(t, []string{"--port=8080"}, data.Container.Args)
+
+	// HTTP endpoint
+	httpEp, ok := data.Endpoints["http-ep"]
+	require.True(t, ok)
+	assert.Equal(t, "HTTP Endpoint", httpEp.DisplayName)
+	assert.Equal(t, int32(8080), httpEp.Port)
+	assert.Equal(t, int32(9090), httpEp.TargetPort)
+	assert.Equal(t, "/api", httpEp.BasePath)
+	assert.Equal(t, "HTTP", httpEp.Type)
+	require.NotNil(t, httpEp.Schema)
+	assert.Equal(t, "openapi", httpEp.Schema.Type)
+	assert.Equal(t, "spec-content", httpEp.Schema.Content)
+
+	// Visibility dedup: "project" always included first, then "external" added (duplicate "project" removed)
+	assert.Equal(t, "project", httpEp.Visibility[0])
+	assert.Contains(t, httpEp.Visibility, "external")
+	// Should not have duplicate "project"
+	projectCount := 0
+	for _, v := range httpEp.Visibility {
+		if v == "project" {
+			projectCount++
+		}
+	}
+	assert.Equal(t, 1, projectCount, "project should appear exactly once")
+
+	// gRPC endpoint: targetPort should fall back to port
+	grpcEp, ok := data.Endpoints["grpc-ep"]
+	require.True(t, ok)
+	assert.Equal(t, int32(9090), grpcEp.Port)
+	assert.Equal(t, int32(9090), grpcEp.TargetPort, "targetPort should fall back to port when 0")
+	assert.Equal(t, "gRPC", grpcEp.Type)
+	assert.Nil(t, grpcEp.Schema)
+
+	// gRPC visibility: project always first, then namespace
+	assert.Equal(t, "project", grpcEp.Visibility[0])
+	assert.Contains(t, grpcEp.Visibility, "namespace")
+}
+
+func TestExtractWorkloadData_NilWorkload(t *testing.T) {
+	data := ExtractWorkloadData(nil)
+	assert.NotNil(t, data.Endpoints, "Endpoints map should be initialized, not nil")
+	assert.Empty(t, data.Endpoints)
+	assert.Empty(t, data.Container.Image)
+}
+
+// --- extractParameters tests ---
+
+func TestExtractParameters_NilRaw(t *testing.T) {
+	result, err := extractParameters(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestExtractParameters_EmptyRaw(t *testing.T) {
+	// RawExtension with nil Raw bytes
+	raw := &runtime.RawExtension{Raw: nil}
+	result, err := extractParameters(raw)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestExtractParameters_InvalidJSON(t *testing.T) {
+	raw := &runtime.RawExtension{Raw: []byte(`{bad json`)}
+	result, err := extractParameters(raw)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestExtractParameters_ValidJSON(t *testing.T) {
+	raw := &runtime.RawExtension{Raw: []byte(`{"replicas":3,"name":"test"}`)}
+	result, err := extractParameters(raw)
+	require.NoError(t, err)
+	assert.Equal(t, float64(3), result["replicas"])
+	assert.Equal(t, "test", result["name"])
+}
+
+// --- BuildStructuralSchemas tests ---
+
+func TestBuildStructuralSchemas_OneSchemaValid(t *testing.T) {
+	input := &SchemaInput{
+		ParametersSchema: openAPIV3Schema(objectSchema(map[string]any{
+			"replicas": integerPropSchema(1),
+		})),
+		EnvironmentConfigsSchema: nil,
+	}
+
+	paramBundle, envBundle, err := BuildStructuralSchemas(input)
+	require.NoError(t, err)
+	require.NotNil(t, paramBundle)
+	assert.NotNil(t, paramBundle.Structural)
+	assert.NotNil(t, paramBundle.JSONSchema)
+	assert.Nil(t, envBundle)
+}
+
+func TestBuildStructuralSchemas_BothNil(t *testing.T) {
+	input := &SchemaInput{
+		ParametersSchema:         nil,
+		EnvironmentConfigsSchema: nil,
+	}
+
+	paramBundle, envBundle, err := BuildStructuralSchemas(input)
+	require.NoError(t, err)
+	assert.Nil(t, paramBundle)
+	assert.Nil(t, envBundle)
+}
+
+func TestBuildStructuralSchemas_InvalidSchema(t *testing.T) {
+	input := &SchemaInput{
+		ParametersSchema: &v1alpha1.SchemaSection{
+			OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(`{"type": "object", "properties": "invalid"}`)},
+		},
+	}
+
+	paramBundle, envBundle, err := BuildStructuralSchemas(input)
+	require.Error(t, err)
+	assert.Nil(t, paramBundle)
+	assert.Nil(t, envBundle)
+	assert.Contains(t, err.Error(), "parameters schema")
+}

--- a/internal/pipeline/component/context/embedded_trait.go
+++ b/internal/pipeline/component/context/embedded_trait.go
@@ -155,6 +155,7 @@ func BuildEmbeddedTraitContext(input *EmbeddedTraitContextInput) (*TraitContext,
 
 	ctx.DataPlane = extractDataPlaneData(input.DataPlane)
 	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane, input.DefaultNotificationChannel)
+	ctx.Gateway = ctx.Environment.Gateway
 	ctx.Workload = input.WorkloadData
 	ctx.Configurations = input.Configurations
 	ctx.Connections = newConnectionsContextData(input.Connections)

--- a/internal/pipeline/component/context/embedded_trait_test.go
+++ b/internal/pipeline/component/context/embedded_trait_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -186,8 +188,16 @@ func TestBuildEmbeddedTraitContext(t *testing.T) {
 	baseTrait.Spec.Parameters = &v1alpha1.SchemaSection{
 		OpenAPIV3Schema: &runtime.RawExtension{
 			Raw: mustMarshalJSON(t, map[string]any{
-				"mountPath": "string",
-				"size":      "string | default=\"5Gi\"",
+				"type": "object",
+				"properties": map[string]any{
+					"mountPath": map[string]any{
+						"type": "string",
+					},
+					"size": map[string]any{
+						"type":    "string",
+						"default": "5Gi",
+					},
+				},
 			}),
 		},
 	}
@@ -249,14 +259,26 @@ func TestBuildEmbeddedTraitContext(t *testing.T) {
 					t.Spec.Parameters = &v1alpha1.SchemaSection{
 						OpenAPIV3Schema: &runtime.RawExtension{
 							Raw: mustMarshalJSON(nil, map[string]any{
-								"format": "string | default=\"json\"",
+								"type": "object",
+								"properties": map[string]any{
+									"format": map[string]any{
+										"type":    "string",
+										"default": "json",
+									},
+								},
 							}),
 						},
 					}
 					t.Spec.EnvironmentConfigs = &v1alpha1.SchemaSection{
 						OpenAPIV3Schema: &runtime.RawExtension{
 							Raw: mustMarshalJSON(nil, map[string]any{
-								"logLevel": "string | default=\"info\"",
+								"type": "object",
+								"properties": map[string]any{
+									"logLevel": map[string]any{
+										"type":    "string",
+										"default": "info",
+									},
+								},
 							}),
 						},
 					}
@@ -289,7 +311,13 @@ func TestBuildEmbeddedTraitContext(t *testing.T) {
 					t.Spec.EnvironmentConfigs = &v1alpha1.SchemaSection{
 						OpenAPIV3Schema: &runtime.RawExtension{
 							Raw: mustMarshalJSON(nil, map[string]any{
-								"logLevel": "string | default=\"info\"",
+								"type": "object",
+								"properties": map[string]any{
+									"logLevel": map[string]any{
+										"type":    "string",
+										"default": "info",
+									},
+								},
 							}),
 						},
 					}
@@ -317,8 +345,17 @@ func TestBuildEmbeddedTraitContext(t *testing.T) {
 					t.Spec.Parameters = &v1alpha1.SchemaSection{
 						OpenAPIV3Schema: &runtime.RawExtension{
 							Raw: mustMarshalJSON(nil, map[string]any{
-								"timeout": "string | default=\"30s\"",
-								"retries": "number | default=3",
+								"type": "object",
+								"properties": map[string]any{
+									"timeout": map[string]any{
+										"type":    "string",
+										"default": "30s",
+									},
+									"retries": map[string]any{
+										"type":    "number",
+										"default": float64(3),
+									},
+								},
 							}),
 						},
 					}
@@ -400,4 +437,267 @@ func mustMarshalJSON(t *testing.T, v any) []byte {
 		panic(err)
 	}
 	return data
+}
+
+// validEmbeddedTraitContextInput returns a minimal valid EmbeddedTraitContextInput for use in tests.
+func validEmbeddedTraitContextInput() *EmbeddedTraitContextInput {
+	trait := &v1alpha1.Trait{}
+	trait.Name = "embedded-trait"
+
+	return &EmbeddedTraitContextInput{
+		Trait:          trait,
+		InstanceName:   "embedded-instance",
+		Component:      &v1alpha1.Component{},
+		WorkloadData:   ExtractWorkloadData(nil),
+		Configurations: ExtractConfigurationsFromWorkload(nil, nil),
+		Metadata:       validMetadata(),
+		DataPlane:      &v1alpha1.DataPlane{},
+		Environment: &v1alpha1.Environment{
+			Spec: v1alpha1.EnvironmentSpec{
+				DataPlaneRef: &v1alpha1.DataPlaneRef{
+					Kind: v1alpha1.DataPlaneRefKindDataPlane,
+					Name: "test-dp",
+				},
+			},
+		},
+	}
+}
+
+func TestResolveEmbeddedTraitBindings_EnvConfigsError(t *testing.T) {
+	engine := template.NewEngineWithOptions(
+		template.WithCELExtensions(CELExtensions()...),
+	)
+
+	embeddedTrait := v1alpha1.ComponentTypeTrait{
+		Name:         "bad-env-trait",
+		InstanceName: "bad-env-1",
+		EnvironmentConfigs: &runtime.RawExtension{
+			Raw: mustMarshalJSON(t, map[string]any{
+				"level": "${invalid.nonexistent.field}",
+			}),
+		},
+	}
+
+	componentContext := map[string]any{
+		"parameters": map[string]any{},
+	}
+
+	_, _, err := ResolveEmbeddedTraitBindings(engine, embeddedTrait, componentContext)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environmentConfigs")
+}
+
+func TestResolveBindings_NilRaw(t *testing.T) {
+	engine := template.NewEngineWithOptions(
+		template.WithCELExtensions(CELExtensions()...),
+	)
+
+	// nil RawExtension
+	result, err := resolveBindings(engine, nil, map[string]any{})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	// Non-nil RawExtension but nil Raw bytes
+	result, err = resolveBindings(engine, &runtime.RawExtension{Raw: nil}, map[string]any{})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestResolveBindings_UnmarshalError(t *testing.T) {
+	engine := template.NewEngineWithOptions(
+		template.WithCELExtensions(CELExtensions()...),
+	)
+
+	raw := &runtime.RawExtension{
+		Raw: []byte(`{invalid json`),
+	}
+
+	result, err := resolveBindings(engine, raw, map[string]any{})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestBuildEmbeddedTraitContext_ValidationError(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *EmbeddedTraitContextInput
+	}{
+		{
+			name: "nil Trait",
+			input: func() *EmbeddedTraitContextInput {
+				in := validEmbeddedTraitContextInput()
+				in.Trait = nil
+				return in
+			}(),
+		},
+		{
+			name: "empty InstanceName",
+			input: func() *EmbeddedTraitContextInput {
+				in := validEmbeddedTraitContextInput()
+				in.InstanceName = ""
+				return in
+			}(),
+		},
+		{
+			name: "nil Component",
+			input: func() *EmbeddedTraitContextInput {
+				in := validEmbeddedTraitContextInput()
+				in.Component = nil
+				return in
+			}(),
+		},
+		{
+			name: "nil DataPlane",
+			input: func() *EmbeddedTraitContextInput {
+				in := validEmbeddedTraitContextInput()
+				in.DataPlane = nil
+				return in
+			}(),
+		},
+		{
+			name: "nil Environment",
+			input: func() *EmbeddedTraitContextInput {
+				in := validEmbeddedTraitContextInput()
+				in.Environment = nil
+				return in
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := BuildEmbeddedTraitContext(tt.input)
+			require.Error(t, err)
+			assert.Nil(t, ctx)
+			assert.Contains(t, err.Error(), "validation failed")
+		})
+	}
+}
+
+func TestBuildEmbeddedTraitContext_NilMetadataMaps(t *testing.T) {
+	// Nil maps fail validation because of validate:"required" tags on MetadataContext.
+	input := validEmbeddedTraitContextInput()
+	input.Metadata.Labels = nil
+	input.Metadata.Annotations = nil
+	input.Metadata.PodSelectors = nil
+
+	ctx, err := BuildEmbeddedTraitContext(input)
+	require.Error(t, err, "nil metadata maps should be rejected by validator")
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "validation failed")
+
+	// When empty maps are provided (passing validation), verify the init code
+	// preserves them as initialized (not nil).
+	input2 := validEmbeddedTraitContextInput()
+	input2.Metadata.Labels = map[string]string{}
+	input2.Metadata.Annotations = map[string]string{}
+	input2.Metadata.PodSelectors = map[string]string{"app": "test"}
+
+	ctx2, err := BuildEmbeddedTraitContext(input2)
+	require.NoError(t, err)
+	require.NotNil(t, ctx2)
+	assert.NotNil(t, ctx2.Metadata.Labels)
+	assert.NotNil(t, ctx2.Metadata.Annotations)
+	assert.NotNil(t, ctx2.Metadata.PodSelectors)
+}
+
+func TestBuildEmbeddedTraitContext_GatewaySet(t *testing.T) {
+	input := validEmbeddedTraitContextInput()
+	input.DataPlane.Spec.Gateway = v1alpha1.GatewaySpec{
+		Ingress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      "ext-gw",
+				Namespace: "gw-ns",
+				HTTPS: &v1alpha1.GatewayListenerSpec{
+					ListenerName: "https",
+					Port:         443,
+					Host:         "api.example.com",
+				},
+			},
+		},
+	}
+
+	ctx, err := BuildEmbeddedTraitContext(input)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	// Gateway should be derived from Environment (which merges with DataPlane)
+	require.NotNil(t, ctx.Gateway, "ctx.Gateway should not be nil when DataPlane has gateway config")
+	assert.Equal(t, ctx.Environment.Gateway, ctx.Gateway,
+		"ctx.Gateway should equal ctx.Environment.Gateway")
+
+	// Verify the gateway data is populated correctly
+	require.NotNil(t, ctx.Gateway.Ingress)
+	require.NotNil(t, ctx.Gateway.Ingress.External)
+	assert.Equal(t, "ext-gw", ctx.Gateway.Ingress.External.Name)
+	require.NotNil(t, ctx.Gateway.Ingress.External.HTTPS)
+	assert.Equal(t, "api.example.com", ctx.Gateway.Ingress.External.HTTPS.Host)
+	assert.Equal(t, int32(443), ctx.Gateway.Ingress.External.HTTPS.Port)
+}
+
+func TestProcessEmbeddedTraitParameters_SchemaError(t *testing.T) {
+	input := validEmbeddedTraitContextInput()
+	input.Trait.Spec.Parameters = &v1alpha1.SchemaSection{
+		OpenAPIV3Schema: &runtime.RawExtension{
+			Raw: []byte(`{"type": "object", "properties": "invalid"}`),
+		},
+	}
+
+	ctx, err := BuildEmbeddedTraitContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "failed to build trait schemas")
+}
+
+func TestProcessEmbeddedTraitParameters_ValidationFailure(t *testing.T) {
+	input := validEmbeddedTraitContextInput()
+	input.Trait.Spec.Parameters = openAPIV3Schema(objectSchema(map[string]any{
+		"count": integerPropSchema(),
+	}))
+	// Provide a string value where integer is expected
+	input.ResolvedParameters = map[string]any{
+		"count": "not-a-number",
+	}
+
+	ctx, err := BuildEmbeddedTraitContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "parameters validation failed")
+}
+
+func TestProcessEmbeddedTraitParameters_PruneAndDefault(t *testing.T) {
+	input := validEmbeddedTraitContextInput()
+	input.Trait.Spec.Parameters = openAPIV3Schema(objectSchema(map[string]any{
+		"name":    stringPropSchema(),
+		"timeout": stringPropSchema("30s"),
+	}))
+	input.Trait.Spec.EnvironmentConfigs = openAPIV3Schema(objectSchema(map[string]any{
+		"replicas": integerPropSchema(1),
+	}))
+
+	// Provide parameters: one valid key, one extra key to be pruned, and omit "timeout" for default
+	input.ResolvedParameters = map[string]any{
+		"name":     "my-app",
+		"extraKey": "should-be-pruned",
+	}
+	// Provide empty environmentConfigs so defaults are applied
+	input.ResolvedEnvironmentConfigs = map[string]any{}
+
+	ctx, err := BuildEmbeddedTraitContext(input)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	// extraKey should be pruned
+	_, hasExtra := ctx.Parameters["extraKey"]
+	assert.False(t, hasExtra, "extraKey should have been pruned from parameters")
+
+	// name should remain
+	assert.Equal(t, "my-app", ctx.Parameters["name"])
+
+	// timeout should get schema default
+	assert.Equal(t, "30s", ctx.Parameters["timeout"])
+
+	// replicas should get schema default (schema defaults produce int64 for integers)
+	assert.Equal(t, int64(1), ctx.EnvironmentConfigs["replicas"])
 }

--- a/internal/pipeline/component/context/trait_unit_test.go
+++ b/internal/pipeline/component/context/trait_unit_test.go
@@ -1,0 +1,266 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// validTraitContextInput returns a minimal valid TraitContextInput for use as a base in tests.
+func validTraitContextInput() *TraitContextInput {
+	trait := &v1alpha1.Trait{}
+	trait.Name = "my-trait"
+
+	return &TraitContextInput{
+		Trait: trait,
+		Instance: v1alpha1.ComponentTrait{
+			Name:         "my-trait",
+			InstanceName: "my-trait-instance",
+		},
+		Component:      &v1alpha1.Component{},
+		WorkloadData:   ExtractWorkloadData(nil),
+		Configurations: ExtractConfigurationsFromWorkload(nil, nil),
+		Metadata:       validMetadata(),
+		DataPlane:      &v1alpha1.DataPlane{},
+		Environment: &v1alpha1.Environment{
+			Spec: v1alpha1.EnvironmentSpec{
+				DataPlaneRef: &v1alpha1.DataPlaneRef{
+					Kind: v1alpha1.DataPlaneRefKindDataPlane,
+					Name: "test-dp",
+				},
+			},
+		},
+	}
+}
+
+func TestBuildTraitContext_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *TraitContextInput
+	}{
+		{
+			name: "nil Trait",
+			input: func() *TraitContextInput {
+				in := validTraitContextInput()
+				in.Trait = nil
+				return in
+			}(),
+		},
+		{
+			name: "nil Component",
+			input: func() *TraitContextInput {
+				in := validTraitContextInput()
+				in.Component = nil
+				return in
+			}(),
+		},
+		{
+			name: "nil DataPlane",
+			input: func() *TraitContextInput {
+				in := validTraitContextInput()
+				in.DataPlane = nil
+				return in
+			}(),
+		},
+		{
+			name: "nil Environment",
+			input: func() *TraitContextInput {
+				in := validTraitContextInput()
+				in.Environment = nil
+				return in
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := BuildTraitContext(tt.input)
+			require.Error(t, err)
+			assert.Nil(t, ctx)
+			assert.Contains(t, err.Error(), "validation failed")
+		})
+	}
+}
+
+func TestBuildTraitContext_EmptyInstanceName(t *testing.T) {
+	input := validTraitContextInput()
+	input.Instance.InstanceName = ""
+
+	ctx, err := BuildTraitContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "trait instance name is required")
+}
+
+func TestBuildTraitContext_NilMetadataMaps(t *testing.T) {
+	// Nil maps fail validation because of validate:"required" tags on MetadataContext.
+	// Verify the validator rejects nil maps.
+	input := validTraitContextInput()
+	input.Metadata.Labels = nil
+	input.Metadata.Annotations = nil
+	input.Metadata.PodSelectors = nil
+
+	ctx, err := BuildTraitContext(input)
+	require.Error(t, err, "nil metadata maps should be rejected by validator")
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "validation failed")
+
+	// When empty maps are provided (passing validation), verify the init code
+	// preserves them as initialized (not nil).
+	input2 := validTraitContextInput()
+	input2.Metadata.Labels = map[string]string{}
+	input2.Metadata.Annotations = map[string]string{}
+	input2.Metadata.PodSelectors = map[string]string{"app": "test"}
+
+	ctx2, err := BuildTraitContext(input2)
+	require.NoError(t, err)
+	require.NotNil(t, ctx2)
+	assert.NotNil(t, ctx2.Metadata.Labels)
+	assert.NotNil(t, ctx2.Metadata.Annotations)
+	assert.NotNil(t, ctx2.Metadata.PodSelectors)
+}
+
+func TestProcessTraitParameters_SchemaError(t *testing.T) {
+	input := validTraitContextInput()
+	// Provide an invalid OpenAPI v3 schema: properties is not an object.
+	input.Trait.Spec.Parameters = &v1alpha1.SchemaSection{
+		OpenAPIV3Schema: &runtime.RawExtension{
+			Raw: []byte(`{"type": "object", "properties": "invalid"}`),
+		},
+	}
+
+	ctx, err := BuildTraitContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "failed to build trait schemas")
+}
+
+func TestProcessTraitParameters_ValidationFailure(t *testing.T) {
+	input := validTraitContextInput()
+	// Schema expects an integer
+	input.Trait.Spec.Parameters = openAPIV3Schema(objectSchema(map[string]any{
+		"count": integerPropSchema(),
+	}))
+	// Provide a string where integer is expected
+	input.Instance.Parameters = &runtime.RawExtension{
+		Raw: toJSON(t, map[string]any{
+			"count": "not-a-number",
+		}),
+	}
+
+	ctx, err := BuildTraitContext(input)
+	require.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "parameters validation failed")
+}
+
+func TestProcessTraitParameters_NoReleaseBinding(t *testing.T) {
+	input := validTraitContextInput()
+	input.ReleaseBinding = nil
+
+	// Set up a trait with environmentConfigs schema so we can verify envConfigs is empty
+	input.Trait.Spec.EnvironmentConfigs = openAPIV3Schema(objectSchema(map[string]any{
+		"replicas": integerPropSchema(1),
+	}))
+
+	ctx, err := BuildTraitContext(input)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+	// With nil ReleaseBinding, envConfigs should get schema defaults applied.
+	// Schema defaults produce int64 values for integer types.
+	assert.Equal(t, map[string]any{"replicas": int64(1)}, ctx.EnvironmentConfigs)
+}
+
+func TestProcessTraitParameters_EnvConfigsMissing(t *testing.T) {
+	input := validTraitContextInput()
+	input.ReleaseBinding = &v1alpha1.ReleaseBinding{
+		Spec: v1alpha1.ReleaseBindingSpec{
+			TraitEnvironmentConfigs: map[string]runtime.RawExtension{
+				"other-instance": {
+					Raw: toJSON(t, map[string]any{"size": "large"}),
+				},
+			},
+		},
+	}
+
+	// Trait has environmentConfigs schema
+	input.Trait.Spec.EnvironmentConfigs = openAPIV3Schema(objectSchema(map[string]any{
+		"size": stringPropSchema("small"),
+	}))
+
+	ctx, err := BuildTraitContext(input)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+	// The instanceName is "my-trait-instance" but ReleaseBinding only has "other-instance",
+	// so envConfigs should be empty map with defaults applied from schema
+	assert.Equal(t, map[string]any{"size": "small"}, ctx.EnvironmentConfigs)
+}
+
+func TestProcessTraitParameters_SchemaCache(t *testing.T) {
+	input := validTraitContextInput()
+
+	// Build valid schemas for both parameters and environmentConfigs and cache them.
+	// Both must be non-nil in the cache — the code rebuilds if either is nil.
+	paramSchema := openAPIV3Schema(objectSchema(map[string]any{
+		"name": stringPropSchema("hello"),
+	}))
+	envConfigSchema := openAPIV3Schema(objectSchema(map[string]any{
+		"level": stringPropSchema("info"),
+	}))
+	cache := make(map[string]*SchemaBundle)
+	paramBundle, _, err := BuildStructuralSchemas(&SchemaInput{
+		ParametersSchema: paramSchema,
+	})
+	require.NoError(t, err)
+	envConfigBundle, _, err := BuildStructuralSchemas(&SchemaInput{
+		ParametersSchema: envConfigSchema,
+	})
+	require.NoError(t, err)
+	cache["my-trait:parameters"] = paramBundle
+	cache["my-trait:environmentConfigs"] = envConfigBundle
+	input.SchemaCache = cache
+
+	// Poison the live trait schema so that rebuilding from scratch would fail.
+	// If the cache is used, this broken schema is never parsed.
+	input.Trait.Spec.Parameters = &v1alpha1.SchemaSection{
+		OpenAPIV3Schema: &runtime.RawExtension{
+			Raw: []byte(`{"type": "object", "properties": "invalid"}`),
+		},
+	}
+
+	ctx, err := BuildTraitContext(input)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	// Default from the cached schema should be applied
+	assert.Equal(t, "hello", ctx.Parameters["name"])
+}
+
+func TestGetCachedSchemaBundle_NilCache(t *testing.T) {
+	result := getCachedSchemaBundle(nil, "any-key")
+	assert.Nil(t, result)
+}
+
+func TestSetCachedSchemaBundle_NilCache(t *testing.T) {
+	// Should not panic
+	bundle := &SchemaBundle{}
+	assert.NotPanics(t, func() {
+		setCachedSchemaBundle(nil, "any-key", bundle)
+	})
+}
+
+// toJSON marshals v to JSON, failing the test on error.
+func toJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}

--- a/internal/pipeline/component/pipeline_test.go
+++ b/internal/pipeline/component/pipeline_test.go
@@ -120,7 +120,10 @@ spec:
     spec:
       parameters:
         openAPIV3Schema:
-          replicas: "integer"
+          type: object
+          properties:
+            replicas:
+              type: integer
       resources:
         - id: deployment
           template:
@@ -169,7 +172,10 @@ spec:
     spec:
       parameters:
         openAPIV3Schema:
-          expose: "boolean"
+          type: object
+          properties:
+            expose:
+              type: boolean
       resources:
         - id: deployment
           template:
@@ -235,7 +241,12 @@ spec:
     spec:
       parameters:
         openAPIV3Schema:
-          secrets: "[]string"
+          type: object
+          properties:
+            secrets:
+              type: array
+              items:
+                type: string
       resources:
         - id: secrets
           forEach: ${parameters.secrets}
@@ -310,7 +321,10 @@ spec:
       spec:
         parameters:
           openAPIV3Schema:
-            database: "string"
+            type: object
+            properties:
+              database:
+                type: string
         creates:
           - template:
               apiVersion: v1
@@ -442,7 +456,10 @@ spec:
     spec:
       parameters:
         openAPIV3Schema:
-          mountPath: "string"
+          type: object
+          properties:
+            mountPath:
+              type: string
       traits:
         - name: storage
           instanceName: app-storage
@@ -462,8 +479,12 @@ spec:
       spec:
         parameters:
           openAPIV3Schema:
-            mountPath: "string"
-            volumeName: "string"
+            type: object
+            properties:
+              mountPath:
+                type: string
+              volumeName:
+                type: string
         creates:
           - template:
               apiVersion: v1
@@ -607,7 +628,10 @@ spec:
     spec:
       parameters:
         openAPIV3Schema:
-          database: "string"
+          type: object
+          properties:
+            database:
+              type: string
       traits:
         - name: monitoring
           instanceName: embedded-mon
@@ -635,7 +659,10 @@ spec:
       spec:
         parameters:
           openAPIV3Schema:
-            database: "string"
+            type: object
+            properties:
+              database:
+                type: string
         creates:
           - template:
               apiVersion: v1
@@ -709,7 +736,10 @@ spec:
     spec:
       parameters:
         openAPIV3Schema:
-          appPort: "integer"
+          type: object
+          properties:
+            appPort:
+              type: integer
       traits:
         - name: service-exposure
           instanceName: expose-1
@@ -729,8 +759,13 @@ spec:
       spec:
         parameters:
           openAPIV3Schema:
-            port: "integer"
-            protocol: "string | default=\"TCP\""
+            type: object
+            properties:
+              port:
+                type: integer
+              protocol:
+                type: string
+                default: TCP
         creates:
           - template:
               apiVersion: v1
@@ -1037,7 +1072,11 @@ func TestPipeline_SchemaValidation(t *testing.T) {
 spec:
   parameters:
     openAPIV3Schema:
-      replicas: integer
+      type: object
+      required: [replicas]
+      properties:
+        replicas:
+          type: integer
   resources:
     - id: deployment
       template: {apiVersion: v1, kind: Pod, metadata: {name: x}}
@@ -1051,7 +1090,11 @@ spec:
 spec:
   environmentConfigs:
     openAPIV3Schema:
-      logLevel: string
+      type: object
+      required: [logLevel]
+      properties:
+        logLevel:
+          type: string
   resources:
     - id: deployment
       template: {apiVersion: v1, kind: Pod, metadata: {name: x}}
@@ -1080,7 +1123,11 @@ spec:
   spec:
     parameters:
       openAPIV3Schema:
-        size: string
+        type: object
+        required: [size]
+        properties:
+          size:
+            type: string
 `,
 			wantErrMsg: "parameters validation failed",
 		},
@@ -1103,7 +1150,11 @@ spec:
   spec:
     environmentConfigs:
       openAPIV3Schema:
-        storageClass: string
+        type: object
+        required: [storageClass]
+        properties:
+          storageClass:
+            type: string
 `,
 			releaseBindingYAML: `spec: {traitEnvironmentConfigs: {vol1: {}}}`,
 			wantErrMsg:         "environmentConfigs validation failed",
@@ -1193,7 +1244,11 @@ func TestPipeline_ValidationRules(t *testing.T) {
 spec:
   parameters:
     openAPIV3Schema:
-      replicas: "integer | default=1"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
   validations:
     - rule: "${parameters.replicas > 0}"
       message: "replicas must be positive"
@@ -1210,7 +1265,11 @@ spec:
 spec:
   parameters:
     openAPIV3Schema:
-      replicas: "integer | default=1"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
   validations:
     - rule: "${parameters.replicas > 5}"
       message: "replicas must be greater than 5"
@@ -1248,7 +1307,11 @@ spec:
   spec:
     parameters:
       openAPIV3Schema:
-        size: "integer | default=1"
+        type: object
+        properties:
+          size:
+            type: integer
+            default: 1
     validations:
       - rule: "${parameters.size > 0}"
         message: "size must be positive"
@@ -1278,7 +1341,11 @@ spec:
   spec:
     parameters:
       openAPIV3Schema:
-        size: "integer | default=1"
+        type: object
+        properties:
+          size:
+            type: integer
+            default: 1
     validations:
       - rule: "${parameters.size > 0}"
         message: "size must be positive"
@@ -1299,8 +1366,14 @@ spec:
 spec:
   parameters:
     openAPIV3Schema:
-      replicas: "integer | default=1"
-      name: "string | default=app"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
+        name:
+          type: string
+          default: app
   validations:
     - rule: "${parameters.replicas > 10}"
       message: "replicas too low"

--- a/internal/pipeline/component/renderer/controlflow_test.go
+++ b/internal/pipeline/component/renderer/controlflow_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/template"
 )
@@ -127,4 +130,56 @@ func TestEvaluateValidationRules(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEvalForEach_EvalError(t *testing.T) {
+	engine := template.NewEngine()
+
+	_, err := EvalForEach(engine, "${nonexistent.list}", "item", map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestEvalForEach_ConversionError(t *testing.T) {
+	engine := template.NewEngine()
+
+	// forEach expression evaluates to an integer, which is not iterable
+	_, err := EvalForEach(engine, "${parameters.count}", "item", map[string]any{
+		"parameters": map[string]any{
+			"count": 42,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "array or map", "error should mention expected types")
+}
+
+func TestEvalForEach_DefaultVarName(t *testing.T) {
+	engine := template.NewEngine()
+
+	ctx := map[string]any{
+		"items": []any{"a", "b"},
+	}
+	// Pass empty varName to use the default "item"
+	contexts, err := EvalForEach(engine, "${items}", "", ctx)
+	require.NoError(t, err)
+	require.Len(t, contexts, 2)
+
+	// Verify the default variable name "item" is used in the context
+	assert.Equal(t, "a", contexts[0]["item"])
+	assert.Equal(t, "b", contexts[1]["item"])
+}
+
+func TestTruncateRule_LongRule(t *testing.T) {
+	// Create a rule string longer than 120 characters
+	longRule := "${" + strings.Repeat("a", 200) + "}"
+	result := truncateRule(longRule, 120)
+	assert.Len(t, []rune(result), 123, "truncated result should be maxLen runes + 3 for '...'")
+	assert.True(t, strings.HasSuffix(result, "..."), "truncated result should end with '...'")
+	assert.True(t, strings.HasPrefix(result, "${"+strings.Repeat("a", 118)), "truncated result should preserve the original prefix")
+}
+
+func TestTruncateRule_ShortRule(t *testing.T) {
+	shortRule := "${parameters.replicas > 0}"
+	result := truncateRule(shortRule, 120)
+	assert.Equal(t, shortRule, result, "short rule should be returned as-is")
 }

--- a/internal/pipeline/component/renderer/renderer_test.go
+++ b/internal/pipeline/component/renderer/renderer_test.go
@@ -4,8 +4,11 @@
 package renderer
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -763,4 +766,148 @@ func TestValidateResource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderResources_IncludeWhenError(t *testing.T) {
+	engine := template.NewEngine()
+	r := NewRenderer(engine)
+
+	templatesYAML := `
+- id: my-service
+  includeWhen: ${nonexistent.field}
+  template:
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service
+`
+	var templates []v1alpha1.ResourceTemplate
+	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
+
+	_, err := r.RenderResources(templates, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "my-service", "error should reference the resource ID")
+	assert.Contains(t, err.Error(), "includeWhen", "error should mention includeWhen")
+}
+
+func TestRenderResources_ForEachError(t *testing.T) {
+	engine := template.NewEngine()
+	r := NewRenderer(engine)
+
+	templatesYAML := `
+- id: my-configmap
+  forEach: ${nonexistent.list}
+  var: item
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${item}
+`
+	var templates []v1alpha1.ResourceTemplate
+	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
+
+	_, err := r.RenderResources(templates, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "my-configmap", "error should reference the resource ID")
+}
+
+func TestRenderResources_TemplateRenderError(t *testing.T) {
+	engine := template.NewEngine()
+	r := NewRenderer(engine)
+
+	templatesYAML := `
+- id: my-deployment
+  template:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ${nonexistent.field}
+`
+	var templates []v1alpha1.ResourceTemplate
+	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
+
+	_, err := r.RenderResources(templates, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "my-deployment", "error should reference the resource ID")
+}
+
+func TestRenderResources_TargetPlane(t *testing.T) {
+	engine := template.NewEngine()
+	r := NewRenderer(engine)
+
+	templatesYAML := `
+- id: deployment
+  targetPlane: dataplane
+  template:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test-app
+- id: observability
+  targetPlane: observabilityplane
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: obs-config
+`
+	var templates []v1alpha1.ResourceTemplate
+	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
+
+	results, err := r.RenderResources(templates, map[string]any{})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "dataplane", results[0].TargetPlane)
+	assert.Equal(t, "observabilityplane", results[1].TargetPlane)
+}
+
+func TestRenderResources_ForEachTargetPlane(t *testing.T) {
+	engine := template.NewEngine()
+	r := NewRenderer(engine)
+
+	templatesYAML := `
+- id: configmap
+  targetPlane: dataplane
+  forEach: ${items}
+  var: item
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${item}
+`
+	var templates []v1alpha1.ResourceTemplate
+	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
+
+	ctx := map[string]any{
+		"items": []any{"cfg1", "cfg2", "cfg3"},
+	}
+	results, err := r.RenderResources(templates, ctx)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	for i, res := range results {
+		assert.Equal(t, "dataplane", res.TargetPlane, "forEach resource at index %d should inherit targetPlane", i)
+	}
+
+	// Verify that each resource also has the correct name
+	names := make([]string, len(results))
+	for i, res := range results {
+		metadata := res.Resource["metadata"].(map[string]any)
+		names[i] = metadata["name"].(string)
+	}
+	assert.ElementsMatch(t, []string{"cfg1", "cfg2", "cfg3"}, names)
+}
+
+func TestShouldInclude_NonBooleanResult(t *testing.T) {
+	engine := template.NewEngine()
+
+	got, err := ShouldInclude(engine, "${parameters.name}", map[string]any{
+		"parameters": map[string]any{
+			"name": "my-app",
+		},
+	})
+	require.Error(t, err)
+	assert.False(t, got)
+	assert.True(t, strings.Contains(err.Error(), "boolean"), "error should mention boolean, got: %s", err.Error())
 }

--- a/internal/pipeline/component/testdata/configurations-and-secrets/snapshot-with-config-helpers.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/snapshot-with-config-helpers.yaml
@@ -12,7 +12,10 @@ spec:
     spec:
       environmentConfigs:
         openAPIV3Schema:
-          replicas: "integer"
+          type: object
+          properties:
+            replicas:
+              type: integer
       resources:
         - id: deployment
           template:

--- a/internal/pipeline/component/testdata/configurations-and-secrets/snapshot.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/snapshot.yaml
@@ -12,7 +12,10 @@ spec:
     spec:
       environmentConfigs:
         openAPIV3Schema:
-          replicas: "integer"
+          type: object
+          properties:
+            replicas:
+              type: integer
       resources:
         - id: deployment
           template:

--- a/internal/pipeline/component/trait/processor_test.go
+++ b/internal/pipeline/component/trait/processor_test.go
@@ -4,9 +4,13 @@
 package trait
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -1344,6 +1348,804 @@ func TestFindTargetResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+// singleDeploymentResourceYAML is a common YAML snippet used across multiple tests.
+const singleDeploymentResourceYAML = `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+`
+
+func TestApplyTraitCreates_ForEach(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: sidecar-trait
+spec:
+  creates:
+    - forEach: ${parameters.sidecars}
+      var: sidecar
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${sidecar.name}-config
+        data:
+          port: ${sidecar.port}
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{
+		"parameters": map[string]any{
+			"sidecars": []any{
+				map[string]any{"name": "envoy", "port": "9901"},
+				map[string]any{"name": "fluentd", "port": "24224"},
+				map[string]any{"name": "otel", "port": "4317"},
+			},
+		},
+	}
+
+	got, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+
+	names := make([]string, len(got))
+	ports := make([]string, len(got))
+	for i, rr := range got {
+		metadata := rr.Resource["metadata"].(map[string]any)
+		names[i] = metadata["name"].(string)
+		data := rr.Resource["data"].(map[string]any)
+		ports[i] = data["port"].(string)
+	}
+	assert.Equal(t, []string{"envoy-config", "fluentd-config", "otel-config"}, names)
+	assert.Equal(t, []string{"9901", "24224", "4317"}, ports)
+}
+
+func TestApplyTraitCreates_ForEachError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: broken-trait
+spec:
+  creates:
+    - forEach: ${nonexistent.field}
+      var: item
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${item}
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	_, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forEach")
+}
+
+func TestApplyTraitCreates_RenderError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: bad-template-trait
+spec:
+  creates:
+    - template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${nonexistent.deeply.nested.field}
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	_, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "render")
+}
+
+func TestApplyTraitCreates_TargetPlane(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: obs-trait
+spec:
+  creates:
+    - targetPlane: observabilityplane
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: metrics-config
+    - targetPlane: dataplane
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: app-config
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	got, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "metrics-config", got[0].Resource["metadata"].(map[string]any)["name"])
+	assert.Equal(t, v1alpha1.TargetPlaneObservabilityPlane, got[0].TargetPlane)
+	assert.Equal(t, "app-config", got[1].Resource["metadata"].(map[string]any)["name"])
+	assert.Equal(t, v1alpha1.TargetPlaneDataPlane, got[1].TargetPlane)
+}
+
+func TestApplyTraitPatches_ForEach(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+    labels: {}
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: label-trait
+spec:
+  patches:
+    - forEach: ${parameters.labels}
+      var: lbl
+      target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: add
+          path: /metadata/labels/${lbl.key}
+          value: ${lbl.value}
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{
+		"parameters": map[string]any{
+			"labels": []any{
+				map[string]any{"key": "env", "value": "prod"},
+				map[string]any{"key": "team", "value": "platform"},
+			},
+		},
+	}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.NoError(t, err)
+
+	labels := resources[0].Resource["metadata"].(map[string]any)["labels"].(map[string]any)
+	assert.Equal(t, "prod", labels["env"])
+	assert.Equal(t, "platform", labels["team"])
+}
+
+func TestApplyTraitPatches_ForEachError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: broken-trait
+spec:
+  patches:
+    - forEach: ${nonexistent.field}
+      var: item
+      target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: add
+          path: /metadata/labels/key
+          value: val
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forEach")
+}
+
+func TestApplyTraitPatches_WhereClause(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web
+    labels:
+      tier: frontend
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: api
+    labels:
+      tier: backend
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: admin
+    labels:
+      tier: frontend
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: frontend-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+        where: ${resource.metadata.labels.tier == "frontend"}
+      operations:
+        - op: add
+          path: /metadata/annotations
+          value:
+            ingress: "true"
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.NoError(t, err)
+
+	// "web" and "admin" should have annotations, "api" should not
+	webMeta := resources[0].Resource["metadata"].(map[string]any)
+	assert.Equal(t, "true", webMeta["annotations"].(map[string]any)["ingress"])
+
+	apiMeta := resources[1].Resource["metadata"].(map[string]any)
+	_, hasAnnotations := apiMeta["annotations"]
+	assert.False(t, hasAnnotations, "backend deployment should not have annotations")
+
+	adminMeta := resources[2].Resource["metadata"].(map[string]any)
+	assert.Equal(t, "true", adminMeta["annotations"].(map[string]any)["ingress"])
+}
+
+func TestApplyTraitPatches_WhereClauseError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: broken-where-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+        where: ${nonexistent.deeply.nested}
+      operations:
+        - op: add
+          path: /metadata/labels/key
+          value: val
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "where clause")
+}
+
+func TestApplyTraitPatches_WhereClauseNonBoolean(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+    labels:
+      tier: frontend
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// where clause evaluates to a string instead of a boolean
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: nonbool-where-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+        where: ${resource.metadata.labels.tier}
+      operations:
+        - op: add
+          path: /metadata/labels/key
+          value: val
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boolean")
+}
+
+func TestApplyTraitPatches_WhereFiltersAll(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+    labels:
+      tier: backend
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Snapshot the resource before patching to verify it is truly unmodified
+	before := deepCopy(resources[0].Resource)
+
+	// where clause matches nothing (looking for frontend, only backend exists)
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: no-match-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+        where: ${resource.metadata.labels.tier == "frontend"}
+      operations:
+        - op: add
+          path: /metadata/annotations
+          value:
+            patched: "true"
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.NoError(t, err)
+
+	// Resource must be completely unmodified
+	if diff := cmp.Diff(before, resources[0].Resource); diff != "" {
+		t.Errorf("resource was modified despite where filtering all targets (-before +after):\n%s", diff)
+	}
+}
+
+func TestApplyTraitPatches_WherePreservesResourceBinding(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+    labels:
+      tier: frontend
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: where-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+        where: ${resource.metadata.labels.tier == "frontend"}
+      operations:
+        - op: add
+          path: /metadata/annotations
+          value:
+            patched: "true"
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	// Set up a context that already has a "resource" key to verify it's preserved
+	existingResourceValue := map[string]any{"existing": "data"}
+	ctx := map[string]any{
+		"resource": existingResourceValue,
+	}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.NoError(t, err)
+
+	// Verify the original "resource" binding is preserved/restored after filtering
+	assert.Equal(t, existingResourceValue, ctx["resource"], "original resource binding should be preserved after where clause evaluation")
+}
+
+func TestApplyTraitPatches_NoMatchingResources(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: my-svc
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Patch targets Deployment but only a Service exists
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: noop-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: add
+          path: /metadata/labels/key
+          value: val
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	before := deepCopy(resources[0].Resource)
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.NoError(t, err, "patching with no matching resources should be a no-op")
+
+	if diff := cmp.Diff(before, resources[0].Resource); diff != "" {
+		t.Errorf("resource was modified despite no matching targets (-before +after):\n%s", diff)
+	}
+}
+
+func TestApplyTraitPatches_PatchApplyError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := `
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: my-deploy
+`
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Use "replace" on a nonexistent path to trigger an error in patch application
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: bad-patch-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: replace
+          path: /spec/nonexistent/deeply/nested/path
+          value: broken
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Deployment/my-deploy")
+}
+
+func TestRenderOperations_PathError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Path references a nonexistent variable
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: bad-path-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: add
+          path: /metadata/labels/${nonexistent.var}
+          value: something
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path")
+}
+
+func TestRenderOperations_NonStringPath(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Path evaluates to an integer instead of a string
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: int-path-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: add
+          path: ${parameters.pathVal}
+          value: something
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{
+		"parameters": map[string]any{
+			"pathVal": 42,
+		},
+	}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "string")
+}
+
+func TestRenderOperations_ValueUnmarshalError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Construct a trait programmatically with invalid Value.Raw bytes
+	trait := v1alpha1.Trait{}
+	trait.Name = "bad-value-trait"
+	trait.Spec.Patches = []v1alpha1.TraitPatch{
+		{
+			Target: v1alpha1.PatchTarget{
+				Kind:    "Deployment",
+				Version: "v1",
+				Group:   "apps",
+			},
+			Operations: []v1alpha1.JSONPatchOperation{
+				{
+					Op:    "add",
+					Path:  "/metadata/labels/key",
+					Value: &runtime.RawExtension{Raw: []byte("not valid json {{{")},
+				},
+			},
+		},
+	}
+
+	ctx := map[string]any{}
+
+	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestRenderOperations_ValueRenderError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Construct a trait with a value containing invalid CEL
+	valueJSON, err := json.Marshal("${nonexistent.deeply.nested}")
+	require.NoError(t, err)
+
+	trait := v1alpha1.Trait{}
+	trait.Name = "bad-cel-trait"
+	trait.Spec.Patches = []v1alpha1.TraitPatch{
+		{
+			Target: v1alpha1.PatchTarget{
+				Kind:    "Deployment",
+				Version: "v1",
+				Group:   "apps",
+			},
+			Operations: []v1alpha1.JSONPatchOperation{
+				{
+					Op:    "add",
+					Path:  "/metadata/labels/key",
+					Value: &runtime.RawExtension{Raw: valueJSON},
+				},
+			},
+		},
+	}
+
+	ctx := map[string]any{}
+
+	err = processor.ApplyTraitPatches(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "render value")
+}
+
+func TestProcessTraits_CreatesError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Create a trait with a broken creates template (references nonexistent variable)
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: broken-creates-trait
+spec:
+  creates:
+    - template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${nonexistent.deeply.nested}
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	_, err := processor.ProcessTraits(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "render")
+}
+
+func TestProcessTraits_PatchesError(t *testing.T) {
+	engine := template.NewEngine()
+	processor := NewProcessor(engine)
+
+	resourcesYAML := singleDeploymentResourceYAML
+	var resourceMaps []map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(resourcesYAML), &resourceMaps))
+	resources := toRenderedResources(resourceMaps)
+
+	// Create a trait with valid creates but broken patches (references nonexistent variable in path)
+	traitYAML := `
+apiVersion: choreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: broken-patches-trait
+spec:
+  patches:
+    - target:
+        kind: Deployment
+        version: v1
+        group: apps
+      operations:
+        - op: add
+          path: /metadata/labels/${nonexistent.field}
+          value: something
+`
+	var trait v1alpha1.Trait
+	require.NoError(t, yaml.Unmarshal([]byte(traitYAML), &trait))
+
+	ctx := map[string]any{}
+
+	_, err := processor.ProcessTraits(resources, &trait, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path")
 }
 
 // Helper functions

--- a/internal/pipeline/workflow/pipeline_test.go
+++ b/internal/pipeline/workflow/pipeline_test.go
@@ -1929,9 +1929,20 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 				Spec: v1alpha1.WorkflowSpec{
 					Parameters: &v1alpha1.SchemaSection{
 						OpenAPIV3Schema: mustRawExtension(t, map[string]any{
-							"branch":   "string | default=main",
-							"replicas": "integer | default=1",
-							"repo":     "string",
+							"type": "object",
+							"properties": map[string]any{
+								"branch": map[string]any{
+									"type":    "string",
+									"default": "main",
+								},
+								"replicas": map[string]any{
+									"type":    "integer",
+									"default": int64(1),
+								},
+								"repo": map[string]any{
+									"type": "string",
+								},
+							},
 						}),
 					},
 					RunTemplate: mustRawExtension(t, map[string]any{
@@ -1973,6 +1984,10 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 		repoParam := params[1].(map[string]any)
 		if repoParam["value"] != testRepoURL {
 			t.Errorf("expected repo value, got %v", repoParam["value"])
+		}
+		replicasParam := params[2].(map[string]any)
+		if replicasParam["value"] != int64(1) {
+			t.Errorf("expected replicas default 1, got %v", replicasParam["value"])
 		}
 	})
 

--- a/internal/scaffold/component/generator_test.go
+++ b/internal/scaffold/component/generator_test.go
@@ -215,17 +215,8 @@ func validateComponentParameters(t *testing.T, params map[string]any, componentT
 		return
 	}
 
-	// Convert schema to JSONSchema
-	paramsMap, err := rawExtensionToMap(componentType.Spec.Parameters.GetRaw())
-	if err != nil {
-		t.Fatalf("failed to convert ComponentType parameters: %v", err)
-	}
-
-	def := schema.Definition{
-		Schemas: []map[string]any{paramsMap},
-	}
-
-	jsonSchema, err := schema.ToJSONSchema(def)
+	// Convert schema to JSONSchema using OpenAPI v3 path (schemas are now in proper OpenAPI v3 format)
+	jsonSchema, err := schema.SectionToJSONSchema(componentType.Spec.Parameters)
 	if err != nil {
 		t.Fatalf("failed to convert to JSON schema: %v", err)
 	}
@@ -265,17 +256,8 @@ func validateTraitParameters(t *testing.T, traitsSection []any, traits []*corev1
 			continue
 		}
 
-		// Convert trait schema to JSONSchema
-		paramsMap, err := rawExtensionToMap(trait.Spec.Parameters.GetRaw())
-		if err != nil {
-			t.Fatalf("failed to convert Trait %s parameters: %v", traitName, err)
-		}
-
-		def := schema.Definition{
-			Schemas: []map[string]any{paramsMap},
-		}
-
-		jsonSchema, err := schema.ToJSONSchema(def)
+		// Convert trait schema to JSONSchema using OpenAPI v3 path
+		jsonSchema, err := schema.SectionToJSONSchema(trait.Spec.Parameters)
 		if err != nil {
 			t.Fatalf("failed to convert Trait %s to JSON schema: %v", traitName, err)
 		}
@@ -301,17 +283,8 @@ func validateWorkflowParameters(t *testing.T, workflowSection map[string]any, wo
 		return
 	}
 
-	// Convert workflow schema to JSONSchema
-	paramsMap, err := rawExtensionToMap(workflow.Spec.Parameters.GetRaw())
-	if err != nil {
-		t.Fatalf("failed to convert Workflow parameters: %v", err)
-	}
-
-	def := schema.Definition{
-		Schemas: []map[string]any{paramsMap},
-	}
-
-	jsonSchema, err := schema.ToJSONSchema(def)
+	// Convert workflow schema to JSONSchema using OpenAPI v3 path
+	jsonSchema, err := schema.SectionToJSONSchema(workflow.Spec.Parameters)
 	if err != nil {
 		t.Fatalf("failed to convert Workflow to JSON schema: %v", err)
 	}

--- a/internal/scaffold/component/schema_analyzer.go
+++ b/internal/scaffold/component/schema_analyzer.go
@@ -4,10 +4,7 @@
 package component
 
 import (
-	"encoding/json"
-
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // GetFieldTypeOrder returns the sort order for a field type.
@@ -32,17 +29,4 @@ func GetFieldTypeOrder(prop extv1.JSONSchemaProps) int {
 	default:
 		return 6 // unknown types last
 	}
-}
-
-// rawExtensionToMap converts a runtime.RawExtension to map[string]any.
-func rawExtensionToMap(ext *runtime.RawExtension) (map[string]any, error) {
-	if ext == nil || len(ext.Raw) == 0 {
-		return nil, nil
-	}
-
-	var result map[string]any
-	if err := json.Unmarshal(ext.Raw, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
 }

--- a/internal/scaffold/component/testdata/array_scaffolding_input.yaml
+++ b/internal/scaffold/component/testdata/array_scaffolding_input.yaml
@@ -12,31 +12,95 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      $types:
-        EnvVar:
-          name: string
-          value: 'string | description="Environment variable value"'
-          valueFrom:
-            secretKeyRef:
-              name: string
-              key: string
-        Endpoint:
-          name: 'string | description="Endpoint name"'
-          port: 'integer | description="Port number"'
-          protocol: string | enum=http,https,grpc | default=http
-          path: string | default=/
-      # Simple scalar arrays
-      tags: '[]string | description="Resource tags"'
-      ports: '[]integer'
+      type: object
+      required:
+        - tags
+        - ports
+        - env
+        - endpoints
+      properties:
+        # Simple scalar arrays
+        tags:
+          type: array
+          description: "Resource tags"
+          items:
+            type: string
+        ports:
+          type: array
+          items:
+            type: integer
 
-      # Array of objects with multiple fields
-      env: '[]EnvVar | description="Environment variables"'
+        # Array of objects with multiple fields
+        env:
+          type: array
+          description: "Environment variables"
+          items:
+            type: object
+            required:
+              - name
+              - value
+              - valueFrom
+            properties:
+              name:
+                type: string
+              value:
+                type: string
+                description: "Environment variable value"
+              valueFrom:
+                type: object
+                required:
+                  - secretKeyRef
+                properties:
+                  secretKeyRef:
+                    type: object
+                    required:
+                      - name
+                      - key
+                    properties:
+                      name:
+                        type: string
+                      key:
+                        type: string
 
-      # Array of objects with different field types
-      endpoints: '[]Endpoint | description="Service endpoints"'
+        # Array of objects with different field types
+        endpoints:
+          type: array
+          description: "Service endpoints"
+          items:
+            type: object
+            required:
+              - name
+              - port
+            properties:
+              name:
+                type: string
+                description: "Endpoint name"
+              port:
+                type: integer
+                description: "Port number"
+              protocol:
+                type: string
+                enum:
+                  - http
+                  - https
+                  - grpc
+                default: "http"
+              path:
+                type: string
+                default: "/"
 
-      # Optional array with default
-      extraLabels: '[]string | default=["app", "service"]'
+        # Optional array with default
+        extraLabels:
+          type: array
+          default:
+            - "app"
+            - "service"
+          items:
+            type: string
 
-      # Optional array with empty default
-      customAnnotations: '[]string | default=[]'
+        # Optional array with empty default
+        customAnnotations:
+          type: array
+          default: []
+          items:
+            type: string

--- a/internal/scaffold/component/testdata/basic_types_input.yaml
+++ b/internal/scaffold/component/testdata/basic_types_input.yaml
@@ -12,6 +12,22 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      port: 'integer | description="Container port"'
-      replicas: 'integer | default=2 description="Number of pod replicas"'
-      protocol: 'string | enum=http,https,grpc description="Service protocol"'
+      type: object
+      required:
+        - port
+        - protocol
+      properties:
+        port:
+          type: integer
+          description: "Container port"
+        replicas:
+          type: integer
+          default: 2
+          description: "Number of pod replicas"
+        protocol:
+          type: string
+          enum:
+            - http
+            - https
+            - grpc
+          description: "Service protocol"

--- a/internal/scaffold/component/testdata/collection_shapes_input.yaml
+++ b/internal/scaffold/component/testdata/collection_shapes_input.yaml
@@ -12,38 +12,203 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      $types:
-        EndpointConfig:
-          host: string
-          port: integer
-          protocol: string
-        ServiceConfig:
-          name: string
-          enabled: boolean
-          endpoints: '[]EndpointConfig'
-      # []map<T> - Array of maps with primitive values
-      envMappings: '[]map<string> | description="Array of maps with string values"'
-      portMappings: '[]map<integer> | description="Array of maps with integer values"'
-      featureSets: '[]map<boolean> | description="Array of maps with boolean values"'
+      type: object
+      required:
+        - envMappings
+        - portMappings
+        - featureSets
+        - endpoints
+        - tagGroups
+        - portGroups
+        - serviceGroups
+        - services
+      properties:
+        # []map<T> - Array of maps with primitive values
+        envMappings:
+          type: array
+          description: "Array of maps with string values"
+          items:
+            type: object
+            additionalProperties:
+              type: string
+        portMappings:
+          type: array
+          description: "Array of maps with integer values"
+          items:
+            type: object
+            additionalProperties:
+              type: integer
+        featureSets:
+          type: array
+          description: "Array of maps with boolean values"
+          items:
+            type: object
+            additionalProperties:
+              type: boolean
 
-      # []map<CustomType> - Array of maps with custom type values
-      endpoints: '[]map<EndpointConfig> | description="Array of maps with custom type values"'
+        # []map<CustomType> - Array of maps with custom type values
+        endpoints:
+          type: array
+          description: "Array of maps with custom type values"
+          items:
+            type: object
+            additionalProperties:
+              type: object
+              required:
+                - host
+                - port
+                - protocol
+              properties:
+                host:
+                  type: string
+                port:
+                  type: integer
+                protocol:
+                  type: string
 
-      # map<[]T> - Map of arrays with primitives
-      tagGroups: 'map<[]string> | description="Map of arrays with string values"'
-      portGroups: 'map<[]integer> | description="Map of arrays with integer values"'
+        # map<[]T> - Map of arrays with primitives
+        tagGroups:
+          type: object
+          description: "Map of arrays with string values"
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        portGroups:
+          type: object
+          description: "Map of arrays with integer values"
+          additionalProperties:
+            type: array
+            items:
+              type: integer
 
-      # map<[]CustomType> - Map of arrays with custom type objects
-      serviceGroups: 'map<[]ServiceConfig> | description="Map of arrays with ServiceConfig objects"'
+        # map<[]CustomType> - Map of arrays with custom type objects
+        serviceGroups:
+          type: object
+          description: "Map of arrays with ServiceConfig objects"
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              required:
+                - enabled
+                - endpoints
+                - name
+              properties:
+                name:
+                  type: string
+                enabled:
+                  type: boolean
+                endpoints:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - host
+                      - port
+                      - protocol
+                    properties:
+                      host:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
 
-      # map<CustomType> - Map with custom type that includes array of objects
-      services: 'map<ServiceConfig> | description="Map of services where ServiceConfig includes array of endpoints"'
+        # map<CustomType> - Map with custom type that includes array of objects
+        services:
+          type: object
+          description: "Map of services where ServiceConfig includes array of endpoints"
+          additionalProperties:
+            type: object
+            required:
+              - enabled
+              - endpoints
+              - name
+            properties:
+              name:
+                type: string
+              enabled:
+                type: boolean
+              endpoints:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - host
+                    - port
+                    - protocol
+                  properties:
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
 
-      # Optional variants with defaults
-      defaultEnvMappings: '[]map<string> | default=[{"DEBUG": "true", "LOG_LEVEL": "info"}, {"CACHE_TTL": "300"}] description="Optional []map with default"'
-      defaultTagGroups: 'map<[]string> | default={"app": ["web", "api"], "env": ["prod"]} description="Optional map<[]T> with default"'
-      customMappings: '[]map<string> | default=[] description="Optional []map with empty default"'
-      customGroups: 'map<[]string> | default={} description="Optional map<[]T> with empty default"'
+        # Optional variants with defaults
+        defaultEnvMappings:
+          type: array
+          description: "Optional []map with default"
+          default:
+            - DEBUG: "true"
+              LOG_LEVEL: "info"
+            - CACHE_TTL: "300"
+          items:
+            type: object
+            additionalProperties:
+              type: string
+        defaultTagGroups:
+          type: object
+          description: "Optional map<[]T> with default"
+          default:
+            app:
+              - "web"
+              - "api"
+            env:
+              - "prod"
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        customMappings:
+          type: array
+          description: "Optional []map with empty default"
+          default: []
+          items:
+            type: object
+            additionalProperties:
+              type: string
+        customGroups:
+          type: object
+          description: "Optional map<[]T> with empty default"
+          default: {}
+          additionalProperties:
+            type: array
+            items:
+              type: string
 
-      # []CustomType with default - tests that array of objects preserves structure (not stringified)
-      defaultEndpoints: '[]EndpointConfig | default=[{"host": "api.example.com", "port": 8080, "protocol": "https"}, {"host": "metrics.example.com", "port": 9090, "protocol": "http"}] description="Optional []CustomType with default"'
+        # []CustomType with default - tests that array of objects preserves structure (not stringified)
+        defaultEndpoints:
+          type: array
+          description: "Optional []CustomType with default"
+          default:
+            - host: "api.example.com"
+              port: 8080
+              protocol: "https"
+            - host: "metrics.example.com"
+              port: 9090
+              protocol: "http"
+          items:
+            type: object
+            required:
+              - host
+              - port
+              - protocol
+            properties:
+              host:
+                type: string
+              port:
+                type: integer
+              protocol:
+                type: string

--- a/internal/scaffold/component/testdata/escaping_quoting_input.yaml
+++ b/internal/scaffold/component/testdata/escaping_quoting_input.yaml
@@ -12,13 +12,63 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      environment: 'string | enum="development environment","staging environment","production environment" description="Enum with spaces in values"'
-      logFormat: 'string | enum=json,text,"key=value pairs" description="Enum with special characters"'
-      greeting: 'string | default="Hello, World!" description="Default with comma and exclamation"'
-      timeFormat: 'string | default="HH:mm:ss" description="Default with colons (YAML special)"'
-      queryTemplate: 'string | default="SELECT * FROM \"users\" WHERE status = ''active''" description="Default with quotes inside"'
-      trueFalseString: 'string | default="true" description="Boolean-like string that needs quoting"'
-      zipCode: 'string | default="00123" description="Number-like string with leading zeros"'
-      multiline: 'string | default="line1\\nline2" description="Default with escaped newline"'
-      specialTags: '[]string | default=["tag:value", "key=pair", "with spaces"] description="Array with special string values"'
-      specialLabels: 'map<string> | default={"app.kubernetes.io/name": "my-app", "version": "1.0.0"} description="Map with special key format"'
+      type: object
+      required:
+        - environment
+        - logFormat
+      properties:
+        environment:
+          type: string
+          enum:
+            - "development environment"
+            - "staging environment"
+            - "production environment"
+          description: "Enum with spaces in values"
+        logFormat:
+          type: string
+          enum:
+            - json
+            - text
+            - "key=value pairs"
+          description: "Enum with special characters"
+        greeting:
+          type: string
+          default: "Hello, World!"
+          description: "Default with comma and exclamation"
+        timeFormat:
+          type: string
+          default: "HH:mm:ss"
+          description: "Default with colons (YAML special)"
+        queryTemplate:
+          type: string
+          default: "SELECT * FROM \"users\" WHERE status = 'active'"
+          description: "Default with quotes inside"
+        trueFalseString:
+          type: string
+          default: "true"
+          description: "Boolean-like string that needs quoting"
+        zipCode:
+          type: string
+          default: "00123"
+          description: "Number-like string with leading zeros"
+        multiline:
+          type: string
+          default: "line1\\nline2"
+          description: "Default with escaped newline"
+        specialTags:
+          type: array
+          default:
+            - "tag:value"
+            - "key=pair"
+            - "with spaces"
+          description: "Array with special string values"
+          items:
+            type: string
+        specialLabels:
+          type: object
+          default:
+            app.kubernetes.io/name: my-app
+            version: 1.0.0
+          description: "Map with special key format"
+          additionalProperties:
+            type: string

--- a/internal/scaffold/component/testdata/map_scaffolding_input.yaml
+++ b/internal/scaffold/component/testdata/map_scaffolding_input.yaml
@@ -12,28 +12,69 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      $types:
-        # Custom type for testing map<CustomType>
-        ServiceConfig:
-          endpoint: string
-          port: 'integer | minimum=1 maximum=65535'
-          enabled: 'boolean | default=true'
-          timeout: 'integer | default=30 minimum=1'
+      type: object
+      required:
+        - labels
+        - ports
+        - featureFlags
+        - services
+      properties:
+        # Map with string values (required)
+        labels:
+          type: object
+          description: "Resource labels"
+          additionalProperties:
+            type: string
 
-      # Map with string values (required)
-      labels: 'map<string> | description="Resource labels"'
+        # Map with integer values (required)
+        ports:
+          type: object
+          description: "Named port mappings"
+          additionalProperties:
+            type: integer
 
-      # Map with integer values (required)
-      ports: 'map<integer> | description="Named port mappings"'
+        # Map with boolean values (required)
+        featureFlags:
+          type: object
+          description: "Feature toggle flags"
+          additionalProperties:
+            type: boolean
 
-      # Map with boolean values (required)
-      featureFlags: 'map<boolean> | description="Feature toggle flags"'
+        # Map with custom type values (required)
+        services:
+          type: object
+          description: "Service configurations"
+          additionalProperties:
+            type: object
+            required:
+              - endpoint
+              - port
+            properties:
+              endpoint:
+                type: string
+              port:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              enabled:
+                type: boolean
+                default: true
+              timeout:
+                type: integer
+                default: 30
+                minimum: 1
 
-      # Map with custom type values (required)
-      services: 'map<ServiceConfig> | description="Service configurations"'
+        # Optional map with default
+        annotations:
+          type: object
+          default:
+            app.kubernetes.io/name: my-app
+          additionalProperties:
+            type: string
 
-      # Optional map with default
-      annotations: 'map<string> | default={"app.kubernetes.io/name": "my-app"}'
-
-      # Optional map with empty default
-      customMetadata: 'map<string> | default={}'
+        # Optional map with empty default
+        customMetadata:
+          type: object
+          default: {}
+          additionalProperties:
+            type: string

--- a/internal/scaffold/component/testdata/minimal_comments_false_input.yaml
+++ b/internal/scaffold/component/testdata/minimal_comments_false_input.yaml
@@ -12,4 +12,10 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      port: 'integer | description="Container port"'
+      type: object
+      required:
+        - port
+      properties:
+        port:
+          type: integer
+          description: "Container port"

--- a/internal/scaffold/component/testdata/minimal_comments_true_input.yaml
+++ b/internal/scaffold/component/testdata/minimal_comments_true_input.yaml
@@ -12,4 +12,10 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      port: 'integer | description="Container port"'
+      type: object
+      required:
+        - port
+      properties:
+        port:
+          type: integer
+          description: "Container port"

--- a/internal/scaffold/component/testdata/object_defaults_input.yaml
+++ b/internal/scaffold/component/testdata/object_defaults_input.yaml
@@ -13,117 +13,236 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      $types:
-        # Type with $default - all children have defaults
-        Monitoring:
-          $default: {}
-          enabled: 'boolean | default=false'
-          port: 'integer | default=9090'
-          path: 'string | default=/metrics'
+      type: object
+      required:
+        - endpoint
+        - logging
+        - resources
+        - retryPolicy
+        - service
+        - timeouts
+      properties:
+        # Case 1: Inline object with default, all children have defaults
+        cache:
+          type: object
+          default: {}
+          properties:
+            enabled:
+              type: boolean
+              default: false
+            ttl:
+              type: integer
+              default: 300
+            maxSize:
+              type: integer
+              default: 1000
 
-        # Type with $default - all children have defaults
-        Database:
-          $default: {}
-          host: 'string | default=localhost'
-          port: 'integer | default=5432'
-          ssl: 'boolean | default=true'
+        # Case 2: Inline object with default, all children have defaults
+        storage:
+          type: object
+          default: {}
+          properties:
+            type:
+              type: string
+              default: "persistent"
+            size:
+              type: string
+              default: "10Gi"
+            class:
+              type: string
+              default: "standard"
 
-        # Type without $default - all children have defaults
-        Timeouts:
-          connect: 'integer | default=5'
-          read: 'integer | default=30'
-          write: 'integer | default=30'
+        # Case 3: Inline object without default, all children have defaults
+        retryPolicy:
+          type: object
+          properties:
+            attempts:
+              type: integer
+              default: 3
+            backoff:
+              type: integer
+              default: 1000
+            maxBackoff:
+              type: integer
+              default: 30000
 
-        # Type without $default - has required children
-        ResourceLimits:
-          cpu: string  # required
-          memory: string  # required
-          storage: 'string | default=10Gi'
+        # Case 4: Inline object without default, has required children
+        service:
+          type: object
+          required:
+            - name
+            - port
+          properties:
+            name:
+              type: string
+            port:
+              type: integer
+            protocol:
+              type: string
+              default: "http"
 
-      # Case 1: Inline object with $default, all children have defaults
-      cache:
-        $default: {}
-        enabled: 'boolean | default=false'
-        ttl: 'integer | default=300'
-        maxSize: 'integer | default=1000'
+        # Case 5: Inline object without default, has required children
+        endpoint:
+          type: object
+          required:
+            - host
+            - port
+          properties:
+            host:
+              type: string
+            port:
+              type: integer
+            protocol:
+              type: string
+              default: "https"
 
-      # Case 2: Inline object with $default, all children have defaults
-      storage:
-        $default: {}
-        type: 'string | default=persistent'
-        size: 'string | default=10Gi'
-        class: 'string | default=standard'
+        # Case 6: Reference to type with default, all children have defaults
+        monitoring:
+          type: object
+          default: {}
+          properties:
+            enabled:
+              type: boolean
+              default: false
+            port:
+              type: integer
+              default: 9090
+            path:
+              type: string
+              default: "/metrics"
 
-      # Case 3: Inline object without $default, all children have defaults
-      retryPolicy:
-        attempts: 'integer | default=3'
-        backoff: 'integer | default=1000'
-        maxBackoff: 'integer | default=30000'
+        # Case 7: Reference to type with default, all children have defaults
+        database:
+          type: object
+          default: {}
+          properties:
+            host:
+              type: string
+              default: "localhost"
+            port:
+              type: integer
+              default: 5432
+            ssl:
+              type: boolean
+              default: true
 
-      # Case 4: Inline object without $default, has required children
-      service:
-        name: string  # required
-        port: integer  # required
-        protocol: 'string | default=http'
+        # Case 8: Reference to type without default, all children have defaults
+        timeouts:
+          type: object
+          properties:
+            connect:
+              type: integer
+              default: 5
+            read:
+              type: integer
+              default: 30
+            write:
+              type: integer
+              default: 30
 
-      # Case 5: Inline object without $default, has required children
-      endpoint:
-        host: string  # required
-        port: integer  # required
-        protocol: 'string | default=https'
+        # Case 9: Reference to type without default, has required children
+        resources:
+          type: object
+          required:
+            - cpu
+            - memory
+          properties:
+            cpu:
+              type: string
+            memory:
+              type: string
+            storage:
+              type: string
+              default: "10Gi"
 
-      # Case 6: Reference to type with $default, all children have defaults
-      monitoring: Monitoring
+        # Case 10: Nested objects with mixed defaults
+        logging:
+          type: object
+          required:
+            - format
+          properties:
+            level:
+              type: string
+              default: "info"
+            outputs:
+              type: object
+              default: {}
+              properties:
+                console:
+                  type: boolean
+                  default: true
+                file:
+                  type: boolean
+                  default: false
+                filePath:
+                  type: string
+                  default: "/var/log/app.log"
+            format:
+              type: object
+              properties:
+                type:
+                  type: string
+                  default: "json"
+                timestamp:
+                  type: boolean
+                  default: true
 
-      # Case 7: Reference to type with $default, all children have defaults
-      database: Database
+        # Case 11: Object with non-empty default (should expand, not use {} pattern)
+        config:
+          type: object
+          default:
+            mode: production
+            debug: false
+          properties:
+            mode:
+              type: string
+              default: "development"
+            debug:
+              type: boolean
+              default: true
+            verbose:
+              type: boolean
+              default: false
 
-      # Case 8: Reference to type without $default, all children have defaults
-      timeouts: Timeouts
+        # Case 12: Deep nesting with defaults
+        advanced:
+          type: object
+          default: {}
+          properties:
+            security:
+              type: object
+              default: {}
+              properties:
+                enabled:
+                  type: boolean
+                  default: false
+                maxAttempts:
+                  type: integer
+                  default: 3
+            performance:
+              type: object
+              default: {}
+              properties:
+                caching:
+                  type: object
+                  default: {}
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                    ttl:
+                      type: integer
+                      default: 600
 
-      # Case 9: Reference to type without $default, has required children
-      resources: ResourceLimits
-
-      # Case 10: Nested objects with mixed defaults
-      logging:
-        level: 'string | default=info'
-        outputs:
-          $default: {}
-          console: 'boolean | default=true'
-          file: 'boolean | default=false'
-          filePath: 'string | default=/var/log/app.log'
-        format:
-          type: 'string | default=json'
-          timestamp: 'boolean | default=true'
-
-      # Case 11: Object with non-empty $default (should expand, not use {} pattern)
-      config:
-        $default:
-          mode: production
-          debug: false
-        mode: 'string | default=development'
-        debug: 'boolean | default=true'
-        verbose: 'boolean | default=false'
-
-      # Case 12: Deep nesting with defaults
-      advanced:
-        $default: {}
-        security:
-          $default: {}
-          enabled: 'boolean | default=false'
-          maxAttempts: 'integer | default=3'
-        performance:
-          $default: {}
-          caching:
-            $default: {}
-            enabled: 'boolean | default=false'
-            ttl: 'integer | default=600'
-
-      # Case 13: Optional object with $default where children have no individual defaults
-      # Tests that children render with example values instead of blank
-      connection:
-        $default:
-          host: localhost
-          port: 5432
-        host: string
-        port: integer
+        # Case 13: Optional object with default where children have no individual defaults
+        # Tests that children render with example values instead of blank
+        connection:
+          type: object
+          default:
+            host: localhost
+            port: 5432
+          properties:
+            host:
+              type: string
+            port:
+              type: integer

--- a/internal/scaffold/component/testdata/validation_and_types_input.yaml
+++ b/internal/scaffold/component/testdata/validation_and_types_input.yaml
@@ -12,49 +12,127 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      $types:
-        # Object with $default
-        Monitoring:
-          $default: {}
-          enabled: 'boolean | default=false'
-          port: 'integer | default=9090'
-          interval: 'integer | default=30'
+      type: object
+      required:
+        - enableMetrics
+        - memoryLimit
+        - username
+        - email
+        - region
+        - port
+        - database
+      properties:
+        # Boolean type
+        debug:
+          type: boolean
+          default: false
+        enableMetrics:
+          type: boolean
 
-      # Boolean type
-      debug: 'boolean | default=false'
-      enableMetrics: boolean
+        # Number type (float)
+        cpuThreshold:
+          type: number
+          minimum: 0.1
+          maximum: 1.0
+          default: 0.8
+        memoryLimit:
+          type: number
+          minimum: 0
 
-      # Number type (float)
-      cpuThreshold: 'number | minimum=0.1 maximum=1.0 default=0.8'
-      memoryLimit: 'number | minimum=0'
+        # String with validation constraints
+        username:
+          type: string
+          minLength: 3
+          maxLength: 20
+          pattern: "^[a-z][a-z0-9_]*$"
+        email:
+          type: string
+          format: email
+        region:
+          type: string
+          minLength: 2
+          maxLength: 50
 
-      # String with validation constraints
-      username: 'string | minLength=3 maxLength=20 pattern=^[a-z][a-z0-9_]*$'
-      email: 'string | format=email'
-      region: 'string | minLength=2 maxLength=50'
+        # Integer with validation constraints
+        replicas:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 3
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+        timeout:
+          type: integer
+          minimum: 0
+          maximum: 3600
+          default: 30
 
-      # Integer with validation constraints
-      replicas: 'integer | minimum=1 maximum=100 default=3'
-      port: 'integer | minimum=1 maximum=65535'
-      timeout: 'integer | minimum=0 maximum=3600 default=30'
+        # Nested inline objects
+        database:
+          type: object
+          required:
+            - host
+            - options
+            - username
+            - password
+          properties:
+            host:
+              type: string
+            port:
+              type: integer
+              default: 5432
+              minimum: 1
+              maximum: 65535
+            username:
+              type: string
+            password:
+              type: string
+            options:
+              type: object
+              properties:
+                ssl:
+                  type: boolean
+                  default: true
+                timeout:
+                  type: integer
+                  default: 30
+                  minimum: 1
+                maxConnections:
+                  type: integer
+                  default: 10
+                  minimum: 1
+                  maximum: 1000
 
-      # Nested inline objects
-      database:
-        host: string
-        port: 'integer | default=5432 minimum=1 maximum=65535'
-        username: string
-        password: string
-        options:
-          ssl: 'boolean | default=true'
-          timeout: 'integer | default=30 minimum=1'
-          maxConnections: 'integer | default=10 minimum=1 maximum=1000'
+        # Object with default
+        monitoring:
+          type: object
+          default: {}
+          properties:
+            enabled:
+              type: boolean
+              default: false
+            port:
+              type: integer
+              default: 9090
+            interval:
+              type: integer
+              default: 30
 
-      # Reference to type with $default
-      monitoring: Monitoring
-
-      # Nested object with $default
-      cache:
-        $default: {}
-        enabled: 'boolean | default=false'
-        ttl: 'integer | default=300 minimum=60'
-        maxSize: 'integer | default=1000 minimum=100'
+        # Nested object with default
+        cache:
+          type: object
+          default: {}
+          properties:
+            enabled:
+              type: boolean
+              default: false
+            ttl:
+              type: integer
+              default: 300
+              minimum: 60
+            maxSize:
+              type: integer
+              default: 1000
+              minimum: 100

--- a/internal/scaffold/component/testdata/with_traits_input.yaml
+++ b/internal/scaffold/component/testdata/with_traits_input.yaml
@@ -16,7 +16,12 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      port: "integer"
+      type: object
+      required:
+        - port
+      properties:
+        port:
+          type: integer
 ---
 # Multiple traits to verify deterministic ordering (alphabetical: logging, networking, storage)
 apiVersion: openchoreo.dev/v1alpha1
@@ -26,8 +31,16 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      mountPath: 'string | description="Mount path"'
-      size: string | default=10Gi
+      type: object
+      required:
+        - mountPath
+      properties:
+        mountPath:
+          type: string
+          description: "Mount path"
+        size:
+          type: string
+          default: "10Gi"
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Trait
@@ -36,7 +49,16 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      level: string | enum=debug,info,warn,error | default=info
+      type: object
+      properties:
+        level:
+          type: string
+          enum:
+            - debug
+            - info
+            - warn
+            - error
+          default: "info"
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Trait
@@ -45,4 +67,10 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      ingress: 'boolean | description="Enable ingress"'
+      type: object
+      required:
+        - ingress
+      properties:
+        ingress:
+          type: boolean
+          description: "Enable ingress"

--- a/internal/scaffold/component/testdata/with_workflow_input.yaml
+++ b/internal/scaffold/component/testdata/with_workflow_input.yaml
@@ -13,7 +13,12 @@ spec:
   workloadType: deployment
   parameters:
     openAPIV3Schema:
-      port: "integer"
+      type: object
+      required:
+        - port
+      properties:
+        port:
+          type: integer
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Workflow
@@ -22,6 +27,20 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      context: 'string | default=. description="Docker build context"'
-      dockerfile: 'string | default=./Dockerfile description="Path to Dockerfile"'
-      buildArgs: 'map<string> | description="Build arguments"'
+      type: object
+      required:
+        - buildArgs
+      properties:
+        context:
+          type: string
+          default: "."
+          description: "Docker build context"
+        dockerfile:
+          type: string
+          default: "./Dockerfile"
+          description: "Path to Dockerfile"
+        buildArgs:
+          type: object
+          additionalProperties:
+            type: string
+          description: "Build arguments"

--- a/internal/schema/definition.go
+++ b/internal/schema/definition.go
@@ -9,17 +9,13 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
-	"github.com/openchoreo/openchoreo/internal/clone"
-	"github.com/openchoreo/openchoreo/internal/schema/extractor"
 )
 
 const (
@@ -29,297 +25,74 @@ const (
 	typeArray   = "array"
 )
 
-// Definition represents a schematized object assembled from one or more field maps.
-type Definition struct {
-	Schemas []map[string]any
-	Options extractor.Options
-}
-
 // ResolveSectionToStructural converts a SchemaSection into a Kubernetes structural schema.
 // Returns nil if the section is nil or empty.
 func ResolveSectionToStructural(section *v1alpha1.SchemaSection) (*apiextschema.Structural, error) {
-	raw := sectionRaw(section)
-	if raw == nil || len(raw.Raw) == 0 {
-		return nil, nil
-	}
-
-	fields, err := unmarshalSection(raw)
+	fields, err := unmarshalSectionSchema(section)
 	if err != nil {
 		return nil, err
 	}
-
-	if isOpenAPIV3Content(fields) {
-		return OpenAPIV3ToStructural(fields)
+	if fields == nil {
+		return nil, nil
 	}
-
-	return ToStructural(Definition{Schemas: []map[string]any{fields}})
+	return OpenAPIV3ToStructural(fields)
 }
 
 // ResolveSectionToBundle converts a SchemaSection into both structural and JSON schema formats.
 // Returns nil for both if the section is nil or empty.
 func ResolveSectionToBundle(section *v1alpha1.SchemaSection) (*apiextschema.Structural, *extv1.JSONSchemaProps, error) {
-	raw := sectionRaw(section)
-	if raw == nil || len(raw.Raw) == 0 {
-		return nil, nil, nil
-	}
-
-	fields, err := unmarshalSection(raw)
+	fields, err := unmarshalSectionSchema(section)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if isOpenAPIV3Content(fields) {
-		return OpenAPIV3ToStructuralAndJSONSchema(fields)
+	if fields == nil {
+		return nil, nil, nil
 	}
-
-	return ToStructuralAndJSONSchema(Definition{Schemas: []map[string]any{fields}})
+	return OpenAPIV3ToStructuralAndJSONSchema(fields)
 }
 
 // SectionToJSONSchema converts a SchemaSection to JSON Schema for API responses.
 func SectionToJSONSchema(section *v1alpha1.SchemaSection) (*extv1.JSONSchemaProps, error) {
-	raw := sectionRaw(section)
-	if raw == nil || len(raw.Raw) == 0 {
+	fields, err := unmarshalSectionSchema(section)
+	if err != nil {
+		return nil, err
+	}
+	if fields == nil {
 		return &extv1.JSONSchemaProps{
 			Type:       "object",
 			Properties: map[string]extv1.JSONSchemaProps{},
 		}, nil
 	}
-
-	fields, err := unmarshalSection(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	if isOpenAPIV3Content(fields) {
-		return OpenAPIV3ToJSONSchema(fields)
-	}
-
-	return ToJSONSchema(Definition{Schemas: []map[string]any{fields}})
+	return OpenAPIV3ToJSONSchema(fields)
 }
 
 // SectionToRawJSONSchema converts a SchemaSection to a raw map for API responses.
-// For openAPIV3Schema, this preserves vendor extensions (x-*) that are lost when
-// converting through extv1.JSONSchemaProps.
+// This preserves vendor extensions (x-*) that are lost when converting through extv1.JSONSchemaProps.
 func SectionToRawJSONSchema(section *v1alpha1.SchemaSection) (map[string]any, error) {
-	raw := sectionRaw(section)
-	if raw == nil || len(raw.Raw) == 0 {
+	fields, err := unmarshalSectionSchema(section)
+	if err != nil {
+		return nil, err
+	}
+	if fields == nil {
 		return map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
 		}, nil
 	}
-
-	fields, err := unmarshalSection(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	if isOpenAPIV3Content(fields) {
-		return OpenAPIV3ToResolvedSchema(fields)
-	}
-
-	// For shorthand schema, convert through the extractor and re-marshal to map
-	jsonSchema, err := ToJSONSchema(Definition{Schemas: []map[string]any{fields}})
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonSchemaToMap(jsonSchema)
+	return OpenAPIV3ToResolvedSchema(fields)
 }
 
-// jsonSchemaToMap converts extv1.JSONSchemaProps to a raw map via JSON round-trip.
-func jsonSchemaToMap(schema *extv1.JSONSchemaProps) (map[string]any, error) {
-	data, err := json.Marshal(schema)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal schema: %w", err)
+// unmarshalSectionSchema extracts and unmarshals the OpenAPI v3 schema from a SchemaSection.
+// Returns (nil, nil) if the section is nil or has no schema content.
+func unmarshalSectionSchema(section *v1alpha1.SchemaSection) (map[string]any, error) {
+	if section == nil || section.OpenAPIV3Schema == nil || len(section.OpenAPIV3Schema.Raw) == 0 {
+		return nil, nil
 	}
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal schema to map: %w", err)
-	}
-	return result, nil
-}
-
-// sectionRaw returns the raw extension from a SchemaSection, or nil if empty.
-func sectionRaw(section *v1alpha1.SchemaSection) *runtime.RawExtension {
-	if section == nil {
-		return nil
-	}
-	return section.GetRaw()
-}
-
-// isOpenAPIV3Content determines if unmarshaled fields represent standard OpenAPI V3 JSON Schema
-// or shorthand schema format based on content inspection.
-// Returns true if any top-level key is a structural or compositional JSON Schema keyword that
-// would never appear as a field name in shorthand schemas.
-// This is a temporary bridge for Phase 1 — Phase 2 will remove the shorthand extractor entirely.
-//
-// NOTE: We intentionally exclude generic keywords (type, format, description, default, enum,
-// pattern, title, etc.) because these are valid shorthand field names that would cause
-// misclassification. Only structural/object-level markers that unambiguously indicate
-// OpenAPI V3 content are included.
-func isOpenAPIV3Content(fields map[string]any) bool {
-	if len(fields) == 0 {
-		return true
-	}
-	for key := range fields {
-		if openAPIStructuralKeywords[key] {
-			return true
-		}
-	}
-	// A top-level "type" with value "object" or "array" is unambiguously OpenAPI V3.
-	// In shorthand, these are not valid type descriptors at the root level.
-	if typeVal, ok := fields["type"].(string); ok {
-		if typeVal == "object" || typeVal == "array" {
-			return true
-		}
-	}
-	return false
-}
-
-// openAPIStructuralKeywords contains only structural and compositional JSON Schema keywords
-// that unambiguously indicate OpenAPI V3 content. Generic keywords like "type", "format",
-// "description", "default", "enum", "pattern", etc. are excluded because they can also be
-// valid field names in shorthand schemas (e.g., a field named "format" or "description").
-var openAPIStructuralKeywords = map[string]bool{
-	// Structural keywords — define object/array shape
-	"properties": true, "items": true,
-	"additionalProperties": true, "patternProperties": true,
-	// Composition keywords
-	"allOf": true, "oneOf": true, "anyOf": true, "not": true,
-	// Reference keywords ($ prefix never appears in shorthand field names)
-	"$ref": true, "$defs": true, "$id": true, "$schema": true,
-	// Kubernetes extensions
-	"x-kubernetes-preserve-unknown-fields": true,
-	"x-kubernetes-int-or-string":           true,
-	"x-kubernetes-embedded-resource":       true,
-	"x-kubernetes-validations":             true,
-}
-
-// unmarshalSection unmarshals a raw extension into a field map.
-func unmarshalSection(raw *runtime.RawExtension) (map[string]any, error) {
 	var fields map[string]any
-	if err := yaml.Unmarshal(raw.Raw, &fields); err != nil {
+	if err := json.Unmarshal(section.OpenAPIV3Schema.Raw, &fields); err != nil {
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
 	return fields, nil
-}
-
-// ToJSONSchema converts a schema definition into an OpenAPI v3 JSON schema.
-//
-// This is the primary entry point for converting ComponentType and Trait schemas
-// from the shorthand format into standard JSON Schema that can be used for validation.
-//
-// Process:
-//  1. Merge all schema maps (parameters, environmentConfigs, trait config) into one
-//  2. Convert from shorthand syntax to full JSON Schema via extractor (internal type)
-//  3. Convert from internal to v1 type (for API compatibility and JSON serialization)
-//  4. Sort required fields for deterministic output
-//
-// Example input (shorthand):
-//
-//	schemas: [{replicas: "integer | default=1"}, {environment: "string"}]
-//
-// Example output (JSON Schema):
-//
-//	{type: "object", properties: {replicas: {type: "integer", default: 1}, environment: {type: "string"}}}
-func ToJSONSchema(def Definition) (*extv1.JSONSchemaProps, error) {
-	merged := mergeFieldMaps(def.Schemas)
-	if len(merged) == 0 {
-		return &extv1.JSONSchemaProps{
-			Type:       "object",
-			Properties: map[string]extv1.JSONSchemaProps{},
-		}, nil
-	}
-
-	internalSchema, err := extractor.ExtractSchema(merged, nil, def.Options)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert schema to OpenAPI: %w", err)
-	}
-
-	// Convert from internal to v1 type for API responses (v1 has JSON tags for proper serialization)
-	v1Schema := new(extv1.JSONSchemaProps)
-	if err := extv1.Convert_apiextensions_JSONSchemaProps_To_v1_JSONSchemaProps(internalSchema, v1Schema, nil); err != nil {
-		return nil, fmt.Errorf("failed to convert schema to v1: %w", err)
-	}
-
-	sortRequiredFields(v1Schema)
-	return v1Schema, nil
-}
-
-// ToStructural converts the definition into a Kubernetes structural schema.
-//
-// Structural schemas are a stricter variant of JSON Schema used by Kubernetes for:
-//  1. Server-side validation of CRD instances
-//  2. Defaulting field values based on schema defaults
-//  3. Pruning unknown fields during admission
-//
-// The conversion process:
-//  1. Extract schema using shorthand syntax (returns internal type)
-//  2. Validate and convert to structural format (enforces additional constraints)
-//
-// Structural schema constraints include:
-//   - All objects must have explicit type: "object"
-//   - All arrays must specify item schema
-//   - No x-kubernetes-* extensions in certain contexts
-//
-// This is primarily used with ApplyDefaults to populate default values.
-func ToStructural(def Definition) (*apiextschema.Structural, error) {
-	merged := mergeFieldMaps(def.Schemas)
-	if len(merged) == 0 {
-		emptySchema := &apiext.JSONSchemaProps{
-			Type:       "object",
-			Properties: map[string]apiext.JSONSchemaProps{},
-		}
-		structural, err := apiextschema.NewStructural(emptySchema)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build structural schema: %w", err)
-		}
-		return structural, nil
-	}
-
-	internalSchema, err := extractor.ExtractSchema(merged, nil, def.Options)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert schema to OpenAPI: %w", err)
-	}
-
-	structural, err := apiextschema.NewStructural(internalSchema)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build structural schema: %w", err)
-	}
-	return structural, nil
-}
-
-// ToStructuralAndJSONSchema converts a schema definition to both structural and JSON schema formats.
-// Use this when you need both formats, e.g., for applying defaults (structural) then validating (JSON schema).
-func ToStructuralAndJSONSchema(def Definition) (*apiextschema.Structural, *extv1.JSONSchemaProps, error) {
-	merged := mergeFieldMaps(def.Schemas)
-
-	var internalSchema *apiext.JSONSchemaProps
-	if len(merged) == 0 {
-		internalSchema = &apiext.JSONSchemaProps{
-			Type:       "object",
-			Properties: map[string]apiext.JSONSchemaProps{},
-		}
-	} else {
-		var err error
-		internalSchema, err = extractor.ExtractSchema(merged, nil, def.Options)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert schema to OpenAPI: %w", err)
-		}
-	}
-
-	structural, err := apiextschema.NewStructural(internalSchema)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to build structural schema: %w", err)
-	}
-
-	v1Schema := new(extv1.JSONSchemaProps)
-	if err := extv1.Convert_apiextensions_JSONSchemaProps_To_v1_JSONSchemaProps(internalSchema, v1Schema, nil); err != nil {
-		return nil, nil, fmt.Errorf("failed to convert schema to v1: %w", err)
-	}
-
-	return structural, v1Schema, nil
 }
 
 // ApplyDefaults applies schema default values to a target object using Kubernetes defaulting logic.
@@ -349,66 +122,6 @@ func ApplyDefaults(target map[string]any, structural *apiextschema.Structural) m
 	}
 	defaulting.Default(target, structural)
 	return target
-}
-
-// mergeFieldMaps combines multiple schema maps into a single unified schema.
-//
-// ComponentType separate schemas into logical groups:
-//   - schema.parameters: Component-level configuration
-//   - schema.environmentConfigs: Environment-specific overrides
-//   - schema.traitConfig: Trait instance configuration (for Traits)
-//
-// This function merges them using deep merge semantics so that:
-//  1. Nested objects are merged recursively
-//  2. Later schemas can extend or override earlier ones
-//  3. The result matches how templates access these values (all under ${spec.*})
-//
-// Example:
-//
-//	Input: [{port: "integer"}, {replicas: "integer"}]
-//	Output: {port: "integer", replicas: "integer"}
-func mergeFieldMaps(maps []map[string]any) map[string]any {
-	result := map[string]any{}
-	for _, fields := range maps {
-		mergeInto(result, fields)
-	}
-	return result
-}
-
-// mergeInto recursively merges src into dst, modifying dst in place.
-//
-// Merge behavior:
-//   - If src value is a map and dst has a map at that key: recursively merge
-//   - Otherwise: overwrite dst's value with a deep copy of src's value
-//   - All values are deep copied to avoid shared references
-//
-// This ensures that nested object schemas are properly combined rather than replaced.
-//
-// Example:
-//
-//	dst: {db: {host: "string"}}
-//	src: {db: {port: "integer"}, replicas: "integer"}
-//	Result: {db: {host: "string", port: "integer"}, replicas: "integer"}
-func mergeInto(dst map[string]any, src map[string]any) {
-	if src == nil {
-		return
-	}
-	if dst == nil {
-		// should not happen, but guard anyway
-		return
-	}
-	for k, v := range src {
-		if vMap, ok := v.(map[string]any); ok {
-			existing, ok := dst[k].(map[string]any)
-			if !ok {
-				dst[k] = clone.DeepCopy(vMap)
-				continue
-			}
-			mergeInto(existing, vMap)
-			continue
-		}
-		dst[k] = clone.DeepCopy(v)
-	}
 }
 
 // sortRequiredFields recursively sorts the 'required' arrays in a JSON schema.

--- a/internal/schema/definition_test.go
+++ b/internal/schema/definition_test.go
@@ -22,22 +22,25 @@ const (
 )
 
 func TestApplyDefaults_ArrayFieldBehaviour(t *testing.T) {
-	def := Definition{
-		Schemas: []map[string]any{
-			{
-				"$types": map[string]any{
-					"Item": map[string]any{
-						"name": "string | default=default-name",
+	// Array field without a default value should not be created by defaulting
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"list": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string", "default": "default-name"},
 					},
 				},
-				"list": "[]Item",
 			},
 		},
 	}
 
-	structural, err := ToStructural(def)
+	structural, err := OpenAPIV3ToStructural(schema)
 	if err != nil {
-		t.Fatalf("ToStructural returned error: %v", err)
+		t.Fatalf("OpenAPIV3ToStructural returned error: %v", err)
 	}
 
 	defaults := ApplyDefaults(nil, structural)
@@ -45,22 +48,26 @@ func TestApplyDefaults_ArrayFieldBehaviour(t *testing.T) {
 		t.Fatalf("expected no default array elements when only item defaults are present, got %v", defaults["list"])
 	}
 
-	defWithArrayDefault := Definition{
-		Schemas: []map[string]any{
-			{
-				"$types": map[string]any{
-					"Item": map[string]any{
-						"name": "string | default=default-name",
+	// Array field WITH a default value should be created by defaulting
+	schemaWithDefault := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"list": map[string]any{
+				"type":    "array",
+				"default": []any{map[string]any{"name": "custom"}},
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string", "default": "default-name"},
 					},
 				},
-				"list": "[]Item | default=[{\"name\":\"custom\"}]",
 			},
 		},
 	}
 
-	structural, err = ToStructural(defWithArrayDefault)
+	structural, err = OpenAPIV3ToStructural(schemaWithDefault)
 	if err != nil {
-		t.Fatalf("ToStructural returned error: %v", err)
+		t.Fatalf("OpenAPIV3ToStructural returned error: %v", err)
 	}
 
 	defaults = ApplyDefaults(nil, structural)
@@ -74,26 +81,28 @@ func TestApplyDefaults_ArrayFieldBehaviour(t *testing.T) {
 }
 
 func TestApplyDefaults_ArrayItems(t *testing.T) {
-	def := Definition{
-		Schemas: []map[string]any{
-			{
-				"$types": map[string]any{
-					"MountConfig": map[string]any{
-						"containerName": "string",
-						"mountPath":     "string",
-						"readOnly":      "boolean | default=true",
-						"subPath":       "string | default=\"\"",
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"volumeName": map[string]any{"type": "string"},
+			"mounts": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"containerName": map[string]any{"type": "string"},
+						"mountPath":     map[string]any{"type": "string"},
+						"readOnly":      map[string]any{"type": "boolean", "default": true},
+						"subPath":       map[string]any{"type": "string", "default": ""},
 					},
 				},
-				"volumeName": "string",
-				"mounts":     "[]MountConfig",
 			},
 		},
 	}
 
-	structural, err := ToStructural(def)
+	structural, err := OpenAPIV3ToStructural(schema)
 	if err != nil {
-		t.Fatalf("ToStructural returned error: %v", err)
+		t.Fatalf("OpenAPIV3ToStructural returned error: %v", err)
 	}
 
 	values := map[string]any{
@@ -131,17 +140,15 @@ func TestApplyDefaults_ArrayItems(t *testing.T) {
 	}
 }
 
-func makeSchemaSection(isOpenAPIV3 bool, schema map[string]any) *v1alpha1.SchemaSection {
+func makeSchemaSection(schema map[string]any) *v1alpha1.SchemaSection {
 	data, _ := json.Marshal(schema)
-	raw := &runtime.RawExtension{Raw: data}
-	if isOpenAPIV3 {
-		return &v1alpha1.SchemaSection{OpenAPIV3Schema: raw}
+	return &v1alpha1.SchemaSection{
+		OpenAPIV3Schema: &runtime.RawExtension{Raw: data},
 	}
-	return &v1alpha1.SchemaSection{OpenAPIV3Schema: raw}
 }
 
 func TestResolveSectionToStructural_OpenAPIV3(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"replicas": map[string]any{
@@ -171,7 +178,7 @@ func TestResolveSectionToStructural_OpenAPIV3(t *testing.T) {
 }
 
 func TestResolveSectionToStructural_OpenAPIV3_WithRefs(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"$defs": map[string]any{
 			"Port": map[string]any{
@@ -202,7 +209,7 @@ func TestResolveSectionToStructural_OpenAPIV3_WithRefs(t *testing.T) {
 }
 
 func TestResolveSectionToBundle_OpenAPIV3(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"name": map[string]any{
@@ -242,7 +249,7 @@ func TestResolveSectionToStructural_NilSection(t *testing.T) {
 }
 
 func TestSectionToJSONSchema_OpenAPIV3(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"env": map[string]any{
@@ -270,27 +277,6 @@ func TestSectionToJSONSchema_OpenAPIV3(t *testing.T) {
 	}
 }
 
-func TestSectionToJSONSchema_ShorthandSchema(t *testing.T) {
-	section := makeSchemaSection(false, map[string]any{
-		"replicas": "integer | default=1",
-		"image":    "string",
-	})
-
-	jsonSchema, err := SectionToJSONSchema(section)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if jsonSchema == nil {
-		t.Fatal("expected non-nil jsonSchema")
-	}
-	if jsonSchema.Type != typeObject {
-		t.Fatalf("expected type=object, got %s", jsonSchema.Type)
-	}
-	if _, ok := jsonSchema.Properties["replicas"]; !ok {
-		t.Fatal("expected 'replicas' property")
-	}
-}
-
 func TestSectionToJSONSchema_NilSection(t *testing.T) {
 	jsonSchema, err := SectionToJSONSchema(nil)
 	if err != nil {
@@ -305,7 +291,7 @@ func TestSectionToJSONSchema_NilSection(t *testing.T) {
 }
 
 func TestResolveSectionToStructural_OpenAPIV3_DefaultsWork(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"replicas": map[string]any{
@@ -521,7 +507,7 @@ func TestTestdata_SimpleOpenAPIV3_JSONSchema(t *testing.T) {
 func TestSectionToJSONSchema_PreservesVendorExtensions(t *testing.T) {
 	// Task 2.11: Verify that SectionToJSONSchema preserves x-* vendor extensions
 	// in API responses for openAPIV3Schema input.
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"url": map[string]any{
@@ -571,7 +557,7 @@ func TestSectionToJSONSchema_PreservesVendorExtensions(t *testing.T) {
 func TestResolveSectionToBundle_OpenAPIV3_VendorExtensionsStrippedFromStructural(t *testing.T) {
 	// Task 2.11: Verify that the structural schema path strips x-* extensions
 	// (K8s rejects them) while JSON schema path preserves them.
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"url": map[string]any{
@@ -607,7 +593,7 @@ func TestResolveSectionToBundle_OpenAPIV3_VendorExtensionsStrippedFromStructural
 
 func TestValidateWithJSONSchema_OpenAPIV3(t *testing.T) {
 	// End-to-end: openAPIV3Schema → JSON Schema → validate values
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"replicas": map[string]any{
@@ -670,7 +656,7 @@ func TestResolveSectionToBundle_NilSection(t *testing.T) {
 
 func TestSectionToJSONSchema_EmptyOpenAPIV3(t *testing.T) {
 	// OpenAPIV3Schema with no properties should return a valid empty object schema
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 	})
 
@@ -688,7 +674,7 @@ func TestSectionToJSONSchema_EmptyOpenAPIV3(t *testing.T) {
 
 func TestOpenAPIV3_EndToEnd_DefaultsAndValidation(t *testing.T) {
 	// Full pipeline: openAPIV3Schema → structural + JSON schema → defaults → validate
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"$defs": map[string]any{
 			"ResourceQuantity": map[string]any{
@@ -774,26 +760,31 @@ func TestTestdata_WithRefsOpenAPIV3_JSONSchemaPreservesFields(t *testing.T) {
 }
 
 func TestSectionToRawJSONSchema_OpenAPIV3_PreservesVendorExtensions(t *testing.T) {
-	rawYAML := `
-type: object
-properties:
-  replicas:
-    type: integer
-    default: 1
-    x-openchoreo-backstage-portal:
-      ui:field: RepoUrlPicker
-      ui:options:
-        allowedHosts:
-          - github.com
-  imagePullPolicy:
-    type: string
-    default: IfNotPresent
-    x-openchoreo-pull-portal:
-      ui:field: RepoUrlPicker
-`
+	rawJSON := `{
+  "type": "object",
+  "properties": {
+    "replicas": {
+      "type": "integer",
+      "default": 1,
+      "x-openchoreo-backstage-portal": {
+        "ui:field": "RepoUrlPicker",
+        "ui:options": {
+          "allowedHosts": ["github.com"]
+        }
+      }
+    },
+    "imagePullPolicy": {
+      "type": "string",
+      "default": "IfNotPresent",
+      "x-openchoreo-pull-portal": {
+        "ui:field": "RepoUrlPicker"
+      }
+    }
+  }
+}`
 
 	section := &v1alpha1.SchemaSection{
-		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawYAML)},
+		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawJSON)},
 	}
 
 	result, err := SectionToRawJSONSchema(section)
@@ -825,25 +816,32 @@ properties:
 }
 
 func TestSectionToRawJSONSchema_OpenAPIV3_RefWithVendorExtension(t *testing.T) {
-	rawYAML := `
-type: object
-$defs:
-  ResourceRequirements:
-    type: object
-    properties:
-      cpu:
-        type: string
-        default: "100m"
-    default: {}
-properties:
-  resources:
-    $ref: "#/$defs/ResourceRequirements"
-    x-openchoreo-resources-portal:
-      ui:field: ResourcePicker
-`
+	rawJSON := `{
+  "type": "object",
+  "$defs": {
+    "ResourceRequirements": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "default": "100m"
+        }
+      },
+      "default": {}
+    }
+  },
+  "properties": {
+    "resources": {
+      "$ref": "#/$defs/ResourceRequirements",
+      "x-openchoreo-resources-portal": {
+        "ui:field": "ResourcePicker"
+      }
+    }
+  }
+}`
 
 	section := &v1alpha1.SchemaSection{
-		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawYAML)},
+		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawJSON)},
 	}
 
 	result, err := SectionToRawJSONSchema(section)
@@ -884,35 +882,6 @@ func TestSectionToRawJSONSchema_NilSection(t *testing.T) {
 	}
 }
 
-func TestSectionToRawJSONSchema_ShorthandSchema(t *testing.T) {
-	rawYAML := `
-replicas: "integer | default=1"
-name: "string"
-`
-	section := &v1alpha1.SchemaSection{
-		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawYAML)},
-	}
-
-	result, err := SectionToRawJSONSchema(section)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result["type"] != typeObject {
-		t.Fatalf("expected type=object, got %v", result["type"])
-	}
-	props, ok := result["properties"].(map[string]any)
-	if !ok {
-		t.Fatal("expected properties map")
-	}
-	if _, ok := props["replicas"]; !ok {
-		t.Fatal("expected 'replicas' property")
-	}
-	if _, ok := props["name"]; !ok {
-		t.Fatal("expected 'name' property")
-	}
-}
-
 func TestResolveSectionToStructural_BothSchemasSet(t *testing.T) {
 	// When openAPIV3Schema is set, it is used directly.
 	section := &v1alpha1.SchemaSection{
@@ -938,7 +907,7 @@ func TestResolveSectionToStructural_BothSchemasSet(t *testing.T) {
 }
 
 func TestSectionToJSONSchema_ComplexNestedOpenAPIV3(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"$defs": map[string]any{
 			"Credentials": map[string]any{
@@ -1043,7 +1012,7 @@ func TestSectionToJSONSchema_ComplexNestedOpenAPIV3(t *testing.T) {
 
 func TestOpenAPIV3_EndToEnd_DefaultsThenValidation(t *testing.T) {
 	// Full end-to-end: openAPIV3Schema with defaults applied, then validated
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"replicas": map[string]any{
@@ -1107,7 +1076,7 @@ func TestOpenAPIV3_EndToEnd_DefaultsThenValidation(t *testing.T) {
 }
 
 func TestValidateWithJSONSchema_OpenAPIV3_WrongType(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"replicas": map[string]any{"type": "integer"},
@@ -1131,7 +1100,7 @@ func TestValidateWithJSONSchema_OpenAPIV3_WrongType(t *testing.T) {
 }
 
 func TestValidateWithJSONSchema_OpenAPIV3_ExtraFields(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"name": map[string]any{"type": "string"},
@@ -1155,7 +1124,7 @@ func TestValidateWithJSONSchema_OpenAPIV3_ExtraFields(t *testing.T) {
 }
 
 func TestValidateWithJSONSchema_OpenAPIV3_MissingRequired(t *testing.T) {
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"name":  map[string]any{"type": "string"},
@@ -1194,26 +1163,33 @@ func TestValidateWithJSONSchema_OpenAPIV3_MissingRequired(t *testing.T) {
 }
 
 func TestSectionToRawJSONSchema_DeeplyNestedVendorExtensions(t *testing.T) {
-	rawYAML := `
-type: object
-properties:
-  config:
-    type: object
-    x-section: main
-    properties:
-      database:
-        type: object
-        x-category: storage
-        properties:
-          host:
-            type: string
-            x-widget: text-input
-            x-validation:
-              pattern: "^[a-z]+$"
-              message: "Only lowercase letters"
-`
+	rawJSON := `{
+  "type": "object",
+  "properties": {
+    "config": {
+      "type": "object",
+      "x-section": "main",
+      "properties": {
+        "database": {
+          "type": "object",
+          "x-category": "storage",
+          "properties": {
+            "host": {
+              "type": "string",
+              "x-widget": "text-input",
+              "x-validation": {
+                "pattern": "^[a-z]+$",
+                "message": "Only lowercase letters"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
 	section := &v1alpha1.SchemaSection{
-		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawYAML)},
+		OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(rawJSON)},
 	}
 
 	result, err := SectionToRawJSONSchema(section)
@@ -1277,7 +1253,7 @@ func TestResolveSectionToStructural_EmptyRaw(t *testing.T) {
 
 func TestSectionToRawJSONSchema_EmptyOpenAPIV3(t *testing.T) {
 	// OpenAPIV3Schema with just "type: object" and no properties
-	section := makeSchemaSection(true, map[string]any{
+	section := makeSchemaSection(map[string]any{
 		"type": "object",
 	})
 
@@ -1308,39 +1284,5 @@ func TestSectionToJSONSchema_BothSchemasSet(t *testing.T) {
 
 	if _, ok := jsonSchema.Properties["name"]; !ok {
 		t.Fatal("expected 'name' from openAPIV3Schema")
-	}
-}
-
-func TestMergeFieldMaps_EmptyInput(t *testing.T) {
-	result := mergeFieldMaps(nil)
-	if len(result) != 0 {
-		t.Fatalf("expected empty map, got %v", result)
-	}
-
-	result = mergeFieldMaps([]map[string]any{})
-	if len(result) != 0 {
-		t.Fatalf("expected empty map, got %v", result)
-	}
-}
-
-func TestMergeFieldMaps_NestedMerge(t *testing.T) {
-	maps := []map[string]any{
-		{"db": map[string]any{"host": "localhost"}},
-		{"db": map[string]any{"port": "5432"}, "name": "test"},
-	}
-
-	result := mergeFieldMaps(maps)
-	db, ok := result["db"].(map[string]any)
-	if !ok {
-		t.Fatal("expected db to be map")
-	}
-	if db["host"] != "localhost" {
-		t.Fatalf("expected db.host=localhost, got %v", db["host"])
-	}
-	if db["port"] != "5432" {
-		t.Fatalf("expected db.port=5432, got %v", db["port"])
-	}
-	if result["name"] != "test" {
-		t.Fatalf("expected name=test, got %v", result["name"])
 	}
 }

--- a/internal/validation/schemautil/extract_test.go
+++ b/internal/validation/schemautil/extract_test.go
@@ -15,12 +15,12 @@ import (
 func TestExtractStructuralSchemas_ValidSchemas(t *testing.T) {
 	params := &v1alpha1.SchemaSection{
 		OpenAPIV3Schema: &runtime.RawExtension{
-			Raw: []byte(`{"replicas": "integer | default=1", "name": "string"}`),
+			Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1},"name":{"type":"string"}},"required":["name"]}`),
 		},
 	}
 	envConfigs := &v1alpha1.SchemaSection{
 		OpenAPIV3Schema: &runtime.RawExtension{
-			Raw: []byte(`{"environment": "string | default=dev"}`),
+			Raw: []byte(`{"type":"object","properties":{"environment":{"type":"string","default":"dev"}}}`),
 		},
 	}
 
@@ -54,7 +54,7 @@ func TestExtractStructuralSchemas_ValidSchemas(t *testing.T) {
 func TestExtractStructuralSchemas_WithTypes(t *testing.T) {
 	params := &v1alpha1.SchemaSection{
 		OpenAPIV3Schema: &runtime.RawExtension{
-			Raw: []byte(`{"$types": {"Port": {"containerPort": "integer", "protocol": "string | default=TCP"}}, "ports": "[]Port"}`),
+			Raw: []byte(`{"type":"object","properties":{"ports":{"type":"array","items":{"type":"object","properties":{"containerPort":{"type":"integer"},"protocol":{"type":"string","default":"TCP"}},"required":["containerPort"]}}},"required":["ports"]}`),
 		},
 	}
 

--- a/internal/webhook/clustercomponenttype/webhook_test.go
+++ b/internal/webhook/clustercomponenttype/webhook_test.go
@@ -48,10 +48,8 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 		It("should admit valid ClusterComponentType with parameters and matching workload resource", func() {
 			obj.Spec.WorkloadType = workloadTypeDeployment
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -68,18 +66,14 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 		It("should admit valid ClusterComponentType with parameters and environmentConfigs", func() {
 			obj.Spec.WorkloadType = workloadTypeDeployment
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"image": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"image":{"type":"string"}},"required":["image"]}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -106,10 +100,8 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 			// Set up valid newObj
 			obj.Spec.WorkloadType = workloadTypeDeployment
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=2"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":2}}}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -190,12 +182,10 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 			}
 		})
 
-		It("should reject unknown shorthand type in parameters", func() {
+		It("should reject invalid OpenAPI v3 schema in parameters", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"field": "unknown-type"}`),
+					Raw: []byte(`{"type":"object","properties":"not-an-object"}`),
 				},
 			}
 
@@ -204,12 +194,10 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to parse parameters schema"))
 		})
 
-		It("should reject invalid type reference in parameters", func() {
+		It("should reject circular $ref in parameters", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"$types": {"Database": {"host": "string", "port": "integer"}}, "db": "NonExistent"}`),
+					Raw: []byte(`{"type":"object","$defs":{"A":{"$ref":"#/$defs/B"},"B":{"$ref":"#/$defs/A"}},"properties":{"val":{"$ref":"#/$defs/A"}}}`),
 				},
 			}
 
@@ -289,10 +277,8 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 
 		It("should reject forEach with non-iterable expression", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer"}},"required":["replicas"]}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{

--- a/internal/webhook/clustertrait/webhook_test.go
+++ b/internal/webhook/clustertrait/webhook_test.go
@@ -81,33 +81,29 @@ var _ = Describe("ClusterTrait Webhook", func() {
 	Context("When creating or updating ClusterTrait under Validating Webhook", func() {
 		It("Should admit cluster trait with valid parameters and environmentConfigs", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"mountPath": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"}},"required":["mountPath"]}`),
 				},
 			}
 
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"size": "string | default=10Gi", "storageClass": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"},"storageClass":{"type":"string"}},"required":["storageClass"]}`),
 				},
 			}
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Should reject cluster trait with invalid environmentConfigs schema syntax", func() {
+		It("Should reject cluster trait with invalid environmentConfigs schema", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"mountPath": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"}}}`),
 				},
 			}
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"size": "unknown-type"}`), // invalid type
+					Raw: []byte(`{"type":"object","properties":"not-an-object"}`), // invalid: properties must be an object
 				},
 			}
 			_, err := validator.ValidateCreate(ctx, obj)
@@ -117,10 +113,8 @@ var _ = Describe("ClusterTrait Webhook", func() {
 
 		It("Should admit cluster trait with only environmentConfigs (no parameters)", func() {
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"size": "string | default=10Gi", "storageClass": "string | default=local-path"}`),
+					Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"},"storageClass":{"type":"string","default":"local-path"}}}`),
 				},
 			}
 			_, err := validator.ValidateCreate(ctx, obj)
@@ -262,10 +256,8 @@ var _ = Describe("ClusterTrait Webhook", func() {
 
 		It("should reject non-boolean CEL expression in validation rule", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"name": "string | default=app"}`),
+					Raw: []byte(`{"type":"object","properties":{"name":{"type":"string","default":"app"}}}`),
 				},
 			}
 			obj.Spec.Validations = []openchoreodevv1alpha1.ValidationRule{
@@ -279,18 +271,14 @@ var _ = Describe("ClusterTrait Webhook", func() {
 
 		It("should admit valid boolean validation rules", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"mountPath": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"}},"required":["mountPath"]}`),
 				},
 			}
 
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"size": "string | default=10Gi"}`),
+					Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"}}}`),
 				},
 			}
 			obj.Spec.Validations = []openchoreodevv1alpha1.ValidationRule{

--- a/internal/webhook/componentrelease/webhook_test.go
+++ b/internal/webhook/componentrelease/webhook_test.go
@@ -92,10 +92,8 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		It("should admit valid ComponentRelease with parameters schema and values", func() {
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -113,15 +111,13 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		})
 
 		It("should admit ComponentRelease when parameter with default is omitted", func() {
-			// Fields with "default=" in the schema are NOT marked as required in the generated JSON Schema.
+			// Fields with defaults are NOT in the required array.
 			// This means omitting them during validation is valid. The actual defaults are applied later
 			// during rendering in the ReleaseBinding controller, not during webhook validation.
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1", "image": "string | default=nginx"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1},"image":{"type":"string","default":"nginx"}}}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -141,10 +137,8 @@ var _ = Describe("ComponentRelease Webhook", func() {
 			// "name" has no default so it's required; "replicas" has a default so it's optional
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1", "name": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1},"name":{"type":"string"}},"required":["name"]}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -171,7 +165,7 @@ var _ = Describe("ComponentRelease Webhook", func() {
 					Spec: openchoreodevv1alpha1.TraitSpec{
 						Parameters: &openchoreodevv1alpha1.SchemaSection{
 							OpenAPIV3Schema: &runtime.RawExtension{
-								Raw: []byte(`{"mountPath": "string", "size": "string | default=10Gi"}`),
+								Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"},"size":{"type":"string","default":"10Gi"}},"required":["mountPath"]}`),
 							},
 						},
 						Creates: []openchoreodevv1alpha1.TraitCreate{
@@ -205,7 +199,7 @@ var _ = Describe("ComponentRelease Webhook", func() {
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"replicas": "integer", "name": "string"}`), // no defaults, both required
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer"},"name":{"type":"string"}},"required":["replicas","name"]}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -227,10 +221,8 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		It("should reject when parameter has wrong type", func() {
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer"}},"required":["replicas"]}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -258,7 +250,7 @@ var _ = Describe("ComponentRelease Webhook", func() {
 					Spec: openchoreodevv1alpha1.TraitSpec{
 						Parameters: &openchoreodevv1alpha1.SchemaSection{
 							OpenAPIV3Schema: &runtime.RawExtension{
-								Raw: []byte(`{"mountPath": "string", "size": "string"}`), // both required
+								Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"},"size":{"type":"string"}},"required":["mountPath","size"]}`),
 							},
 						},
 						Creates: []openchoreodevv1alpha1.TraitCreate{
@@ -673,10 +665,8 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		It("should admit valid CEL expressions in ComponentType", func() {
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1", "enabled": "boolean | default=true"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1},"enabled":{"type":"boolean","default":true}}}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -757,7 +747,7 @@ var _ = Describe("ComponentRelease Webhook", func() {
 					Spec: openchoreodevv1alpha1.TraitSpec{
 						Parameters: &openchoreodevv1alpha1.SchemaSection{
 							OpenAPIV3Schema: &runtime.RawExtension{
-								Raw: []byte(`{"size": "string | default=10Gi"}`),
+								Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"}}}`),
 							},
 						},
 						Creates: []openchoreodevv1alpha1.TraitCreate{
@@ -809,10 +799,8 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		It("should reject non-boolean CEL expression in ComponentType validation rule", func() {
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"name": "string | default=app"}`),
+					Raw: []byte(`{"type":"object","properties":{"name":{"type":"string","default":"app"}}}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Validations = []openchoreodevv1alpha1.ValidationRule{
@@ -827,10 +815,8 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		It("should admit valid validation rules in ComponentType and Traits", func() {
 			obj = validComponentRelease()
 			obj.Spec.ComponentType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 			obj.Spec.ComponentType.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -849,7 +835,7 @@ var _ = Describe("ComponentRelease Webhook", func() {
 					Spec: openchoreodevv1alpha1.TraitSpec{
 						Parameters: &openchoreodevv1alpha1.SchemaSection{
 							OpenAPIV3Schema: &runtime.RawExtension{
-								Raw: []byte(`{"size": "integer | default=10"}`),
+								Raw: []byte(`{"type":"object","properties":{"size":{"type":"integer","default":10}}}`),
 							},
 						},
 						Validations: []openchoreodevv1alpha1.ValidationRule{

--- a/internal/webhook/componenttype/webhook_test.go
+++ b/internal/webhook/componenttype/webhook_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ComponentType Webhook", func() {
 			obj.Spec.WorkloadType = workloadTypeDeployment
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -67,12 +67,12 @@ var _ = Describe("ComponentType Webhook", func() {
 			obj.Spec.WorkloadType = workloadTypeDeployment
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"image": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"image":{"type":"string"}},"required":["image"]}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -99,10 +99,8 @@ var _ = Describe("ComponentType Webhook", func() {
 			// Set up valid newObj
 			obj.Spec.WorkloadType = workloadTypeDeployment
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=2"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":2}}}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -183,12 +181,10 @@ var _ = Describe("ComponentType Webhook", func() {
 			}
 		})
 
-		It("should reject unknown shorthand type in parameters", func() {
+		It("should reject invalid OpenAPI v3 schema in parameters", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"field": "unknown-type"}`),
+					Raw: []byte(`{"type":"object","properties":"not-an-object"}`),
 				},
 			}
 
@@ -197,12 +193,10 @@ var _ = Describe("ComponentType Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to parse parameters schema"))
 		})
 
-		It("should reject invalid type reference in parameters", func() {
+		It("should reject circular $ref in parameters", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"$types": {"Database": {"host": "string", "port": "integer"}}, "db": "NonExistent"}`),
+					Raw: []byte(`{"type":"object","$defs":{"A":{"$ref":"#/$defs/B"},"B":{"$ref":"#/$defs/A"}},"properties":{"val":{"$ref":"#/$defs/A"}}}`),
 				},
 			}
 
@@ -283,10 +277,8 @@ var _ = Describe("ComponentType Webhook", func() {
 		// Schema-aware validation catches forEach with non-iterable types at validation time
 		It("should reject forEach with non-iterable expression", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer"}},"required":["replicas"]}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
@@ -601,10 +593,8 @@ var _ = Describe("ComponentType Webhook", func() {
 
 		It("should reject non-boolean CEL expression in validation rule", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"name": "string | default=app"}`),
+					Raw: []byte(`{"type":"object","properties":{"name":{"type":"string","default":"app"}}}`),
 				},
 			}
 			obj.Spec.Validations = []openchoreodevv1alpha1.ValidationRule{
@@ -618,10 +608,8 @@ var _ = Describe("ComponentType Webhook", func() {
 
 		It("should admit valid boolean validation rules", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"replicas": "integer | default=1"}`),
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
 				},
 			}
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{

--- a/internal/webhook/trait/webhook_test.go
+++ b/internal/webhook/trait/webhook_test.go
@@ -38,33 +38,29 @@ var _ = Describe("Trait Webhook", func() {
 	Context("When creating or updating Trait under Validating Webhook", func() {
 		It("Should admit trait with valid parameters and environmentConfigs", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"mountPath": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"}},"required":["mountPath"]}`),
 				},
 			}
 
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"size": "string | default=10Gi", "storageClass": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"},"storageClass":{"type":"string"}},"required":["storageClass"]}`),
 				},
 			}
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Should reject trait with invalid environmentConfigs schema syntax", func() {
+		It("Should reject trait with invalid environmentConfigs schema", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"mountPath": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"}}}`),
 				},
 			}
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
 				OpenAPIV3Schema: &runtime.RawExtension{
-					Raw: []byte(`{"size": "unknown-type"}`), // invalid type
+					Raw: []byte(`{"type":"object","properties":"not-an-object"}`), // invalid: properties must be an object
 				},
 			}
 			_, err := validator.ValidateCreate(ctx, obj)
@@ -74,10 +70,8 @@ var _ = Describe("Trait Webhook", func() {
 
 		It("Should admit trait with only environmentConfigs (no parameters)", func() {
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"size": "string | default=10Gi", "storageClass": "string | default=local-path"}`),
+					Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"},"storageClass":{"type":"string","default":"local-path"}}}`),
 				},
 			}
 			_, err := validator.ValidateCreate(ctx, obj)
@@ -373,10 +367,8 @@ var _ = Describe("Trait Webhook", func() {
 
 		It("should reject non-boolean CEL expression in validation rule", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"name": "string | default=app"}`),
+					Raw: []byte(`{"type":"object","properties":{"name":{"type":"string","default":"app"}}}`),
 				},
 			}
 			obj.Spec.Validations = []openchoreodevv1alpha1.ValidationRule{
@@ -390,18 +382,14 @@ var _ = Describe("Trait Webhook", func() {
 
 		It("should admit valid boolean validation rules", func() {
 			obj.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"mountPath": "string"}`),
+					Raw: []byte(`{"type":"object","properties":{"mountPath":{"type":"string"}},"required":["mountPath"]}`),
 				},
 			}
 
 			obj.Spec.EnvironmentConfigs = &openchoreodevv1alpha1.SchemaSection{
-
 				OpenAPIV3Schema: &runtime.RawExtension{
-
-					Raw: []byte(`{"size": "string | default=10Gi"}`),
+					Raw: []byte(`{"type":"object","properties":{"size":{"type":"string","default":"10Gi"}}}`),
 				},
 			}
 			obj.Spec.Validations = []openchoreodevv1alpha1.ValidationRule{


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

- Add unit tests for pipeline/component covering context builders, renderer, trait processor, and controlflow error paths
- Convert all shorthand test schemas to OpenAPI v3 across pipeline, scaffold, validation, and webhook packages
- Remove shorthand schema fallback from Section* functions; they now only accept OpenAPI v3 JSON Schema
- Remove dead shorthand schema code: Definition, ToJSONSchema, mergeFieldMaps, isOpenAPIV3Content, and related helpers
- Fix missing ctx.Gateway assignment in BuildEmbeddedTraitContext

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
