### PR TITLE
feat: add alert suppression to deduplicate webhook notifications

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -23,6 +23,7 @@ data:
   LOG_LEVEL: {{ if .Values.observer }}{{ .Values.observer.logLevel | default "info" | quote }}{{ else }}"info"{{ end }}
   AI_RCA_ENABLED: {{ .Values.rca.enabled | default false | quote }}
   ALERT_STORE_BACKEND: {{ .Values.observer.alertStoreBackend | default "sqlite" | quote }}
+  ALERT_SUPPRESSION_WINDOW: {{ .Values.observer.alertSuppressionWindow | quote }}
   OBSERVER_AUTH_CONFIG_PATH: /etc/openchoreo/auth-config.yaml
   AUTHZ_SERVICE_URL: {{ .Values.observer.controlPlaneApiUrl | quote }}
   AUTHZ_TLS_INSECURE_SKIP_VERIFY: {{ .Values.observer.authzTlsInsecureSkipVerify | default false | quote }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -989,6 +989,12 @@
           "title": "alertStoreSqliteSize",
           "type": "string"
         },
+        "alertSuppressionWindow": {
+          "default": "1h",
+          "description": "Duration within which duplicate alerts for the same alert rule are suppressed. Set to \"0\" to disable.",
+          "title": "alertSuppressionWindow",
+          "type": "string"
+        },
         "authzTlsInsecureSkipVerify": {
           "default": false,
           "description": "Skip TLS certificate verification when calling the control plane authz service (use for self-signed certs)",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -424,6 +424,12 @@ observer:
   # @schema
   alertStoreBackend: sqlite
 
+  # @schema
+  # type: string
+  # description: Duration within which duplicate alerts for the same alert rule are suppressed. Set to "0" to disable.
+  # default: 1h
+  # @schema
+  alertSuppressionWindow: 1h
 
   # @schema
   # type: string

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -118,6 +118,9 @@ type AlertingConfig struct {
 	AlertStoreBackend string `koanf:"alert.store.backend"`
 	// AlertStoreDSN is the SQL connection string for alert entry storage.
 	AlertStoreDSN string `koanf:"alert.store.dsn"`
+	// AlertSuppressionWindow is the duration within which duplicate alerts
+	// for the same alert rule are suppressed. Set to 0 to disable suppression.
+	AlertSuppressionWindow time.Duration `koanf:"alert.suppression.window"`
 }
 
 // UIDResolverConfig holds configuration for the resource UID resolver
@@ -205,6 +208,7 @@ func Load() (*Config, error) {
 		"OBSERVABILITY_NAMESPACE":               "alerting.observability.namespace",
 		"ALERT_STORE_BACKEND":                   "alerting.alert.store.backend",
 		"ALERT_STORE_DSN":                       "alerting.alert.store.dsn",
+		"ALERT_SUPPRESSION_WINDOW":              "alerting.alert.suppression.window",
 		"LOG_LEVEL":                             "loglevel",
 		"PORT":                                  "server.port",           // Common alias
 		"INTERNAL_PORT":                         "server.internal.port",  // Common alias
@@ -352,11 +356,12 @@ func getDefaults() map[string]interface{} {
 			"max.log.lines.per.file":  600000,
 		},
 		"alerting": map[string]interface{}{
-			"rca.service.url":         "http://ai-rca-agent:8080",
-			"ai.rca.enabled":          false,
-			"observability.namespace": "openchoreo-observability-plane",
-			"alert.store.backend":     "sqlite",
-			"alert.store.dsn":         "file:/data/alerts.db?_journal=WAL",
+			"rca.service.url":          "http://ai-rca-agent:8080",
+			"ai.rca.enabled":           false,
+			"observability.namespace":  "openchoreo-observability-plane",
+			"alert.store.backend":      "sqlite",
+			"alert.store.dsn":          "file:/data/alerts.db?_journal=WAL",
+			"alert.suppression.window": "1h",
 		},
 		"adapters": map[string]interface{}{
 			"logs.adapter.enabled":    false,

--- a/internal/observer/service/alerts.go
+++ b/internal/observer/service/alerts.go
@@ -187,10 +187,6 @@ func (s *AlertService) DeleteAlertRule(ctx context.Context, ruleName, sourceType
 // It fetches the ObservabilityAlertRule CR, enriches alert details, stores the alert entry,
 // sends a notification, and optionally triggers AI RCA analysis.
 func (s *AlertService) HandleAlertWebhook(ctx context.Context, req gen.AlertWebhookRequest) (*gen.AlertWebhookResponse, error) {
-	if s.k8sClient == nil {
-		return nil, fmt.Errorf("kubernetes client not configured")
-	}
-
 	// Validate required fields
 	ruleName := stringPtrVal(req.RuleName)
 	ruleNamespace := stringPtrVal(req.RuleNamespace)
@@ -199,6 +195,34 @@ func (s *AlertService) HandleAlertWebhook(ctx context.Context, req gen.AlertWebh
 	}
 	if ruleNamespace == "" {
 		return nil, fmt.Errorf("ruleNamespace is required")
+	}
+
+	if s.alertEntryStore == nil {
+		return nil, fmt.Errorf("alert entry store is not initialized")
+	}
+
+	// Check for duplicate alert within the suppression window.
+	// This is done before fetching the CR to avoid unnecessary k8s API calls for suppressed alerts.
+	if s.config.Alerting.AlertSuppressionWindow > 0 {
+		since := time.Now().UTC().Add(-s.config.Alerting.AlertSuppressionWindow)
+		isDuplicate, err := s.alertEntryStore.HasRecentAlert(ctx, ruleName, ruleNamespace, since)
+		if err != nil {
+			s.logger.Warn("Failed to check alert suppression", "error", err, "ruleName", ruleName)
+		} else if isDuplicate {
+			s.logger.Info("Alert suppressed (duplicate within suppression window)",
+				"ruleName", ruleName, "ruleNamespace", ruleNamespace,
+				"suppressionWindow", s.config.Alerting.AlertSuppressionWindow)
+			suppressedStatus := gen.Success
+			msg := "alert suppressed: duplicate within suppression window"
+			return &gen.AlertWebhookResponse{
+				Status:  &suppressedStatus,
+				Message: &msg,
+			}, nil
+		}
+	}
+
+	if s.k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client not configured")
 	}
 
 	// Derive alertValue and timestamp from the request
@@ -253,10 +277,6 @@ func (s *AlertService) HandleAlertWebhook(ctx context.Context, req gen.AlertWebh
 		if alertRule.Spec.Actions.Incident.TriggerAiRca != nil {
 			alertDetails.TriggerAiRca = *alertRule.Spec.Actions.Incident.TriggerAiRca
 		}
-	}
-
-	if s.alertEntryStore == nil {
-		return nil, fmt.Errorf("alert entry store is not initialized")
 	}
 
 	if alertDetails.AlertTimestamp == "" {

--- a/internal/observer/service/alerts_query_test.go
+++ b/internal/observer/service/alerts_query_test.go
@@ -310,6 +310,9 @@ func (f *fakeAlertEntryStore) QueryAlertEntries(_ context.Context, params alerte
 	f.lastQueryParams = params
 	return f.entries, f.total, nil
 }
+func (f *fakeAlertEntryStore) HasRecentAlert(context.Context, string, string, time.Time) (bool, error) {
+	return false, nil
+}
 func (f *fakeAlertEntryStore) Close() error { return nil }
 
 type fakeIncidentEntryStore struct {

--- a/internal/observer/service/alerts_webhook_test.go
+++ b/internal/observer/service/alerts_webhook_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	choreoapis "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/labels"
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	"github.com/openchoreo/openchoreo/internal/observer/config"
+	"github.com/openchoreo/openchoreo/internal/observer/store/alertentry"
+	"github.com/openchoreo/openchoreo/internal/observer/store/incidententry"
+)
+
+const testCRNamespace = "obs-plane"
+
+// testAlertRule returns a minimal ObservabilityAlertRule CR for webhook tests.
+func testAlertRule(crName string, incidentEnabled, triggerRCA bool) *choreoapis.ObservabilityAlertRule {
+	return &choreoapis.ObservabilityAlertRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testCRNamespace,
+			Labels: map[string]string{
+				labels.LabelKeyNamespaceName:   "ns-1",
+				labels.LabelKeyComponentUID:    "comp-uid-1",
+				labels.LabelKeyEnvironmentUID:  "env-uid-1",
+				labels.LabelKeyProjectUID:      "proj-uid-1",
+				labels.LabelKeyComponentName:   "payments",
+				labels.LabelKeyProjectName:     "commerce",
+				labels.LabelKeyEnvironmentName: "prod",
+			},
+		},
+		Spec: choreoapis.ObservabilityAlertRuleSpec{
+			Name:        "High Error Rate",
+			Description: "Error rate exceeded threshold",
+			Severity:    choreoapis.ObservabilityAlertSeverityCritical,
+			Source: choreoapis.ObservabilityAlertSource{
+				Type:  choreoapis.ObservabilityAlertSourceTypeLog,
+				Query: "level=error",
+			},
+			Condition: choreoapis.ObservabilityAlertCondition{
+				Window:    metav1.Duration{Duration: 5 * time.Minute},
+				Interval:  metav1.Duration{Duration: 1 * time.Minute},
+				Operator:  choreoapis.ObservabilityAlertConditionOperatorGt,
+				Threshold: 5,
+			},
+			Actions: choreoapis.ObservabilityAlertActions{
+				Notifications: choreoapis.ObservabilityAlertNotifications{
+					Channels: []choreoapis.NotificationChannelName{"slack-main"},
+				},
+				Incident: &choreoapis.ObservabilityAlertIncident{
+					Enabled:      &incidentEnabled,
+					TriggerAiRca: &triggerRCA,
+				},
+			},
+		},
+	}
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, choreoapis.AddToScheme(scheme))
+	return scheme
+}
+
+type webhookTestFixture struct {
+	svc           *AlertService
+	alertStore    alertentry.AlertEntryStore
+	incidentStore incidententry.IncidentEntryStore
+	rcaCallCount  *atomic.Int32
+	rcaServer     *httptest.Server
+}
+
+func newWebhookTestFixture(t *testing.T, suppressionWindow time.Duration, alertRule *choreoapis.ObservabilityAlertRule, aiRCAEnabled bool) *webhookTestFixture {
+	t.Helper()
+
+	alertDSN := fmt.Sprintf("file:%s_alerts?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	alertStore, err := alertentry.New(alertentry.BackendSQLite, alertDSN, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, alertStore.Close()) })
+	require.NoError(t, alertStore.Initialize(context.Background()))
+
+	incidentDSN := fmt.Sprintf("file:%s_incidents?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	incidentStore, err := incidententry.New(incidententry.BackendSQLite, incidentDSN, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, incidentStore.Close()) })
+	require.NoError(t, incidentStore.Initialize(context.Background()))
+
+	var rcaCallCount atomic.Int32
+	rcaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rcaCallCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(rcaServer.Close)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(alertRule).
+		Build()
+
+	svc := &AlertService{
+		alertEntryStore:    alertStore,
+		incidentEntryStore: incidentStore,
+		k8sClient:          k8sClient,
+		config: &config.Config{
+			Alerting: config.AlertingConfig{
+				AlertSuppressionWindow: suppressionWindow,
+			},
+		},
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		rcaServiceURL: rcaServer.URL,
+		aiRCAEnabled:  aiRCAEnabled,
+	}
+
+	return &webhookTestFixture{
+		svc:           svc,
+		alertStore:    alertStore,
+		incidentStore: incidentStore,
+		rcaCallCount:  &rcaCallCount,
+		rcaServer:     rcaServer,
+	}
+}
+
+func (f *webhookTestFixture) alertCount(t *testing.T) int {
+	t.Helper()
+	_, total, err := f.alertStore.QueryAlertEntries(context.Background(), alertentry.QueryParams{
+		StartTime: "2000-01-01T00:00:00Z",
+		EndTime:   "2099-01-01T00:00:00Z",
+		Limit:     100,
+	})
+	require.NoError(t, err)
+	return total
+}
+
+func (f *webhookTestFixture) incidentCount(t *testing.T) int {
+	t.Helper()
+	_, total, err := f.incidentStore.QueryIncidentEntries(context.Background(), incidententry.QueryParams{
+		StartTime: "2000-01-01T00:00:00Z",
+		EndTime:   "2099-01-01T00:00:00Z",
+		Limit:     100,
+	})
+	require.NoError(t, err)
+	return total
+}
+
+func webhookReq(crName string) gen.AlertWebhookRequest {
+	val := float32(42)
+	now := time.Now().UTC()
+	ns := testCRNamespace
+	return gen.AlertWebhookRequest{
+		RuleName:       &crName,
+		RuleNamespace:  &ns,
+		AlertValue:     &val,
+		AlertTimestamp: &now,
+	}
+}
+
+func TestWebhook_FirstAlert_FullProcessing(t *testing.T) {
+	t.Parallel()
+
+	rule := testAlertRule("rule-cr-1", true, true)
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, true)
+
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, gen.Success, *resp.Status)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	// Alert entry must be persisted
+	assert.Equal(t, 1, f.alertCount(t))
+
+	// Incident and RCA run in goroutines — wait briefly for them
+	assert.Eventually(t, func() bool { return f.incidentCount(t) == 1 }, 2*time.Second, 50*time.Millisecond,
+		"expected 1 incident entry")
+	assert.Eventually(t, func() bool { return f.rcaCallCount.Load() == 1 }, 2*time.Second, 50*time.Millisecond,
+		"expected 1 RCA call")
+}
+
+func TestWebhook_DuplicateWithinWindow_Suppressed(t *testing.T) {
+	t.Parallel()
+
+	rule := testAlertRule("rule-cr-1", true, true)
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, true)
+
+	// First alert — should be processed
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+	assert.Equal(t, 1, f.alertCount(t))
+
+	// Wait for goroutines from first alert
+	assert.Eventually(t, func() bool { return f.incidentCount(t) == 1 }, 2*time.Second, 50*time.Millisecond)
+	assert.Eventually(t, func() bool { return f.rcaCallCount.Load() == 1 }, 2*time.Second, 50*time.Millisecond)
+
+	// Second alert (same rule, within window) — should be suppressed
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "suppressed")
+
+	// No new alert entry, incident, or RCA call
+	assert.Equal(t, 1, f.alertCount(t), "suppressed alert should not write a new entry")
+	assert.Never(t, func() bool { return f.incidentCount(t) > 1 }, 300*time.Millisecond, 50*time.Millisecond,
+		"suppressed alert should not create a new incident")
+	assert.Equal(t, int32(1), f.rcaCallCount.Load(), "suppressed alert should not trigger RCA")
+}
+
+func TestWebhook_DifferentRule_NotSuppressed(t *testing.T) {
+	t.Parallel()
+
+	rule1 := testAlertRule("rule-cr-1", false, false)
+	rule2 := testAlertRule("rule-cr-2", false, false)
+
+	alertDSN := fmt.Sprintf("file:%s_alerts?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	alertStore, err := alertentry.New(alertentry.BackendSQLite, alertDSN, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, alertStore.Close()) })
+	require.NoError(t, alertStore.Initialize(context.Background()))
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(rule1, rule2).
+		Build()
+
+	svc := &AlertService{
+		alertEntryStore: alertStore,
+		k8sClient:       k8sClient,
+		config: &config.Config{
+			Alerting: config.AlertingConfig{
+				AlertSuppressionWindow: 1 * time.Hour,
+			},
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	resp, err := svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	// Different rule — should NOT be suppressed
+	resp, err = svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-2"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	_, total, err := alertStore.QueryAlertEntries(context.Background(), alertentry.QueryParams{
+		StartTime: "2000-01-01T00:00:00Z",
+		EndTime:   "2099-01-01T00:00:00Z",
+		Limit:     100,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "different rules should both be stored")
+}
+
+func TestWebhook_SuppressionDisabled_BothProcessed(t *testing.T) {
+	t.Parallel()
+
+	rule := testAlertRule("rule-cr-1", false, false)
+	f := newWebhookTestFixture(t, 0, rule, false)
+
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	assert.Equal(t, 2, f.alertCount(t), "suppression disabled — both alerts should be stored")
+}
+
+func TestWebhook_IncidentDisabled_NoIncidentCreated(t *testing.T) {
+	t.Parallel()
+
+	rule := testAlertRule("rule-cr-1", false, false)
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, false)
+
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	assert.Equal(t, 1, f.alertCount(t))
+
+	assert.Never(t, func() bool { return f.incidentCount(t) > 0 }, 300*time.Millisecond, 50*time.Millisecond,
+		"incident should not be created when disabled")
+	assert.Equal(t, int32(0), f.rcaCallCount.Load(), "RCA should not be triggered when disabled")
+}
+
+func TestWebhook_RCADisabled_NoRCACall(t *testing.T) {
+	t.Parallel()
+
+	rule := testAlertRule("rule-cr-1", true, true)
+	// aiRCAEnabled=false at service level
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, false)
+
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	assert.Eventually(t, func() bool { return f.incidentCount(t) == 1 }, 2*time.Second, 50*time.Millisecond)
+
+	assert.Never(t, func() bool { return f.rcaCallCount.Load() > 0 }, 300*time.Millisecond, 50*time.Millisecond,
+		"RCA should not be triggered when aiRCAEnabled is false")
+}

