### PR TITLE
test: add unit tests for api handlers

### DIFF
--- a/internal/openchoreo-api/api/handlers/authz_test.go
+++ b/internal/openchoreo-api/api/handlers/authz_test.go
@@ -12,120 +12,18 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	authzsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/authz"
+	authzmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/authz/mocks"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/handlerservices"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
-
-type mockAuthzService struct {
-	listActionsFn       func(ctx context.Context) ([]authzcore.Action, error)
-	evaluateFn          func(ctx context.Context, requests []authzcore.EvaluateRequest) ([]authzcore.Decision, error)
-	getSubjectProfileFn func(ctx context.Context, request *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error)
-}
-
-var _ authzsvc.Service = (*mockAuthzService)(nil)
-
-// --- Cluster Roles (unused in these tests) ---
-
-func (m *mockAuthzService) CreateClusterRole(context.Context, *openchoreov1alpha1.ClusterAuthzRole) (*openchoreov1alpha1.ClusterAuthzRole, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) GetClusterRole(context.Context, string) (*openchoreov1alpha1.ClusterAuthzRole, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) ListClusterRoles(context.Context, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.ClusterAuthzRole], error) {
-	panic("not used")
-}
-func (m *mockAuthzService) UpdateClusterRole(context.Context, *openchoreov1alpha1.ClusterAuthzRole) (*openchoreov1alpha1.ClusterAuthzRole, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) DeleteClusterRole(context.Context, string) error {
-	panic("not used")
-}
-
-// --- Namespace Roles (unused in these tests) ---
-
-func (m *mockAuthzService) CreateNamespaceRole(context.Context, string, *openchoreov1alpha1.AuthzRole) (*openchoreov1alpha1.AuthzRole, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) GetNamespaceRole(context.Context, string, string) (*openchoreov1alpha1.AuthzRole, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) ListNamespaceRoles(context.Context, string, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.AuthzRole], error) {
-	panic("not used")
-}
-func (m *mockAuthzService) UpdateNamespaceRole(context.Context, string, *openchoreov1alpha1.AuthzRole) (*openchoreov1alpha1.AuthzRole, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) DeleteNamespaceRole(context.Context, string, string) error {
-	panic("not used")
-}
-
-// --- Cluster Role Bindings (unused in these tests) ---
-
-func (m *mockAuthzService) CreateClusterRoleBinding(context.Context, *openchoreov1alpha1.ClusterAuthzRoleBinding) (*openchoreov1alpha1.ClusterAuthzRoleBinding, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) GetClusterRoleBinding(context.Context, string) (*openchoreov1alpha1.ClusterAuthzRoleBinding, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) ListClusterRoleBindings(context.Context, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.ClusterAuthzRoleBinding], error) {
-	panic("not used")
-}
-func (m *mockAuthzService) UpdateClusterRoleBinding(context.Context, *openchoreov1alpha1.ClusterAuthzRoleBinding) (*openchoreov1alpha1.ClusterAuthzRoleBinding, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) DeleteClusterRoleBinding(context.Context, string) error {
-	panic("not used")
-}
-
-// --- Namespace Role Bindings (unused in these tests) ---
-
-func (m *mockAuthzService) CreateNamespaceRoleBinding(context.Context, string, *openchoreov1alpha1.AuthzRoleBinding) (*openchoreov1alpha1.AuthzRoleBinding, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) GetNamespaceRoleBinding(context.Context, string, string) (*openchoreov1alpha1.AuthzRoleBinding, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) ListNamespaceRoleBindings(context.Context, string, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.AuthzRoleBinding], error) {
-	panic("not used")
-}
-func (m *mockAuthzService) UpdateNamespaceRoleBinding(context.Context, string, *openchoreov1alpha1.AuthzRoleBinding) (*openchoreov1alpha1.AuthzRoleBinding, error) {
-	panic("not used")
-}
-func (m *mockAuthzService) DeleteNamespaceRoleBinding(context.Context, string, string) error {
-	panic("not used")
-}
-
-// --- Evaluation & Profile ---
-
-func (m *mockAuthzService) Evaluate(ctx context.Context, requests []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
-	if m.evaluateFn == nil {
-		panic("Evaluate not configured")
-	}
-	return m.evaluateFn(ctx, requests)
-}
-
-func (m *mockAuthzService) ListActions(ctx context.Context) ([]authzcore.Action, error) {
-	if m.listActionsFn == nil {
-		panic("ListActions not configured")
-	}
-	return m.listActionsFn(ctx)
-}
-
-func (m *mockAuthzService) GetSubjectProfile(ctx context.Context, request *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
-	if m.getSubjectProfileFn == nil {
-		panic("GetSubjectProfile not configured")
-	}
-	return m.getSubjectProfileFn(ctx, request)
-}
 
 func newHandlerWithAuthzService(t *testing.T, svc authzsvc.Service, cfg *config.Config) *Handler {
 	t.Helper()
@@ -140,14 +38,12 @@ func TestListActionsHandler(t *testing.T) {
 	ctx := testContext()
 
 	t.Run("success", func(t *testing.T) {
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			listActionsFn: func(_ context.Context) ([]authzcore.Action, error) {
-				return []authzcore.Action{
-					{Name: "view", LowestScope: "namespace"},
-					{Name: "create", LowestScope: "cluster"},
-				}, nil
-			},
-		}, &config.Config{})
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().ListActions(mock.Anything).Return([]authzcore.Action{
+			{Name: "view", LowestScope: "namespace"},
+			{Name: "create", LowestScope: "cluster"},
+		}, nil)
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.ListActions(ctx, gen.ListActionsRequestObject{})
 		require.NoError(t, err)
@@ -159,11 +55,9 @@ func TestListActionsHandler(t *testing.T) {
 	})
 
 	t.Run("forbidden returns 403", func(t *testing.T) {
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			listActionsFn: func(_ context.Context) ([]authzcore.Action, error) {
-				return nil, svcpkg.ErrForbidden
-			},
-		}, &config.Config{})
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().ListActions(mock.Anything).Return(nil, svcpkg.ErrForbidden)
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.ListActions(ctx, gen.ListActionsRequestObject{})
 		require.NoError(t, err)
@@ -171,11 +65,9 @@ func TestListActionsHandler(t *testing.T) {
 	})
 
 	t.Run("generic error returns 500", func(t *testing.T) {
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			listActionsFn: func(_ context.Context) ([]authzcore.Action, error) {
-				return nil, errors.New("boom")
-			},
-		}, &config.Config{})
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().ListActions(mock.Anything).Return(nil, errors.New("boom"))
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.ListActions(ctx, gen.ListActionsRequestObject{})
 		require.NoError(t, err)
