### PR TITLE
fix: update doc links

### DIFF
--- a/samples/mcp/README.md
+++ b/samples/mcp/README.md
@@ -15,7 +15,7 @@ You need a running OpenChoreo instance. If you haven't set one up yet:
 
 ### 2. Configure MCP Server
 
-The OpenChoreo MCP server must be configured and accessible. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers) for detailed instructions to obtain:
+The OpenChoreo MCP server must be configured and accessible. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers) for detailed instructions to obtain:
 
 - MCP server endpoint
 - An access token

--- a/samples/mcp/build-failures/README.md
+++ b/samples/mcp/build-failures/README.md
@@ -10,7 +10,7 @@ Additionally, you need:
 
 1. **Go Docker Greeter sample deployed** — follow the [Go Docker Greeter](../../from-source/services/go-docker-greeter/) sample to deploy the greeting service from source. Wait for the initial build (`greeting-service-build-01`) to complete successfully before proceeding.
 2. **Workflow plane** installed and running — see [Setup Workflow Plane](https://openchoreo.dev/docs/getting-started/production/single-cluster/#step-3-setup-workflow-plane-optional) guide
-3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers)
+3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers)
 
 ## What You'll Learn
 

--- a/samples/mcp/configs/README.md
+++ b/samples/mcp/configs/README.md
@@ -2,7 +2,7 @@
 
 This guide has moved to the OpenChoreo documentation site.
 
-**[Configure MCP Servers with AI Assistants →](https://openchoreo.dev/docs/ai/mcp-servers)**
+**[Configure MCP Servers with AI Assistants →](https://openchoreo.dev/docs/next/ai/mcp-servers)**
 
 The docs site covers:
 - Browser-based OAuth authentication (recommended)

--- a/samples/mcp/getting-started/README.md
+++ b/samples/mcp/getting-started/README.md
@@ -22,7 +22,7 @@ Do you have access to the OpenChoreo MCP server? List the available tools.
 
 **Expected:** The assistant should confirm MCP access and list available OpenChoreo tools like `list_namespaces`, `list_projects`, `create_component`, etc.
 
-If the connection isn't working, review the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers) to ensure your setup is correct.
+If the connection isn't working, review the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers) to ensure your setup is correct.
 
 ## Step 2: Explore OpenChoreo Resources
 

--- a/samples/mcp/log-analysis/README.md
+++ b/samples/mcp/log-analysis/README.md
@@ -10,7 +10,7 @@ Additionally, you need:
 
 1. **GCP Microservices Demo deployed** — follow the [GCP Microservices Demo](../../gcp-microservices-demo/) sample to deploy the Online Boutique application
 2. **Observability plane** configured and running — see [Observability & Alerting](https://openchoreo.dev/docs/operations/observability-alerting/) for setup instructions
-3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers)
+3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers)
 
 ## What You'll Learn
 

--- a/samples/mcp/resource-optimization/README.md
+++ b/samples/mcp/resource-optimization/README.md
@@ -10,7 +10,7 @@ Additionally, you need:
 
 1. **GCP Microservices Demo deployed** — follow the [GCP Microservices Demo](../../gcp-microservices-demo/) sample to deploy the Online Boutique application
 2. **Observability plane** configured and running — see [Observability & Alerting](https://openchoreo.dev/docs/operations/observability-alerting/) for setup instructions
-3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers)
+3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers)
 
 ## What You'll Learn
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
MCP config doc links don't contain the doc version. It defaults to the current stable version: 0.17.x, which doesn't have the latest doc structure. This PR updates the doc links to include the doc version: `next`

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)