### PR TITLE
test: improve unit test coverage for observer/api/handlers

### DIFF
--- a/internal/observer/api/handlers/alerts_internal_test.go
+++ b/internal/observer/api/handlers/alerts_internal_test.go
@@ -1,0 +1,570 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	"github.com/openchoreo/openchoreo/internal/observer/service"
+)
+
+// fakeAlertRuleService implements service.AlertRuleService for tests.
+type fakeAlertRuleService struct {
+	createResp  *gen.AlertingRuleSyncResponse
+	createErr   error
+	getResp     *gen.AlertRuleResponse
+	getErr      error
+	updateResp  *gen.AlertingRuleSyncResponse
+	updateErr   error
+	deleteResp  *gen.AlertingRuleSyncResponse
+	deleteErr   error
+	webhookResp *gen.AlertWebhookResponse
+	webhookErr  error
+}
+
+func (f *fakeAlertRuleService) CreateAlertRule(_ context.Context, _ gen.AlertRuleRequest) (*gen.AlertingRuleSyncResponse, error) {
+	return f.createResp, f.createErr
+}
+
+func (f *fakeAlertRuleService) GetAlertRule(_ context.Context, _, _ string) (*gen.AlertRuleResponse, error) {
+	return f.getResp, f.getErr
+}
+
+func (f *fakeAlertRuleService) UpdateAlertRule(_ context.Context, _ string, _ gen.AlertRuleRequest) (*gen.AlertingRuleSyncResponse, error) {
+	return f.updateResp, f.updateErr
+}
+
+func (f *fakeAlertRuleService) DeleteAlertRule(_ context.Context, _, _ string) (*gen.AlertingRuleSyncResponse, error) {
+	return f.deleteResp, f.deleteErr
+}
+
+func (f *fakeAlertRuleService) HandleAlertWebhook(_ context.Context, _ gen.AlertWebhookRequest) (*gen.AlertWebhookResponse, error) {
+	return f.webhookResp, f.webhookErr
+}
+
+// helpers -----------------------------------------------------------------------
+
+const (
+	testRuleName = "test-rule"
+	testNS       = "test-ns"
+)
+
+// validAlertRuleBody returns a minimal valid log-based AlertRuleRequest as a JSON io.Reader.
+func validAlertRuleBody(t *testing.T) io.Reader {
+	t.Helper()
+	uid := "00000000-0000-0000-0000-000000000001"
+	query := "ERROR"
+	raw := map[string]any{
+		"metadata": map[string]any{
+			"name":           testRuleName,
+			"componentUid":   uid,
+			"projectUid":     uid,
+			"environmentUid": uid,
+			"namespace":      testNS,
+		},
+		"source": map[string]any{
+			"type":  sourceTypeLog,
+			"query": query,
+		},
+		"condition": map[string]any{
+			"window":    "5m",
+			"interval":  "1m",
+			"operator":  "gt",
+			"threshold": 1.0,
+			"enabled":   true,
+		},
+	}
+	b, err := json.Marshal(raw)
+	require.NoError(t, err)
+	return bytes.NewReader(b)
+}
+
+func newInternalHandler(svc service.AlertRuleService) *InternalHandler {
+	return &InternalHandler{
+		baseHandler:  baseHandler{logger: noopLogger()},
+		alertService: svc,
+	}
+}
+
+// CreateAlertRule tests ---------------------------------------------------------
+
+func TestCreateAlertRule_InvalidSourceType(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/unknown/rules",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "unknown")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_SOURCE_TYPE")
+}
+
+func TestCreateAlertRule_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/log/rules",
+		strings.NewReader("{not-json"))
+	req.SetPathValue("sourceType", "log")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_REQUEST_BODY")
+}
+
+func TestCreateAlertRule_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	// Missing metadata.name → validation error.
+	raw := map[string]any{
+		"metadata": map[string]any{
+			"name": "",
+		},
+		"source":    map[string]any{"type": "log"},
+		"condition": map[string]any{},
+	}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/log/rules",
+		bytes.NewReader(b))
+	req.SetPathValue("sourceType", "log")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "VALIDATION_ERROR")
+}
+
+func TestCreateAlertRule_SourceTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	// Path says "metric" but body says "log".
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/metric/rules",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "metric")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "SOURCE_TYPE_MISMATCH")
+}
+
+func TestCreateAlertRule_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{createErr: service.ErrAlertRuleAlreadyExists}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/log/rules",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+	assert.Contains(t, rr.Body.String(), "ALREADY_EXISTS")
+}
+
+func TestCreateAlertRule_ServiceError(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{createErr: errors.New("backend failure")}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/log/rules",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "CREATE_FAILED")
+}
+
+func TestCreateAlertRule_Success(t *testing.T) {
+	t.Parallel()
+
+	action := gen.AlertingRuleSyncResponseAction("created")
+	svc := &fakeAlertRuleService{createResp: &gen.AlertingRuleSyncResponse{Action: &action}}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/sources/log/rules",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	rr := httptest.NewRecorder()
+
+	h.CreateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+	assert.Contains(t, rr.Body.String(), "created")
+}
+
+// GetAlertRule tests ------------------------------------------------------------
+
+func TestGetAlertRule_InvalidSourceType(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/alerts/sources/bad/rules/r1", nil)
+	req.SetPathValue("sourceType", "bad")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.GetAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_SOURCE_TYPE")
+}
+
+func TestGetAlertRule_EmptyRuleName(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/alerts/sources/log/rules/", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "")
+	rr := httptest.NewRecorder()
+
+	h.GetAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_RULE_NAME")
+}
+
+func TestGetAlertRule_NotFound(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{getErr: service.ErrAlertRuleNotFound}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/alerts/sources/log/rules/r1", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.GetAlertRule(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), "NOT_FOUND")
+}
+
+func TestGetAlertRule_ServiceError(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{getErr: errors.New("db error")}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/alerts/sources/log/rules/r1", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.GetAlertRule(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "GET_FAILED")
+}
+
+func TestGetAlertRule_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{getResp: &gen.AlertRuleResponse{}}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/alerts/sources/log/rules/r1", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.GetAlertRule(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// UpdateAlertRule tests ---------------------------------------------------------
+
+func TestUpdateAlertRule_InvalidSourceType(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/bad/rules/r1",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "bad")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_SOURCE_TYPE")
+}
+
+func TestUpdateAlertRule_EmptyRuleName(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/log/rules/",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_RULE_NAME")
+}
+
+func TestUpdateAlertRule_SourceTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	// Path says "metric", body has "log".
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/metric/rules/r1",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "metric")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "SOURCE_TYPE_MISMATCH")
+}
+
+func TestUpdateAlertRule_NotFound(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{updateErr: service.ErrAlertRuleNotFound}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/log/rules/r1",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), "NOT_FOUND")
+}
+
+func TestUpdateAlertRule_ServiceError(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{updateErr: errors.New("backend error")}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/log/rules/r1",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "UPDATE_FAILED")
+}
+
+func TestUpdateAlertRule_Success(t *testing.T) {
+	t.Parallel()
+
+	action := gen.AlertingRuleSyncResponseAction("updated")
+	svc := &fakeAlertRuleService{updateResp: &gen.AlertingRuleSyncResponse{Action: &action}}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/log/rules/r1",
+		validAlertRuleBody(t))
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "updated")
+}
+
+// DeleteAlertRule tests ---------------------------------------------------------
+
+func TestDeleteAlertRule_InvalidSourceType(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1alpha1/alerts/sources/bad/rules/r1", nil)
+	req.SetPathValue("sourceType", "bad")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.DeleteAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_SOURCE_TYPE")
+}
+
+func TestDeleteAlertRule_EmptyRuleName(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1alpha1/alerts/sources/log/rules/", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "")
+	rr := httptest.NewRecorder()
+
+	h.DeleteAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_RULE_NAME")
+}
+
+func TestDeleteAlertRule_NotFound(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{deleteErr: service.ErrAlertRuleNotFound}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1alpha1/alerts/sources/log/rules/r1", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.DeleteAlertRule(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), "NOT_FOUND")
+}
+
+func TestDeleteAlertRule_ServiceError(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{deleteErr: errors.New("backend error")}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1alpha1/alerts/sources/log/rules/r1", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.DeleteAlertRule(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "DELETE_FAILED")
+}
+
+func TestDeleteAlertRule_Success(t *testing.T) {
+	t.Parallel()
+
+	action := gen.AlertingRuleSyncResponseAction("deleted")
+	svc := &fakeAlertRuleService{deleteResp: &gen.AlertingRuleSyncResponse{Action: &action}}
+	h := newInternalHandler(svc)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1alpha1/alerts/sources/log/rules/r1", nil)
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.DeleteAlertRule(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "deleted")
+}
+
+// HandleAlertWebhook tests -------------------------------------------------------
+
+func TestHandleAlertWebhook_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/webhook",
+		strings.NewReader("{bad"))
+	rr := httptest.NewRecorder()
+
+	h.HandleAlertWebhook(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_REQUEST_BODY")
+}
+
+func TestHandleAlertWebhook_MissingRuleName(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	ns := testNS
+	raw := gen.AlertWebhookRequest{RuleNamespace: &ns}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/webhook", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	h.HandleAlertWebhook(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "MISSING_RULE_NAME")
+}
+
+func TestHandleAlertWebhook_MissingRuleNamespace(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	name := testRuleName
+	raw := gen.AlertWebhookRequest{RuleName: &name}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/webhook", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	h.HandleAlertWebhook(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "MISSING_RULE_NAMESPACE")
+}
+
+func TestHandleAlertWebhook_ServiceError(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeAlertRuleService{webhookErr: errors.New("processing failed")}
+	h := newInternalHandler(svc)
+	name, ns := testRuleName, testNS
+	raw := gen.AlertWebhookRequest{RuleName: &name, RuleNamespace: &ns}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/webhook", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	h.HandleAlertWebhook(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "WEBHOOK_FAILED")
+}
+
+func TestHandleAlertWebhook_Success(t *testing.T) {
+	t.Parallel()
+
+	msg := "processed"
+	status := gen.AlertWebhookResponseStatus("ok")
+	svc := &fakeAlertRuleService{
+		webhookResp: &gen.AlertWebhookResponse{Message: &msg, Status: &status},
+	}
+	h := newInternalHandler(svc)
+	name, ns := testRuleName, testNS
+	raw := gen.AlertWebhookRequest{RuleName: &name, RuleNamespace: &ns}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/webhook", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	h.HandleAlertWebhook(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "processed")
+}

