### PR TITLE
fix: bump observability-logs-opensearch version and remove unused opensearch ExternalSecret

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -453,28 +453,6 @@ kubectl --context k3d-openchoreo-op apply -f - <<EOF
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: opensearch-admin-credentials
-  namespace: openchoreo-observability-plane
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: default
-  target:
-    name: opensearch-admin-credentials
-  data:
-  - secretKey: username
-    remoteRef:
-      key: opensearch-username
-      property: value
-  - secretKey: password
-    remoteRef:
-      key: opensearch-password
-      property: value
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
   name: observer-secret
   namespace: openchoreo-observability-plane
 spec:
@@ -500,8 +478,7 @@ spec:
 EOF
 
 kubectl --context k3d-openchoreo-op wait -n openchoreo-observability-plane \
-  --for=condition=Ready externalsecret/opensearch-admin-credentials \
-  externalsecret/observer-secret --timeout=60s
+  --for=condition=Ready externalsecret/observer-secret --timeout=60s
 ```
 
 ### Install Observability Plane

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -323,28 +323,6 @@ kubectl apply -f - <<EOF
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: opensearch-admin-credentials
-  namespace: openchoreo-observability-plane
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: default
-  target:
-    name: opensearch-admin-credentials
-  data:
-  - secretKey: username
-    remoteRef:
-      key: opensearch-username
-      property: value
-  - secretKey: password
-    remoteRef:
-      key: opensearch-password
-      property: value
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
   name: observer-secret
   namespace: openchoreo-observability-plane
 spec:
@@ -370,8 +348,7 @@ spec:
 EOF
 
 kubectl wait -n openchoreo-observability-plane \
-  --for=condition=Ready externalsecret/opensearch-admin-credentials \
-  externalsecret/observer-secret --timeout=60s
+  --for=condition=Ready externalsecret/observer-secret --timeout=60s
 ```
 
 ### Install Observability Plane

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1073,13 +1073,13 @@ install_observability_plane() {
     log_info "Installing observability modules..."
 
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.3.9" \
+        "--version" "0.3.10" \
         "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials"
 
     # Enable fluent-bit after opensearch is installed and ready
     log_info "Enabling fluent-bit for log collection..."
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.3.9" \
+        "--version" "0.3.10" \
         "--reuse-values" \
         "--set" "fluent-bit.enabled=true"
 

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -280,7 +280,7 @@ _e2e.install-op:
 	@$(call log_info, Installing observability modules)
 	$(E2E_HELM) upgrade --install observability-logs-opensearch \
 		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
-		--version 0.3.9 \
+		--version 0.3.10 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_HELM) upgrade --install observability-metrics-prometheus \


### PR DESCRIPTION
## Summary
- Bump `observability-logs-opensearch` module version from `0.3.9` to `0.3.10` in quick-start helpers and e2e makefile
- Remove the `opensearch-admin-credentials` ExternalSecret from both single-cluster and multi-cluster setup guides as it is no longer needed