### PR TITLE
feat: validate traits do not create workload resources

### DIFF
--- a/internal/validation/component/resource_template.go
+++ b/internal/validation/component/resource_template.go
@@ -36,7 +36,7 @@ func ValidateWorkloadResources(workloadType string, resources []v1alpha1.Resourc
 
 	// Proxy workload type doesn't require workload resource validation
 	if workloadType == "proxy" {
-		// Still validate template structure for all resources
+		// Still validate template structure and reject workload resources
 		for i, resource := range resources {
 			resourcePath := basePath.Index(i)
 			templatePath := resourcePath.Child("template")
@@ -44,8 +44,15 @@ func ValidateWorkloadResources(workloadType string, resources []v1alpha1.Resourc
 				allErrs = append(allErrs, field.Required(templatePath, "template is required"))
 				continue
 			}
-			_, errs := ValidateResourceTemplateStructure(*resource.Template, templatePath)
+			obj, errs := ValidateResourceTemplateStructure(*resource.Template, templatePath)
 			allErrs = append(allErrs, errs...)
+
+			if obj != nil && IsWorkloadResourceKind(obj.Kind) {
+				allErrs = append(allErrs, field.Forbidden(
+					templatePath.Child("kind"),
+					fmt.Sprintf("proxy ComponentType must not contain workload resources (kind %q)", obj.Kind),
+				))
+			}
 		}
 		return allErrs
 	}
@@ -64,10 +71,20 @@ func ValidateWorkloadResources(workloadType string, resources []v1alpha1.Resourc
 		obj, errs := ValidateResourceTemplateStructure(*resource.Template, templatePath)
 		allErrs = append(allErrs, errs...)
 
+		if obj == nil {
+			continue
+		}
+
 		// Check if this resource's kind matches the workloadType
-		if obj != nil && strings.EqualFold(obj.Kind, workloadType) {
+		if strings.EqualFold(obj.Kind, workloadType) {
 			workloadTypeMatchCount++
 			workloadTypeIndices = append(workloadTypeIndices, i)
+		} else if IsWorkloadResourceKind(obj.Kind) {
+			// Reject workload resource kinds that don't match the declared workloadType
+			allErrs = append(allErrs, field.Forbidden(
+				templatePath.Child("kind"),
+				fmt.Sprintf("resource kind %q is a workload type that does not match the declared workloadType %q; only one workload resource is allowed", obj.Kind, workloadType),
+			))
 		}
 	}
 
@@ -120,11 +137,15 @@ func ValidateResourceTemplateStructure(template runtime.RawExtension, fieldPath 
 			"apiVersion is required in resource template"))
 	}
 
-	// Validate kind exists
+	// Validate kind exists and is a literal value (CEL expressions are not allowed)
 	if header.Kind == "" {
 		allErrs = append(allErrs, field.Required(
 			fieldPath.Child("kind"),
 			"kind is required in resource template"))
+	} else if strings.Contains(header.Kind, "${") {
+		allErrs = append(allErrs, field.Forbidden(
+			fieldPath.Child("kind"),
+			"kind must be a literal value, not a template expression"))
 	}
 
 	// Validate metadata.name exists (can be any value including CEL expression)
@@ -156,6 +177,23 @@ func ValidateResourceTemplateStructure(template runtime.RawExtension, fieldPath 
 	}
 
 	return obj, allErrs
+}
+
+// workloadResourceKinds contains the Kubernetes resource kinds that represent primary workloads.
+// Each component can have only one primary workload defined by the ComponentType.
+// Traits must not create these, and ComponentTypes must not include additional workload kinds
+// beyond the declared workloadType.
+var workloadResourceKinds = map[string]bool{
+	"deployment":  true,
+	"statefulset": true,
+	"daemonset":   true,
+	"cronjob":     true,
+	"job":         true,
+}
+
+// IsWorkloadResourceKind returns true if the given kind (case-insensitive) is a workload resource kind.
+func IsWorkloadResourceKind(kind string) bool {
+	return workloadResourceKinds[strings.ToLower(kind)]
 }
 
 // isAllowedNamespaceValue checks whether the given string is an acceptable

--- a/internal/webhook/clustercomponenttype/webhook_test.go
+++ b/internal/webhook/clustercomponenttype/webhook_test.go
@@ -417,6 +417,69 @@ var _ = Describe("ClusterComponentType Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("metadata.name is required"))
 		})
 
