### PR TITLE
ci: switch backport workflow from comment-based to label-based

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ See: docs/contributors/github_workflow.md#pr-title-convention
 ## Checklist
 - [ ] Tests added or updated (unit, integration, etc.)
 - [ ] Samples updated (if applicable)
+- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
 
 ## Remarks
 > Add any additional context, known issues, or TODOs related to this PR.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,9 +1,11 @@
 # Backport merged pull requests to release branches using cherry-pick.
 #
-# Usage: Comment `/backport <target-branch>` on a merged pull request.
-#   Example: `/backport release-0.1`
+# Backports are triggered automatically when a PR with a `backport/<branch>`
+# label is merged. For example, adding the label `backport/release-v1.0`
+# before merging will create a backport PR targeting the `release-v1.0` branch.
 #
-# Only organization members and collaborators can trigger this command.
+# Labels can also be added after a PR is merged to trigger a backport.
+#
 # The action will create a new PR with the cherry-picked changes targeting
 # the specified branch. If there are conflicts, the action will comment
 # with instructions to resolve them manually.
@@ -11,8 +13,8 @@
 name: Backport merged pull request
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request_target:
+    types: [closed, labeled]
 
 permissions:
   contents: read
@@ -24,50 +26,18 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # Only run when a comment starts with `/backport` on a PR and the commenter
-    # has write access. This prevents arbitrary users from creating branches.
-    if: >
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/backport ') &&
-      (
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.comment.author_association == 'MEMBER'
-      )
+    if: github.event.pull_request.merged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Check if PR is merged
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          merged=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} --jq '.merged')
-          if [ "$merged" != "true" ]; then
-            echo "PR #${{ github.event.issue.number }} is not merged; aborting backport." >&2
-            exit 1
-          fi
-
-      - name: Extract target branch
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          set -euo pipefail
-          line="${COMMENT_BODY%%$'\n'*}"
-          if [[ $line =~ ^/backport[[:space:]]+([^[:space:]]+) ]]; then
-            echo "BACKPORT_TARGET=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
-          else
-            echo "Usage: /backport <target-branch>" >&2
-            exit 1
-          fi
-
-      - name: Create backport pull request
+      - name: Create backport pull requests
         uses: korthout/backport-action@3c06f323a58619da1e8522229ebc8d5de2633e46 # v4.3.0
         with:
-          target_branches: ${{ env.BACKPORT_TARGET }}
-          # Disable label-based detection; we use comment-based triggering only.
-          label_pattern: ''
+          # Match labels like `backport/release-v0.3` and extract `release-v0.3`
+          # as the target branch.
+          label_pattern: '^backport/(.+)$'
           # Copy all labels from the original PR to the backport PR.
           copy_labels_pattern: '.*'
           # Copy reviewers so the backport PR gets reviewed by the same people.

--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -16,6 +16,7 @@ upstream repository.
 - [Before Opening a PR](#before-opening-a-pr)
 - [PR Title Convention](#pr-title-convention)
 - [DCO Sign-off](#dco-sign-off)
+- [Backporting](#backporting)
 - [Merge Strategy](#merge-strategy)
 - [FAQs](#faqs)
 
@@ -224,6 +225,19 @@ Or sign off all commits in your branch:
 git rebase --signoff upstream/main
 git push -f origin feature-branch
 ```
+
+## Backporting
+
+To backport a merged pull request to a release branch, add a `backport/<release-branch>` label to the PR. For example,
+adding the label `backport/release-v1.0` will automatically create a new PR that cherry-picks the changes onto the
+`release-v1.0` branch.
+
+Labels can be added before or after the PR is merged:
+
+- **Before merge**: Add the label during review. The backport PR is created automatically when the PR merges.
+- **After merge**: Add the label to the already-merged PR. The backport PR is created immediately.
+
+If the cherry-pick has conflicts, the workflow will comment on the original PR with instructions for manual resolution.
 
 ## Merge Strategy
 


### PR DESCRIPTION
## Purpose

Switch the backport workflow from comment-based (`/backport <branch>`) to label-based (`backport/<branch>`) triggering. Labels are queryable and trackable in GitHub, making it easier to see what was backported to each release. They also improve discoverability through the PR template checklist and can be added before or after merge.

## Approach

- Replace `issue_comment` trigger with `pull_request_target: [closed, labeled]` to support label-based backporting
- Use `label_pattern: '^backport/(.+)$'` to extract target branch from labels (e.g., `backport/release-v1.0` → `release-v1.0`)
- Remove comment parsing, author association checks, and manual merge verification steps (handled natively by the action and event conditions)
- Add backport checklist item to PR template
- Add backporting section to contributor guide

## Related Issues

Closes #3054

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)