### PR TITLE
test: migrate older occ cmd tests to use testify

### DIFF
--- a/internal/occ/cmd/clustercomponenttype/clustercomponenttype_test.go
+++ b/internal/occ/cmd/clustercomponenttype/clustercomponenttype_test.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
@@ -19,9 +21,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 
 	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
+	require.NoError(t, err)
 
 	origStdout := os.Stdout
 	os.Stdout = w
@@ -37,33 +37,24 @@ func captureStdout(t *testing.T, fn func()) string {
 	w.Close()
 
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("failed to read captured output: %v", err)
-	}
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
 
 	return buf.String()
 }
 
 func TestPrint_Nil(t *testing.T) {
 	out := captureStdout(t, func() {
-		if err := printList(nil); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(nil))
 	})
-	if !strings.Contains(out, "No cluster component types found") {
-		t.Errorf("expected empty message, got %q", out)
-	}
+	assert.Contains(t, out, "No cluster component types found")
 }
 
 func TestPrint_Empty(t *testing.T) {
 	out := captureStdout(t, func() {
-		if err := printList([]gen.ClusterComponentType{}); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList([]gen.ClusterComponentType{}))
 	})
-	if !strings.Contains(out, "No cluster component types found") {
-		t.Errorf("expected empty message, got %q", out)
-	}
+	assert.Contains(t, out, "No cluster component types found")
 }
 
 func TestPrint_WithItems(t *testing.T) {
@@ -87,26 +78,15 @@ func TestPrint_WithItems(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := printList(items); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(items))
 	})
 
-	// Verify header
-	if !strings.Contains(out, "NAME") || !strings.Contains(out, "WORKLOAD TYPE") || !strings.Contains(out, "AGE") {
-		t.Errorf("expected table header with NAME, WORKLOAD TYPE, AGE columns, got %q", out)
-	}
-
-	// Verify items
-	if !strings.Contains(out, "web-app") {
-		t.Errorf("expected output to contain 'web-app', got %q", out)
-	}
-	if !strings.Contains(out, "deployment") {
-		t.Errorf("expected output to contain 'deployment', got %q", out)
-	}
-	if !strings.Contains(out, "batch-job") {
-		t.Errorf("expected output to contain 'batch-job', got %q", out)
-	}
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "WORKLOAD TYPE")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "web-app")
+	assert.Contains(t, out, "deployment")
+	assert.Contains(t, out, "batch-job")
 }
 
 func TestPrint_NilSpec(t *testing.T) {
@@ -122,12 +102,8 @@ func TestPrint_NilSpec(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := printList(items); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(items))
 	})
 
-	if !strings.Contains(out, "no-spec-type") {
-		t.Errorf("expected output to contain 'no-spec-type', got %q", out)
-	}
+	assert.Contains(t, out, "no-spec-type")
 }

--- a/internal/occ/cmd/clustertrait/clustertrait_test.go
+++ b/internal/occ/cmd/clustertrait/clustertrait_test.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
@@ -19,9 +21,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 
 	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
+	require.NoError(t, err)
 
 	origStdout := os.Stdout
 	os.Stdout = w
@@ -37,33 +37,24 @@ func captureStdout(t *testing.T, fn func()) string {
 	w.Close()
 
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("failed to read captured output: %v", err)
-	}
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
 
 	return buf.String()
 }
 
 func TestPrint_Nil(t *testing.T) {
 	out := captureStdout(t, func() {
-		if err := printList(nil); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(nil))
 	})
-	if !strings.Contains(out, "No cluster traits found") {
-		t.Errorf("expected empty message, got %q", out)
-	}
+	assert.Contains(t, out, "No cluster traits found")
 }
 
 func TestPrint_Empty(t *testing.T) {
 	out := captureStdout(t, func() {
-		if err := printList([]gen.ClusterTrait{}); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList([]gen.ClusterTrait{}))
 	})
