### PR TITLE
chore: add unit tests for authz related functions

### DIFF
--- a/internal/authz/casbin/helpers_test.go
+++ b/internal/authz/casbin/helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 )
 
@@ -1109,4 +1111,55 @@ func sliceContainsSameElements(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestResourceMatchWrapper_Errors(t *testing.T) {
+	// Wrong number of args
+	_, err := resourceMatchWrapper("only-one")
+	require.Error(t, err, "resourceMatchWrapper with 1 arg should return error")
+
+	// Non-string first arg
+	_, err = resourceMatchWrapper(42, "ns/acme")
+	require.Error(t, err, "resourceMatchWrapper with non-string first arg should return error")
+
+	// Non-string second arg
+	_, err = resourceMatchWrapper("ns/acme", 42)
+	require.Error(t, err, "resourceMatchWrapper with non-string second arg should return error")
+
+	// Valid args
+	result, err := resourceMatchWrapper("ns/acme", "ns/acme")
+	require.NoError(t, err)
+	require.True(t, result.(bool), "resourceMatchWrapper exact match should be true")
+}
+
+func TestCtxMatchWrapper_Errors(t *testing.T) {
+	// Wrong number of args
+	_, err := ctxMatchWrapper("only-one")
+	require.Error(t, err, "ctxMatchWrapper with 1 arg should return error")
+
+	// Non-string first arg
+	_, err = ctxMatchWrapper(42, "{}")
+	require.Error(t, err, "ctxMatchWrapper with non-string first arg should return error")
+
+	// Non-string second arg
+	_, err = ctxMatchWrapper("{}", 42)
+	require.Error(t, err, "ctxMatchWrapper with non-string second arg should return error")
+
+	// Valid args
+	result, err := ctxMatchWrapper("{}", "{}")
+	require.NoError(t, err)
+	require.True(t, result.(bool), "ctxMatchWrapper exact match should be true")
+}
+
+func TestValidateBatchEvaluateRequest_MissingActionAtIndex(t *testing.T) {
+	validSubject := &authzcore.SubjectContext{
+		Type: "user", EntitlementClaim: "groups", EntitlementValues: []string{"devs"},
+	}
+	req := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{
+			{SubjectContext: validSubject, Resource: authzcore.Resource{Type: "component"}, Action: "component:view"},
+			{SubjectContext: validSubject, Resource: authzcore.Resource{Type: "component"}, Action: ""}, // missing action
+		},
+	}
+	require.Error(t, validateBatchEvaluateRequest(req), "validateBatchEvaluateRequest with empty action should return error")
 }

