### PR TITLE
test: add comprehensive unit tests for request and response models

### DIFF
--- a/internal/openchoreo-api/models/request_test.go
+++ b/internal/openchoreo-api/models/request_test.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -754,5 +755,956 @@ func TestPatchReleaseBindingRequest(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// ---- CreateProjectRequest ----
+
+func TestCreateProjectRequest_Sanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *CreateProjectRequest
+		want *CreateProjectRequest
+	}{
+		{
+			name: "No whitespace",
+			req: &CreateProjectRequest{
+				Name:               "my-project",
+				DisplayName:        "My Project",
+				Description:        "A project",
+				DeploymentPipeline: "default",
+			},
+			want: &CreateProjectRequest{
+				Name:               "my-project",
+				DisplayName:        "My Project",
+				Description:        "A project",
+				DeploymentPipeline: "default",
+			},
+		},
+		{
+			name: "All fields have surrounding whitespace",
+			req: &CreateProjectRequest{
+				Name:               "  my-project  ",
+				DisplayName:        "  My Project  ",
+				Description:        "  A project  ",
+				DeploymentPipeline: "  default  ",
+			},
+			want: &CreateProjectRequest{
+				Name:               "my-project",
+				DisplayName:        "My Project",
+				Description:        "A project",
+				DeploymentPipeline: "default",
+			},
+		},
+		{
+			name: "All fields empty",
+			req:  &CreateProjectRequest{},
+			want: &CreateProjectRequest{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.req.Sanitize()
+			if tt.req.Name != tt.want.Name {
+				t.Errorf("Name = %q, want %q", tt.req.Name, tt.want.Name)
+			}
+			if tt.req.DisplayName != tt.want.DisplayName {
+				t.Errorf("DisplayName = %q, want %q", tt.req.DisplayName, tt.want.DisplayName)
+			}
+			if tt.req.Description != tt.want.Description {
+				t.Errorf("Description = %q, want %q", tt.req.Description, tt.want.Description)
+			}
+			if tt.req.DeploymentPipeline != tt.want.DeploymentPipeline {
+				t.Errorf("DeploymentPipeline = %q, want %q", tt.req.DeploymentPipeline, tt.want.DeploymentPipeline)
+			}
+		})
+	}
+}
+
+// TestCreateProjectRequest_Validate documents that Validate is a no-op stub.
+// This test will catch any future logic added without a corresponding test.
+func TestCreateProjectRequest_Validate(t *testing.T) {
+	reqs := []*CreateProjectRequest{
+		{},
+		{Name: "my-project"},
+		{Name: "my-project", DisplayName: "My Project", Description: "desc"},
+	}
+	for _, req := range reqs {
+		if err := req.Validate(); err != nil {
+			t.Errorf("Validate() on %+v returned unexpected error: %v", req, err)
+		}
+	}
+}
+
+// ---- CreateEnvironmentRequest ----
+
+func TestCreateEnvironmentRequest_Sanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *CreateEnvironmentRequest
+		want *CreateEnvironmentRequest
+	}{
+		{
+			name: "No whitespace",
+			req: &CreateEnvironmentRequest{
+				Name:        "dev",
+				DisplayName: "Development",
+				Description: "dev env",
+				DNSPrefix:   "dev",
+			},
+			want: &CreateEnvironmentRequest{
+				Name:        "dev",
+				DisplayName: "Development",
+				Description: "dev env",
+				DNSPrefix:   "dev",
+			},
+		},
+		{
+			name: "All scalar fields trimmed",
+			req: &CreateEnvironmentRequest{
+				Name:        "  dev  ",
+				DisplayName: "  Development  ",
+				Description: "  dev env  ",
+				DNSPrefix:   "  dev  ",
+			},
+			want: &CreateEnvironmentRequest{
+				Name:        "dev",
+				DisplayName: "Development",
+				Description: "dev env",
+				DNSPrefix:   "dev",
+			},
+		},
+		{
+			name: "DataPlaneRef fields trimmed when set",
+			req: &CreateEnvironmentRequest{
+				Name: "dev",
+				DataPlaneRef: &DataPlaneRef{
+					Kind: "  DataPlane  ",
+					Name: "  primary  ",
+				},
+			},
+			want: &CreateEnvironmentRequest{
+				Name: "dev",
+				DataPlaneRef: &DataPlaneRef{
+					Kind: "DataPlane",
+					Name: "primary",
+				},
+			},
+		},
+		{
+			name: "Nil DataPlaneRef is safe",
+			req: &CreateEnvironmentRequest{
+				Name:         "  dev  ",
+				DataPlaneRef: nil,
+			},
+			want: &CreateEnvironmentRequest{
+				Name:         "dev",
+				DataPlaneRef: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.req.Sanitize()
+			if tt.req.Name != tt.want.Name {
+				t.Errorf("Name = %q, want %q", tt.req.Name, tt.want.Name)
+			}
+			if tt.req.DisplayName != tt.want.DisplayName {
+				t.Errorf("DisplayName = %q, want %q", tt.req.DisplayName, tt.want.DisplayName)
+			}
+			if tt.req.Description != tt.want.Description {
+				t.Errorf("Description = %q, want %q", tt.req.Description, tt.want.Description)
+			}
+			if tt.req.DNSPrefix != tt.want.DNSPrefix {
+				t.Errorf("DNSPrefix = %q, want %q", tt.req.DNSPrefix, tt.want.DNSPrefix)
+			}
+			if tt.want.DataPlaneRef == nil {
+				if tt.req.DataPlaneRef != nil {
+					t.Errorf("DataPlaneRef = %v, want nil", tt.req.DataPlaneRef)
+				}
+			} else {
+				if tt.req.DataPlaneRef == nil {
+					t.Fatal("DataPlaneRef is nil, want non-nil")
+				}
+				if tt.req.DataPlaneRef.Kind != tt.want.DataPlaneRef.Kind {
+					t.Errorf("DataPlaneRef.Kind = %q, want %q", tt.req.DataPlaneRef.Kind, tt.want.DataPlaneRef.Kind)
+				}
+				if tt.req.DataPlaneRef.Name != tt.want.DataPlaneRef.Name {
+					t.Errorf("DataPlaneRef.Name = %q, want %q", tt.req.DataPlaneRef.Name, tt.want.DataPlaneRef.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateEnvironmentRequest_Validate documents that Validate is a no-op stub.
+func TestCreateEnvironmentRequest_Validate(t *testing.T) {
+	reqs := []*CreateEnvironmentRequest{
+		{},
+		{Name: "dev"},
+		{Name: "prod", IsProduction: true, DataPlaneRef: &DataPlaneRef{Kind: "DataPlane", Name: "primary"}},
+	}
+	for _, req := range reqs {
+		if err := req.Validate(); err != nil {
+			t.Errorf("Validate() on %+v returned unexpected error: %v", req, err)
+		}
+	}
+}
+
+// ---- CreateDataPlaneRequest ----
+
+func TestCreateDataPlaneRequest_Sanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *CreateDataPlaneRequest
+		want *CreateDataPlaneRequest
+	}{
+		{
+			name: "No whitespace",
+			req: &CreateDataPlaneRequest{
+				Name:                 "primary",
+				DisplayName:          "Primary",
+				Description:          "main plane",
+				ClusterAgentClientCA: "cert-data",
+			},
+			want: &CreateDataPlaneRequest{
+				Name:                 "primary",
+				DisplayName:          "Primary",
+				Description:          "main plane",
+				ClusterAgentClientCA: "cert-data",
+			},
+		},
+		{
+			name: "All scalar fields trimmed",
+			req: &CreateDataPlaneRequest{
+				Name:                 "  primary  ",
+				DisplayName:          "  Primary  ",
+				Description:          "  main plane  ",
+				ClusterAgentClientCA: "  cert-data  ",
+			},
+			want: &CreateDataPlaneRequest{
+				Name:                 "primary",
+				DisplayName:          "Primary",
+				Description:          "main plane",
+				ClusterAgentClientCA: "cert-data",
+			},
+		},
+		{
+			name: "ObservabilityPlaneRef fields trimmed when set",
+			req: &CreateDataPlaneRequest{
+				Name: "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{
+					Kind: "  ObservabilityPlane  ",
+					Name: "  obs-plane  ",
+				},
+			},
+			want: &CreateDataPlaneRequest{
+				Name: "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{
+					Kind: "ObservabilityPlane",
+					Name: "obs-plane",
+				},
+			},
+		},
+		{
+			name: "Nil ObservabilityPlaneRef is safe",
+			req: &CreateDataPlaneRequest{
+				Name:                  "  primary  ",
+				ObservabilityPlaneRef: nil,
+			},
+			want: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.req.Sanitize()
+			if tt.req.Name != tt.want.Name {
+				t.Errorf("Name = %q, want %q", tt.req.Name, tt.want.Name)
+			}
+			if tt.req.DisplayName != tt.want.DisplayName {
+				t.Errorf("DisplayName = %q, want %q", tt.req.DisplayName, tt.want.DisplayName)
+			}
+			if tt.req.Description != tt.want.Description {
+				t.Errorf("Description = %q, want %q", tt.req.Description, tt.want.Description)
+			}
+			if tt.req.ClusterAgentClientCA != tt.want.ClusterAgentClientCA {
+				t.Errorf("ClusterAgentClientCA = %q, want %q", tt.req.ClusterAgentClientCA, tt.want.ClusterAgentClientCA)
+			}
+			if tt.want.ObservabilityPlaneRef == nil {
+				if tt.req.ObservabilityPlaneRef != nil {
+					t.Errorf("ObservabilityPlaneRef = %v, want nil", tt.req.ObservabilityPlaneRef)
+				}
+			} else {
+				if tt.req.ObservabilityPlaneRef == nil {
+					t.Fatal("ObservabilityPlaneRef is nil, want non-nil")
+				}
+				if tt.req.ObservabilityPlaneRef.Kind != tt.want.ObservabilityPlaneRef.Kind {
+					t.Errorf("ObservabilityPlaneRef.Kind = %q, want %q",
+						tt.req.ObservabilityPlaneRef.Kind, tt.want.ObservabilityPlaneRef.Kind)
+				}
+				if tt.req.ObservabilityPlaneRef.Name != tt.want.ObservabilityPlaneRef.Name {
+					t.Errorf("ObservabilityPlaneRef.Name = %q, want %q",
+						tt.req.ObservabilityPlaneRef.Name, tt.want.ObservabilityPlaneRef.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateDataPlaneRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *CreateDataPlaneRequest
+		wantErr   bool
+		errMsg    string // exact match; empty means skip exact check
+		errPrefix string // prefix match for library-generated messages
+	}{
+		{
+			name:    "No ObservabilityPlaneRef - valid",
+			req:     &CreateDataPlaneRequest{Name: "primary", ClusterAgentClientCA: "cert"},
+			wantErr: false,
+		},
+		{
+			name: "ObservabilityPlaneRef with empty kind",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "", Name: "obs-plane"},
+			},
+			wantErr: true,
+			errMsg:  "observabilityPlaneRef.kind is required when observabilityPlaneRef is provided",
+		},
+		{
+			name: "ObservabilityPlaneRef with invalid kind",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "InvalidKind", Name: "obs-plane"},
+			},
+			wantErr: true,
+			errMsg: "observabilityPlaneRef.kind must be 'ObservabilityPlane' or 'ClusterObservabilityPlane'" +
+				", got 'InvalidKind'",
+		},
+		{
+			name: "ObservabilityPlaneRef with valid kind ObservabilityPlane and empty name",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "ObservabilityPlane", Name: ""},
+			},
+			wantErr: true,
+			errMsg:  "observabilityPlaneRef.name is required when observabilityPlaneRef is provided",
+		},
+		{
+			name: "ObservabilityPlaneRef with whitespace-only name",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "ObservabilityPlane", Name: "   "},
+			},
+			wantErr: true,
+			errMsg:  "observabilityPlaneRef.name is required when observabilityPlaneRef is provided",
+		},
+		{
+			name: "ObservabilityPlaneRef name fails DNS-1123 validation",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "ObservabilityPlane", Name: "UPPERCASE"},
+			},
+			wantErr:   true,
+			errPrefix: "observabilityPlaneRef.name must be a valid DNS-1123 label",
+		},
+		{
+			name: "ObservabilityPlaneRef with kind ObservabilityPlane and valid name",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "ObservabilityPlane", Name: "obs-plane"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ObservabilityPlaneRef with kind ClusterObservabilityPlane and valid name",
+			req: &CreateDataPlaneRequest{
+				Name:                  "primary",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{Kind: "ClusterObservabilityPlane", Name: "cluster-obs"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Validate() expected error but got none")
+					return
+				}
+				if tt.errMsg != "" && err.Error() != tt.errMsg {
+					t.Errorf("Validate() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+				if tt.errPrefix != "" && !strings.HasPrefix(err.Error(), tt.errPrefix) {
+					t.Errorf("Validate() error = %v, want prefix %v", err.Error(), tt.errPrefix)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ---- CreateClusterDataPlaneRequest ----
+
+func TestCreateClusterDataPlaneRequest_Sanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *CreateClusterDataPlaneRequest
+		want *CreateClusterDataPlaneRequest
+	}{
+		{
+			name: "No whitespace",
+			req: &CreateClusterDataPlaneRequest{
+				Name:                 "my-cdp",
+				DisplayName:          "My CDP",
+				Description:          "cluster plane",
+				PlaneID:              "plane-01",
+				ClusterAgentClientCA: "cert-data",
+			},
+			want: &CreateClusterDataPlaneRequest{
+				Name:                 "my-cdp",
+				DisplayName:          "My CDP",
+				Description:          "cluster plane",
+				PlaneID:              "plane-01",
+				ClusterAgentClientCA: "cert-data",
+			},
+		},
+		{
+			name: "All scalar fields trimmed",
+			req: &CreateClusterDataPlaneRequest{
+				Name:                 "  my-cdp  ",
+				DisplayName:          "  My CDP  ",
+				Description:          "  cluster plane  ",
+				PlaneID:              "  plane-01  ",
+				ClusterAgentClientCA: "  cert-data  ",
+			},
+			want: &CreateClusterDataPlaneRequest{
+				Name:                 "my-cdp",
+				DisplayName:          "My CDP",
+				Description:          "cluster plane",
+				PlaneID:              "plane-01",
+				ClusterAgentClientCA: "cert-data",
+			},
+		},
+		{
+			name: "ObservabilityPlaneRef trimmed when set",
+			req: &CreateClusterDataPlaneRequest{
+				Name:    "my-cdp",
+				PlaneID: "plane-01",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{
+					Kind: "  ClusterObservabilityPlane  ",
+					Name: "  obs-cluster  ",
+				},
+			},
+			want: &CreateClusterDataPlaneRequest{
+				Name:    "my-cdp",
+				PlaneID: "plane-01",
+				ObservabilityPlaneRef: &ObservabilityPlaneRef{
+					Kind: "ClusterObservabilityPlane",
+					Name: "obs-cluster",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.req.Sanitize()
+			if tt.req.Name != tt.want.Name {
+				t.Errorf("Name = %q, want %q", tt.req.Name, tt.want.Name)
+			}
+			if tt.req.DisplayName != tt.want.DisplayName {
+				t.Errorf("DisplayName = %q, want %q", tt.req.DisplayName, tt.want.DisplayName)
+			}
+			if tt.req.Description != tt.want.Description {
+				t.Errorf("Description = %q, want %q", tt.req.Description, tt.want.Description)
+			}
+			if tt.req.PlaneID != tt.want.PlaneID {
+				t.Errorf("PlaneID = %q, want %q", tt.req.PlaneID, tt.want.PlaneID)
+			}
+			if tt.req.ClusterAgentClientCA != tt.want.ClusterAgentClientCA {
+				t.Errorf("ClusterAgentClientCA = %q, want %q", tt.req.ClusterAgentClientCA, tt.want.ClusterAgentClientCA)
+			}
+			if tt.want.ObservabilityPlaneRef != nil {
+				if tt.req.ObservabilityPlaneRef == nil {
+					t.Fatal("ObservabilityPlaneRef is nil, want non-nil")
+				}
+				if tt.req.ObservabilityPlaneRef.Kind != tt.want.ObservabilityPlaneRef.Kind {
+					t.Errorf("ObservabilityPlaneRef.Kind = %q, want %q",
+						tt.req.ObservabilityPlaneRef.Kind, tt.want.ObservabilityPlaneRef.Kind)
+				}
+				if tt.req.ObservabilityPlaneRef.Name != tt.want.ObservabilityPlaneRef.Name {
+					t.Errorf("ObservabilityPlaneRef.Name = %q, want %q",
+						tt.req.ObservabilityPlaneRef.Name, tt.want.ObservabilityPlaneRef.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateClusterDataPlaneRequest_Validate(t *testing.T) {
+	validReq := func() *CreateClusterDataPlaneRequest {
+		return &CreateClusterDataPlaneRequest{
+			Name:                 "my-cdp",
+			PlaneID:              "plane-01",
+			ClusterAgentClientCA: "cert-data",
+		}
+	}
+
+	tests := []struct {
+		name      string
+		req       *CreateClusterDataPlaneRequest
+		wantErr   bool
+		errMsg    string // exact match when library output is deterministic
+		errPrefix string // prefix match for DNS-1123 library messages
+	}{
+		{
+			name:    "Valid request - no observability ref",
+			req:     validReq(),
+			wantErr: false,
+		},
+		{
+			name:    "Empty name",
+			req:     &CreateClusterDataPlaneRequest{PlaneID: "p1", ClusterAgentClientCA: "cert"},
+			wantErr: true,
+			errMsg:  "name is required",
+		},
+		{
+			name:    "Whitespace-only name",
+			req:     &CreateClusterDataPlaneRequest{Name: "   ", PlaneID: "p1", ClusterAgentClientCA: "cert"},
+			wantErr: true,
+			errMsg:  "name is required",
+		},
+		{
+			name:      "Name fails DNS-1123 validation",
+			req:       &CreateClusterDataPlaneRequest{Name: "UPPERCASE", PlaneID: "p1", ClusterAgentClientCA: "cert"},
+			wantErr:   true,
+			errPrefix: "name must be a valid DNS-1123 label",
+		},
+		{
+			name:    "Empty planeID",
+			req:     &CreateClusterDataPlaneRequest{Name: "my-cdp", ClusterAgentClientCA: "cert"},
+			wantErr: true,
+			errMsg:  "planeID is required",
+		},
+		{
+			name:    "Whitespace-only planeID",
+			req:     &CreateClusterDataPlaneRequest{Name: "my-cdp", PlaneID: "   ", ClusterAgentClientCA: "cert"},
+			wantErr: true,
+			errMsg:  "planeID is required",
+		},
+		{
+			name:      "PlaneID fails DNS-1123 validation",
+			req:       &CreateClusterDataPlaneRequest{Name: "my-cdp", PlaneID: "INVALID_ID", ClusterAgentClientCA: "cert"},
+			wantErr:   true,
+			errPrefix: "planeID must be a valid DNS-1123 label",
+		},
+		{
+			name:    "Empty clusterAgentClientCA",
+			req:     &CreateClusterDataPlaneRequest{Name: "my-cdp", PlaneID: "p1"},
+			wantErr: true,
+			errMsg:  "clusterAgentClientCA is required",
+		},
+		{
+			name:    "Whitespace-only clusterAgentClientCA",
+			req:     &CreateClusterDataPlaneRequest{Name: "my-cdp", PlaneID: "p1", ClusterAgentClientCA: "  "},
+			wantErr: true,
+			errMsg:  "clusterAgentClientCA is required",
+		},
+		{
+			name: "ObservabilityPlaneRef with empty kind",
+			req: func() *CreateClusterDataPlaneRequest {
+				r := validReq()
+				r.ObservabilityPlaneRef = &ObservabilityPlaneRef{Kind: "", Name: "obs"}
+				return r
+			}(),
+			wantErr: true,
+			errMsg:  "observabilityPlaneRef.kind is required when observabilityPlaneRef is provided",
+		},
+		{
+			// cluster-scoped resources must use ClusterObservabilityPlane, not ObservabilityPlane
+			name: "ObservabilityPlaneRef with namespace-scoped kind is rejected",
+			req: func() *CreateClusterDataPlaneRequest {
+				r := validReq()
+				r.ObservabilityPlaneRef = &ObservabilityPlaneRef{Kind: "ObservabilityPlane", Name: "obs"}
+				return r
+			}(),
+			wantErr: true,
+			errMsg: "observabilityPlaneRef.kind must be 'ClusterObservabilityPlane' for cluster-scoped resources" +
+				", got 'ObservabilityPlane'",
+		},
+		{
+			name: "ObservabilityPlaneRef with empty name",
+			req: func() *CreateClusterDataPlaneRequest {
+				r := validReq()
+				r.ObservabilityPlaneRef = &ObservabilityPlaneRef{Kind: "ClusterObservabilityPlane", Name: ""}
+				return r
+			}(),
+			wantErr: true,
+			errMsg:  "observabilityPlaneRef.name is required when observabilityPlaneRef is provided",
+		},
+		{
+			name: "ObservabilityPlaneRef name fails DNS-1123 validation",
+			req: func() *CreateClusterDataPlaneRequest {
+				r := validReq()
+				r.ObservabilityPlaneRef = &ObservabilityPlaneRef{Kind: "ClusterObservabilityPlane", Name: "INVALID"}
+				return r
+			}(),
+			wantErr:   true,
+			errPrefix: "observabilityPlaneRef.name must be a valid DNS-1123 label",
+		},
+		{
+			name: "Valid request with ClusterObservabilityPlane ref",
+			req: func() *CreateClusterDataPlaneRequest {
+				r := validReq()
+				r.ObservabilityPlaneRef = &ObservabilityPlaneRef{Kind: "ClusterObservabilityPlane", Name: "obs-cluster"}
+				return r
+			}(),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Validate() expected error but got none")
+					return
+				}
+				if tt.errMsg != "" && err.Error() != tt.errMsg {
+					t.Errorf("Validate() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+				if tt.errPrefix != "" && !strings.HasPrefix(err.Error(), tt.errPrefix) {
+					t.Errorf("Validate() error = %v, want prefix %v", err.Error(), tt.errPrefix)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ---- CreateGitSecretRequest ----
+
+func TestCreateGitSecretRequest_Sanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *CreateGitSecretRequest
+		want *CreateGitSecretRequest
+	}{
+		{
+			name: "No whitespace",
+			req: &CreateGitSecretRequest{
+				SecretName: "my-secret",
+				SecretType: "basic-auth",
+				Username:   "user",
+				Token:      "ghp_token",
+			},
+			want: &CreateGitSecretRequest{
+				SecretName: "my-secret",
+				SecretType: "basic-auth",
+				Username:   "user",
+				Token:      "ghp_token",
+			},
+		},
+		{
+			name: "All fields trimmed",
+			req: &CreateGitSecretRequest{
+				SecretName: "  my-secret  ",
+				SecretType: "  ssh-auth  ",
+				Username:   "  user  ",
+				Token:      "  token  ",
+				SSHKey:     "  -----BEGIN...  ",
+				SSHKEYID:   "  APKA...  ",
+			},
+			want: &CreateGitSecretRequest{
+				SecretName: "my-secret",
+				SecretType: "ssh-auth",
+				Username:   "user",
+				Token:      "token",
+				SSHKey:     "-----BEGIN...",
+				SSHKEYID:   "APKA...",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.req.Sanitize()
+			if tt.req.SecretName != tt.want.SecretName {
+				t.Errorf("SecretName = %q, want %q", tt.req.SecretName, tt.want.SecretName)
+			}
+			if tt.req.SecretType != tt.want.SecretType {
+				t.Errorf("SecretType = %q, want %q", tt.req.SecretType, tt.want.SecretType)
+			}
+			if tt.req.Username != tt.want.Username {
+				t.Errorf("Username = %q, want %q", tt.req.Username, tt.want.Username)
+			}
+			if tt.req.Token != tt.want.Token {
+				t.Errorf("Token = %q, want %q", tt.req.Token, tt.want.Token)
+			}
+			if tt.req.SSHKey != tt.want.SSHKey {
+				t.Errorf("SSHKey = %q, want %q", tt.req.SSHKey, tt.want.SSHKey)
+			}
+			if tt.req.SSHKEYID != tt.want.SSHKEYID {
+				t.Errorf("SSHKEYID = %q, want %q", tt.req.SSHKEYID, tt.want.SSHKEYID)
+			}
+		})
+	}
+}
+
+func TestCreateGitSecretRequest_Validate(t *testing.T) {
+	// secretName of exactly 253 characters (at the boundary — must pass).
+	longValidName := strings.Repeat("a", 253)
+	// secretName of 254 characters (one over — must fail).
+	tooLongName := strings.Repeat("a", 254)
+
+	tests := []struct {
+		name    string
+		req     *CreateGitSecretRequest
+		wantErr bool
+		errMsg  string
+	}{
+		// secretName validation
+		{
+			name:    "Empty secretName",
+			req:     &CreateGitSecretRequest{SecretType: "basic-auth"},
+			wantErr: true,
+			errMsg:  "secretName is required",
+		},
+		{
+			name:    "Whitespace-only secretName",
+			req:     &CreateGitSecretRequest{SecretName: "   ", SecretType: "basic-auth"},
+			wantErr: true,
+			errMsg:  "secretName is required",
+		},
+		{
+			name:    "secretName exactly 253 characters passes length check",
+			req:     &CreateGitSecretRequest{SecretName: longValidName, SecretType: "basic-auth", Token: "tok"},
+			wantErr: false,
+		},
+		{
+			name:    "secretName 254 characters exceeds limit",
+			req:     &CreateGitSecretRequest{SecretName: tooLongName, SecretType: "basic-auth"},
+			wantErr: true,
+			errMsg:  "secretName must be at most 253 characters",
+		},
+		// secretType validation
+		{
+			name:    "Empty secretType",
+			req:     &CreateGitSecretRequest{SecretName: "my-secret"},
+			wantErr: true,
+			errMsg:  "secretType must be 'basic-auth' or 'ssh-auth'",
+		},
+		{
+			name:    "Unknown secretType",
+			req:     &CreateGitSecretRequest{SecretName: "my-secret", SecretType: "oauth"},
+			wantErr: true,
+			errMsg:  "secretType must be 'basic-auth' or 'ssh-auth'",
+		},
+		// basic-auth cases
+		{
+			name:    "basic-auth without token",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "basic-auth"},
+			wantErr: true,
+			errMsg:  "token is required for basic-auth type",
+		},
+		{
+			name:    "basic-auth with whitespace-only token",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "basic-auth", Token: "   "},
+			wantErr: true,
+			errMsg:  "token is required for basic-auth type",
+		},
+		{
+			name:    "basic-auth with token and sshKey set (mutually exclusive)",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "basic-auth", Token: "tok", SSHKey: "key"},
+			wantErr: true,
+			errMsg:  "sshKey must not be provided for basic-auth type",
+		},
+		{
+			name: "basic-auth with token and sshKeyId set (mutually exclusive)",
+			req: &CreateGitSecretRequest{
+				SecretName: "s", SecretType: "basic-auth", Token: "tok", SSHKEYID: "APKA123",
+			},
+			wantErr: true,
+			errMsg:  "sshKeyId must not be provided for basic-auth type",
+		},
+		{
+			name:    "basic-auth with token only (no username) is valid",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "basic-auth", Token: "ghp_tok"},
+			wantErr: false,
+		},
+		{
+			name: "basic-auth with username and token is valid",
+			req: &CreateGitSecretRequest{
+				SecretName: "s", SecretType: "basic-auth", Username: "alice", Token: "ghp_tok",
+			},
+			wantErr: false,
+		},
+		// ssh-auth cases
+		{
+			name:    "ssh-auth without sshKey",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "ssh-auth"},
+			wantErr: true,
+			errMsg:  "sshKey is required for ssh-auth type",
+		},
+		{
+			name:    "ssh-auth with whitespace-only sshKey",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "ssh-auth", SSHKey: "   "},
+			wantErr: true,
+			errMsg:  "sshKey is required for ssh-auth type",
+		},
+		{
+			name: "ssh-auth with sshKey and token set (mutually exclusive)",
+			req: &CreateGitSecretRequest{
+				SecretName: "s", SecretType: "ssh-auth", SSHKey: "key", Token: "tok",
+			},
+			wantErr: true,
+			errMsg:  "token must not be provided for ssh-auth type",
+		},
+		{
+			name: "ssh-auth with sshKey and username set (mutually exclusive)",
+			req: &CreateGitSecretRequest{
+				SecretName: "s", SecretType: "ssh-auth", SSHKey: "key", Username: "user",
+			},
+			wantErr: true,
+			errMsg:  "username must not be provided for ssh-auth type",
+		},
+		{
+			name:    "ssh-auth with sshKey only is valid",
+			req:     &CreateGitSecretRequest{SecretName: "s", SecretType: "ssh-auth", SSHKey: "-----BEGIN..."},
+			wantErr: false,
+		},
+		{
+			name: "ssh-auth with sshKey and sshKeyId is valid (AWS CodeCommit)",
+			req: &CreateGitSecretRequest{
+				SecretName: "s", SecretType: "ssh-auth", SSHKey: "-----BEGIN...", SSHKEYID: "APKA123",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Validate() expected error but got none")
+					return
+				}
+				if err.Error() != tt.errMsg {
+					t.Errorf("Validate() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ---- CreateWorkflowRunRequest ----
+
+func TestCreateWorkflowRunRequest_Sanitize(t *testing.T) {
+	tests := []struct {
+		name         string
+		workflowName string
+		want         string
+	}{
+		{name: "No whitespace", workflowName: "my-workflow", want: "my-workflow"},
+		{name: "Leading whitespace", workflowName: "  my-workflow", want: "my-workflow"},
+		{name: "Trailing whitespace", workflowName: "my-workflow  ", want: "my-workflow"},
+		{name: "Both sides", workflowName: "  my-workflow  ", want: "my-workflow"},
+		{name: "Empty string", workflowName: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &CreateWorkflowRunRequest{WorkflowName: tt.workflowName}
+			req.Sanitize()
+			if req.WorkflowName != tt.want {
+				t.Errorf("WorkflowName = %q, want %q", req.WorkflowName, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateWorkflowRunRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name         string
+		workflowName string
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "Valid workflowName",
+			workflowName: "build-and-push",
+			wantErr:      false,
+		},
+		{
+			name:         "Empty workflowName",
+			workflowName: "",
+			wantErr:      true,
+			errMsg:       "workflowName is required",
+		},
+		{
+			name:         "Whitespace-only workflowName",
+			workflowName: "   ",
+			wantErr:      true,
+			errMsg:       "workflowName is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &CreateWorkflowRunRequest{WorkflowName: tt.workflowName}
+			err := req.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Validate() expected error but got none")
+					return
+				}
+				if err.Error() != tt.errMsg {
+					t.Errorf("Validate() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ---- PromoteComponentRequest ----
+
+// TestPromoteComponentRequest_Validate documents that Validate is a no-op stub.
+func TestPromoteComponentRequest_Validate(t *testing.T) {
+	reqs := []*PromoteComponentRequest{
+		{},
+		{SourceEnvironment: "dev", TargetEnvironment: "staging"},
+		{SourceEnvironment: "staging", TargetEnvironment: "prod"},
+	}
+	for _, req := range reqs {
+		if err := req.Validate(); err != nil {
+			t.Errorf("Validate() on %+v returned unexpected error: %v", req, err)
+		}
 	}
 }

--- a/internal/openchoreo-api/models/response_test.go
+++ b/internal/openchoreo-api/models/response_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+import (
+	"testing"
+)
+
+// ---- SuccessResponse ----
+
+func TestSuccessResponse(t *testing.T) {
+	t.Run("String data", func(t *testing.T) {
+		resp := SuccessResponse("hello")
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if resp.Data != "hello" {
+			t.Errorf("Data = %v, want %v", resp.Data, "hello")
+		}
+		if resp.Error != "" {
+			t.Errorf("Error = %q, want empty", resp.Error)
+		}
+		if resp.Code != "" {
+			t.Errorf("Code = %q, want empty", resp.Code)
+		}
+	})
+
+	t.Run("Struct data", func(t *testing.T) {
+		data := ProjectResponse{Name: "my-proj", UID: "uid-1"}
+		resp := SuccessResponse(data)
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if resp.Data.Name != "my-proj" {
+			t.Errorf("Data.Name = %q, want %q", resp.Data.Name, "my-proj")
+		}
+		if resp.Data.UID != "uid-1" {
+			t.Errorf("Data.UID = %q, want %q", resp.Data.UID, "uid-1")
+		}
+	})
+
+	t.Run("Integer data", func(t *testing.T) {
+		resp := SuccessResponse(42)
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if resp.Data != 42 {
+			t.Errorf("Data = %v, want 42", resp.Data)
+		}
+	})
+
+	t.Run("Nil pointer data", func(t *testing.T) {
+		var p *ProjectResponse
+		resp := SuccessResponse(p)
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if resp.Data != nil {
+			t.Errorf("Data = %v, want nil", resp.Data)
+		}
+	})
+}
+
+// ---- ListSuccessResponse ----
+
+func TestListSuccessResponse(t *testing.T) {
+	t.Run("Non-empty list with pagination", func(t *testing.T) {
+		items := []string{"a", "b", "c"}
+		resp := ListSuccessResponse(items, 10, 2, 3)
+
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if len(resp.Data.Items) != 3 {
+			t.Errorf("len(Items) = %d, want 3", len(resp.Data.Items))
+		}
+		if resp.Data.TotalCount != 10 {
+			t.Errorf("TotalCount = %d, want 10", resp.Data.TotalCount)
+		}
+		if resp.Data.Page != 2 {
+			t.Errorf("Page = %d, want 2", resp.Data.Page)
+		}
+		if resp.Data.PageSize != 3 {
+			t.Errorf("PageSize = %d, want 3", resp.Data.PageSize)
+		}
+		if resp.Error != "" {
+			t.Errorf("Error = %q, want empty", resp.Error)
+		}
+	})
+
+	t.Run("Empty list returns empty items not nil", func(t *testing.T) {
+		resp := ListSuccessResponse([]int{}, 0, 1, 20)
+
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if resp.Data.Items == nil {
+			t.Errorf("Items is nil, want empty slice")
+		}
+		if len(resp.Data.Items) != 0 {
+			t.Errorf("len(Items) = %d, want 0", len(resp.Data.Items))
+		}
+		if resp.Data.TotalCount != 0 {
+			t.Errorf("TotalCount = %d, want 0", resp.Data.TotalCount)
+		}
+	})
+
+	t.Run("Struct slice preserves element values", func(t *testing.T) {
+		items := []NamespaceResponse{
+			{Name: "ns-a"},
+			{Name: "ns-b"},
+		}
+		resp := ListSuccessResponse(items, 2, 1, 10)
+
+		if resp.Data.Items[0].Name != "ns-a" {
+			t.Errorf("Items[0].Name = %q, want %q", resp.Data.Items[0].Name, "ns-a")
+		}
+		if resp.Data.Items[1].Name != "ns-b" {
+			t.Errorf("Items[1].Name = %q, want %q", resp.Data.Items[1].Name, "ns-b")
+		}
+	})
+}
+
+// ---- CursorListSuccessResponse ----
+
+func TestCursorListSuccessResponse(t *testing.T) {
+	t.Run("With next cursor and remaining count", func(t *testing.T) {
+		items := []string{"x", "y"}
+		remaining := int64(5)
+		resp := CursorListSuccessResponse(items, "cursor-abc", &remaining)
+
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if len(resp.Data.Items) != 2 {
+			t.Errorf("len(Items) = %d, want 2", len(resp.Data.Items))
+		}
+		if resp.Data.Pagination.NextCursor != "cursor-abc" {
+			t.Errorf("NextCursor = %q, want %q", resp.Data.Pagination.NextCursor, "cursor-abc")
+		}
+		if resp.Data.Pagination.RemainingCount == nil {
+			t.Fatalf("RemainingCount is nil, want non-nil")
+		}
+		if *resp.Data.Pagination.RemainingCount != 5 {
+			t.Errorf("RemainingCount = %d, want 5", *resp.Data.Pagination.RemainingCount)
+		}
+	})
+
+	t.Run("Last page: empty cursor and nil remaining count", func(t *testing.T) {
+		items := []string{"z"}
+		resp := CursorListSuccessResponse(items, "", nil)
+
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if resp.Data.Pagination.NextCursor != "" {
+			t.Errorf("NextCursor = %q, want empty (last page)", resp.Data.Pagination.NextCursor)
+		}
+		if resp.Data.Pagination.RemainingCount != nil {
+			t.Errorf("RemainingCount = %v, want nil (last page)", resp.Data.Pagination.RemainingCount)
+		}
+	})
+
+	t.Run("Empty items with cursor", func(t *testing.T) {
+		resp := CursorListSuccessResponse([]string{}, "next-page", nil)
+
+		if !resp.Success {
+			t.Errorf("Success = false, want true")
+		}
+		if len(resp.Data.Items) != 0 {
+			t.Errorf("len(Items) = %d, want 0", len(resp.Data.Items))
+		}
+	})
+}
+
+// ---- ErrorResponse ----
+
+func TestErrorResponse(t *testing.T) {
+	t.Run("Error with message and code", func(t *testing.T) {
+		resp := ErrorResponse("resource not found", "NOT_FOUND")
+
+		if resp.Success {
+			t.Errorf("Success = true, want false")
+		}
+		if resp.Error != "resource not found" {
+			t.Errorf("Error = %q, want %q", resp.Error, "resource not found")
+		}
+		if resp.Code != "NOT_FOUND" {
+			t.Errorf("Code = %q, want %q", resp.Code, "NOT_FOUND")
+		}
+	})
+
+	t.Run("Error with empty code", func(t *testing.T) {
+		resp := ErrorResponse("something went wrong", "")
+
+		if resp.Success {
+			t.Errorf("Success = true, want false")
+		}
+		if resp.Error != "something went wrong" {
+			t.Errorf("Error = %q, want %q", resp.Error, "something went wrong")
+		}
+		if resp.Code != "" {
+			t.Errorf("Code = %q, want empty", resp.Code)
+		}
+	})
+
+	t.Run("Empty message and code", func(t *testing.T) {
+		resp := ErrorResponse("", "")
+
+		if resp.Success {
+			t.Errorf("Success = true, want false")
+		}
+		if resp.Error != "" {
+			t.Errorf("Error = %q, want empty", resp.Error)
+		}
+	})
+
+	t.Run("Data field is zero value on error", func(t *testing.T) {
+		resp := ErrorResponse("bad request", "INVALID")
+		if resp.Data != nil {
+			t.Errorf("Data = %v, want nil for error response", resp.Data)
+		}
+	})
+}
+
+// ---- BindingStatusType constants ----
+
+// TestBindingStatusTypeConstants verifies that the string values of BindingStatusType
+// constants match the documented API contract. A change here would be a breaking API change.
+func TestBindingStatusTypeConstants(t *testing.T) {
+	cases := []struct {
+		constant BindingStatusType
+		want     string
+	}{
+		{BindingStatusTypeInProgress, "InProgress"},
+		{BindingStatusTypeReady, "Active"},
+		{BindingStatusTypeFailed, "Failed"},
+		{BindingStatusTypeSuspended, "Suspended"},
+		{BindingStatusTypeUndeployed, "NotYetDeployed"},
+	}
+
+	for _, c := range cases {
+		if string(c.constant) != c.want {
+			t.Errorf("constant value = %q, want %q", string(c.constant), c.want)
+		}
+	}
+}
+
+// ---- BindingReleaseState constants ----
+
+// TestReleaseStateConstants verifies the string values of BindingReleaseState constants.
+func TestReleaseStateConstants(t *testing.T) {
+	cases := []struct {
+		constant BindingReleaseState
+		want     string
+	}{
+		{ReleaseStateActive, "Active"},
+		{ReleaseStateUndeploy, "Undeploy"},
+	}
+
+	for _, c := range cases {
+		if string(c.constant) != c.want {
+			t.Errorf("constant value = %q, want %q", string(c.constant), c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Purpose
- Adds unit tests for the internal/openchoreo-api/models package, covering all previously untested request types and all response helper functions.

 ### Request tests (`request_test.go`)

  | Type | What's tested |                                                                                                                       
  |---|---|
  | `CreateProjectRequest` | `Sanitize` (all fields), `Validate` no-op guard |                                                                   
  | `CreateEnvironmentRequest` | `Sanitize` (incl. nil `DataPlaneRef`), `Validate` no-op guard |
  | `CreateDataPlaneRequest` | `Sanitize`, `Validate` — nil ref, empty/invalid/valid `ObservabilityPlaneRef` kinds, DNS-1123 label validation |  
  | `CreateClusterDataPlaneRequest` | `Sanitize`, `Validate` — required-field checks, DNS-1123 on `name` and `planeID`, rejection of namespace-scoped kind, full valid path with/without observability ref |                                                                        
  | `CreateGitSecretRequest` | `Sanitize`, `Validate` — `secretName` length boundary (253 vs 254), both auth types, all mutually-exclusive field combinations, whitespace-only inputs |                                                                                                         
  | `CreateWorkflowRunRequest` | `Sanitize`, `Validate` — empty/whitespace/valid `workflowName` |
  | `PromoteComponentRequest` | `Validate` no-op guard |                                                                                         
                                                            
  ### Response tests (`response_test.go`, new file)                                                                                              
                                                            
  - `SuccessResponse` — data propagation for strings, structs, ints, nil pointers; `Error`/`Code` are empty                                      
  - `ListSuccessResponse` — pagination fields propagated; empty slice is not nil; struct elements preserved
  - `CursorListSuccessResponse` — cursor/remaining-count propagation; last-page nil semantics                                                    
  - `ErrorResponse` — message/code propagated; `Data` is nil; `Success` is false
  - `BindingStatusType` constants — guards all 5 string values against accidental API-breaking changes                                           
  - `BindingReleaseState` constants — guards both string values

## Related Issues
- Fix https://github.com/openchoreo/openchoreo/issues/3002