### PR TITLE
ci: add setup-go composite action to dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/setup-go"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
## Purpose

Dependabot was not tracking the `actions/setup-go` composite action in `.github/actions/setup-go/`, causing it to remain on v6.1.0 (Node.js 20) while GitHub is deprecating Node.js 20 actions.

## Approach

- Change `directory` to `directories` in the GitHub Actions dependabot config
- Add `/.github/actions/setup-go` so dependabot can auto-bump it to a Node.js 24 version

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)