### PR TITLE
ci: fix codecov ignore pattern for generated mocks

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -14,7 +14,7 @@ ignore:
   - "cmd"                                                      # Application entrypoints
   - "tools/helm-gen"                                           # Generated helm files
   - "**/zz_generated.*.go"                                     # Generated deepcopy and register files
-  - "**/mocks"                                                 # Generated mock files (mockery)
+  - "**/mocks/**"                                               # Generated mock files (mockery)
   - "api/v1alpha1/groupversion_info.go"                        # Generated CRD group/version boilerplate
   - "internal/openchoreo-api/api/gen"                          # Generated OpenAPI server, client, and models
   - "internal/observer/api/gen"                                # Generated observer, client, and models


### PR DESCRIPTION
## Purpose

related to https://github.com/openchoreo/openchoreo/issues/2987

Fix the codecov ignore pattern for generated mock files. The current pattern `**/mocks` matches the directory itself but not the files inside it, so mock files still appear in coverage reports with 0% coverage.

## Approach

- Change `**/mocks` to `**/mocks/**` so that all files within any `mocks/` directory are excluded from coverage reporting

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)