--- a/internal/authz/casbin/k8s_watcher_test.go
+++ b/internal/authz/casbin/k8s_watcher_test.go
@@ -4,13 +4,16 @@
 package casbin
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
 	"testing"
 
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	authzv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 )
@@ -1734,4 +1737,895 @@ func TestAuthzInformerHandler_HandleDeleteClusterBinding_Scoped(t *testing.T) {
 	if len(policies) != 0 {
 		t.Errorf("expected 0 policies after delete, got %d. All policies: %v", len(policies), policies)
 	}
+}
+
+// --- OnAdd/OnUpdate/OnDelete wrappers ---
+
+func TestAuthzInformerHandler_OnAdd_Role(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	role := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-add-role", Namespace: "acme"},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	h.OnAdd(role, false) // should not panic
+}
+
+func TestAuthzInformerHandler_OnUpdate_Role(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	old := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-upd-role", Namespace: "acme", Generation: 1},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	newR := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-upd-role", Namespace: "acme", Generation: 2},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:create"}},
+	}
+	// Seed the old policy so the update handler can remove it
+	_, _ = h.enforcer.AddGroupingPolicy("on-upd-role", "component:view", "acme")
+	h.OnUpdate(old, newR)
+	// Verify the OnUpdate wrapper delegated correctly: old action removed, new action added
+	hasOld, _ := h.enforcer.HasGroupingPolicy("on-upd-role", "component:view", "acme")
+	require.False(t, hasOld, "old action component:view should be removed after OnUpdate")
+	hasNew, _ := h.enforcer.HasGroupingPolicy("on-upd-role", "component:create", "acme")
+	require.True(t, hasNew, "new action component:create should be added after OnUpdate")
+}
+
+func TestAuthzInformerHandler_OnDelete_Role(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	role := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-del-role", Namespace: "acme"},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	h.OnDelete(role) // should not panic
+}
+
+func TestAuthzInformerHandler_OnDelete_WithTombstone(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	role := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "tombstone-role", Namespace: "acme"},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	// Wrap in a DeletedFinalStateUnknown tombstone
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "acme/tombstone-role",
+		Obj: role,
+	}
+	h.OnDelete(tombstone) // should not panic
+}
+
+// --- handleAdd dispatcher ---
+
+func TestAuthzInformerHandler_HandleAdd_UnknownCRDType(t *testing.T) {
+	h, _ := setupTestHandler(t, "UnknownType")
+	role := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "acme"},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	err := h.handleAdd(role)
+	require.NoError(t, err, "handleAdd with unknown crdType should return nil")
+}
+
+func TestAuthzInformerHandler_HandleAdd_ClusterRole(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	cr := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "global-admin"},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"*"}},
+	}
+	require.NoError(t, h.handleAdd(cr), "handleAdd ClusterRole error")
+	// Verify the grouping policy was added: [roleName, action, "*"]
+	hasGP, _ := h.enforcer.HasGroupingPolicy("global-admin", "*", "*")
+	require.True(t, hasGP, "expected grouping policy [global-admin, *, *] to exist after handleAdd")
+}
+
+func TestAuthzInformerHandler_HandleAdd_Binding(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	require.NoError(t, h.handleAdd(binding), "handleAdd Binding error")
+	// Verify policy tuple: [subject, resource, roleName, roleNamespace, effect, ctx, bindingRef]
+	hasP, _ := h.enforcer.HasPolicy("groups:devs", "ns/acme", "viewer", "acme", "allow", "{}", "b1")
+	require.True(t, hasP, "expected policy [groups:devs, ns/acme, viewer, acme, allow, {}, b1] after handleAdd")
+}
+
+func TestAuthzInformerHandler_HandleAdd_ClusterBinding(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb1"},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "global-admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	require.NoError(t, h.handleAdd(binding), "handleAdd ClusterBinding error")
+	// Verify policy tuple: cluster bindings use resource "*" (empty scope) and roleNamespace "*"
+	hasP, _ := h.enforcer.HasPolicy("groups:admins", "*", "global-admin", "*", "allow", "{}", "cb1")
+	require.True(t, hasP, "expected policy [groups:admins, *, global-admin, *, allow, {}, cb1] after handleAdd")
+}
+
+// --- handleUpdate dispatcher ---
+
+func TestAuthzInformerHandler_HandleUpdate_UnknownCRDType(t *testing.T) {
+	h, _ := setupTestHandler(t, "UnknownType")
+	old := &authzv1alpha1.AuthzRole{ObjectMeta: metav1.ObjectMeta{Name: "r"}}
+	newR := &authzv1alpha1.AuthzRole{ObjectMeta: metav1.ObjectMeta{Name: "r"}}
+	err := h.handleUpdate(old, newR)
+	require.NoError(t, err, "handleUpdate with unknown crdType should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdate_ClusterRole(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	old := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr", Generation: 1},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	newR := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr", Generation: 2},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:create"}},
+	}
+	_, _ = h.enforcer.AddGroupingPolicy("cr", "component:view", "*")
+	require.NoError(t, h.handleUpdate(old, newR), "handleUpdate ClusterRole error")
+	// Old action must be removed, new action must be added
+	hasOld, _ := h.enforcer.HasGroupingPolicy("cr", "component:view", "*")
+	require.False(t, hasOld, "old grouping policy [cr, component:view, *] should be removed after update")
+	hasNew, _ := h.enforcer.HasGroupingPolicy("cr", "component:create", "*")
+	require.True(t, hasNew, "new grouping policy [cr, component:create, *] should exist after update")
+}
+
+func TestAuthzInformerHandler_HandleUpdate_Binding(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	old := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "acme", Generation: 1},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "acme", Generation: 2},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "editor"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	// Seed the old policy
+	_, _ = h.enforcer.AddPoliciesEx([][]string{{"groups:devs", "ns/acme", "viewer", "acme", "allow", "{}", "b"}})
+	require.NoError(t, h.handleUpdate(old, newB), "handleUpdate Binding error")
+	// Old policy (viewer) must be removed, new policy (editor) must be added
+	hasOld, _ := h.enforcer.HasPolicy("groups:devs", "ns/acme", "viewer", "acme", "allow", "{}", "b")
+	require.False(t, hasOld, "old policy (viewer) should be removed after binding update")
+	hasNew, _ := h.enforcer.HasPolicy("groups:devs", "ns/acme", "editor", "acme", "allow", "{}", "b")
+	require.True(t, hasNew, "new policy (editor) should exist after binding update")
+}
+
+func TestAuthzInformerHandler_HandleUpdate_ClusterBinding(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	old := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb", Generation: 1},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "viewer"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb", Generation: 2},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "editor"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	// Seed the old policy
+	_, _ = h.enforcer.AddPoliciesEx([][]string{{"groups:admins", "*", "viewer", "*", "allow", "{}", "cb"}})
+	require.NoError(t, h.handleUpdate(old, newB), "handleUpdate ClusterBinding error")
+	// Old policy (viewer) must be removed, new policy (editor) must be added
+	hasOld, _ := h.enforcer.HasPolicy("groups:admins", "*", "viewer", "*", "allow", "{}", "cb")
+	require.False(t, hasOld, "old policy (viewer) should be removed after cluster binding update")
+	hasNew, _ := h.enforcer.HasPolicy("groups:admins", "*", "editor", "*", "allow", "{}", "cb")
+	require.True(t, hasNew, "new policy (editor) should exist after cluster binding update")
+}
+
+// --- handleDelete dispatcher ---
+
+func TestAuthzInformerHandler_HandleDelete_UnknownCRDType(t *testing.T) {
+	h, _ := setupTestHandler(t, "UnknownType")
+	role := &authzv1alpha1.AuthzRole{ObjectMeta: metav1.ObjectMeta{Name: "r"}}
+	err := h.handleDelete(role)
+	require.NoError(t, err, "handleDelete with unknown crdType should return nil")
+}
+
+func TestAuthzInformerHandler_HandleDelete_ClusterRole(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	cr := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr-del"},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	// Seed the policy so deletion has something to remove
+	_, _ = h.enforcer.AddGroupingPoliciesEx([][]string{{"cr-del", "component:view", "*"}})
+	require.NoError(t, h.handleDelete(cr), "handleDelete ClusterRole error")
+	// Verify the grouping policy was removed
+	hasGP, _ := h.enforcer.HasGroupingPolicy("cr-del", "component:view", "*")
+	require.False(t, hasGP, "grouping policy should be removed after handleDelete ClusterRole")
+}
+
+func TestAuthzInformerHandler_HandleDelete_Binding(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-del", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	// Seed the policy so deletion has something to remove
+	_, _ = h.enforcer.AddPoliciesEx([][]string{{"groups:devs", "ns/acme", "viewer", "acme", "allow", "{}", "b-del"}})
+	require.NoError(t, h.handleDelete(binding), "handleDelete Binding error")
+	// Verify the policy was removed
+	hasP, _ := h.enforcer.HasPolicy("groups:devs", "ns/acme", "viewer", "acme", "allow", "{}", "b-del")
+	require.False(t, hasP, "policy should be removed after handleDelete Binding")
+}
+
+func TestAuthzInformerHandler_HandleDelete_ClusterBinding(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb-del"},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "global-admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	// Seed the policy so deletion has something to remove
+	_, _ = h.enforcer.AddPoliciesEx([][]string{{"groups:admins", "*", "global-admin", "*", "allow", "{}", "cb-del"}})
+	require.NoError(t, h.handleDelete(binding), "handleDelete ClusterBinding error")
+	// Verify the policy was removed
+	hasP, _ := h.enforcer.HasPolicy("groups:admins", "*", "global-admin", "*", "allow", "{}", "cb-del")
+	require.False(t, hasP, "policy should be removed after handleDelete ClusterBinding")
+}
+
+// --- Wrong-type object paths ---
+
+func TestAuthzInformerHandler_HandleAddRole_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	err := h.handleAddRole("not-an-authz-role")
+	require.NoError(t, err, "handleAddRole with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleAddClusterRole_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	err := h.handleAddClusterRole("not-a-cluster-role")
+	require.NoError(t, err, "handleAddClusterRole with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleAddBinding_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	err := h.handleAddBinding("not-a-binding")
+	require.NoError(t, err, "handleAddBinding with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleAddBinding_EmptyEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-effect", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // empty effect
+		},
+	}
+	err := h.handleAddBinding(binding)
+	require.Error(t, err, "handleAddBinding with empty effect should return error")
+}
+
+func TestAuthzInformerHandler_HandleAddClusterBinding_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	err := h.handleAddClusterBinding("not-a-cluster-binding")
+	require.NoError(t, err, "handleAddClusterBinding with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleAddClusterBinding_EmptyEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-effect-cb"},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: "", // empty effect
+		},
+	}
+	err := h.handleAddClusterBinding(binding)
+	require.Error(t, err, "handleAddClusterBinding with empty effect should return error")
+}
+
+// --- UpdateRole edge cases ---
+
+func TestAuthzInformerHandler_HandleUpdateRole_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	err := h.handleUpdateRole("not-a-role", "also-not-a-role")
+	require.NoError(t, err, "handleUpdateRole with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdateRole_SameGeneration(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	role := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-gen", Namespace: "acme", Generation: 5},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	// same generation → should skip and return nil
+	err := h.handleUpdateRole(role, role)
+	require.NoError(t, err, "handleUpdateRole same generation should return nil")
+}
+
+// --- UpdateClusterRole edge cases ---
+
+func TestAuthzInformerHandler_HandleUpdateClusterRole_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	err := h.handleUpdateClusterRole("not-a-role", "also-not-a-role")
+	require.NoError(t, err, "handleUpdateClusterRole with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdateClusterRole_SameGeneration(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	role := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-gen-cr", Generation: 3},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"*"}},
+	}
+	err := h.handleUpdateClusterRole(role, role)
+	require.NoError(t, err, "handleUpdateClusterRole same generation should return nil")
+}
+
+// --- UpdateBinding edge cases ---
+
+func TestAuthzInformerHandler_HandleUpdateBinding_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	err := h.handleUpdateBinding("not-a-binding", "also-not-a-binding")
+	require.NoError(t, err, "handleUpdateBinding with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdateBinding_SameGeneration(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-gen-b", Namespace: "acme", Generation: 7},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateBinding(binding, binding)
+	require.NoError(t, err, "handleUpdateBinding same generation should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdateBinding_EmptyOldEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	old := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-empty-old", Namespace: "acme", Generation: 1},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // empty
+		},
+	}
+	newB := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-empty-old", Namespace: "acme", Generation: 2},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateBinding(old, newB)
+	require.Error(t, err, "handleUpdateBinding with empty old effect should return error")
+}
+
+func TestAuthzInformerHandler_HandleUpdateBinding_EmptyNewEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	old := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-empty-new", Namespace: "acme", Generation: 1},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-empty-new", Namespace: "acme", Generation: 2},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // empty
+		},
+	}
+	err := h.handleUpdateBinding(old, newB)
+	require.Error(t, err, "handleUpdateBinding with empty new effect should return error")
+}
+
+// --- UpdateClusterBinding edge cases ---
+
+func TestAuthzInformerHandler_HandleUpdateClusterBinding_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	err := h.handleUpdateClusterBinding("not-a-binding", "also-not-a-binding")
+	require.NoError(t, err, "handleUpdateClusterBinding with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdateClusterBinding_SameGeneration(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-gen-cb", Generation: 4},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateClusterBinding(binding, binding)
+	require.NoError(t, err, "handleUpdateClusterBinding same generation should return nil")
+}
+
+func TestAuthzInformerHandler_HandleUpdateClusterBinding_EmptyOldEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	old := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb-empty-old", Generation: 1},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: "", // empty
+		},
+	}
+	newB := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb-empty-old", Generation: 2},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateClusterBinding(old, newB)
+	require.Error(t, err, "handleUpdateClusterBinding with empty old effect should return error")
+}
+
+func TestAuthzInformerHandler_HandleUpdateClusterBinding_EmptyNewEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	old := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb-empty-new", Generation: 1},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cb-empty-new", Generation: 2},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: "", // empty
+		},
+	}
+	err := h.handleUpdateClusterBinding(old, newB)
+	require.Error(t, err, "handleUpdateClusterBinding with empty new effect should return error")
+}
+
+// --- DeleteRole edge cases ---
+
+func TestAuthzInformerHandler_HandleDeleteRole_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+	err := h.handleDeleteRole("not-a-role")
+	require.NoError(t, err, "handleDeleteRole with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleDeleteClusterRole_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+	err := h.handleDeleteClusterRole("not-a-cluster-role")
+	require.NoError(t, err, "handleDeleteClusterRole with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleDeleteBinding_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	err := h.handleDeleteBinding("not-a-binding")
+	require.NoError(t, err, "handleDeleteBinding with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleDeleteBinding_EmptyEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "del-empty-effect", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // empty
+		},
+	}
+	err := h.handleDeleteBinding(binding)
+	require.Error(t, err, "handleDeleteBinding with empty effect should return error")
+}
+
+func TestAuthzInformerHandler_HandleDeleteClusterBinding_WrongType(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	err := h.handleDeleteClusterBinding("not-a-cluster-binding")
+	require.NoError(t, err, "handleDeleteClusterBinding with wrong type should return nil")
+}
+
+func TestAuthzInformerHandler_HandleDeleteClusterBinding_EmptyEffect(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "del-cb-empty-effect"},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: "", // empty
+		},
+	}
+	err := h.handleDeleteClusterBinding(binding)
+	require.Error(t, err, "handleDeleteClusterBinding with empty effect should return error")
+}
+
+// --- OnAdd/OnUpdate/OnDelete error-logging paths ---
+
+// OnAdd logs the error when the handler returns one (e.g. empty effect in binding).
+func TestAuthzInformerHandler_OnAdd_ErrorLogged(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	var logs bytes.Buffer
+	h.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	badBinding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-add-err", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // causes handleAddBinding to return an error
+		},
+	}
+	h.OnAdd(badBinding, false)
+	require.Contains(t, logs.String(), "Incremental add failed")
+	require.Contains(t, logs.String(), "level=ERROR")
+}
+
+// OnUpdate logs the error when the handler returns one.
+func TestAuthzInformerHandler_OnUpdate_ErrorLogged(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	var logs bytes.Buffer
+	h.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	// Old binding with empty effect → handleUpdateBinding errors immediately on old effect
+	old := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-upd-err", Namespace: "acme", Generation: 1},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // empty → triggers error in handleUpdateBinding
+		},
+	}
+	newB := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-upd-err", Namespace: "acme", Generation: 2},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "editor"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	h.OnUpdate(old, newB)
+	require.Contains(t, logs.String(), "Incremental update failed")
+	require.Contains(t, logs.String(), "level=ERROR")
+}
+
+// OnDelete logs the error when the handler returns one.
+func TestAuthzInformerHandler_OnDelete_ErrorLogged(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	var logs bytes.Buffer
+	h.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	badBinding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "on-del-err", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       "", // empty → triggers error in handleDeleteBinding
+		},
+	}
+	h.OnDelete(badBinding)
+	require.Contains(t, logs.String(), "Incremental delete failed")
+	require.Contains(t, logs.String(), "level=WARN")
+}
+
+// --- handleAddClusterBinding — formatSubject error (empty claim) ---
+
+func TestAuthzInformerHandler_HandleAddClusterBinding_EmptyClaim(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-claim-cb"},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "", Value: "admins"}, // empty claim
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleAddClusterBinding(binding)
+	require.Error(t, err, "handleAddClusterBinding with empty claim should return error")
+}
+
+// --- handleDeleteBinding / handleDeleteClusterBinding — formatSubject errors ---
+
+func TestAuthzInformerHandler_HandleDeleteBinding_EmptyClaim(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "del-empty-claim", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "", Value: "devs"}, // empty claim
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleDeleteBinding(binding)
+	require.Error(t, err, "handleDeleteBinding with empty claim should return error")
+}
+
+func TestAuthzInformerHandler_HandleDeleteClusterBinding_EmptyClaim(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	binding := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "del-cb-empty-claim"},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "", Value: "admins"}, // empty claim
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleDeleteClusterBinding(binding)
+	require.Error(t, err, "handleDeleteClusterBinding with empty claim should return error")
+}
+
+// --- handleUpdateRole / handleUpdateClusterRole — "not removed" and "not added" branches ---
+
+// When an action to be removed was never in the enforcer, RemoveGroupingPolicy
+// returns (false, nil) and the handler logs a debug message.
+func TestAuthzInformerHandler_HandleUpdateRole_ActionNotRemovedNotInEnforcer(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+
+	// Old role has "component:view", new role has "component:create".
+	// We do NOT pre-seed "component:view" in the enforcer, so removal returns false.
+	old := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "update-not-removed", Namespace: "acme", Generation: 1},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	newR := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "update-not-removed", Namespace: "acme", Generation: 2},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:create"}},
+	}
+	require.NoError(t, h.handleUpdateRole(old, newR), "handleUpdateRole should succeed even when policy was not in enforcer")
+}
+
+// When an action to be added is already in the enforcer, AddGroupingPolicy
+// returns (false, nil) and the handler logs a debug message.
+func TestAuthzInformerHandler_HandleUpdateRole_ActionNotAddedAlreadyExists(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRole)
+
+	// Pre-seed "component:create" so it already exists.
+	_, _ = h.enforcer.AddGroupingPolicy("update-already-added", "component:create", "acme")
+	_, _ = h.enforcer.AddGroupingPolicy("update-already-added", "component:view", "acme")
+
+	old := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "update-already-added", Namespace: "acme", Generation: 1},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	newR := &authzv1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "update-already-added", Namespace: "acme", Generation: 2},
+		Spec:       authzv1alpha1.AuthzRoleSpec{Actions: []string{"component:create"}},
+	}
+	require.NoError(t, h.handleUpdateRole(old, newR), "handleUpdateRole should succeed even when new action already exists")
+}
+
+// handleUpdateClusterRole — "Old cluster grouping policy did not exist"
+func TestAuthzInformerHandler_HandleUpdateClusterRole_ActionNotRemovedNotInEnforcer(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+
+	old := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr-not-removed", Generation: 1},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	newR := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr-not-removed", Generation: 2},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:create"}},
+	}
+	// Do NOT seed "component:view" — RemoveGroupingPolicy will return false.
+	require.NoError(t, h.handleUpdateClusterRole(old, newR), "handleUpdateClusterRole should succeed even when policy was not in enforcer")
+}
+
+// handleUpdateClusterRole — "New cluster grouping policy already exists"
+func TestAuthzInformerHandler_HandleUpdateClusterRole_ActionNotAddedAlreadyExists(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRole)
+
+	_, _ = h.enforcer.AddGroupingPolicy("cr-already-added", "component:create", "*")
+	_, _ = h.enforcer.AddGroupingPolicy("cr-already-added", "component:view", "*")
+
+	old := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr-already-added", Generation: 1},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+	}
+	newR := &authzv1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr-already-added", Generation: 2},
+		Spec:       authzv1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:create"}},
+	}
+	require.NoError(t, h.handleUpdateClusterRole(old, newR), "handleUpdateClusterRole should succeed even when new action already exists")
+}
+
+// --- handleUpdateBinding — formatSubject errors for old and new binding ---
+
+func TestAuthzInformerHandler_HandleUpdateBinding_OldFormatSubjectError(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	old := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-b-old-claim", Namespace: "acme", Generation: 1},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "", Value: "devs"}, // empty claim → formatSubject error
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-b-old-claim", Namespace: "acme", Generation: 2},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "editor"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateBinding(old, newB)
+	require.Error(t, err, "handleUpdateBinding with empty old claim should return error")
+}
+
+func TestAuthzInformerHandler_HandleUpdateBinding_NewFormatSubjectError(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	old := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-b-new-claim", Namespace: "acme", Generation: 1},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"}, // valid
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-b-new-claim", Namespace: "acme", Generation: 2},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement:  authzv1alpha1.EntitlementClaim{Claim: "", Value: "devs"}, // empty claim → formatSubject error
+			RoleMappings: []authzv1alpha1.RoleMapping{{RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindAuthzRole, Name: "editor"}}},
+			Effect:       authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateBinding(old, newB)
+	require.Error(t, err, "handleUpdateBinding with empty new claim should return error")
+}
+
+// --- handleUpdateClusterBinding — formatSubject errors for old and new binding ---
+
+func TestAuthzInformerHandler_HandleUpdateClusterBinding_OldFormatSubjectError(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	old := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-cb-old-claim", Generation: 1},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "", Value: "admins"}, // empty claim
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-cb-old-claim", Generation: 2},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "editor"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateClusterBinding(old, newB)
+	require.Error(t, err, "handleUpdateClusterBinding with empty old claim should return error")
+}
+
+func TestAuthzInformerHandler_HandleUpdateClusterBinding_NewFormatSubjectError(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeClusterAuthzRoleBinding)
+	old := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-cb-new-claim", Generation: 1},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"}, // valid
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	newB := &authzv1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "upd-cb-new-claim", Generation: 2},
+		Spec: authzv1alpha1.ClusterAuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "", Value: "admins"}, // empty claim
+			RoleMappings: []authzv1alpha1.ClusterRoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, Name: "editor"},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	err := h.handleUpdateClusterBinding(old, newB)
+	require.Error(t, err, "handleUpdateClusterBinding with empty new claim should return error")
+}
+
+// --- handleAddBinding — ClusterAuthzRole reference (roleNamespace = "*" branch) ---
+
+func TestAuthzInformerHandler_HandleAddBinding_ClusterRoleRef(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	// A namespaced binding that references a ClusterAuthzRole triggers `roleNamespace = "*"`
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-binding-cluster-ref", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{
+					Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, // ← triggers roleNamespace = "*"
+					Name: "global-viewer",
+				},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	require.NoError(t, h.handleAddBinding(binding), "handleAddBinding with ClusterAuthzRole ref error")
+	// The policy tuple must use roleNamespace="*" (not "acme") because the RoleRef is ClusterAuthzRole
+	hasP, _ := h.enforcer.HasPolicy("groups:devs", "ns/acme", "global-viewer", "*", "allow", "{}", "ns-binding-cluster-ref")
+	require.True(t, hasP, "expected policy with roleNamespace=\"*\" when AuthzRoleBinding references a ClusterAuthzRole")
+}
+
+// --- handleDeleteBinding — ClusterAuthzRole reference (roleNamespace = "*" branch) ---
+
+func TestAuthzInformerHandler_HandleDeleteBinding_ClusterRoleRef(t *testing.T) {
+	h, _ := setupTestHandler(t, CRDTypeAuthzRoleBinding)
+	binding := &authzv1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "del-ns-binding-cluster-ref", Namespace: "acme"},
+		Spec: authzv1alpha1.AuthzRoleBindingSpec{
+			Entitlement: authzv1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+			RoleMappings: []authzv1alpha1.RoleMapping{{
+				RoleRef: authzv1alpha1.RoleRef{
+					Kind: authzv1alpha1.RoleRefKindClusterAuthzRole, // ← triggers roleNamespace = "*"
+					Name: "global-viewer",
+				},
+			}},
+			Effect: authzv1alpha1.EffectAllow,
+		},
+	}
+	// Seed the policy with roleNamespace="*" (as it would have been stored on add)
+	_, _ = h.enforcer.AddPoliciesEx([][]string{{"groups:devs", "ns/acme", "global-viewer", "*", "allow", "{}", "del-ns-binding-cluster-ref"}})
+	require.NoError(t, h.handleDeleteBinding(binding), "handleDeleteBinding with ClusterAuthzRole ref error")
+	// Verify the policy with roleNamespace="*" was removed
+	hasP, _ := h.enforcer.HasPolicy("groups:devs", "ns/acme", "global-viewer", "*", "allow", "{}", "del-ns-binding-cluster-ref")
+	require.False(t, hasP, "policy with roleNamespace=\"*\" should be removed after handleDeleteBinding with ClusterAuthzRole ref")
 }

