### PR TITLE
chore: add k3d observability plane setup script

### DIFF
--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -1,8 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION=$1
-GITHUB_REF=${2:-main}
+# Installs the OpenChoreo observability plane and default modules into
+# the current k3d cluster.
+#
+# Designed to work with curl | bash:
+#   curl -sL https://raw.githubusercontent.com/openchoreo/openchoreo/main/install/k3d/k3d-observability-plane.sh | bash
+#
+# Or run from a local checkout:
+#   install/k3d/k3d-observability-plane.sh
+
+# -- versions (update these on release branches) --
+OPENCHOREO_REF="main"
+OPENCHOREO_OP_VERSION="v1.0.0-rc.1"
+LOGS_OPENSEARCH_VERSION="0.3.11"
+TRACES_OPENSEARCH_VERSION="0.3.10"
+METRICS_PROMETHEUS_VERSION="0.2.5"
+
+# -- derived constants --
+RAW_BASE="https://raw.githubusercontent.com/openchoreo/openchoreo/${OPENCHOREO_REF}"
+OP_NS="openchoreo-observability-plane"
 
 step() {
   echo ""
@@ -11,25 +28,25 @@ step() {
 
 step "Installing observability plane core services..."
 helm upgrade --install openchoreo-observability-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
-  --version $VERSION \
-  --namespace openchoreo-observability-plane \
-  --values "https://raw.githubusercontent.com/openchoreo/openchoreo/${GITHUB_REF}/install/k3d/single-cluster/values-op.yaml" \
+  --version "$OPENCHOREO_OP_VERSION" \
+  --namespace "$OP_NS" \
+  --values "${RAW_BASE}/install/k3d/single-cluster/values-op.yaml" \
   --timeout 25m
 
 step "Installing OpenSearch-based logs module..."
 helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
-  --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --namespace "$OP_NS" \
+  --version "$LOGS_OPENSEARCH_VERSION" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 
 step "Installing OpenSearch-based traces module..."
 helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
-  --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --namespace "$OP_NS" \
+  --version "$TRACES_OPENSEARCH_VERSION" \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 
@@ -37,14 +54,14 @@ step "Installing Prometheus-based metrics module..."
 helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
-  --namespace openchoreo-observability-plane \
-  --version 0.2.5
+  --namespace "$OP_NS" \
+  --version "$METRICS_PROMETHEUS_VERSION"
 
 step "Enabling logs collection in the configured logs module..."
 helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
-  --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --namespace "$OP_NS" \
+  --version "$LOGS_OPENSEARCH_VERSION" \
   --reuse-values \
   --set fluent-bit.enabled=true
 


### PR DESCRIPTION
## Summary
- Moves `k3d-observability-plane.sh` from the docs site into `install/k3d/` so it lives alongside the other k3d setup scripts
- This lets the docs reference scripts from the code repo via `raw.githubusercontent.com` instead of hosting them on the docs site

## Related
- Docs PR: openchoreo/openchoreo.github.io#482