### PR TITLE
docs: add missing namespace to bootstrap mapping scope schema

### DIFF
--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2641,8 +2641,12 @@
                                           "description": "Component scope (requires project)",
                                           "type": "string"
                                         },
+                                        "namespace": {
+                                          "description": "Namespace scope (ClusterAuthzRoleBinding only, omit for cluster-wide)",
+                                          "type": "string"
+                                        },
                                         "project": {
-                                          "description": "Project scope",
+                                          "description": "Project scope (requires namespace for cluster bindings)",
                                           "type": "string"
                                         }
                                       },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1365,9 +1365,12 @@ openchoreoApi:
           #             type: object
           #             description: Scopes this mapping within the ownership hierarchy
           #             properties:
+          #               namespace:
+          #                 type: string
+          #                 description: Namespace scope (ClusterAuthzRoleBinding only, omit for cluster-wide)
           #               project:
           #                 type: string
-          #                 description: Project scope
+          #                 description: Project scope (requires namespace for cluster bindings)
           #               component:
           #                 type: string
           #                 description: Component scope (requires project)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
 The scope schema comments in values.yaml and values.schema.json were                                       
  missing the namespace property that is supported by the helm template                 
  and the ClusterTargetScope CRD type.  

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
