### PR TITLE
fix: add a config to toggle between browser redirection and popup for login in backstage

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -102,6 +102,8 @@ spec:
           value: {{ .Values.security.enabled | quote }}
         - name: OPENCHOREO_FEATURES_AUTHZ_ENABLED
           value: {{ .Values.security.authz.enabled | quote }}
+        - name: OPENCHOREO_FEATURES_AUTH_REDIRECT_FLOW_ENABLED
+          value: {{ .Values.backstage.features.auth.redirectFlow.enabled | quote }}
         # External CI Platform Integrations
         # Jenkins: requires jenkins.io/job-full-name annotation on entity
         - name: JENKINS_BASE_URL

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -405,6 +405,30 @@
           "additionalProperties": false,
           "description": "Feature flags for enabling/disabling OpenChoreo features in Backstage",
           "properties": {
+            "auth": {
+              "additionalProperties": false,
+              "description": "Authentication feature flags",
+              "properties": {
+                "redirectFlow": {
+                  "additionalProperties": false,
+                  "description": "Experimental redirect flow authentication configuration",
+                  "properties": {
+                    "enabled": {
+                      "default": true,
+                      "description": "Enable experimental redirect flow - silently redirects to IDP instead of showing sign-in popup",
+                      "title": "enabled",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [],
+                  "title": "redirectFlow",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "auth",
+              "type": "object"
+            },
             "observability": {
               "additionalProperties": false,
               "description": "Observability plane features (Metrics, Traces, Runtime Logs)",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2260,6 +2260,22 @@ backstage:
       # default: true
       # @schema
       enabled: true
+    # @schema
+    # type: object
+    # description: Authentication feature flags
+    # @schema
+    auth:
+      # @schema
+      # type: object
+      # description: Experimental redirect flow authentication configuration
+      # @schema
+      redirectFlow:
+        # @schema
+        # type: boolean
+        # description: Enable experimental redirect flow - silently redirects to IDP instead of showing sign-in popup
+        # default: true
+        # @schema
+        enabled: true
 
   # @schema
   # type: object


### PR DESCRIPTION
Depends on https://github.com/openchoreo/backstage-plugins/pull/440

This pull request introduces a new experimental authentication feature flag for Backstage in the OpenChoreo control plane Helm chart. The main change is the addition of the `redirectFlow` authentication option, which enables a silent redirect to the identity provider instead of showing a sign-in popup. The change is reflected in the deployment template, values file, and schema.

Authentication feature flag additions:

* Added a new `auth.redirectFlow.enabled` feature flag under `backstage.features` in `values.yaml`, allowing configuration of the experimental redirect flow authentication.
* Updated the Helm values schema (`values.schema.json`) to define the structure and documentation for the new `auth.redirectFlow.enabled` flag, including its default value and description.
* Modified the Backstage deployment template to set the `OPENCHOREO_FEATURES_AUTH_REDIRECT_FLOW_ENABLED` environment variable based on the new flag, enabling the feature at runtime.