### PR TITLE
test: add unit tests for gateway and kubernetes clients using testify

### DIFF
--- a/internal/clients/gateway/client_test.go
+++ b/internal/clients/gateway/client_test.go
@@ -5,11 +5,15 @@ package gateway
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProxyK8sRequest(t *testing.T) {
@@ -34,7 +38,6 @@ func TestProxyK8sRequest(t *testing.T) {
 			crNamespace:  "acme",
 			crName:       "prod-dp",
 			k8sPath:      "api/v1/namespaces/default/pods",
-			rawQuery:     "",
 			serverStatus: http.StatusOK,
 			serverBody:   `{"kind":"PodList","items":[]}`,
 			wantURLPath:  "/api/proxy/dataplane/prod-cluster/acme/prod-dp/k8s/api/v1/namespaces/default/pods",
@@ -58,7 +61,6 @@ func TestProxyK8sRequest(t *testing.T) {
 			crNamespace:  "_cluster",
 			crName:       "shared-dp",
 			k8sPath:      "api/v1/namespaces/default/pods",
-			rawQuery:     "",
 			serverStatus: http.StatusOK,
 			serverBody:   `{"kind":"PodList","items":[]}`,
 			wantURLPath:  "/api/proxy/dataplane/shared-cluster/_cluster/shared-dp/k8s/api/v1/namespaces/default/pods",
@@ -70,7 +72,6 @@ func TestProxyK8sRequest(t *testing.T) {
 			crNamespace:  "acme",
 			crName:       "ci-wp",
 			k8sPath:      "api/v1/namespaces/workflow-ns/pods",
-			rawQuery:     "",
 			serverStatus: http.StatusOK,
 			serverBody:   `{"kind":"PodList","items":[]}`,
 			wantURLPath:  "/api/proxy/workflowplane/ci-cluster/acme/ci-wp/k8s/api/v1/namespaces/workflow-ns/pods",
@@ -82,7 +83,6 @@ func TestProxyK8sRequest(t *testing.T) {
 			crNamespace:  "acme",
 			crName:       "obs-op",
 			k8sPath:      "api/v1/namespaces/monitoring/pods",
-			rawQuery:     "",
 			serverStatus: http.StatusOK,
 			serverBody:   `{"kind":"PodList","items":[]}`,
 			wantURLPath:  "/api/proxy/observabilityplane/obs-cluster/acme/obs-op/k8s/api/v1/namespaces/monitoring/pods",
@@ -94,7 +94,6 @@ func TestProxyK8sRequest(t *testing.T) {
 			crNamespace:  "acme",
 			crName:       "prod-dp",
 			k8sPath:      "api/v1/namespaces/default/pods/nonexistent",
-			rawQuery:     "",
 			serverStatus: http.StatusNotFound,
 			serverBody:   `{"kind":"Status","status":"Failure","message":"pods \"nonexistent\" not found"}`,
 			wantURLPath:  "/api/proxy/dataplane/prod-cluster/acme/prod-dp/k8s/api/v1/namespaces/default/pods/nonexistent",
@@ -106,7 +105,6 @@ func TestProxyK8sRequest(t *testing.T) {
 			crNamespace:   "acme",
 			crName:        "prod-dp",
 			k8sPath:       "api/v1/namespaces/default/pods",
-			rawQuery:      "",
 			serverStatus:  http.StatusOK,
 			serverBody:    `{"kind":"PodList","items":[]}`,
 			serverHeaders: map[string]string{"X-Custom-Header": "test-value"},
@@ -116,101 +114,58 @@ func TestProxyK8sRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var receivedPath string
-			var receivedQuery string
+			var receivedPath, receivedQuery string
 
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				receivedPath = r.URL.Path
 				receivedQuery = r.URL.RawQuery
-
-				// Verify it's a GET request
-				if r.Method != http.MethodGet {
-					t.Errorf("Expected GET method, got %s", r.Method)
-				}
-
-				// Verify Accept header
-				if r.Header.Get("Accept") != "application/json" {
-					t.Errorf("Expected Accept: application/json, got %s", r.Header.Get("Accept"))
-				}
-
-				// Set custom headers if specified
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
 				for k, v := range tt.serverHeaders {
 					w.Header().Set(k, v)
 				}
-
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.serverStatus)
 				_, _ = w.Write([]byte(tt.serverBody))
 			}))
 			defer server.Close()
 
-			client := &Client{
-				baseURL:    server.URL,
-				httpClient: server.Client(),
-			}
-
-			resp, err := client.ProxyK8sRequest(context.Background(), tt.planeType, tt.planeID, tt.crNamespace, tt.crName, tt.k8sPath, tt.rawQuery)
+			c := &Client{baseURL: server.URL, httpClient: server.Client()}
+			resp, err := c.ProxyK8sRequest(context.Background(), tt.planeType, tt.planeID,
+				tt.crNamespace, tt.crName, tt.k8sPath, tt.rawQuery)
 
 			if tt.wantErr {
-				if err == nil {
-					t.Error("Expected error, got nil")
-				}
+				assert.Error(t, err)
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			// Verify the URL path
-			if receivedPath != tt.wantURLPath {
-				t.Errorf("Request URL path = %q, want %q", receivedPath, tt.wantURLPath)
+			assert.Equal(t, tt.wantURLPath, receivedPath)
+			if tt.rawQuery != "" {
+				assert.Equal(t, tt.rawQuery, receivedQuery)
 			}
+			assert.Equal(t, tt.serverStatus, resp.StatusCode)
 
-			// Verify query string
-			if tt.rawQuery != "" && receivedQuery != tt.rawQuery {
-				t.Errorf("Request query = %q, want %q", receivedQuery, tt.rawQuery)
-			}
-
-			// Verify response status code
-			if resp.StatusCode != tt.serverStatus {
-				t.Errorf("Response status = %d, want %d", resp.StatusCode, tt.serverStatus)
-			}
-
-			// Verify response body
 			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatalf("Failed to read response body: %v", err)
-			}
-			if string(body) != tt.serverBody {
-				t.Errorf("Response body = %q, want %q", string(body), tt.serverBody)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.serverBody, string(body))
 
-			// Verify custom response headers
 			for k, v := range tt.serverHeaders {
-				if resp.Header.Get(k) != v {
-					t.Errorf("Response header %s = %q, want %q", k, resp.Header.Get(k), v)
-				}
+				assert.Equal(t, v, resp.Header.Get(k))
 			}
 		})
 	}
 }
 
 func TestProxyK8sRequest_NetworkError(t *testing.T) {
-	client := &Client{
-		baseURL:    "https://localhost:1", // unreachable port
-		httpClient: http.DefaultClient,
-	}
+	c := &Client{baseURL: "https://localhost:1", httpClient: http.DefaultClient}
 
-	_, err := client.ProxyK8sRequest(context.Background(), "dataplane", "test", "ns", "name", "api/v1/pods", "")
-	if err == nil {
-		t.Error("Expected error for unreachable server, got nil")
-	}
+	_, err := c.ProxyK8sRequest(context.Background(), "dataplane", "test", "ns", "name", "api/v1/pods", "")
 
-	if !IsTransientError(err) {
-		t.Errorf("Expected TransientError, got %T: %v", err, err)
-	}
+	require.Error(t, err)
+	assert.True(t, IsTransientError(err), "expected TransientError, got %T: %v", err, err)
 }
 
 func TestProxyK8sRequest_URLConstruction(t *testing.T) {
@@ -231,7 +186,6 @@ func TestProxyK8sRequest_URLConstruction(t *testing.T) {
 			crNamespace:  "ns",
 			crName:       "dp",
 			k8sPath:      "api/v1/pods",
-			rawQuery:     "",
 			wantContains: "/api/proxy/dataplane/prod/ns/dp/k8s/api/v1/pods",
 		},
 		{
@@ -255,20 +209,13 @@ func TestProxyK8sRequest_URLConstruction(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := &Client{
-				baseURL:    server.URL,
-				httpClient: server.Client(),
-			}
-
-			resp, err := client.ProxyK8sRequest(context.Background(), tt.planeType, tt.planeID, tt.crNamespace, tt.crName, tt.k8sPath, tt.rawQuery)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			c := &Client{baseURL: server.URL, httpClient: server.Client()}
+			resp, err := c.ProxyK8sRequest(context.Background(), tt.planeType, tt.planeID,
+				tt.crNamespace, tt.crName, tt.k8sPath, tt.rawQuery)
+			require.NoError(t, err)
 			resp.Body.Close()
 
-			if !strings.Contains(receivedURL, tt.wantContains) {
-				t.Errorf("Received URL %q does not contain %q", receivedURL, tt.wantContains)
-			}
+			assert.Contains(t, receivedURL, tt.wantContains)
 		})
 	}
 }
