### PR TITLE
fix: add scope configs for backstage helm charts

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -93,6 +93,12 @@ spec:
             secretKeyRef:
               name: {{ .Values.backstage.secretName }}
               key: client-secret
+        - name: OPENCHOREO_AUTH_OIDC_SCOPE
+          value: {{ .Values.backstage.auth.oidcScope | quote }}
+        {{- if .Values.backstage.auth.scope }}
+        - name: OPENCHOREO_AUTH_SCOPE
+          value: {{ .Values.backstage.auth.scope | quote }}
+        {{- end }}
         # Feature flags for OpenChoreo functionality
         - name: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED
           value: {{ .Values.backstage.features.workflows.enabled | quote }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -24,6 +24,12 @@
               "title": "clientId",
               "type": "string"
             },
+            "oidcScope": {
+              "default": "openid profile email",
+              "description": "Space-separated OIDC scopes for the OIDC provider (e.g. 'openid profile email')",
+              "title": "oidcScope",
+              "type": "string"
+            },
             "redirectUrls": {
               "default": [],
               "description": "OAuth redirect URLs",
@@ -32,6 +38,12 @@
               },
               "title": "redirectUrls",
               "type": "array"
+            },
+            "scope": {
+              "default": "",
+              "description": "Space-separated scopes for the OpenChoreo service token authenticator (e.g. 'openid' or 'api://client-id/.default openid')",
+              "title": "scope",
+              "type": "string"
             }
           },
           "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2362,6 +2362,18 @@ backstage:
     # @schema
     clientId: "openchoreo-backstage-client"
     # @schema
+    # type: string
+    # description: Space-separated OIDC scopes for the OIDC provider (e.g. 'openid profile email')
+    # default: "openid profile email"
+    # @schema
+    oidcScope: "openid profile email"
+    # @schema
+    # type: string
+    # description: Space-separated scopes for the OpenChoreo service token authenticator (e.g. 'openid' or 'api://client-id/.default openid')
+    # default: ""
+    # @schema
+    scope: ""
+    # @schema
     # type: array
     # description: OAuth redirect URLs
     # items:


### PR DESCRIPTION
This pull request adds support for configuring OIDC and service token scopes for Backstage authentication in the OpenChoreo Helm chart. The main changes introduce new configuration options for specifying OIDC scopes and service token scopes, and ensure these values are passed as environment variables to the Backstage deployment.

**Authentication configuration enhancements:**

* Added `oidcScope` and `scope` fields to the `backstage.auth` section in `values.yaml`, allowing users to specify OIDC and service token scopes for authentication. (`install/helm/openchoreo-control-plane/values.yaml` [install/helm/openchoreo-control-plane/values.yamlR2365-R2376](diffhunk://#diff-ab83a1231e7c4c99180d05ea0d8e9c86f80b4a8eb656999b7cc5375ca837c2b9R2365-R2376))
* Updated the Helm values schema to include the new `oidcScope` and `scope` fields, with descriptions and default values. (`install/helm/openchoreo-control-plane/values.schema.json` [install/helm/openchoreo-control-plane/values.schema.jsonR27-R38](diffhunk://#diff-5c7308e4dd394e2a981e27c2748ac12e889689b0bf906e3a4e87402b34b535e8R27-R38))

**Deployment environment variable updates:**

* Modified the Backstage deployment template to set the `OPENCHOREO_AUTH_OIDC_SCOPE` and (if provided) `OPENCHOREO_AUTH_SCOPE` environment variables from the new Helm values. (`install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml` [install/helm/openchoreo-control-plane/templates/backstage/deployment.yamlR96-R101](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aR96-R101))