### PR TITLE
ci: add failure comment with workflow run link to backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,9 +33,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create backport pull requests
+        id: backport
         uses: korthout/backport-action@3c06f323a58619da1e8522229ebc8d5de2633e46 # v4.3.0
         with:
-          # Match labels like `backport/release-v0.3` and extract `release-v0.3`
+          # Match labels like `backport/release-v1.0` and extract `release-v1.0`
           # as the target branch.
           label_pattern: '^backport/(.+)$'
           # Copy all labels from the original PR to the backport PR.
@@ -51,3 +52,12 @@ jobs:
             ## Original description
 
             ${pull_description}
+
+      - name: Comment on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Backport failed. See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."


### PR DESCRIPTION
## Purpose

When a backport fails, the action's default error comment (e.g., "Git push to origin failed") is not descriptive enough. This adds a follow-up comment with a direct link to the workflow run so maintainers can quickly diagnose the issue.

## Approach

- Add a failure step (`if: failure()`) that posts a comment with a link to the workflow run
- Uses `gh pr comment` to post on the original PR

## Related Issues

Related #3054
Related: https://github.com/korthout/backport-action/issues/415

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)