### PR TITLE
fix: add deployment strategy for rca-agent

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
     {{- include "openchoreo-observability-plane.componentLabels" (dict "context" . "component" .Values.rca.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.rca.replicas }}
+  strategy:
+    type: {{ ternary "Recreate" "RollingUpdate" (eq (.Values.rca.reportBackend | default "sqlite") "sqlite") }}
   selector:
     matchLabels:
       {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" .Values.rca.name) | nindent 6 }}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces a configurable deployment strategy for the AI RCA Agent in the Helm chart. The deployment strategy now changes automatically based on the value of the `reportBackend` setting, enhancing deployment flexibility and reliability.

**Helm deployment improvements:**

* The `deployment.yaml` for the AI RCA Agent now sets the deployment `strategy.type` to `Recreate` if the `reportBackend` is `sqlite`, otherwise it uses `RollingUpdate`. This ensures safer deployments when using SQLite, which does not support concurrent write access.

## Approach
Use Recreate strategy when reportBackend is sqlite to handle the ReadWriteOnce PVC constraint, otherwise default to RollingUpdate.
Similar to https://github.com/openchoreo/openchoreo/pull/2981

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
