### PR TITLE
fix: include dependencies in component release generation

### DIFF
--- a/internal/openchoreo-api/services/component/service.go
+++ b/internal/openchoreo-api/services/component/service.go
@@ -289,8 +289,9 @@ func (s *componentService) GenerateRelease(ctx context.Context, namespaceName, c
 	}
 
 	workloadTemplateSpec := openchoreov1alpha1.WorkloadTemplateSpec{
-		Container: workload.Spec.Container,
-		Endpoints: workload.Spec.Endpoints,
+		Container:    workload.Spec.Container,
+		Endpoints:    workload.Spec.Endpoints,
+		Dependencies: workload.Spec.Dependencies,
 	}
 
 	crSpec, err := componentrelease.BuildSpec(componentrelease.BuildInput{


### PR DESCRIPTION
## Purpose

- Include `Dependencies` field in `WorkloadTemplateSpec` when generating a component release from API, ensuring dependency information (connections) is propagated to releases

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
