### PR TITLE
test(cli): add tests for fsmode generator package

### DIFF
--- a/internal/occ/fsmode/generator/component_release_test.go
+++ b/internal/occ/fsmode/generator/component_release_test.go
@@ -116,8 +116,11 @@ func addTrait(t *testing.T, idx *index.Index, name string, spec map[string]any, 
 }
 
 // addComponentWithTraits adds a Component with trait references to the index.
-func addComponentWithTraits(t *testing.T, idx *index.Index, namespace, name, project, componentTypeName string, traits []map[string]any, filePath string) {
+func addComponentWithTraits(t *testing.T, idx *index.Index, namespace string, traits []map[string]any, filePath string) {
 	t.Helper()
+	const name = "my-svc"
+	const project = "myproj"
+	const componentTypeName = "deployment/service"
 	spec := map[string]any{
 		"owner": map[string]any{
 			"projectName": project,
@@ -157,7 +160,7 @@ func TestGenerateRelease_ManifestShape(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace, componentName, projectName, "deployment/service",
+	addComponentWithTraits(t, idx, namespace,
 		[]map[string]any{
 			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-1"},
 			{"name": "logging", "instanceName": "logging-1"},
@@ -368,7 +371,7 @@ func TestGenerateRelease_ClusterTrait(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace, componentName, projectName, "deployment/service",
+	addComponentWithTraits(t, idx, namespace,
 		[]map[string]any{
 			{"kind": "ClusterTrait", "name": "global-ingress", "instanceName": "gi-1"},
 		},
@@ -430,7 +433,7 @@ func TestGenerateRelease_MissingClusterTraitErrors(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace, componentName, projectName, "deployment/service",
+	addComponentWithTraits(t, idx, namespace,
 		[]map[string]any{
 			{"kind": "ClusterTrait", "name": "global-ingress", "instanceName": "gi-1"},
 		},
@@ -676,6 +679,142 @@ func TestGenerateRelease_WorkloadConnectionsIncluded(t *testing.T) {
 
 	second := connSlice[1].(map[string]interface{})
 	assert.Equal(t, "nats", second["component"])
+}
+
+func TestGenerateRelease_ProjectNameMismatch(t *testing.T) {
+	idx := index.New("/repo")
+
+	addComponent(t, idx, "my-svc", "actual-project", "deployment/service",
+		"/repo/projects/actual-project/components/my-svc/component.yaml")
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+	addWorkload(t, idx, "default", "my-svc-workload", "actual-project", "my-svc",
+		map[string]any{"container": map[string]any{"image": "img:v1"}},
+		"/repo/projects/actual-project/components/my-svc/workload.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	_, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: "my-svc",
+		ProjectName:   "wrong-project",
+		Namespace:     "default",
+		ReleaseName:   "test-release",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "belongs to project")
+}
+
+func TestGenerateRelease_UnsupportedTraitKindErrors(t *testing.T) {
+	idx := index.New("/repo")
+
+	addComponentWithTraits(t, idx, "default",
+		[]map[string]any{
+			{"kind": "UnknownTraitKind", "name": "my-trait", "instanceName": "t-1"},
+		},
+		"/repo/projects/myproj/components/my-svc/component.yaml")
+
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+
+	addWorkload(t, idx, "default", "my-svc-workload", "myproj", "my-svc",
+		map[string]any{"container": map[string]any{"image": "img:v1"}},
+		"/repo/projects/myproj/components/my-svc/workload.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	_, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: "my-svc",
+		ProjectName:   "myproj",
+		Namespace:     "default",
+		ReleaseName:   "test-release",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported trait kind")
+}
+
+func TestGenerateRelease_WithComponentParameters(t *testing.T) {
+	idx := index.New("/repo")
+
+	// Add component with parameters
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata":   map[string]any{"name": "my-svc", "namespace": "default"},
+				"spec": map[string]any{
+					"owner":         map[string]any{"projectName": "myproj"},
+					"componentType": map[string]any{"name": "deployment/service", "kind": "ComponentType"},
+					"parameters":    map[string]any{"port": float64(8080), "replicas": float64(3)},
+				},
+			},
+		},
+		FilePath: "/repo/comp.yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+
+	addComponentType(t, idx, "service", "deployment",
+		"/repo/platform/component-types/service.yaml")
+	addWorkload(t, idx, "default", "my-svc-workload", "myproj", "my-svc",
+		map[string]any{"container": map[string]any{"image": "img:v1"}},
+		"/repo/wl.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	release, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: "my-svc",
+		ProjectName:   "myproj",
+		Namespace:     "default",
+		ReleaseName:   "test-release",
+	})
+	require.NoError(t, err)
+
+	// Verify componentProfile.parameters is present
+	params, ok, _ := unstructured.NestedMap(release.Object, "spec", "componentProfile", "parameters")
+	require.True(t, ok, "expected spec.componentProfile.parameters")
+	assert.Equal(t, float64(8080), params["port"])
+	assert.Equal(t, float64(3), params["replicas"])
+}
+
+func TestGenerateRelease_DuplicateTraitsDeduped(t *testing.T) {
+	idx := index.New("/repo")
+
+	// Component references the same trait twice with different instance names
+	addComponentWithTraits(t, idx, "default",
+		[]map[string]any{
+			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-a"},
+			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-b"},
+		},
+		"/repo/comp.yaml")
+
+	addComponentType(t, idx, "service", "deployment", "/repo/ct.yaml")
+	addTrait(t, idx, "ingress", map[string]any{}, "/repo/traits/ingress.yaml")
+	addWorkload(t, idx, "default", "my-svc-workload", "myproj", "my-svc",
+		map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	release, err := gen.GenerateRelease(ReleaseOptions{
+		ComponentName: "my-svc",
+		ProjectName:   "myproj",
+		Namespace:     "default",
+		ReleaseName:   "test-release",
+	})
+	require.NoError(t, err)
+
+	// spec.traits should be deduped to 1 entry
+	traitsSlice, ok, _ := unstructured.NestedSlice(release.Object, "spec", "traits")
+	require.True(t, ok)
+	assert.Len(t, traitsSlice, 1)
+
+	// spec.componentProfile.traits should have both instances
+	profileTraits, ok, _ := unstructured.NestedSlice(release.Object, "spec", "componentProfile", "traits")
+	require.True(t, ok)
+	assert.Len(t, profileTraits, 2)
 }
 
 func TestGenerateRelease_WorkloadWithoutEndpoints(t *testing.T) {

--- a/internal/occ/fsmode/generator/release_binding_test.go
+++ b/internal/occ/fsmode/generator/release_binding_test.go
@@ -31,8 +31,9 @@ func newTestPipelineInfo() *pipeline.PipelineInfo {
 // generateMatchingRelease generates a ComponentRelease whose spec matches the
 // current component state, using the ReleaseGenerator. This ensures the release
 // spec is exactly what the hash-based comparison expects.
-func generateMatchingRelease(t *testing.T, idx *index.Index, namespace, releaseName, projectName, componentName string) *unstructured.Unstructured {
+func generateMatchingRelease(t *testing.T, idx *index.Index, releaseName, projectName, componentName string) *unstructured.Unstructured {
 	t.Helper()
+	const namespace = "test-ns"
 	tmpIndex := fsmode.WrapIndex(idx)
 	gen := NewReleaseGenerator(tmpIndex)
 	release, err := gen.GenerateRelease(ReleaseOptions{
@@ -70,7 +71,7 @@ func TestGenerateBindingWithInfo_Create(t *testing.T) {
 		"/repo/projects/my-proj/components/my-comp/workload.yaml")
 
 	// Generate a ComponentRelease whose spec matches the current component state
-	release := generateMatchingRelease(t, idx, namespace, releaseName, projectName, componentName)
+	release := generateMatchingRelease(t, idx, releaseName, projectName, componentName)
 
 	// Add the matching release to the index
 	releaseEntry := &index.ResourceEntry{
@@ -151,7 +152,7 @@ spec:
 		filepath.Join(tmpDir, "projects", projectName, "components", componentName, "workload.yaml"))
 
 	// Generate a ComponentRelease whose spec matches the current component state
-	release := generateMatchingRelease(t, idx, namespace, newRelease, projectName, componentName)
+	release := generateMatchingRelease(t, idx, newRelease, projectName, componentName)
 
 	// Add the matching release to the index
 	releaseEntry := &index.ResourceEntry{
@@ -354,6 +355,409 @@ func TestSelectComponentRelease_CompareSpecsError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "comparing release specs")
+}
+
+func TestGenerateBinding_ValidationErrors(t *testing.T) {
+	idx := index.New("/repo")
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewBindingGenerator(ocIndex)
+
+	pipelineInfo := newTestPipelineInfo()
+
+	tests := []struct {
+		name    string
+		opts    BindingOptions
+		wantErr string
+	}{
+		{
+			name:    "missing project name",
+			opts:    BindingOptions{ComponentName: "c", TargetEnv: "dev", PipelineInfo: pipelineInfo, Namespace: "ns"},
+			wantErr: "project name is required",
+		},
+		{
+			name:    "missing component name",
+			opts:    BindingOptions{ProjectName: "p", TargetEnv: "dev", PipelineInfo: pipelineInfo, Namespace: "ns"},
+			wantErr: "component name is required",
+		},
+		{
+			name:    "missing target env",
+			opts:    BindingOptions{ProjectName: "p", ComponentName: "c", PipelineInfo: pipelineInfo, Namespace: "ns"},
+			wantErr: "target environment is required",
+		},
+		{
+			name:    "missing pipeline info",
+			opts:    BindingOptions{ProjectName: "p", ComponentName: "c", TargetEnv: "dev", Namespace: "ns"},
+			wantErr: "pipeline info is required",
+		},
+		{
+			name:    "missing namespace",
+			opts:    BindingOptions{ProjectName: "p", ComponentName: "c", TargetEnv: "dev", PipelineInfo: pipelineInfo},
+			wantErr: "namespace is required",
+		},
+		{
+			name:    "invalid environment",
+			opts:    BindingOptions{ProjectName: "p", ComponentName: "c", TargetEnv: "prod", PipelineInfo: pipelineInfo, Namespace: "ns"},
+			wantErr: "prod",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gen.GenerateBinding(tt.opts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestSelectComponentRelease_ExplicitRelease(t *testing.T) {
+	const (
+		namespace     = "test-ns"
+		projectName   = "my-proj"
+		componentName = "my-comp"
+		releaseName   = "my-comp-20260101-0"
+	)
+
+	idx := index.New("/repo")
+
+	// Add component and a matching release
+	addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
+		"ComponentType",
+		"/repo/projects/my-proj/components/my-comp.yaml")
+	addComponentType(t, idx, "my-type", "Deployment",
+		"/repo/component-types/my-type.yaml")
+	addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
+		map[string]any{"container": map[string]any{"image": "img:v1"}},
+		"/repo/projects/my-proj/components/my-comp/workload.yaml")
+
+	// Add release owned by the component
+	releaseEntry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentRelease",
+				"metadata":   map[string]any{"name": releaseName, "namespace": namespace},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   projectName,
+						"componentName": componentName,
+					},
+				},
+			},
+		},
+		FilePath: "/repo/releases/" + releaseName + ".yaml",
+	}
+	require.NoError(t, idx.Add(releaseEntry))
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewBindingGenerator(ocIndex)
+
+	t.Run("explicit release found", func(t *testing.T) {
+		binding, err := gen.GenerateBinding(BindingOptions{
+			ProjectName:      projectName,
+			ComponentName:    componentName,
+			ComponentRelease: releaseName,
+			TargetEnv:        "dev",
+			PipelineInfo:     newTestPipelineInfo(),
+			Namespace:        namespace,
+		})
+		require.NoError(t, err)
+		gotRelease := getNestedString(binding.Object, "spec", "releaseName")
+		assert.Equal(t, releaseName, gotRelease)
+	})
+
+	t.Run("explicit release not found", func(t *testing.T) {
+		_, err := gen.GenerateBinding(BindingOptions{
+			ProjectName:      projectName,
+			ComponentName:    componentName,
+			ComponentRelease: "nonexistent-release",
+			TargetEnv:        "dev",
+			PipelineInfo:     newTestPipelineInfo(),
+			Namespace:        namespace,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found or does not belong")
+	})
+}
+
+func TestSelectComponentRelease_NonRootEnvPromotion(t *testing.T) {
+	const (
+		namespace     = "test-ns"
+		projectName   = "my-proj"
+		componentName = "my-comp"
+		releaseName   = "my-comp-20260101-0"
+	)
+
+	// Pipeline with dev -> staging
+	pipelineInfo := &pipeline.PipelineInfo{
+		Name:            "test-pipeline",
+		RootEnvironment: "dev",
+		Environments:    []string{"dev", "staging"},
+		PromotionPaths:  map[string][]string{"dev": {"staging"}, "staging": {}},
+		EnvPosition:     map[string]int{"dev": 0, "staging": 1},
+	}
+
+	t.Run("promote from previous env", func(t *testing.T) {
+		idx := index.New("/repo")
+		addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
+			"ComponentType", "/repo/comp.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
+
+		// Add a binding in the previous env (dev) with a release name
+		addReleaseBinding(t, idx, namespace, componentName+"-dev", projectName, componentName, "dev",
+			releaseName, "/repo/bindings/dev.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		binding, err := gen.GenerateBinding(BindingOptions{
+			ProjectName:   projectName,
+			ComponentName: componentName,
+			TargetEnv:     "staging",
+			PipelineInfo:  pipelineInfo,
+			Namespace:     namespace,
+		})
+		require.NoError(t, err)
+		gotRelease := getNestedString(binding.Object, "spec", "releaseName")
+		assert.Equal(t, releaseName, gotRelease)
+	})
+
+	t.Run("no binding in previous env", func(t *testing.T) {
+		idx := index.New("/repo")
+		addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
+			"ComponentType", "/repo/comp.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		_, err := gen.GenerateBinding(BindingOptions{
+			ProjectName:   projectName,
+			ComponentName: componentName,
+			TargetEnv:     "staging",
+			PipelineInfo:  pipelineInfo,
+			Namespace:     namespace,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ReleaseBinding found in previous environment")
+	})
+
+	t.Run("previous env binding has empty releaseName", func(t *testing.T) {
+		idx := index.New("/repo")
+		addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
+			"ComponentType", "/repo/comp.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
+
+		// Binding in dev but with no releaseName
+		addReleaseBinding(t, idx, namespace, componentName+"-dev", projectName, componentName, "dev",
+			"", "/repo/bindings/dev.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		_, err := gen.GenerateBinding(BindingOptions{
+			ProjectName:   projectName,
+			ComponentName: componentName,
+			TargetEnv:     "staging",
+			PipelineInfo:  pipelineInfo,
+			Namespace:     namespace,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no releaseName set")
+	})
+}
+
+func TestGenerateBulkBindings(t *testing.T) {
+	const (
+		namespace = "test-ns"
+	)
+
+	pipelineInfo := newTestPipelineInfo()
+
+	t.Run("validation errors", func(t *testing.T) {
+		idx := index.New("/repo")
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		_, err := gen.GenerateBulkBindings(BulkBindingOptions{All: true, Namespace: "ns", PipelineInfo: pipelineInfo})
+		// TargetEnv is missing
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target environment is required")
+
+		_, err = gen.GenerateBulkBindings(BulkBindingOptions{All: true, TargetEnv: "dev", Namespace: "ns"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pipeline info is required")
+
+		_, err = gen.GenerateBulkBindings(BulkBindingOptions{All: true, TargetEnv: "dev", PipelineInfo: pipelineInfo})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace is required")
+
+		_, err = gen.GenerateBulkBindings(BulkBindingOptions{TargetEnv: "dev", PipelineInfo: pipelineInfo, Namespace: "ns"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "either All or ProjectName must be specified")
+	})
+
+	t.Run("all components", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// Add two components in different projects
+		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
+		addComponentWithKind(t, idx, namespace, "comp-b", "proj-b", "my-type", "ComponentType", "/repo/comp-b.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
+		addWorkload(t, idx, namespace, "comp-b-workload", "proj-b", "comp-b",
+			map[string]any{"container": map[string]any{"image": "img:v2"}}, "/repo/wl-b.yaml")
+
+		// Add matching releases for both
+		for _, info := range []struct{ proj, comp, release string }{
+			{"proj-a", "comp-a", "comp-a-20260101-0"},
+			{"proj-b", "comp-b", "comp-b-20260101-0"},
+		} {
+			release := generateMatchingRelease(t, idx, info.release, info.proj, info.comp)
+			require.NoError(t, idx.Add(&index.ResourceEntry{
+				Resource: release,
+				FilePath: "/repo/releases/" + info.release + ".yaml",
+			}))
+		}
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		result, err := gen.GenerateBulkBindings(BulkBindingOptions{
+			All:          true,
+			TargetEnv:    "dev",
+			PipelineInfo: pipelineInfo,
+			Namespace:    namespace,
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.Bindings, 2)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("by project name", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
+		addComponentWithKind(t, idx, namespace, "comp-b", "proj-a", "my-type", "ComponentType", "/repo/comp-b.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
+		addWorkload(t, idx, namespace, "comp-b-workload", "proj-a", "comp-b",
+			map[string]any{"container": map[string]any{"image": "img:v2"}}, "/repo/wl-b.yaml")
+
+		for _, info := range []struct{ comp, release string }{
+			{"comp-a", "comp-a-20260101-0"},
+			{"comp-b", "comp-b-20260101-0"},
+		} {
+			release := generateMatchingRelease(t, idx, info.release, "proj-a", info.comp)
+			require.NoError(t, idx.Add(&index.ResourceEntry{
+				Resource: release,
+				FilePath: "/repo/releases/" + info.release + ".yaml",
+			}))
+		}
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		result, err := gen.GenerateBulkBindings(BulkBindingOptions{
+			ProjectName:  "proj-a",
+			TargetEnv:    "dev",
+			PipelineInfo: pipelineInfo,
+			Namespace:    namespace,
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.Bindings, 2)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("all components across multiple projects", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// Set up 3 components across 2 projects
+		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
+		addComponentWithKind(t, idx, namespace, "comp-b", "proj-a", "my-type", "ComponentType", "/repo/comp-b.yaml")
+		addComponentWithKind(t, idx, namespace, "comp-c", "proj-b", "my-type", "ComponentType", "/repo/comp-c.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
+		addWorkload(t, idx, namespace, "comp-b-workload", "proj-a", "comp-b",
+			map[string]any{"container": map[string]any{"image": "img:v2"}}, "/repo/wl-b.yaml")
+		addWorkload(t, idx, namespace, "comp-c-workload", "proj-b", "comp-c",
+			map[string]any{"container": map[string]any{"image": "img:v3"}}, "/repo/wl-c.yaml")
+
+		for _, info := range []struct{ proj, comp, release string }{
+			{"proj-a", "comp-a", "comp-a-20260101-0"},
+			{"proj-a", "comp-b", "comp-b-20260101-0"},
+			{"proj-b", "comp-c", "comp-c-20260101-0"},
+		} {
+			release := generateMatchingRelease(t, idx, info.release, info.proj, info.comp)
+			require.NoError(t, idx.Add(&index.ResourceEntry{
+				Resource: release,
+				FilePath: "/repo/releases/" + info.release + ".yaml",
+			}))
+		}
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		result, err := gen.GenerateBulkBindings(BulkBindingOptions{
+			All:          true,
+			TargetEnv:    "dev",
+			PipelineInfo: pipelineInfo,
+			Namespace:    namespace,
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.Bindings, 3)
+		assert.Empty(t, result.Errors)
+
+		// Verify bindings are generated for both projects
+		projectCounts := make(map[string]int)
+		for _, b := range result.Bindings {
+			projectCounts[b.ProjectName]++
+		}
+		assert.Equal(t, 2, projectCounts["proj-a"])
+		assert.Equal(t, 1, projectCounts["proj-b"])
+	})
+
+	t.Run("partial errors", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		// comp-a is valid, comp-b has no releases -> will error
+		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
+		addComponentWithKind(t, idx, namespace, "comp-b", "proj-a", "my-type", "ComponentType", "/repo/comp-b.yaml")
+		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
+			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
+		addWorkload(t, idx, namespace, "comp-b-workload", "proj-a", "comp-b",
+			map[string]any{"container": map[string]any{"image": "img:v2"}}, "/repo/wl-b.yaml")
+
+		// Only add release for comp-a
+		release := generateMatchingRelease(t, idx, "comp-a-20260101-0", "proj-a", "comp-a")
+		require.NoError(t, idx.Add(&index.ResourceEntry{
+			Resource: release,
+			FilePath: "/repo/releases/comp-a-20260101-0.yaml",
+		}))
+
+		ocIndex := fsmode.WrapIndex(idx)
+		gen := NewBindingGenerator(ocIndex)
+
+		result, err := gen.GenerateBulkBindings(BulkBindingOptions{
+			ProjectName:  "proj-a",
+			TargetEnv:    "dev",
+			PipelineInfo: pipelineInfo,
+			Namespace:    namespace,
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.Bindings, 1)
+		assert.Len(t, result.Errors, 1)
+		assert.Equal(t, "comp-b", result.Errors[0].ComponentName)
+	})
 }
 
 // addReleaseBinding adds a ReleaseBinding resource entry to the index.

--- a/internal/occ/fsmode/output/workload_writer_test.go
+++ b/internal/occ/fsmode/output/workload_writer_test.go
@@ -4,11 +4,15 @@
 package output
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
 	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
 )
@@ -36,6 +40,70 @@ func makeEntry(kind, namespace, name, filePath string, extra map[string]any) *in
 	}
 	u := &unstructured.Unstructured{Object: obj}
 	return &index.ResourceEntry{Resource: u, FilePath: filePath}
+}
+
+func TestWriteWorkload(t *testing.T) {
+	t.Run("writes workload to disk", func(t *testing.T) {
+		dir := t.TempDir()
+		idx := buildIndex(t)
+		w := NewWorkloadWriter(idx)
+
+		wl := &openchoreov1alpha1.Workload{}
+		wl.SetName("my-workload")
+		wl.SetNamespace("ns")
+		wl.SetGroupVersionKind(openchoreov1alpha1.GroupVersion.WithKind("Workload"))
+		wl.Spec.Owner.ProjectName = "proj"
+		wl.Spec.Owner.ComponentName = "comp"
+		wl.Spec.Container.Image = "nginx:latest"
+
+		outputPath := filepath.Join(dir, "workload.yaml")
+		path, err := w.WriteWorkload(WorkloadWriteParams{
+			Namespace:     "ns",
+			RepoPath:      dir,
+			ProjectName:   "proj",
+			ComponentName: "comp",
+			OutputPath:    outputPath,
+			WorkloadCR:    wl,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, outputPath, path)
+		assert.FileExists(t, outputPath)
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "nginx:latest")
+	})
+
+	t.Run("dry run does not write file", func(t *testing.T) {
+		dir := t.TempDir()
+		idx := buildIndex(t)
+		w := NewWorkloadWriter(idx)
+
+		wl := &openchoreov1alpha1.Workload{}
+		wl.SetName("my-workload")
+		wl.SetNamespace("ns")
+		wl.SetGroupVersionKind(openchoreov1alpha1.GroupVersion.WithKind("Workload"))
+		wl.Spec.Owner.ProjectName = "proj"
+		wl.Spec.Owner.ComponentName = "comp"
+		wl.Spec.Container.Image = "nginx:latest"
+
+		outputPath := filepath.Join(dir, "workload.yaml")
+		path, err := w.WriteWorkload(WorkloadWriteParams{
+			Namespace:     "ns",
+			RepoPath:      dir,
+			ProjectName:   "proj",
+			ComponentName: "comp",
+			OutputPath:    outputPath,
+			WorkloadCR:    wl,
+			DryRun:        true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, outputPath, path)
+
+		// File should not exist in dry-run mode
+		_, err = os.Stat(outputPath)
+		assert.True(t, os.IsNotExist(err))
+	})
 }
 
 func TestWorkloadWriterResolveOutputPath(t *testing.T) {

--- a/internal/occ/fsmode/output/writer.go
+++ b/internal/occ/fsmode/output/writer.go
@@ -461,7 +461,11 @@ func (w *Writer) WriteBulkBindings(
 		projectName := getNestedString(binding.Object, "spec", "owner", "projectName")
 		componentName := getNestedString(binding.Object, "spec", "owner", "componentName")
 
-		outputPath := w.resolveBindingOutputPath(binding, projectName, componentName, opts)
+		outputPath, err := w.resolveBindingOutputPath(binding, projectName, componentName, opts)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("failed to resolve output path for %s: %w", binding.GetName(), err))
+			continue
+		}
 
 		// Marshal to YAML
 		data, err := yaml.Marshal(binding.Object)
@@ -493,13 +497,17 @@ func (w *Writer) resolveBindingOutputPath(
 	binding *unstructured.Unstructured,
 	projectName, componentName string,
 	opts BulkBindingWriteOptions,
-) string {
+) (string, error) {
 	bindingName := binding.GetName()
 
-	// Priority 0: If an existing file path is known (update-in-place), return it directly
+	// Priority 0: If an existing file path is known (update-in-place), validate and return it
 	if opts.ExistingPaths != nil {
 		if existingPath, ok := opts.ExistingPaths[bindingName]; ok && existingPath != "" {
-			return existingPath
+			cleanedPath, err := w.validatePathWithinBase(existingPath)
+			if err != nil {
+				return "", fmt.Errorf("existing path for %q is invalid: %w", bindingName, err)
+			}
+			return cleanedPath, nil
 		}
 	}
 
@@ -510,7 +518,7 @@ func (w *Writer) resolveBindingOutputPath(
 		if !filepath.IsAbs(outputDir) {
 			outputDir = filepath.Join(w.baseDir, outputDir)
 		}
-		return filepath.Join(outputDir, bindingName+".yaml")
+		return filepath.Join(outputDir, bindingName+".yaml"), nil
 	}
 
 	// Priority 2: Check config file for component-specific or project-specific path
@@ -520,7 +528,7 @@ func (w *Writer) resolveBindingOutputPath(
 			if !filepath.IsAbs(configDir) {
 				configDir = filepath.Join(w.baseDir, configDir)
 			}
-			return filepath.Join(configDir, bindingName+".yaml")
+			return filepath.Join(configDir, bindingName+".yaml"), nil
 		}
 	}
 
@@ -530,7 +538,7 @@ func (w *Writer) resolveBindingOutputPath(
 			if !filepath.IsAbs(resolvedDir) {
 				resolvedDir = filepath.Join(w.baseDir, resolvedDir)
 			}
-			return filepath.Join(resolvedDir, bindingName+".yaml")
+			return filepath.Join(resolvedDir, bindingName+".yaml"), nil
 		}
 	}
 
@@ -542,5 +550,21 @@ func (w *Writer) resolveBindingOutputPath(
 		"components", componentName,
 		"release-bindings",
 		bindingName+".yaml",
-	)
+	), nil
+}
+
+// validatePathWithinBase ensures the given path, after cleaning and resolving,
+// falls within the writer's base directory. This prevents path traversal attacks
+// via ".." components in user-supplied paths.
+func (w *Writer) validatePathWithinBase(path string) (string, error) {
+	cleaned := filepath.Clean(path)
+	if !filepath.IsAbs(cleaned) {
+		cleaned = filepath.Join(w.baseDir, cleaned)
+	}
+
+	baseDir := filepath.Clean(w.baseDir)
+	if !strings.HasPrefix(cleaned, baseDir+string(filepath.Separator)) && cleaned != baseDir {
+		return "", fmt.Errorf("path %q escapes base directory %q", path, baseDir)
+	}
+	return cleaned, nil
 }

--- a/internal/occ/fsmode/output/writer_test.go
+++ b/internal/occ/fsmode/output/writer_test.go
@@ -155,19 +155,40 @@ func TestResolveBindingOutputPath(t *testing.T) {
 
 	t.Run("priority 0: existing path for update-in-place", func(t *testing.T) {
 		opts := BulkBindingWriteOptions{
-			ExistingPaths: map[string]string{"svc-dev": "/existing/path/svc-dev.yaml"},
+			ExistingPaths: map[string]string{"svc-dev": "/repo/existing/path/svc-dev.yaml"},
 		}
-		path := w.resolveBindingOutputPath(binding, "proj", "svc", opts)
-		assert.Equal(t, "/existing/path/svc-dev.yaml", path)
+		path, err := w.resolveBindingOutputPath(binding, "proj", "svc", opts)
+		require.NoError(t, err)
+		assert.Equal(t, "/repo/existing/path/svc-dev.yaml", path)
+	})
+
+	t.Run("priority 0: existing path escaping base dir is rejected", func(t *testing.T) {
+		opts := BulkBindingWriteOptions{
+			ExistingPaths: map[string]string{"svc-dev": "/repo/../etc/svc-dev.yaml"},
+		}
+		_, err := w.resolveBindingOutputPath(binding, "proj", "svc", opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes base directory")
+	})
+
+	t.Run("priority 0: existing path outside base dir is rejected", func(t *testing.T) {
+		opts := BulkBindingWriteOptions{
+			ExistingPaths: map[string]string{"svc-dev": "/outside/path/svc-dev.yaml"},
+		}
+		_, err := w.resolveBindingOutputPath(binding, "proj", "svc", opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes base directory")
 	})
 
 	t.Run("priority 1: output dir flag", func(t *testing.T) {
-		path := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{OutputDir: "/out"})
+		path, err := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{OutputDir: "/out"})
+		require.NoError(t, err)
 		assert.Equal(t, "/out/svc-dev.yaml", path)
 	})
 
 	t.Run("priority 1: relative output dir resolved against baseDir", func(t *testing.T) {
-		path := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{OutputDir: "out"})
+		path, err := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{OutputDir: "out"})
+		require.NoError(t, err)
 		assert.Equal(t, "/repo/out/svc-dev.yaml", path)
 	})
 
@@ -175,12 +196,14 @@ func TestResolveBindingOutputPath(t *testing.T) {
 		resolver := func(project, component string) string {
 			return "/resolved/" + project + "/" + component
 		}
-		path := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{Resolver: resolver})
+		path, err := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{Resolver: resolver})
+		require.NoError(t, err)
 		assert.Equal(t, "/resolved/proj/svc/svc-dev.yaml", path)
 	})
 
 	t.Run("priority 4: default path", func(t *testing.T) {
-		path := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{})
+		path, err := w.resolveBindingOutputPath(binding, "proj", "svc", BulkBindingWriteOptions{})
+		require.NoError(t, err)
 		assert.Equal(t, "/repo/projects/proj/components/svc/release-bindings/svc-dev.yaml", path)
 	})
 }
@@ -215,6 +238,42 @@ func TestWriteRelease(t *testing.T) {
 	})
 }
 
+func TestWriteRelease_SkipIfUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+
+	// Create a release and write it
+	release := makeReleaseObj("my-comp-20250315-1", "proj", "my-comp")
+	path, skipped, err := w.WriteRelease(release, WriteOptions{OutputDir: dir})
+	require.NoError(t, err)
+	assert.False(t, skipped)
+	assert.FileExists(t, path)
+
+	// Try writing the same release again with SkipIfUnchanged
+	_, skipped, err = w.WriteRelease(release, WriteOptions{OutputDir: dir, SkipIfUnchanged: true})
+	require.NoError(t, err)
+	assert.True(t, skipped, "should skip writing identical release")
+}
+
+func TestWriteRelease_AutoIncrementVersion(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+
+	// Write first release
+	release1 := makeReleaseObj("my-comp-20250315-0", "proj", "my-comp")
+	path1, _, err := w.WriteRelease(release1, WriteOptions{OutputDir: dir})
+	require.NoError(t, err)
+	assert.Contains(t, path1, "my-comp-20250315-0.yaml")
+
+	// Write a different release with the same name - should auto-increment
+	release2 := makeReleaseObj("my-comp-20250315-0", "proj", "my-comp")
+	// Add a different field to make it not identical
+	_ = unstructured.SetNestedField(release2.Object, "new-value", "spec", "extraField")
+	path2, _, err := w.WriteRelease(release2, WriteOptions{OutputDir: dir})
+	require.NoError(t, err)
+	assert.Contains(t, path2, "my-comp-20250315-1.yaml")
+}
+
 func TestWriteBinding(t *testing.T) {
 	t.Run("dry run writes to stdout buffer", func(t *testing.T) {
 		w := NewWriter("/repo")
@@ -240,5 +299,158 @@ func TestWriteBinding(t *testing.T) {
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
 		assert.Contains(t, string(data), "my-comp-dev")
+	})
+}
+
+func TestWriteResource(t *testing.T) {
+	t.Run("writes to disk", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		resource := makeReleaseObj("test-resource", "proj", "comp")
+		outputPath := filepath.Join(dir, "subdir", "test-resource.yaml")
+
+		err := w.WriteResource(resource, outputPath, false)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "test-resource")
+	})
+
+	t.Run("dry run does not write file", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		resource := makeReleaseObj("test-resource", "proj", "comp")
+		outputPath := filepath.Join(dir, "test-resource.yaml")
+
+		err := w.WriteResource(resource, outputPath, true)
+		require.NoError(t, err)
+
+		// File should not exist
+		_, err = os.Stat(outputPath)
+		assert.True(t, os.IsNotExist(err))
+	})
+}
+
+func TestWriteBulkReleases(t *testing.T) {
+	t.Run("dry run writes all to stdout", func(t *testing.T) {
+		w := NewWriter("/repo")
+		releases := []*unstructured.Unstructured{
+			makeReleaseObj("comp-a-20250315-0", "proj", "comp-a"),
+			makeReleaseObj("comp-b-20250315-0", "proj", "comp-b"),
+		}
+		var buf bytes.Buffer
+
+		result, err := w.WriteBulkReleases(releases, BulkWriteOptions{DryRun: true, Stdout: &buf})
+		require.NoError(t, err)
+		assert.Empty(t, result.OutputPaths)
+		assert.Empty(t, result.Errors)
+		assert.Contains(t, buf.String(), "comp-a-20250315-0")
+		assert.Contains(t, buf.String(), "comp-b-20250315-0")
+	})
+
+	t.Run("writes files to disk", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		releases := []*unstructured.Unstructured{
+			makeReleaseObj("comp-a-20250315-0", "proj", "comp-a"),
+			makeReleaseObj("comp-b-20250315-0", "proj", "comp-b"),
+		}
+
+		result, err := w.WriteBulkReleases(releases, BulkWriteOptions{OutputDir: dir})
+		require.NoError(t, err)
+		assert.Len(t, result.OutputPaths, 2)
+		assert.Empty(t, result.Errors)
+
+		for _, p := range result.OutputPaths {
+			assert.FileExists(t, p)
+		}
+	})
+
+	t.Run("skip if unchanged", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		release := makeReleaseObj("comp-a-20250315-0", "proj", "comp-a")
+
+		// Write first time
+		_, err := w.WriteBulkReleases([]*unstructured.Unstructured{release}, BulkWriteOptions{OutputDir: dir})
+		require.NoError(t, err)
+
+		// Write again with SkipIfUnchanged
+		result, err := w.WriteBulkReleases([]*unstructured.Unstructured{release}, BulkWriteOptions{
+			OutputDir:       dir,
+			SkipIfUnchanged: true,
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.Skipped, 1)
+		assert.Equal(t, "comp-a-20250315-0", result.Skipped[0])
+	})
+}
+
+func TestWriteBulkBindings(t *testing.T) {
+	t.Run("dry run writes all to stdout", func(t *testing.T) {
+		w := NewWriter("/repo")
+		bindings := []*unstructured.Unstructured{
+			makeBindingObj("comp-a-dev", "proj", "comp-a"),
+			makeBindingObj("comp-b-dev", "proj", "comp-b"),
+		}
+		var buf bytes.Buffer
+
+		result, err := w.WriteBulkBindings(bindings, BulkBindingWriteOptions{DryRun: true, Stdout: &buf})
+		require.NoError(t, err)
+		assert.Empty(t, result.OutputPaths)
+		assert.Empty(t, result.Errors)
+		assert.Contains(t, buf.String(), "comp-a-dev")
+		assert.Contains(t, buf.String(), "comp-b-dev")
+	})
+
+	t.Run("writes files to disk", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		bindings := []*unstructured.Unstructured{
+			makeBindingObj("comp-a-dev", "proj", "comp-a"),
+			makeBindingObj("comp-b-dev", "proj", "comp-b"),
+		}
+
+		result, err := w.WriteBulkBindings(bindings, BulkBindingWriteOptions{OutputDir: dir})
+		require.NoError(t, err)
+		assert.Len(t, result.OutputPaths, 2)
+		assert.Empty(t, result.Errors)
+
+		for _, p := range result.OutputPaths {
+			assert.FileExists(t, p)
+		}
+	})
+
+	t.Run("with existing paths for update-in-place", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		binding := makeBindingObj("comp-a-dev", "proj", "comp-a")
+
+		existingPath := filepath.Join(dir, "existing", "comp-a-dev.yaml")
+
+		result, err := w.WriteBulkBindings([]*unstructured.Unstructured{binding}, BulkBindingWriteOptions{
+			ExistingPaths: map[string]string{"comp-a-dev": existingPath},
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.OutputPaths, 1)
+		assert.Equal(t, existingPath, result.OutputPaths[0])
+		assert.FileExists(t, existingPath)
+	})
+
+	t.Run("with existing paths escaping base dir are rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		w := NewWriter(dir)
+		binding := makeBindingObj("comp-a-dev", "proj", "comp-a")
+
+		escapedPath := filepath.Join(dir, "..", "escaped", "comp-a-dev.yaml")
+
+		result, err := w.WriteBulkBindings([]*unstructured.Unstructured{binding}, BulkBindingWriteOptions{
+			ExistingPaths: map[string]string{"comp-a-dev": escapedPath},
+		})
+		require.NoError(t, err) // WriteBulkBindings itself doesn't return error, it collects them
+		assert.Empty(t, result.OutputPaths)
+		assert.Len(t, result.Errors, 1)
+		assert.Contains(t, result.Errors[0].Error(), "escapes base directory")
 	})
 }


### PR DESCRIPTION
## Purpose

Add tests for the `internal/occ/fsmode/generator` package to improve confidence in componentrelease and releasebinding generation logic.

## Approach

**release_binding_test.go:**
- Add tests for `GenerateBinding` validation errors (missing project, component, env, pipeline, namespace)
- Add tests for `selectComponentRelease` with explicit release name (found and not-found cases)
- Add tests for non-root environment promotion path (promote from previous env, no binding in previous env, empty releaseName in previous binding)
- Add tests for `GenerateBulkBindings` (all components, by project name, partial errors, validation errors)

**component_release_test.go:**
- Add test for project name mismatch error
- Add test for unsupported trait kind error
- Add test for component with parameters (verifies componentProfile.parameters)
- Add test for duplicate trait deduplication (same trait, different instance names)

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)