### PR TITLE
fix: deployment pipeline cannot be deleted which are mapped with projects

### DIFF
--- a/internal/controller/deploymentpipeline/controller.go
+++ b/internal/controller/deploymentpipeline/controller.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -32,6 +33,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=deploymentpipelines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=deploymentpipelines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=deploymentpipelines/finalizers,verbs=update
+// +kubebuilder:rbac:groups=openchoreo.dev,resources=projects,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -93,6 +95,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openchoreov1alpha1.DeploymentPipeline{}).
+		Watches(
+			&openchoreov1alpha1.Project{},
+			handler.EnqueueRequestsFromMapFunc(r.findDeploymentPipelineForProject),
+		).
 		Named("deploymentpipeline").
 		Complete(r)
 }

--- a/internal/controller/deploymentpipeline/controller_finalize.go
+++ b/internal/controller/deploymentpipeline/controller_finalize.go
@@ -6,26 +6,63 @@ package deploymentpipeline
 import (
 	"context"
 	"fmt"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
 const (
-	// PipelineCleanupFinalizer is the finalizer for DeploymentPipeline cleanup.
+	// PipelineCleanupFinalizer prevents the DeploymentPipeline from being deleted
+	// while Projects that reference it are still finalizing. Projects depend on
+	// the DeploymentPipeline to resolve environment names and compute data plane
+	// namespace names during their own cleanup.
 	PipelineCleanupFinalizer = "openchoreo.dev/deployment-pipeline-cleanup"
+
+	// ReasonDeletionBlocked is the reason used when a deployment pipeline cannot be
+	// deleted because it is still referenced by projects.
+	ReasonDeletionBlocked controller.ConditionReason = "DeletionBlocked"
+
+	// DeletionBlockedRequeueInterval is the interval at which the controller re-checks
+	// whether referencing projects have been removed.
+	DeletionBlockedRequeueInterval = 5 * time.Second
 )
 
-// finalize removes the finalizer to allow the DeploymentPipeline to be deleted.
-// It is the user's responsibility to remove project references before deleting a pipeline.
+// finalize removes the finalizer once no Projects reference this DeploymentPipeline.
 func (r *Reconciler) finalize(ctx context.Context, pipeline *openchoreov1alpha1.DeploymentPipeline) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("deploymentPipeline", pipeline.Name)
 
 	if !controllerutil.ContainsFinalizer(pipeline, PipelineCleanupFinalizer) {
 		return ctrl.Result{}, nil
+	}
+
+	refCount, err := r.countReferencingProjects(ctx, pipeline)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check referencing projects: %w", err)
+	}
+
+	if refCount > 0 {
+		msg := fmt.Sprintf("Deletion blocked: deployment pipeline is still referenced by %d project(s)", refCount)
+		logger.Info(msg)
+		if err := controller.UpdateCondition(
+			ctx,
+			r.Status(),
+			pipeline,
+			&pipeline.Status.Conditions,
+			controller.TypeAvailable,
+			metav1.ConditionFalse,
+			string(ReasonDeletionBlocked),
+			msg,
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update status condition: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: DeletionBlockedRequeueInterval}, nil
 	}
 
 	if controllerutil.RemoveFinalizer(pipeline, PipelineCleanupFinalizer) {
@@ -36,4 +73,17 @@ func (r *Reconciler) finalize(ctx context.Context, pipeline *openchoreov1alpha1.
 
 	logger.Info("Successfully finalized DeploymentPipeline")
 	return ctrl.Result{}, nil
+}
+
+// countReferencingProjects returns the number of Projects in the same namespace that reference this DeploymentPipeline.
+func (r *Reconciler) countReferencingProjects(ctx context.Context, pipeline *openchoreov1alpha1.DeploymentPipeline) (int, error) {
+	projectList := &openchoreov1alpha1.ProjectList{}
+	if err := r.List(ctx, projectList,
+		client.InNamespace(pipeline.Namespace),
+		client.MatchingFields{controller.IndexKeyProjectDeploymentPipelineRef: pipeline.Name},
+	); err != nil {
+		return 0, fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	return len(projectList.Items), nil
 }

--- a/internal/controller/deploymentpipeline/controller_integration_test.go
+++ b/internal/controller/deploymentpipeline/controller_integration_test.go
@@ -41,6 +41,18 @@ func forceDeletePipeline(nn types.NamespacedName) {
 	}, "5s", "100ms").Should(BeTrue())
 }
 
+// forceDeleteProject deletes a Project, ignoring not-found errors.
+func forceDeleteProject(nn types.NamespacedName) {
+	project := &openchoreov1alpha1.Project{}
+	if err := k8sClient.Get(ctx, nn, project); err != nil {
+		return
+	}
+	_ = k8sClient.Delete(ctx, project)
+	Eventually(func() bool {
+		return apierrors.IsNotFound(k8sClient.Get(ctx, nn, &openchoreov1alpha1.Project{}))
+	}, "5s", "100ms").Should(BeTrue())
+}
+
 var _ = Describe("DeploymentPipeline Controller", func() {
 
 	const ns = "default"
@@ -171,4 +183,93 @@ var _ = Describe("DeploymentPipeline Controller", func() {
 		})
 	})
 