@@ -187,12 +79,8 @@ func TestEvaluatesHandler(t *testing.T) {
 	ctx := testContext()
 
 	t.Run("nil body returns 400", func(t *testing.T) {
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			evaluateFn: func(context.Context, []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
-				t.Fatal("Evaluate should not be called for nil body")
-				return nil, nil
-			},
-		}, &config.Config{})
+		svc := authzmocks.NewMockService(t)
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.Evaluates(ctx, gen.EvaluatesRequestObject{Body: nil})
 		require.NoError(t, err)
@@ -213,15 +101,15 @@ func TestEvaluatesHandler(t *testing.T) {
 				EntitlementValues: nil,
 			},
 		}}
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			evaluateFn: func(_ context.Context, reqs []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
-				require.Len(t, reqs, 1)
-				assert.Equal(t, "view", reqs[0].Action)
-				assert.Equal(t, "project", reqs[0].Resource.Type)
-				assert.Equal(t, "", reqs[0].Resource.ID, "nil pointer must convert to empty string")
-				return nil, authzcore.ErrInvalidRequest
-			},
-		}, &config.Config{})
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().Evaluate(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, reqs []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
+			require.Len(t, reqs, 1)
+			assert.Equal(t, "view", reqs[0].Action)
+			assert.Equal(t, "project", reqs[0].Resource.Type)
+			assert.Equal(t, "", reqs[0].Resource.ID, "nil pointer must convert to empty string")
+			return nil, authzcore.ErrInvalidRequest
+		})
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.Evaluates(ctx, gen.EvaluatesRequestObject{Body: &body})
 		require.NoError(t, err)
@@ -265,22 +153,22 @@ func TestEvaluatesHandler(t *testing.T) {
 			},
 		}
 
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			evaluateFn: func(_ context.Context, reqs []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
-				require.Len(t, reqs, 2)
-				assert.Equal(t, id, reqs[0].Resource.ID)
-				assert.Equal(t, ns, reqs[0].Resource.Hierarchy.Namespace)
-				require.NotNil(t, reqs[0].SubjectContext)
-				assert.Equal(t, "user", reqs[0].SubjectContext.Type)
-				assert.Equal(t, "groups", reqs[0].SubjectContext.EntitlementClaim)
-				assert.Equal(t, []string{"admin"}, reqs[0].SubjectContext.EntitlementValues)
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().Evaluate(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, reqs []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
+			require.Len(t, reqs, 2)
+			assert.Equal(t, id, reqs[0].Resource.ID)
+			assert.Equal(t, ns, reqs[0].Resource.Hierarchy.Namespace)
+			require.NotNil(t, reqs[0].SubjectContext)
+			assert.Equal(t, "user", reqs[0].SubjectContext.Type)
+			assert.Equal(t, "groups", reqs[0].SubjectContext.EntitlementClaim)
+			assert.Equal(t, []string{"admin"}, reqs[0].SubjectContext.EntitlementValues)
 
-				return []authzcore.Decision{
-					{Decision: true, Context: &authzcore.DecisionContext{Reason: reason}},
-					{Decision: false, Context: &authzcore.DecisionContext{}},
-				}, nil
-			},
-		}, &config.Config{})
+			return []authzcore.Decision{
+				{Decision: true, Context: &authzcore.DecisionContext{Reason: reason}},
+				{Decision: false, Context: &authzcore.DecisionContext{}},
+			}, nil
+		})
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.Evaluates(ctx, gen.EvaluatesRequestObject{Body: &body})
 		require.NoError(t, err)
