### PR TITLE
chore: upgrade Go from 1.24 to 1.26

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.24",
+  "image": "golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/check-tools.sh
+++ b/check-tools.sh
@@ -30,7 +30,7 @@ checkVersion() {
 }
 
 # Format: <Command Display Name> <Min Version> <Max Version> <Version Command Line> <Version Line Number> <Version Extract RegEx>
-checkVersion "Go Language" "1.24.0" "1.25.0" "go version" 1 "[0-9]\.[0-9]+\.[0-9]+"
+checkVersion "Go Language" "1.26.0" "1.27.0" "go version" 1 "[0-9]\.[0-9]+\.[0-9]+"
 checkVersion "GNU Make" "3.8" "4.5" "make -version" 1 "[0-9]\.[0-9]+"
 checkVersion "Kind" "v0.27.0" "v0.27.0" "kind version" 1 "v[0-9]\.[0-9]+\.[0-9]+"
 checkVersion "Docker Client" "23.0.0" "28.0.0" "docker version --format '{{.Client.Version}}'" 1 "[0-9]+\.[0-9]+\.[0-9]+"

--- a/docs/contributors/contribute.md
+++ b/docs/contributors/contribute.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go version v1.24.0+
+- Go version v1.26.0+
 - Docker version 23.0+
 - Make version 3.81+
 - Kubernetes cluster with version v1.30.0+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openchoreo/openchoreo
 
-go 1.24.12
+go 1.26.1
 
 require (
 	github.com/casbin/casbin/v2 v2.135.0

--- a/tools/licenser/go.mod
+++ b/tools/licenser/go.mod
@@ -1,6 +1,6 @@
 module licenser
 
-go 1.24.12
+go 1.26.1
 
 require (
 	github.com/onsi/ginkgo/v2 v2.23.4


### PR DESCRIPTION
## Purpose

Go 1.24 is EOL and no longer receives security patches. This PR upgrades the project to Go 1.26.1 to stay on a supported version and fix 4 known stdlib vulnerabilities reported by Trivy:

- **CVE-2025-68121** (critical): `crypto/tls` unexpected session resumption
- **CVE-2026-25679** (high): `net/url` incorrect parsing of IPv6 host literals
- **CVE-2026-27142** (medium): `html/template` URLs in meta content not escaped
- **CVE-2026-27139** (low): `os` FileInfo can escape from a Root

## Approach

- Bump `go` directive in `go.mod` and `tools/licenser/go.mod` from 1.24.12 to 1.26.1
- Update devcontainer image from `golang:1.24` to `golang:1.26`
- Update `check-tools.sh` version bounds from 1.24.0–1.25.0 to 1.26.0–1.27.0
- Update contributor guide prerequisite from v1.24.0+ to v1.26.0+
- Verified: all binaries build and all tests pass with Go 1.26.1

## Related Issues

Closes #3014

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)