### PR TITLE
feat: simplify cel expressions in sample componenet types

### DIFF
--- a/docs/templating/context.md
+++ b/docs/templating/context.md
@@ -335,15 +335,15 @@ spec:
 ```yaml
 # Create HTTPRoutes only for endpoints with external visibility
 - id: httproute-external
-  forEach: '${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+  forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
   var: endpoint
   template:
     apiVersion: gateway.networking.k8s.io/v1
     kind: HTTPRoute
     metadata:
-      name: ${oc_generate_name(metadata.componentName, endpoint)}
+      name: ${oc_generate_name(metadata.componentName, endpoint.key)}
       namespace: ${metadata.namespace}
-      labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "external"})}'
+      labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
     spec:
       parentRefs:
         - name: ${gateway.ingress.external.name}
@@ -356,28 +356,28 @@ spec:
       - matches:
         - path:
             type: PathPrefix
-            value: /${metadata.componentName}-${endpoint}
+            value: /${metadata.componentName}-${endpoint.key}
         filters:
           - type: URLRewrite
             urlRewrite:
               path:
                 type: ReplacePrefixMatch
-                replacePrefixMatch: '${workload.endpoints[endpoint].?basePath.orValue("") != "" ? workload.endpoints[endpoint].?basePath.orValue("") : "/"}'
+                replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
         backendRefs:
         - name: ${metadata.componentName}
-          port: ${workload.endpoints[endpoint].port}
+          port: ${endpoint.value.port}
 
 # Create HTTPRoutes only for endpoints with internal visibility
 - id: httproute-internal
-  forEach: '${workload.endpoints.transformList(name, ep, ("internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+  forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
   var: endpoint
   template:
     apiVersion: gateway.networking.k8s.io/v1
     kind: HTTPRoute
     metadata:
-      name: '${oc_generate_name(metadata.componentName, endpoint, "internal")}'
+      name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
       namespace: ${metadata.namespace}
-      labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "internal"})}'
+      labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
     spec:
       parentRefs:
         - name: ${gateway.ingress.internal.name}
@@ -390,16 +390,16 @@ spec:
       - matches:
         - path:
             type: PathPrefix
-            value: /${metadata.componentName}-${endpoint}
+            value: /${metadata.componentName}-${endpoint.key}
         filters:
           - type: URLRewrite
             urlRewrite:
               path:
                 type: ReplacePrefixMatch
-                replacePrefixMatch: '${workload.endpoints[endpoint].?basePath.orValue("") != "" ? workload.endpoints[endpoint].?basePath.orValue("") : "/"}'
+                replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
         backendRefs:
         - name: ${metadata.componentName}
-          port: ${workload.endpoints[endpoint].port}
+          port: ${endpoint.value.port}
 ```
 
 **Iterating over all endpoints (generic pattern):**

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -406,7 +406,7 @@ files: |
 `,
 		},
 		{
-			name: "optional types with safe navigation",
+			name: "optional types with safe navigation - key absent",
 			template: `
 metadata:
   annotations: '${{"app": metadata.name, ?"custom": spec.?annotations.?custom}}'
