### PR TITLE
feat: expand workflowplane CEL context with planeID and observabilityPlane

### DIFF
--- a/internal/controller/reference.go
+++ b/internal/controller/reference.go
@@ -253,6 +253,17 @@ func (r *WorkflowPlaneResult) GetK8sClient(
 	return nil, fmt.Errorf("no workflow plane set in result")
 }
 
+// GetPlaneID returns the plane ID of the workflow plane (either WorkflowPlane or ClusterWorkflowPlane).
+func (r *WorkflowPlaneResult) GetPlaneID() string {
+	if r.WorkflowPlane != nil {
+		return r.WorkflowPlane.Spec.PlaneID
+	}
+	if r.ClusterWorkflowPlane != nil {
+		return r.ClusterWorkflowPlane.Spec.PlaneID
+	}
+	return ""
+}
+
 // GetSecretStoreName returns the secret store name from the workflow plane (either WorkflowPlane or ClusterWorkflowPlane).
 // Returns empty string if no secret store ref is configured.
 func (r *WorkflowPlaneResult) GetSecretStoreName() string {
@@ -261,6 +272,18 @@ func (r *WorkflowPlaneResult) GetSecretStoreName() string {
 	}
 	if r.ClusterWorkflowPlane != nil && r.ClusterWorkflowPlane.Spec.SecretStoreRef != nil {
 		return r.ClusterWorkflowPlane.Spec.SecretStoreRef.Name
+	}
+	return ""
+}
+
+// GetObservabilityPlaneName returns the name of the observability plane from the workflow plane.
+// Returns empty string if no observability plane ref is configured.
+func (r *WorkflowPlaneResult) GetObservabilityPlaneName() string {
+	if r.WorkflowPlane != nil && r.WorkflowPlane.Spec.ObservabilityPlaneRef != nil {
+		return r.WorkflowPlane.Spec.ObservabilityPlaneRef.Name
+	}
+	if r.ClusterWorkflowPlane != nil && r.ClusterWorkflowPlane.Spec.ObservabilityPlaneRef != nil {
+		return r.ClusterWorkflowPlane.Spec.ObservabilityPlaneRef.Name
 	}
 	return ""
 }

--- a/internal/controller/workflowrun/controller.go
+++ b/internal/controller/workflowrun/controller.go
@@ -210,7 +210,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			WorkflowRunName: workflowRun.Name,
 			Labels:          workflowRun.Labels,
 			WorkflowPlane: workflowpipeline.WorkflowPlaneData{
-				SecretStore: workflowPlaneResult.GetSecretStoreName(),
+				PlaneID:            workflowPlaneResult.GetPlaneID(),
+				SecretStore:        workflowPlaneResult.GetSecretStoreName(),
+				ObservabilityPlane: workflowPlaneResult.GetObservabilityPlaneName(),
 			},
 		},
 	}

--- a/internal/pipeline/workflow/pipeline.go
+++ b/internal/pipeline/workflow/pipeline.go
@@ -230,7 +230,9 @@ func (p *Pipeline) BuildCELContext(input *RenderInput) (map[string]any, error) {
 	}
 
 	workflowplane := map[string]any{
-		"secretStore": input.Context.WorkflowPlane.SecretStore,
+		"planeID":            input.Context.WorkflowPlane.PlaneID,
+		"secretStore":        input.Context.WorkflowPlane.SecretStore,
+		"observabilityPlane": input.Context.WorkflowPlane.ObservabilityPlane,
 	}
 
 	celContext := map[string]any{

--- a/internal/pipeline/workflow/pipeline_test.go
+++ b/internal/pipeline/workflow/pipeline_test.go
@@ -1387,6 +1387,59 @@ func TestPipeline_Render_WorkflowPlaneVariables(t *testing.T) {
 		}
 	})
 