@@ -280,25 +227,523 @@ func TestProxyK8sRequest_CallerMustCloseBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &Client{
-		baseURL:    server.URL,
-		httpClient: server.Client(),
-	}
+	c := &Client{baseURL: server.URL, httpClient: server.Client()}
+	resp, err := c.ProxyK8sRequest(context.Background(), "dataplane", "test", "ns", "name", "api/v1/pods", "")
+	require.NoError(t, err)
 
-	resp, err := client.ProxyK8sRequest(context.Background(), "dataplane", "test", "ns", "name", "api/v1/pods", "")
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	// Verify body is readable (not already closed)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body: %v", err)
-	}
-	if string(body) != "test body" {
-		t.Errorf("Body = %q, want %q", string(body), "test body")
+	require.NoError(t, err)
+	assert.Equal(t, "test body", string(body))
+	resp.Body.Close()
+}
+
+// ─── Pure-logic tests ─────────────────────────────────────────────────────────
+
+// mockLogger captures calls to Error for use in HandleGatewayError tests.
+type mockLogger struct {
+	called bool
+	err    error
+	msg    string
+}
+
+func (m *mockLogger) Error(err error, msg string, keysAndValues ...any) {
+	m.called = true
+	m.err = err
+	m.msg = msg
+}
+
+func TestTransientError_Error(t *testing.T) {
+	t.Run("with status code", func(t *testing.T) {
+		e := &TransientError{StatusCode: 503, Message: "service unavailable"}
+		assert.Equal(t, "transient gateway error (status 503): service unavailable", e.Error())
+	})
+
+	t.Run("without status code", func(t *testing.T) {
+		e := &TransientError{Message: "network fail"}
+		assert.Equal(t, "transient gateway error: network fail", e.Error())
+	})
+}
+
+func TestTransientError_Unwrap(t *testing.T) {
+	inner := errors.New("underlying cause")
+	e := &TransientError{Err: inner}
+	assert.Equal(t, inner, e.Unwrap())
+
+	eNoInner := &TransientError{}
+	assert.Nil(t, eNoInner.Unwrap())
+}
+
+func TestPermanentError_Error(t *testing.T) {
+	t.Run("with status code", func(t *testing.T) {
+		e := &PermanentError{StatusCode: 404, Message: "not found"}
+		assert.Equal(t, "permanent gateway error (status 404): not found", e.Error())
+	})
+
+	t.Run("without status code", func(t *testing.T) {
+		e := &PermanentError{Message: "invalid"}
+		assert.Equal(t, "permanent gateway error: invalid", e.Error())
+	})
+}
+
+func TestIsPermanentError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"PermanentError", &PermanentError{StatusCode: 404}, true},
+		{"wrapped PermanentError", fmt.Errorf("wrapped: %w", &PermanentError{StatusCode: 400}), true},
+		{"TransientError", &TransientError{StatusCode: 500}, false},
+		{"plain error", errors.New("random"), false},
 	}
 
