### PR TITLE
docs: fix broken documentation URLs in MCP sample READMEs

### DIFF
--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -5,7 +5,7 @@ All-in-one OpenChoreo setup with all planes running in a single k3d cluster.
 > [!NOTE]
 > This guide is for **contributors and developers** working from a local checkout.
 > It uses local Helm charts (`install/helm/...`) and standalone setup scripts.
-> If you just want to try OpenChoreo, follow the [public getting-started guide](https://openchoreo.dev/docs/getting-started/try-it-out/locally/) instead, which uses published OCI chart releases.
+> If you just want to try OpenChoreo, follow the [public getting-started guide](https://openchoreo.dev/docs/getting-started/try-it-out/on-k3d-locally/) instead, which uses published OCI chart releases.
 
 > [!IMPORTANT]
 > If you're using Colima, set `K3D_FIX_DNS=0` when creating clusters.

--- a/samples/gcp-microservices-demo/README.md
+++ b/samples/gcp-microservices-demo/README.md
@@ -102,7 +102,7 @@ done
 > [!NOTE]
 > `shipping` (Go), `ad` (Java), and `cart` (C#/.NET) do not have OpenTelemetry tracing implemented in the current upstream source and will not emit traces regardless of configuration.
 
-For more details on traces, see the [Observability & Alerting guide](https://openchoreo.dev/docs/next/platform-engineer-guide/observability-alerting/#traces).
+For more details on traces, see the [Observability & Alerting guide](https://openchoreo.dev/docs/platform-engineer-guide/observability-alerting/#traces).
 
 ## Step 3: Test the Application
 

--- a/samples/mcp/README.md
+++ b/samples/mcp/README.md
@@ -11,11 +11,11 @@ Before you begin, ensure you have completed the following prerequisites:
 You need a running OpenChoreo instance. If you haven't set one up yet:
 
 - Complete the [Quick Start Guide](https://openchoreo.dev/docs/getting-started/quick-start-guide/)
-- Or follow the [Installation Guide](https://openchoreo.dev/docs/getting-started/production/deployment-planning/) for your preferred setup method
+- Or follow the [Installation Guide](https://openchoreo.dev/docs/getting-started/try-it-out/on-k3d-locally/) for your preferred setup method
 
 ### 2. Configure MCP Server
 
-The OpenChoreo MCP server must be configured and accessible. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers) for detailed instructions to obtain:
+The OpenChoreo MCP server must be configured and accessible. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers) for detailed instructions to obtain:
 
 - MCP server endpoint
 - An access token

--- a/samples/mcp/build-failures/README.md
+++ b/samples/mcp/build-failures/README.md
@@ -9,8 +9,8 @@ Before starting this guide, ensure you have completed all [prerequisites](../REA
 Additionally, you need:
 
 1. **Go Docker Greeter sample deployed** — follow the [Go Docker Greeter](../../from-source/services/go-docker-greeter/) sample to deploy the greeting service from source. Wait for the initial build (`greeting-service-build-01`) to complete successfully before proceeding.
-2. **Workflow plane** installed and running — see [Setup Workflow Plane](https://openchoreo.dev/docs/getting-started/production/single-cluster/#step-3-setup-workflow-plane-optional) guide
-3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers)
+2. **Workflow plane** installed and running — see [Setup Workflow Plane](https://openchoreo.dev/docs/getting-started/try-it-out/on-k3d-locally/#step-6-setup-workflow-plane-optional) guide
+3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers)
 
 ## What You'll Learn
 

--- a/samples/mcp/configs/README.md
+++ b/samples/mcp/configs/README.md
@@ -2,7 +2,7 @@
 
 This guide has moved to the OpenChoreo documentation site.
 
-**[Configure MCP Servers with AI Assistants →](https://openchoreo.dev/docs/next/ai/mcp-servers)**
+**[Configure MCP Servers with AI Assistants →](https://openchoreo.dev/docs/ai/mcp-servers)**
 
 The docs site covers:
 - Browser-based OAuth authentication (recommended)

--- a/samples/mcp/getting-started/README.md
+++ b/samples/mcp/getting-started/README.md
@@ -22,7 +22,7 @@ Do you have access to the OpenChoreo MCP server? List the available tools.
 
 **Expected:** The assistant should confirm MCP access and list available OpenChoreo tools like `list_namespaces`, `list_projects`, `create_component`, etc.
 
-If the connection isn't working, review the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers) to ensure your setup is correct.
+If the connection isn't working, review the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers) to ensure your setup is correct.
 
 ## Step 2: Explore OpenChoreo Resources
 

--- a/samples/mcp/log-analysis/README.md
+++ b/samples/mcp/log-analysis/README.md
@@ -9,8 +9,8 @@ Before starting this guide, ensure you have completed all [prerequisites](../REA
 Additionally, you need:
 
 1. **GCP Microservices Demo deployed** — follow the [GCP Microservices Demo](../../gcp-microservices-demo/) sample to deploy the Online Boutique application
-2. **Observability plane** configured and running — see [Observability & Alerting](https://openchoreo.dev/docs/operations/observability-alerting/) for setup instructions
-3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers)
+2. **Observability plane** configured and running — see [Observability & Alerting](https://openchoreo.dev/docs/platform-engineer-guide/observability-alerting/) for setup instructions
+3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers)
 
 ## What You'll Learn
 

--- a/samples/mcp/resource-optimization/README.md
+++ b/samples/mcp/resource-optimization/README.md
@@ -9,8 +9,8 @@ Before starting this guide, ensure you have completed all [prerequisites](../REA
 Additionally, you need:
 
 1. **GCP Microservices Demo deployed** — follow the [GCP Microservices Demo](../../gcp-microservices-demo/) sample to deploy the Online Boutique application
-2. **Observability plane** configured and running — see [Observability & Alerting](https://openchoreo.dev/docs/operations/observability-alerting/) for setup instructions
-3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/next/ai/mcp-servers)
+2. **Observability plane** configured and running — see [Observability & Alerting](https://openchoreo.dev/docs/platform-engineer-guide/observability-alerting/) for setup instructions
+3. **Both MCP servers configured** — you need both the Control Plane and Observability Plane MCP servers connected to your AI assistant. See the [Configuration Guide](https://openchoreo.dev/docs/ai/mcp-servers)
 
 ## What You'll Learn
 

--- a/samples/mcp/service-deployment/README.md
+++ b/samples/mcp/service-deployment/README.md
@@ -11,7 +11,7 @@ Additionally, for service deployment you need:
 1. **OpenChoreo instance** with at least two environments configured (development and production)
    - If you need to create environments, see the [platform configuration samples](../../platform-config/new-environments/)
 2. **Component workflows** configured (Docker or Buildpacks)
-   - Make sure you've installed the workflow plane. See [Setup Workflow Plane](https://openchoreo.dev/docs/getting-started/production/single-cluster/#step-3-setup-workflow-plane-optional) guide.
+   - Make sure you've installed the workflow plane. See [Setup Workflow Plane](https://openchoreo.dev/docs/getting-started/try-it-out/on-k3d-locally/#step-6-setup-workflow-plane-optional) guide.
 
 ## Deployment Guides
 

--- a/samples/mcp/service-deployment/developer-chat/README.md
+++ b/samples/mcp/service-deployment/developer-chat/README.md
@@ -21,7 +21,7 @@ This guide uses a conversational workflow where you interact naturally with your
 ### Step 1: Enter the Agent's system prompt
 
 ```
-You're a useful agent to help make OpenChoreo tasks easier for OpenChoreo users. You can use only the OpenChoreo MCP server. Specifically, you can't use curl and kubectl. You may refer to OpenChoreo docs: https://openchoreo.dev/docs/next/. You may ask back the user questions when you want further input for a task.
+You're a useful agent to help make OpenChoreo tasks easier for OpenChoreo users. You can use only the OpenChoreo MCP server. Specifically, you can't use curl and kubectl. You may refer to OpenChoreo docs: https://openchoreo.dev/docs/. You may ask back the user questions when you want further input for a task.
 
 You execute the MCP tools efficiently and avoid unnecessary tool calls. You reply concisely and keep the conversation clean. You don't generate .md files and other artifacts unless you're asked to.
 

--- a/samples/occ-cli/go-greeter-manual-deploy/README.md
+++ b/samples/occ-cli/go-greeter-manual-deploy/README.md
@@ -21,8 +21,8 @@ https://github.com/openchoreo/sample-workloads/tree/main/service-go-greeter
 
 ## Prerequisites
 
-- A running OpenChoreo cluster (see [Getting Started](https://openchoreo.dev/docs/getting-started/))
-- The `occ` CLI installed and configured (see [CLI Installation](https://openchoreo.dev/docs/user-guide/cli-installation/))
+- A running OpenChoreo cluster (see [Getting Started](https://openchoreo.dev/docs/getting-started/quick-start-guide/))
+- The `occ` CLI installed and configured (see [CLI Installation](https://openchoreo.dev/docs/developer-guide/cli-installation/))
 - Logged in via `occ login`
 - [`yq`](https://github.com/mikefarah/yq#install) installed (used to extract the invoke URL in Step 5)
 


### PR DESCRIPTION
## Purpose
Fix broken documentation URLs in MCP sample READMEs that reference old page paths.

## Approach
Updated 4 broken links in MCP sample READMEs:
- `operations/observability-alerting/` → `platform-engineer-guide/observability-alerting/` (2 files)
- `getting-started/production/single-cluster/#step-3-setup-workflow-plane-optional` → `getting-started/try-it-out/on-k3d-locally/#step-6-setup-workflow-plane-optional` (2 files)

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
These links broke during the docs restructuring that renamed `operations/` to `platform-engineer-guide/` and `getting-started/production/` to `getting-started/try-it-out/`.