### PR TITLE
test(cli): add tests for fsmode Index methods

### DIFF
--- a/internal/occ/fsmode/index_test.go
+++ b/internal/occ/fsmode/index_test.go
@@ -206,3 +206,500 @@ func TestGetTypedClusterTrait(t *testing.T) {
 		assert.Contains(t, err.Error(), "nonexistent")
 	})
 }
+
+// Helper functions for building test entries
+
+func addComponentEntry(t *testing.T, idx *index.Index, namespace, name, projectName string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName": projectName,
+					},
+					"componentType": map[string]any{
+						"name": "deployment/http-service",
+					},
+				},
+			},
+		},
+		FilePath: "/repo/projects/" + projectName + "/components/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addComponentTypeEntry(t *testing.T, idx *index.Index, namespace, name string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentType",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"workloadType": "deployment",
+					"resources":    []any{},
+				},
+			},
+		},
+		FilePath: "/repo/component-types/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addTraitEntry(t *testing.T, idx *index.Index, namespace, name string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Trait",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{},
+			},
+		},
+		FilePath: "/repo/traits/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addWorkloadEntry(t *testing.T, idx *index.Index, namespace, name, projectName, componentName string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Workload",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   projectName,
+						"componentName": componentName,
+					},
+					"container": map[string]any{
+						"image": "nginx:latest",
+					},
+				},
+			},
+		},
+		FilePath: "/repo/projects/" + projectName + "/workloads/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addComponentReleaseEntry(t *testing.T, idx *index.Index, namespace, name, projectName, componentName string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentRelease",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   projectName,
+						"componentName": componentName,
+					},
+				},
+			},
+		},
+		FilePath: "/repo/releases/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addReleaseBindingEntry(t *testing.T, idx *index.Index, namespace, name, projectName, componentName, envName string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ReleaseBinding",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   projectName,
+						"componentName": componentName,
+					},
+					"environment": envName,
+				},
+			},
+		},
+		FilePath: "/repo/bindings/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addProjectEntry(t *testing.T, idx *index.Index, namespace, name string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Project",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{},
+			},
+		},
+		FilePath: "/repo/projects/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addDeploymentPipelineEntry(t *testing.T, idx *index.Index, namespace, name string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "DeploymentPipeline",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"promotionPaths": []any{
+						map[string]any{
+							"sourceEnvironmentRef": map[string]any{"name": "dev"},
+							"targetEnvironmentRef": map[string]any{"name": "staging"},
+						},
+					},
+				},
+			},
+		},
+		FilePath: "/repo/pipelines/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+// buildFullIndex creates an index populated with all resource types for comprehensive testing
+func buildFullIndex(t *testing.T) *Index {
+	t.Helper()
+	idx := index.New("/repo")
+
+	// Components
+	addComponentEntry(t, idx, "ns1", "web-app", "proj-a")
+	addComponentEntry(t, idx, "ns1", "api-service", "proj-a")
+	addComponentEntry(t, idx, "ns2", "worker", "proj-b")
+
+	// ComponentTypes
+	addComponentTypeEntry(t, idx, "ns1", "http-service")
+
+	// Traits
+	addTraitEntry(t, idx, "ns1", "autoscaler")
+
+	// ClusterComponentTypes & ClusterTraits (already have helpers)
+	addClusterComponentTypeEntry(t, idx, "service")
+	addClusterTraitEntry(t, idx, "global-ingress")
+
+	// Workloads
+	addWorkloadEntry(t, idx, "ns1", "web-app-workload", "proj-a", "web-app")
+
+	// ComponentReleases
+	addComponentReleaseEntry(t, idx, "ns1", "web-app-20260401-v1", "proj-a", "web-app")
+	addComponentReleaseEntry(t, idx, "ns1", "web-app-20260401-v2", "proj-a", "web-app")
+
+	// ReleaseBindings
+	addReleaseBindingEntry(t, idx, "ns1", "web-app-dev-binding", "proj-a", "web-app", "dev")
+	addReleaseBindingEntry(t, idx, "ns1", "web-app-staging-binding", "proj-a", "web-app", "staging")
+
+	// Projects
+	addProjectEntry(t, idx, "ns1", "proj-a")
+
+	// DeploymentPipelines
+	addDeploymentPipelineEntry(t, idx, "ns1", "default-pipeline")
+
+	return WrapIndex(idx)
+}
+
+func TestGetComponent(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetComponent("ns1", "web-app")
+		require.True(t, ok)
+		assert.Equal(t, "web-app", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetComponent("ns1", "nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestGetComponentType(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetComponentType("http-service")
+		require.True(t, ok)
+		assert.Equal(t, "http-service", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetComponentType("nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestGetTrait(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetTrait("autoscaler")
+		require.True(t, ok)
+		assert.Equal(t, "autoscaler", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetTrait("nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestGetWorkloadForComponent(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetWorkloadForComponent("proj-a", "web-app")
+		require.True(t, ok)
+		assert.Equal(t, "web-app-workload", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetWorkloadForComponent("proj-a", "nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestGetTypedWorkloadForComponent(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		wl, err := ocIndex.GetTypedWorkloadForComponent("proj-a", "web-app")
+		require.NoError(t, err)
+		require.NotNil(t, wl)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ocIndex.GetTypedWorkloadForComponent("proj-a", "nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonexistent")
+	})
+}
+
+func TestListComponents(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+	components := ocIndex.ListComponents()
+	assert.Len(t, components, 3)
+}
+
+func TestListComponentsForProject(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("project with components", func(t *testing.T) {
+		components := ocIndex.ListComponentsForProject("proj-a")
+		assert.Len(t, components, 2)
+	})
+
+	t.Run("project with no components", func(t *testing.T) {
+		components := ocIndex.ListComponentsForProject("nonexistent")
+		assert.Empty(t, components)
+	})
+}
+
+func TestListReleases(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+	releases := ocIndex.ListReleases()
+	assert.Len(t, releases, 2)
+}
+
+func TestListReleasesForComponent(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("component with releases", func(t *testing.T) {
+		releases := ocIndex.ListReleasesForComponent("proj-a", "web-app")
+		assert.Len(t, releases, 2)
+	})
+
+	t.Run("component with no releases", func(t *testing.T) {
+		releases := ocIndex.ListReleasesForComponent("proj-b", "worker")
+		assert.Empty(t, releases)
+	})
+}
+
+func TestGetTypedComponent(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		comp, err := ocIndex.GetTypedComponent("ns1", "web-app")
+		require.NoError(t, err)
+		assert.Equal(t, "proj-a", comp.ProjectName())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ocIndex.GetTypedComponent("ns1", "nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonexistent")
+	})
+}
+
+func TestGetTypedComponentType(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		ct, err := ocIndex.GetTypedComponentType("http-service")
+		require.NoError(t, err)
+		assert.Equal(t, "deployment", ct.WorkloadType())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ocIndex.GetTypedComponentType("nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonexistent")
+	})
+}
+
+func TestGetTypedTrait(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		trait, err := ocIndex.GetTypedTrait("autoscaler")
+		require.NoError(t, err)
+		require.NotNil(t, trait)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ocIndex.GetTypedTrait("nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonexistent")
+	})
+}
+
+func TestGetProject(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetProject("ns1", "proj-a")
+		require.True(t, ok)
+		assert.Equal(t, "proj-a", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetProject("ns1", "nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestGetDeploymentPipeline(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetDeploymentPipeline("default-pipeline")
+		require.True(t, ok)
+		assert.Equal(t, "default-pipeline", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetDeploymentPipeline("nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestListReleaseBindings(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+	bindings := ocIndex.ListReleaseBindings()
+	assert.Len(t, bindings, 2)
+}
+
+func TestGetReleaseBindingForEnv(t *testing.T) {
+	ocIndex := buildFullIndex(t)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := ocIndex.GetReleaseBindingForEnv("proj-a", "web-app", "dev")
+		require.True(t, ok)
+		assert.Equal(t, "web-app-dev-binding", entry.Name())
+	})
+
+	t.Run("different environment", func(t *testing.T) {
+		entry, ok := ocIndex.GetReleaseBindingForEnv("proj-a", "web-app", "staging")
+		require.True(t, ok)
+		assert.Equal(t, "web-app-staging-binding", entry.Name())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := ocIndex.GetReleaseBindingForEnv("proj-a", "web-app", "prod")
+		assert.False(t, ok)
+	})
+}
+
+func TestAddToSpecializedIndexesUnsafe(t *testing.T) {
+	// Test that all resource types are properly indexed when added
+	idx := index.New("/repo")
+	ocIndex := WrapIndex(idx)
+
+	// Add each resource type and verify it's indexed
+	t.Run("component indexed by project", func(t *testing.T) {
+		entry := &index.ResourceEntry{
+			Resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "openchoreo.dev/v1alpha1",
+					"kind":       "Component",
+					"metadata":   map[string]any{"name": "svc-1", "namespace": "ns1"},
+					"spec": map[string]any{
+						"owner":         map[string]any{"projectName": "proj-x"},
+						"componentType": map[string]any{"name": "deployment/web"},
+					},
+				},
+			},
+			FilePath: "/repo/comp.yaml",
+		}
+		require.NoError(t, idx.Add(entry))
+		ocIndex.rebuildSpecializedIndexes()
+		comps := ocIndex.ListComponentsForProject("proj-x")
+		assert.Len(t, comps, 1)
+	})
+
+	t.Run("deployment pipeline indexed by name", func(t *testing.T) {
+		entry := &index.ResourceEntry{
+			Resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "openchoreo.dev/v1alpha1",
+					"kind":       "DeploymentPipeline",
+					"metadata":   map[string]any{"name": "my-pipeline", "namespace": "ns1"},
+					"spec":       map[string]any{},
+				},
+			},
+			FilePath: "/repo/pipeline.yaml",
+		}
+		require.NoError(t, idx.Add(entry))
+		ocIndex.rebuildSpecializedIndexes()
+		_, ok := ocIndex.GetDeploymentPipeline("my-pipeline")
+		assert.True(t, ok)
+	})
+}


### PR DESCRIPTION
## Purpose

Add test coverage for the `internal/occ/fsmode` Index methods to improve confidence in the specialized index lookup functionality.

## Approach

- Add tests for all Index query methods: `GetComponent`, `GetComponentType`, `GetTrait`, `GetWorkloadForComponent`, `ListComponents`, `ListComponentsForProject`, `ListReleases`, `ListReleasesForComponent`, `GetTypedComponent`, `GetTypedComponentType`, `GetTypedTrait`, `GetTypedWorkloadForComponent`, `GetProject`, `GetDeploymentPipeline`, `ListReleaseBindings`, `GetReleaseBindingForEnv`
- Add test for `addToSpecializedIndexesUnsafe` covering Component and DeploymentPipeline resource types
- Add a `buildFullIndex` helper that populates an Index with all resource types (components, component types, traits, workloads, releases, bindings, projects, pipelines) for comprehensive testing
- Each method is tested for both found and not-found cases

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)