### PR TITLE
fix: change middleware order to capture auth failures logs

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -202,12 +202,15 @@ func main() {
 	}
 
 	// Create OpenAPI handler with middleware chain (order: logger → auth → webhookBody → handler)
-	// webhookRawBodyMiddleware must run innermost (before the strict handler decodes the body)
+	// Middlewares are applied last-to-first (last entry becomes the outermost wrapper).
+	// Execution order: loggerMiddleware → authMiddleware → webhookRawBodyMiddleware → handler.
+	// loggerMiddleware must be outermost so it captures all responses, including 401s from auth.
+	// webhookRawBodyMiddleware must be innermost (before the strict handler decodes the body)
 	// so that HMAC signature validation can access the original raw bytes.
 	// The generated routes are registered on the baseMux alongside /mcp.
 	handler := gen.HandlerWithOptions(strictHandler, gen.StdHTTPServerOptions{
 		BaseRouter:  baseMux,
-		Middlewares: []gen.MiddlewareFunc{openapihandlers.WebhookRawBodyMiddleware, loggerMiddleware, authMiddleware},
+		Middlewares: []gen.MiddlewareFunc{openapihandlers.WebhookRawBodyMiddleware, authMiddleware, loggerMiddleware},
 	})
 
 	// Create server from configuration


### PR DESCRIPTION
This pull request updates the middleware configuration for the OpenAPI handler in `main.go` to clarify and correct the order in which middlewares are applied. The main focus is ensuring that logging, authentication, and webhook body processing happen in the intended sequence for proper request handling and security.

**Middleware configuration improvements:**

* Clarified comments to explain that middlewares are applied last-to-first, with the last entry being the outermost wrapper, and explicitly described the intended execution order for clarity.
* Changed the order of middleware functions in the `Middlewares` slice to ensure `loggerMiddleware` is the outermost (captures all responses), `authMiddleware` is next (handles authentication), and `webhookRawBodyMiddleware` is innermost (so it can access the raw request body before decoding).