+		It("should reject additional workload resource kind that does not match workloadType", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID:       "deployment",
+					Template: validDeploymentTemplate(),
+				},
+				{
+					ID: "statefulset",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "StatefulSet", "metadata": {"name": "extra-sts"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not match the declared workloadType"))
+			Expect(err.Error()).To(ContainSubstring("StatefulSet"))
+		})
+
+		It("should admit primary workload with non-workload resources like Service", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID:       "deployment",
+					Template: validDeploymentTemplate(),
+				},
+				{
+					ID: "service",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "test-svc"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject workload resource in proxy ClusterComponentType", func() {
+			obj.Spec.WorkloadType = "proxy"
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "gateway",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "gateway.networking.k8s.io/v1", "kind": "Gateway", "metadata": {"name": "test"}}`),
+					},
+				},
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("proxy ComponentType must not contain workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Deployment"))
+		})
+
 		It("should allow workloadType=proxy without matching resource kind", func() {
 			obj.Spec.WorkloadType = "proxy"
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{

--- a/internal/webhook/clustertrait/webhook.go
+++ b/internal/webhook/clustertrait/webhook.go
@@ -150,8 +150,15 @@ func validateClusterTraitCreatesTemplateStructure(ct *openchoreodevv1alpha1.Clus
 			continue
 		}
 
-		_, errs := component.ValidateResourceTemplateStructure(*create.Template, templatePath)
+		obj, errs := component.ValidateResourceTemplateStructure(*create.Template, templatePath)
 		allErrs = append(allErrs, errs...)
+
+		if obj != nil && component.IsWorkloadResourceKind(obj.Kind) {
+			allErrs = append(allErrs, field.Forbidden(
+				templatePath.Child("kind"),
+				fmt.Sprintf("traits must not create workload resources (kind %q); the primary workload is defined by the ComponentType", obj.Kind),
+			))
+		}
 	}
 
 	return allErrs

--- a/internal/webhook/clustertrait/webhook_test.go
+++ b/internal/webhook/clustertrait/webhook_test.go
@@ -241,6 +241,101 @@ var _ = Describe("ClusterTrait Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("apiVersion is required"))
 		})
+
+		It("should reject Deployment kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra-deploy"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Deployment"))
+		})
+
+		It("should reject StatefulSet kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "StatefulSet", "metadata": {"name": "extra-sts"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("StatefulSet"))
+		})
+
+		It("should reject CronJob kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "batch/v1", "kind": "CronJob", "metadata": {"name": "extra-cron"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("CronJob"))
+		})
+
+		It("should reject Job kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "batch/v1", "kind": "Job", "metadata": {"name": "extra-job"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Job"))
+		})
+
+		It("should reject workload resource kind case-insensitively", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "deployment", "metadata": {"name": "extra"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+		})
+
+		It("should reject workload resource in creates on update", func() {
+			oldObj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "test"}}`),
+					},
+				},
+			}
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+		})
 	})
 
 	Context("Validation Rules CEL Validation", func() {

--- a/internal/webhook/componentrelease/webhook.go
+++ b/internal/webhook/componentrelease/webhook.go
@@ -312,12 +312,20 @@ func validateEmbeddedResourceTemplates(release *openchoreodevv1alpha1.ComponentR
 	traitsBasePath := field.NewPath("spec", "traits")
 	for i, rt := range release.Spec.Traits {
 		traitKey := string(rt.Kind) + ":" + rt.Name
-		traitPath := traitsBasePath.Key(traitKey).Child("creates")
+		traitPath := traitsBasePath.Key(traitKey).Child("spec", "creates")
 		for j, create := range rt.Spec.Creates {
 			createPath := traitPath.Index(j)
 			if create.Template != nil && len(create.Template.Raw) > 0 {
-				_, errs := component.ValidateResourceTemplateStructure(*create.Template, createPath.Child("template"))
+				templatePath := createPath.Child("template")
+				obj, errs := component.ValidateResourceTemplateStructure(*create.Template, templatePath)
 				allErrs = append(allErrs, errs...)
+
+				if obj != nil && component.IsWorkloadResourceKind(obj.Kind) {
+					allErrs = append(allErrs, field.Forbidden(
+						templatePath.Child("kind"),
+						fmt.Sprintf("traits must not create workload resources (kind %q); the primary workload is defined by the ComponentType", obj.Kind),
+					))
+				}
 			}
 		}
 

--- a/internal/webhook/componentrelease/webhook_test.go
+++ b/internal/webhook/componentrelease/webhook_test.go
@@ -947,6 +947,101 @@ var _ = Describe("ComponentRelease Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("workload container must have an image"))
 		})
+
+		It("should reject Deployment kind in embedded Trait creates", func() {
+			obj = validComponentRelease()
+			obj.Spec.Traits = []openchoreodevv1alpha1.ComponentReleaseTrait{
+				{
+					Kind: openchoreodevv1alpha1.TraitRefKindTrait,
+					Name: "bad-trait",
+					Spec: openchoreodevv1alpha1.TraitSpec{
+						Creates: []openchoreodevv1alpha1.TraitCreate{
+							{
+								Template: &runtime.RawExtension{
+									Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra-deploy"}}`),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Deployment"))
+		})
+
+		It("should reject StatefulSet kind in embedded Trait creates", func() {
+			obj = validComponentRelease()
+			obj.Spec.Traits = []openchoreodevv1alpha1.ComponentReleaseTrait{
+				{
+					Kind: openchoreodevv1alpha1.TraitRefKindTrait,
+					Name: "bad-trait",
+					Spec: openchoreodevv1alpha1.TraitSpec{
+						Creates: []openchoreodevv1alpha1.TraitCreate{
+							{
+								Template: &runtime.RawExtension{
+									Raw: []byte(`{"apiVersion": "apps/v1", "kind": "StatefulSet", "metadata": {"name": "extra-sts"}}`),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("StatefulSet"))
+		})
+
+		It("should reject Job kind in embedded Trait creates", func() {
+			obj = validComponentRelease()
+			obj.Spec.Traits = []openchoreodevv1alpha1.ComponentReleaseTrait{
+				{
+					Kind: openchoreodevv1alpha1.TraitRefKindTrait,
+					Name: "bad-trait",
+					Spec: openchoreodevv1alpha1.TraitSpec{
+						Creates: []openchoreodevv1alpha1.TraitCreate{
+							{
+								Template: &runtime.RawExtension{
+									Raw: []byte(`{"apiVersion": "batch/v1", "kind": "Job", "metadata": {"name": "extra-job"}}`),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Job"))
+		})
+
+		It("should reject workload resource kind case-insensitively in embedded Trait creates", func() {
+			obj = validComponentRelease()
+			obj.Spec.Traits = []openchoreodevv1alpha1.ComponentReleaseTrait{
+				{
+					Kind: openchoreodevv1alpha1.TraitRefKindTrait,
+					Name: "bad-trait",
+					Spec: openchoreodevv1alpha1.TraitSpec{
+						Creates: []openchoreodevv1alpha1.TraitCreate{
+							{
+								Template: &runtime.RawExtension{
+									Raw: []byte(`{"apiVersion": "apps/v1", "kind": "deployment", "metadata": {"name": "extra"}}`),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+		})
 	})
 
 	Context("Schema Parsing Failures", func() {

--- a/internal/webhook/componenttype/webhook_test.go
+++ b/internal/webhook/componenttype/webhook_test.go
@@ -13,7 +13,10 @@ import (
 	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 )
 
-const workloadTypeDeployment = "deployment"
+const (
+	workloadTypeDeployment = "deployment"
+	workloadTypeProxy      = "proxy"
+)
 
 var _ = Describe("ComponentType Webhook", func() {
 	var (
@@ -371,7 +374,7 @@ var _ = Describe("ComponentType Webhook", func() {
 		})
 
 		It("should reject nil template in proxy workloadType", func() {
-			obj.Spec.WorkloadType = "proxy"
+			obj.Spec.WorkloadType = workloadTypeProxy
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
 				{
 					ID:       "gateway",
@@ -432,8 +435,98 @@ var _ = Describe("ComponentType Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("metadata.name is required"))
 		})
 
+		It("should reject additional workload resource kind that does not match workloadType", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID:       "deployment",
+					Template: validDeploymentTemplate(),
+				},
+				{
+					ID: "statefulset",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "StatefulSet", "metadata": {"name": "extra-sts"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not match the declared workloadType"))
+			Expect(err.Error()).To(ContainSubstring("StatefulSet"))
+		})
+
+		It("should reject multiple non-matching workload resource kinds", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID:       "deployment",
+					Template: validDeploymentTemplate(),
+				},
+				{
+					ID: "job",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "batch/v1", "kind": "Job", "metadata": {"name": "extra-job"}}`),
+					},
+				},
+				{
+					ID: "cronjob",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "batch/v1", "kind": "CronJob", "metadata": {"name": "extra-cron"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(`"Job"`))
+			Expect(err.Error()).To(ContainSubstring("CronJob"))
+		})
+
+		It("should admit Deployment with non-workload resources like Service", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID:       "deployment",
+					Template: validDeploymentTemplate(),
+				},
+				{
+					ID: "service",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "test-svc"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject workload resource in proxy ComponentType", func() {
+			obj.Spec.WorkloadType = workloadTypeProxy
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "gateway",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "gateway.networking.k8s.io/v1", "kind": "Gateway", "metadata": {"name": "test"}}`),
+					},
+				},
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("proxy ComponentType must not contain workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Deployment"))
+		})
+
 		It("should allow workloadType=proxy without matching resource kind", func() {
-			obj.Spec.WorkloadType = "proxy"
+			obj.Spec.WorkloadType = workloadTypeProxy
 			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
 				{
 					ID: "gateway",
@@ -445,6 +538,22 @@ var _ = Describe("ComponentType Webhook", func() {
 
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject template expression in kind field", func() {
+			obj.Spec.WorkloadType = workloadTypeDeployment
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTemplate{
+				{
+					ID: "deployment",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "${parameters.kind}", "metadata": {"name": "test"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kind must be a literal value"))
 		})
 
 		It("should match workloadType case-insensitively", func() {

--- a/internal/webhook/trait/webhook.go
+++ b/internal/webhook/trait/webhook.go
@@ -150,8 +150,15 @@ func validateTraitCreatesTemplateStructure(trait *openchoreodevv1alpha1.Trait) f
 			continue
 		}
 
-		_, errs := component.ValidateResourceTemplateStructure(*create.Template, templatePath)
+		obj, errs := component.ValidateResourceTemplateStructure(*create.Template, templatePath)
 		allErrs = append(allErrs, errs...)
+
+		if obj != nil && component.IsWorkloadResourceKind(obj.Kind) {
+			allErrs = append(allErrs, field.Forbidden(
+				templatePath.Child("kind"),
+				fmt.Sprintf("traits must not create workload resources (kind %q); the primary workload is defined by the ComponentType", obj.Kind),
+			))
+		}
 	}
 
 	return allErrs

--- a/internal/webhook/trait/webhook_test.go
+++ b/internal/webhook/trait/webhook_test.go
@@ -313,6 +313,20 @@ var _ = Describe("Trait Webhook", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should reject template expression in creates kind field", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "${parameters.kind}", "metadata": {"name": "test"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kind must be a literal value"))
+		})
+
 		It("should allow creates template with metadata.namespace set to ${metadata.namespace}", func() {
 			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
 				{
@@ -362,6 +376,101 @@ var _ = Describe("Trait Webhook", func() {
 			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("apiVersion is required"))
+		})
+
+		It("should reject Deployment kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra-deploy"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Deployment"))
+		})
+
+		It("should reject StatefulSet kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "StatefulSet", "metadata": {"name": "extra-sts"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("StatefulSet"))
+		})
+
+		It("should reject CronJob kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "batch/v1", "kind": "CronJob", "metadata": {"name": "extra-cron"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("CronJob"))
+		})
+
+		It("should reject Job kind in creates template", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "batch/v1", "kind": "Job", "metadata": {"name": "extra-job"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+			Expect(err.Error()).To(ContainSubstring("Job"))
+		})
+
+		It("should reject workload resource kind case-insensitively", func() {
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "deployment", "metadata": {"name": "extra"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
+		})
+
+		It("should reject workload resource in creates on update", func() {
+			oldObj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "test"}}`),
+					},
+				},
+			}
+			obj.Spec.Creates = []openchoreodevv1alpha1.TraitCreate{
+				{
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "extra"}}`),
+					},
+				},
+			}
+
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("traits must not create workload resources"))
 		})
 	})
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Traits must not create k8s workload resources (Deployment, StatefulSet, CronJob, Job) since each component can only have one primary workload defined by the ComponentType. Add validation to Trait, ClusterTrait, and ComponentRelease webhooks to reject workload kinds in the creates section.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