-	if !strings.Contains(out, "No cluster traits found") {
-		t.Errorf("expected empty message, got %q", out)
-	}
+	assert.Contains(t, out, "No cluster traits found")
 }
 
 func TestPrint_WithItems(t *testing.T) {
@@ -83,23 +74,13 @@ func TestPrint_WithItems(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := printList(items); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(items))
 	})
 
-	// Verify header
-	if !strings.Contains(out, "NAME") || !strings.Contains(out, "AGE") {
-		t.Errorf("expected table header with NAME, AGE columns, got %q", out)
-	}
-
-	// Verify items
-	if !strings.Contains(out, "ingress") {
-		t.Errorf("expected output to contain 'ingress', got %q", out)
-	}
-	if !strings.Contains(out, "storage") {
-		t.Errorf("expected output to contain 'storage', got %q", out)
-	}
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "ingress")
+	assert.Contains(t, out, "storage")
 }
 
 func TestPrint_NilTimestamp(t *testing.T) {
@@ -113,12 +94,8 @@ func TestPrint_NilTimestamp(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := printList(items); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(items))
 	})
 
-	if !strings.Contains(out, "no-timestamp") {
-		t.Errorf("expected output to contain 'no-timestamp', got %q", out)
-	}
+	assert.Contains(t, out, "no-timestamp")
 }

--- a/internal/occ/cmd/clusterworkflow/clusterworkflow_test.go
+++ b/internal/occ/cmd/clusterworkflow/clusterworkflow_test.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
@@ -19,9 +21,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 
 	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
+	require.NoError(t, err)
 
 	origStdout := os.Stdout
 	os.Stdout = w
@@ -37,33 +37,24 @@ func captureStdout(t *testing.T, fn func()) string {
 	w.Close()
 
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("failed to read captured output: %v", err)
-	}
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
 
 	return buf.String()
 }
 
 func TestPrint_Nil(t *testing.T) {
 	out := captureStdout(t, func() {
-		if err := printList(nil); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(nil))
 	})
-	if !strings.Contains(out, "No cluster workflows found") {
-		t.Errorf("expected empty message, got %q", out)
-	}
+	assert.Contains(t, out, "No cluster workflows found")
 }
 
 func TestPrint_Empty(t *testing.T) {
 	out := captureStdout(t, func() {
-		if err := printList([]gen.ClusterWorkflow{}); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList([]gen.ClusterWorkflow{}))
 	})
-	if !strings.Contains(out, "No cluster workflows found") {
-		t.Errorf("expected empty message, got %q", out)
-	}
+	assert.Contains(t, out, "No cluster workflows found")
 }
 
 func TestPrint_WithItems(t *testing.T) {
@@ -83,23 +74,13 @@ func TestPrint_WithItems(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := printList(items); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(items))
 	})
 
-	// Verify header
-	if !strings.Contains(out, "NAME") || !strings.Contains(out, "AGE") {
-		t.Errorf("expected table header with NAME, AGE columns, got %q", out)
-	}
-
-	// Verify items
-	if !strings.Contains(out, "build-go") {
-		t.Errorf("expected output to contain 'build-go', got %q", out)
-	}
-	if !strings.Contains(out, "build-docker") {
-		t.Errorf("expected output to contain 'build-docker', got %q", out)
-	}
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "build-go")
+	assert.Contains(t, out, "build-docker")
 }
 
 func TestPrint_NilTimestamp(t *testing.T) {
@@ -113,12 +94,8 @@ func TestPrint_NilTimestamp(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := printList(items); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, printList(items))
 	})
 
-	if !strings.Contains(out, "no-timestamp") {
-		t.Errorf("expected output to contain 'no-timestamp', got %q", out)
-	}
+	assert.Contains(t, out, "no-timestamp")
 }

