### PR TITLE
feat: add typed return types for CEL helper function validation

### DIFF
--- a/internal/pipeline/component/context/cel_extensions.go
+++ b/internal/pipeline/component/context/cel_extensions.go
@@ -27,7 +27,9 @@ const (
 	protocolUDP              = "UDP"
 )
 
-// CELExtensions returns CEL environment options for configuration helpers.
+// CELExtensions returns CEL environment options for configuration helpers used by the runtime template engine.
+// IMPORTANT: Keep in sync with CELValidationExtensions() in cel_return_types.go.
+// When adding a new function or macro here, add the corresponding typed declaration there.
 // These include:
 //   - Macro: configurations.toConfigFileList() -> configurationsToConfigFileList(configurations, prefix)
 //   - Function: configurationsToConfigFileList

--- a/internal/pipeline/component/context/cel_return_types.go
+++ b/internal/pipeline/component/context/cel_return_types.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"github.com/google/cel-go/cel"
+)
+
+// Return type structs for CEL helper functions.
+// These mirror the map[string]any shapes returned at runtime and are used
+// by the validation environment to provide typed function declarations so
+// that CEL's type checker can catch invalid field access in forEach loops.
+
+// ConfigFileListEntry represents an element returned by configurations.toConfigFileList().
+type ConfigFileListEntry struct {
+	Name         string         `json:"name"`
+	MountPath    string         `json:"mountPath"`
+	Value        string         `json:"value"`
+	ResourceName string         `json:"resourceName"`
+	RemoteRef    *RemoteRefData `json:"remoteRef,omitempty"`
+}
+
+// SecretFileListEntry represents an element returned by configurations.toSecretFileList().
+type SecretFileListEntry struct {
+	Name         string         `json:"name"`
+	MountPath    string         `json:"mountPath"`
+	ResourceName string         `json:"resourceName"`
+	RemoteRef    *RemoteRefData `json:"remoteRef,omitempty"`
+}
+
+// EnvFromEntry represents an element returned by configurations.toContainerEnvFrom().
+type EnvFromEntry struct {
+	ConfigMapRef *NameRef `json:"configMapRef,omitempty"`
+	SecretRef    *NameRef `json:"secretRef,omitempty"`
+}
+
+// NameRef is a reference containing a name field.
+type NameRef struct {
+	Name string `json:"name"`
+}
+
+// VolumeMountEntry represents an element returned by configurations.toContainerVolumeMounts().
+type VolumeMountEntry struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mountPath"`
+	SubPath   string `json:"subPath"`
+}
+
+// VolumeEntry represents an element returned by configurations.toVolumes().
+type VolumeEntry struct {
+	Name      string           `json:"name"`
+	ConfigMap *ConfigMapVolume `json:"configMap,omitempty"`
+	Secret    *SecretVolume    `json:"secret,omitempty"`
+}
+
+// ConfigMapVolume represents a configMap volume source.
+type ConfigMapVolume struct {
+	Name string `json:"name"`
+}
+
+// SecretVolume represents a secret volume source.
+type SecretVolume struct {
+	SecretName string `json:"secretName"`
+}
+
+// EnvsByContainerEntry represents an element returned by
+// configurations.toConfigEnvsByContainer() or configurations.toSecretEnvsByContainer().
+type EnvsByContainerEntry struct {
+	ResourceName string             `json:"resourceName"`
+	Envs         []EnvConfiguration `json:"envs"`
+}
+
+// ServicePortEntry represents an element returned by workload.toServicePorts().
+type ServicePortEntry struct {
+	Name       string `json:"name"`
+	Port       int64  `json:"port"`
+	TargetPort int64  `json:"targetPort"`
+	Protocol   string `json:"protocol"`
+}
+
+// CELValidationExtensions returns CEL environment options for the validation environment.
+// Unlike CELExtensions(), function overloads declare typed return types instead of dyn,
+// enabling the type checker to validate field access on forEach loop variables.
+// No binding functions are registered since validation never evaluates expressions.
+func CELValidationExtensions() []cel.EnvOption {
+	return []cel.EnvOption{
+		// Same macros as the runtime environment
+		cel.Macros(toConfigFileListMacro, toSecretFileListMacro, toContainerEnvFromMacro, toContainerVolumeMountsMacro, toVolumesMacro, toConfigEnvsByContainerMacro, toSecretEnvsByContainerMacro, toServicePortsMacro, toContainerEnvMacro),
+		// Typed function declarations for validation
+		cel.Function("configurationsToConfigFileList",
+			cel.Overload("configurationsToConfigFileList_dyn_string_typed",
+				[]*cel.Type{cel.DynType, cel.StringType}, cel.ListType(cel.ObjectType("ConfigFileListEntry")),
+			),
+		),
+		cel.Function("configurationsToSecretFileList",
+			cel.Overload("configurationsToSecretFileList_dyn_string_typed",
+				[]*cel.Type{cel.DynType, cel.StringType}, cel.ListType(cel.ObjectType("SecretFileListEntry")),
+			),
+		),
+		cel.Function("configurationsToContainerEnvFrom",
+			cel.Overload("configurationsToContainerEnvFrom_dyn_string_typed",
+				[]*cel.Type{cel.DynType, cel.StringType}, cel.ListType(cel.ObjectType("EnvFromEntry")),
+			),
+		),
+		cel.Function("configurationsToContainerVolumeMounts",
+			cel.Overload("configurationsToContainerVolumeMounts_dyn_typed",
+				[]*cel.Type{cel.DynType}, cel.ListType(cel.ObjectType("VolumeMountEntry")),
+			),
+		),
+		cel.Function("configurationsToVolumes",
+			cel.Overload("configurationsToVolumes_dyn_string_typed",
+				[]*cel.Type{cel.DynType, cel.StringType}, cel.ListType(cel.ObjectType("VolumeEntry")),
+			),
+		),
+		cel.Function("configurationsToConfigEnvsByContainer",
+			cel.Overload("configurationsToConfigEnvsByContainer_dyn_string_typed",
+				[]*cel.Type{cel.DynType, cel.StringType}, cel.ListType(cel.ObjectType("EnvsByContainerEntry")),
+			),
+		),
+		cel.Function("configurationsToSecretEnvsByContainer",
+			cel.Overload("configurationsToSecretEnvsByContainer_dyn_string_typed",
+				[]*cel.Type{cel.DynType, cel.StringType}, cel.ListType(cel.ObjectType("EnvsByContainerEntry")),
+			),
+		),
+		cel.Function("workloadToServicePorts",
+			cel.Overload("workloadToServicePorts_dyn_typed",
+				[]*cel.Type{cel.DynType}, cel.ListType(cel.ObjectType("ServicePortEntry")),
+			),
+		),
+	}
+}

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -28,6 +28,19 @@ var (
 	traitContextFields     = decltype.ExtractFields(reflect.TypeFor[context.TraitContext](), schemaBasedFields)
 )
 
