### PR TITLE
fix: add timezone support to scheduled-task component type

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -807,6 +807,8 @@ spec:
         restartPolicy:
           type: string
           default: OnFailure
+        timeZone:
+          type: string
 
   environmentConfigs:
     openAPIV3Schema:
@@ -855,6 +857,8 @@ spec:
           labels: ${metadata.labels}
         spec:
           schedule: ${environmentConfigs.schedule}
+          timeZone: |
+            ${has(parameters.timeZone) ? parameters.timeZone : oc_omit()}
           successfulJobsHistoryLimit: ${parameters.successfulJobsHistoryLimit}
           failedJobsHistoryLimit: ${parameters.failedJobsHistoryLimit}
           concurrencyPolicy: ${parameters.concurrencyPolicy}

--- a/samples/getting-started/component-types/scheduled-task.yaml
+++ b/samples/getting-started/component-types/scheduled-task.yaml
@@ -41,6 +41,8 @@ spec:
         restartPolicy:
           type: string
           default: OnFailure
+        timeZone:
+          type: string
 
   environmentConfigs:
     openAPIV3Schema:
@@ -89,6 +91,8 @@ spec:
           labels: ${metadata.labels}
         spec:
           schedule: ${environmentConfigs.schedule}
+          timeZone: |
+            ${has(parameters.timeZone) ? parameters.timeZone : oc_omit()}
           successfulJobsHistoryLimit: ${parameters.successfulJobsHistoryLimit}
           failedJobsHistoryLimit: ${parameters.failedJobsHistoryLimit}
           concurrencyPolicy: ${parameters.concurrencyPolicy}


### PR DESCRIPTION
## Purpose
- The `scheduled-task` component type had no way to set a timezone for 
  the CronJob schedule, so all schedules were interpreted in UTC regardless
  of the user's intent.                                                                                                                                                  
                                                                                                                                                                         
  - Add an optional `timeZone` parameter to the `scheduled-task` component type                                                                                          
  - When set, the value is passed to the Kubernetes CronJob `spec.timeZone` field                                                                                        
  - When omitted, the field is excluded from the rendered CronJob and Kubernetes defaults to UTC 
- Fix #3077

## Usage                                                                                                                                                               
- Set `timeZone` in `Component.spec.parameters` alongside the other CronJob parameters.                                                                                  
- The value must be a valid [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)                                                           (e.g. `America/New_York`, `Asia/Colombo`, `Europe/London`).                                                 
When omitted, Kubernetes defaults to UTC.                                                                                                                              
                                                                                                                                                                         
  ```yaml                                                                                                                                                                
  apiVersion: openchoreo.dev/v1alpha1                                                                                                                                    
  kind: Component                                                      
  metadata:                                                                                                                                                              
    name: my-scheduled-task
  spec:                                                                                                                                                                  
    componentType:                                                     
      kind: ClusterComponentType
      name: cronjob/scheduled-task
    parameters:                   
      timeZone: "America/New_York"   # optional — omit for UTC
      concurrencyPolicy: Forbid                                                                                                                                          
      backoffLimit: 3          
      activeDeadlineSeconds: 300                                                                                                                                         
      restartPolicy: OnFailure    