### PR TITLE
chore: add tests for observer authz package

### DIFF
--- a/internal/observer/authz/client_test.go
+++ b/internal/observer/authz/client_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/observer/config"
+)
+
+// ─────────────────────── NewClient ───────────────────────
+
+func TestNewClient_EmptyServiceURL(t *testing.T) {
+	cfg := &config.AuthzConfig{
+		ServiceURL: "",
+		Timeout:    10 * time.Second,
+	}
+	_, err := NewClient(cfg, noopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authz service URL is required")
+}
+
+func TestNewClient_ZeroTimeout(t *testing.T) {
+	cfg := &config.AuthzConfig{
+		ServiceURL: "http://localhost:8080",
+		Timeout:    0,
+	}
+	_, err := NewClient(cfg, noopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authz timeout must be positive")
+}
+
+func TestNewClient_NegativeTimeout(t *testing.T) {
+	cfg := &config.AuthzConfig{
+		ServiceURL: "http://localhost:8080",
+		Timeout:    -5 * time.Second,
+	}
+	_, err := NewClient(cfg, noopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authz timeout must be positive")
+}
+
+func TestNewClient_Valid(t *testing.T) {
+	cfg := &config.AuthzConfig{
+		ServiceURL: "http://localhost:8080",
+		Timeout:    30 * time.Second,
+	}
+	c, err := NewClient(cfg, noopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "http://localhost:8080", c.baseURL)
+}
+
+func TestNewClient_TLSInsecureSkipVerify(t *testing.T) {
+	cfg := &config.AuthzConfig{
+		ServiceURL:            "https://localhost:8443",
+		Timeout:               30 * time.Second,
+		TLSInsecureSkipVerify: true,
+	}
+	c, err := NewClient(cfg, noopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	// TLS transport should be configured
+	require.NotNil(t, c.httpClient.Transport, "transport should be set when TLS skip verify is enabled")
+}
+
+func TestNewClient_NoTLSSkip(t *testing.T) {
+	cfg := &config.AuthzConfig{
+		ServiceURL:            "https://localhost:8443",
+		Timeout:               30 * time.Second,
+		TLSInsecureSkipVerify: false,
+	}
+	c, err := NewClient(cfg, noopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	// Default transport (nil) is used when TLS skip verify is disabled
+	assert.Nil(t, c.httpClient.Transport)
+}
+
+// ─────────────────────── Evaluate ───────────────────────
+
+func TestEvaluate_NilRequest(t *testing.T) {
+	c := newTestClient(t, "http://unused")
+	_, err := c.Evaluate(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evaluate request must not be nil")
+}
+
+func TestEvaluate_ServerReturns200WithDecision(t *testing.T) {
+	decisions := []authzcore.Decision{{Decision: true}}
+	srv := newDecisionServer(t, decisions)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{
+		Action:   string(ActionViewLogs),
+		Resource: authzcore.Resource{Type: string(ResourceTypeComponent), ID: "api"},
+	}
+
+	decision, err := c.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.True(t, decision.Decision)
+}
+
+func TestEvaluate_ServerReturns200WithDeniedDecision(t *testing.T) {
+	decisions := []authzcore.Decision{{Decision: false}}
+	srv := newDecisionServer(t, decisions)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{
+		Action:   string(ActionViewLogs),
+		Resource: authzcore.Resource{Type: string(ResourceTypeComponent), ID: "api"},
+	}
+
+	decision, err := c.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.False(t, decision.Decision)
+}
+
+func TestEvaluate_ServerReturnsEmptyDecisions(t *testing.T) {
+	srv := newDecisionServer(t, []authzcore.Decision{})
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	assert.ErrorIs(t, err, ErrAuthzInvalidResponse)
+}
+
+func TestEvaluate_ServerReturns401(t *testing.T) {
+	srv := newStatusServer(t, http.StatusUnauthorized)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	assert.ErrorIs(t, err, ErrAuthzUnauthorized)
+}
+
+func TestEvaluate_ServerReturns403(t *testing.T) {
+	srv := newStatusServer(t, http.StatusForbidden)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	assert.ErrorIs(t, err, ErrAuthzForbidden)
+}
+
+func TestEvaluate_ServerReturns500(t *testing.T) {
+	srv := newStatusServer(t, http.StatusInternalServerError)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestEvaluate_ServerUnreachable(t *testing.T) {
+	c := newTestClient(t, "http://127.0.0.1:1") // port 1 is unreachable
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	assert.ErrorIs(t, err, ErrAuthzServiceUnavailable)
+}
+
+func TestEvaluate_ServerReturnsInvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-valid-json"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	assert.ErrorIs(t, err, ErrAuthzInvalidResponse)
+}
+
+func TestEvaluate_NoTokenInContext_NoAuthorizationHeader(t *testing.T) {
+	var receivedAuthHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		decisions := []authzcore.Decision{{Decision: true}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(decisions)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	// No JWT token in context - Authorization header should not be sent
+	_, err := c.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	assert.Empty(t, receivedAuthHeader, "no Authorization header should be forwarded when context has no token")
+}
+
+// ─────────────────────── BatchEvaluate ───────────────────────
+
+func TestBatchEvaluate_NilRequest(t *testing.T) {
+	c := newTestClient(t, "http://unused")
+	_, err := c.BatchEvaluate(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "batch evaluate request must not be nil")
+}
+
+func TestBatchEvaluate_MatchingDecisions(t *testing.T) {
+	decisions := []authzcore.Decision{{Decision: true}, {Decision: false}}
+	srv := newDecisionServer(t, decisions)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	batchReq := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{
+			{Action: string(ActionViewLogs)},
+			{Action: string(ActionViewMetrics)},
+		},
+	}
+
+	resp, err := c.BatchEvaluate(context.Background(), batchReq)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Decisions, 2)
+	assert.True(t, resp.Decisions[0].Decision)
+	assert.False(t, resp.Decisions[1].Decision)
+}
+
+func TestBatchEvaluate_MismatchedDecisionsCount(t *testing.T) {
+	// Server returns fewer decisions than requested
+	decisions := []authzcore.Decision{{Decision: true}}
+	srv := newDecisionServer(t, decisions)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	batchReq := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{
+			{Action: string(ActionViewLogs)},
+			{Action: string(ActionViewMetrics)},
+		},
+	}
+
+	_, err := c.BatchEvaluate(context.Background(), batchReq)
+	assert.ErrorIs(t, err, ErrAuthzInvalidResponse)
+}
+
+func TestBatchEvaluate_ServerReturns401(t *testing.T) {
+	srv := newStatusServer(t, http.StatusUnauthorized)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	batchReq := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{{Action: string(ActionViewLogs)}},
+	}
+
+	_, err := c.BatchEvaluate(context.Background(), batchReq)
+	assert.ErrorIs(t, err, ErrAuthzUnauthorized)
+}
+
+func TestBatchEvaluate_ServerUnreachable(t *testing.T) {
+	c := newTestClient(t, "http://127.0.0.1:1")
+	batchReq := &authzcore.BatchEvaluateRequest{
+		Requests: []authzcore.EvaluateRequest{{Action: string(ActionViewLogs)}},
+	}
+
+	_, err := c.BatchEvaluate(context.Background(), batchReq)
+	assert.ErrorIs(t, err, ErrAuthzServiceUnavailable)
+}
+
+// ─────────────────────── GetSubjectProfile ───────────────────────
+
+// ─────────────────────── evaluate() internal paths ───────────────────────
+
+func TestEvaluate_InvalidURLCausesRequestCreationError(t *testing.T) {
+	// Bypass NewClient to inject an invalid URL directly, which causes
+	// http.NewRequestWithContext to fail.
+	c := &Client{
+		baseURL:    "://not-a-valid-url",
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		logger:     noopLogger(),
+	}
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create HTTP request")
+}
+
+func TestEvaluate_BrokenBodyReturnsInvalidResponse(t *testing.T) {
+	// Server sends headers with Content-Length: 100 but writes no body,
+	// causing the client to receive an incomplete response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	req := &authzcore.EvaluateRequest{Action: string(ActionViewLogs)}
+
+	_, err := c.Evaluate(context.Background(), req)
+	require.Error(t, err)
+}
+
+func TestGetSubjectProfile_AlwaysReturnsError(t *testing.T) {
+	c := newTestClient(t, "http://unused")
+	_, err := c.GetSubjectProfile(context.Background(), &authzcore.ProfileRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+// ─────────────────────── test helpers ───────────────────────
+
+// newTestClient builds a Client pointing at the given base URL with a short timeout.
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	cfg := &config.AuthzConfig{
+		ServiceURL: baseURL,
+		Timeout:    5 * time.Second,
+	}
+	c, err := NewClient(cfg, noopLogger())
+	require.NoError(t, err)
+	return c
+}
+
+// newDecisionServer starts a test HTTP server that responds with 200 OK and
+// a JSON-encoded decisions payload.
+func newDecisionServer(t *testing.T, decisions []authzcore.Decision) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, evaluatesEndpoint, r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(decisions)
+	}))
+}
+
+// newStatusServer starts a test HTTP server that responds with the given status code.
+func newStatusServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+}