--- a/internal/occ/cmd/componentrelease/resolver_test.go
+++ b/internal/occ/cmd/componentrelease/resolver_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
@@ -20,73 +22,48 @@ func TestBuildOutputDirResolver(t *testing.T) {
 	t.Run("priority 1: existing releases directory", func(t *testing.T) {
 		idx := index.New("/repo")
 
-		// Add a component
 		addComponent(t, idx, namespace, "my-comp", "my-proj", "/repo/projects/my-proj/components/my-comp/component.yaml")
-
-		// Add an existing release for the component
 		addRelease(t, idx, namespace, "my-comp-20250101-001", "my-proj", "my-comp", "/repo/projects/my-proj/components/my-comp/releases/my-comp-20250101-001.yaml")
 
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("my-proj", "my-comp")
-		want := "/repo/projects/my-proj/components/my-comp/releases"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, "/repo/projects/my-proj/components/my-comp/releases", resolver("my-proj", "my-comp"))
 	})
 
 	t.Run("priority 2: releases dir next to component (does not exist on disk)", func(t *testing.T) {
 		idx := index.New("/repo")
 
-		// Use a temp directory for the component so os.Stat works
 		tmpDir := t.TempDir()
 		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
-		if err := os.MkdirAll(compDir, 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(compDir, 0755))
 		compFile := filepath.Join(compDir, "component.yaml")
-		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(compFile, []byte(""), 0600))
 
 		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
 
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("my-proj", "my-comp")
-		want := filepath.Join(compDir, "releases")
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, filepath.Join(compDir, "releases"), resolver("my-proj", "my-comp"))
 	})
 
 	t.Run("releases dir already exists (empty): still uses releases/", func(t *testing.T) {
 		idx := index.New("/repo")
 
-		// Use a temp directory and create an empty releases/ dir
 		tmpDir := t.TempDir()
 		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
 		releasesDir := filepath.Join(compDir, "releases")
-		if err := os.MkdirAll(releasesDir, 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(releasesDir, 0755))
 		compFile := filepath.Join(compDir, "component.yaml")
-		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(compFile, []byte(""), 0600))
 
 		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
 
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("my-proj", "my-comp")
-		want := filepath.Join(compDir, "releases")
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, filepath.Join(compDir, "releases"), resolver("my-proj", "my-comp"))
 	})
 
 	t.Run("component not found: returns empty string", func(t *testing.T) {
@@ -94,10 +71,7 @@ func TestBuildOutputDirResolver(t *testing.T) {
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("nonexistent-proj", "nonexistent-comp")
-		if got != "" {
-			t.Errorf("expected empty string for unknown component, got %q", got)
-		}
+		assert.Empty(t, resolver("nonexistent-proj", "nonexistent-comp"))
 	})
 }
 
@@ -122,9 +96,7 @@ func addComponent(t *testing.T, idx *index.Index, namespace, name, project, file
 		},
 		FilePath: filePath,
 	}
-	if err := idx.Add(entry); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, idx.Add(entry))
 }
 
 // addRelease adds a ComponentRelease resource entry to the index.
@@ -149,7 +121,5 @@ func addRelease(t *testing.T, idx *index.Index, namespace, name, project, compon
 		},
 		FilePath: filePath,
 	}
-	if err := idx.Add(entry); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, idx.Add(entry))
 }