+	// -------------------------------------------------------------------------
+	// Finalization: referenced by Projects
+	// -------------------------------------------------------------------------
+	Context("When deleting a DeploymentPipeline that is referenced by Projects", func() {
+		const pipelineName = "dp-finalize-with-ref"
+		const projectName = "proj-refs-dp"
+		pipelineNN := types.NamespacedName{Name: pipelineName, Namespace: ns}
+		projectNN := types.NamespacedName{Name: projectName, Namespace: ns}
+
+		BeforeEach(func() {
+			pipeline := &openchoreov1alpha1.DeploymentPipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       pipelineName,
+					Namespace:  ns,
+					Finalizers: []string{PipelineCleanupFinalizer},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pipeline)).To(Succeed())
+
+			project := &openchoreov1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      projectName,
+					Namespace: ns,
+				},
+				Spec: openchoreov1alpha1.ProjectSpec{
+					DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: pipelineName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+
+			// Wait for the Project to appear in the cache (field index requires cache)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, projectNN, &openchoreov1alpha1.Project{})
+			}, "5s", "100ms").Should(Succeed())
+		})
+
+		AfterEach(func() {
+			forceDeleteProject(projectNN)
+			forceDeletePipeline(pipelineNN)
+		})
+
+		It("should set DeletionBlocked condition and requeue", func() {
+			pipeline := &openchoreov1alpha1.DeploymentPipeline{}
+			Expect(k8sClient.Get(ctx, pipelineNN, pipeline)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, pipeline)).To(Succeed())
+
+			r := testReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: pipelineNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(DeletionBlockedRequeueInterval))
+
+			fresh := &openchoreov1alpha1.DeploymentPipeline{}
+			Expect(k8sClient.Get(ctx, pipelineNN, fresh)).To(Succeed())
+			cond := apimeta.FindStatusCondition(fresh.Status.Conditions, controller.TypeAvailable)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(string(ReasonDeletionBlocked)))
+			Expect(cond.Message).To(ContainSubstring("1 project(s)"))
+		})
+
+		It("should proceed to finalize after the referencing project is removed", func() {
+			pipeline := &openchoreov1alpha1.DeploymentPipeline{}
+			Expect(k8sClient.Get(ctx, pipelineNN, pipeline)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, pipeline)).To(Succeed())
+
+			r := testReconciler()
+
+			By("first reconcile — blocked by referencing project")
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: pipelineNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(DeletionBlockedRequeueInterval))
+
+			By("removing the referencing project")
+			project := &openchoreov1alpha1.Project{}
+			Expect(k8sClient.Get(ctx, projectNN, project)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, project)).To(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, projectNN, &openchoreov1alpha1.Project{}))
+			}, "5s", "100ms").Should(BeTrue())
+
+			By("second reconcile — removes finalizer and deletes pipeline")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: pipelineNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, pipelineNN, &openchoreov1alpha1.DeploymentPipeline{}))
+			}, "5s", "100ms").Should(BeTrue())
+		})
+	})
 })

--- a/internal/controller/deploymentpipeline/controller_watch.go
+++ b/internal/controller/deploymentpipeline/controller_watch.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deploymentpipeline
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// findDeploymentPipelineForProject maps a Project change to the DeploymentPipeline it references.
+// This ensures the DeploymentPipeline is reconciled when a referring Project is created, updated, or deleted,
+// allowing finalization to proceed once the reference is removed.
+func (r *Reconciler) findDeploymentPipelineForProject(_ context.Context, obj client.Object) []reconcile.Request {
+	project, ok := obj.(*openchoreov1alpha1.Project)
+	if !ok {
+		return nil
+	}
+
+	pipelineRef := project.Spec.DeploymentPipelineRef
+	if pipelineRef.Name == "" {
+		return nil
+	}
+
+	log.Log.V(1).Info("Project change detected, enqueueing DeploymentPipeline",
+		"project", project.Name, "deploymentPipeline", pipelineRef.Name)
+
+	return []reconcile.Request{
+		{
+			NamespacedName: client.ObjectKey{
+				Namespace: project.Namespace,
+				Name:      pipelineRef.Name,
+			},
+		},
+	}
+}

--- a/internal/controller/deploymentpipeline/suite_test.go
+++ b/internal/controller/deploymentpipeline/suite_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -22,6 +23,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -70,19 +72,40 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:scheme
 
+	// Create a manager with cache enabled for Project (needed for field index queries
+	// in the DeploymentPipeline finalizer). All other types bypass cache.
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&openchoreov1alpha1.Project{}: {},
+			},
+			DefaultNamespaces: map[string]cache.Config{},
+		},
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{
+					&openchoreov1alpha1.DataPlane{},
+					&openchoreov1alpha1.Environment{},
 					&openchoreov1alpha1.DeploymentPipeline{},
 				},
 			},
 		},
 	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register the field index used by the DeploymentPipeline finalizer to find referencing Projects
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},
+		controller.IndexKeyProjectDeploymentPipelineRef, func(obj client.Object) []string {
+			project := obj.(*openchoreov1alpha1.Project)
+			if project.Spec.DeploymentPipelineRef.Name == "" {
+				return nil
+			}
+			return []string{project.Spec.DeploymentPipelineRef.Name}
+		})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Start the manager in a goroutine
@@ -95,6 +118,8 @@ var _ = BeforeSuite(func() {
 	// Wait for cache to sync before running tests
 	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 
+	// Use the manager's client which has field index support for Project
+	// but reads directly from API server for other types
 	k8sClient = mgr.GetClient()
 	Expect(k8sClient).NotTo(BeNil())
 })


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
We decided to block deployment pipeline deletion if it is mapped with a project and user can switch the deployment pipeline and delete unused pipelines. 

This is to revert the - https://github.com/openchoreo/openchoreo/pull/2768

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2411

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
