### PR TITLE
fix: add deployment strategy for observer

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -13,6 +13,8 @@ metadata:
     {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" "observer") | nindent 4 }}
 spec:
   replicas: {{ .Values.observer.replicas | default 1 }}
+  strategy:
+    type: {{ ternary "Recreate" "RollingUpdate" (eq (.Values.observer.alertStoreBackend | default "sqlite") "sqlite") }}
   selector:
     matchLabels:
       {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" "observer") | nindent 6 }}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces a deployment strategy configuration for the `observer` component in the Helm chart. The most significant change is the addition of logic to select between "Recreate" and "RollingUpdate" deployment strategies based on the `alertStoreBackend` value. This is needed because the PVC for sqlite is in `ReadWriteOnce`

Deployment strategy configuration:

* [`install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml`](diffhunk://#diff-f9a62b2edc4ff66205af1531e9988574d7f2f1cd01aabdf96b2383e89301a440R16-R17): Added a conditional deployment `strategy` that uses "Recreate" if the `alertStoreBackend` is set to `sqlite`, otherwise defaults to "RollingUpdate". This ensures proper handling of stateful backends like SQLite during deployments.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
