### PR TITLE
feat: validate metadata.namespace in resource templates

### DIFF
--- a/internal/validation/component/resource_template.go
+++ b/internal/validation/component/resource_template.go
@@ -21,9 +21,14 @@ type resourceTemplateHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
 	Metadata   struct {
-		Name any `json:"name"` // Can be string or CEL expression
+		Name      any  `json:"name"`      // Can be string or CEL expression
+		Namespace *any `json:"namespace"` // Optional; if present, must be ${metadata.namespace}
 	} `json:"metadata"`
 }
+
+// allowedNamespaceValue is the only permitted value for metadata.namespace in resource templates.
+// The rendering pipeline sets the target namespace, so templates must not hardcode it.
+const allowedNamespaceValue = "${metadata.namespace}"
 
 // ValidateWorkloadResources validates resource templates and ensures workloadType matches a resource kind
 func ValidateWorkloadResources(workloadType string, resources []v1alpha1.ResourceTemplate, basePath *field.Path) field.ErrorList {
@@ -129,6 +134,19 @@ func ValidateResourceTemplateStructure(template runtime.RawExtension, fieldPath 
 			"metadata.name is required in resource template"))
 	}
 
+	// Validate metadata.namespace if present: only ${metadata.namespace} is allowed.
+	// We trim outer whitespace and normalize inner CEL whitespace so that
+	// "  ${metadata.namespace}  " and "${ metadata.namespace }" are accepted.
+	if header.Metadata.Namespace != nil {
+		nsStr, ok := (*header.Metadata.Namespace).(string)
+		if !ok || !isAllowedNamespaceValue(nsStr) {
+			allErrs = append(allErrs, field.Invalid(
+				fieldPath.Child("metadata", "namespace"),
+				*header.Metadata.Namespace,
+				fmt.Sprintf("if metadata.namespace is specified, it must be %q", allowedNamespaceValue)))
+		}
+	}
+
 	// Build partial object metadata for return value (for kind matching)
 	obj := &metav1.PartialObjectMetadata{}
 	obj.APIVersion = header.APIVersion
@@ -138,4 +156,17 @@ func ValidateResourceTemplateStructure(template runtime.RawExtension, fieldPath 
 	}
 
 	return obj, allErrs
+}
+
+// isAllowedNamespaceValue checks whether the given string is an acceptable
+// metadata.namespace value. It trims outer whitespace and normalizes
+// whitespace inside the ${...} delimiters so that variations like
+// "  ${metadata.namespace}  " and "${ metadata.namespace }" are accepted.
+func isAllowedNamespaceValue(val string) bool {
+	trimmed := strings.TrimSpace(val)
+	if !strings.HasPrefix(trimmed, "${") || !strings.HasSuffix(trimmed, "}") {
+		return false
+	}
+	inner := strings.TrimSpace(trimmed[2 : len(trimmed)-1])
+	return inner == "metadata.namespace"
 }

--- a/internal/webhook/componenttype/webhook_test.go
+++ b/internal/webhook/componenttype/webhook_test.go
@@ -461,6 +461,83 @@ var _ = Describe("ComponentType Webhook", func() {
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should allow template with metadata.namespace set to ${metadata.namespace}", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "test", "namespace": "${metadata.namespace}"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject template with hardcoded metadata.namespace", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "test", "namespace": "my-namespace"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("${metadata.namespace}"))
+		})
+
+		It("should allow template with whitespace inside ${metadata.namespace}", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "test", "namespace": "${ metadata.namespace }"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject template with different CEL expression in metadata.namespace", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "test", "namespace": "${parameters.namespace}"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("${metadata.namespace}"))
+		})
+
+		It("should allow template without metadata.namespace", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "test"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("Embedded Traits Validation", func() {

--- a/internal/webhook/trait/webhook_test.go
+++ b/internal/webhook/trait/webhook_test.go
@@ -313,6 +313,33 @@ var _ = Describe("Trait Webhook", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should allow creates template with metadata.namespace set to ${metadata.namespace}", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"name": "test-pvc", "namespace": "${metadata.namespace}"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject creates template with hardcoded metadata.namespace", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"name": "test-pvc", "namespace": "hardcoded-ns"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("${metadata.namespace}"))
+		})
+
 		It("should validate creates templates on update", func() {
 			// Valid old object
 			oldObj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Reject resource templates that hardcode metadata.namespace to arbitrary values. If specified, the only allowed value is ${metadata.namespace} (with optional whitespace). This applies to ComponentType, ClusterComponentType, Trait, ClusterTrait, and ComponentRelease webhooks via shared validation. 

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