--- a/internal/observer/api/handlers/alerts_query_test.go
+++ b/internal/observer/api/handlers/alerts_query_test.go
@@ -1,0 +1,392 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/service"
+)
+
+// configAlertIncidentService is a fully configurable fake that implements
+// service.AlertIncidentService. Unlike fakeAlertIncidentService in incidents_test.go,
+// this one does not panic on QueryAlerts/QueryIncidents.
+type configAlertIncidentService struct {
+	alertsResp    *gen.AlertsQueryResponse
+	alertsErr     error
+	incidentsResp *gen.IncidentsQueryResponse
+	incidentsErr  error
+	updateResp    *gen.IncidentPutResponse
+	updateErr     error
+}
+
+func (f *configAlertIncidentService) QueryAlerts(_ context.Context, _ gen.AlertsQueryRequest) (*gen.AlertsQueryResponse, error) {
+	return f.alertsResp, f.alertsErr
+}
+
+func (f *configAlertIncidentService) QueryIncidents(_ context.Context, _ gen.IncidentsQueryRequest) (*gen.IncidentsQueryResponse, error) {
+	return f.incidentsResp, f.incidentsErr
+}
+
+func (f *configAlertIncidentService) UpdateIncident(_ context.Context, _ string, _ gen.IncidentPutRequest) (*gen.IncidentPutResponse, error) {
+	return f.updateResp, f.updateErr
+}
+
+// helpers -----------------------------------------------------------------------
+
+func validAlertsRequestBody(t *testing.T) io.Reader {
+	t.Helper()
+	now := time.Now().UTC()
+	raw := map[string]any{
+		"startTime":   now.Add(-1 * time.Hour).Format(time.RFC3339),
+		"endTime":     now.Format(time.RFC3339),
+		"searchScope": map[string]any{"namespace": "test-ns"},
+	}
+	b, err := json.Marshal(raw)
+	require.NoError(t, err)
+	return bytes.NewReader(b)
+}
+
+func validIncidentsRequestBody(t *testing.T) io.Reader {
+	t.Helper()
+	now := time.Now().UTC()
+	raw := map[string]any{
+		"startTime":   now.Add(-1 * time.Hour).Format(time.RFC3339),
+		"endTime":     now.Format(time.RFC3339),
+		"searchScope": map[string]any{"namespace": "test-ns"},
+	}
+	b, err := json.Marshal(raw)
+	require.NoError(t, err)
+	return bytes.NewReader(b)
+}
+
+// QueryAlerts tests -------------------------------------------------------------
+
+func TestQueryAlerts_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &configAlertIncidentService{alertsResp: &gen.AlertsQueryResponse{}}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestQueryAlerts_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", bytes.NewReader([]byte("{bad")))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryAlerts_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{},
+	}
+
+	// Missing namespace → validation failure.
+	raw := map[string]any{
+		"startTime":   "2024-01-01T00:00:00Z",
+		"endTime":     "2024-01-02T00:00:00Z",
+		"searchScope": map[string]any{},
+	}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "VALIDATION_ERROR")
+}
+
+func TestQueryAlerts_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "SERVICE_NOT_READY")
+}
+
+func TestQueryAlerts_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: observerAuthz.ErrAuthzForbidden},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestQueryAlerts_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: observerAuthz.ErrAuthzUnauthorized},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestQueryAlerts_AuthzServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: observerAuthz.ErrAuthzServiceUnavailable},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestQueryAlerts_AuthzTimeout(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: observerAuthz.ErrAuthzTimeout},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestQueryAlerts_ScopeNotFound(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("%w: %w", service.ErrAlertsResolveSearchScope, service.ErrScopeNotFound)
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: err},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "SCOPE_NOT_FOUND")
+}
+
+func TestQueryAlerts_ResolveScopeFailed(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("%w: infra error", service.ErrAlertsResolveSearchScope)
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: err},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "RESOLVE_SCOPE_FAILED")
+}
+
+func TestQueryAlerts_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{alertsErr: errors.New("boom")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/alerts/query", validAlertsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryAlerts(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "QUERY_ALERTS_FAILED")
+}
+
+// QueryIncidents tests ----------------------------------------------------------
+
+func TestQueryIncidents_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &configAlertIncidentService{incidentsResp: &gen.IncidentsQueryResponse{}}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", validIncidentsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestQueryIncidents_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", bytes.NewReader([]byte("!!!")))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryIncidents_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{},
+	}
+
+	raw := map[string]any{
+		"startTime":   "2024-01-01T00:00:00Z",
+		"endTime":     "2024-01-02T00:00:00Z",
+		"searchScope": map[string]any{}, // missing namespace
+	}
+	b, _ := json.Marshal(raw)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryIncidents_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", validIncidentsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "SERVICE_NOT_READY")
+}
+
+func TestQueryIncidents_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{incidentsErr: observerAuthz.ErrAuthzForbidden},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", validIncidentsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestQueryIncidents_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{incidentsErr: observerAuthz.ErrAuthzUnauthorized},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", validIncidentsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestQueryIncidents_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{incidentsErr: errors.New("db error")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", validIncidentsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "QUERY_INCIDENTS_FAILED")
+}

