### PR TITLE
fix: delete releasebinding during environment deletion

### DIFF
--- a/internal/controller/environment/controller_finalize.go
+++ b/internal/controller/environment/controller_finalize.go
@@ -77,13 +77,13 @@ func (r *Reconciler) finalize(ctx context.Context, old, environment *openchoreov
 		return ctrl.Result{}, nil
 	}
 
-	// Step 2: Wait for all release bindings referencing this environment to be gone.
-	pendingCount, err := r.countReleaseBindings(ctx, environment)
+	// Step 2: Delete all release bindings referencing this environment and wait for them to be gone.
+	pendingCount, err := r.deleteAndCountReleaseBindings(ctx, environment)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if pendingCount > 0 {
-		msg := fmt.Sprintf("Waiting for %d release binding(s) to be removed", pendingCount)
+		msg := fmt.Sprintf("Deleting %d release binding(s)", pendingCount)
 		logger.Info(msg)
 		if meta.SetStatusCondition(&environment.Status.Conditions, NewReleaseBindingsPendingCondition(environment.Generation, msg)) {
 			if err := controller.UpdateStatusConditions(ctx, r.Client, old, environment); err != nil {
@@ -226,8 +226,9 @@ func (r *Reconciler) findReferencingPipeline(ctx context.Context, environment *o
 	return "", nil
 }
 
-// countReleaseBindings returns the number of release bindings that still reference this environment.
-func (r *Reconciler) countReleaseBindings(ctx context.Context, environment *openchoreov1alpha1.Environment) (int, error) {
+// deleteAndCountReleaseBindings deletes all release bindings that reference this environment
+// and returns the count of those still present (pending deletion or not yet deleted).
+func (r *Reconciler) deleteAndCountReleaseBindings(ctx context.Context, environment *openchoreov1alpha1.Environment) (int, error) {
 	releaseBindingList := &openchoreov1alpha1.ReleaseBindingList{}
 	if err := r.List(ctx, releaseBindingList, client.InNamespace(environment.Namespace)); err != nil {
 		return 0, fmt.Errorf("failed to list release bindings: %w", err)
@@ -235,8 +236,15 @@ func (r *Reconciler) countReleaseBindings(ctx context.Context, environment *open
 
 	count := 0
 	for i := range releaseBindingList.Items {
-		if releaseBindingList.Items[i].Spec.Environment == environment.Name {
-			count++
+		rb := &releaseBindingList.Items[i]
+		if rb.Spec.Environment != environment.Name {
+			continue
+		}
+		count++
+		if rb.DeletionTimestamp.IsZero() {
+			if err := r.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
+				return 0, fmt.Errorf("failed to delete release binding %s: %w", rb.Name, err)
+			}
 		}
 	}
 

--- a/internal/controller/environment/controller_integration_test.go
+++ b/internal/controller/environment/controller_integration_test.go
@@ -527,8 +527,9 @@ var _ = Describe("Environment Controller", func() {
 				rbNN = types.NamespacedName{Namespace: ns, Name: "rb-for-env-cleanup"}
 				rb := &openchoreov1alpha1.ReleaseBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      rbNN.Name,
-						Namespace: ns,
+						Name:       rbNN.Name,
+						Namespace:  ns,
+						Finalizers: []string{"openchoreo.dev/releasebinding-cleanup"},
 					},
 					Spec: openchoreov1alpha1.ReleaseBindingSpec{
 						Owner: openchoreov1alpha1.ReleaseBindingOwner{
@@ -554,7 +555,7 @@ var _ = Describe("Environment Controller", func() {
 				}
 			})
 
-			It("should wait for release bindings without deleting them and requeue", func() {
+			It("should delete release bindings and requeue while they are still present", func() {
 				r := newTestReconciler()
 
 				By("first reconcile — sets Finalizing condition")
@@ -562,15 +563,15 @@ var _ = Describe("Environment Controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Requeue).To(BeFalse())
 
-				By("second reconcile — detects release binding and requeues")
+				By("second reconcile — deletes release binding and requeues")
 				result, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RequeueAfter).To(Equal(5 * time.Second))
 
-				By("verifying the release binding is NOT deleted (controller only waits)")
+				By("verifying the release binding is being deleted")
 				rb := &openchoreov1alpha1.ReleaseBinding{}
 				Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
-				Expect(rb.DeletionTimestamp).To(BeNil())
+				Expect(rb.DeletionTimestamp).NotTo(BeNil())
 
 				By("verifying the ReleaseBindingsPending condition is set")
 				env := &openchoreov1alpha1.Environment{}
@@ -581,27 +582,29 @@ var _ = Describe("Environment Controller", func() {
 				Expect(cond.Reason).To(Equal(string(ReasonReleaseBindingsPending)))
 			})
 
-			It("should proceed with finalization after release bindings are externally removed", func() {
+			It("should proceed with finalization after release bindings are deleted", func() {
 				r := newTestReconciler()
 
 				By("first reconcile — sets Finalizing condition")
 				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 				Expect(err).NotTo(HaveOccurred())
 
-				By("second reconcile — waits for release bindings")
+				By("second reconcile — deletes the release binding and requeues")
 				result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RequeueAfter).To(Equal(5 * time.Second))
 
-				By("externally removing the release binding")
-				Expect(k8sClient.Delete(ctx, &openchoreov1alpha1.ReleaseBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: rbNN.Name, Namespace: ns},
-				})).To(Succeed())
+				By("simulating ReleaseBinding controller: removing finalizer so deletion completes")
+				rb := &openchoreov1alpha1.ReleaseBinding{}
+				Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				Expect(rb.DeletionTimestamp).NotTo(BeNil())
+				controllerutil.RemoveFinalizer(rb, "openchoreo.dev/releasebinding-cleanup")
+				Expect(k8sClient.Update(ctx, rb)).To(Succeed())
 				Eventually(func() bool {
 					return apierrors.IsNotFound(k8sClient.Get(ctx, rbNN, &openchoreov1alpha1.ReleaseBinding{}))
 				}, "5s", "100ms").Should(BeTrue())
 
-				By("third reconcile — no release bindings, re-sets Finalizing condition")
+				By("third reconcile — no release bindings, Finalizing guard passes, proceeds to namespace cleanup")
 				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This pull request updates the environment finalization logic so that, during deletion of an environment, all related release bindings are now actively deleted instead of waiting for them to be removed externally. The integration tests are also updated to reflect this new behavior, ensuring that the controller initiates deletion and waits for the bindings to be fully removed before completing finalization.

**Controller logic changes:**

* The `finalize` method in `controller_finalize.go` now calls a new `deleteAndCountReleaseBindings` function, which deletes all release bindings referencing the environment and waits for them to be gone, instead of just counting them and waiting for external deletion.
* Added the `deleteAndCountReleaseBindings` function, which iterates through release bindings, deletes those referencing the environment if not already marked for deletion, and returns the count of those still present.

**Integration test updates:**

* Release bindings in tests are now created with a finalizer to simulate real-world deletion flow.
* Test descriptions and logic are updated to verify that the controller initiates deletion of release bindings, checks for deletion timestamps, and only proceeds with environment finalization once bindings are fully deleted. [[1]](diffhunk://#diff-40d13a561499ab1c5281d60691829f6cd37e4fa57cf9feda632a98b9deefa96aL557-R574) [[2]](diffhunk://#diff-40d13a561499ab1c5281d60691829f6cd37e4fa57cf9feda632a98b9deefa96aL584-R607)