### PR TITLE
chore: update cert-manager to v1.19.4 and external-secrets to v2.0.1

### DIFF
--- a/install/k3d/k3d-prerequisites.sh
+++ b/install/k3d/k3d-prerequisites.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 # -- versions (update these on release branches) --
 OPENCHOREO_REF="main"
 GATEWAY_API_VERSION="v1.4.1"
-CERT_MANAGER_VERSION="v1.19.2"
-ESO_VERSION="1.3.2"
+CERT_MANAGER_VERSION="v1.19.4"
+ESO_VERSION="2.0.1"
 KGATEWAY_VERSION="v2.2.1"
 OPENBAO_CHART_VERSION="0.25.6"
 

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -49,7 +49,7 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --kube-context k3d-openchoreo-cp \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.19.2 \
+  --version v1.19.4 \
   --set crds.enabled=true
 
 kubectl --context k3d-openchoreo-cp wait --for=condition=Available deployment/cert-manager \
@@ -139,7 +139,7 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --kube-context k3d-openchoreo-dp \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.19.2 \
+  --version v1.19.4 \
   --set crds.enabled=true
 
 kubectl --context k3d-openchoreo-dp wait --for=condition=Available deployment/cert-manager \
@@ -150,7 +150,7 @@ helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/ex
   --kube-context k3d-openchoreo-dp \
   --namespace external-secrets \
   --create-namespace \
-  --version 1.3.2 \
+  --version 2.0.1 \
   --set installCRDs=true
 
 kubectl --context k3d-openchoreo-dp wait --for=condition=Available deployment/external-secrets \
@@ -262,7 +262,7 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --kube-context k3d-openchoreo-wp \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.19.2 \
+  --version v1.19.4 \
   --set crds.enabled=true
 
 kubectl --context k3d-openchoreo-wp wait --for=condition=Available deployment/cert-manager \
@@ -273,7 +273,7 @@ helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/ex
   --kube-context k3d-openchoreo-wp \
   --namespace external-secrets \
   --create-namespace \
-  --version 1.3.2 \
+  --version 2.0.1 \
   --set installCRDs=true
 
 kubectl --context k3d-openchoreo-wp wait --for=condition=Available deployment/external-secrets \
@@ -396,7 +396,7 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --kube-context k3d-openchoreo-op \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.19.2 \
+  --version v1.19.4 \
   --set crds.enabled=true
 
 kubectl --context k3d-openchoreo-op wait --for=condition=Available deployment/cert-manager \
@@ -407,7 +407,7 @@ helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/ex
   --kube-context k3d-openchoreo-op \
   --namespace external-secrets \
   --create-namespace \
-  --version 1.3.2 \
+  --version 2.0.1 \
   --set installCRDs=true
 
 kubectl --context k3d-openchoreo-op wait --for=condition=Available deployment/external-secrets \

--- a/install/k3d/registry-cache/README.md
+++ b/install/k3d/registry-cache/README.md
@@ -89,7 +89,7 @@ Use the purge script to invalidate stale images:
 ./purge-cache.sh openchoreo/*
 
 # Purge from any registry (auto-detected)
-./purge-cache.sh external-secrets/external-secrets:v1.3.2
+./purge-cache.sh external-secrets/external-secrets:v2.0.1
 
 # Purge everything from all caches
 ./purge-cache.sh --all

--- a/install/k3d/registry-cache/purge-cache.sh
+++ b/install/k3d/registry-cache/purge-cache.sh
@@ -2,7 +2,7 @@
 # Purge cached images from the registry caches.
 #
 # Usage:
-#   ./purge-cache.sh external-secrets/external-secrets:v1.3.2   # Purge a specific image:tag
+#   ./purge-cache.sh external-secrets/external-secrets:v2.0.1   # Purge a specific image:tag
 #   ./purge-cache.sh openchoreo/controller                      # Purge all tags of a repo
 #   ./purge-cache.sh openchoreo/*                               # Purge all openchoreo repos
 #   ./purge-cache.sh --all                                      # Purge everything from all caches
@@ -43,8 +43,8 @@ The image is automatically found and purged from whichever cache contains it.
 Examples:
   $0 openchoreo/controller:latest-dev
   $0 openchoreo/*
-  $0 external-secrets/external-secrets:v1.3.2
-  $0 jetstack/cert-manager-controller:v1.19.2
+  $0 external-secrets/external-secrets:v2.0.1
+  $0 jetstack/cert-manager-controller:v1.19.4
   $0 --all
 EOF
 }

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -38,7 +38,7 @@ kubectl apply --server-side \
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.19.2 \
+  --version v1.19.4 \
   --set crds.enabled=true
 ```
 
@@ -53,7 +53,7 @@ kubectl wait --for=condition=Available deployment/cert-manager \
 helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets \
   --namespace external-secrets \
   --create-namespace \
-  --version 1.3.2 \
+  --version 2.0.1 \
   --set installCRDs=true
 ```
 

--- a/install/quick-start/.config.sh
+++ b/install/quick-start/.config.sh
@@ -18,11 +18,11 @@ THUNDER_NS="thunder"
 HELM_REPO="oci://ghcr.io/openchoreo/helm-charts"
 
 # Cert-manager configuration
-CERT_MANAGER_VERSION="v1.19.2"
+CERT_MANAGER_VERSION="v1.19.4"
 CERT_MANAGER_REPO="oci://quay.io/jetstack/charts"
 
 # External Secrets Operator configuration
-ESO_VERSION="v1.3.2"
+ESO_VERSION="v2.0.1"
 ESO_REPO="oci://ghcr.io/external-secrets/charts"
 
 # kgateway configuration

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -27,8 +27,8 @@ E2E_OP_NS              := openchoreo-observability-plane
 
 # Dependency versions (keep in sync with install/k3d/single-cluster/README.md)
 GATEWAY_API_VERSION    ?= v1.4.1
-CERT_MANAGER_VERSION   ?= v1.19.2
-ESO_VERSION            ?= 1.3.2
+CERT_MANAGER_VERSION   ?= v1.19.4
+ESO_VERSION            ?= 2.0.1
 KGATEWAY_VERSION       ?= v2.1.1
 THUNDER_VERSION        ?= 0.28.0
 


### PR DESCRIPTION
This PR updates the following dependencies across all install configurations:

- **cert-manager**: v1.19.2 → v1.19.4
  Includes bug fixes and stability improvements

- **external-secrets operator**: 1.3.2 → 2.0.1  
  Major version with improved features and compatibility

## Changes:
- Updated in quick-start/.config.sh
- Updated in install/k3d/k3d-prerequisites.sh
- Updated documentation (multi-cluster, single-cluster, registry-cache)
- Updated make/e2e.mk
- Updated all related example/test configurations

All configuration files and documentation reflect the new versions.