-	// Now close it (caller's responsibility)
-	resp.Body.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPermanentError(tt.err))
+		})
+	}
+}
+
+func TestIsNetworkError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"connection refused", errors.New("dial tcp: connection refused"), true},
+		{"connection reset", errors.New("read: connection reset by peer"), true},
+		{"no such host", errors.New("dial tcp: no such host"), true},
+		{"network unreachable", errors.New("network is unreachable"), true},
+		{"i/o timeout", errors.New("i/o timeout"), true},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"wrapped DeadlineExceeded", fmt.Errorf("operation: %w", context.DeadlineExceeded), true},
+		{"unrelated error", errors.New("something else"), false},
+		{"PermanentError (not network)", &PermanentError{StatusCode: 404}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNetworkError(tt.err))
+		})
+	}
+}
+
+func TestClassifyHTTPError(t *testing.T) {
+	tests := []struct {
+		code          int
+		wantTransient bool
+		wantMsg       string
+	}{
+		{500, true, "gateway server error"},
+		{502, true, "gateway server error"},
+		{503, true, "gateway server error"},
+		{599, true, "gateway server error"},
+		{429, true, "gateway rate limited"},
+		{400, false, "gateway client error"},
+		{401, false, "gateway client error"},
+		{404, false, "gateway client error"},
+		{499, false, "gateway client error"},
+		{301, true, "unexpected status code"},
+		{200, true, "unexpected status code"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("HTTP %d", tt.code), func(t *testing.T) {
+			err := classifyHTTPError(tt.code)
+			require.Error(t, err)
+			if tt.wantTransient {
+				assert.True(t, IsTransientError(err), "code %d: expected TransientError, got %T", tt.code, err)
+			} else {
+				assert.True(t, IsPermanentError(err), "code %d: expected PermanentError, got %T", tt.code, err)
+			}
+			assert.Contains(t, err.Error(), tt.wantMsg)
+		})
+	}
+}
+
+func TestHandleGatewayError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantRetry  bool
+		wantNilErr bool
+	}{
+		{
+			name:       "TransientError → retry",
+			err:        &TransientError{Message: "timeout"},
+			wantRetry:  true,
+			wantNilErr: false,
+		},
+		{
+			name:       "network error is transient → retry",
+			err:        errors.New("connection refused"),
+			wantRetry:  true,
+			wantNilErr: false,
+		},
+		{
+			name:       "PermanentError → no retry, nil returned error",
+			err:        &PermanentError{Message: "bad request"},
+			wantRetry:  false,
+			wantNilErr: true,
+		},
+		{
+			name:       "generic error → no retry, nil returned error",
+			err:        errors.New("unknown"),
+			wantRetry:  false,
+			wantNilErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &mockLogger{}
+			shouldRetry, _, retryErr := HandleGatewayError(logger, tt.err, "test-operation")
+
+			assert.Equal(t, tt.wantRetry, shouldRetry)
+			assert.Equal(t, tt.wantNilErr, retryErr == nil)
+			assert.True(t, logger.called, "expected logger.Error to be called")
+		})
+	}
+}
+
+// ─── Gateway HTTP endpoint tests ─────────────────────────────────────────────
+
+func newTestGatewayClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	return &Client{baseURL: server.URL, httpClient: server.Client()}
+}
+
+func TestNotifyPlaneLifecycle(t *testing.T) {
+	t.Run("success returns response", func(t *testing.T) {
+		var capturedMethod, capturedPath, capturedContentType string
+		var capturedBody []byte
+
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			capturedContentType = r.Header.Get("Content-Type")
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"success":true,"disconnectedAgents":2}`))
+		})
+
+		notification := &PlaneNotification{
+			PlaneType: "dataplane", PlaneID: "prod",
+			Event: "created", Namespace: "default", Name: "my-dp",
+		}
+		resp, err := c.NotifyPlaneLifecycle(context.Background(), notification)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, capturedMethod)
+		assert.Equal(t, "/api/v1/planes/notify", capturedPath)
+		assert.Equal(t, "application/json", capturedContentType)
+		assert.Contains(t, string(capturedBody), "dataplane")
+		assert.True(t, resp.Success)
+		assert.Equal(t, 2, resp.DisconnectedAgents)
+	})
+
+	t.Run("500 returns TransientError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := c.NotifyPlaneLifecycle(context.Background(), &PlaneNotification{})
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err), "expected TransientError, got %T: %v", err, err)
+	})
+
+	t.Run("429 returns TransientError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		})
+		_, err := c.NotifyPlaneLifecycle(context.Background(), &PlaneNotification{})
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err), "expected TransientError, got %T: %v", err, err)
+	})
+
+	t.Run("400 returns PermanentError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		})
+		_, err := c.NotifyPlaneLifecycle(context.Background(), &PlaneNotification{})
+		require.Error(t, err)
+		assert.True(t, IsPermanentError(err), "expected PermanentError, got %T: %v", err, err)
+	})
+
+	t.Run("network error returns TransientError", func(t *testing.T) {
+		c := &Client{baseURL: "https://localhost:1", httpClient: http.DefaultClient}
+		_, err := c.NotifyPlaneLifecycle(context.Background(), &PlaneNotification{})
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err), "expected TransientError for network error, got %T", err)
+	})
+
+	t.Run("invalid JSON response returns decode error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not json"))
+		})
+		_, err := c.NotifyPlaneLifecycle(context.Background(), &PlaneNotification{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
+	})
+}
+
+func TestForceReconnect(t *testing.T) {
+	t.Run("success with correct URL and POST", func(t *testing.T) {
+		var capturedMethod, capturedPath string
+		var capturedBodyLen int
+
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			body, _ := io.ReadAll(r.Body)
+			capturedBodyLen = len(body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"success":true,"disconnectedAgents":0}`))
+		})
+
+		resp, err := c.ForceReconnect(context.Background(), "dataplane", "prod-cluster")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, capturedMethod)
+		assert.Equal(t, "/api/v1/planes/dataplane/prod-cluster/reconnect", capturedPath)
+		assert.Equal(t, 0, capturedBodyLen, "request body should be empty")
+		assert.True(t, resp.Success)
+	})
+
+	t.Run("500 returns TransientError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := c.ForceReconnect(context.Background(), "dataplane", "prod")
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
+
+	t.Run("404 returns PermanentError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		_, err := c.ForceReconnect(context.Background(), "dataplane", "prod")
+		require.Error(t, err)
+		assert.True(t, IsPermanentError(err))
+	})
+
+	t.Run("network error returns TransientError", func(t *testing.T) {
+		c := &Client{baseURL: "https://localhost:1", httpClient: http.DefaultClient}
+		_, err := c.ForceReconnect(context.Background(), "dataplane", "prod")
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
+}
+
+func TestGetPlaneStatus(t *testing.T) {
+	t.Run("success without namespace and name", func(t *testing.T) {
+		var capturedMethod, capturedQuery string
+
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"planeType":"dataplane","planeID":"prod","connected":true,"connectedAgents":1}`))
+		})
+
+		status, err := c.GetPlaneStatus(context.Background(), "dataplane", "prod", "", "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, capturedMethod)
+		assert.Empty(t, capturedQuery)
+		assert.True(t, status.Connected)
+		assert.Equal(t, 1, status.ConnectedAgents)
+	})
+
+	t.Run("success with namespace and name adds query params", func(t *testing.T) {
+		var capturedQuery string
+
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"planeType":"dataplane","planeID":"prod","connected":true}`))
+		})
+
+		_, err := c.GetPlaneStatus(context.Background(), "dataplane", "prod", "acme", "my-dp")
+
+		require.NoError(t, err)
+		assert.Contains(t, capturedQuery, "namespace=acme")
+		assert.Contains(t, capturedQuery, "name=my-dp")
+	})
+
+	t.Run("500 returns TransientError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := c.GetPlaneStatus(context.Background(), "dataplane", "prod", "", "")
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
+
+	t.Run("invalid JSON response returns decode error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not valid json"))
+		})
+		_, err := c.GetPlaneStatus(context.Background(), "dataplane", "prod", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
+	})
+}
+
+func TestGetPodLogsFromPlane(t *testing.T) {
+	podRef := &PodReference{Namespace: "default", Name: "my-pod"}
+
+	t.Run("success with no options", func(t *testing.T) {
+		var capturedPath string
+
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.RequestURI()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("log line 1\nlog line 2\n"))
+		})
+
+		logs, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", podRef, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "log line 1\nlog line 2\n", logs)
+		assert.Contains(t, capturedPath, "/pods/my-pod/log")
+		assert.Contains(t, capturedPath, "namespaces/default")
+	})
+
+	t.Run("with container name adds query param", func(t *testing.T) {
+		var capturedURI string
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("container logs"))
+		})
+
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp",
+			podRef, &PodLogsOptions{ContainerName: "mycontainer"})
+		require.NoError(t, err)
+		assert.Equal(t, "/api/proxy/dataplane/prod/acme/my-dp/k8s/api/v1/namespaces/default/pods/my-pod/log?container=mycontainer", capturedURI)
+	})
+
+	t.Run("with timestamps adds query param", func(t *testing.T) {
+		var capturedURI string
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.WriteHeader(http.StatusOK)
+		})
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp",
+			podRef, &PodLogsOptions{IncludeTimestamps: true})
+		require.NoError(t, err)
+		assert.Equal(t, "/api/proxy/dataplane/prod/acme/my-dp/k8s/api/v1/namespaces/default/pods/my-pod/log?timestamps=true", capturedURI)
+	})
+
+	t.Run("with sinceSeconds adds query param", func(t *testing.T) {
+		var capturedURI string
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.WriteHeader(http.StatusOK)
+		})
+		seconds := int64(300)
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp",
+			podRef, &PodLogsOptions{SinceSeconds: &seconds})
+		require.NoError(t, err)
+		assert.Equal(t, "/api/proxy/dataplane/prod/acme/my-dp/k8s/api/v1/namespaces/default/pods/my-pod/log?sinceSeconds=300", capturedURI)
+	})
+
+	t.Run("nil pod reference returns error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {})
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty pod name returns error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {})
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp",
+			&PodReference{Namespace: "default", Name: ""}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty pod namespace returns error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {})
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp",
+			&PodReference{Namespace: "", Name: "pod"}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("500 returns TransientError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", podRef, nil)
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
+
+	t.Run("network error returns TransientError", func(t *testing.T) {
+		c := &Client{baseURL: "https://localhost:1", httpClient: http.DefaultClient}
+		_, err := c.GetPodLogsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", podRef, nil)
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
+}
+
+func TestGetPodEventsFromPlane(t *testing.T) {
+	podRef := &PodReference{Namespace: "default", Name: "my-pod"}
+
+	t.Run("success returns event bytes", func(t *testing.T) {
+		var capturedURI, capturedAccept string
+
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			capturedAccept = r.Header.Get("Accept")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kind":"EventList","items":[]}`))
+		})
+
+		body, err := c.GetPodEventsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", podRef)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, body)
+		assert.Equal(t, "application/json", capturedAccept)
+		assert.Equal(t, "/api/proxy/dataplane/prod/acme/my-dp/k8s/api/v1/namespaces/default/events?fieldSelector=involvedObject.name%3Dmy-pod%2CinvolvedObject.kind%3DPod", capturedURI)
+	})
+
+	t.Run("nil pod reference returns error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {})
+		_, err := c.GetPodEventsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty pod name returns error", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {})
+		_, err := c.GetPodEventsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp",
+			&PodReference{Namespace: "default", Name: ""})
+		require.Error(t, err)
+	})
+
+	t.Run("500 returns TransientError", func(t *testing.T) {
+		c := newTestGatewayClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := c.GetPodEventsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", podRef)
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
+
+	t.Run("network error returns TransientError", func(t *testing.T) {
+		c := &Client{baseURL: "https://localhost:1", httpClient: http.DefaultClient}
+		_, err := c.GetPodEventsFromPlane(context.Background(), "dataplane", "prod", "acme", "my-dp", podRef)
+		require.Error(t, err)
+		assert.True(t, IsTransientError(err))
+	})
 }

--- a/internal/clients/kubernetes/client_test.go
+++ b/internal/clients/kubernetes/client_test.go
@@ -1,0 +1,428 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// ────────────────── KubeMultiClientManager tests ──────────────────
+
+func TestNewManager(t *testing.T) {
+	mgr := NewManager()
+	require.NotNil(t, mgr)
+	assert.NotNil(t, mgr.clients)
+	assert.Empty(t, mgr.clients)
+	assert.Nil(t, mgr.ProxyTLSConfig)
+}
+
+func TestNewManagerWithProxyTLS(t *testing.T) {
+	tlsCfg := &ProxyTLSConfig{
+		CACertPath:     "/path/to/ca.crt",
+		ClientCertPath: "/path/to/client.crt",
+		ClientKeyPath:  "/path/to/client.key",
+	}
+	mgr := NewManagerWithProxyTLS(tlsCfg)
+	require.NotNil(t, mgr)
+	assert.Same(t, tlsCfg, mgr.ProxyTLSConfig)
+	assert.Empty(t, mgr.clients)
+}
+
+func TestGetOrAddClient_CacheMiss(t *testing.T) {
+	mgr := NewManager()
+	callCount := 0
+
+	cl, err := mgr.GetOrAddClient("key1", func() (client.Client, error) {
+		callCount++
+		return &ProxyClient{}, nil
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, cl)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestGetOrAddClient_CacheHit(t *testing.T) {
+	mgr := NewManager()
+	callCount := 0
+
+	createFunc := func() (client.Client, error) {
+		callCount++
+		return &ProxyClient{}, nil
+	}
+
+	cl1, err := mgr.GetOrAddClient("key1", createFunc)
+	require.NoError(t, err)
+
+	cl2, err := mgr.GetOrAddClient("key1", createFunc)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, callCount, "createFunc should only be called once on cache hit")
+	assert.Same(t, cl1.(*ProxyClient), cl2.(*ProxyClient))
+}
+
+func TestGetOrAddClient_ErrorPropagated(t *testing.T) {
+	mgr := NewManager()
+
+	_, err := mgr.GetOrAddClient("key1", func() (client.Client, error) {
+		return nil, errTest("create failed")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "create failed", err.Error())
+
+	// Failed creation should NOT be cached
+	callCount := 0
+	_, _ = mgr.GetOrAddClient("key1", func() (client.Client, error) {
+		callCount++
+		return &ProxyClient{}, nil
+	})
+	assert.Equal(t, 1, callCount, "after failed creation, createFunc should be called again")
+}
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
+func TestGetOrAddClient_Concurrent(t *testing.T) {
+	mgr := NewManager()
+	var callCount int64
+
+	createFunc := func() (client.Client, error) { //nolint:unparam // always returns nil error to satisfy the factory signature
+		atomic.AddInt64(&callCount, 1)
+		return &ProxyClient{}, nil
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = mgr.GetOrAddClient("shared-key", createFunc)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&callCount), "createFunc should be called exactly once across all goroutines")
+}
+
+func TestRemoveClient(t *testing.T) {
+	t.Run("remove existing client causes re-creation", func(t *testing.T) {
+		mgr := NewManager()
+		callCount := 0
+		createFunc := func() (client.Client, error) {
+			callCount++
+			return &ProxyClient{}, nil
+		}
+
+		_, _ = mgr.GetOrAddClient("key1", createFunc)
+		require.Equal(t, 1, callCount)
+
+		mgr.RemoveClient("key1")
+
+		_, _ = mgr.GetOrAddClient("key1", createFunc)
+		assert.Equal(t, 2, callCount, "after RemoveClient, createFunc should be called again")
+	})
+
+	t.Run("remove non-existent key does not panic", func(t *testing.T) {
+		mgr := NewManager()
+		// Should not panic
+		assert.NotPanics(t, func() { mgr.RemoveClient("nonexistent") })
+	})
+}
+
+// ──────────────────────── Plane factory function tests ────────────────────────
+
+const testGatewayURL = "https://gateway.example.com"
+
+func TestGetK8sClientFromDataPlane(t *testing.T) {
+	t.Run("empty gatewayURL returns error", func(t *testing.T) {
+		mgr := NewManager()
+		dp := &openchoreov1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-dp", Namespace: "default"},
+		}
+		_, err := GetK8sClientFromDataPlane(mgr, dp, "")
+		require.Error(t, err)
+	})
+
+	t.Run("uses PlaneID from spec", func(t *testing.T) {
+		mgr := NewManager()
+		dp := &openchoreov1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-dp", Namespace: "default"},
+			Spec:       openchoreov1alpha1.DataPlaneSpec{PlaneID: "custom-id"},
+		}
+		cl, err := GetK8sClientFromDataPlane(mgr, dp, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "custom-id", pc.planeID)
+		assert.Equal(t, "dataplane", pc.planeType)
+		assert.Equal(t, "default", pc.crNamespace)
+		assert.Equal(t, "my-dp", pc.crName)
+	})
+
+	t.Run("PlaneID defaults to CR name", func(t *testing.T) {
+		mgr := NewManager()
+		dp := &openchoreov1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-dp", Namespace: "default"},
+		}
+		cl, err := GetK8sClientFromDataPlane(mgr, dp, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "my-dp", pc.planeID)
+		assert.Equal(t, "dataplane", pc.planeType)
+		assert.Equal(t, "default", pc.crNamespace)
+		assert.Equal(t, "my-dp", pc.crName)
+	})
+
+	t.Run("caches client on repeated calls", func(t *testing.T) {
+		mgr := NewManager()
+		dp := &openchoreov1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-dp", Namespace: "default"},
+			Spec:       openchoreov1alpha1.DataPlaneSpec{PlaneID: "prod"},
+		}
+		cl1, err := GetK8sClientFromDataPlane(mgr, dp, testGatewayURL)
+		require.NoError(t, err)
+
+		cl2, err := GetK8sClientFromDataPlane(mgr, dp, testGatewayURL)
+		require.NoError(t, err)
+
+		assert.Same(t, cl1.(*ProxyClient), cl2.(*ProxyClient))
+	})
+}
+
+func TestGetK8sClientFromWorkflowPlane(t *testing.T) {
+	t.Run("empty gatewayURL returns error", func(t *testing.T) {
+		mgr := NewManager()
+		wp := &openchoreov1alpha1.WorkflowPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-wp", Namespace: "default"},
+		}
+		_, err := GetK8sClientFromWorkflowPlane(mgr, wp, "")
+		require.Error(t, err)
+	})
+
+	t.Run("PlaneID defaults to CR name", func(t *testing.T) {
+		mgr := NewManager()
+		wp := &openchoreov1alpha1.WorkflowPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "ci-wp", Namespace: "default"},
+		}
+		cl, err := GetK8sClientFromWorkflowPlane(mgr, wp, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "ci-wp", pc.planeID)
+		assert.Equal(t, "workflowplane", pc.planeType)
+		assert.Equal(t, "default", pc.crNamespace)
+		assert.Equal(t, "ci-wp", pc.crName)
+	})
+
+	t.Run("caches client on repeated calls", func(t *testing.T) {
+		mgr := NewManager()
+		wp := &openchoreov1alpha1.WorkflowPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "ci-wp", Namespace: "default"},
+			Spec:       openchoreov1alpha1.WorkflowPlaneSpec{PlaneID: "ci"},
+		}
+		cl1, _ := GetK8sClientFromWorkflowPlane(mgr, wp, testGatewayURL)
+		cl2, _ := GetK8sClientFromWorkflowPlane(mgr, wp, testGatewayURL)
+		assert.Same(t, cl1.(*ProxyClient), cl2.(*ProxyClient))
+	})
+}
+
+func TestGetK8sClientFromClusterWorkflowPlane(t *testing.T) {
+	t.Run("empty gatewayURL returns error", func(t *testing.T) {
+		mgr := NewManager()
+		cwp := &openchoreov1alpha1.ClusterWorkflowPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "ci-cwp"},
+		}
+		_, err := GetK8sClientFromClusterWorkflowPlane(mgr, cwp, "")
+		require.Error(t, err)
+	})
+
+	t.Run("cluster-scoped uses _cluster namespace", func(t *testing.T) {
+		mgr := NewManager()
+		cwp := &openchoreov1alpha1.ClusterWorkflowPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "global-wp"},
+			Spec:       openchoreov1alpha1.ClusterWorkflowPlaneSpec{PlaneID: "global"},
+		}
+		cl, err := GetK8sClientFromClusterWorkflowPlane(mgr, cwp, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "_cluster", pc.crNamespace)
+	})
+}
+
+func TestGetK8sClientFromClusterDataPlane(t *testing.T) {
+	t.Run("empty gatewayURL returns error", func(t *testing.T) {
+		mgr := NewManager()
+		cdp := &openchoreov1alpha1.ClusterDataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "global-dp"},
+		}
+		_, err := GetK8sClientFromClusterDataPlane(mgr, cdp, "")
+		require.Error(t, err)
+	})
+
+	t.Run("cluster-scoped uses _cluster namespace", func(t *testing.T) {
+		mgr := NewManager()
+		cdp := &openchoreov1alpha1.ClusterDataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "global-dp"},
+			Spec:       openchoreov1alpha1.ClusterDataPlaneSpec{PlaneID: "global"},
+		}
+		cl, err := GetK8sClientFromClusterDataPlane(mgr, cdp, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "_cluster", pc.crNamespace)
+	})
+
+	t.Run("caches client on repeated calls", func(t *testing.T) {
+		mgr := NewManager()
+		cdp := &openchoreov1alpha1.ClusterDataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "global-dp"},
+			Spec:       openchoreov1alpha1.ClusterDataPlaneSpec{PlaneID: "global"},
+		}
+		cl1, _ := GetK8sClientFromClusterDataPlane(mgr, cdp, testGatewayURL)
+		cl2, _ := GetK8sClientFromClusterDataPlane(mgr, cdp, testGatewayURL)
+		assert.Same(t, cl1.(*ProxyClient), cl2.(*ProxyClient))
+	})
+}
+
+func TestGetK8sClientFromObservabilityPlane(t *testing.T) {
+	t.Run("no ClusterAgent.ClientCA.Value returns error", func(t *testing.T) {
+		mgr := NewManager()
+		op := &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "obs", Namespace: "default"},
+		}
+		_, err := GetK8sClientFromObservabilityPlane(mgr, op, testGatewayURL)
+		require.Error(t, err)
+	})
+
+	t.Run("with ClientCA.Value but empty gatewayURL returns error", func(t *testing.T) {
+		mgr := NewManager()
+		op := &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "obs", Namespace: "default"},
+			Spec: openchoreov1alpha1.ObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{Value: "some-ca"},
+				},
+			},
+		}
+		_, err := GetK8sClientFromObservabilityPlane(mgr, op, "")
+		require.Error(t, err)
+	})
+
+	t.Run("with ClientCA.Value and valid gatewayURL returns client", func(t *testing.T) {
+		mgr := NewManager()
+		op := &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "obs", Namespace: "default"},
+			Spec: openchoreov1alpha1.ObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{Value: "some-ca"},
+				},
+			},
+		}
+		cl, err := GetK8sClientFromObservabilityPlane(mgr, op, testGatewayURL)
+		require.NoError(t, err)
+		assert.NotNil(t, cl)
+	})
+
+	t.Run("PlaneID defaults to CR name", func(t *testing.T) {
+		mgr := NewManager()
+		op := &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-obs", Namespace: "default"},
+			Spec: openchoreov1alpha1.ObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{Value: "ca"},
+				},
+			},
+		}
+		cl, err := GetK8sClientFromObservabilityPlane(mgr, op, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "my-obs", pc.planeID)
+		assert.Equal(t, "observabilityplane", pc.planeType)
+		assert.Equal(t, "default", pc.crNamespace)
+		assert.Equal(t, "my-obs", pc.crName)
+	})
+}
+
+func TestGetK8sClientFromClusterObservabilityPlane(t *testing.T) {
+	t.Run("no ClusterAgent.ClientCA.Value returns error", func(t *testing.T) {
+		mgr := NewManager()
+		cop := &openchoreov1alpha1.ClusterObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-obs"},
+		}
+		_, err := GetK8sClientFromClusterObservabilityPlane(mgr, cop, testGatewayURL)
+		require.Error(t, err)
+	})
+
+	t.Run("with ClientCA.Value but empty gatewayURL returns error", func(t *testing.T) {
+		mgr := NewManager()
+		cop := &openchoreov1alpha1.ClusterObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-obs"},
+			Spec: openchoreov1alpha1.ClusterObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{Value: "ca"},
+				},
+			},
+		}
+		_, err := GetK8sClientFromClusterObservabilityPlane(mgr, cop, "")
+		require.Error(t, err)
+	})
+
+	t.Run("with ClientCA.Value and valid gatewayURL returns client", func(t *testing.T) {
+		mgr := NewManager()
+		cop := &openchoreov1alpha1.ClusterObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-obs"},
+			Spec: openchoreov1alpha1.ClusterObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{Value: "some-ca"},
+				},
+			},
+		}
+		cl, err := GetK8sClientFromClusterObservabilityPlane(mgr, cop, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+
+		// Cluster-scoped uses _cluster namespace
+		pc, ok := cl.(*ProxyClient)
+		require.True(t, ok, "expected *ProxyClient")
+		assert.Equal(t, "_cluster", pc.crNamespace)
+	})
+
+	t.Run("caches client on repeated calls", func(t *testing.T) {
+		mgr := NewManager()
+		cop := &openchoreov1alpha1.ClusterObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-obs"},
+			Spec: openchoreov1alpha1.ClusterObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{Value: "ca"},
+				},
+			},
+		}
+		cl1, _ := GetK8sClientFromClusterObservabilityPlane(mgr, cop, testGatewayURL)
+		cl2, _ := GetK8sClientFromClusterObservabilityPlane(mgr, cop, testGatewayURL)
+		assert.Same(t, cl1.(*ProxyClient), cl2.(*ProxyClient))
+	})
+}