--- a/internal/authz/casbin/pap_test.go
+++ b/internal/authz/casbin/pap_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1428,4 +1429,238 @@ func TestCasbinEnforcer_DeleteNamespacedRoleBinding(t *testing.T) {
 			t.Errorf("DeleteNamespacedRoleBinding() error = %v, want ErrRoleMappingNotFound", err)
 		}
 	})
+}
+
+func TestCasbinEnforcer_ListClusterRoles_WithLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+
+	// Seed 3 cluster roles
+	for _, name := range []string{"limit-cr-1", "limit-cr-2", "limit-cr-3"} {
+		_, err := enforcer.CreateClusterRole(ctx, &openchoreov1alpha1.ClusterAuthzRole{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       openchoreov1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+		})
+		require.NoError(t, err, "CreateClusterRole(%s) error", name)
+	}
+
+	// First page: limit=2 from 3 items
+	page1, err := enforcer.ListClusterRoles(ctx, 2, "")
+	require.NoError(t, err, "ListClusterRoles(limit=2) error")
+	require.NotNil(t, page1, "ListClusterRoles(limit=2) returned nil")
+	// The fake k8s client may not enforce limit; accept either paginated (2 items + cursor) or all items at once
+	if page1.NextCursor != "" {
+		require.Len(t, page1.Items, 2, "when pagination cursor is returned, expected exactly 2 items on first page")
+	}
+
+	// If the client returns a cursor, use it to fetch the remaining item
+	if page1.NextCursor != "" {
+		page2, err := enforcer.ListClusterRoles(ctx, 2, page1.NextCursor)
+		require.NoError(t, err, "ListClusterRoles(page2) error")
+		require.Len(t, page2.Items, 1, "expected 1 item on second page")
+		// Items across pages must not overlap
+		seen := make(map[string]bool)
+		for _, r := range page1.Items {
+			seen[r.Name] = true
+		}
+		for _, r := range page2.Items {
+			require.False(t, seen[r.Name], "item %q appeared on both pages", r.Name)
+		}
+	}
+}
+
+func TestCasbinEnforcer_ListClusterRoles_NoLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+
+	// Seed 2 items so there's something to count
+	for _, name := range []string{"nolimit-cr-1", "nolimit-cr-2"} {
+		_, err := enforcer.CreateClusterRole(ctx, &openchoreov1alpha1.ClusterAuthzRole{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       openchoreov1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+		})
+		require.NoError(t, err, "CreateClusterRole(%s) error", name)
+	}
+
+	result, err := enforcer.ListClusterRoles(ctx, 0, "")
+	require.NoError(t, err, "ListClusterRoles(limit=0) error")
+	require.GreaterOrEqual(t, len(result.Items), 2, "expected at least 2 items with no limit")
+}
+
+func TestCasbinEnforcer_ListClusterRoles_CursorWithoutLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+
+	// cursor without limit should be ignored gracefully
+	_, err := enforcer.ListClusterRoles(ctx, 0, "some-cursor")
+	require.NoError(t, err, "ListClusterRoles(limit=0,cursor) error")
+}
+
+func TestCasbinEnforcer_ListNamespacedRoles_WithLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	ns := "test-ns-list"
+
+	for _, name := range []string{"limit-r-1", "limit-r-2"} {
+		_, err := enforcer.CreateNamespacedRole(ctx, &openchoreov1alpha1.AuthzRole{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       openchoreov1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+		})
+		require.NoError(t, err, "CreateNamespacedRole(%s) error", name)
+	}
+
+	// First page: limit=1 from 2 items
+	page1, err := enforcer.ListNamespacedRoles(ctx, ns, 1, "")
+	require.NoError(t, err, "ListNamespacedRoles(limit=1) error")
+	require.NotNil(t, page1, "ListNamespacedRoles(limit=1) returned nil")
+	// The fake k8s client may not enforce limit; accept either paginated (1 item + cursor) or all items at once
+	if page1.NextCursor != "" {
+		require.Len(t, page1.Items, 1, "when pagination cursor is returned, expected exactly 1 item on first page")
+	}
+
+	// If the client returns a cursor, use it to fetch the second item
+	if page1.NextCursor != "" {
+		page2, err := enforcer.ListNamespacedRoles(ctx, ns, 1, page1.NextCursor)
+		require.NoError(t, err, "ListNamespacedRoles(page2) error")
+		require.Len(t, page2.Items, 1, "expected 1 item on second page")
+		require.NotEqual(t, page1.Items[0].Name, page2.Items[0].Name, "same item appeared on both pages")
+	}
+}
+
+func TestCasbinEnforcer_ListClusterRoleBindings_WithLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"limit-crb-1", "limit-crb-2"} {
+		_, err := enforcer.CreateClusterRoleBinding(ctx, &openchoreov1alpha1.ClusterAuthzRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: openchoreov1alpha1.ClusterAuthzRoleBindingSpec{
+				Entitlement: openchoreov1alpha1.EntitlementClaim{Claim: "groups", Value: "admins"},
+				RoleMappings: []openchoreov1alpha1.ClusterRoleMapping{{
+					RoleRef: openchoreov1alpha1.RoleRef{Kind: openchoreov1alpha1.RoleRefKindClusterAuthzRole, Name: "admin"},
+				}},
+				Effect: openchoreov1alpha1.EffectAllow,
+			},
+		})
+		require.NoError(t, err, "CreateClusterRoleBinding(%s) error", name)
+	}
+
+	// First page: limit=1 from 2 items
+	page1, err := enforcer.ListClusterRoleBindings(ctx, 1, "")
+	require.NoError(t, err, "ListClusterRoleBindings(limit=1) error")
+	require.NotNil(t, page1, "ListClusterRoleBindings(limit=1) returned nil")
+	// The fake k8s client may not enforce limit; accept either paginated (1 item + cursor) or all items at once
+	if page1.NextCursor != "" {
+		require.Len(t, page1.Items, 1, "when pagination cursor is returned, expected exactly 1 item on first page")
+	}
+
+	// If the client returns a cursor, use it to fetch the second item
+	if page1.NextCursor != "" {
+		page2, err := enforcer.ListClusterRoleBindings(ctx, 1, page1.NextCursor)
+		require.NoError(t, err, "ListClusterRoleBindings(page2) error")
+		require.Len(t, page2.Items, 1, "expected 1 item on second page")
+		require.NotEqual(t, page1.Items[0].Name, page2.Items[0].Name, "same item appeared on both pages")
+	}
+}
+
+func TestCasbinEnforcer_ListNamespacedRoleBindings_WithLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	ns := "test-ns-rb-list"
+
+	for _, name := range []string{"limit-rb-1", "limit-rb-2"} {
+		_, err := enforcer.CreateNamespacedRoleBinding(ctx, &openchoreov1alpha1.AuthzRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: openchoreov1alpha1.AuthzRoleBindingSpec{
+				Entitlement:  openchoreov1alpha1.EntitlementClaim{Claim: "groups", Value: "devs"},
+				RoleMappings: []openchoreov1alpha1.RoleMapping{{RoleRef: openchoreov1alpha1.RoleRef{Kind: openchoreov1alpha1.RoleRefKindAuthzRole, Name: "viewer"}}},
+				Effect:       openchoreov1alpha1.EffectAllow,
+			},
+		})
+		require.NoError(t, err, "CreateNamespacedRoleBinding(%s) error", name)
+	}
+
+	// First page: limit=1 from 2 items
+	page1, err := enforcer.ListNamespacedRoleBindings(ctx, ns, 1, "")
+	require.NoError(t, err, "ListNamespacedRoleBindings(limit=1) error")
+	require.NotNil(t, page1, "ListNamespacedRoleBindings(limit=1) returned nil")
+	// The fake k8s client may not enforce limit; accept either paginated (1 item + cursor) or all items at once
+	if page1.NextCursor != "" {
+		require.Len(t, page1.Items, 1, "when pagination cursor is returned, expected exactly 1 item on first page")
+	}
+
+	// If the client returns a cursor, use it to fetch the second item
+	if page1.NextCursor != "" {
+		page2, err := enforcer.ListNamespacedRoleBindings(ctx, ns, 1, page1.NextCursor)
+		require.NoError(t, err, "ListNamespacedRoleBindings(page2) error")
+		require.Len(t, page2.Items, 1, "expected 1 item on second page")
+		require.NotEqual(t, page1.Items[0].Name, page2.Items[0].Name, "same item appeared on both pages")
+	}
+}
+
+func TestCasbinEnforcer_UpdateClusterRole_NotFound(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.UpdateClusterRole(ctx, &openchoreov1alpha1.ClusterAuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "non-existent-cr"},
+		Spec:       openchoreov1alpha1.ClusterAuthzRoleSpec{Actions: []string{"component:view"}},
+	})
+	require.Error(t, err, "UpdateClusterRole non-existent should return error")
+}
+
+func TestCasbinEnforcer_UpdateNamespacedRole_NotFound(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.UpdateNamespacedRole(ctx, &openchoreov1alpha1.AuthzRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "non-existent-r", Namespace: "acme"},
+		Spec:       openchoreov1alpha1.AuthzRoleSpec{Actions: []string{"component:view"}},
+	})
+	require.Error(t, err, "UpdateNamespacedRole non-existent should return error")
+}
+
+func TestCasbinEnforcer_UpdateClusterRoleBinding_NotFound(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.UpdateClusterRoleBinding(ctx, &openchoreov1alpha1.ClusterAuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "non-existent-crb"},
+	})
+	require.Error(t, err, "UpdateClusterRoleBinding non-existent should return error")
+}
+
+func TestCasbinEnforcer_UpdateNamespacedRoleBinding_NotFound(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.UpdateNamespacedRoleBinding(ctx, &openchoreov1alpha1.AuthzRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "non-existent-rb", Namespace: "acme"},
+	})
+	require.Error(t, err, "UpdateNamespacedRoleBinding non-existent should return error")
+}
+
+func TestCasbinEnforcer_ListClusterRoles_WithCursorAndLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	// Fake client doesn't enforce cursor but exercises the branch
+	_, err := enforcer.ListClusterRoles(ctx, 1, "some-cursor-token")
+	require.NoError(t, err, "ListClusterRoles(limit=1,cursor) error")
+}
+
+func TestCasbinEnforcer_ListNamespacedRoles_WithCursor(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.ListNamespacedRoles(ctx, "acme", 0, "some-cursor-token")
+	require.NoError(t, err, "ListNamespacedRoles(cursor) error")
+}
+
+func TestCasbinEnforcer_ListClusterRoleBindings_WithCursorAndLimit(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.ListClusterRoleBindings(ctx, 1, "some-cursor-token")
+	require.NoError(t, err, "ListClusterRoleBindings(limit=1,cursor) error")
+}
+
+func TestCasbinEnforcer_ListNamespacedRoleBindings_WithCursor(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	ctx := context.Background()
+	_, err := enforcer.ListNamespacedRoleBindings(ctx, "acme", 0, "some-cursor-token")
+	require.NoError(t, err, "ListNamespacedRoleBindings(cursor) error")
 }