--- a/internal/observer/store/alertentry/sql.go
+++ b/internal/observer/store/alertentry/sql.go
@@ -71,6 +71,9 @@ func (s *sqlStore) Initialize(ctx context.Context) error {
 	if _, err := s.db.ExecContext(initCtx, createNamespaceTimestampIndexQuery); err != nil {
 		return fmt.Errorf("failed to create alert_entries index: %w", err)
 	}
+	if _, err := s.db.ExecContext(initCtx, createAlertRuleCRTimestampIndexQuery); err != nil {
+		return fmt.Errorf("failed to create alert_entries cr index: %w", err)
+	}
 	return nil
 }
 
@@ -314,6 +317,21 @@ func (s *sqlStore) QueryAlertEntries(ctx context.Context, params QueryParams) ([
 	return entries, total, nil
 }
 
+func (s *sqlStore) HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace string, since time.Time) (bool, error) {
+	sinceNS := since.UnixNano()
+	var query string
+	if s.backend == BackendPostgreSQL {
+		query = hasRecentAlertPostgresQuery
+	} else {
+		query = hasRecentAlertSQLiteQuery
+	}
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, query, alertRuleCRName, alertRuleCRNamespace, sinceNS).Scan(&exists); err != nil {
+		return false, fmt.Errorf("failed to check recent alert: %w", err)
+	}
+	return exists, nil
+}
+
 func normalizeTimestamp(value string) (string, error) {
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err == nil {
@@ -393,6 +411,20 @@ INSERT INTO alert_entries (
 	source_type, source_query, source_metric,
 	condition_operator, condition_threshold, condition_window, condition_interval
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+
+const createAlertRuleCRTimestampIndexQuery = `
+CREATE INDEX IF NOT EXISTS idx_alert_entries_cr_ts
+ON alert_entries(alert_rule_cr_name, alert_rule_cr_namespace, timestamp_ns);`
+
+const hasRecentAlertSQLiteQuery = `
+SELECT EXISTS(SELECT 1 FROM alert_entries
+WHERE alert_rule_cr_name = ? AND alert_rule_cr_namespace = ? AND timestamp_ns >= ?
+LIMIT 1);`
+
+const hasRecentAlertPostgresQuery = `
+SELECT EXISTS(SELECT 1 FROM alert_entries
+WHERE alert_rule_cr_name = $1 AND alert_rule_cr_namespace = $2 AND timestamp_ns >= $3
+LIMIT 1);`
 
 const insertAlertEntryPostgresQuery = `
 INSERT INTO alert_entries (

--- a/internal/observer/store/alertentry/sql_test.go
+++ b/internal/observer/store/alertentry/sql_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,4 +140,74 @@ func TestQueryAlertEntries(t *testing.T) {
 	require.Equal(t, 1, total)
 	require.Len(t, got, 1)
 	assert.Equal(t, "rule-b", got[0].AlertRuleName)
+}
+
+func TestHasRecentAlert(t *testing.T) {
+	t.Parallel()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	store, err := New(BackendSQLite, dsn, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+
+	now := time.Now().UTC()
+
+	_, err = store.WriteAlertEntry(ctx, &AlertEntry{
+		Timestamp:            now.Add(-30 * time.Minute).Format(time.RFC3339Nano),
+		AlertRuleName:        "high-error-rate",
+		AlertRuleCRName:      "rule-cr-1",
+		AlertRuleCRNamespace: "obs-plane",
+		AlertValue:           "42",
+		NamespaceName:        "ns-1",
+		ComponentName:        "payments",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		crName      string
+		crNamespace string
+		since       time.Time
+		want        bool
+	}{
+		{
+			name:        "match within window",
+			crName:      "rule-cr-1",
+			crNamespace: "obs-plane",
+			since:       now.Add(-1 * time.Hour),
+			want:        true,
+		},
+		{
+			name:        "no match - outside window",
+			crName:      "rule-cr-1",
+			crNamespace: "obs-plane",
+			since:       now.Add(-10 * time.Minute),
+			want:        false,
+		},
+		{
+			name:        "no match - different cr name",
+			crName:      "rule-cr-other",
+			crNamespace: "obs-plane",
+			since:       now.Add(-1 * time.Hour),
+			want:        false,
+		},
+		{
+			name:        "no match - different namespace",
+			crName:      "rule-cr-1",
+			crNamespace: "other-ns",
+			since:       now.Add(-1 * time.Hour),
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := store.HasRecentAlert(ctx, tt.crName, tt.crNamespace, tt.since)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/observer/store/alertentry/store.go
+++ b/internal/observer/store/alertentry/store.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 )
 
 const (
@@ -60,6 +61,7 @@ type AlertEntryStore interface {
 	Initialize(ctx context.Context) error
 	WriteAlertEntry(ctx context.Context, entry *AlertEntry) (id string, err error)
 	QueryAlertEntries(ctx context.Context, params QueryParams) ([]AlertEntry, int, error)
+	HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace string, since time.Time) (bool, error)
 	Close() error
 }
 


### PR DESCRIPTION
## Summary
- Adds observer-side alert suppression that deduplicates webhook notifications for the same alert rule within a configurable time window (default: 1h)
- When OpenSearch alert flapping causes the same rule to fire multiple times (due to brief dips in the query window), duplicate notifications, incidents, and RCA triggers are now suppressed
- The suppression window is configurable via `ALERT_SUPPRESSION_WINDOW` env var / `observer.alertSuppressionWindow` helm value, and can be disabled by setting it to `0`