### PR TITLE
fix: add workload:view permission to workload-publisher role

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1097,6 +1097,7 @@ openchoreoApi:
               actions:
                 - "workload:create"
                 - "workload:update"
+                - "workload:view"
                 - "workflowrun:view"
                 - "workflowrun:update"
             


### PR DESCRIPTION
## Purpose

The `workload-publisher` ClusterAuthzRole was missing the `workload:view` permission, causing CI workflow steps that need to read the existing workload (e.g., for conditional update logic) to fail with authorization errors.

## Approach

- Add `workload:view` action to the `workload-publisher` role in the control plane Helm chart values

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)