--- a/internal/authz/casbin/pdp_test.go
+++ b/internal/authz/casbin/pdp_test.go
@@ -5,11 +5,14 @@ package casbin
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1397,4 +1400,240 @@ func TestCasbinEnforcer_Evaluate_ScopedClusterBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// enforcer.go coverage
+// =============================================================================
+
+func TestNewEnforcer_NilClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, err := NewEnforcer(context.Background(), CasbinConfig{K8sClient: nil}, logger)
+	require.Error(t, err, "NewEnforcer() with nil K8sClient should return error")
+}
+
+func TestNewEnforcer_WithCache(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ce := setupTestEnforcer(t) // reuse the fake client from the shared helper
+	enforcer, err := NewEnforcer(context.Background(), CasbinConfig{
+		K8sClient:    ce.k8sClient,
+		CacheEnabled: true,
+		CacheTTL:     time.Minute,
+	}, logger)
+	require.NoError(t, err, "NewEnforcer() with cache error")
+	require.True(t, enforcer.enableCache, "NewEnforcer() with CacheEnabled=true should set enableCache=true")
+	require.Equal(t, int(time.Minute), enforcer.cacheTTL, "NewEnforcer() cacheTTL mismatch")
+}
+
+func TestNewEnforcer_WithCacheDefaultTTL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ce := setupTestEnforcer(t)
+	// CacheTTL=0 should use the default (5m)
+	enforcer, err := NewEnforcer(context.Background(), CasbinConfig{
+		K8sClient:    ce.k8sClient,
+		CacheEnabled: true,
+		CacheTTL:     0,
+	}, logger)
+	require.NoError(t, err, "NewEnforcer() with zero TTL error")
+	require.True(t, enforcer.enableCache, "NewEnforcer() with CacheEnabled=true should set enableCache=true")
+	require.Equal(t, int(5*time.Minute), enforcer.cacheTTL, "NewEnforcer() cacheTTL should use 5m default")
+}
+
+func TestCasbinEnforcer_GetEnforcer(t *testing.T) {
+	ce := setupTestEnforcer(t)
+	e := ce.GetEnforcer()
+	require.NotNil(t, e, "GetEnforcer() returned nil")
+}
+
+// =============================================================================
+// pdp.go coverage — validation errors, context cancellation, resource ID in reason
+// =============================================================================
+
+func TestCasbinEnforcer_Evaluate_NilRequest(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	_, err := enforcer.Evaluate(context.Background(), nil)
+	require.Error(t, err, "Evaluate(nil) should return error")
+}
+
+func TestCasbinEnforcer_BatchEvaluate_NilRequest(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	_, err := enforcer.BatchEvaluate(context.Background(), nil)
+	require.Error(t, err, "BatchEvaluate(nil) should return error")
+}
+
+func TestCasbinEnforcer_BatchEvaluate_ContextCancelled(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+
+	// Pre-seed a policy so the first request succeeds
+	syncGroupingPolicies(t, enforcer, [][]string{
+		{"viewer", "component:view", "*"},
+	})
+	syncPolicies(t, enforcer, [][]string{
+		{"groups:devs", "*", "viewer", "*", "allow", "{}", "binding-ctx"},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	req := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{
+			{
+				SubjectContext: &authzcore.SubjectContext{
+					Type:              "user",
+					EntitlementClaim:  "groups",
+					EntitlementValues: []string{"devs"},
+				},
+				Resource: authzcore.Resource{Type: "component"},
+				Action:   "component:view",
+			},
+		},
+	}
+
+	_, err := enforcer.BatchEvaluate(ctx, req)
+	require.Error(t, err, "BatchEvaluate with cancelled context should return error")
+}
+
+func TestCasbinEnforcer_GetSubjectProfile_MissingSubjectContext(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	// Pass a non-nil request with nil SubjectContext; validateProfileRequest will return an error.
+	_, err := enforcer.GetSubjectProfile(context.Background(), &authzcore.ProfileRequest{
+		SubjectContext: nil,
+	})
+	require.Error(t, err, "GetSubjectProfile with nil SubjectContext should return error")
+}
+
+func TestCasbinEnforcer_Check_NilSubjectContext(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	// Call check directly to exercise the nil subjectCtx guard
+	decision, err := enforcer.check(&authzcore.EvaluateRequest{
+		SubjectContext: nil,
+		Resource:       authzcore.Resource{Type: "component"},
+		Action:         "component:view",
+	})
+	require.Error(t, err, "check with nil SubjectContext should return error")
+	require.NotNil(t, decision, "check with nil SubjectContext should return a decision")
+	require.False(t, decision.Decision, "check with nil SubjectContext should return deny decision")
+}
+
+func TestCasbinEnforcer_FilterPolicies_MalformedPolicy(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+
+	subjectCtx := &authzcore.SubjectContext{
+		Type:              "user",
+		EntitlementClaim:  "groups",
+		EntitlementValues: []string{"devs"},
+	}
+
+	// Seed a valid 7-field policy and a malformed 3-field policy via the raw enforcer
+	_, _ = enforcer.enforcer.AddPolicy("groups:devs", "ns/acme", "viewer", "acme", "allow", "{}", "b1")
+	// Add a malformed policy (only 3 fields) — filterPoliciesBySubjectAndScope must skip it
+	_, _ = enforcer.enforcer.AddPolicy("groups:devs", "ns/acme", "bad")
+
+	profile, err := enforcer.GetSubjectProfile(context.Background(), &authzcore.ProfileRequest{
+		SubjectContext: subjectCtx,
+		Scope:          authzcore.ResourceHierarchy{Namespace: "acme"},
+	})
+	// The malformed policy must be skipped silently (logged as warning); no error expected
+	require.NoError(t, err, "GetSubjectProfile with malformed policy returned unexpected error")
+	require.NotNil(t, profile, "GetSubjectProfile returned nil profile")
+	// The malformed tuple has roleName "bad"; since it is skipped, no capability
+	// derived from "bad" should appear — capabilities may be empty or contain only
+	// entries from the valid policy (which itself has no grouping rules seeded here).
+	for action, cap := range profile.Capabilities {
+		for _, allowed := range cap.Allowed {
+			require.NotEqual(t, "bad", allowed.Path, "capability for action %s contains unexpected 'bad' path from malformed policy", action)
+		}
+	}
+}
+
+func TestCasbinEnforcer_Check_WithResourceID(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+
+	// Seed policies: viewer role grants component:view, bound to groups:devs on ns/acme
+	syncGroupingPolicies(t, enforcer, [][]string{
+		{"viewer", "component:view", "*"},
+	})
+	syncPolicies(t, enforcer, [][]string{
+		{"groups:devs", "ns/acme", "viewer", "*", "allow", "{}", "binding-rid"},
+	})
+
+	// Evaluate with a non-empty Resource.ID to exercise the resourceInfo branch
+	decision, err := enforcer.Evaluate(context.Background(), &authzcore.EvaluateRequest{
+		SubjectContext: &authzcore.SubjectContext{
+			Type:              "user",
+			EntitlementClaim:  "groups",
+			EntitlementValues: []string{"devs"},
+		},
+		Resource: authzcore.Resource{
+			Type: "component",
+			ID:   "comp-123", // non-empty ID
+			Hierarchy: authzcore.ResourceHierarchy{
+				Namespace: "acme",
+			},
+		},
+		Action: "component:view",
+	})
+	require.NoError(t, err, "Evaluate() error")
+	require.True(t, decision.Decision, "Evaluate() expected allow, got deny")
+	require.NotNil(t, decision.Context, "Evaluate() expected non-nil context")
+	require.NotEmpty(t, decision.Context.Reason, "Evaluate() expected non-empty reason")
+}
+
+func TestCasbinEnforcer_BatchEvaluate_CheckError(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	req := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{
+			{
+				SubjectContext: &authzcore.SubjectContext{
+					Type:              "user",
+					EntitlementClaim:  "", // empty claim → formatSubject error in check()
+					EntitlementValues: []string{"devs"},
+				},
+				Resource: authzcore.Resource{Type: "component"},
+				Action:   "component:view",
+			},
+		},
+	}
+	_, err := enforcer.BatchEvaluate(context.Background(), req)
+	require.Error(t, err, "BatchEvaluate with empty EntitlementClaim should return error")
+}
+
+func TestCasbinEnforcer_GetSubjectProfile_FormatSubjectError(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+	// Empty EntitlementClaim causes formatSubject to error inside filterPoliciesBySubjectAndScope
+	_, err := enforcer.GetSubjectProfile(context.Background(), &authzcore.ProfileRequest{
+		SubjectContext: &authzcore.SubjectContext{
+			Type:              "user",
+			EntitlementClaim:  "", // empty claim
+			EntitlementValues: []string{"devs"},
+		},
+		Scope: authzcore.ResourceHierarchy{Namespace: "acme"},
+	})
+	require.Error(t, err, "GetSubjectProfile with empty EntitlementClaim should return error")
+}
+
+func TestCasbinEnforcer_GetSubjectProfile_OutOfScopePolicy(t *testing.T) {
+	enforcer := setupTestEnforcer(t)
+
+	// Seed a role and a policy for "ns/other" — unrelated to the queried scope "ns/acme"
+	syncGroupingPolicies(t, enforcer, [][]string{
+		{"viewer", "component:view", "*"},
+	})
+	syncPolicies(t, enforcer, [][]string{
+		// Policy for "ns/other" — completely outside scope "ns/acme"
+		{"groups:devs", "ns/other", "viewer", "*", "allow", "{}", "oos-binding"},
+	})
+
+	result, err := enforcer.GetSubjectProfile(context.Background(), &authzcore.ProfileRequest{
+		SubjectContext: &authzcore.SubjectContext{
+			Type:              "user",
+			EntitlementClaim:  "groups",
+			EntitlementValues: []string{"devs"},
+		},
+		Scope: authzcore.ResourceHierarchy{Namespace: "acme"}, // "ns/acme" — out-of-scope policy is skipped
+	})
+	require.NoError(t, err, "GetSubjectProfile out-of-scope error")
+	require.NotNil(t, result, "GetSubjectProfile returned nil result")
+	// The out-of-scope policy (ns/other) must not appear in capabilities for scope ns/acme
+	require.Empty(t, result.Capabilities, "expected no capabilities for out-of-scope policy")
 }


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2996

