### PR TITLE
docs: update sample source URLs to openchoreo/sample-workloads

### DIFF
--- a/samples/from-source/services/ballerina-buildpack-patient-management/README.md
+++ b/samples/from-source/services/ballerina-buildpack-patient-management/README.md
@@ -34,7 +34,7 @@ The service exposes several REST endpoints for performing these operations.
 **Functionality:** Retrieves all patients.
 
 The source code is available at:
-https://github.com/wso2/choreo-samples/tree/main/patient-management-service
+https://github.com/openchoreo/sample-workloads/tree/main/service-ballerina-patient-management
 
 
 ## Step 1: Deploy the Application

--- a/samples/from-source/services/go-docker-greeter/README.md
+++ b/samples/from-source/services/go-docker-greeter/README.md
@@ -14,7 +14,7 @@ Exposed REST endpoints:
 **Functionality:** Sends a greeting to the user.
 
 The source code is available at:
-https://github.com/wso2/choreo-samples/tree/main/greeting-service-go
+https://github.com/openchoreo/sample-workloads/tree/main/service-go-greeter
 
 ## Step 1: Deploy the Application
 

--- a/samples/from-source/services/go-google-buildpack-reading-list/README.md
+++ b/samples/from-source/services/go-google-buildpack-reading-list/README.md
@@ -34,7 +34,7 @@ The service exposes several REST endpoints for performing these operations.
 **Functionality:** Retrieves all books from the reading list.
 
 The source code is available at:
-https://github.com/wso2/choreo-samples/tree/main/go-reading-list-rest-api
+https://github.com/openchoreo/sample-workloads/tree/main/service-go-reading-list
 
 ## Step 1: Deploy the Application
 


### PR DESCRIPTION
## Purpose
- Updated source code links in sample README files to point to the new `openchoreo/sample-workloads` repository instead of the old `wso2/choreo-samples` repository
- Affected samples: `ballerina-buildpack-patient-management`, `go-docker-greeter`, `go-google-buildpack-reading-list`
- Fix https://github.com/openchoreo/openchoreo/issues/2797