--- a/internal/occ/cmd/releasebinding/derive_pipeline_test.go
+++ b/internal/occ/cmd/releasebinding/derive_pipeline_test.go
@@ -6,6 +6,8 @@ package releasebinding
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
@@ -24,18 +26,9 @@ func TestDeriveUsePipeline(t *testing.T) {
 		addProject(t, idx, namespace, projectName, pipelineName)
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			ProjectName: projectName,
-		}
-
-		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if params.UsePipeline != pipelineName {
-			t.Errorf("UsePipeline = %q, want %q", params.UsePipeline, pipelineName)
-		}
+		params := GenerateParams{ProjectName: projectName}
+		require.NoError(t, deriveUsePipeline(ocIndex, namespace, &params))
+		assert.Equal(t, pipelineName, params.UsePipeline)
 	})
 
 	t.Run("skips derivation when UsePipeline already set", func(t *testing.T) {
@@ -43,97 +36,49 @@ func TestDeriveUsePipeline(t *testing.T) {
 		addProject(t, idx, namespace, projectName, pipelineName)
 		ocIndex := fsmode.WrapIndex(idx)
 
-		explicit := "explicit-pipeline"
-		params := GenerateParams{
-			ProjectName: projectName,
-			UsePipeline: explicit,
-		}
-
-		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if params.UsePipeline != explicit {
-			t.Errorf("UsePipeline = %q, want %q (should keep explicit value)", params.UsePipeline, explicit)
-		}
+		params := GenerateParams{ProjectName: projectName, UsePipeline: "explicit-pipeline"}
+		require.NoError(t, deriveUsePipeline(ocIndex, namespace, &params))
+		assert.Equal(t, "explicit-pipeline", params.UsePipeline)
 	})
 
 	t.Run("error when project not found", func(t *testing.T) {
 		idx := index.New("/repo")
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			ProjectName: "nonexistent",
-		}
-
+		params := GenerateParams{ProjectName: "nonexistent"}
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error for missing project, got nil")
-		}
-
-		want := `project "nonexistent" not found in namespace "test-ns"`
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, `project "nonexistent" not found in namespace "test-ns"`, err.Error())
 	})
 
 	t.Run("error when deploymentPipelineRef is empty", func(t *testing.T) {
 		idx := index.New("/repo")
-		addProject(t, idx, namespace, projectName, "") // empty pipelineRef
+		addProject(t, idx, namespace, projectName, "")
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			ProjectName: projectName,
-		}
-
+		params := GenerateParams{ProjectName: projectName}
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error for empty deploymentPipelineRef, got nil")
-		}
-
-		want := `project "my-proj" has no deploymentPipelineRef set`
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, `project "my-proj" has no deploymentPipelineRef set`, err.Error())
 	})
 
 	t.Run("error when --all is set and UsePipeline is empty", func(t *testing.T) {
 		idx := index.New("/repo")
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			All: true,
-		}
-
+		params := GenerateParams{All: true}
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error when --all is set without --use-pipeline, got nil")
-		}
-
-		want := "--use-pipeline is required when using --all"
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, "--use-pipeline is required when using --all", err.Error())
 	})
 
 	t.Run("no error when --all is set and UsePipeline is provided", func(t *testing.T) {
 		idx := index.New("/repo")
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			All:         true,
-			UsePipeline: pipelineName,
-		}
-
-		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if params.UsePipeline != pipelineName {
-			t.Errorf("UsePipeline = %q, want %q", params.UsePipeline, pipelineName)
-		}
+		params := GenerateParams{All: true, UsePipeline: pipelineName}
+		require.NoError(t, deriveUsePipeline(ocIndex, namespace, &params))
+		assert.Equal(t, pipelineName, params.UsePipeline)
 	})
 
 	t.Run("error when both UsePipeline and ProjectName are empty", func(t *testing.T) {
@@ -141,16 +86,9 @@ func TestDeriveUsePipeline(t *testing.T) {
 		ocIndex := fsmode.WrapIndex(idx)
 
 		params := GenerateParams{}
-
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error when pipeline cannot be derived, got nil")
-		}
-
-		want := "--use-pipeline is required (could not derive from project)"
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, "--use-pipeline is required (could not derive from project)", err.Error())
 	})
 
 	t.Run("error when ProjectName is empty and UsePipeline is empty", func(t *testing.T) {
@@ -158,18 +96,10 @@ func TestDeriveUsePipeline(t *testing.T) {
 		addProject(t, idx, namespace, projectName, pipelineName)
 		ocIndex := fsmode.WrapIndex(idx)
 
-		// ProjectName is empty, so derivation is skipped; UsePipeline is also empty
 		params := GenerateParams{}
-
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-
-		want := "--use-pipeline is required (could not derive from project)"
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, "--use-pipeline is required (could not derive from project)", err.Error())
 	})
 
 	t.Run("project in different namespace is not found", func(t *testing.T) {
@@ -177,40 +107,21 @@ func TestDeriveUsePipeline(t *testing.T) {
 		addProject(t, idx, "other-ns", "other-proj", pipelineName)
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			ProjectName: "other-proj",
-		}
-
+		params := GenerateParams{ProjectName: "other-proj"}
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error when project is in different namespace, got nil")
-		}
-
-		want := `project "other-proj" not found in namespace "test-ns"`
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, `project "other-proj" not found in namespace "test-ns"`, err.Error())
 	})
 
 	t.Run("project without spec field returns empty pipelineRef error", func(t *testing.T) {
 		idx := index.New("/repo")
-		// Add a project with no spec at all
 		addProjectRaw(t, idx, namespace, projectName, nil)
 		ocIndex := fsmode.WrapIndex(idx)
 
-		params := GenerateParams{
-			ProjectName: projectName,
-		}
-
+		params := GenerateParams{ProjectName: projectName}
 		err := deriveUsePipeline(ocIndex, namespace, &params)
-		if err == nil {
-			t.Fatal("expected error for project without spec, got nil")
-		}
-
-		want := `project "my-proj" has no deploymentPipelineRef set`
-		if err.Error() != want {
-			t.Errorf("error = %q, want %q", err.Error(), want)
-		}
+		require.Error(t, err)
+		assert.Equal(t, `project "my-proj" has no deploymentPipelineRef set`, err.Error())
 	})
 }
 
