### PR TITLE
test(cli): add tests for fsmode typed package

### DIFF
--- a/internal/occ/fsmode/typed/component_test.go
+++ b/internal/occ/fsmode/typed/component_test.go
@@ -6,8 +6,195 @@ package typed
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
 )
+
+func makeComponentEntry(t *testing.T, comp *v1alpha1.Component) *index.ResourceEntry {
+	t.Helper()
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(comp)
+	require.NoError(t, err)
+	obj := &unstructured.Unstructured{Object: raw}
+	obj.SetGroupVersionKind(v1alpha1.GroupVersion.WithKind("Component"))
+	return &index.ResourceEntry{Resource: obj}
+}
+
+func TestNewComponent(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   *index.ResourceEntry
+		wantErr bool
+	}{
+		{
+			name: "valid entry",
+			entry: makeComponentEntry(t, &v1alpha1.Component{
+				Spec: v1alpha1.ComponentSpec{
+					Owner:         v1alpha1.ComponentOwner{ProjectName: "my-project"},
+					ComponentType: v1alpha1.ComponentTypeRef{Name: "deployment/http-service"},
+				},
+			}),
+		},
+		{
+			name:    "nil entry",
+			entry:   nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp, err := NewComponent(tt.entry)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, comp)
+			assert.Equal(t, "my-project", comp.ProjectName())
+		})
+	}
+}
+
+func TestComponentProjectName(t *testing.T) {
+	comp := &Component{
+		Component: &v1alpha1.Component{
+			Spec: v1alpha1.ComponentSpec{
+				Owner: v1alpha1.ComponentOwner{ProjectName: "test-project"},
+			},
+		},
+	}
+	assert.Equal(t, "test-project", comp.ProjectName())
+}
+
+func TestComponentGetParameters(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  *runtime.RawExtension
+		wantNil bool
+		wantKey string
+	}{
+		{
+			name:    "with parameters",
+			params:  &runtime.RawExtension{Raw: []byte(`{"port":8080,"replicas":3}`)},
+			wantKey: "port",
+		},
+		{
+			name:    "nil parameters",
+			params:  nil,
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := &Component{
+				Component: &v1alpha1.Component{
+					Spec: v1alpha1.ComponentSpec{
+						Parameters: tt.params,
+					},
+				},
+			}
+			result := comp.GetParameters()
+			if tt.wantNil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			assert.Contains(t, result, tt.wantKey)
+		})
+	}
+}
+
+func TestComponentGetTraitRefs(t *testing.T) {
+	tests := []struct {
+		name     string
+		traits   []v1alpha1.ComponentTrait
+		wantNil  bool
+		wantLen  int
+		validate func(t *testing.T, refs []TraitRef)
+	}{
+		{
+			name:    "no traits",
+			traits:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty traits",
+			traits:  []v1alpha1.ComponentTrait{},
+			wantNil: true,
+		},
+		{
+			name: "single trait with explicit kind",
+			traits: []v1alpha1.ComponentTrait{
+				{
+					Kind:         "ClusterTrait",
+					Name:         "autoscaler",
+					InstanceName: "my-autoscaler",
+					Parameters:   &runtime.RawExtension{Raw: []byte(`{"minReplicas":2}`)},
+				},
+			},
+			wantLen: 1,
+			validate: func(t *testing.T, refs []TraitRef) {
+				assert.Equal(t, "ClusterTrait", refs[0].Kind)
+				assert.Equal(t, "autoscaler", refs[0].Name)
+				assert.Equal(t, "my-autoscaler", refs[0].InstanceName)
+				require.NotNil(t, refs[0].Parameters)
+				assert.Equal(t, float64(2), refs[0].Parameters["minReplicas"])
+			},
+		},
+		{
+			name: "trait with empty kind defaults to Trait",
+			traits: []v1alpha1.ComponentTrait{
+				{
+					Kind:         "",
+					Name:         "logging",
+					InstanceName: "my-logging",
+				},
+			},
+			wantLen: 1,
+			validate: func(t *testing.T, refs []TraitRef) {
+				assert.Equal(t, "Trait", refs[0].Kind)
+				assert.Equal(t, "logging", refs[0].Name)
+				assert.Nil(t, refs[0].Parameters)
+			},
+		},
+		{
+			name: "multiple traits",
+			traits: []v1alpha1.ComponentTrait{
+				{Kind: "Trait", Name: "logging", InstanceName: "log1"},
+				{Kind: "ClusterTrait", Name: "autoscaler", InstanceName: "as1"},
+			},
+			wantLen: 2,
+			validate: func(t *testing.T, refs []TraitRef) {
+				assert.Equal(t, "logging", refs[0].Name)
+				assert.Equal(t, "autoscaler", refs[1].Name)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := &Component{
+				Component: &v1alpha1.Component{
+					Spec: v1alpha1.ComponentSpec{
+						Traits: tt.traits,
+					},
+				},
+			}
+			refs := comp.GetTraitRefs()
+			if tt.wantNil {
+				assert.Nil(t, refs)
+				return
+			}
+			require.Len(t, refs, tt.wantLen)
+			if tt.validate != nil {
+				tt.validate(t, refs)
+			}
+		})
+	}
+}
 
 func TestComponentTypeName(t *testing.T) {
 	tests := []struct {

--- a/internal/occ/fsmode/typed/componenttype_test.go
+++ b/internal/occ/fsmode/typed/componenttype_test.go
@@ -168,6 +168,17 @@ func TestComponentTypeGetResources(t *testing.T) {
 			name:    "empty resources",
 			wantNil: true,
 		},
+		{
+			name: "resource with forEach and var",
+			resources: []v1alpha1.ResourceTemplate{
+				{
+					ID:      "pvc",
+					ForEach: "${parameters.volumes}",
+					Var:     "volume",
+				},
+			},
+			wantLen: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -185,6 +196,12 @@ func TestComponentTypeGetResources(t *testing.T) {
 			}
 			require.Len(t, result, tt.wantLen)
 			first := result[0].(map[string]any)
+			if tt.name == "resource with forEach and var" {
+				assert.Equal(t, "pvc", first["id"])
+				assert.Equal(t, "${parameters.volumes}", first["forEach"])
+				assert.Equal(t, "volume", first["var"])
+				return
+			}
 			assert.Equal(t, "deployment", first["id"])
 			assert.Equal(t, "dataplane", first["targetPlane"])
 			assert.Contains(t, first, "template")

--- a/internal/occ/fsmode/typed/trait_test.go
+++ b/internal/occ/fsmode/typed/trait_test.go
@@ -55,12 +55,14 @@ func TestNewTrait(t *testing.T) {
 
 func TestTraitGetSpec(t *testing.T) {
 	schemaJSON := []byte(`{"type":"object"}`)
+	templateJSON := []byte(`{"apiVersion":"v1","kind":"ConfigMap"}`)
 
 	tests := []struct {
 		name       string
 		trait      *Trait
 		wantParams bool
 		wantEnv    bool
+		validate   func(t *testing.T, spec map[string]interface{})
 	}{
 		{
 			name: "parameters present",
@@ -92,6 +94,124 @@ func TestTraitGetSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with creates",
+			trait: &Trait{
+				Trait: &v1alpha1.Trait{
+					Spec: v1alpha1.TraitSpec{
+						Creates: []v1alpha1.TraitCreate{
+							{
+								TargetPlane: "dataplane",
+								IncludeWhen: "${parameters.enabled}",
+								ForEach:     "${parameters.items}",
+								Var:         "item",
+								Template:    &runtime.RawExtension{Raw: templateJSON},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				creates := spec["creates"].([]interface{})
+				require.Len(t, creates, 1)
+				c := creates[0].(map[string]interface{})
+				assert.Equal(t, "dataplane", c["targetPlane"])
+				assert.Equal(t, "${parameters.enabled}", c["includeWhen"])
+				assert.Equal(t, "${parameters.items}", c["forEach"])
+				assert.Equal(t, "item", c["var"])
+				require.Contains(t, c, "template")
+				tmpl := c["template"].(map[string]interface{})
+				assert.Equal(t, "ConfigMap", tmpl["kind"])
+			},
+		},
+		{
+			name: "with patches including where and operations with value",
+			trait: &Trait{
+				Trait: &v1alpha1.Trait{
+					Spec: v1alpha1.TraitSpec{
+						Patches: []v1alpha1.TraitPatch{
+							{
+								ForEach:     "${parameters.mounts}",
+								Var:         "mount",
+								TargetPlane: "dataplane",
+								Target: v1alpha1.PatchTarget{
+									Group:   "apps",
+									Version: "v1",
+									Kind:    "Deployment",
+									Where:   "${item.name == 'main'}",
+								},
+								Operations: []v1alpha1.JSONPatchOperation{
+									{
+										Op:    "add",
+										Path:  "/spec/replicas",
+										Value: &runtime.RawExtension{Raw: []byte(`3`)},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				patches := spec["patches"].([]interface{})
+				require.Len(t, patches, 1)
+				p := patches[0].(map[string]interface{})
+				assert.Equal(t, "${parameters.mounts}", p["forEach"])
+				assert.Equal(t, "mount", p["var"])
+				assert.Equal(t, "dataplane", p["targetPlane"])
+
+				target := p["target"].(map[string]interface{})
+				assert.Equal(t, "apps", target["group"])
+				assert.Equal(t, "v1", target["version"])
+				assert.Equal(t, "Deployment", target["kind"])
+				assert.Equal(t, "${item.name == 'main'}", target["where"])
+
+				ops := p["operations"].([]interface{})
+				require.Len(t, ops, 1)
+				op := ops[0].(map[string]interface{})
+				assert.Equal(t, "add", op["op"])
+				assert.Equal(t, "/spec/replicas", op["path"])
+				assert.Contains(t, op, "value")
+			},
+		},
+		{
+			name: "patch without optional fields",
+			trait: &Trait{
+				Trait: &v1alpha1.Trait{
+					Spec: v1alpha1.TraitSpec{
+						Patches: []v1alpha1.TraitPatch{
+							{
+								Target: v1alpha1.PatchTarget{
+									Group:   "",
+									Version: "v1",
+									Kind:    "Service",
+								},
+								Operations: []v1alpha1.JSONPatchOperation{
+									{
+										Op:   "remove",
+										Path: "/spec/ports/0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				patches := spec["patches"].([]interface{})
+				p := patches[0].(map[string]interface{})
+				assert.NotContains(t, p, "forEach")
+				assert.NotContains(t, p, "var")
+				assert.NotContains(t, p, "targetPlane")
+
+				target := p["target"].(map[string]interface{})
+				assert.NotContains(t, target, "where")
+
+				ops := p["operations"].([]interface{})
+				op := ops[0].(map[string]interface{})
+				assert.NotContains(t, op, "value")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -118,6 +238,9 @@ func TestTraitGetSpec(t *testing.T) {
 				assert.Equal(t, "object", schema["type"], "spec[\"environmentConfigs\"][\"openAPIV3Schema\"][\"type\"] should match input schema")
 			} else {
 				assert.NotContains(t, spec, "environmentConfigs")
+			}
+			if tt.validate != nil {
+				tt.validate(t, spec)
 			}
 		})
 	}

--- a/internal/occ/fsmode/typed/workload_test.go
+++ b/internal/occ/fsmode/typed/workload_test.go
@@ -6,8 +6,186 @@ package typed
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
 )
+
+func makeWorkloadEntry(t *testing.T, wl *v1alpha1.Workload) *index.ResourceEntry {
+	t.Helper()
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(wl)
+	require.NoError(t, err)
+	obj := &unstructured.Unstructured{Object: raw}
+	obj.SetGroupVersionKind(v1alpha1.GroupVersion.WithKind("Workload"))
+	return &index.ResourceEntry{Resource: obj}
+}
+
+func TestNewWorkload(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   *index.ResourceEntry
+		wantErr bool
+	}{
+		{
+			name: "valid entry",
+			entry: makeWorkloadEntry(t, &v1alpha1.Workload{
+				Spec: v1alpha1.WorkloadSpec{
+					WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+						Container: v1alpha1.Container{Image: "nginx:latest"},
+					},
+				},
+			}),
+		},
+		{
+			name:    "nil entry",
+			entry:   nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wl, err := NewWorkload(tt.entry)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, wl)
+		})
+	}
+}
+
+func TestGetContainer(t *testing.T) {
+	tests := []struct {
+		name      string
+		container v1alpha1.Container
+		wantNil   bool
+		validate  func(t *testing.T, result map[string]interface{})
+	}{
+		{
+			name:      "empty image returns nil",
+			container: v1alpha1.Container{},
+			wantNil:   true,
+		},
+		{
+			name:      "image only",
+			container: v1alpha1.Container{Image: "nginx:latest"},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, "nginx:latest", result["image"])
+				assert.NotContains(t, result, "command")
+				assert.NotContains(t, result, "args")
+				assert.NotContains(t, result, "env")
+				assert.NotContains(t, result, "files")
+			},
+		},
+		{
+			name: "with command and args",
+			container: v1alpha1.Container{
+				Image:   "app:v1",
+				Command: []string{"/bin/sh", "-c"},
+				Args:    []string{"echo", "hello"},
+			},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				cmd := result["command"].([]interface{})
+				require.Len(t, cmd, 2)
+				assert.Equal(t, "/bin/sh", cmd[0])
+				assert.Equal(t, "-c", cmd[1])
+
+				args := result["args"].([]interface{})
+				require.Len(t, args, 2)
+				assert.Equal(t, "echo", args[0])
+			},
+		},
+		{
+			name: "with env vars - literal and secret ref",
+			container: v1alpha1.Container{
+				Image: "app:v1",
+				Env: []v1alpha1.EnvVar{
+					{Key: "PORT", Value: "8080"},
+					{Key: "SECRET", ValueFrom: &v1alpha1.EnvVarValueFrom{
+						SecretKeyRef: &v1alpha1.SecretKeyRef{Name: "my-secret", Key: "password"},
+					}},
+				},
+			},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				env := result["env"].([]interface{})
+				require.Len(t, env, 2)
+
+				e0 := env[0].(map[string]interface{})
+				assert.Equal(t, "PORT", e0["key"])
+				assert.Equal(t, "8080", e0["value"])
+
+				e1 := env[1].(map[string]interface{})
+				assert.Equal(t, "SECRET", e1["key"])
+				assert.NotContains(t, e1, "value")
+				vf := e1["valueFrom"].(map[string]interface{})
+				skr := vf["secretKeyRef"].(map[string]interface{})
+				assert.Equal(t, "my-secret", skr["name"])
+				assert.Equal(t, "password", skr["key"])
+			},
+		},
+		{
+			name: "with files - literal and secret ref",
+			container: v1alpha1.Container{
+				Image: "app:v1",
+				Files: []v1alpha1.FileVar{
+					{Key: "config.yaml", MountPath: "/etc/app/config.yaml", Value: "key: val"},
+					{Key: "cert.pem", MountPath: "/etc/certs/cert.pem", ValueFrom: &v1alpha1.EnvVarValueFrom{
+						SecretKeyRef: &v1alpha1.SecretKeyRef{Name: "tls-secret", Key: "cert"},
+					}},
+				},
+			},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				files := result["files"].([]interface{})
+				require.Len(t, files, 2)
+
+				f0 := files[0].(map[string]interface{})
+				assert.Equal(t, "config.yaml", f0["key"])
+				assert.Equal(t, "/etc/app/config.yaml", f0["mountPath"])
+				assert.Equal(t, "key: val", f0["value"])
+
+				f1 := files[1].(map[string]interface{})
+				assert.Equal(t, "cert.pem", f1["key"])
+				assert.NotContains(t, f1, "value")
+				vf := f1["valueFrom"].(map[string]interface{})
+				skr := vf["secretKeyRef"].(map[string]interface{})
+				assert.Equal(t, "tls-secret", skr["name"])
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wl := &Workload{
+				Workload: &v1alpha1.Workload{
+					Spec: v1alpha1.WorkloadSpec{
+						WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+							Container: tt.container,
+						},
+					},
+				},
+			}
+			result := wl.GetContainer()
+			if tt.wantNil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			tt.validate(t, result)
+		})
+	}
+}
+
+func TestStringsToInterfaceSlice(t *testing.T) {
+	result := stringsToInterfaceSlice([]string{"a", "b", "c"})
+	require.Len(t, result, 3)
+	assert.Equal(t, "a", result[0])
+	assert.Equal(t, "b", result[1])
+	assert.Equal(t, "c", result[2])
+}
 
 func TestGetEndpoints(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Purpose

Add test coverage for the `internal/occ/fsmode/typed` package to improve confidence in the type-safe wrapper functionality used by the CLI.

## Approach

- Add tests for `Component`: `NewComponent`, `GetParameters`, `GetTraitRefs` (with explicit/empty kind, multiple traits, parameters), `ProjectName`
- Add tests for `Workload`: `NewWorkload`, `GetContainer` (covering env vars with literal values and secret refs, files with literal values and secret refs, command/args), `stringsToInterfaceSlice`
- Add tests for `Trait.GetSpec`: creates with all optional fields (targetPlane, includeWhen, forEach, var, template), patches with all optional fields (forEach, var, targetPlane, target with where, operations with value), and minimal patches without optional fields
- Add test for `ComponentType.GetResources` covering forEach and var fields

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)