--- a/internal/clients/kubernetes/proxy_client_test.go
+++ b/internal/clients/kubernetes/proxy_client_test.go
@@ -1,0 +1,909 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ───────────────────────── Test helpers ─────────────────────────
+
+func newTestProxyClient(t *testing.T, handler http.HandlerFunc) *ProxyClient {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	return &ProxyClient{
+		gatewayURL:  server.URL,
+		planeType:   "dataplane",
+		planeID:     "test-plane",
+		crNamespace: "test-ns",
+		crName:      "test-cr",
+		httpClient:  server.Client(),
+		scheme:      k8sscheme.Scheme,
+	}
+}
+
+func fakeResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+const (
+	testPodName      = "nginx"
+	testPodNamespace = "default"
+
+	testPodJSON     = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","namespace":"default"}}`
+	testPodListJSON = `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+)
+
+// ───────────────────────── Pure-logic helper tests ─────────────────────────
+
+func TestPluralizeKind(t *testing.T) {
+	tests := []struct {
+		kind string
+		want string
+	}{
+		// Special-cased values
+		{"Endpoints", "endpoints"},
+		{"Ingress", "ingresses"},
+		{"NetworkPolicy", "networkpolicies"},
+		// Ends with 's' → add 'es'
+		{"Class", "classes"},
+		// Ends with 'x' → add 'es'
+		{"Prefix", "prefixes"},
+		// Ends with 'sh' → add 'es'
+		{"Mesh", "meshes"},
+		// Ends with 'ch' → add 'es'
+		{"Patch", "patches"},
+		// Ends with consonant-y → change to 'ies'
+		{"StoragePolicy", "storagepolicies"},
+		{"Canary", "canaries"},
+		// Vowel-y → just add 's'
+		{"Key", "keys"},
+		// Default: just add 's'
+		{"Pod", "pods"},
+		{"Service", "services"},
+		{"Deployment", "deployments"},
+		{"ConfigMap", "configmaps"},
+		{"Namespace", "namespaces"},
+		{"Node", "nodes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			assert.Equal(t, tt.want, pluralizeKind(tt.kind))
+		})
+	}
+}
+
+func TestIsNamespaced(t *testing.T) {
+	tests := []struct {
+		kind string
+		want bool
+	}{
+		// Cluster-scoped resources
+		{"Namespace", false},
+		{"Node", false},
+		{"PersistentVolume", false},
+		{"ClusterRole", false},
+		{"ClusterRoleBinding", false},
+		{"StorageClass", false},
+		{"CustomResourceDefinition", false},
+		{"APIService", false},
+		{"ValidatingWebhookConfiguration", false},
+		{"MutatingWebhookConfiguration", false},
+		{"PriorityClass", false},
+		// Namespaced resources (not in cluster-scoped map)
+		{"Pod", true},
+		{"Service", true},
+		{"Deployment", true},
+		{"ConfigMap", true},
+		{"Secret", true},
+		{"ServiceAccount", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			gvk := schema.GroupVersionKind{Kind: tt.kind}
+			assert.Equal(t, tt.want, isNamespaced(gvk))
+		})
+	}
+}
+
+func TestGetGVK(t *testing.T) {
+	// Pod is in the core group (empty string)
+	pod := &corev1.Pod{}
+	gvk, err := getGVK(pod, k8sscheme.Scheme)
+	require.NoError(t, err)
+	assert.Equal(t, "", gvk.Group)
+	assert.Equal(t, "v1", gvk.Version)
+	assert.Equal(t, "Pod", gvk.Kind)
+
+	// ConfigMap is also core
+	cm := &corev1.ConfigMap{}
+	gvk, err = getGVK(cm, k8sscheme.Scheme)
+	require.NoError(t, err)
+	assert.Equal(t, "ConfigMap", gvk.Kind)
+	assert.Equal(t, "v1", gvk.Version)
+}
+
+func TestGetGVKForList(t *testing.T) {
+	// PodList → Pod
+	podList := &corev1.PodList{}
+	gvk, err := getGVKForList(podList, k8sscheme.Scheme)
+	require.NoError(t, err)
+	assert.Equal(t, "Pod", gvk.Kind)
+	assert.Equal(t, "v1", gvk.Version)
+	assert.Equal(t, "", gvk.Group)
+
+	// ConfigMapList → ConfigMap
+	cmList := &corev1.ConfigMapList{}
+	gvk, err = getGVKForList(cmList, k8sscheme.Scheme)
+	require.NoError(t, err)
+	assert.Equal(t, "ConfigMap", gvk.Kind)
+}
+
+func TestBuildGetPath(t *testing.T) {
+	pc := &ProxyClient{}
+
+	tests := []struct {
+		name      string
+		gvk       schema.GroupVersionKind
+		namespace string
+		resName   string
+		want      string
+	}{
+		{
+			name:      "core namespaced",
+			gvk:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			namespace: testPodNamespace,
+			resName:   testPodName,
+			want:      "/api/v1/namespaces/default/pods/nginx",
+		},
+		{
+			name:      "core cluster-scoped",
+			gvk:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			namespace: "",
+			resName:   "kube-system",
+			want:      "/api/v1/namespaces/kube-system",
+		},
+		{
+			name:      "core cluster-scoped with namespace arg ignored",
+			gvk:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"},
+			namespace: testPodNamespace, // should be ignored since Node is cluster-scoped
+			resName:   "node-1",
+			want:      "/api/v1/nodes/node-1",
+		},
+		{
+			name:      "non-core namespaced",
+			gvk:       schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			namespace: testPodNamespace,
+			resName:   "web",
+			want:      "/apis/apps/v1/namespaces/default/deployments/web",
+		},
+		{
+			name:      "non-core cluster-scoped",
+			gvk:       schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+			namespace: "",
+			resName:   "admin",
+			want:      "/apis/rbac.authorization.k8s.io/v1/clusterroles/admin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pc.buildGetPath(tt.gvk, tt.namespace, tt.resName))
+		})
+	}
+}
+
+func TestBuildListPath(t *testing.T) {
+	pc := &ProxyClient{}
+
+	tests := []struct {
+		name      string
+		gvk       schema.GroupVersionKind
+		namespace string
+		want      string
+	}{
+		{
+			name:      "core namespaced",
+			gvk:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			namespace: testPodNamespace,
+			want:      "/api/v1/namespaces/default/pods",
+		},
+		{
+			name:      "core cluster-scoped",
+			gvk:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			namespace: "",
+			want:      "/api/v1/namespaces",
+		},
+		{
+			name:      "non-core namespaced",
+			gvk:       schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			namespace: "ns1",
+			want:      "/apis/apps/v1/namespaces/ns1/deployments",
+		},
+		{
+			name:      "non-core cluster-scoped",
+			gvk:       schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+			namespace: "",
+			want:      "/apis/rbac.authorization.k8s.io/v1/clusterroles",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pc.buildListPath(tt.gvk, tt.namespace))
+		})
+	}
+}
+
+func TestBuildStatusPath(t *testing.T) {
+	pc := &ProxyClient{}
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+	got := pc.buildStatusPath(gvk, testPodNamespace, "web")
+	assert.Equal(t, "/apis/apps/v1/namespaces/default/deployments/web/status", got)
+}
+
+// TestBuildPathDelegates verifies that buildCreatePath delegates to buildListPath,
+// and that buildUpdatePath and buildDeletePath both delegate to buildGetPath.
+func TestBuildPathDelegates(t *testing.T) {
+	pc := &ProxyClient{}
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+
+	assert.Equal(t, pc.buildListPath(gvk, testPodNamespace), pc.buildCreatePath(gvk, testPodNamespace), "buildCreatePath should delegate to buildListPath")
+	assert.Equal(t, pc.buildGetPath(gvk, testPodNamespace, testPodName), pc.buildUpdatePath(gvk, testPodNamespace, testPodName), "buildUpdatePath should delegate to buildGetPath")
+	assert.Equal(t, pc.buildGetPath(gvk, testPodNamespace, testPodName), pc.buildDeletePath(gvk, testPodNamespace, testPodName), "buildDeletePath should delegate to buildGetPath")
+}
+
+func TestBuildProxyURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		gatewayURL  string
+		planeType   string
+		planeID     string
+		crNamespace string
+		crName      string
+		apiPath     string
+		want        string
+	}{
+		{
+			name:        "standard namespaced",
+			gatewayURL:  "https://gateway.example.com",
+			planeType:   "dataplane",
+			planeID:     "prod",
+			crNamespace: "acme",
+			crName:      "dp1",
+			apiPath:     "/api/v1/pods",
+			want:        "https://gateway.example.com/api/proxy/dataplane/prod/acme/dp1/k8s/api/v1/pods",
+		},
+		{
+			name:        "cluster-scoped with _cluster namespace",
+			gatewayURL:  "https://gw",
+			planeType:   "dataplane",
+			planeID:     "shared",
+			crNamespace: "_cluster",
+			crName:      "shared-dp",
+			apiPath:     "/api/v1/nodes",
+			want:        "https://gw/api/proxy/dataplane/shared/_cluster/shared-dp/k8s/api/v1/nodes",
+		},
+		{
+			name:        "workflowplane",
+			gatewayURL:  "https://gw",
+			planeType:   "workflowplane",
+			planeID:     "ci",
+			crNamespace: "team-a",
+			crName:      "ci-wp",
+			apiPath:     "/apis/argoproj.io/v1alpha1/workflows",
+			want:        "https://gw/api/proxy/workflowplane/ci/team-a/ci-wp/k8s/apis/argoproj.io/v1alpha1/workflows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &ProxyClient{
+				gatewayURL:  tt.gatewayURL,
+				planeType:   tt.planeType,
+				planeID:     tt.planeID,
+				crNamespace: tt.crNamespace,
+				crName:      tt.crName,
+			}
+			assert.Equal(t, tt.want, pc.buildProxyURL(tt.apiPath))
+		})
+	}
+}
+
+func TestBuildListQueryParams(t *testing.T) {
+	pc := &ProxyClient{}
+
+	t.Run("empty options", func(t *testing.T) {
+		opts := &client.ListOptions{}
+		assert.Empty(t, pc.buildListQueryParams(opts))
+	})
+
+	t.Run("label selector only", func(t *testing.T) {
+		opts := &client.ListOptions{}
+		client.MatchingLabels{"app": "web"}.ApplyToList(opts)
+		got := pc.buildListQueryParams(opts)
+		assert.Contains(t, got, "labelSelector=")
+		assert.Contains(t, got, "app")
+	})
+
+	t.Run("limit only", func(t *testing.T) {
+		opts := &client.ListOptions{Limit: 100}
+		assert.Equal(t, "limit=100", pc.buildListQueryParams(opts))
+	})
+
+	t.Run("continue token only", func(t *testing.T) {
+		opts := &client.ListOptions{Continue: "abc123"}
+		assert.Equal(t, "continue=abc123", pc.buildListQueryParams(opts))
+	})
+
+	t.Run("limit and continue", func(t *testing.T) {
+		opts := &client.ListOptions{Limit: 50, Continue: "tok"}
+		got := pc.buildListQueryParams(opts)
+		assert.Contains(t, got, "limit=50")
+		assert.Contains(t, got, "continue=tok")
+	})
+}
+
+func TestBuildPatchQueryParams(t *testing.T) {
+	pc := &ProxyClient{}
+
+	tests := []struct {
+		name         string
+		opts         *client.PatchOptions
+		wantContains []string
+		wantEmpty    bool
+	}{
+		{
+			name:      "empty opts",
+			opts:      &client.PatchOptions{},
+			wantEmpty: true,
+		},
+		{
+			name:         "field manager only",
+			opts:         &client.PatchOptions{FieldManager: "my-controller"},
+			wantContains: []string{"fieldManager=my-controller"},
+		},
+		{
+			name:         "force true",
+			opts:         &client.PatchOptions{Force: boolPtr(true)},
+			wantContains: []string{"force=true"},
+		},
+		{
+			name:      "force false",
+			opts:      &client.PatchOptions{Force: boolPtr(false)},
+			wantEmpty: true,
+		},
+		{
+			name:         "field manager and force",
+			opts:         &client.PatchOptions{FieldManager: "mgr", Force: boolPtr(true)},
+			wantContains: []string{"fieldManager=mgr", "force=true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pc.buildPatchQueryParams(tt.opts)
+			if tt.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}
+
+func TestBuildSubResourcePatchQueryParams(t *testing.T) {
+	pc := &ProxyClient{}
+
+	t.Run("empty", func(t *testing.T) {
+		opts := &client.SubResourcePatchOptions{}
+		assert.Empty(t, pc.buildSubResourcePatchQueryParams(opts))
+	})
+
+	t.Run("field manager and force", func(t *testing.T) {
+		opts := &client.SubResourcePatchOptions{}
+		opts.FieldManager = "test-mgr"
+		opts.Force = boolPtr(true)
+		got := pc.buildSubResourcePatchQueryParams(opts)
+		assert.Contains(t, got, "fieldManager=test-mgr")
+		assert.Contains(t, got, "force=true")
+	})
+}
+
+func TestHandleErrorResponse(t *testing.T) {
+	pc := &ProxyClient{}
+	podGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		errCheck   func(error) bool
+		wantMsg    string
+	}{
+		{
+			name:       "kubernetes Status object → StatusError",
+			statusCode: http.StatusNotFound,
+			body:       `{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","message":"pods \"nginx\" not found","code":404}`,
+			errCheck:   apierrors.IsNotFound,
+		},
+		{
+			name:       "plain 404 body → NotFound",
+			statusCode: http.StatusNotFound,
+			body:       "pod not found",
+			errCheck:   apierrors.IsNotFound,
+		},
+		{
+			name:       "409 conflict",
+			statusCode: http.StatusConflict,
+			body:       "already exists",
+			errCheck:   apierrors.IsConflict,
+		},
+		{
+			name:       "403 forbidden",
+			statusCode: http.StatusForbidden,
+			body:       "forbidden",
+			errCheck:   apierrors.IsForbidden,
+		},
+		{
+			name:       "401 unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       "unauthorized",
+			errCheck:   apierrors.IsUnauthorized,
+		},
+		{
+			name:       "400 bad request",
+			statusCode: http.StatusBadRequest,
+			body:       "bad request",
+			errCheck:   apierrors.IsBadRequest,
+		},
+		{
+			name:       "500 internal error",
+			statusCode: http.StatusInternalServerError,
+			body:       "internal error",
+			errCheck:   apierrors.IsInternalError,
+		},
+		{
+			name:       "503 service unavailable → internal error",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "unavailable",
+			errCheck:   apierrors.IsInternalError,
+		},
+		{
+			name:       "unknown 418 → generic error with status code",
+			statusCode: 418,
+			body:       "teapot",
+			wantMsg:    "418",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := fakeResponse(tt.statusCode, tt.body)
+			err := pc.handleErrorResponse(resp, podGVK, testPodName)
+
+			require.Error(t, err)
+			if tt.errCheck != nil {
+				assert.True(t, tt.errCheck(err), "errCheck failed for error: %v (type %T)", err, err)
+			}
+			if tt.wantMsg != "" {
+				assert.Contains(t, err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+// ───────────────────────── ProxyClient HTTP CRUD tests ─────────────────────────
+
+func TestProxyClientGet(t *testing.T) {
+	t.Run("success returns populated object", func(t *testing.T) {
+		var capturedMethod, capturedPath, capturedAccept string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			capturedAccept = r.Header.Get("Accept")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodJSON))
+		})
+
+		pod := &corev1.Pod{}
+		err := pc.Get(context.Background(), client.ObjectKey{Namespace: testPodNamespace, Name: testPodName}, pod)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, capturedMethod)
+		assert.True(t, strings.HasSuffix(capturedPath, "/pods/nginx"), "path %q should end with /pods/nginx", capturedPath)
+		assert.Equal(t, "application/json", capturedAccept)
+		assert.Equal(t, testPodName, pod.Name)
+	})
+
+	t.Run("404 returns NotFound error", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","code":404}`))
+		})
+
+		pod := &corev1.Pod{}
+		err := pc.Get(context.Background(), client.ObjectKey{Namespace: testPodNamespace, Name: testPodName}, pod)
+
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "expected NotFound error, got %T: %v", err, err)
+	})
+
+	t.Run("500 returns error", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal error"))
+		})
+
+		pod := &corev1.Pod{}
+		err := pc.Get(context.Background(), client.ObjectKey{Namespace: testPodNamespace, Name: testPodName}, pod)
+
+		require.Error(t, err)
+	})
+}
+
+func TestProxyClientList(t *testing.T) {
+	t.Run("success returns list", func(t *testing.T) {
+		var capturedPath string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodListJSON))
+		})
+
+		podList := &corev1.PodList{}
+		err := pc.List(context.Background(), podList)
+
+		require.NoError(t, err)
+		assert.True(t, strings.HasSuffix(capturedPath, "/pods"), "list path %q should end with /pods", capturedPath)
+		assert.Len(t, podList.Items, 1)
+	})
+
+	t.Run("with label selector adds query param", func(t *testing.T) {
+		var capturedQuery string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodListJSON))
+		})
+
+		podList := &corev1.PodList{}
+		err := pc.List(context.Background(), podList, client.MatchingLabels{"app": "web"})
+
+		require.NoError(t, err)
+		assert.Contains(t, capturedQuery, "labelSelector=")
+	})
+
+	t.Run("with namespace sets namespaced path", func(t *testing.T) {
+		var capturedPath string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodListJSON))
+		})
+
+		podList := &corev1.PodList{}
+		err := pc.List(context.Background(), podList, client.InNamespace("my-ns"))
+
+		require.NoError(t, err)
+		assert.Contains(t, capturedPath, "namespaces/my-ns")
+	})
+
+	t.Run("500 returns error", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		err := pc.List(context.Background(), &corev1.PodList{})
+		require.Error(t, err)
+	})
+}
+
+func TestProxyClientCreate(t *testing.T) {
+	t.Run("success updates object from response", func(t *testing.T) {
+		var capturedMethod, capturedContentType string
+		var capturedPath string
+		const serverAssignedUID = "server-assigned-uid-abc123"
+		serverResponse := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","namespace":"default","uid":"` + serverAssignedUID + `","resourceVersion":"42"}}`
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedContentType = r.Header.Get("Content-Type")
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(serverResponse))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		err := pc.Create(context.Background(), pod)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, capturedMethod)
+		assert.Equal(t, "application/json", capturedContentType)
+		// Create path should not include the pod name (collection path)
+		assert.False(t, strings.HasSuffix(capturedPath, "/"+testPodName), "create path %q should not end with resource name", capturedPath)
+		// Server-assigned fields must be decoded back into the passed-in object
+		assert.Equal(t, serverAssignedUID, string(pod.UID), "pod.UID should be set from server response")
+		assert.Equal(t, "42", pod.ResourceVersion, "pod.ResourceVersion should be set from server response")
+	})
+
+	t.Run("409 conflict returns error", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte("already exists"))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		err := pc.Create(context.Background(), pod)
+
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "expected Conflict, got %T: %v", err, err)
+	})
+}
+
+func TestProxyClientUpdate(t *testing.T) {
+	t.Run("success with PUT method", func(t *testing.T) {
+		var capturedMethod string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodJSON))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		err := pc.Update(context.Background(), pod)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPut, capturedMethod)
+	})
+
+	t.Run("404 not found returns error", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		err := pc.Update(context.Background(), pod)
+
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "expected NotFound, got %T: %v", err, err)
+	})
+}
+
+func TestProxyClientPatch(t *testing.T) {
+	t.Run("merge patch uses correct content-type", func(t *testing.T) {
+		var capturedMethod, capturedContentType string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedContentType = r.Header.Get("Content-Type")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodJSON))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		patch := client.RawPatch(types.MergePatchType, []byte(`{"metadata":{"labels":{"x":"y"}}}`))
+		err := pc.Patch(context.Background(), pod, patch)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPatch, capturedMethod)
+		assert.Equal(t, string(types.MergePatchType), capturedContentType)
+	})
+
+	t.Run("patch with field manager adds query param", func(t *testing.T) {
+		var capturedQuery string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodJSON))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		patch := client.RawPatch(types.MergePatchType, []byte(`{}`))
+		err := pc.Patch(context.Background(), pod, patch, &client.PatchOptions{FieldManager: "test-ctrl"})
+
+		require.NoError(t, err)
+		assert.Contains(t, capturedQuery, "fieldManager=test-ctrl")
+	})
+}
+
+func TestProxyClientDelete(t *testing.T) {
+	t.Run("200 OK is success", func(t *testing.T) {
+		var capturedMethod string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			w.WriteHeader(http.StatusOK)
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		err := pc.Delete(context.Background(), pod)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodDelete, capturedMethod)
+	})
+
+	t.Run("404 is not an error for delete", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		// 404 on delete is intentionally treated as success
+		assert.NoError(t, pc.Delete(context.Background(), pod))
+	})
+
+	t.Run("500 returns error", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal error"))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		require.Error(t, pc.Delete(context.Background(), pod))
+	})
+}
+
+func TestProxyClientStatusUpdate(t *testing.T) {
+	t.Run("status update uses PUT to /status path", func(t *testing.T) {
+		var capturedMethod, capturedPath string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodJSON))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		err := pc.Status().Update(context.Background(), pod)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPut, capturedMethod)
+		assert.True(t, strings.HasSuffix(capturedPath, "/status"), "path %q should end with /status", capturedPath)
+	})
+
+	t.Run("status create is not supported", func(t *testing.T) {
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {})
+		pod := &corev1.Pod{}
+		require.Error(t, pc.Status().Create(context.Background(), pod, pod))
+	})
+}
+
+func TestProxyClientStatusPatch(t *testing.T) {
+	t.Run("status patch uses PATCH to /status path", func(t *testing.T) {
+		var capturedMethod, capturedPath, capturedContentType string
+		pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			capturedContentType = r.Header.Get("Content-Type")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testPodJSON))
+		})
+
+		pod := &corev1.Pod{}
+		pod.Name = testPodName
+		pod.Namespace = testPodNamespace
+		patch := client.RawPatch(types.MergePatchType, []byte(`{"status":{}}`))
+		err := pc.Status().Patch(context.Background(), pod, patch)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPatch, capturedMethod)
+		assert.True(t, strings.HasSuffix(capturedPath, "/status"), "path %q should end with /status", capturedPath)
+		assert.Equal(t, string(types.MergePatchType), capturedContentType)
+	})
+}
+
+func TestProxyClientStubs(t *testing.T) {
+	pc := newTestProxyClient(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	t.Run("DeleteAllOf returns not-implemented error", func(t *testing.T) {
+		err := pc.DeleteAllOf(context.Background(), &corev1.Pod{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+
+	t.Run("SubResource.Get returns not-implemented", func(t *testing.T) {
+		err := pc.SubResource("logs").Get(context.Background(), &corev1.Pod{}, &corev1.Pod{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+
+	t.Run("SubResource.Create returns not-implemented", func(t *testing.T) {
+		err := pc.SubResource("logs").Create(context.Background(), &corev1.Pod{}, &corev1.Pod{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+
+	t.Run("SubResource.Update returns not-implemented", func(t *testing.T) {
+		err := pc.SubResource("logs").Update(context.Background(), &corev1.Pod{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+
+	t.Run("SubResource.Patch returns not-implemented", func(t *testing.T) {
+		patch := client.RawPatch(types.MergePatchType, []byte(`{}`))
+		err := pc.SubResource("logs").Patch(context.Background(), &corev1.Pod{}, patch)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+
+	t.Run("Scheme returns non-nil", func(t *testing.T) {
+		assert.NotNil(t, pc.Scheme())
+	})
+
+	t.Run("RESTMapper returns nil", func(t *testing.T) {
+		assert.Nil(t, pc.RESTMapper())
+	})
+
+	t.Run("GroupVersionKindFor returns Pod GVK", func(t *testing.T) {
+		gvk, err := pc.GroupVersionKindFor(&corev1.Pod{})
+		require.NoError(t, err)
+		assert.Equal(t, "Pod", gvk.Kind)
+	})
+
+	t.Run("IsObjectNamespaced Pod returns true", func(t *testing.T) {
+		namespaced, err := pc.IsObjectNamespaced(&corev1.Pod{})
+		require.NoError(t, err)
+		assert.True(t, namespaced, "Pod should be namespaced")
+	})
+
+	t.Run("IsObjectNamespaced Namespace returns false", func(t *testing.T) {
+		namespaced, err := pc.IsObjectNamespaced(&corev1.Namespace{})
+		require.NoError(t, err)
+		assert.False(t, namespaced, "Namespace resource should not be namespaced")
+	})
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR,
- Adds new tests for the gateway client and the k8s client
- Migrates existing tests to use testify

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2944

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)