@@ -242,7 +153,5 @@ func addProjectRaw(t *testing.T, idx *index.Index, namespace, name string, spec 
 		Resource: &unstructured.Unstructured{Object: obj},
 		FilePath: "/repo/projects/" + name + "/project.yaml",
 	}
-	if err := idx.Add(entry); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, idx.Add(entry))
 }

--- a/internal/occ/cmd/releasebinding/resolver_test.go
+++ b/internal/occ/cmd/releasebinding/resolver_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
@@ -20,20 +22,13 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 	t.Run("priority 1: existing bindings directory", func(t *testing.T) {
 		idx := index.New("/repo")
 
-		// Add a component
 		addComponent(t, idx, namespace, "my-comp", "my-proj", "/repo/projects/my-proj/components/my-comp/component.yaml")
-
-		// Add an existing binding for the component
 		addBinding(t, idx, namespace, "my-comp-dev", "my-proj", "my-comp", "dev", "/repo/projects/my-proj/components/my-comp/bindings/my-comp-dev.yaml")
 
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("my-proj", "my-comp")
-		want := "/repo/projects/my-proj/components/my-comp/bindings"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, "/repo/projects/my-proj/components/my-comp/bindings", resolver("my-proj", "my-comp"))
 	})
 
 	t.Run("priority 2: bindings dir next to component (does not exist on disk)", func(t *testing.T) {
@@ -41,24 +36,16 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
-		if err := os.MkdirAll(compDir, 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(compDir, 0755))
 		compFile := filepath.Join(compDir, "component.yaml")
-		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(compFile, []byte(""), 0600))
 
 		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
 
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("my-proj", "my-comp")
-		want := filepath.Join(compDir, "release-bindings")
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, filepath.Join(compDir, "release-bindings"), resolver("my-proj", "my-comp"))
 	})
 
 	t.Run("release-bindings dir already exists (empty): still uses release-bindings/", func(t *testing.T) {
@@ -67,24 +54,16 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 		tmpDir := t.TempDir()
 		compDir := filepath.Join(tmpDir, "projects", "my-proj", "components", "my-comp")
 		bindingsDir := filepath.Join(compDir, "release-bindings")
-		if err := os.MkdirAll(bindingsDir, 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(bindingsDir, 0755))
 		compFile := filepath.Join(compDir, "component.yaml")
-		if err := os.WriteFile(compFile, []byte(""), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(compFile, []byte(""), 0600))
 
 		addComponent(t, idx, namespace, "my-comp", "my-proj", compFile)
 
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("my-proj", "my-comp")
-		want := filepath.Join(compDir, "release-bindings")
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, filepath.Join(compDir, "release-bindings"), resolver("my-proj", "my-comp"))
 	})
 
 	t.Run("component not found: returns empty string", func(t *testing.T) {
@@ -92,10 +71,7 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 		ocIndex := fsmode.WrapIndex(idx)
 		resolver := buildBindingOutputDirResolver(ocIndex, namespace)
 
-		got := resolver("nonexistent-proj", "nonexistent-comp")
-		if got != "" {
-			t.Errorf("expected empty string for unknown component, got %q", got)
-		}
+		assert.Empty(t, resolver("nonexistent-proj", "nonexistent-comp"))
 	})
 }
 
