### PR TITLE
fix: update default schedule for scheduled-task component to valid cron expression

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -833,7 +833,7 @@ spec:
       properties:
         schedule:
           type: string
-          default: "0 0 31 2 *"
+          default: "1 * * * *"
         resources:
           $ref: "#/$defs/ResourceRequirements"
         imagePullPolicy:

--- a/samples/getting-started/component-types/scheduled-task.yaml
+++ b/samples/getting-started/component-types/scheduled-task.yaml
@@ -67,7 +67,7 @@ spec:
       properties:
         schedule:
           type: string
-          default: "0 0 31 2 *"
+          default: "1 * * * *"
         resources:
           $ref: "#/$defs/ResourceRequirements"
         imagePullPolicy:


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

To fix the current default cron syntax (`0 0 31 2 *` = every Feb 31) is invalid.  

## Approach
> Summarize the solution and implementation details.

Update it to `1 * * * *` = run once an hour

## Related Issues
> Include any related issues that are resolved by this PR.

https://github.com/openchoreo/openchoreo/issues/2954

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
