### PR TITLE
fix: intermittent agent disconnect when HA enabled

### DIFF
--- a/internal/cluster-gateway/plane_api.go
+++ b/internal/cluster-gateway/plane_api.go
@@ -90,31 +90,20 @@ func (api *PlaneAPI) handlePlaneNotification(w http.ResponseWriter, r *http.Requ
 	result.Success = true
 
 	switch notification.Event {
-	case "created":
-		// New CR: Disconnect agents to pick up new CA
-		disconnectedCount := api.connMgr.DisconnectAllForPlane(notification.PlaneType, notification.PlaneID)
-		api.logger.Info("disconnected agents for new CR",
-			"planeType", notification.PlaneType,
-			"planeID", notification.PlaneID,
-			"disconnectedAgents", disconnectedCount,
-		)
-		result.Action = "disconnect"
-		result.DisconnectedAgents = &disconnectedCount
-
-	case "updated":
+	case "created", "updated":
+		// For both "created" and "updated" events, attempt to revalidate agent certificates
+		// using the CR's CA. This avoids disconnecting all HA agent replicas unnecessarily.
 		caData, err := api.fetchCRClientCA(notification)
 		if err != nil {
-			api.logger.Error("failed to fetch CR CA for re-validation", "error", err)
-			// Fall back to disconnect on error
-			disconnectedCount := api.connMgr.DisconnectAllForPlane(notification.PlaneType, notification.PlaneID)
-			api.logger.Warn("falling back to disconnect due to CA fetch error",
+			api.logger.Error("failed to fetch CR CA for re-validation", "error", err,
 				"planeType", notification.PlaneType,
 				"planeID", notification.PlaneID,
-				"disconnectedAgents", disconnectedCount,
+				"event", notification.Event,
 			)
-			result.Action = "disconnect_fallback"
-			result.DisconnectedAgents = &disconnectedCount
-			result.Error = err.Error()
+			// Return 503 so the controller treats this as a transient error and retries.
+			// Do NOT disconnect agents — existing connections are still valid.
+			http.Error(w, fmt.Sprintf("failed to fetch CR CA for re-validation: %v", err), http.StatusServiceUnavailable)
+			return
 		} else {
 			updated, removed, err := api.connMgr.RevalidateCR(
 				notification.PlaneType,
@@ -131,6 +120,7 @@ func (api *PlaneAPI) handlePlaneNotification(w http.ResponseWriter, r *http.Requ
 			api.logger.Info("CR re-validation completed",
 				"planeType", notification.PlaneType,
 				"planeID", notification.PlaneID,
+				"event", notification.Event,
 				"cr", fmt.Sprintf("%s/%s", notification.Namespace, notification.Name),
 				"authorizationsGranted", updated,
 				"authorizationsRevoked", removed,

--- a/internal/controller/clusterdataplane/controller.go
+++ b/internal/controller/clusterdataplane/controller.go
@@ -106,19 +106,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Notify gateway of ClusterDataPlane reconciliation (create/update)
 	// Using "updated" since Reconcile handles both CREATE and UPDATE events
 	// and the gateway treats both identically (triggers agent reconnection)
+	gatewayNotified := false
 	if r.GatewayClient != nil {
 		if err := r.notifyGateway(ctx, clusterDataPlane, "updated"); err != nil {
 			if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "ClusterDataPlane reconciliation"); shouldRetry {
 				return result, retryErr
 			}
+		} else {
+			gatewayNotified = true
 		}
 	}
 
-	// Query agent connection status from gateway and add to clusterDataPlane status
-	// This must be done BEFORE updating status to avoid conflicts
-	if err := r.populateAgentConnectionStatus(ctx, clusterDataPlane); err != nil {
-		logger.Error(err, "failed to get agent connection status")
-		// Don't fail reconciliation for status query errors
+	// Skip immediate status poll after gateway notification — agents may be reconnecting
+	// after a revalidation/disconnect cycle. The next periodic requeue will capture the
+	// settled state, avoiding false "disconnected" flaps with HA agent replicas.
+	if !gatewayNotified {
+		if err := r.populateAgentConnectionStatus(ctx, clusterDataPlane); err != nil {
+			logger.Error(err, "failed to get agent connection status")
+			// Don't fail reconciliation for status query errors
+		}
+	} else {
+		logger.Info("skipping immediate status poll after gateway notification, agents may be reconnecting")
 	}
 
 	// We use Status().Update() directly instead of UpdateStatusConditions to preserve agentConnection field

--- a/internal/controller/clusterdataplane/controller_gateway_test.go
+++ b/internal/controller/clusterdataplane/controller_gateway_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ClusterDataPlane Controller — gateway paths", func() {
 		})
 		AfterEach(func() { forceDeleteCDP(ctx, nn) })
 
-		It("notifies gateway and populates AgentConnection when status GET succeeds", func() {
+		It("notifies gateway and skips immediate status poll to avoid HA flapping", func() {
 			gwClient, calls, shutdown := testgateway.StartFakeGateway(http.StatusOK, &gw.PlaneConnectionStatus{
 				Connected: true, ConnectedAgents: 1,
 			})
@@ -51,11 +51,12 @@ var _ = Describe("ClusterDataPlane Controller — gateway paths", func() {
 			Expect(result.RequeueAfter).To(Equal(controller.StatusUpdateInterval))
 			Expect(*calls).To(Equal(1))
 
+			// After gateway notification, status poll is intentionally skipped to avoid
+			// catching agents mid-reconnect (HA flapping). AgentConnection will be
+			// populated on the next periodic requeue.
 			fresh := &openchoreov1alpha1.ClusterDataPlane{}
 			Expect(k8sClient.Get(ctx, nn, fresh)).To(Succeed())
-			Expect(fresh.Status.AgentConnection).NotTo(BeNil())
-			Expect(fresh.Status.AgentConnection.Connected).To(BeTrue())
-			Expect(fresh.Status.AgentConnection.Message).To(Equal("1 agent connected"))
+			Expect(fresh.Status.AgentConnection).To(BeNil())
 		})
 
 		// When populateAgentConnectionStatus returns an error (status GET fails),

--- a/internal/controller/clusterobservabilityplane/controller.go
+++ b/internal/controller/clusterobservabilityplane/controller.go
@@ -109,19 +109,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Notify gateway of ClusterObservabilityPlane reconciliation (create/update)
 	// Using "updated" since Reconcile handles both CREATE and UPDATE events
 	// and the gateway treats both identically (triggers agent reconnection)
+	gatewayNotified := false
 	if r.GatewayClient != nil {
 		if err := r.notifyGateway(ctx, clusterObservabilityPlane, "updated"); err != nil {
 			if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "ClusterObservabilityPlane reconciliation"); shouldRetry {
 				return result, retryErr
 			}
+		} else {
+			gatewayNotified = true
 		}
 	}
 
-	// Query agent connection status from gateway and add to clusterObservabilityPlane status
-	// This must be done BEFORE updating status to avoid conflicts
-	if err := r.populateAgentConnectionStatus(ctx, clusterObservabilityPlane); err != nil {
-		logger.Error(err, "failed to get agent connection status")
-		// Don't fail reconciliation for status query errors
+	// Skip immediate status poll after gateway notification — agents may be reconnecting
+	// after a revalidation/disconnect cycle. The next periodic requeue will capture the
+	// settled state, avoiding false "disconnected" flaps with HA agent replicas.
+	if !gatewayNotified {
+		if err := r.populateAgentConnectionStatus(ctx, clusterObservabilityPlane); err != nil {
+			logger.Error(err, "failed to get agent connection status")
+			// Don't fail reconciliation for status query errors
+		}
+	} else {
+		logger.Info("skipping immediate status poll after gateway notification, agents may be reconnecting")
 	}
 
 	// Update status with both conditions and agent connection status in a single update

--- a/internal/controller/clusterworkflowplane/controller.go
+++ b/internal/controller/clusterworkflowplane/controller.go
@@ -108,19 +108,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Notify gateway of ClusterWorkflowPlane reconciliation (create/update)
 	// Using "updated" since Reconcile handles both CREATE and UPDATE events
 	// and the gateway treats both identically (triggers agent reconnection)
+	gatewayNotified := false
 	if r.GatewayClient != nil {
 		if err := r.notifyGateway(ctx, clusterWorkflowPlane, "updated"); err != nil {
 			if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "ClusterWorkflowPlane reconciliation"); shouldRetry {
 				return result, retryErr
 			}
+		} else {
+			gatewayNotified = true
 		}
 	}
 
-	// Query agent connection status from gateway and add to clusterWorkflowPlane status
-	// This must be done BEFORE updating status to avoid conflicts
-	if err := r.populateAgentConnectionStatus(ctx, clusterWorkflowPlane); err != nil {
-		logger.Error(err, "failed to get agent connection status")
-		// Don't fail reconciliation for status query errors
+	// Skip immediate status poll after gateway notification — agents may be reconnecting
+	// after a revalidation/disconnect cycle. The next periodic requeue will capture the
+	// settled state, avoiding false "disconnected" flaps with HA agent replicas.
+	if !gatewayNotified {
+		if err := r.populateAgentConnectionStatus(ctx, clusterWorkflowPlane); err != nil {
+			logger.Error(err, "failed to get agent connection status")
+			// Don't fail reconciliation for status query errors
+		}
+	} else {
+		logger.Info("skipping immediate status poll after gateway notification, agents may be reconnecting")
 	}
 
 	// Update status with both conditions and agent connection status in a single update

--- a/internal/controller/dataplane/controller.go
+++ b/internal/controller/dataplane/controller.go
@@ -87,6 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Check if spec has changed (generation > observedGeneration)
 		// If so, notify gateway to re-validate agent certificates with updated CA
 		specChanged := dataPlane.Status.ObservedGeneration < dataPlane.Generation
+		specChangeNotified := false
 		if specChanged && r.GatewayClient != nil {
 			logger.Info("detected spec change, notifying gateway for certificate re-validation",
 				"generation", dataPlane.Generation,
@@ -96,14 +97,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "DataPlane spec update"); shouldRetry {
 					return result, retryErr
 				}
+			} else {
+				specChangeNotified = true
 			}
 			// Update observedGeneration to track that we processed this change
 			dataPlane.Status.ObservedGeneration = dataPlane.Generation
 		}
 
-		if err := r.populateAgentConnectionStatus(ctx, dataPlane); err != nil {
-			logger.Error(err, "failed to get agent connection status")
-			// Don't fail reconciliation for status query errors
+		// Skip immediate status poll after gateway notification — agents may be reconnecting
+		// after a revalidation cycle. The next periodic requeue will capture the settled state.
+		if !specChangeNotified {
+			if err := r.populateAgentConnectionStatus(ctx, dataPlane); err != nil {
+				logger.Error(err, "failed to get agent connection status")
+				// Don't fail reconciliation for status query errors
+			}
+		} else {
+			logger.Info("skipping immediate status poll after spec-change notification, agents may be reconnecting")
 		}
 
 		// We use Status().Update() directly instead of UpdateStatusConditions to preserve agentConnection field
@@ -127,19 +136,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Notify gateway of DataPlane reconciliation (create/update)
 	// Using "updated" since Reconcile handles both CREATE and UPDATE events
 	// and the gateway treats both identically (triggers agent reconnection)
+	gatewayNotified := false
 	if r.GatewayClient != nil {
 		if err := r.notifyGateway(ctx, dataPlane, "updated"); err != nil {
 			if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "DataPlane reconciliation"); shouldRetry {
 				return result, retryErr
 			}
+		} else {
+			gatewayNotified = true
 		}
 	}
 
-	// Query agent connection status from gateway and add to dataPlane status
-	// This must be done BEFORE updating status to avoid conflicts
-	if err := r.populateAgentConnectionStatus(ctx, dataPlane); err != nil {
-		logger.Error(err, "failed to get agent connection status")
-		// Don't fail reconciliation for status query errors
+	// Skip immediate status poll after gateway notification — agents may be reconnecting
+	// after a revalidation/disconnect cycle. The next periodic requeue will capture the
+	// settled state, avoiding false "disconnected" flaps with HA agent replicas.
+	if !gatewayNotified {
+		if err := r.populateAgentConnectionStatus(ctx, dataPlane); err != nil {
+			logger.Error(err, "failed to get agent connection status")
+			// Don't fail reconciliation for status query errors
+		}
+	} else {
+		logger.Info("skipping immediate status poll after gateway notification, agents may be reconnecting")
 	}
 
 	// We use Status().Update() directly instead of UpdateStatusConditions to preserve agentConnection field

--- a/internal/controller/dataplane/controller_gateway_test.go
+++ b/internal/controller/dataplane/controller_gateway_test.go
@@ -50,7 +50,7 @@ var _ = Describe("DataPlane Controller — gateway paths", func() {
 		})
 		AfterEach(func() { forceDeleteDP(ctx, nn) })
 
-		It("notifies gateway and populates AgentConnection when status GET succeeds", func() {
+		It("notifies gateway and skips immediate status poll to avoid HA flapping", func() {
 			gwClient, calls, shutdown := testgateway.StartFakeGateway(http.StatusOK, &gw.PlaneConnectionStatus{
 				Connected: true, ConnectedAgents: 1,
 			})
@@ -61,11 +61,12 @@ var _ = Describe("DataPlane Controller — gateway paths", func() {
 			Expect(result.RequeueAfter).To(Equal(controller.StatusUpdateInterval))
 			Expect(*calls).To(Equal(1))
 
+			// After gateway notification, status poll is intentionally skipped to avoid
+			// catching agents mid-reconnect (HA flapping). AgentConnection will be
+			// populated on the next periodic requeue.
 			fresh := &openchoreov1alpha1.DataPlane{}
 			Expect(k8sClient.Get(ctx, nn, fresh)).To(Succeed())
-			Expect(fresh.Status.AgentConnection).NotTo(BeNil())
-			Expect(fresh.Status.AgentConnection.Connected).To(BeTrue())
-			Expect(fresh.Status.AgentConnection.Message).To(Equal("1 agent connected"))
+			Expect(fresh.Status.AgentConnection).To(BeNil())
 		})
 
 		// When populateAgentConnectionStatus returns an error (status GET fails),

--- a/internal/controller/observabilityplane/controller.go
+++ b/internal/controller/observabilityplane/controller.go
@@ -87,6 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Check if spec has changed (generation > observedGeneration)
 		// If so, notify gateway to re-validate agent certificates with updated CA
 		specChanged := observabilityPlane.Status.ObservedGeneration < observabilityPlane.Generation
+		specChangeNotified := false
 		if specChanged && r.GatewayClient != nil {
 			logger.Info("detected spec change, notifying gateway for certificate re-validation",
 				"generation", observabilityPlane.Generation,
@@ -96,14 +97,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "ObservabilityPlane spec update"); shouldRetry {
 					return result, retryErr
 				}
+			} else {
+				specChangeNotified = true
 			}
 			// Update observedGeneration to track that we processed this change
 			observabilityPlane.Status.ObservedGeneration = observabilityPlane.Generation
 		}
 
-		if err := r.populateAgentConnectionStatus(ctx, observabilityPlane); err != nil {
-			logger.Error(err, "failed to get agent connection status")
-			// Don't fail reconciliation for status query errors
+		// Skip immediate status poll after gateway notification — agents may be reconnecting
+		// after a revalidation cycle. The next periodic requeue will capture the settled state.
+		if !specChangeNotified {
+			if err := r.populateAgentConnectionStatus(ctx, observabilityPlane); err != nil {
+				logger.Error(err, "failed to get agent connection status")
+				// Don't fail reconciliation for status query errors
+			}
+		} else {
+			logger.Info("skipping immediate status poll after spec-change notification, agents may be reconnecting")
 		}
 
 		if err := r.Status().Update(ctx, observabilityPlane); err != nil {
@@ -126,19 +135,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Notify gateway of ObservabilityPlane reconciliation (create/update)
 	// Using "updated" since Reconcile handles both CREATE and UPDATE events
 	// and the gateway treats both identically (triggers agent reconnection)
+	gatewayNotified := false
 	if r.GatewayClient != nil {
 		if err := r.notifyGateway(ctx, observabilityPlane, "updated"); err != nil {
 			if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "ObservabilityPlane reconciliation"); shouldRetry {
 				return result, retryErr
 			}
+		} else {
+			gatewayNotified = true
 		}
 	}
 
-	// Query agent connection status from gateway and add to observabilityPlane status
-	// This must be done BEFORE updating status to avoid conflicts
-	if err := r.populateAgentConnectionStatus(ctx, observabilityPlane); err != nil {
-		logger.Error(err, "failed to get agent connection status")
-		// Don't fail reconciliation for status query errors
+	// Skip immediate status poll after gateway notification — agents may be reconnecting
+	// after a revalidation/disconnect cycle. The next periodic requeue will capture the
+	// settled state, avoiding false "disconnected" flaps with HA agent replicas.
+	if !gatewayNotified {
+		if err := r.populateAgentConnectionStatus(ctx, observabilityPlane); err != nil {
+			logger.Error(err, "failed to get agent connection status")
+			// Don't fail reconciliation for status query errors
+		}
+	} else {
+		logger.Info("skipping immediate status poll after gateway notification, agents may be reconnecting")
 	}
 
 	// Update status with both conditions and agent connection status in a single update

--- a/internal/controller/workflowplane/controller.go
+++ b/internal/controller/workflowplane/controller.go
@@ -86,6 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Check if spec has changed (generation > observedGeneration)
 		// If so, notify gateway to re-validate agent certificates with updated CA
 		specChanged := workflowPlane.Status.ObservedGeneration < workflowPlane.Generation
+		specChangeNotified := false
 		if specChanged && r.GatewayClient != nil {
 			logger.Info("detected spec change, notifying gateway for certificate re-validation",
 				"generation", workflowPlane.Generation,
@@ -95,14 +96,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "WorkflowPlane spec update"); shouldRetry {
 					return result, retryErr
 				}
+			} else {
+				specChangeNotified = true
 			}
 			// Update observedGeneration to track that we processed this change
 			workflowPlane.Status.ObservedGeneration = workflowPlane.Generation
 		}
 
-		if err := r.populateAgentConnectionStatus(ctx, workflowPlane); err != nil {
-			logger.Error(err, "failed to get agent connection status")
-			// Don't fail reconciliation for status query errors
+		// Skip immediate status poll after gateway notification — agents may be reconnecting
+		// after a revalidation cycle. The next periodic requeue will capture the settled state.
+		if !specChangeNotified {
+			if err := r.populateAgentConnectionStatus(ctx, workflowPlane); err != nil {
+				logger.Error(err, "failed to get agent connection status")
+				// Don't fail reconciliation for status query errors
+			}
+		} else {
+			logger.Info("skipping immediate status poll after spec-change notification, agents may be reconnecting")
 		}
 
 		if err := r.Status().Update(ctx, workflowPlane); err != nil {
@@ -125,19 +134,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Notify gateway of WorkflowPlane reconciliation (create/update)
 	// Using "updated" since Reconcile handles both CREATE and UPDATE events
 	// and the gateway treats both identically (triggers agent reconnection)
+	gatewayNotified := false
 	if r.GatewayClient != nil {
 		if err := r.notifyGateway(ctx, workflowPlane, "updated"); err != nil {
 			if shouldRetry, result, retryErr := gatewayClient.HandleGatewayError(logger, err, "WorkflowPlane reconciliation"); shouldRetry {
 				return result, retryErr
 			}
+		} else {
+			gatewayNotified = true
 		}
 	}
 
-	// Query agent connection status from gateway and add to workflowPlane status
-	// This must be done BEFORE updating status to avoid conflicts
-	if err := r.populateAgentConnectionStatus(ctx, workflowPlane); err != nil {
-		logger.Error(err, "failed to get agent connection status")
-		// Don't fail reconciliation for status query errors
+	// Skip immediate status poll after gateway notification — agents may be reconnecting
+	// after a revalidation/disconnect cycle. The next periodic requeue will capture the
+	// settled state, avoiding false "disconnected" flaps with HA agent replicas.
+	if !gatewayNotified {
+		if err := r.populateAgentConnectionStatus(ctx, workflowPlane); err != nil {
+			logger.Error(err, "failed to get agent connection status")
+			// Don't fail reconciliation for status query errors
+		}
+	} else {
+		logger.Info("skipping immediate status poll after gateway notification, agents may be reconnecting")
 	}
 
 	// Update status with both conditions and agent connection status in a single update

--- a/internal/controller/workflowplane/controller_gateway_test.go
+++ b/internal/controller/workflowplane/controller_gateway_test.go
@@ -39,7 +39,7 @@ var _ = Describe("WorkflowPlane Controller — gateway paths", func() {
 		})
 		AfterEach(func() { forceDeleteWP(ctx, nn) })
 
-		It("notifies gateway once and populates AgentConnection status", func() {
+		It("notifies gateway once and skips immediate status poll to avoid HA flapping", func() {
 			gwClient, calls, shutdown := testgateway.StartFakeGateway(http.StatusOK, &gw.PlaneConnectionStatus{
 				Connected: true, ConnectedAgents: 2,
 			})
@@ -50,12 +50,12 @@ var _ = Describe("WorkflowPlane Controller — gateway paths", func() {
 			Expect(result.RequeueAfter).To(Equal(controller.StatusUpdateInterval))
 			Expect(*calls).To(Equal(1))
 
+			// After gateway notification, status poll is intentionally skipped to avoid
+			// catching agents mid-reconnect (HA flapping). AgentConnection will be
+			// populated on the next periodic requeue.
 			fresh := &openchoreov1alpha1.WorkflowPlane{}
 			Expect(k8sClient.Get(ctx, nn, fresh)).To(Succeed())
-			Expect(fresh.Status.AgentConnection).NotTo(BeNil())
-			Expect(fresh.Status.AgentConnection.Connected).To(BeTrue())
-			Expect(fresh.Status.AgentConnection.ConnectedAgents).To(BeEquivalentTo(2))
-			Expect(fresh.Status.AgentConnection.Message).To(Equal("2 agents connected (HA mode)"))
+			Expect(fresh.Status.AgentConnection).To(BeNil())
 		})
 
 		It("returns error on transient gateway failure (5xx)", func() {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
With HA cluster-agents (multiple replicas per plane), the Backstage UI randomly shows planes as "disconnected" even though agents are healthy. This happens because of a race condition between the controller's gateway notification and its immediate status poll.

#### Root Cause

  The sequence was:

  1. Controller reconciles a plane CR → sends notifyGateway("updated") to the gateway
  2. Gateway handles the notification → may disconnect agents (for revalidation or as a fallback on error)
  3. Agents start reconnecting (takes ~5-15s with staggered HA replicas)
  4. Controller immediately polls populateAgentConnectionStatus() — catches agents mid-reconnect
  5. Status written as connected=false → Backstage shows "disconnected"
  6. Next poll (1 min later) sees agents back → "connected" → flapping
## Approach

#### Fix 1: Skip status poll after gateway notification

- What changed: After a successful notifyGateway() call, we track gatewayNotified = true and skip the immediate populateAgentConnectionStatus() call. The status will be populated on the next periodic requeue (1 minute), by which time agents have settled.
- Why: The gateway notification may trigger agent disconnection/revalidation. Polling status within milliseconds of that is unreliable — especially with multiple HA replicas reconnecting at different times. Waiting for the next 1-minute cycle is safer and avoids false negatives.

#### Fix 2: Remove fallback-to-disconnect on CA fetch error

- A transient CA fetch error doesn't mean agent connections are invalid. Disconnecting all healthy agents because of an unrelated API server blip is too aggressive, especially with HA where the blast radius is N replicas.

####  Fix 3: Use revalidate instead of disconnect for "created" events
- Revalidation is surgical — it only disconnects agents whose certificates are actually invalid. Mass disconnection is unnecessary when the existing agents may already have valid certificates for the new CR.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2225

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
