### PR TITLE
ci: use action output to detect backport failure

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -54,7 +54,7 @@ jobs:
             ${pull_description}
 
       - name: Comment on failure
-        if: failure()
+        if: failure() || steps.backport.outputs.was_successful == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Purpose

The backport action reports step-level success even when the push or cherry-pick fails internally — it handles errors by posting a comment but doesn't fail the step. This means the `if: failure()` condition added in #3066 never triggers.

## Approach

- Change failure detection from `if: failure()` to `if: failure() || steps.backport.outputs.was_successful == 'false'`
- Uses the action's `was_successful` output to detect internal failures

## Related Issues

Related #3054

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)