+// functionReturnDeclTypes are DeclTypes for the return types of CEL helper functions.
+// Registered with the DeclTypeProvider so the type checker can resolve field access
+// on forEach loop variables that iterate over function results.
+var functionReturnDeclTypes = []*apiservercel.DeclType{
+	decltype.FromGoType(reflect.TypeFor[context.ConfigFileListEntry]()),
+	decltype.FromGoType(reflect.TypeFor[context.SecretFileListEntry]()),
+	decltype.FromGoType(reflect.TypeFor[context.EnvFromEntry]()),
+	decltype.FromGoType(reflect.TypeFor[context.VolumeMountEntry]()),
+	decltype.FromGoType(reflect.TypeFor[context.VolumeEntry]()),
+	decltype.FromGoType(reflect.TypeFor[context.EnvsByContainerEntry]()),
+	decltype.FromGoType(reflect.TypeFor[context.ServicePortEntry]()),
+}
+
 // SchemaOptions provides schema configuration for CEL environment and validation.
 // Used by both component and trait CEL environments.
 type SchemaOptions struct {
@@ -53,7 +66,7 @@ func BuildComponentCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeP
 	}
 
 	numFields := len(componentContextFields) + len(schemaBasedFields)
-	declTypes := make([]*apiservercel.DeclType, 0, numFields)
+	declTypes := make([]*apiservercel.DeclType, 0, numFields+len(functionReturnDeclTypes))
 	varOpts := make([]cel.EnvOption, 0, numFields)
 
 	// Register schema-based fields
@@ -70,6 +83,9 @@ func BuildComponentCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeP
 		declTypes = append(declTypes, f.DeclType)
 		varOpts = append(varOpts, cel.Variable(f.Name, f.DeclType.CelType()))
 	}
+
+	// Register function return types so the type checker can validate field access
+	declTypes = append(declTypes, functionReturnDeclTypes...)
 
 	provider := apiservercel.NewDeclTypeProvider(declTypes...)
 	providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
@@ -98,7 +114,7 @@ func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeProvi
 	}
 
 	numFields := len(traitContextFields) + len(schemaBasedFields)
-	declTypes := make([]*apiservercel.DeclType, 0, numFields)
+	declTypes := make([]*apiservercel.DeclType, 0, numFields+len(functionReturnDeclTypes))
 	varOpts := make([]cel.EnvOption, 0, numFields)
 
 	// Register schema-based fields
