### PR TITLE
chore(deps): bump podman-runner image to v1.1

### DIFF
--- a/install/k3d/common/push-buildpack-cache-images.yaml
+++ b/install/k3d/common/push-buildpack-cache-images.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: push-images
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -26,7 +26,7 @@ spec:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c
@@ -107,7 +107,7 @@ spec:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c
@@ -189,7 +189,7 @@ spec:
           - name: git-revision
           - name: build-env
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c
@@ -273,7 +273,7 @@ spec:
           - name: build-env
           - name: build-args
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -10,7 +10,7 @@ spec:
           - name: git-revision
           - name: build-env
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/containerfile-build.yaml
+++ b/samples/getting-started/workflow-templates/containerfile-build.yaml
@@ -11,7 +11,7 @@ spec:
           - name: build-env
           - name: build-args
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
@@ -9,7 +9,7 @@ spec:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
@@ -27,7 +27,7 @@ spec:
           - name: api-server-host-header
             default: "api.openchoreo.localhost"
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/generate-workload.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload.yaml
@@ -23,7 +23,7 @@ spec:
           - name: api-server-url
             default: "http://host.k3d.internal:8080"
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
@@ -9,7 +9,7 @@ spec:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/publish-image-k3d.yaml
+++ b/samples/getting-started/workflow-templates/publish-image-k3d.yaml
@@ -19,7 +19,7 @@ spec:
             optional: true
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c

--- a/samples/getting-started/workflow-templates/publish-image.yaml
+++ b/samples/getting-started/workflow-templates/publish-image.yaml
@@ -19,7 +19,7 @@ spec:
             optional: true
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.1
         command:
           - sh
           - -c


### PR DESCRIPTION
## Summary
- bump podman-runner image from v1.0 to v1.1 in getting-started workflow templates
- bump podman-runner image from v1.0 to v1.1 in k3d buildpack cache push manifest

## Changes
- update image tag references in 10 YAML files

## Validation
- static template updates only