### PR TITLE
fix: add missing openAPIV3Schema wrapper in trait specs for componentrelease generate

### DIFF
--- a/internal/occ/fsmode/typed/clustertrait.go
+++ b/internal/occ/fsmode/typed/clustertrait.go
@@ -30,10 +30,14 @@ func (t *ClusterTrait) GetSpec() map[string]interface{} {
 
 	// Add schema sections
 	if params := t.Spec.Parameters.GetRaw(); params != nil {
-		spec["parameters"] = rawExtensionToMap(params)
+		spec["parameters"] = map[string]interface{}{
+			"openAPIV3Schema": rawExtensionToMap(params),
+		}
 	}
 	if envConfig := t.Spec.EnvironmentConfigs.GetRaw(); envConfig != nil {
-		spec["environmentConfigs"] = rawExtensionToMap(envConfig)
+		spec["environmentConfigs"] = map[string]interface{}{
+			"openAPIV3Schema": rawExtensionToMap(envConfig),
+		}
 	}
 
 	// Add creates

--- a/internal/occ/fsmode/typed/clustertrait_test.go
+++ b/internal/occ/fsmode/typed/clustertrait_test.go
@@ -147,12 +147,24 @@ func TestClusterTraitGetSpec(t *testing.T) {
 			spec := tt.trait.GetSpec()
 			require.NotNil(t, spec)
 			if tt.wantParams {
-				assert.Contains(t, spec, "parameters")
+				require.Contains(t, spec, "parameters", "spec should contain 'parameters' key")
+				paramsMap, ok := spec["parameters"].(map[string]interface{})
+				require.True(t, ok, "spec[\"parameters\"] should be a map[string]interface{}")
+				require.Contains(t, paramsMap, "openAPIV3Schema", "spec[\"parameters\"] should contain 'openAPIV3Schema' key")
+				schema, ok := paramsMap["openAPIV3Schema"].(map[string]interface{})
+				require.True(t, ok, "spec[\"parameters\"][\"openAPIV3Schema\"] should be a map[string]interface{}")
+				assert.Equal(t, "object", schema["type"], "spec[\"parameters\"][\"openAPIV3Schema\"][\"type\"] should match input schema")
 			} else {
 				assert.NotContains(t, spec, "parameters")
 			}
 			if tt.wantEnv {
-				assert.Contains(t, spec, "environmentConfigs")
+				require.Contains(t, spec, "environmentConfigs", "spec should contain 'environmentConfigs' key")
+				envMap, ok := spec["environmentConfigs"].(map[string]interface{})
+				require.True(t, ok, "spec[\"environmentConfigs\"] should be a map[string]interface{}")
+				require.Contains(t, envMap, "openAPIV3Schema", "spec[\"environmentConfigs\"] should contain 'openAPIV3Schema' key")
+				schema, ok := envMap["openAPIV3Schema"].(map[string]interface{})
+				require.True(t, ok, "spec[\"environmentConfigs\"][\"openAPIV3Schema\"] should be a map[string]interface{}")
+				assert.Equal(t, "object", schema["type"], "spec[\"environmentConfigs\"][\"openAPIV3Schema\"][\"type\"] should match input schema")
 			} else {
 				assert.NotContains(t, spec, "environmentConfigs")
 			}

--- a/internal/occ/fsmode/typed/trait.go
+++ b/internal/occ/fsmode/typed/trait.go
@@ -30,10 +30,14 @@ func (t *Trait) GetSpec() map[string]interface{} {
 
 	// Add schema sections
 	if params := t.Spec.Parameters.GetRaw(); params != nil {
-		spec["parameters"] = rawExtensionToMap(params)
+		spec["parameters"] = map[string]interface{}{
+			"openAPIV3Schema": rawExtensionToMap(params),
+		}
 	}
 	if envConfig := t.Spec.EnvironmentConfigs.GetRaw(); envConfig != nil {
-		spec["environmentConfigs"] = rawExtensionToMap(envConfig)
+		spec["environmentConfigs"] = map[string]interface{}{
+			"openAPIV3Schema": rawExtensionToMap(envConfig),
+		}
 	}
 
 	// Add creates

--- a/internal/occ/fsmode/typed/trait_test.go
+++ b/internal/occ/fsmode/typed/trait_test.go
@@ -98,12 +98,24 @@ func TestTraitGetSpec(t *testing.T) {
 			spec := tt.trait.GetSpec()
 			require.NotNil(t, spec)
 			if tt.wantParams {
-				assert.Contains(t, spec, "parameters")
+				require.Contains(t, spec, "parameters", "spec should contain 'parameters' key")
+				paramsMap, ok := spec["parameters"].(map[string]interface{})
+				require.True(t, ok, "spec[\"parameters\"] should be a map[string]interface{}")
+				require.Contains(t, paramsMap, "openAPIV3Schema", "spec[\"parameters\"] should contain 'openAPIV3Schema' key")
+				schema, ok := paramsMap["openAPIV3Schema"].(map[string]interface{})
+				require.True(t, ok, "spec[\"parameters\"][\"openAPIV3Schema\"] should be a map[string]interface{}")
+				assert.Equal(t, "object", schema["type"], "spec[\"parameters\"][\"openAPIV3Schema\"][\"type\"] should match input schema")
 			} else {
 				assert.NotContains(t, spec, "parameters")
 			}
 			if tt.wantEnv {
-				assert.Contains(t, spec, "environmentConfigs")
+				require.Contains(t, spec, "environmentConfigs", "spec should contain 'environmentConfigs' key")
+				envMap, ok := spec["environmentConfigs"].(map[string]interface{})
+				require.True(t, ok, "spec[\"environmentConfigs\"] should be a map[string]interface{}")
+				require.Contains(t, envMap, "openAPIV3Schema", "spec[\"environmentConfigs\"] should contain 'openAPIV3Schema' key")
+				schema, ok := envMap["openAPIV3Schema"].(map[string]interface{})
+				require.True(t, ok, "spec[\"environmentConfigs\"][\"openAPIV3Schema\"] should be a map[string]interface{}")
+				assert.Equal(t, "object", schema["type"], "spec[\"environmentConfigs\"][\"openAPIV3Schema\"][\"type\"] should match input schema")
 			} else {
 				assert.NotContains(t, spec, "environmentConfigs")
 			}


### PR DESCRIPTION
## Purpose
  - **Fix:** `Trait.GetSpec()` and `ClusterTrait.GetSpec()` in the `occ componentrelease generate`                                                                                        
    CLI were placing `parameters` and `environmentConfigs` schema content directly
    (e.g., `parameters.properties`), instead of wrapping it under `openAPIV3Schema`                                                                                                       
    (e.g., `parameters.openAPIV3Schema.properties`) as required by the `SchemaSection` CRD type.                                                                                          
  - **Root cause:** `ComponentType.GetSchema()` correctly wrapped with `openAPIV3Schema`, but the                                                                                         
    trait equivalents did not — the raw extension was assigned directly to the map key.                                                                                                   
  - **Fix applied to:** `internal/occ/fsmode/typed/trait.go` and `internal/occ/fsmode/typed/clustertrait.go`

## Approach
> Summarize the solution and implementation details.

## Related Issues
fixes https://github.com/openchoreo/openchoreo/issues/2956

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