This pull request significantly expands test coverage for the Casbin authorization logic, focusing on both the policy decision point (`pdp.go`) and policy administration point (`enforcer.go`). The new tests cover error handling, edge cases, and validation logic, ensuring more robust behavior for policy evaluation, resource/role listing, and input validation.

The most important changes include:

**Expanded test coverage for policy evaluation and error handling:**

* Added tests for `Evaluate`, `BatchEvaluate`, and `GetSubjectProfile` methods to cover nil requests, context cancellation, missing or malformed subject context, malformed policies, and out-of-scope policies. This ensures the system handles invalid input and edge cases gracefully.

* Added tests for the `check` method to verify correct deny decisions and error returns when subject context is missing or malformed.

**Enforcer instantiation and configuration:**

* Added tests for `NewEnforcer` to cover error cases (such as nil Kubernetes client) and cache configuration, including default TTL handling.

**Validation and helper function testing:**

* Added tests for context and resource matching helpers (`ctxMatch`, `resourceMatchWrapper`, `ctxMatchWrapper`) to verify correct match logic and error handling for invalid arguments.

* Added a test for batch evaluation request validation, ensuring that requests with missing actions are correctly rejected.

**Policy administration (role and binding management):**

* Added comprehensive tests for listing cluster and namespaced roles and role bindings, including pagination (`limit` and `cursor`) scenarios and not-found errors for update operations. This improves confidence in the policy administration API.

**Minor improvements:**

* Included additional imports (`io`, `time`) required for new tests.