+	t.Run("workflowplane.planeID and observabilityPlane rendered correctly", func(t *testing.T) {
+		input := &RenderInput{
+			WorkflowRun: &v1alpha1.WorkflowRun{
+				Spec: v1alpha1.WorkflowRunSpec{
+					Workflow: v1alpha1.WorkflowRunConfig{
+						Name: "test-workflow",
+					},
+				},
+			},
+			Workflow: &v1alpha1.Workflow{
+				Spec: v1alpha1.WorkflowSpec{
+					RunTemplate: mustRawExtension(t, map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name": "expanded-wp-test",
+						},
+						"data": map[string]interface{}{
+							"planeID":            "${workflowplane.planeID}",
+							"secretStore":        "${workflowplane.secretStore}",
+							"observabilityPlane": "${workflowplane.observabilityPlane}",
+						},
+					}),
+				},
+			},
+			Context: WorkflowContext{
+				NamespaceName:   "test-namespace",
+				WorkflowRunName: "test-run",
+				WorkflowPlane: WorkflowPlaneData{
+					PlaneID:            "prod-plane-01",
+					SecretStore:        "prod-secrets",
+					ObservabilityPlane: "central-observability",
+				},
+			},
+		}
+
+		output, err := NewPipeline().Render(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data := output.Resource["data"].(map[string]interface{})
+		if data["planeID"] != "prod-plane-01" {
+			t.Errorf("expected planeID 'prod-plane-01', got %v", data["planeID"])
+		}
+		if data["secretStore"] != "prod-secrets" {
+			t.Errorf("expected secretStore 'prod-secrets', got %v", data["secretStore"])
+		}
+		if data["observabilityPlane"] != "central-observability" {
+			t.Errorf("expected observabilityPlane 'central-observability', got %v", data["observabilityPlane"])
+		}
+	})
+
 	t.Run("workflowplane.secretStore defaults to empty string when not set", func(t *testing.T) {
 		input := &RenderInput{
 			WorkflowRun: &v1alpha1.WorkflowRun{
@@ -1406,6 +1459,7 @@ func TestPipeline_Render_WorkflowPlaneVariables(t *testing.T) {
 						},
 						"data": map[string]interface{}{
 							"secretStoreName": "${workflowplane.secretStore}",
+							"planeID":         "${workflowplane.planeID}",
 						},
 					}),
 				},
@@ -1425,6 +1479,9 @@ func TestPipeline_Render_WorkflowPlaneVariables(t *testing.T) {
 		data := output.Resource["data"].(map[string]interface{})
 		if data["secretStoreName"] != "" {
 			t.Errorf("expected secretStoreName to be empty, got %v", data["secretStoreName"])
+		}
+		if data["planeID"] != "" {
+			t.Errorf("expected planeID to be empty, got %v", data["planeID"])
 		}
 	})
 }

--- a/internal/pipeline/workflow/types.go
+++ b/internal/pipeline/workflow/types.go
@@ -78,7 +78,15 @@ type WorkflowContext struct {
 
 // WorkflowPlaneData contains workflow plane configuration exposed to CEL templates.
 type WorkflowPlaneData struct {
+	// PlaneID is the identifier for the workflow plane.
+	// Exposed as ${workflowplane.planeID}.
+	PlaneID string
+
 	// SecretStore is the name of the ESO ClusterSecretStore configured on the workflow plane.
 	// Exposed as ${workflowplane.secretStore}.
 	SecretStore string
+
+	// ObservabilityPlane is the name of the ObservabilityPlane configured on the workflow plane.
+	// Exposed as ${workflowplane.observabilityPlane}.
+	ObservabilityPlane string
 }


### PR DESCRIPTION
Connected to #3097

## Purpose
Currently, the Workflow pipeline's CEL context only exposes the secretStore from the WorkflowPlane. Other critical environment-aware attributes like the PlaneID and the resolved observabilityPlane name are missing, limiting the dynamic configuration of observability-related resources (e.g., OpenTelemetry collectors, tracers) in workflows.

This PR expands the workflowplane context to include these missing attributes, enabling advanced, environment-aware workflow configurations.

## Approach
- **Internal Model**: Added PlaneID and ObservabilityPlane to WorkflowPlaneData struct in internal/pipeline/workflow/types.go.
- **Reference Resolution**: Added helper methods to WorkflowPlaneResult in internal/controller/reference.go to retrieve attributes from both WorkflowPlane and ClusterWorkflowPlane.
- **CEL Injection**: Updated BuildCELContext in internal/pipeline/workflow/pipeline.go to inject the new variables.
- **Controller Update**: Updated WorkflowRun reconciler in internal/controller/workflowrun/controller.go to populate the new fields.
- **Verification**: Verified the rendering and default behaviors with new unit tests in internal/pipeline/workflow/pipeline_test.go.

## Related Issues
- Connected to #3097