--- a/internal/observer/api/handlers/coverage_gaps_test.go
+++ b/internal/observer/api/handlers/coverage_gaps_test.go
@@ -1,0 +1,361 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+// coverage_gaps_test.go closes the remaining coverage gaps identified after the
+// initial test run: UpdateIncident authorization/error paths, additional
+// ValidateIncidentsQueryRequest cases, and QuerySpansForTrace validation errors.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/store/incidententry"
+)
+
+// UpdateIncident additional error paths (authz, invalid transition, generic, nil service).
+
+func TestUpdateIncident_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeAlertIncidentService{updateErr: observerAuthz.ErrAuthzForbidden}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: updater,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestUpdateIncident_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeAlertIncidentService{updateErr: observerAuthz.ErrAuthzUnauthorized}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: updater,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestUpdateIncident_AuthzServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeAlertIncidentService{updateErr: observerAuthz.ErrAuthzServiceUnavailable}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: updater,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestUpdateIncident_InvalidStatusTransition(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeAlertIncidentService{updateErr: incidententry.ErrInvalidStatusTransition}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: updater,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_STATUS_TRANSITION")
+}
+
+func TestUpdateIncident_GenericError(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeAlertIncidentService{updateErr: fmt.Errorf("db timeout")}
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: updater,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "UPDATE_INCIDENT_FAILED")
+}
+
+func TestUpdateIncident_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "SERVICE_NOT_READY")
+}
+
+func TestUpdateIncident_EmptyIncidentID(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &fakeAlertIncidentService{},
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/",
+		bytes.NewReader([]byte(`{"status":"active"}`)))
+	req.SetPathValue("incidentId", "   ") // whitespace only
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_INCIDENT_ID")
+}
+
+// ValidateIncidentsQueryRequest additional cases.
+
+func TestValidateIncidentsQueryRequest_ComponentWithoutProject(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	comp := "comp"
+	req := &gen.IncidentsQueryRequest{
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now,
+		SearchScope: gen.ComponentSearchScope{
+			Namespace: "ns",
+			Component: &comp,
+		},
+	}
+
+	err := ValidateIncidentsQueryRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project is required when")
+}
+
+func TestValidateIncidentsQueryRequest_BadLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	lim := -1
+	req := &gen.IncidentsQueryRequest{
+		StartTime:   now.Add(-time.Hour),
+		EndTime:     now,
+		SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+		Limit:       &lim,
+	}
+
+	err := ValidateIncidentsQueryRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "positive integer")
+}
+
+func TestValidateIncidentsQueryRequest_InvalidSortOrder(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	order := gen.IncidentsQueryRequestSortOrder("random")
+	req := &gen.IncidentsQueryRequest{
+		StartTime:   now.Add(-time.Hour),
+		EndTime:     now,
+		SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+		SortOrder:   &order,
+	}
+
+	err := ValidateIncidentsQueryRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sortOrder must be either")
+}
+
+// UpdateIncident: invalid JSON body and validation error paths.
+
+func TestUpdateIncident_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &fakeAlertIncidentService{},
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte("{bad json")))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_REQUEST_BODY")
+}
+
+func TestUpdateIncident_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &fakeAlertIncidentService{},
+	}
+
+	// status "pending" is not a valid value → ValidateIncidentPutRequest returns error.
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/incidents/inc-1",
+		bytes.NewReader([]byte(`{"status":"pending"}`)))
+	req.SetPathValue("incidentId", "inc-1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateIncident(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "VALIDATION_ERROR")
+}
+
+// UpdateAlertRule: invalid JSON body path.
+
+func TestUpdateAlertRule_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/log/rules/r1",
+		bytes.NewReader([]byte("{bad")))
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "INVALID_REQUEST_BODY")
+}
+
+func TestUpdateAlertRule_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := newInternalHandler(&fakeAlertRuleService{})
+	// Missing metadata.name → validation error.
+	raw, _ := json.Marshal(map[string]any{
+		"metadata":  map[string]any{"name": ""},
+		"source":    map[string]any{"type": "log"},
+		"condition": map[string]any{},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1alpha1/alerts/sources/log/rules/r1",
+		bytes.NewReader(raw))
+	req.SetPathValue("sourceType", "log")
+	req.SetPathValue("ruleName", "r1")
+	rr := httptest.NewRecorder()
+
+	h.UpdateAlertRule(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "VALIDATION_ERROR")
+}
+
+// QuerySpansForTrace: validation error path (already covered by scope_auth but missing
+// the body-binding error).
+
+func TestQuerySpansForTrace_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query",
+		bytes.NewReader([]byte("{bad")))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQuerySpansForTrace_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{},
+	}
+
+	raw, _ := json.Marshal(map[string]any{
+		"startTime":   "2024-01-01T00:00:00Z",
+		"endTime":     "2024-01-02T00:00:00Z",
+		"searchScope": map[string]any{}, // missing namespace
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query",
+		bytes.NewReader(raw))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// QueryIncidents: authz service unavailable path.
+
+func TestQueryIncidents_AuthzServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:          baseHandler{logger: noopLogger()},
+		alertIncidentService: &configAlertIncidentService{incidentsErr: observerAuthz.ErrAuthzServiceUnavailable},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/incidents/query", validIncidentsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryIncidents(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}

--- a/internal/observer/api/handlers/handler.go
+++ b/internal/observer/api/handlers/handler.go
@@ -45,7 +45,7 @@ func (b *baseHandler) writeErrorResponse(
 // than bare service instances.
 type Handler struct {
 	baseHandler
-	healthService        *service.HealthService
+	healthService        service.HealthChecker
 	logsService          service.LogsQuerier
 	metricsService       service.MetricsQuerier
 	alertIncidentService service.AlertIncidentService
@@ -54,7 +54,7 @@ type Handler struct {
 
 // NewHandler creates a new public Handler instance.
 func NewHandler(
-	healthService *service.HealthService,
+	healthService service.HealthChecker,
 	logsService service.LogsQuerier,
 	metricsService service.MetricsQuerier,
 	alertIncidentService service.AlertIncidentService,
@@ -72,16 +72,15 @@ func NewHandler(
 }
 
 // InternalHandler contains the HTTP handlers that run on the internal port (8081)
-// without JWT authentication. Only the concrete *AlertService is needed here because
-// these handlers manage alert rules and process incoming webhooks.
+// without JWT authentication. It manages alert rules and processes incoming webhooks.
 type InternalHandler struct {
 	baseHandler
-	alertService *service.AlertService
+	alertService service.AlertRuleService
 }
 
 // NewInternalHandler creates a new InternalHandler instance.
 func NewInternalHandler(
-	alertService *service.AlertService,
+	alertService service.AlertRuleService,
 	logger *slog.Logger,
 ) *InternalHandler {
 	return &InternalHandler{

--- a/internal/observer/api/handlers/health_test.go
+++ b/internal/observer/api/handlers/health_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeHealthChecker implements service.HealthChecker for tests.
+type fakeHealthChecker struct {
+	err error
+}
+
+func (f *fakeHealthChecker) Check(_ context.Context) error { return f.err }
+
+func TestHealth_Healthy(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		healthService: &fakeHealthChecker{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+
+	h.Health(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"status":"healthy"`)
+}
+
+func TestHealth_Unhealthy(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		healthService: &fakeHealthChecker{err: errors.New("backend unavailable")},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+
+	h.Health(rr, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"status":"unhealthy"`)
+}

--- a/internal/observer/api/handlers/logs_test.go
+++ b/internal/observer/api/handlers/logs_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/service"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// fakeLogsQuerier implements service.LogsQuerier for tests.
+type fakeLogsQuerier struct {
+	resp *types.LogsQueryResponse
+	err  error
+}
+
+func (f *fakeLogsQuerier) QueryLogs(_ context.Context, _ *types.LogsQueryRequest) (*types.LogsQueryResponse, error) {
+	return f.resp, f.err
+}
+
+func TestQueryLogs_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeLogsQuerier{
+		resp: &types.LogsQueryResponse{
+			Logs:   []types.LogEntry{{Timestamp: "2024-01-01T00:00:00Z", Log: "hello"}},
+			Total:  1,
+			TookMs: 5,
+		},
+	}
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"total":1`)
+}
+
+func TestQueryLogs_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", strings.NewReader("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryLogs_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{},
+	}
+
+	// Missing searchScope → validation failure.
+	body := `{"startTime":"2024-01-01T00:00:00Z","endTime":"2024-01-02T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryLogs_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1LogsServiceNotReady)
+}
+
+func TestQueryLogs_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{err: observerAuthz.ErrAuthzForbidden},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestQueryLogs_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{err: observerAuthz.ErrAuthzUnauthorized},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestQueryLogs_ResolveSearchScopeError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{err: fmt.Errorf("%w: resolver failed", service.ErrLogsResolveSearchScope)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1LogsResolverFailed)
+}
+
+func TestQueryLogs_RetrievalError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{err: fmt.Errorf("%w: backend error", service.ErrLogsRetrieval)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1LogsRetrievalFailed)
+}
+
+func TestQueryLogs_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler: baseHandler{logger: noopLogger()},
+		logsService: &fakeLogsQuerier{err: errors.New("unexpected error")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/query", validLogsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryLogs(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1LogsInternalGeneric)
+}

--- a/internal/observer/api/handlers/metrics_test.go
+++ b/internal/observer/api/handlers/metrics_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/service"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// fakeMetricsQuerier implements service.MetricsQuerier for tests.
+type fakeMetricsQuerier struct {
+	resp any
+	err  error
+}
+
+func (f *fakeMetricsQuerier) QueryMetrics(_ context.Context, _ *types.MetricsQueryRequest) (any, error) {
+	return f.resp, f.err
+}
+
+func TestQueryMetrics_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeMetricsQuerier{resp: map[string]any{"data": "ok"}}
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"data"`)
+}
+
+func TestQueryMetrics_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", strings.NewReader("{bad json"))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryMetrics_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{},
+	}
+
+	// Missing metric field → validation failure.
+	body := `{"searchScope":{"namespace":"ns"},"startTime":"2024-01-01T00:00:00Z","endTime":"2024-01-02T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryMetrics_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1MetricsServiceNotReady)
+}
+
+func TestQueryMetrics_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{err: observerAuthz.ErrAuthzForbidden},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestQueryMetrics_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{err: observerAuthz.ErrAuthzUnauthorized},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestQueryMetrics_InvalidRequestError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{err: fmt.Errorf("%w: bad step", service.ErrMetricsInvalidRequest)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryMetrics_ResolveSearchScopeError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{err: fmt.Errorf("%w: scope failed", service.ErrMetricsResolveSearchScope)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1MetricsResolverFailed)
+}
+
+func TestQueryMetrics_RetrievalError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{err: fmt.Errorf("%w: backend error", service.ErrMetricsRetrieval)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1MetricsRetrievalFailed)
+}
+
+func TestQueryMetrics_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:    baseHandler{logger: noopLogger()},
+		metricsService: &fakeMetricsQuerier{err: errors.New("unexpected")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/query", validMetricsRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryMetrics(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1MetricsInternalGeneric)
+}

--- a/internal/observer/api/handlers/traces_handler_test.go
+++ b/internal/observer/api/handlers/traces_handler_test.go
@@ -1,0 +1,461 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+// traces_handler_test.go covers the HTTP handler paths for QueryTraces,
+// QuerySpansForTrace, and GetSpanDetailsForTrace that are NOT already covered
+// by scope_auth_test.go (scope-auth error) or traces_test.go (conversion functions).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/service"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// fakeTracesQuerier implements service.TracesQuerier for tests.
+type fakeTracesQuerier struct {
+	tracesResp *types.TracesQueryResponse
+	tracesErr  error
+	spansResp  *types.SpansQueryResponse
+	spansErr   error
+	spanInfo   *types.SpanInfo
+	spanErr    error
+}
+
+func (f *fakeTracesQuerier) QueryTraces(_ context.Context, _ *types.TracesQueryRequest) (*types.TracesQueryResponse, error) {
+	return f.tracesResp, f.tracesErr
+}
+
+func (f *fakeTracesQuerier) QuerySpans(_ context.Context, _ string, _ *types.TracesQueryRequest) (*types.SpansQueryResponse, error) {
+	return f.spansResp, f.spansErr
+}
+
+func (f *fakeTracesQuerier) GetSpanDetails(_ context.Context, _, _ string) (*types.SpanInfo, error) {
+	return f.spanInfo, f.spanErr
+}
+
+// QueryTraces tests -------------------------------------------------------------
+
+func TestQueryTraces_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeTracesQuerier{tracesResp: &types.TracesQueryResponse{}}
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestQueryTraces_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", strings.NewReader("{bad"))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryTraces_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{},
+	}
+
+	// Missing namespace → validation failure.
+	body := `{"startTime":"2024-01-01T00:00:00Z","endTime":"2024-01-02T00:00:00Z","searchScope":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryTraces_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesServiceNotReady)
+}
+
+func TestQueryTraces_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{tracesErr: observerAuthz.ErrAuthzForbidden},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestQueryTraces_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{tracesErr: observerAuthz.ErrAuthzUnauthorized},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestQueryTraces_ResolveSearchScopeError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{tracesErr: fmt.Errorf("%w: scope failed", service.ErrTracesResolveSearchScope)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesResolverFailed)
+}
+
+func TestQueryTraces_RetrievalError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{tracesErr: fmt.Errorf("%w: backend error", service.ErrTracesRetrieval)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesRetrievalFailed)
+}
+
+func TestQueryTraces_InvalidRequestError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{tracesErr: fmt.Errorf("%w: bad param", service.ErrTracesInvalidRequest)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQueryTraces_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{tracesErr: errors.New("unexpected")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/query", validTracesRequestBody(t))
+	rr := httptest.NewRecorder()
+
+	h.QueryTraces(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
+}
+
+// QuerySpansForTrace tests -------------------------------------------------------
+
+func TestQuerySpansForTrace_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeTracesQuerier{spansResp: &types.SpansQueryResponse{}}
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query", validTracesRequestBody(t))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestQuerySpansForTrace_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query", validTracesRequestBody(t))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesServiceNotReady)
+}
+
+func TestQuerySpansForTrace_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spansErr: observerAuthz.ErrAuthzForbidden},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query", validTracesRequestBody(t))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestQuerySpansForTrace_RetrievalError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spansErr: fmt.Errorf("%w: backend error", service.ErrTracesRetrieval)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query", validTracesRequestBody(t))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesRetrievalFailed)
+}
+
+func TestQuerySpansForTrace_InvalidRequestError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spansErr: fmt.Errorf("%w: bad param", service.ErrTracesInvalidRequest)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query", validTracesRequestBody(t))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestQuerySpansForTrace_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spansErr: errors.New("unknown")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/query", validTracesRequestBody(t))
+	req.SetPathValue("traceId", "trace-1")
+	rr := httptest.NewRecorder()
+
+	h.QuerySpansForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
+}
+
+// GetSpanDetailsForTrace tests ---------------------------------------------------
+
+func TestGetSpanDetailsForTrace_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeTracesQuerier{spanInfo: &types.SpanInfo{SpanID: "span-1"}}
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestGetSpanDetailsForTrace_EmptyTraceID(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces//spans/span-1", nil)
+	req.SetPathValue("traceId", "")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "traceId is required")
+}
+
+func TestGetSpanDetailsForTrace_EmptySpanID(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "spanId is required")
+}
+
+func TestGetSpanDetailsForTrace_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesServiceNotReady)
+}
+
+func TestGetSpanDetailsForTrace_SpanNotFound(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spanErr: service.ErrSpanNotFound},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-99", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-99")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesSpanNotFound)
+}
+
+func TestGetSpanDetailsForTrace_RetrievalError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spanErr: fmt.Errorf("%w: backend", service.ErrTracesRetrieval)},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesRetrievalFailed)
+}
+
+func TestGetSpanDetailsForTrace_GenericError(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: &fakeTracesQuerier{spanErr: errors.New("unexpected")},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
+}

--- a/internal/observer/api/handlers/validations_test.go
+++ b/internal/observer/api/handlers/validations_test.go
@@ -1,0 +1,953 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	"github.com/openchoreo/openchoreo/internal/observer/config"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// nonZeroUUID returns a UUID with all bytes set to 1 — used to satisfy required UUID fields.
+var nonZeroUUID = openapi_types.UUID{1}
+
+func TestValidateTimeRange(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validStart = "2024-01-01T00:00:00Z"
+		validEnd   = "2024-01-02T00:00:00Z"
+	)
+
+	tests := []struct {
+		name        string
+		start       string
+		end         string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "missing startTime", start: "", end: validEnd, wantErr: true, errContains: "startTime is required"},
+		{name: "missing endTime", start: validStart, end: "", wantErr: true, errContains: "endTime is required"},
+		{name: "invalid start format", start: "2024-01-01", end: validEnd, wantErr: true, errContains: "startTime must be in RFC3339"},
+		{name: "invalid end format", start: validStart, end: "not-a-time", wantErr: true, errContains: "endTime must be in RFC3339"},
+		{name: "end before start", start: "2024-01-02T00:00:00Z", end: "2024-01-01T00:00:00Z", wantErr: true, errContains: "endTime must be after startTime"},
+		{name: "range exceeds 30 days", start: "2024-01-01T00:00:00Z", end: "2024-02-02T00:00:00Z", wantErr: true, errContains: "cannot exceed"},
+		{name: "valid range", start: validStart, end: validEnd, wantErr: false},
+		{name: "range exactly 30 days", start: "2024-01-01T00:00:00Z", end: "2024-01-31T00:00:00Z", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateTimeRange(tt.start, tt.end)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAndSetLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		limit       int
+		wantErr     bool
+		errContains string
+		wantLimit   int
+	}{
+		{name: "zero sets default", limit: 0, wantErr: false, wantLimit: defaultLimit},
+		{name: "negative returns error", limit: -1, wantErr: true, errContains: "positive integer"},
+		{name: "exceeds max returns error", limit: config.MaxLimit + 1, wantErr: true, errContains: "cannot exceed"},
+		{name: "valid positive limit", limit: 50, wantErr: false, wantLimit: 50},
+		{name: "max limit is allowed", limit: config.MaxLimit, wantErr: false, wantLimit: config.MaxLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			l := tt.limit
+			err := ValidateAndSetLimit(&l)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantLimit, l)
+			}
+		})
+	}
+}
+
+func TestValidateAndSetSortOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantOrder string
+	}{
+		{name: "empty sets default desc", input: "", wantErr: false, wantOrder: "desc"},
+		{name: "asc is valid", input: "asc", wantErr: false, wantOrder: "asc"},
+		{name: "desc is valid", input: "desc", wantErr: false, wantOrder: "desc"},
+		{name: "invalid order", input: "random", wantErr: true},
+		{name: "case sensitive invalid", input: "ASC", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := tt.input
+			err := ValidateAndSetSortOrder(&s)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "sortOrder must be either")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantOrder, s)
+			}
+		})
+	}
+}
+
+func TestValidateLogLevels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		levels      []string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "empty list is valid", levels: nil, wantErr: false},
+		{name: "all valid levels", levels: []string{"DEBUG", "INFO", "WARN", "ERROR"}, wantErr: false},
+		{name: "single valid level", levels: []string{"INFO"}, wantErr: false},
+		{name: "invalid level", levels: []string{"TRACE"}, wantErr: true, errContains: "invalid log level"},
+		{name: "lowercase invalid", levels: []string{"info"}, wantErr: true, errContains: "invalid log level"},
+		{name: "duplicate level", levels: []string{"INFO", "INFO"}, wantErr: true, errContains: "duplicate log level"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateLogLevels(tt.levels)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateLogsQueryRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	validStart := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	validEnd := now.Format(time.RFC3339)
+
+	validComponentScope := &types.SearchScope{
+		Component: &types.ComponentSearchScope{Namespace: "test-ns"},
+	}
+	validWorkflowScope := &types.SearchScope{
+		Workflow: &types.WorkflowSearchScope{Namespace: "test-ns"},
+	}
+
+	tests := []struct {
+		name        string
+		req         *types.LogsQueryRequest
+		wantErr     bool
+		errContains string
+	}{
+		{name: "nil request", req: nil, wantErr: true, errContains: "required"},
+		{
+			name:        "nil searchScope",
+			req:         &types.LogsQueryRequest{StartTime: validStart, EndTime: validEnd},
+			wantErr:     true,
+			errContains: "searchScope is required",
+		},
+		{
+			name: "both component and workflow scope",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{Namespace: "ns"},
+					Workflow:  &types.WorkflowSearchScope{Namespace: "ns"},
+				},
+				StartTime: validStart, EndTime: validEnd,
+			},
+			wantErr:     true,
+			errContains: "cannot be both",
+		},
+		{
+			name: "neither component nor workflow scope",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{},
+				StartTime:   validStart, EndTime: validEnd,
+			},
+			wantErr:     true,
+			errContains: "must be either",
+		},
+		{
+			name: "component scope missing namespace",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{Namespace: ""},
+				},
+				StartTime: validStart, EndTime: validEnd,
+			},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name: "component without project when component set",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{Namespace: "ns", Component: "comp"},
+				},
+				StartTime: validStart, EndTime: validEnd,
+			},
+			wantErr:     true,
+			errContains: "project is required when",
+		},
+		{
+			name: "workflow scope missing namespace",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Workflow: &types.WorkflowSearchScope{Namespace: ""},
+				},
+				StartTime: validStart, EndTime: validEnd,
+			},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name: "invalid time range",
+			req: &types.LogsQueryRequest{
+				SearchScope: validComponentScope,
+				StartTime:   validEnd, EndTime: validStart, // reversed
+			},
+			wantErr:     true,
+			errContains: "endTime must be after startTime",
+		},
+		{
+			name: "invalid log level",
+			req: &types.LogsQueryRequest{
+				SearchScope: validComponentScope,
+				StartTime:   validStart, EndTime: validEnd,
+				LogLevels: []string{"INVALID"},
+			},
+			wantErr:     true,
+			errContains: "invalid log level",
+		},
+		{
+			name: "valid component scope",
+			req: &types.LogsQueryRequest{
+				SearchScope: validComponentScope,
+				StartTime:   validStart, EndTime: validEnd,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid workflow scope",
+			req: &types.LogsQueryRequest{
+				SearchScope: validWorkflowScope,
+				StartTime:   validStart, EndTime: validEnd,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid component with project",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{Namespace: "ns", Project: "proj", Component: "comp"},
+				},
+				StartTime: validStart, EndTime: validEnd,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateLogsQueryRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateMetricsQueryRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	validStart := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	validEnd := now.Format(time.RFC3339)
+
+	tests := []struct {
+		name        string
+		req         *types.MetricsQueryRequest
+		wantErr     bool
+		errContains string
+	}{
+		{name: "nil request", req: nil, wantErr: true, errContains: "must not be nil"},
+		{
+			name:        "missing metric",
+			req:         &types.MetricsQueryRequest{StartTime: validStart, EndTime: validEnd, SearchScope: types.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "metric is required",
+		},
+		{
+			name:        "invalid metric type",
+			req:         &types.MetricsQueryRequest{Metric: "invalid", StartTime: validStart, EndTime: validEnd, SearchScope: types.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "metric must be either",
+		},
+		{
+			name:        "missing namespace",
+			req:         &types.MetricsQueryRequest{Metric: "resource", StartTime: validStart, EndTime: validEnd},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name: "component without project",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: validStart, EndTime: validEnd,
+				SearchScope: types.ComponentSearchScope{Namespace: "ns", Component: "comp"},
+			},
+			wantErr:     true,
+			errContains: "project is required when",
+		},
+		{
+			name: "invalid step format",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: validStart, EndTime: validEnd,
+				SearchScope: types.ComponentSearchScope{Namespace: "ns"},
+				Step:        strPtr("not-a-duration"),
+			},
+			wantErr:     true,
+			errContains: "valid duration",
+		},
+		{
+			name: "zero step",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: validStart, EndTime: validEnd,
+				SearchScope: types.ComponentSearchScope{Namespace: "ns"},
+				Step:        strPtr("0s"),
+			},
+			wantErr:     true,
+			errContains: "greater than 0",
+		},
+		{
+			name: "valid resource metric",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: validStart, EndTime: validEnd,
+				SearchScope: types.ComponentSearchScope{Namespace: "ns"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid http metric",
+			req: &types.MetricsQueryRequest{
+				Metric:    "http",
+				StartTime: validStart, EndTime: validEnd,
+				SearchScope: types.ComponentSearchScope{Namespace: "ns"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with step",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: validStart, EndTime: validEnd,
+				SearchScope: types.ComponentSearchScope{Namespace: "ns"},
+				Step:        strPtr("5m"),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateMetricsQueryRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateTracesQueryRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	start := now.Add(-1 * time.Hour)
+	end := now
+
+	ptrComponent := func(s string) *string { return &s }
+
+	tests := []struct {
+		name        string
+		req         *gen.TracesQueryRequest
+		wantErr     bool
+		errContains string
+	}{
+		{name: "nil request", req: nil, wantErr: true, errContains: "required"},
+		{
+			name:        "zero startTime",
+			req:         &gen.TracesQueryRequest{EndTime: end, SearchScope: gen.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "startTime is required",
+		},
+		{
+			name:        "zero endTime",
+			req:         &gen.TracesQueryRequest{StartTime: start, SearchScope: gen.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "endTime is required",
+		},
+		{
+			name:        "missing namespace",
+			req:         &gen.TracesQueryRequest{StartTime: start, EndTime: end, SearchScope: gen.ComponentSearchScope{}},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name: "component without project",
+			req: &gen.TracesQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns", Component: ptrComponent("comp")},
+			},
+			wantErr:     true,
+			errContains: "project is required when",
+		},
+		{
+			name: "negative limit",
+			req: &gen.TracesQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+				Limit:       intPtr(-1),
+			},
+			wantErr:     true,
+			errContains: "positive integer",
+		},
+		{
+			name: "limit exceeds max",
+			req: &gen.TracesQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+				Limit:       intPtr(config.MaxLimit + 1),
+			},
+			wantErr:     true,
+			errContains: "cannot exceed",
+		},
+		{
+			name: "invalid sort order",
+			req: &gen.TracesQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+				SortOrder:   (*gen.TracesQueryRequestSortOrder)(strPtr("invalid")),
+			},
+			wantErr:     true,
+			errContains: "sortOrder must be either",
+		},
+		{
+			name: "valid minimal request",
+			req: &gen.TracesQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with all fields",
+			req: &gen.TracesQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns", Project: ptrComponent("proj"), Component: ptrComponent("comp")},
+				Limit:       intPtr(50),
+				SortOrder:   (*gen.TracesQueryRequestSortOrder)(strPtr("asc")),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateTracesQueryRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAlertsQueryRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	start := now.Add(-1 * time.Hour)
+	end := now
+
+	ptrComponent := func(s string) *string { return &s }
+
+	tests := []struct {
+		name        string
+		req         *gen.AlertsQueryRequest
+		wantErr     bool
+		errContains string
+	}{
+		{name: "nil request", req: nil, wantErr: true, errContains: "required"},
+		{
+			name:        "zero startTime",
+			req:         &gen.AlertsQueryRequest{EndTime: end, SearchScope: gen.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "startTime is required",
+		},
+		{
+			name:        "zero endTime",
+			req:         &gen.AlertsQueryRequest{StartTime: start, SearchScope: gen.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "endTime is required",
+		},
+		{
+			name:        "missing namespace",
+			req:         &gen.AlertsQueryRequest{StartTime: start, EndTime: end},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name:        "whitespace namespace",
+			req:         &gen.AlertsQueryRequest{StartTime: start, EndTime: end, SearchScope: gen.ComponentSearchScope{Namespace: "   "}},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name: "component without project",
+			req: &gen.AlertsQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns", Component: ptrComponent("comp")},
+			},
+			wantErr:     true,
+			errContains: "project is required when",
+		},
+		{
+			name: "invalid limit",
+			req: &gen.AlertsQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+				Limit:       intPtr(-1),
+			},
+			wantErr:     true,
+			errContains: "positive integer",
+		},
+		{
+			name: "invalid sort order",
+			req: &gen.AlertsQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+				SortOrder:   (*gen.AlertsQueryRequestSortOrder)(strPtr("RANDOM")),
+			},
+			wantErr:     true,
+			errContains: "sortOrder must be either",
+		},
+		{
+			name: "valid minimal",
+			req: &gen.AlertsQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with project and component",
+			req: &gen.AlertsQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns", Project: ptrComponent("proj"), Component: ptrComponent("comp")},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateAlertsQueryRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateIncidentsQueryRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	start := now.Add(-1 * time.Hour)
+	end := now
+
+	// Mirror alerts — identical validation logic.
+	tests := []struct {
+		name        string
+		req         *gen.IncidentsQueryRequest
+		wantErr     bool
+		errContains string
+	}{
+		{name: "nil request", req: nil, wantErr: true, errContains: "required"},
+		{
+			name:        "zero startTime",
+			req:         &gen.IncidentsQueryRequest{EndTime: end, SearchScope: gen.ComponentSearchScope{Namespace: "ns"}},
+			wantErr:     true,
+			errContains: "startTime is required",
+		},
+		{
+			name:        "missing namespace",
+			req:         &gen.IncidentsQueryRequest{StartTime: start, EndTime: end},
+			wantErr:     true,
+			errContains: "namespace is required",
+		},
+		{
+			name: "valid minimal",
+			req: &gen.IncidentsQueryRequest{
+				StartTime: start, EndTime: end,
+				SearchScope: gen.ComponentSearchScope{Namespace: "ns"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateIncidentsQueryRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateIncidentPutRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		req         *gen.IncidentPutRequest
+		wantErr     bool
+		errContains string
+	}{
+		{name: "nil request", req: nil, wantErr: true, errContains: "required"},
+		{
+			name:        "empty status",
+			req:         &gen.IncidentPutRequest{Status: ""},
+			wantErr:     true,
+			errContains: "status is required",
+		},
+		{
+			name:        "invalid status",
+			req:         &gen.IncidentPutRequest{Status: "pending"},
+			wantErr:     true,
+			errContains: "status must be one of",
+		},
+		{
+			name:    "status active",
+			req:     &gen.IncidentPutRequest{Status: gen.IncidentPutRequestStatusActive},
+			wantErr: false,
+		},
+		{
+			name:    "status acknowledged",
+			req:     &gen.IncidentPutRequest{Status: gen.IncidentPutRequestStatusAcknowledged},
+			wantErr: false,
+		},
+		{
+			name:    "status resolved",
+			req:     &gen.IncidentPutRequest{Status: gen.IncidentPutRequestStatusResolved},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateIncidentPutRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAlertRuleRequest(t *testing.T) {
+	t.Parallel()
+
+	uid := nonZeroUUID
+	logQuery := "ERROR"
+	cpuMetric := gen.AlertRuleRequestSourceMetric("cpu_usage")
+	memMetric := gen.AlertRuleRequestSourceMetric("memory_usage")
+	invalidMetric := gen.AlertRuleRequestSourceMetric("disk_usage")
+
+	// Helper: build a minimal valid log-based rule and let each test mutate a field.
+	baseLogRule := func() gen.AlertRuleRequest {
+		req := gen.AlertRuleRequest{}
+		req.Metadata.Name = "test-rule"
+		req.Metadata.ComponentUid = uid
+		req.Metadata.ProjectUid = uid
+		req.Metadata.EnvironmentUid = uid
+		req.Source.Type = "log"
+		req.Source.Query = &logQuery
+		req.Condition.Window = "5m"
+		req.Condition.Interval = "1m"
+		req.Condition.Operator = "gt"
+		req.Condition.Threshold = 1
+		return req
+	}
+
+	tests := []struct {
+		name        string
+		req         func() gen.AlertRuleRequest
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "missing name",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Metadata.Name = ""; return r },
+			wantErr:     true,
+			errContains: "metadata.name is required",
+		},
+		{
+			name: "missing componentUid",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Metadata.ComponentUid = openapi_types.UUID{}
+				return r
+			},
+			wantErr:     true,
+			errContains: "metadata.componentUid is required",
+		},
+		{
+			name: "missing projectUid",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Metadata.ProjectUid = openapi_types.UUID{}
+				return r
+			},
+			wantErr:     true,
+			errContains: "metadata.projectUid is required",
+		},
+		{
+			name: "missing environmentUid",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Metadata.EnvironmentUid = openapi_types.UUID{}
+				return r
+			},
+			wantErr:     true,
+			errContains: "metadata.environmentUid is required",
+		},
+		{
+			name:        "invalid source type",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Source.Type = "trace"; return r },
+			wantErr:     true,
+			errContains: "source.type must be",
+		},
+		{
+			name:        "log rule missing query",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Source.Query = nil; return r },
+			wantErr:     true,
+			errContains: "source.query is required",
+		},
+		{
+			name: "metric rule missing metric field",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Source.Type = sourceTypeMetric
+				r.Source.Query = nil
+				r.Source.Metric = nil
+				return r
+			},
+			wantErr:     true,
+			errContains: "source.metric is required",
+		},
+		{
+			name: "metric rule invalid metric value",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Source.Type = sourceTypeMetric
+				r.Source.Query = nil
+				r.Source.Metric = &invalidMetric
+				return r
+			},
+			wantErr:     true,
+			errContains: "source.metric must be",
+		},
+		{
+			name:        "invalid window duration",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Condition.Window = "not-duration"; return r },
+			wantErr:     true,
+			errContains: "condition.window must be a valid duration",
+		},
+		{
+			name:        "zero window duration",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Condition.Window = "0s"; return r },
+			wantErr:     true,
+			errContains: "condition.window must be greater than zero",
+		},
+		{
+			name:        "invalid interval duration",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Condition.Interval = "bad"; return r },
+			wantErr:     true,
+			errContains: "condition.interval must be a valid duration",
+		},
+		{
+			name:        "interval exceeds window",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Condition.Interval = "10m"; return r },
+			wantErr:     true,
+			errContains: "interval must not exceed",
+		},
+		{
+			name:        "invalid operator",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Condition.Operator = "between"; return r },
+			wantErr:     true,
+			errContains: "condition.operator must be one of",
+		},
+		{
+			name:        "threshold not positive",
+			req:         func() gen.AlertRuleRequest { r := baseLogRule(); r.Condition.Threshold = 0; return r },
+			wantErr:     true,
+			errContains: "condition.threshold must be greater than zero",
+		},
+		{name: "valid log rule", req: baseLogRule, wantErr: false},
+		{
+			name: "valid metric rule cpu_usage",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Source.Type = sourceTypeMetric
+				r.Source.Query = nil
+				r.Source.Metric = &cpuMetric
+				return r
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid metric rule memory_usage",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Source.Type = sourceTypeMetric
+				r.Source.Query = nil
+				r.Source.Metric = &memMetric
+				return r
+			},
+			wantErr: false,
+		},
+		{
+			name: "all valid operators",
+			req: func() gen.AlertRuleRequest {
+				r := baseLogRule()
+				r.Condition.Operator = "gte"
+				return r
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateAlertRuleRequest(tt.req())
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSourceType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sourceType string
+		wantErr    bool
+	}{
+		{name: "log is valid", sourceType: "log", wantErr: false},
+		{name: "metric is valid", sourceType: sourceTypeMetric, wantErr: false},
+		{name: "trace is invalid", sourceType: "trace", wantErr: true},
+		{name: "empty is invalid", sourceType: "", wantErr: true},
+		{name: "Log is invalid (case sensitive)", sourceType: "Log", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateSourceType(tt.sourceType)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// strPtr is a helper to get a pointer to a string literal. Used in validations tests.
+func strPtr(s string) *string { return &s }
+
+// intPtr is a helper to get a pointer to an int literal. Used in validations tests.
+func intPtr(i int) *int { return &i }

--- a/internal/observer/service/interfaces.go
+++ b/internal/observer/service/interfaces.go
@@ -10,6 +10,11 @@ import (
 	"github.com/openchoreo/openchoreo/internal/observer/types"
 )
 
+// HealthChecker is the interface for checking service health.
+type HealthChecker interface {
+	Check(ctx context.Context) error
+}
+
 // LogsQuerier is the interface for querying logs.
 type LogsQuerier interface {
 	QueryLogs(ctx context.Context, req *types.LogsQueryRequest) (*types.LogsQueryResponse, error)
@@ -49,4 +54,14 @@ type AlertIncidentService interface {
 	AlertsQuerier
 	IncidentsQuerier
 	IncidentsUpdater
+}
+
+// AlertRuleService is the interface for managing alert rules
+// and processing incoming alert webhooks.
+type AlertRuleService interface {
+	CreateAlertRule(ctx context.Context, req gen.AlertRuleRequest) (*gen.AlertingRuleSyncResponse, error)
+	GetAlertRule(ctx context.Context, ruleName, sourceType string) (*gen.AlertRuleResponse, error)
+	UpdateAlertRule(ctx context.Context, ruleName string, req gen.AlertRuleRequest) (*gen.AlertingRuleSyncResponse, error)
+	DeleteAlertRule(ctx context.Context, ruleName, sourceType string) (*gen.AlertingRuleSyncResponse, error)
+	HandleAlertWebhook(ctx context.Context, req gen.AlertWebhookRequest) (*gen.AlertWebhookResponse, error)
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request significantly improves the test coverage for the `internal/observer/api/handlers` package, particularly focusing on error handling and validation paths for alert, incident, and trace-related endpoints. It introduces new and more configurable test doubles, adds comprehensive tests for previously uncovered scenarios, and refactors the handler interfaces to use more flexible service abstractions.

**Test Coverage Improvements:**

* Added a new test suite `coverage_gaps_test.go` to cover previously untested error and validation branches for `UpdateIncident`, `UpdateAlertRule`, `QuerySpansForTrace`, and `QueryIncidents` endpoints, including authorization errors, invalid request bodies, and validation failures.
* Introduced `alerts_query_test.go` with a configurable fake service to thoroughly test all error and success paths for `QueryAlerts` and `QueryIncidents`, including service not initialized, authorization errors, validation errors, and generic failures.
* Added `health_test.go` to verify both healthy and unhealthy responses from the `/health` endpoint using a fake health checker.

**Handler Interface Refactoring:**

* Refactored the `Handler` struct and its constructor to accept the `healthService` and `alertService` as interface types (`HealthChecker`, `AlertRuleService`) instead of concrete implementations, improving testability and flexibility. [[1]](diffhunk://#diff-0e1edc8601078c6daa9f4ec9151ff048f5506d7caec31781fcc448344cc25f5aL48-R48) [[2]](diffhunk://#diff-0e1edc8601078c6daa9f4ec9151ff048f5506d7caec31781fcc448344cc25f5aL57-R57) [[3]](diffhunk://#diff-0e1edc8601078c6daa9f4ec9151ff048f5506d7caec31781fcc448344cc25f5aL75-R83)

These changes together ensure more robust and maintainable code by enforcing stricter test coverage and decoupling handler logic from specific service implementations.

## Approach
Extract AlertRuleService and HealthChecker interfaces so InternalHandler and Handler can be tested with lightweight fakes instead of concrete types.

Add 7 new test files covering all HTTP handler paths:
- validations_test.go: table-driven tests for all 12 validation functions
- health_test.go: Health() handler
- logs_test.go: QueryLogs handler with all service error codes
- metrics_test.go: QueryMetrics handler with all service error codes
- alerts_query_test.go: QueryAlerts and QueryIncidents handlers
- alerts_internal_test.go: all 5 InternalHandler CRUD+webhook methods
- traces_handler_test.go: QueryTraces, QuerySpansForTrace, GetSpanDetailsForTrace
- coverage_gaps_test.go: supplementary cases closing remaining branch gaps

Coverage moves from ~20% to 96% of statements.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