@@ -120,9 +96,7 @@ func addComponent(t *testing.T, idx *index.Index, namespace, name, project, file
 		},
 		FilePath: filePath,
 	}
-	if err := idx.Add(entry); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, idx.Add(entry))
 }
 
 // addBinding adds a ReleaseBinding resource entry to the index.
@@ -148,7 +122,5 @@ func addBinding(t *testing.T, idx *index.Index, namespace, name, project, compon
 		},
 		FilePath: filePath,
 	}
-	if err := idx.Add(entry); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, idx.Add(entry))
 }

--- a/internal/occ/cmd/setoverride/setoverride_test.go
+++ b/internal/occ/cmd/setoverride/setoverride_test.go
@@ -5,6 +5,9 @@ package setoverride
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToSjsonPath(t *testing.T) {
@@ -13,84 +16,24 @@ func TestToSjsonPath(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{
-			name:     "simple dot path unchanged",
-			input:    "spec.replicas",
-			expected: "spec.replicas",
-		},
-		{
-			name:     "bracket index at end",
-			input:    "spec.containers[0]",
-			expected: "spec.containers.0",
-		},
-		{
-			name:     "bracket index in middle",
-			input:    "spec.containers[0].name",
-			expected: "spec.containers.0.name",
-		},
-		{
-			name:     "multiple bracket indices",
-			input:    "spec.containers[0].ports[1].containerPort",
-			expected: "spec.containers.0.ports.1.containerPort",
-		},
-		{
-			name:     "negative index for append",
-			input:    "spec.containers[-1]",
-			expected: "spec.containers.-1",
-		},
-		{
-			name:     "nested array indices",
-			input:    "matrix[0][1]",
-			expected: "matrix.0.1",
-		},
-		{
-			name:     "single key unchanged",
-			input:    "name",
-			expected: "name",
-		},
-		{
-			name:     "deeply nested with mixed notation",
-			input:    "a.b[0].c.d[2].e",
-			expected: "a.b.0.c.d.2.e",
-		},
-		{
-			name:     "bare numeric segment becomes object key",
-			input:    "spec.containers.0.image",
-			expected: "spec.containers.:0.image",
-		},
-		{
-			name:     "multiple bare numeric segments become object keys",
-			input:    "a.1.b.2.c",
-			expected: "a.:1.b.:2.c",
-		},
-		{
-			name:     "bare numeric only",
-			input:    "0",
-			expected: ":0",
-		},
-		{
-			name:     "mixed bracket and bare numeric",
-			input:    "spec.items[0].configs.1.name",
-			expected: "spec.items.0.configs.:1.name",
-		},
-		{
-			name:     "escaped dot preserves single key",
-			input:    `labels.foo\.0`,
-			expected: `labels.foo\.0`,
-		},
-		{
-			name:     "escaped dot with deeper path",
-			input:    `metadata.labels.app\.kubernetes\.io/name`,
-			expected: `metadata.labels.app\.kubernetes\.io/name`,
-		},
+		{name: "simple dot path unchanged", input: "spec.replicas", expected: "spec.replicas"},
+		{name: "bracket index at end", input: "spec.containers[0]", expected: "spec.containers.0"},
+		{name: "bracket index in middle", input: "spec.containers[0].name", expected: "spec.containers.0.name"},
+		{name: "multiple bracket indices", input: "spec.containers[0].ports[1].containerPort", expected: "spec.containers.0.ports.1.containerPort"},
+		{name: "negative index for append", input: "spec.containers[-1]", expected: "spec.containers.-1"},
+		{name: "nested array indices", input: "matrix[0][1]", expected: "matrix.0.1"},
+		{name: "single key unchanged", input: "name", expected: "name"},
+		{name: "deeply nested with mixed notation", input: "a.b[0].c.d[2].e", expected: "a.b.0.c.d.2.e"},
+		{name: "bare numeric segment becomes object key", input: "spec.containers.0.image", expected: "spec.containers.:0.image"},
+		{name: "multiple bare numeric segments become object keys", input: "a.1.b.2.c", expected: "a.:1.b.:2.c"},
+		{name: "bare numeric only", input: "0", expected: ":0"},
+		{name: "mixed bracket and bare numeric", input: "spec.items[0].configs.1.name", expected: "spec.items.0.configs.:1.name"},
+		{name: "escaped dot preserves single key", input: `labels.foo\.0`, expected: `labels.foo\.0`},
+		{name: "escaped dot with deeper path", input: `metadata.labels.app\.kubernetes\.io/name`, expected: `metadata.labels.app\.kubernetes\.io/name`},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ToSjsonPath(tt.input)
-			if got != tt.expected {
-				t.Errorf("ToSjsonPath(%q) = %q, want %q", tt.input, got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, ToSjsonPath(tt.input))
 		})
 	}
 }