@@ -116,6 +132,9 @@ func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeProvi
 		varOpts = append(varOpts, cel.Variable(f.Name, f.DeclType.CelType()))
 	}
 
+	// Register function return types so the type checker can validate field access
+	declTypes = append(declTypes, functionReturnDeclTypes...)
+
 	provider := apiservercel.NewDeclTypeProvider(declTypes...)
 	providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
 	if err != nil {
@@ -131,11 +150,13 @@ func BuildTraitCELEnv(opts SchemaOptions) (*cel.Env, *apiservercel.DeclTypeProvi
 }
 
 // createBaseEnv creates the base CEL environment with standard extensions.
+// Uses CELValidationExtensions() which provides typed function return types
+// so the type checker can validate field access on forEach loop variables.
 func createBaseEnv(includeConfigExtensions bool) (*cel.Env, error) {
 	baseEnvOpts := template.BaseCELExtensions()
 
 	if includeConfigExtensions {
-		baseEnvOpts = append(baseEnvOpts, context.CELExtensions()...)
+		baseEnvOpts = append(baseEnvOpts, context.CELValidationExtensions()...)
 	}
 
 	return cel.NewEnv(baseEnvOpts...)

--- a/internal/validation/component/componenttype_test.go
+++ b/internal/validation/component/componenttype_test.go
@@ -303,7 +303,7 @@ func TestValidateResourceTemplate_ForEachListFieldAccess(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "valid list forEach with dyn-typed elements",
+			name: "valid list forEach with typed elements from toConfigFileList",
 			cct: &v1alpha1.ClusterComponentType{
 				Spec: v1alpha1.ClusterComponentTypeSpec{
 					Resources: []v1alpha1.ResourceTemplate{
@@ -366,6 +366,81 @@ func TestValidateResourceTemplate_ForEachListFieldAccess(t *testing.T) {
 							Var:     "endpoint",
 							Template: &runtime.RawExtension{
 								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${endpoint.key}"}, "spec": {"port": "${endpoint.value.nonExistent}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'nonExistent'",
+		},
+		{
+			name: "valid forEach with toSecretEnvsByContainer accessing valid fields",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "secret",
+							ForEach: `${configurations.toSecretEnvsByContainer()}`,
+							Var:     "secretEnv",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Secret", "metadata": {"name": "${secretEnv.resourceName}"}, "data": "${secretEnv.envs}"}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid forEach with toSecretEnvsByContainer accessing invalid field",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "secret",
+							ForEach: `${configurations.toSecretEnvsByContainer()}`,
+							Var:     "secretEnv",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Secret", "metadata": {"name": "${secretEnv.nonExistent}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'nonExistent'",
+		},
+		{
+			name: "invalid forEach with toConfigFileList accessing invalid field",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "config",
+							ForEach: `${configurations.toConfigFileList()}`,
+							Var:     "config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "${config.nonExistent}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'nonExistent'",
+		},
+		{
+			name: "invalid forEach with toServicePorts accessing invalid field",
+			cct: &v1alpha1.ClusterComponentType{
+				Spec: v1alpha1.ClusterComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID:      "service-port",
+							ForEach: `${workload.toServicePorts()}`,
+							Var:     "sp",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "${sp.nonExistent}"}}`),
 							},
 						},
 					},

--- a/internal/validation/component/decltype/reflect.go
+++ b/internal/validation/component/decltype/reflect.go
@@ -15,10 +15,15 @@ const (
 	maxMapSize  = 1000
 )
 
-// fromGoType converts a Go type to a CEL DeclType using reflection.
+// FromGoType converts a Go type to a CEL DeclType using reflection.
 // This is used for fixed-structure types like MetadataContext, WorkloadData, etc.
-func fromGoType(t reflect.Type) *apiservercel.DeclType {
+func FromGoType(t reflect.Type) *apiservercel.DeclType {
 	return typeToDecl(t, make(map[reflect.Type]*apiservercel.DeclType))
+}
+
+// fromGoType is an internal alias for FromGoType.
+func fromGoType(t reflect.Type) *apiservercel.DeclType {
+	return FromGoType(t)
 }
 
 func typeToDecl(t reflect.Type, seen map[reflect.Type]*apiservercel.DeclType) *apiservercel.DeclType {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
CEL helper functions (e.g., configurations.toSecretEnvsByContainer()) declared list(dyn) return types, so forEach loop variables were typed as dyn and the validation webhook couldn't catch field access typos.

Introduce CELValidationExtensions() with properly typed function declarations for the validation environment only. Register return type DeclTypes with the DeclTypeProvider so the type checker resolves fields on forEach loop variables and rejects invalid access like secretEnv.nonExistent.


## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