@@ -302,11 +190,9 @@ func TestEvaluatesHandler(t *testing.T) {
 			Resource:       gen.Resource{Type: "project"},
 			SubjectContext: gen.SubjectContext{Type: gen.SubjectContextType("user")},
 		}}
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			evaluateFn: func(context.Context, []authzcore.EvaluateRequest) ([]authzcore.Decision, error) {
-				return nil, errors.New("unexpected failure")
-			},
-		}, &config.Config{})
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().Evaluate(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected failure"))
+		h := newHandlerWithAuthzService(t, svc, &config.Config{})
 
 		resp, err := h.Evaluates(ctx, gen.EvaluatesRequestObject{Body: &body})
 		require.NoError(t, err)
@@ -318,12 +204,8 @@ func TestGetSubjectProfileHandler(t *testing.T) {
 	cfg := &config.Config{}
 
 	t.Run("missing subject context returns 403", func(t *testing.T) {
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			getSubjectProfileFn: func(context.Context, *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
-				t.Fatal("GetSubjectProfile should not be called without subject context")
-				return nil, nil
-			},
-		}, cfg)
+		svc := authzmocks.NewMockService(t)
+		h := newHandlerWithAuthzService(t, svc, cfg)
 
 		resp, err := h.GetSubjectProfile(context.Background(), gen.GetSubjectProfileRequestObject{})
 		require.NoError(t, err)
@@ -332,11 +214,9 @@ func TestGetSubjectProfileHandler(t *testing.T) {
 
 	t.Run("invalid request returns 400", func(t *testing.T) {
 		ctx := testContext()
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			getSubjectProfileFn: func(context.Context, *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
-				return nil, authzcore.ErrInvalidRequest
-			},
-		}, cfg)
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().GetSubjectProfile(mock.Anything, mock.Anything).Return(nil, authzcore.ErrInvalidRequest)
+		h := newHandlerWithAuthzService(t, svc, cfg)
 
 		resp, err := h.GetSubjectProfile(ctx, gen.GetSubjectProfileRequestObject{})
 		require.NoError(t, err)
@@ -345,11 +225,9 @@ func TestGetSubjectProfileHandler(t *testing.T) {
 
 	t.Run("forbidden returns 403", func(t *testing.T) {
 		ctx := testContext()
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			getSubjectProfileFn: func(context.Context, *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
-				return nil, svcpkg.ErrForbidden
-			},
-		}, cfg)
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().GetSubjectProfile(mock.Anything, mock.Anything).Return(nil, svcpkg.ErrForbidden)
+		h := newHandlerWithAuthzService(t, svc, cfg)
 
 		resp, err := h.GetSubjectProfile(ctx, gen.GetSubjectProfileRequestObject{})
 		require.NoError(t, err)
@@ -358,11 +236,9 @@ func TestGetSubjectProfileHandler(t *testing.T) {
 
 	t.Run("generic error returns 500", func(t *testing.T) {
 		ctx := testContext()
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			getSubjectProfileFn: func(context.Context, *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
-				return nil, errors.New("internal failure")
-			},
-		}, cfg)
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().GetSubjectProfile(mock.Anything, mock.Anything).Return(nil, errors.New("internal failure"))
+		h := newHandlerWithAuthzService(t, svc, cfg)
 
 		resp, err := h.GetSubjectProfile(ctx, gen.GetSubjectProfileRequestObject{})
 		require.NoError(t, err)
@@ -393,12 +269,12 @@ func TestGetSubjectProfileHandler(t *testing.T) {
 		}
 
 		var captured *authzcore.ProfileRequest
-		h := newHandlerWithAuthzService(t, &mockAuthzService{
-			getSubjectProfileFn: func(_ context.Context, req *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
-				captured = req
-				return profile, nil
-			},
-		}, cfg)
+		svc := authzmocks.NewMockService(t)
+		svc.EXPECT().GetSubjectProfile(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, req *authzcore.ProfileRequest) (*authzcore.UserCapabilitiesResponse, error) {
+			captured = req
+			return profile, nil
+		})
+		h := newHandlerWithAuthzService(t, svc, cfg)
 
 		ns := "acme"
 		resp, err := h.GetSubjectProfile(ctx, gen.GetSubjectProfileRequestObject{
@@ -452,7 +328,8 @@ func TestListSubjectTypesHandler(t *testing.T) {
 		},
 	}
 
-	h := newHandlerWithAuthzService(t, &mockAuthzService{}, cfg)
+	svc := authzmocks.NewMockService(t)
+	h := newHandlerWithAuthzService(t, svc, cfg)
 
 	resp, err := h.ListSubjectTypes(testContext(), gen.ListSubjectTypesRequestObject{})
 	require.NoError(t, err)

--- a/internal/openchoreo-api/api/handlers/cluster_scoped_handlers_test.go
+++ b/internal/openchoreo-api/api/handlers/cluster_scoped_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,7 +22,9 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clustercomponenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustercomponenttype"
+	cctsvcmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustercomponenttype/mocks"
 	clustertraitsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustertrait"
+	clustertraitmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustertrait/mocks"
 	clusterworkflowsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clusterworkflow"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/handlerservices"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
@@ -504,78 +507,13 @@ func TestGetClusterWorkflowSchemaHandler(t *testing.T) {
 	})
 }
 
-type mockClusterComponentTypeService struct {
-	updateFn func(ctx context.Context, cct *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error)
-	createFn func(ctx context.Context, cct *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error)
-}
-
-var _ clustercomponenttypesvc.Service = (*mockClusterComponentTypeService)(nil)
-
-func (m *mockClusterComponentTypeService) CreateClusterComponentType(ctx context.Context, cct *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error) {
-	if m.createFn == nil {
-		panic("CreateClusterComponentType not configured")
-	}
-	return m.createFn(ctx, cct)
-}
-func (m *mockClusterComponentTypeService) UpdateClusterComponentType(ctx context.Context, cct *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error) {
-	if m.updateFn == nil {
-		panic("UpdateClusterComponentType not configured")
-	}
-	return m.updateFn(ctx, cct)
-}
-func (m *mockClusterComponentTypeService) ListClusterComponentTypes(context.Context, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.ClusterComponentType], error) {
-	panic("not used")
-}
-func (m *mockClusterComponentTypeService) GetClusterComponentType(context.Context, string) (*openchoreov1alpha1.ClusterComponentType, error) {
-	panic("not used")
-}
-func (m *mockClusterComponentTypeService) DeleteClusterComponentType(context.Context, string) error {
-	panic("not used")
-}
-func (m *mockClusterComponentTypeService) GetClusterComponentTypeSchema(context.Context, string) (map[string]any, error) {
-	panic("not used")
-}
-
-type mockClusterTraitService struct {
-	updateFn func(ctx context.Context, ct *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error)
-	createFn func(ctx context.Context, ct *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error)
-}
-
-var _ clustertraitsvc.Service = (*mockClusterTraitService)(nil)
-
-func (m *mockClusterTraitService) CreateClusterTrait(ctx context.Context, ct *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error) {
-	if m.createFn == nil {
-		panic("CreateClusterTrait not configured")
-	}
-	return m.createFn(ctx, ct)
-}
-func (m *mockClusterTraitService) UpdateClusterTrait(ctx context.Context, ct *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error) {
-	if m.updateFn == nil {
-		panic("UpdateClusterTrait not configured")
-	}
-	return m.updateFn(ctx, ct)
-}
-func (m *mockClusterTraitService) ListClusterTraits(context.Context, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.ClusterTrait], error) {
-	panic("not used")
-}
-func (m *mockClusterTraitService) GetClusterTrait(context.Context, string) (*openchoreov1alpha1.ClusterTrait, error) {
-	panic("not used")
-}
-func (m *mockClusterTraitService) DeleteClusterTrait(context.Context, string) error {
-	panic("not used")
-}
-func (m *mockClusterTraitService) GetClusterTraitSchema(context.Context, string) (map[string]any, error) {
-	panic("not used")
-}
-
 func TestUpdateClusterComponentTypeHandler_UsesPathName(t *testing.T) {
 	ctx := testContext()
-	svc := &mockClusterComponentTypeService{
-		updateFn: func(_ context.Context, cct *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error) {
-			assert.Equal(t, "from-path", cct.Name)
-			return cct, nil
-		},
-	}
+	svc := cctsvcmocks.NewMockService(t)
+	svc.EXPECT().UpdateClusterComponentType(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, cct *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error) {
+		assert.Equal(t, "from-path", cct.Name)
+		return cct, nil
+	})
 	h := &Handler{
 		services: &handlerservices.Services{ClusterComponentTypeService: svc},
 		logger:   slog.Default(),
@@ -606,11 +544,8 @@ func TestCreateClusterComponentTypeHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &mockClusterComponentTypeService{
-				createFn: func(context.Context, *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error) {
-					return nil, tt.svcErr
-				},
-			}
+			svc := cctsvcmocks.NewMockService(t)
+			svc.EXPECT().CreateClusterComponentType(mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
 				services: &handlerservices.Services{ClusterComponentTypeService: svc},
 				logger:   slog.Default(),
@@ -625,12 +560,11 @@ func TestCreateClusterComponentTypeHandler_MapsErrors(t *testing.T) {
 
 func TestUpdateClusterTraitHandler_UsesPathName(t *testing.T) {
 	ctx := testContext()
-	svc := &mockClusterTraitService{
-		updateFn: func(_ context.Context, ct *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error) {
-			assert.Equal(t, "from-path", ct.Name)
-			return ct, nil
-		},
-	}
+	svc := clustertraitmocks.NewMockService(t)
+	svc.EXPECT().UpdateClusterTrait(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, ct *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error) {
+		assert.Equal(t, "from-path", ct.Name)
+		return ct, nil
+	})
 	h := &Handler{
 		services: &handlerservices.Services{ClusterTraitService: svc},
 		logger:   slog.Default(),
@@ -661,11 +595,8 @@ func TestCreateClusterTraitHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &mockClusterTraitService{
-				createFn: func(context.Context, *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error) {
-					return nil, tt.svcErr
-				},
-			}
+			svc := clustertraitmocks.NewMockService(t)
+			svc.EXPECT().CreateClusterTrait(mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
 				services: &handlerservices.Services{ClusterTraitService: svc},
 				logger:   slog.Default(),
@@ -693,11 +624,8 @@ func TestUpdateClusterComponentTypeHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &mockClusterComponentTypeService{
-				updateFn: func(context.Context, *openchoreov1alpha1.ClusterComponentType) (*openchoreov1alpha1.ClusterComponentType, error) {
-					return nil, tt.svcErr
-				},
-			}
+			svc := cctsvcmocks.NewMockService(t)
+			svc.EXPECT().UpdateClusterComponentType(mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
 				services: &handlerservices.Services{ClusterComponentTypeService: svc},
 				logger:   slog.Default(),
@@ -725,11 +653,8 @@ func TestUpdateClusterTraitHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &mockClusterTraitService{
-				updateFn: func(context.Context, *openchoreov1alpha1.ClusterTrait) (*openchoreov1alpha1.ClusterTrait, error) {
-					return nil, tt.svcErr
-				},
-			}
+			svc := clustertraitmocks.NewMockService(t)
+			svc.EXPECT().UpdateClusterTrait(mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
 				services: &handlerservices.Services{ClusterTraitService: svc},
 				logger:   slog.Default(),

--- a/internal/openchoreo-api/api/handlers/components_test.go
+++ b/internal/openchoreo-api/api/handlers/components_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +21,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	componentsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/component"
+	componentsvcmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/component/mocks"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/handlerservices"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/testutil"
 )
@@ -345,60 +346,9 @@ func TestListComponentsHandler(t *testing.T) {
 	})
 }
 
-type mockComponentService struct {
-	createFn      func(ctx context.Context, namespace string, component *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error)
-	updateFn      func(ctx context.Context, namespace string, component *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error)
-	generateRelFn func(ctx context.Context, namespace, componentName string, req *componentsvc.GenerateReleaseRequest) (*openchoreov1alpha1.ComponentRelease, error)
-	getSchemaFn   func(ctx context.Context, namespace, componentName string) (*extv1.JSONSchemaProps, error)
-}
-
-var _ componentsvc.Service = (*mockComponentService)(nil)
-
-func (m *mockComponentService) CreateComponent(ctx context.Context, namespaceName string, component *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
-	if m.createFn == nil {
-		panic("CreateComponent not configured")
-	}
-	return m.createFn(ctx, namespaceName, component)
-}
-func (m *mockComponentService) UpdateComponent(ctx context.Context, namespaceName string, component *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
-	if m.updateFn == nil {
-		panic("UpdateComponent not configured")
-	}
-	return m.updateFn(ctx, namespaceName, component)
-}
-func (m *mockComponentService) ListComponents(context.Context, string, string, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.Component], error) {
-	panic("not used")
-}
-func (m *mockComponentService) GetComponent(context.Context, string, string) (*openchoreov1alpha1.Component, error) {
-	panic("not used")
-}
-func (m *mockComponentService) DeleteComponent(context.Context, string, string) error {
-	panic("not used")
-}
-func (m *mockComponentService) GenerateRelease(ctx context.Context, namespaceName, componentName string, req *componentsvc.GenerateReleaseRequest) (*openchoreov1alpha1.ComponentRelease, error) {
-	if m.generateRelFn == nil {
-		panic("GenerateRelease not configured")
-	}
-	return m.generateRelFn(ctx, namespaceName, componentName, req)
-}
-func (m *mockComponentService) GetComponentSchema(ctx context.Context, namespaceName, componentName string) (*extv1.JSONSchemaProps, error) {
-	if m.getSchemaFn == nil {
-		panic("GetComponentSchema not configured")
-	}
-	return m.getSchemaFn(ctx, namespaceName, componentName)
-}
-func (m *mockComponentService) GetComponentReleaseSchema(context.Context, string, string, string) (*extv1.JSONSchemaProps, error) {
-	panic("not used")
-}
-
 func TestCreateComponentHandler_NamespaceMismatchReturns400(t *testing.T) {
 	ctx := testContext()
-	svc := &mockComponentService{
-		createFn: func(context.Context, string, *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
-			t.Fatal("service should not be called when namespace mismatches")
-			return nil, nil
-		},
-	}
+	svc := componentsvcmocks.NewMockService(t)
 	h := &Handler{
 		services: &handlerservices.Services{ComponentService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -422,13 +372,12 @@ func TestUpdateComponentHandler_UsesPathNameAndValidatesNamespace(t *testing.T) 
 	ctx := testContext()
 
 	t.Run("uses path name", func(t *testing.T) {
-		svc := &mockComponentService{
-			updateFn: func(_ context.Context, namespace string, component *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
-				assert.Equal(t, "test-ns", namespace)
-				assert.Equal(t, "comp-from-path", component.Name, "path must override body name")
-				return component, nil
-			},
-		}
+		svc := componentsvcmocks.NewMockService(t)
+		svc.EXPECT().UpdateComponent(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace string, component *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
+			assert.Equal(t, "test-ns", namespace)
+			assert.Equal(t, "comp-from-path", component.Name, "path must override body name")
+			return component, nil
+		})
 		h := &Handler{
 			services: &handlerservices.Services{ComponentService: svc},
 			logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -449,12 +398,7 @@ func TestUpdateComponentHandler_UsesPathNameAndValidatesNamespace(t *testing.T) 
 	})
 
 	t.Run("namespace mismatch returns 400", func(t *testing.T) {
-		svc := &mockComponentService{
-			updateFn: func(context.Context, string, *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
-				t.Fatal("UpdateComponent should not be called for namespace mismatch")
-				return nil, nil
-			},
-		}
+		svc := componentsvcmocks.NewMockService(t)
 		h := &Handler{
 			services: &handlerservices.Services{ComponentService: svc},
 			logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -478,15 +422,14 @@ func TestUpdateComponentHandler_UsesPathNameAndValidatesNamespace(t *testing.T) 
 
 func TestGenerateReleaseHandler_MapsValidationErrorTo400AndForwardsReleaseName(t *testing.T) {
 	ctx := testContext()
-	svc := &mockComponentService{
-		generateRelFn: func(_ context.Context, namespace, componentName string, req *componentsvc.GenerateReleaseRequest) (*openchoreov1alpha1.ComponentRelease, error) {
-			assert.Equal(t, "test-ns", namespace)
-			assert.Equal(t, "comp-a", componentName)
-			require.NotNil(t, req)
-			assert.Equal(t, "r-1", req.ReleaseName)
-			return nil, componentsvc.ErrValidation
-		},
-	}
+	svc := componentsvcmocks.NewMockService(t)
+	svc.EXPECT().GenerateRelease(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace, componentName string, req *componentsvc.GenerateReleaseRequest) (*openchoreov1alpha1.ComponentRelease, error) {
+		assert.Equal(t, "test-ns", namespace)
+		assert.Equal(t, "comp-a", componentName)
+		require.NotNil(t, req)
+		assert.Equal(t, "r-1", req.ReleaseName)
+		return nil, componentsvc.ErrValidation
+	})
 	h := &Handler{
 		services: &handlerservices.Services{ComponentService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -519,11 +462,8 @@ func TestGetComponentSchemaHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &mockComponentService{
-				getSchemaFn: func(context.Context, string, string) (*extv1.JSONSchemaProps, error) {
-					return nil, tt.svcErr
-				},
-			}
+			svc := componentsvcmocks.NewMockService(t)
+			svc.EXPECT().GetComponentSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
 				services: &handlerservices.Services{ComponentService: svc},
 				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -552,11 +492,8 @@ func TestUpdateComponentHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &mockComponentService{
-				updateFn: func(context.Context, string, *openchoreov1alpha1.Component) (*openchoreov1alpha1.Component, error) {
-					return nil, tt.svcErr
-				},
-			}
+			svc := componentsvcmocks.NewMockService(t)
+			svc.EXPECT().UpdateComponent(mock.Anything, mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
 				services: &handlerservices.Services{ComponentService: svc},
 				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/internal/openchoreo-api/api/handlers/git_secrets_test.go
+++ b/internal/openchoreo-api/api/handlers/git_secrets_test.go
@@ -11,51 +11,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	gitsecretsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/gitsecret"
+	gitsecretmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/gitsecret/mocks"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/handlerservices"
 )
 
-type mockGitSecretService struct {
-	listFn   func(ctx context.Context, namespace string) ([]gitsecretsvc.GitSecretInfo, error)
-	createFn func(ctx context.Context, namespace string, req *gitsecretsvc.CreateGitSecretParams) (*gitsecretsvc.GitSecretInfo, error)
-	deleteFn func(ctx context.Context, namespace, name string) error
-}
-
-var _ gitsecretsvc.Service = (*mockGitSecretService)(nil)
-
-func (m *mockGitSecretService) ListGitSecrets(ctx context.Context, namespaceName string) ([]gitsecretsvc.GitSecretInfo, error) {
-	if m.listFn == nil {
-		panic("ListGitSecrets not configured")
-	}
-	return m.listFn(ctx, namespaceName)
-}
-func (m *mockGitSecretService) CreateGitSecret(ctx context.Context, namespaceName string, req *gitsecretsvc.CreateGitSecretParams) (*gitsecretsvc.GitSecretInfo, error) {
-	if m.createFn == nil {
-		panic("CreateGitSecret not configured")
-	}
-	return m.createFn(ctx, namespaceName, req)
-}
-func (m *mockGitSecretService) DeleteGitSecret(ctx context.Context, namespaceName, secretName string) error {
-	if m.deleteFn == nil {
-		panic("DeleteGitSecret not configured")
-	}
-	return m.deleteFn(ctx, namespaceName, secretName)
-}
-
 func TestListGitSecretsHandler_OnlySetsWorkflowPlanePointersWhenPresent(t *testing.T) {
 	ctx := testContext()
-	svc := &mockGitSecretService{
-		listFn: func(context.Context, string) ([]gitsecretsvc.GitSecretInfo, error) {
-			return []gitsecretsvc.GitSecretInfo{
-				{Name: "s1", Namespace: "ns1", WorkflowPlaneKind: "WorkflowPlane", WorkflowPlaneName: "wp1"},
-				{Name: "s2", Namespace: "ns1"},
-			}, nil
-		},
-	}
+	svc := gitsecretmocks.NewMockService(t)
+	svc.EXPECT().ListGitSecrets(mock.Anything, "ns1").Return([]gitsecretsvc.GitSecretInfo{
+		{Name: "s1", Namespace: "ns1", WorkflowPlaneKind: "WorkflowPlane", WorkflowPlaneName: "wp1"},
+		{Name: "s2", Namespace: "ns1"},
+	}, nil)
 	h := &Handler{
 		services: &handlerservices.Services{GitSecretService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -78,9 +50,9 @@ func TestListGitSecretsHandler_OnlySetsWorkflowPlanePointersWhenPresent(t *testi
 func TestCreateGitSecretHandler_ForwardsOptionalFields(t *testing.T) {
 	ctx := testContext()
 	var captured *gitsecretsvc.CreateGitSecretParams
-	svc := &mockGitSecretService{
-		createFn: func(_ context.Context, namespace string, req *gitsecretsvc.CreateGitSecretParams) (*gitsecretsvc.GitSecretInfo, error) {
-			assert.Equal(t, "test-ns", namespace)
+	svc := gitsecretmocks.NewMockService(t)
+	svc.EXPECT().CreateGitSecret(mock.Anything, "test-ns", mock.Anything).
+		RunAndReturn(func(_ context.Context, namespace string, req *gitsecretsvc.CreateGitSecretParams) (*gitsecretsvc.GitSecretInfo, error) {
 			captured = req
 			return &gitsecretsvc.GitSecretInfo{
 				Name:              req.SecretName,
@@ -88,8 +60,7 @@ func TestCreateGitSecretHandler_ForwardsOptionalFields(t *testing.T) {
 				WorkflowPlaneKind: req.WorkflowPlaneKind,
 				WorkflowPlaneName: req.WorkflowPlaneName,
 			}, nil
-		},
-	}
+		})
 	h := &Handler{
 		services: &handlerservices.Services{GitSecretService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -181,11 +152,8 @@ func TestMapDeleteGitSecretError(t *testing.T) {
 
 func TestListGitSecretsHandler_ServiceErrorReturns500(t *testing.T) {
 	ctx := testContext()
-	svc := &mockGitSecretService{
-		listFn: func(context.Context, string) ([]gitsecretsvc.GitSecretInfo, error) {
-			return nil, errors.New("storage unavailable")
-		},
-	}
+	svc := gitsecretmocks.NewMockService(t)
+	svc.EXPECT().ListGitSecrets(mock.Anything, "ns1").Return(nil, errors.New("storage unavailable"))
 	h := &Handler{
 		services: &handlerservices.Services{GitSecretService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -198,12 +166,7 @@ func TestListGitSecretsHandler_ServiceErrorReturns500(t *testing.T) {
 
 func TestCreateGitSecretHandler_NilBodyReturns400(t *testing.T) {
 	ctx := testContext()
-	svc := &mockGitSecretService{
-		createFn: func(context.Context, string, *gitsecretsvc.CreateGitSecretParams) (*gitsecretsvc.GitSecretInfo, error) {
-			t.Fatal("CreateGitSecret should not be called for nil body")
-			return nil, nil
-		},
-	}
+	svc := gitsecretmocks.NewMockService(t)
 	h := &Handler{
 		services: &handlerservices.Services{GitSecretService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -216,14 +179,8 @@ func TestCreateGitSecretHandler_NilBodyReturns400(t *testing.T) {
 
 func TestDeleteGitSecretHandler_SuccessReturns204(t *testing.T) {
 	ctx := testContext()
-	var gotNamespace, gotSecret string
-	svc := &mockGitSecretService{
-		deleteFn: func(_ context.Context, namespace, secretName string) error {
-			gotNamespace = namespace
-			gotSecret = secretName
-			return nil
-		},
-	}
+	svc := gitsecretmocks.NewMockService(t)
+	svc.EXPECT().DeleteGitSecret(mock.Anything, "ns1", "s1").Return(nil)
 	h := &Handler{
 		services: &handlerservices.Services{GitSecretService: svc},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -232,6 +189,4 @@ func TestDeleteGitSecretHandler_SuccessReturns204(t *testing.T) {
 	resp, err := h.DeleteGitSecret(ctx, gen.DeleteGitSecretRequestObject{NamespaceName: "ns1", GitSecretName: "s1"})
 	require.NoError(t, err)
 	assert.IsType(t, gen.DeleteGitSecret204Response{}, resp)
-	assert.Equal(t, "ns1", gotNamespace)
-	assert.Equal(t, "s1", gotSecret)
 }

--- a/internal/openchoreo-api/api/handlers/releasebinding_k8sresources_test.go
+++ b/internal/openchoreo-api/api/handlers/releasebinding_k8sresources_test.go
@@ -4,12 +4,12 @@
 package handlers
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -18,34 +18,8 @@ import (
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/handlerservices"
 	k8sresourcessvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/k8sresources"
+	k8sresourcesmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/k8sresources/mocks"
 )
-
-type mockK8sResourcesService struct {
-	treeFn   func(ctx context.Context, namespace, rb string) (*k8sresourcessvc.K8sResourceTreeResult, error)
-	eventsFn func(ctx context.Context, namespace, rb, group, version, kind, name string) (*models.ResourceEventsResponse, error)
-	logsFn   func(ctx context.Context, namespace, rb, pod string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error)
-}
-
-var _ k8sresourcessvc.Service = (*mockK8sResourcesService)(nil)
-
-func (m *mockK8sResourcesService) GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (*k8sresourcessvc.K8sResourceTreeResult, error) {
-	if m.treeFn == nil {
-		panic("GetResourceTree not configured")
-	}
-	return m.treeFn(ctx, namespaceName, releaseBindingName)
-}
-func (m *mockK8sResourcesService) GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (*models.ResourceEventsResponse, error) {
-	if m.eventsFn == nil {
-		panic("GetResourceEvents not configured")
-	}
-	return m.eventsFn(ctx, namespaceName, releaseBindingName, group, version, kind, name)
-}
-func (m *mockK8sResourcesService) GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName, podName string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error) {
-	if m.logsFn == nil {
-		panic("GetResourceLogs not configured")
-	}
-	return m.logsFn(ctx, namespaceName, releaseBindingName, podName, sinceSeconds)
-}
 
 func TestGetReleaseBindingK8sResourceTreeHandler_MapsNotFoundAndForbidden(t *testing.T) {
 	ctx := testContext()
@@ -63,15 +37,11 @@ func TestGetReleaseBindingK8sResourceTreeHandler_MapsNotFoundAndForbidden(t *tes
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			svc := k8sresourcesmocks.NewMockService(t)
+			svc.EXPECT().GetResourceTree(mock.Anything, mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
-				services: &handlerservices.Services{
-					K8sResourcesService: &mockK8sResourcesService{
-						treeFn: func(context.Context, string, string) (*k8sresourcessvc.K8sResourceTreeResult, error) {
-							return nil, tt.svcErr
-						},
-					},
-				},
-				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				services: &handlerservices.Services{K8sResourcesService: svc},
+				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 			}
 
 			resp, err := h.GetReleaseBindingK8sResourceTree(ctx, gen.GetReleaseBindingK8sResourceTreeRequestObject{
@@ -90,32 +60,26 @@ func TestGetReleaseBindingK8sResourceTreeHandler_ConvertsReleasesAndOptionalRend
 	rendered := &openchoreov1alpha1.RenderedRelease{}
 	rendered.Name = "rr-1"
 
-	h := &Handler{
-		services: &handlerservices.Services{
-			K8sResourcesService: &mockK8sResourcesService{
-				treeFn: func(context.Context, string, string) (*k8sresourcessvc.K8sResourceTreeResult, error) {
-					return &k8sresourcessvc.K8sResourceTreeResult{
-						RenderedReleases: []k8sresourcessvc.ReleaseResourceTree{
-							{
-								Name:        "rel-a",
-								TargetPlane: "dataplane",
-								Nodes: []models.ResourceNode{
-									{Kind: "Deployment", Name: "dep-a"},
-								},
-								Release: rendered,
-							},
-							{
-								Name:        "rel-b",
-								TargetPlane: "observabilityplane",
-								Nodes:       nil,
-								Release:     nil,
-							},
-						},
-					}, nil
-				},
+	svc := k8sresourcesmocks.NewMockService(t)
+	svc.EXPECT().GetResourceTree(mock.Anything, mock.Anything, mock.Anything).Return(&k8sresourcessvc.K8sResourceTreeResult{
+		RenderedReleases: []k8sresourcessvc.ReleaseResourceTree{
+			{
+				Name:        "rel-a",
+				TargetPlane: "dataplane",
+				Nodes:       []models.ResourceNode{{Kind: "Deployment", Name: "dep-a"}},
+				Release:     rendered,
+			},
+			{
+				Name:        "rel-b",
+				TargetPlane: "observabilityplane",
+				Nodes:       nil,
+				Release:     nil,
 			},
 		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}, nil)
+	h := &Handler{
+		services: &handlerservices.Services{K8sResourcesService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	resp, err := h.GetReleaseBindingK8sResourceTree(ctx, gen.GetReleaseBindingK8sResourceTreeRequestObject{
@@ -139,19 +103,12 @@ func TestGetReleaseBindingK8sResourceTreeHandler_ConvertsReleasesAndOptionalRend
 func TestGetReleaseBindingK8sResourceEventsHandler_DefaultsGroupToEmptyString(t *testing.T) {
 	ctx := testContext()
 
+	svc := k8sresourcesmocks.NewMockService(t)
+	svc.EXPECT().GetResourceEvents(mock.Anything, "test-ns", "rb-1", "", "v1", "Pod", "p1").
+		Return(&models.ResourceEventsResponse{Events: nil}, nil)
 	h := &Handler{
-		services: &handlerservices.Services{
-			K8sResourcesService: &mockK8sResourcesService{
-				eventsFn: func(_ context.Context, namespace, rb, group, version, kind, name string) (*models.ResourceEventsResponse, error) {
-					assert.Equal(t, "", group)
-					assert.Equal(t, "v1", version)
-					assert.Equal(t, "Pod", kind)
-					assert.Equal(t, "p1", name)
-					return &models.ResourceEventsResponse{Events: nil}, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		services: &handlerservices.Services{K8sResourcesService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	resp, err := h.GetReleaseBindingK8sResourceEvents(ctx, gen.GetReleaseBindingK8sResourceEventsRequestObject{
@@ -184,15 +141,11 @@ func TestGetReleaseBindingK8sResourceEventsHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			svc := k8sresourcesmocks.NewMockService(t)
+			svc.EXPECT().GetResourceEvents(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
-				services: &handlerservices.Services{
-					K8sResourcesService: &mockK8sResourcesService{
-						eventsFn: func(context.Context, string, string, string, string, string, string) (*models.ResourceEventsResponse, error) {
-							return nil, tt.svcErr
-						},
-					},
-				},
-				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				services: &handlerservices.Services{K8sResourcesService: svc},
+				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 			}
 			resp, err := h.GetReleaseBindingK8sResourceEvents(ctx, gen.GetReleaseBindingK8sResourceEventsRequestObject{
 				NamespaceName:      "test-ns",
@@ -208,17 +161,14 @@ func TestGetReleaseBindingK8sResourceEventsHandler_MapsErrors(t *testing.T) {
 func TestGetReleaseBindingK8sResourceEventsHandler_SuccessReturnsEvents(t *testing.T) {
 	ctx := testContext()
 
+	svc := k8sresourcesmocks.NewMockService(t)
+	svc.EXPECT().GetResourceEvents(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(&models.ResourceEventsResponse{Events: []models.ResourceEvent{
+			{Type: "Normal", Reason: "Started", Message: "container started"},
+		}}, nil)
 	h := &Handler{
-		services: &handlerservices.Services{
-			K8sResourcesService: &mockK8sResourcesService{
-				eventsFn: func(context.Context, string, string, string, string, string, string) (*models.ResourceEventsResponse, error) {
-					return &models.ResourceEventsResponse{Events: []models.ResourceEvent{
-						{Type: "Normal", Reason: "Started", Message: "container started"},
-					}}, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		services: &handlerservices.Services{K8sResourcesService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	resp, err := h.GetReleaseBindingK8sResourceEvents(ctx, gen.GetReleaseBindingK8sResourceEventsRequestObject{
@@ -239,22 +189,14 @@ func TestGetReleaseBindingK8sResourceLogsHandler_SuccessReturnsLogs(t *testing.T
 	ctx := testContext()
 	since := int64(60)
 
+	svc := k8sresourcesmocks.NewMockService(t)
+	svc.EXPECT().GetResourceLogs(mock.Anything, "test-ns", "rb-1", "pod-1", &since).
+		Return(&models.ResourcePodLogsResponse{LogEntries: []models.PodLogEntry{
+			{Timestamp: "2026-01-02T03:04:05Z", Log: "hello"},
+		}}, nil)
 	h := &Handler{
-		services: &handlerservices.Services{
-			K8sResourcesService: &mockK8sResourcesService{
-				logsFn: func(_ context.Context, namespace, rb, pod string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error) {
-					assert.Equal(t, "test-ns", namespace)
-					assert.Equal(t, "rb-1", rb)
-					assert.Equal(t, "pod-1", pod)
-					require.NotNil(t, sinceSeconds)
-					assert.EqualValues(t, 60, *sinceSeconds)
-					return &models.ResourcePodLogsResponse{LogEntries: []models.PodLogEntry{
-						{Timestamp: "2026-01-02T03:04:05Z", Log: "hello"},
-					}}, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		services: &handlerservices.Services{K8sResourcesService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	resp, err := h.GetReleaseBindingK8sResourceLogs(ctx, gen.GetReleaseBindingK8sResourceLogsRequestObject{
@@ -287,15 +229,11 @@ func TestGetReleaseBindingK8sResourceLogsHandler_MapsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			svc := k8sresourcesmocks.NewMockService(t)
+			svc.EXPECT().GetResourceLogs(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, tt.svcErr)
 			h := &Handler{
-				services: &handlerservices.Services{
-					K8sResourcesService: &mockK8sResourcesService{
-						logsFn: func(context.Context, string, string, string, *int64) (*models.ResourcePodLogsResponse, error) {
-							return nil, tt.svcErr
-						},
-					},
-				},
-				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				services: &handlerservices.Services{K8sResourcesService: svc},
+				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 			}
 			resp, err := h.GetReleaseBindingK8sResourceLogs(ctx, gen.GetReleaseBindingK8sResourceLogsRequestObject{
 				NamespaceName:      "test-ns",

--- a/internal/openchoreo-api/api/handlers/workflows_test.go
+++ b/internal/openchoreo-api/api/handlers/workflows_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,8 +24,9 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/handlerservices"
-	workflowsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflow"
+	workflowmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflow/mocks"
 	workflowrunsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflowrun"
+	workflowrunmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflowrun/mocks"
 )
 
 func newWorkflowRunService(t *testing.T, objects []client.Object, pdp authzcore.PDP) workflowrunsvc.Service {
@@ -92,96 +94,17 @@ func TestDeleteWorkflowRunHandler(t *testing.T) {
 	})
 }
 
-type mockWorkflowService struct {
-	updateFn func(ctx context.Context, namespace string, wf *openchoreov1alpha1.Workflow) (*openchoreov1alpha1.Workflow, error)
-}
-
-var _ workflowsvc.Service = (*mockWorkflowService)(nil)
-
-func (m *mockWorkflowService) ListWorkflows(context.Context, string, svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.Workflow], error) {
-	panic("not used")
-}
-func (m *mockWorkflowService) GetWorkflow(context.Context, string, string) (*openchoreov1alpha1.Workflow, error) {
-	panic("not used")
-}
-func (m *mockWorkflowService) GetWorkflowSchema(context.Context, string, string) (map[string]any, error) {
-	panic("not used")
-}
-func (m *mockWorkflowService) CreateWorkflow(context.Context, string, *openchoreov1alpha1.Workflow) (*openchoreov1alpha1.Workflow, error) {
-	panic("not used")
-}
-func (m *mockWorkflowService) UpdateWorkflow(ctx context.Context, namespaceName string, wf *openchoreov1alpha1.Workflow) (*openchoreov1alpha1.Workflow, error) {
-	if m.updateFn == nil {
-		panic("UpdateWorkflow not configured")
-	}
-	return m.updateFn(ctx, namespaceName, wf)
-}
-func (m *mockWorkflowService) DeleteWorkflow(context.Context, string, string) error {
-	panic("not used")
-}
-
-type mockWorkflowRunService struct {
-	updateFn func(ctx context.Context, namespace string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error)
-	listFn   func(ctx context.Context, namespaceName, projectName, componentName, workflowName string, opts svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.WorkflowRun], error)
-	logsFn   func(ctx context.Context, namespace, runName, taskName, gatewayURL string, sinceSeconds *int64) ([]models.WorkflowRunLogEntry, error)
-	eventsFn func(ctx context.Context, namespace, runName, taskName, gatewayURL string) ([]models.WorkflowRunEventEntry, error)
-}
-
-var _ workflowrunsvc.Service = (*mockWorkflowRunService)(nil)
-
-func (m *mockWorkflowRunService) CreateWorkflowRun(context.Context, string, *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
-	panic("not used")
-}
-func (m *mockWorkflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceName string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
-	if m.updateFn == nil {
-		panic("UpdateWorkflowRun not configured")
-	}
-	return m.updateFn(ctx, namespaceName, wfRun)
-}
-func (m *mockWorkflowRunService) ListWorkflowRuns(ctx context.Context, namespaceName, projectName, componentName, workflowName string, opts svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.WorkflowRun], error) {
-	if m.listFn == nil {
-		panic("ListWorkflowRuns not configured")
-	}
-	return m.listFn(ctx, namespaceName, projectName, componentName, workflowName, opts)
-}
-func (m *mockWorkflowRunService) GetWorkflowRun(context.Context, string, string) (*openchoreov1alpha1.WorkflowRun, error) {
-	panic("not used")
-}
-func (m *mockWorkflowRunService) GetWorkflowRunStatus(context.Context, string, string, string) (*models.WorkflowRunStatusResponse, error) {
-	panic("not used")
-}
-func (m *mockWorkflowRunService) GetWorkflowRunLogs(ctx context.Context, namespaceName, runName, taskName, gatewayURL string, sinceSeconds *int64) ([]models.WorkflowRunLogEntry, error) {
-	if m.logsFn == nil {
-		panic("GetWorkflowRunLogs not configured")
-	}
-	return m.logsFn(ctx, namespaceName, runName, taskName, gatewayURL, sinceSeconds)
-}
-func (m *mockWorkflowRunService) GetWorkflowRunEvents(ctx context.Context, namespaceName, runName, taskName, gatewayURL string) ([]models.WorkflowRunEventEntry, error) {
-	if m.eventsFn == nil {
-		panic("GetWorkflowRunEvents not configured")
-	}
-	return m.eventsFn(ctx, namespaceName, runName, taskName, gatewayURL)
-}
-func (m *mockWorkflowRunService) DeleteWorkflowRun(context.Context, string, string) error {
-	panic("not used")
-}
-func (m *mockWorkflowRunService) TriggerWorkflow(context.Context, string, string, string, string) (*models.WorkflowRunTriggerResponse, error) {
-	panic("not used")
-}
-
 func TestUpdateWorkflowHandler_UsesPathName(t *testing.T) {
 	ctx := testContext()
+	svc := workflowmocks.NewMockService(t)
+	svc.EXPECT().UpdateWorkflow(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace string, wf *openchoreov1alpha1.Workflow) (*openchoreov1alpha1.Workflow, error) {
+		assert.Equal(t, "test-ns", namespace)
+		assert.Equal(t, "wf-from-path", wf.Name, "path must override body name")
+		return wf, nil
+	})
 	h := &Handler{
-		services: &handlerservices.Services{
-			WorkflowService: &mockWorkflowService{
-				updateFn: func(_ context.Context, namespace string, wf *openchoreov1alpha1.Workflow) (*openchoreov1alpha1.Workflow, error) {
-					assert.Equal(t, "test-ns", namespace)
-					assert.Equal(t, "wf-from-path", wf.Name, "path must override body name")
-					return wf, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		services: &handlerservices.Services{WorkflowService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	body := gen.Workflow{Metadata: gen.ObjectMeta{Name: "wf-from-body"}}
@@ -198,20 +121,17 @@ func TestUpdateWorkflowHandler_UsesPathName(t *testing.T) {
 
 func TestUpdateWorkflowRunHandler_ClearsStatusAndUsesPathName(t *testing.T) {
 	ctx := testContext()
-
+	svc := workflowrunmocks.NewMockService(t)
+	svc.EXPECT().UpdateWorkflowRun(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
+		assert.Equal(t, "test-ns", namespace)
+		assert.Equal(t, "run-from-path", wfRun.Name, "path must override body name")
+		assert.Empty(t, wfRun.Status, "handler must clear status to avoid user-set status updates")
+		return wfRun, nil
+	})
 	h := &Handler{
-		services: &handlerservices.Services{
-			WorkflowRunService: &mockWorkflowRunService{
-				updateFn: func(_ context.Context, namespace string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
-					assert.Equal(t, "test-ns", namespace)
-					assert.Equal(t, "run-from-path", wfRun.Name, "path must override body name")
-					assert.Empty(t, wfRun.Status, "handler must clear status to avoid user-set status updates")
-					return wfRun, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Config: &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gateway.example"}},
+		services: &handlerservices.Services{WorkflowRunService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:   &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gateway.example"}},
 	}
 
 	body := gen.WorkflowRun{
@@ -233,27 +153,25 @@ func TestUpdateWorkflowRunHandler_ClearsStatusAndUsesPathName(t *testing.T) {
 
 func TestGetWorkflowRunLogsHandler_ParsesRFC3339AndRFC3339Nano(t *testing.T) {
 	ctx := testContext()
+	svc := workflowrunmocks.NewMockService(t)
+	svc.EXPECT().GetWorkflowRunLogs(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace, runName, taskName, gatewayURL string, sinceSeconds *int64) ([]models.WorkflowRunLogEntry, error) {
+		require.Equal(t, "test-ns", namespace)
+		require.Equal(t, "run-1", runName)
+		require.Equal(t, "task-a", taskName)
+		require.Equal(t, "https://gw", gatewayURL)
+		require.NotNil(t, sinceSeconds)
+		assert.Equal(t, int64(12), *sinceSeconds)
+		return []models.WorkflowRunLogEntry{
+			{Log: "a", Timestamp: "2026-01-02T03:04:05Z"},
+			{Log: "b", Timestamp: "2026-01-02T03:04:05.123456789Z"},
+			{Log: "c", Timestamp: "not-a-time"},
+			{Log: "d", Timestamp: ""},
+		}, nil
+	})
 	h := &Handler{
-		services: &handlerservices.Services{
-			WorkflowRunService: &mockWorkflowRunService{
-				logsFn: func(_ context.Context, namespace, runName, taskName, gatewayURL string, sinceSeconds *int64) ([]models.WorkflowRunLogEntry, error) {
-					require.Equal(t, "test-ns", namespace)
-					require.Equal(t, "run-1", runName)
-					require.Equal(t, "task-a", taskName)
-					require.Equal(t, "https://gw", gatewayURL)
-					require.NotNil(t, sinceSeconds)
-					assert.Equal(t, int64(12), *sinceSeconds)
-					return []models.WorkflowRunLogEntry{
-						{Log: "a", Timestamp: "2026-01-02T03:04:05Z"},
-						{Log: "b", Timestamp: "2026-01-02T03:04:05.123456789Z"},
-						{Log: "c", Timestamp: "not-a-time"},
-						{Log: "d", Timestamp: ""},
-					}, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Config: &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gw"}},
+		services: &handlerservices.Services{WorkflowRunService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:   &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gw"}},
 	}
 
 	task := "task-a"
@@ -282,19 +200,17 @@ func TestGetWorkflowRunLogsHandler_ParsesRFC3339AndRFC3339Nano(t *testing.T) {
 
 func TestGetWorkflowRunEventsHandler_InvalidTimestampDoesNotPanic(t *testing.T) {
 	ctx := testContext()
+	svc := workflowrunmocks.NewMockService(t)
+	svc.EXPECT().GetWorkflowRunEvents(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace, runName, taskName, gatewayURL string) ([]models.WorkflowRunEventEntry, error) {
+		return []models.WorkflowRunEventEntry{
+			{Timestamp: "not-a-time", Type: "Warning", Reason: "X", Message: "bad ts"},
+			{Timestamp: "2026-01-02T03:04:05Z", Type: "Normal", Reason: "Y", Message: "good ts"},
+		}, nil
+	})
 	h := &Handler{
-		services: &handlerservices.Services{
-			WorkflowRunService: &mockWorkflowRunService{
-				eventsFn: func(_ context.Context, namespace, runName, taskName, gatewayURL string) ([]models.WorkflowRunEventEntry, error) {
-					return []models.WorkflowRunEventEntry{
-						{Timestamp: "not-a-time", Type: "Warning", Reason: "X", Message: "bad ts"},
-						{Timestamp: "2026-01-02T03:04:05Z", Type: "Normal", Reason: "Y", Message: "good ts"},
-					}, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Config: &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gw"}},
+		services: &handlerservices.Services{WorkflowRunService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:   &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gw"}},
 	}
 
 	resp, err := h.GetWorkflowRunEvents(ctx, gen.GetWorkflowRunEventsRequestObject{
@@ -313,20 +229,18 @@ func TestGetWorkflowRunEventsHandler_InvalidTimestampDoesNotPanic(t *testing.T) 
 
 func TestListWorkflowRunsHandler_ForwardsWorkflowFilter(t *testing.T) {
 	ctx := testContext()
+	svc := workflowrunmocks.NewMockService(t)
+	svc.EXPECT().ListWorkflowRuns(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, namespace, project, component, workflow string, _ svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.WorkflowRun], error) {
+		assert.Equal(t, "test-ns", namespace)
+		assert.Equal(t, "", project)
+		assert.Equal(t, "", component)
+		assert.Equal(t, "wf-a", workflow)
+		return &svcpkg.ListResult[openchoreov1alpha1.WorkflowRun]{Items: nil}, nil
+	})
 	h := &Handler{
-		services: &handlerservices.Services{
-			WorkflowRunService: &mockWorkflowRunService{
-				listFn: func(_ context.Context, namespace, project, component, workflow string, _ svcpkg.ListOptions) (*svcpkg.ListResult[openchoreov1alpha1.WorkflowRun], error) {
-					assert.Equal(t, "test-ns", namespace)
-					assert.Equal(t, "", project)
-					assert.Equal(t, "", component)
-					assert.Equal(t, "wf-a", workflow)
-					return &svcpkg.ListResult[openchoreov1alpha1.WorkflowRun]{Items: nil}, nil
-				},
-			},
-		},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Config: &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gw"}},
+		services: &handlerservices.Services{WorkflowRunService: svc},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:   &config.Config{ClusterGateway: config.ClusterGatewayConfig{URL: "https://gw"}},
 	}
 
 	wf := "wf-a"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds unit tests for authz, git secrets, k8s resources, component, and workflow handlers
Also, it migrates existing handler tests to use testify

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2109

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)