@@ -418,6 +418,22 @@ metadata:
 			want: `metadata:
   annotations:
     app: my-app
+`,
+		},
+		{
+			name: "optional types with safe navigation - key present",
+			template: `
+metadata:
+  annotations: '${{"app": metadata.name, ?"custom": spec.?annotations.?custom}}'
+`,
+			inputs: `{
+  "metadata": {"name": "my-app"},
+  "spec": {"annotations": {"custom": "my-value"}}
+}`,
+			want: `metadata:
+  annotations:
+    app: my-app
+    custom: my-value
 `,
 		},
 		{

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -24,8 +24,8 @@ var schemaBasedFields = map[string]bool{
 
 // Cached field info derived from context types (excludes schema-based fields).
 var (
-	componentContextFields = decltype.ExtractFields(reflect.TypeOf(context.ComponentContext{}), schemaBasedFields)
-	traitContextFields     = decltype.ExtractFields(reflect.TypeOf(context.TraitContext{}), schemaBasedFields)
+	componentContextFields = decltype.ExtractFields(reflect.TypeFor[context.ComponentContext](), schemaBasedFields)
+	traitContextFields     = decltype.ExtractFields(reflect.TypeFor[context.TraitContext](), schemaBasedFields)
 )
 
 // SchemaOptions provides schema configuration for CEL environment and validation.
@@ -44,10 +44,12 @@ type SchemaOptions struct {
 // Variables are derived from ComponentContext struct fields:
 //   - parameters, environmentConfigs: Schema-aware types (or empty object if not provided)
 //   - metadata, dataplane, workload, configurations: Types derived via reflection
-func BuildComponentCELEnv(opts SchemaOptions) (*cel.Env, error) {
+//
+// Returns the environment and the DeclTypeProvider (for forEach value type resolution).
+func BuildComponentCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeProvider, error) {
 	baseEnv, err := createBaseEnv(true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	numFields := len(componentContextFields) + len(schemaBasedFields)
@@ -72,21 +74,27 @@ func BuildComponentCELEnv(opts SchemaOptions) (*cel.Env, error) {
 	provider := apiservercel.NewDeclTypeProvider(declTypes...)
 	providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	varOpts = append(varOpts, providerOpts...)
 
-	return baseEnv.Extend(varOpts...)
+	env, err := baseEnv.Extend(varOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return env, provider, nil
 }
 
 // BuildTraitCELEnv creates a schema-aware CEL environment for trait validation.
 // Variables are derived from TraitContext struct fields:
 //   - parameters, environmentConfigs: Schema-aware types (or empty object if not provided)
 //   - trait, metadata, dataplane, workload, configurations: Types derived via reflection
-func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, error) {
+//
+// Returns the environment and the DeclTypeProvider (for forEach value type resolution).
+func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeProvider, error) {
 	baseEnv, err := createBaseEnv(true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	numFields := len(traitContextFields) + len(schemaBasedFields)
@@ -111,11 +119,15 @@ func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, error) {
 	provider := apiservercel.NewDeclTypeProvider(declTypes...)
 	providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	varOpts = append(varOpts, providerOpts...)
 
-	return baseEnv.Extend(varOpts...)
+	env, err := baseEnv.Extend(varOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return env, provider, nil
 }
 
 // createBaseEnv creates the base CEL environment with standard extensions.

--- a/internal/validation/component/cel_env_test.go
+++ b/internal/validation/component/cel_env_test.go
@@ -21,7 +21,7 @@ func TestBuildComponentCELEnv_WithParametersSchema(t *testing.T) {
 		},
 	}
 
-	env, err := BuildComponentCELEnv(SchemaOptions{
+	env, _, err := BuildComponentCELEnv(SchemaOptions{
 		ParametersSchema: structural,
 	})
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestBuildComponentCELEnv_WithEnvironmentConfigsSchema(t *testing.T) {
 		},
 	}
 
-	env, err := BuildComponentCELEnv(SchemaOptions{
+	env, _, err := BuildComponentCELEnv(SchemaOptions{
 		EnvironmentConfigsSchema: structural,
 	})
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestBuildComponentCELEnv_WithEnvironmentConfigsSchema(t *testing.T) {
 
 func TestBuildComponentCELEnv_WithoutSchema(t *testing.T) {
 	// Without schema, parameters and environmentConfigs should be empty objects
-	env, err := BuildComponentCELEnv(SchemaOptions{})
+	env, _, err := BuildComponentCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
 
@@ -93,7 +93,7 @@ func TestBuildComponentCELEnv_WithoutSchema(t *testing.T) {
 
 func TestBuildComponentCELEnv_OtherVariables(t *testing.T) {
 	// Other variables (metadata, workload, etc.) should be accessible
-	env, err := BuildComponentCELEnv(SchemaOptions{})
+	env, _, err := BuildComponentCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
 
@@ -117,7 +117,7 @@ func TestBuildComponentCELEnv_OtherVariables(t *testing.T) {
 
 func TestBuildComponentCELEnv_CustomFunctions(t *testing.T) {
 	// Verify custom functions are available
-	env, err := BuildComponentCELEnv(SchemaOptions{})
+	env, _, err := BuildComponentCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
 
@@ -147,7 +147,7 @@ func TestBuildTraitCELEnv_WithParametersSchema(t *testing.T) {
 		},
 	}
 
-	env, err := BuildTraitCELEnv(SchemaOptions{
+	env, _, err := BuildTraitCELEnv(SchemaOptions{
 		ParametersSchema: structural,
 	})
 	require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestBuildTraitCELEnv_WithParametersSchema(t *testing.T) {
 
 func TestBuildTraitCELEnv_AllVariables(t *testing.T) {
 	// Traits should have access to all variables including workload and configurations
-	env, err := BuildTraitCELEnv(SchemaOptions{})
+	env, _, err := BuildTraitCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
 
@@ -191,7 +191,7 @@ func TestBuildTraitCELEnv_AllVariables(t *testing.T) {
 
 func TestBuildTraitCELEnv_WithoutSchema(t *testing.T) {
 	// Without schema, parameters and environmentConfigs should be empty objects
-	env, err := BuildTraitCELEnv(SchemaOptions{})
+	env, _, err := BuildTraitCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
 
@@ -206,7 +206,7 @@ func TestBuildTraitCELEnv_WithoutSchema(t *testing.T) {
 }
 
 func TestBuildComponentCELEnv_ReflectionBasedTypes(t *testing.T) {
-	env, err := BuildComponentCELEnv(SchemaOptions{})
+	env, _, err := BuildComponentCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -267,7 +267,7 @@ func TestBuildComponentCELEnv_ReflectionBasedTypes(t *testing.T) {
 }
 
 func TestBuildTraitCELEnv_ReflectionBasedTypes(t *testing.T) {
-	env, err := BuildTraitCELEnv(SchemaOptions{})
+	env, _, err := BuildTraitCELEnv(SchemaOptions{})
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/internal/validation/component/cel_validator.go
+++ b/internal/validation/component/cel_validator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
+	apiservercel "k8s.io/apiserver/pkg/cel"
 )
 
 // ResourceType indicates which type of resource is being validated
@@ -23,6 +24,7 @@ const (
 // CELValidator provides comprehensive CEL expression validation with AST analysis
 type CELValidator struct {
 	baseEnv      *cel.Env
+	typeProvider *apiservercel.DeclTypeProvider
 	resourceType ResourceType
 }
 
@@ -32,13 +34,14 @@ type CELValidator struct {
 // Provides schema-aware type checking when schemas are provided in opts.
 func NewCELValidator(resourceType ResourceType, opts SchemaOptions) (*CELValidator, error) {
 	var env *cel.Env
+	var provider *apiservercel.DeclTypeProvider
 	var err error
 
 	switch resourceType {
 	case ComponentTypeResource:
-		env, err = BuildComponentCELEnv(opts)
+		env, provider, err = BuildComponentCELEnv(opts)
 	case TraitResource:
-		env, err = BuildTraitCELEnv(opts)
+		env, provider, err = BuildTraitCELEnv(opts)
 	default:
 		return nil, fmt.Errorf("unknown resource type: %v", resourceType)
 	}
@@ -49,6 +52,7 @@ func NewCELValidator(resourceType ResourceType, opts SchemaOptions) (*CELValidat
 
 	return &CELValidator{
 		baseEnv:      env,
+		typeProvider: provider,
 		resourceType: resourceType,
 	}, nil
 }
@@ -121,4 +125,10 @@ func (v *CELValidator) ValidateIterableExpression(expr string, env *cel.Env) err
 // GetBaseEnv returns the base CEL environment for this validator
 func (v *CELValidator) GetBaseEnv() *cel.Env {
 	return v.baseEnv
+}
+
+// GetTypeProvider returns the DeclTypeProvider for this validator.
+// Used by forEach analysis to resolve map value types for field validation.
+func (v *CELValidator) GetTypeProvider() *apiservercel.DeclTypeProvider {
+	return v.typeProvider
 }

--- a/internal/validation/component/componenttype.go
+++ b/internal/validation/component/componenttype.go
@@ -76,7 +76,7 @@ func ValidateResourceTemplate(
 
 		// Extend environment with the loop variable
 		if forEachInfo != nil {
-			extendedEnv, err := ExtendEnvWithForEach(env, forEachInfo)
+			extendedEnv, err := ExtendEnvWithForEach(env, forEachInfo, validator.GetTypeProvider())
 			if err != nil {
 				allErrs = append(allErrs, field.InternalError(
 					basePath.Child("forEach"),

--- a/internal/validation/component/componenttype_test.go
+++ b/internal/validation/component/componenttype_test.go
@@ -160,6 +160,238 @@ func TestValidateClusterComponentTypeResourcesWithSchema_WithTypedSchema(t *test
 	}
 }
 
+func TestValidateResourceTemplate_ForEachMapFieldAccess(t *testing.T) {
+	tests := []struct {
+		name      string
+		cct       *v1alpha1.ClusterComponentType
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name: "valid map forEach with .key and .value access",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${{"http": 80, "grpc": 9090}}`,
+							Var:     "endpoint",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${endpoint.key}"}, "spec": {"port": "${endpoint.value}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid map forEach accessing undefined field on loop variable",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${{"http": 80, "grpc": 9090}}`,
+							Var:     "endpoint",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${endpoint.key}"}, "spec": {"port": "${endpoint.value2}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'value2'",
+		},
+		{
+			name: "valid map forEach with optional field access on .value",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${{"http": 80, "grpc": 9090}}`,
+							Var:     "item",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${item.key}"}, "spec": {"port": "${item.value}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid deep field access on workload.endpoints map value",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${workload.endpoints}`,
+							Var:     "ep",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${ep.key}"}, "spec": {"port": "${ep.value.port}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid deep field access on workload.endpoints map value",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${workload.endpoints}`,
+							Var:     "ep",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${ep.key}"}, "spec": {"path": "${ep.value.basePath2}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'basePath2'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateClusterComponentTypeResourcesWithSchema(tt.cct, nil, nil)
+			if tt.wantError {
+				assert.NotEmpty(t, errs, "expected validation error")
+				if tt.errMsg != "" {
+					errStr := errs.ToAggregate().Error()
+					assert.Contains(t, errStr, tt.errMsg)
+				}
+			} else {
+				assert.Empty(t, errs, "unexpected validation errors: %v", errs)
+			}
+		})
+	}
+}
+
+func TestValidateResourceTemplate_ForEachListFieldAccess(t *testing.T) {
+	tests := []struct {
+		name      string
+		cct       *v1alpha1.ClusterComponentType
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name: "valid list forEach with element access",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "config",
+							ForEach: `${["a", "b", "c"]}`,
+							Var:     "item",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "${item}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid list forEach with dyn-typed elements",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "config",
+							ForEach: `${configurations.toConfigFileList()}`,
+							Var:     "config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "${config.resourceName}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid list forEach without explicit var uses default item",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "config",
+							ForEach: `${["x", "y"]}`,
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "${item}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid map forEach with transformMap preserves type checking",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${workload.endpoints.transformMap(name, ep, ep.type == "HTTP", ep)}`,
+							Var:     "endpoint",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${endpoint.key}"}, "spec": {"port": "${endpoint.value.port}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid map forEach with transformMap catches bad field on value",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "route",
+							ForEach: `${workload.endpoints.transformMap(name, ep, ep.type == "HTTP", ep)}`,
+							Var:     "endpoint",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${endpoint.key}"}, "spec": {"port": "${endpoint.value.nonExistent}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'nonExistent'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateClusterComponentTypeResourcesWithSchema(tt.cct, nil, nil)
+			if tt.wantError {
+				assert.NotEmpty(t, errs, "expected validation error")
+				if tt.errMsg != "" {
+					errStr := errs.ToAggregate().Error()
+					assert.Contains(t, errStr, tt.errMsg)
+				}
+			} else {
+				assert.Empty(t, errs, "unexpected validation errors: %v", errs)
+			}
+		})
+	}
+}
+
 func TestValidateValidationRuleForClusterComponentType(t *testing.T) {
 	// ClusterComponentType passes nil for validations, so the validation rules loop is skipped.
 	// This test verifies that ValidateClusterComponentTypeResourcesWithSchema works correctly

--- a/internal/validation/component/foreach_types.go
+++ b/internal/validation/component/foreach_types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
+	apiservercel "k8s.io/apiserver/pkg/cel"
 )
 
 // ForEachType represents the type of iteration in a forEach expression
@@ -46,6 +47,11 @@ type ForEachInfo struct {
 	// For maps: ObjectType with "key" and "value" fields
 	// For lists: The element type
 	VarType *cel.Type
+
+	// VarDeclType is the DeclType for the loop variable (only for ForEachMap).
+	// Used to register a proper object type with key/value fields so that
+	// CEL can validate field access on the loop variable.
+	VarDeclType *apiservercel.DeclType
 
 	// KeyType is the type of map keys (only for ForEachMap)
 	KeyType *cel.Type
@@ -105,11 +111,10 @@ func AnalyzeForEachExpression(forEachExpr string, varName string, env *cel.Env) 
 			info.ValueType = cel.DynType
 		}
 
-		// Create MapEntry type for the loop variable
-		// This matches CEL's behavior when iterating over maps
-		// For now, we'll use DynType since cel.ObjectType has different signature
-		// In practice, the map iteration will still work correctly
-		info.VarType = cel.DynType
+		// MapEntry DeclType is created in ExtendEnvWithForEach where we have
+		// access to the DeclTypeProvider for resolving the value's actual type.
+		// For now, just record the value type for later resolution.
+		info.VarType = cel.DynType // placeholder; replaced in ExtendEnvWithForEach
 
 	case types.ListKind:
 		// List iteration: loop variable type is the element type
@@ -135,13 +140,87 @@ func AnalyzeForEachExpression(forEachExpr string, varName string, env *cel.Env) 
 }
 
 // ExtendEnvWithForEach extends a CEL environment with the forEach loop variable.
-// The variable is typed appropriately based on the forEach analysis.
-func ExtendEnvWithForEach(env *cel.Env, info *ForEachInfo) (*cel.Env, error) {
+// For map iterations, creates a MapEntry DeclType with properly typed key/value fields
+// so CEL validates field access on the loop variable. The typeProvider is used to
+// resolve the map's value type for deep field validation.
+func ExtendEnvWithForEach(env *cel.Env, info *ForEachInfo, typeProvider *apiservercel.DeclTypeProvider) (*cel.Env, error) {
 	if info == nil {
 		return env, nil
+	}
+
+	if info.Type == ForEachMap {
+		return extendEnvWithMapForEach(env, info, typeProvider)
 	}
 
 	return env.Extend(
 		cel.Variable(info.VarName, info.VarType),
 	)
+}
+
+// extendEnvWithMapForEach creates a MapEntry DeclType with key (string) and value
+// (resolved from the provider if possible, otherwise dyn) fields, registers it,
+// and declares the loop variable with the proper type.
+func extendEnvWithMapForEach(env *cel.Env, info *ForEachInfo, typeProvider *apiservercel.DeclTypeProvider) (*cel.Env, error) {
+	// Resolve the value's DeclType from the provider if the value type is a known object type
+	valueDeclType := resolveValueDeclType(info.ValueType, typeProvider)
+
+	mapEntryType := apiservercel.NewObjectType("MapEntry", map[string]*apiservercel.DeclField{
+		"key":   apiservercel.NewDeclField("key", apiservercel.StringType, true, nil, nil),
+		"value": apiservercel.NewDeclField("value", valueDeclType, true, nil, nil),
+	})
+
+	info.VarDeclType = mapEntryType
+	info.VarType = mapEntryType.CelType()
+
+	provider := apiservercel.NewDeclTypeProvider(mapEntryType)
+	providerOpts, err := provider.EnvOptions(env.CELTypeProvider())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create type provider for forEach variable: %w", err)
+	}
+	opts := make([]cel.EnvOption, 0, 1+len(providerOpts))
+	opts = append(opts, cel.Variable(info.VarName, info.VarType))
+	opts = append(opts, providerOpts...)
+	return env.Extend(opts...)
+}
+
+// resolveValueDeclType creates a shadow DeclType for the map value that mirrors
+// the original type's field structure but uses unique names to avoid conflicts
+// with types already registered in the base environment. Recursively shadows
+// nested object types so that field validation works at all depths.
+func resolveValueDeclType(valueType *cel.Type, typeProvider *apiservercel.DeclTypeProvider) *apiservercel.DeclType {
+	if valueType == nil || typeProvider == nil {
+		return apiservercel.DynType
+	}
+
+	if valueType.Kind() != types.StructKind {
+		return apiservercel.DynType
+	}
+
+	typeName := valueType.String()
+	srcType, found := typeProvider.FindDeclType(typeName)
+	if !found || len(srcType.Fields) == 0 {
+		return apiservercel.DynType
+	}
+
+	return shadowDeclType(srcType, "MapEntry.value", make(map[string]bool))
+}
+
+// shadowDeclType recursively creates a shadow copy of a DeclType with a unique
+// name prefix. Nested object-type fields are shadowed recursively; primitive
+// and other types fall back to DynType.
+func shadowDeclType(src *apiservercel.DeclType, shadowName string, seen map[string]bool) *apiservercel.DeclType {
+	if seen[src.TypeName()] {
+		return apiservercel.DynType
+	}
+	seen[src.TypeName()] = true
+
+	fields := make(map[string]*apiservercel.DeclField, len(src.Fields))
+	for name, field := range src.Fields {
+		fieldType := apiservercel.DynType
+		if field.Type != nil && field.Type.IsObject() && len(field.Type.Fields) > 0 {
+			fieldType = shadowDeclType(field.Type, shadowName+"."+name, seen)
+		}
+		fields[name] = apiservercel.NewDeclField(name, fieldType, field.Required, nil, nil)
+	}
+	return apiservercel.NewObjectType(shadowName, fields)
 }

--- a/internal/validation/component/trait.go
+++ b/internal/validation/component/trait.go
@@ -180,7 +180,7 @@ func ValidateTraitCreate(
 
 			// Extend environment with the loop variable
 			if forEachInfo != nil {
-				extendedEnv, err := ExtendEnvWithForEach(env, forEachInfo)
+				extendedEnv, err := ExtendEnvWithForEach(env, forEachInfo, validator.GetTypeProvider())
 				if err != nil {
 					allErrs = append(allErrs, field.InternalError(
 						basePath.Child("forEach"),
@@ -261,7 +261,7 @@ func ValidateTraitPatch(
 
 			// Extend environment with the loop variable
 			if forEachInfo != nil {
-				extendedEnv, err := ExtendEnvWithForEach(env, forEachInfo)
+				extendedEnv, err := ExtendEnvWithForEach(env, forEachInfo, validator.GetTypeProvider())
 				if err != nil {
 					allErrs = append(allErrs, field.InternalError(
 						basePath.Child("forEach"),

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -245,7 +245,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external
@@ -299,6 +299,16 @@ spec:
   validations:
     - rule: "${size(workload.endpoints) > 0}"
       message: "Service components must have at least one endpoint. Use 'deployment/worker' for components without endpoints."
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.external)
+          : true}
+      message: "Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane."
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "internal" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.internal)
+          : true}
+      message: "Endpoints with 'internal' visibility require gateway.ingress.internal to be configured on the Environment or DataPlane."
 
   environmentConfigs:
     openAPIV3Schema:
@@ -388,15 +398,15 @@ spec:
           selector: ${metadata.podSelectors}
           ports: ${workload.toServicePorts()}
     - id: httproute-external
-      forEach: '${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: ${oc_generate_name(metadata.componentName, endpoint)}
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "external"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.external.name}
@@ -409,26 +419,26 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
-                value: /${metadata.componentName}-${endpoint}
+                value: /${metadata.componentName}-${endpoint.key}
             filters:
               - type: URLRewrite
                 urlRewrite:
                   path:
                     type: ReplacePrefixMatch
-                    replacePrefixMatch: '${workload.endpoints[endpoint].?basePath.orValue("") != "" ? workload.endpoints[endpoint].?basePath.orValue("") : "/"}'
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
             backendRefs:
             - name: ${metadata.componentName}
-              port: ${workload.endpoints[endpoint].port}
+              port: ${endpoint.value.port}
     - id: httproute-internal
-      forEach: '${workload.endpoints.transformList(name, ep, ("internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: '${oc_generate_name(metadata.componentName, endpoint, "internal")}'
+          name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "internal"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.internal.name}
@@ -441,16 +451,16 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
-                value: /${metadata.componentName}-${endpoint}
+                value: /${metadata.componentName}-${endpoint.key}
             filters:
               - type: URLRewrite
                 urlRewrite:
                   path:
                     type: ReplacePrefixMatch
-                    replacePrefixMatch: '${workload.endpoints[endpoint].?basePath.orValue("") != "" ? workload.endpoints[endpoint].?basePath.orValue("") : "/"}'
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
             backendRefs:
             - name: ${metadata.componentName}
-              port: ${workload.endpoints[endpoint].port}
+              port: ${endpoint.value.port}
     - id: env-config
       forEach: ${configurations.toConfigEnvsByContainer()}
       var: envConfig
@@ -496,7 +506,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external
@@ -638,15 +648,15 @@ spec:
           ports: ${workload.toServicePorts()}
 
     - id: httproute-external
-      forEach: '${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: ${oc_generate_name(metadata.componentName, endpoint)}
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "external"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.external.name}
@@ -654,21 +664,21 @@ spec:
           hostnames: |
             ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, oc_dns_label(endpoint, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
+              .map(h, oc_dns_label(endpoint.key, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
           rules:
             - backendRefs:
                 - name: ${metadata.componentName}
-                  port: ${workload.endpoints[endpoint].port}
+                  port: ${endpoint.value.port}
     - id: httproute-internal
-      forEach: '${workload.endpoints.transformList(name, ep, ("internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: '${oc_generate_name(metadata.componentName, endpoint, "internal")}'
+          name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "internal"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.internal.name}
@@ -676,11 +686,11 @@ spec:
           hostnames: |
             ${[gateway.ingress.internal.?http, gateway.ingress.internal.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, oc_dns_label(endpoint, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
+              .map(h, oc_dns_label(endpoint.key, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
           rules:
             - backendRefs:
                 - name: ${metadata.componentName}
-                  port: ${workload.endpoints[endpoint].port}
+                  port: ${endpoint.value.port}
     - id: env-config
       forEach: ${configurations.toConfigEnvsByContainer()}
       var: envConfig
@@ -726,7 +736,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external
@@ -924,7 +934,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external

--- a/samples/getting-started/component-types/scheduled-task.yaml
+++ b/samples/getting-started/component-types/scheduled-task.yaml
@@ -168,7 +168,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external

--- a/samples/getting-started/component-types/service.yaml
+++ b/samples/getting-started/component-types/service.yaml
@@ -24,6 +24,16 @@ spec:
   validations:
     - rule: "${size(workload.endpoints) > 0}"
       message: "Service components must have at least one endpoint. Use 'deployment/worker' for components without endpoints."
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.external)
+          : true}
+      message: "Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane."
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "internal" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.internal)
+          : true}
+      message: "Endpoints with 'internal' visibility require gateway.ingress.internal to be configured on the Environment or DataPlane."
 
   environmentConfigs:
     openAPIV3Schema:
@@ -113,15 +123,15 @@ spec:
           selector: ${metadata.podSelectors}
           ports: ${workload.toServicePorts()}
     - id: httproute-external
-      forEach: '${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: ${oc_generate_name(metadata.componentName, endpoint)}
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "external"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.external.name}
@@ -134,26 +144,26 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
-                value: /${metadata.componentName}-${endpoint}
+                value: /${metadata.componentName}-${endpoint.key}
             filters:
               - type: URLRewrite
                 urlRewrite:
                   path:
                     type: ReplacePrefixMatch
-                    replacePrefixMatch: '${workload.endpoints[endpoint].?basePath.orValue("") != "" ? workload.endpoints[endpoint].?basePath.orValue("") : "/"}'
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
             backendRefs:
             - name: ${metadata.componentName}
-              port: ${workload.endpoints[endpoint].port}
+              port: ${endpoint.value.port}
     - id: httproute-internal
-      forEach: '${workload.endpoints.transformList(name, ep, ("internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: '${oc_generate_name(metadata.componentName, endpoint, "internal")}'
+          name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "internal"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.internal.name}
@@ -166,16 +176,16 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
-                value: /${metadata.componentName}-${endpoint}
+                value: /${metadata.componentName}-${endpoint.key}
             filters:
               - type: URLRewrite
                 urlRewrite:
                   path:
                     type: ReplacePrefixMatch
-                    replacePrefixMatch: '${workload.endpoints[endpoint].?basePath.orValue("") != "" ? workload.endpoints[endpoint].?basePath.orValue("") : "/"}'
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
             backendRefs:
             - name: ${metadata.componentName}
-              port: ${workload.endpoints[endpoint].port}
+              port: ${endpoint.value.port}
     - id: env-config
       forEach: ${configurations.toConfigEnvsByContainer()}
       var: envConfig
@@ -221,7 +231,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external

--- a/samples/getting-started/component-types/webapp.yaml
+++ b/samples/getting-started/component-types/webapp.yaml
@@ -112,15 +112,15 @@ spec:
           ports: ${workload.toServicePorts()}
 
     - id: httproute-external
-      forEach: '${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: ${oc_generate_name(metadata.componentName, endpoint)}
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "external"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.external.name}
@@ -128,21 +128,21 @@ spec:
           hostnames: |
             ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, oc_dns_label(endpoint, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
+              .map(h, oc_dns_label(endpoint.key, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
           rules:
             - backendRefs:
                 - name: ${metadata.componentName}
-                  port: ${workload.endpoints[endpoint].port}
+                  port: ${endpoint.value.port}
     - id: httproute-internal
-      forEach: '${workload.endpoints.transformList(name, ep, ("internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         metadata:
-          name: '${oc_generate_name(metadata.componentName, endpoint, "internal")}'
+          name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
           namespace: ${metadata.namespace}
-          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "internal"})}'
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
         spec:
           parentRefs:
             - name: ${gateway.ingress.internal.name}
@@ -150,11 +150,11 @@ spec:
           hostnames: |
             ${[gateway.ingress.internal.?http, gateway.ingress.internal.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, oc_dns_label(endpoint, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
+              .map(h, oc_dns_label(endpoint.key, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
           rules:
             - backendRefs:
                 - name: ${metadata.componentName}
-                  port: ${workload.endpoints[endpoint].port}
+                  port: ${endpoint.value.port}
     - id: env-config
       forEach: ${configurations.toConfigEnvsByContainer()}
       var: envConfig
@@ -200,7 +200,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external

--- a/samples/getting-started/component-types/worker.yaml
+++ b/samples/getting-started/component-types/worker.yaml
@@ -144,7 +144,7 @@ spec:
               "secretKey": secret.name,
               "remoteRef": {
                 "key": secret.remoteRef.key,
-                "property": has(secret.remoteRef.property) ? secret.remoteRef.property : oc_omit()
+                ?"property": secret.remoteRef.?property
               }
             })}
     - id: secret-file-external


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
  - Simplify forEach expressions in sample ComponentTypes by replacing verbose `transformList(...).flatten()` patterns with the cleaner
  transformMap(name, ep, predicate, ep) macro, and updating template references from `endpoint / workload.endpoints[endpoint]` to `endpoint.key / endpoint.value`
  - Simplify optional field expressions using CEL optional syntax (`?"key": obj.?field`) instead of verbose ternary patterns (`"property": has(x) ? x : oc_omit()`)
  - Add gateway validation rules to the service ComponentType ensuring gateway.ingress.external or gateway.ingress.internal is configured on
  the Environment or DataPlane when endpoints use the corresponding visibility

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