--- a/internal/observer/authz/helpers_test.go
+++ b/internal/observer/authz/helpers_test.go
@@ -1,0 +1,358 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	coremocks "github.com/openchoreo/openchoreo/internal/authz/core/mocks"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
+)
+
+// noopLogger returns a logger that discards all output, suitable for tests.
+func noopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// ─────────────────────── ComponentScopeAuthz ───────────────────────
+
+func TestComponentScopeAuthz(t *testing.T) {
+	tests := []struct {
+		name             string
+		namespace        string
+		project          string
+		component        string
+		wantResourceType ResourceType
+		wantResourceName string
+		wantHierarchy    authzcore.ResourceHierarchy
+	}{
+		{
+			name:             "all empty returns unknown",
+			wantResourceType: ResourceTypeUnknown,
+			wantResourceName: "",
+			wantHierarchy:    authzcore.ResourceHierarchy{},
+		},
+		{
+			name:             "namespace only returns namespace type",
+			namespace:        "acme",
+			wantResourceType: ResourceTypeNamespace,
+			wantResourceName: "acme",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme"},
+		},
+		{
+			name:             "namespace and project returns project type",
+			namespace:        "acme",
+			project:          "payments",
+			wantResourceType: ResourceTypeProject,
+			wantResourceName: "payments",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme", Project: "payments"},
+		},
+		{
+			name:             "namespace project and component returns component type",
+			namespace:        "acme",
+			project:          "payments",
+			component:        "api",
+			wantResourceType: ResourceTypeComponent,
+			wantResourceName: "api",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme", Project: "payments", Component: "api"},
+		},
+		{
+			name:             "component without namespace or project returns component type",
+			component:        "orphan",
+			wantResourceType: ResourceTypeComponent,
+			wantResourceName: "orphan",
+			wantHierarchy:    authzcore.ResourceHierarchy{Component: "orphan"},
+		},
+		{
+			name:             "component with namespace but no project returns component type",
+			namespace:        "acme",
+			component:        "api",
+			wantResourceType: ResourceTypeComponent,
+			wantResourceName: "api",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme", Component: "api"},
+		},
+		{
+			name:             "project without namespace returns project type",
+			project:          "payments",
+			wantResourceType: ResourceTypeProject,
+			wantResourceName: "payments",
+			wantHierarchy:    authzcore.ResourceHierarchy{Project: "payments"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotName, gotHierarchy := ComponentScopeAuthz(tt.namespace, tt.project, tt.component)
+			assert.Equal(t, tt.wantResourceType, gotType)
+			assert.Equal(t, tt.wantResourceName, gotName)
+			assert.Equal(t, tt.wantHierarchy, gotHierarchy)
+		})
+	}
+}
+
+// ─────────────────────── LogsScopeAuthz ───────────────────────
+
+func TestLogsScopeAuthz(t *testing.T) {
+	tests := []struct {
+		name             string
+		req              *types.LogsQueryRequest
+		wantResourceType ResourceType
+		wantResourceName string
+		wantHierarchy    authzcore.ResourceHierarchy
+		wantErr          bool
+		wantErrMsg       string
+	}{
+		{
+			name:       "nil request returns error",
+			req:        nil,
+			wantErr:    true,
+			wantErrMsg: "request is required",
+		},
+		{
+			name:       "nil search scope returns error",
+			req:        &types.LogsQueryRequest{SearchScope: nil},
+			wantErr:    true,
+			wantErrMsg: "search scope is required",
+		},
+		{
+			name: "neither component nor workflow scope set returns error",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{},
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid search scope",
+		},
+		{
+			name: "component scope with namespace only returns namespace type",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{Namespace: "acme"},
+				},
+			},
+			wantResourceType: ResourceTypeNamespace,
+			wantResourceName: "acme",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme"},
+		},
+		{
+			name: "component scope with namespace and project returns project type",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{Namespace: "acme", Project: "payments"},
+				},
+			},
+			wantResourceType: ResourceTypeProject,
+			wantResourceName: "payments",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme", Project: "payments"},
+		},
+		{
+			name: "component scope with all fields returns component type",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Component: &types.ComponentSearchScope{
+						Namespace: "acme", Project: "payments", Component: "api",
+					},
+				},
+			},
+			wantResourceType: ResourceTypeComponent,
+			wantResourceName: "api",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme", Project: "payments", Component: "api"},
+		},
+		{
+			name: "workflow scope with workflowRunName returns workflowRun type",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Workflow: &types.WorkflowSearchScope{
+						Namespace: "acme", WorkflowRunName: "run-abc",
+					},
+				},
+			},
+			wantResourceType: ResourceTypeWorkflowRun,
+			wantResourceName: "run-abc",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme"},
+		},
+		{
+			name: "workflow scope without workflowRunName returns namespace type",
+			req: &types.LogsQueryRequest{
+				SearchScope: &types.SearchScope{
+					Workflow: &types.WorkflowSearchScope{Namespace: "acme"},
+				},
+			},
+			wantResourceType: ResourceTypeNamespace,
+			wantResourceName: "acme",
+			wantHierarchy:    authzcore.ResourceHierarchy{Namespace: "acme"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotName, gotHierarchy, err := LogsScopeAuthz(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResourceType, gotType)
+			assert.Equal(t, tt.wantResourceName, gotName)
+			assert.Equal(t, tt.wantHierarchy, gotHierarchy)
+		})
+	}
+}
+
+// ─────────────────────── CheckAuthorization ───────────────────────
+
+func newSubjectContext() *auth.SubjectContext {
+	return &auth.SubjectContext{
+		ID:                "user-123",
+		Type:              "user",
+		EntitlementClaim:  "groups",
+		EntitlementValues: []string{"dev-team"},
+	}
+}
+
+func ctxWithSubject() context.Context {
+	return auth.SetSubjectContext(context.Background(), newSubjectContext())
+}
+
+func TestCheckAuthorization_PDPNil(t *testing.T) {
+	err := CheckAuthorization(
+		context.Background(),
+		noopLogger(),
+		nil,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{Namespace: "acme"},
+	)
+	assert.NoError(t, err, "nil PDP should skip authorization")
+}
+
+func TestCheckAuthorization_NoSubjectContext(t *testing.T) {
+	mockPDP := coremocks.NewMockPDP(t)
+
+	err := CheckAuthorization(
+		context.Background(), // no subject context set
+		noopLogger(),
+		mockPDP,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{},
+	)
+	assert.ErrorIs(t, err, ErrAuthzUnauthorized)
+}
+
+func TestCheckAuthorization_PDPEvaluateError(t *testing.T) {
+	upstreamErr := fmt.Errorf("upstream failure")
+	simpleMock := &simplePDPMock{evaluateErr: upstreamErr}
+
+	err := CheckAuthorization(
+		ctxWithSubject(),
+		noopLogger(),
+		simpleMock,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{Namespace: "acme"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upstream failure")
+}
+
+func TestCheckAuthorization_DecisionAllowed(t *testing.T) {
+	simpleMock := &simplePDPMock{
+		decision: &authzcore.Decision{Decision: true},
+	}
+
+	err := CheckAuthorization(
+		ctxWithSubject(),
+		noopLogger(),
+		simpleMock,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{Namespace: "acme"},
+	)
+	assert.NoError(t, err)
+}
+
+func TestCheckAuthorization_DecisionDenied(t *testing.T) {
+	simpleMock := &simplePDPMock{
+		decision: &authzcore.Decision{Decision: false},
+	}
+
+	err := CheckAuthorization(
+		ctxWithSubject(),
+		noopLogger(),
+		simpleMock,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{Namespace: "acme"},
+	)
+	assert.ErrorIs(t, err, ErrAuthzForbidden)
+}
+
+func TestCheckAuthorization_BuildsCorrectRequest(t *testing.T) {
+	var capturedReq *authzcore.EvaluateRequest
+	captureMock := &simplePDPMock{
+		decision:       &authzcore.Decision{Decision: true},
+		captureRequest: func(r *authzcore.EvaluateRequest) { capturedReq = r },
+	}
+
+	hierarchy := authzcore.ResourceHierarchy{Namespace: "acme", Project: "payments", Component: "api"}
+	err := CheckAuthorization(
+		ctxWithSubject(),
+		noopLogger(),
+		captureMock,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		hierarchy,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, string(ActionViewLogs), capturedReq.Action)
+	assert.Equal(t, string(ResourceTypeComponent), capturedReq.Resource.Type)
+	assert.Equal(t, "api", capturedReq.Resource.ID)
+	assert.Equal(t, hierarchy, capturedReq.Resource.Hierarchy)
+	require.NotNil(t, capturedReq.SubjectContext)
+	assert.Equal(t, "user", capturedReq.SubjectContext.Type)
+	assert.Equal(t, "groups", capturedReq.SubjectContext.EntitlementClaim)
+	assert.Equal(t, []string{"dev-team"}, capturedReq.SubjectContext.EntitlementValues)
+}
+
+// ─────────────────────── test helpers ───────────────────────
+
+// simplePDPMock is a minimal hand-rolled mock for authzcore.PDP.
+type simplePDPMock struct {
+	decision       *authzcore.Decision
+	evaluateErr    error
+	captureRequest func(*authzcore.EvaluateRequest)
+}
+
+func (m *simplePDPMock) Evaluate(_ context.Context, req *authzcore.EvaluateRequest) (*authzcore.Decision, error) {
+	if m.captureRequest != nil {
+		m.captureRequest(req)
+	}
+	return m.decision, m.evaluateErr
+}
+
+func (m *simplePDPMock) BatchEvaluate(_ context.Context, _ *authzcore.BatchEvaluateRequest) (*authzcore.BatchEvaluateResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *simplePDPMock) GetSubjectProfile(_ context.Context, _ *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2997

This pull request adds comprehensive unit tests for the `authz` package in the observer component, significantly increasing test coverage for core authorization logic, helper functions, and client-server interactions. The new tests cover various edge cases, error handling, and correct construction of requests for both individual and batch authorization checks.

The most important changes include:

**New Test Coverage for Client Logic:**
- Added `internal/observer/authz/client_test.go` with extensive tests for the `Client`'s construction and its `Evaluate`, `BatchEvaluate`, and `GetSubjectProfile` methods. These tests cover scenarios like invalid configuration, server errors, unreachable endpoints, malformed responses, and correct handling of authorization headers.

**New Test Coverage for Helper Functions:**
- Added `internal/observer/authz/helpers_test.go` with tests for helper functions such as `ComponentScopeAuthz`, `LogsScopeAuthz`, and `CheckAuthorization`. The tests verify correct resource type resolution, error handling for invalid inputs, and correct request construction for authorization checks.

**Test Utilities and Mocks:**
- Introduced test helpers like `noopLogger`, `newTestClient`, `newDecisionServer`, and minimal PDP mocks to facilitate isolated and reliable testing of authorization behaviors. [[1]](diffhunk://#diff-dc263027d06cd01e51a3d3952258eac48d9df4e6a14fd2212cf1a49e0d30191dR1-R373) [[2]](diffhunk://#diff-8a45844e482a94054c75725ac1ecc886f51ec7e38fd200bdf1b26e097ab2af19R1-R358)

These changes ensure the authorization logic is robust, well-tested, and maintainable.