@@ -125,13 +68,9 @@ func TestToJSONLiteral(t *testing.T) {
 		{name: "word", input: "hello", expected: `"hello"`},
 		{name: "empty", input: "", expected: `""`},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toJSONLiteral(tt.input)
-			if got != tt.expected {
-				t.Errorf("toJSONLiteral(%q) = %q, want %q", tt.input, got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, toJSONLiteral(tt.input))
 		})
 	}
 }
@@ -144,96 +83,29 @@ func TestApply(t *testing.T) {
 		expected  string
 		wantErr   bool
 	}{
-		{
-			name:      "set simple string value",
-			jsonStr:   `{"spec":{"name":"old"}}`,
-			setValues: []string{"spec.name=new"},
-			expected:  `{"spec":{"name":"new"}}`,
-		},
-		{
-			name:      "set numeric value",
-			jsonStr:   `{"spec":{"replicas":1}}`,
-			setValues: []string{"spec.replicas=3"},
-			expected:  `{"spec":{"replicas":3}}`,
-		},
-		{
-			name:      "set boolean value",
-			jsonStr:   `{"spec":{"enabled":false}}`,
-			setValues: []string{"spec.enabled=true"},
-			expected:  `{"spec":{"enabled":true}}`,
-		},
-		{
-			name:      "set array element with bracket notation",
-			jsonStr:   `{"spec":{"items":["a","b","c"]}}`,
-			setValues: []string{"spec.items[1]=x"},
-			expected:  `{"spec":{"items":["a","x","c"]}}`,
-		},
-		{
-			name:      "set nested object in array with bracket notation",
-			jsonStr:   `{"spec":{"containers":[{"name":"app","image":"old"}]}}`,
-			setValues: []string{"spec.containers[0].image=new"},
-			expected:  `{"spec":{"containers":[{"name":"app","image":"new"}]}}`,
-		},
-		{
-			name:      "multiple set values",
-			jsonStr:   `{"spec":{"name":"old","replicas":1}}`,
-			setValues: []string{"spec.name=new", "spec.replicas=5"},
-			expected:  `{"spec":{"name":"new","replicas":5}}`,
-		},
-		{
-			name:      "bare numeric creates object key not array index",
-			jsonStr:   `{"spec":{}}`,
-			setValues: []string{"spec.0=hello"},
-			expected:  `{"spec":{"0":"hello"}}`,
-		},
-		{
-			name:      "empty set values is no-op",
-			jsonStr:   `{"spec":{"name":"old"}}`,
-			setValues: []string{},
-			expected:  `{"spec":{"name":"old"}}`,
-		},
-		{
-			name:      "missing equals sign",
-			jsonStr:   `{}`,
-			setValues: []string{"spec.name"},
-			wantErr:   true,
-		},
-		{
-			name:      "empty key",
-			jsonStr:   `{}`,
-			setValues: []string{"=value"},
-			wantErr:   true,
-		},
-		{
-			name:      "set null value",
-			jsonStr:   `{"spec":{"name":"old"}}`,
-			setValues: []string{"spec.name=null"},
-			expected:  `{"spec":{"name":null}}`,
-		},
-		{
-			name:      "leading zero stays as string",
-			jsonStr:   `{"spec":{}}`,
-			setValues: []string{"spec.id=01"},
-			expected:  `{"spec":{"id":"01"}}`,
-		},
-		{
-			name:      "leading plus stays as string",
-			jsonStr:   `{"spec":{}}`,
-			setValues: []string{"spec.val=+1"},
-			expected:  `{"spec":{"val":"+1"}}`,
-		},
+		{name: "set simple string value", jsonStr: `{"spec":{"name":"old"}}`, setValues: []string{"spec.name=new"}, expected: `{"spec":{"name":"new"}}`},
+		{name: "set numeric value", jsonStr: `{"spec":{"replicas":1}}`, setValues: []string{"spec.replicas=3"}, expected: `{"spec":{"replicas":3}}`},
+		{name: "set boolean value", jsonStr: `{"spec":{"enabled":false}}`, setValues: []string{"spec.enabled=true"}, expected: `{"spec":{"enabled":true}}`},
+		{name: "set array element with bracket notation", jsonStr: `{"spec":{"items":["a","b","c"]}}`, setValues: []string{"spec.items[1]=x"}, expected: `{"spec":{"items":["a","x","c"]}}`},
+		{name: "set nested object in array with bracket notation", jsonStr: `{"spec":{"containers":[{"name":"app","image":"old"}]}}`, setValues: []string{"spec.containers[0].image=new"}, expected: `{"spec":{"containers":[{"name":"app","image":"new"}]}}`},
+		{name: "multiple set values", jsonStr: `{"spec":{"name":"old","replicas":1}}`, setValues: []string{"spec.name=new", "spec.replicas=5"}, expected: `{"spec":{"name":"new","replicas":5}}`},
+		{name: "bare numeric creates object key not array index", jsonStr: `{"spec":{}}`, setValues: []string{"spec.0=hello"}, expected: `{"spec":{"0":"hello"}}`},
+		{name: "empty set values is no-op", jsonStr: `{"spec":{"name":"old"}}`, setValues: []string{}, expected: `{"spec":{"name":"old"}}`},
+		{name: "missing equals sign", jsonStr: `{}`, setValues: []string{"spec.name"}, wantErr: true},
+		{name: "empty key", jsonStr: `{}`, setValues: []string{"=value"}, wantErr: true},
+		{name: "set null value", jsonStr: `{"spec":{"name":"old"}}`, setValues: []string{"spec.name=null"}, expected: `{"spec":{"name":null}}`},
+		{name: "leading zero stays as string", jsonStr: `{"spec":{}}`, setValues: []string{"spec.id=01"}, expected: `{"spec":{"id":"01"}}`},
+		{name: "leading plus stays as string", jsonStr: `{"spec":{}}`, setValues: []string{"spec.val=+1"}, expected: `{"spec":{"val":"+1"}}`},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Apply(tt.jsonStr, tt.setValues)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Apply() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !tt.wantErr && got != tt.expected {
-				t.Errorf("Apply() = %q, want %q", got, tt.expected)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
$subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2818

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
