### PR TITLE
fix: enfore trace limit at OpenSearch end using aggregations

### DIFF
--- a/internal/observer/adaptor/traces_default.go
+++ b/internal/observer/adaptor/traces_default.go
@@ -5,6 +5,7 @@ package adaptor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -57,7 +58,49 @@ func (a *DefaultTracesAdaptor) GetTraces(ctx context.Context, params observabili
 		osParams.ComponentUIDs = []string{params.ComponentID}
 	}
 
-	// Build and execute query
+	// When listing traces (no specific traceID), use aggregation query so that
+	// the limit controls the number of distinct traces, not individual spans.
+	if params.TraceID == "" {
+		return a.getTracesWithAggregation(ctx, osParams)
+	}
+
+	return a.getTracesWithSpanQuery(ctx, osParams)
+}
+
+// getTracesWithAggregation uses a terms aggregation on traceId to return the
+// requested number of distinct traces.
+func (a *DefaultTracesAdaptor) getTracesWithAggregation(ctx context.Context, osParams opensearch.TracesRequestParams) (*observability.TracesQueryResult, error) {
+	query := a.queryBuilder.BuildTracesAggregationQuery(osParams)
+	response, err := a.osClient.Search(ctx, []string{"otel-traces-*"}, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute traces aggregation search: %w", err)
+	}
+
+	aggResult, err := parseTracesAggregation(response.Aggregations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse traces aggregation: %w", err)
+	}
+
+	traces := make([]observability.Trace, 0, len(aggResult.Traces.Buckets))
+	for _, bucket := range aggResult.Traces.Buckets {
+		trace := buildTraceFromBucket(bucket)
+		traces = append(traces, trace)
+	}
+
+	totalCount := aggResult.TraceCount.Value
+	if totalCount > config.MaxLimit {
+		totalCount = config.MaxLimit
+	}
+
+	return &observability.TracesQueryResult{
+		Traces:     traces,
+		TotalCount: totalCount,
+		Took:       response.Took,
+	}, nil
+}
+
+// getTracesWithSpanQuery uses the span-level query (for fetching spans of a specific trace).
+func (a *DefaultTracesAdaptor) getTracesWithSpanQuery(ctx context.Context, osParams opensearch.TracesRequestParams) (*observability.TracesQueryResult, error) {
 	query := a.queryBuilder.BuildTracesQuery(osParams)
 	response, err := a.osClient.Search(ctx, []string{"otel-traces-*"}, query)
 	if err != nil {
@@ -93,6 +136,83 @@ func (a *DefaultTracesAdaptor) GetTraces(ctx context.Context, params observabili
 		TotalCount: min(response.Hits.Total.Value, config.MaxLimit),
 		Took:       response.Took,
 	}, nil
+}
+
+// parseTracesAggregation parses the raw aggregation JSON from the OpenSearch response.
+func parseTracesAggregation(raw json.RawMessage) (*opensearch.TracesAggregationResult, error) {
+	if len(raw) == 0 {
+		return &opensearch.TracesAggregationResult{}, nil
+	}
+	var result opensearch.TracesAggregationResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal aggregation result: %w", err)
+	}
+	return &result, nil
+}
+
+// buildTraceFromBucket converts an aggregation bucket into an observability.Trace.
+func buildTraceFromBucket(bucket opensearch.TraceBucket) observability.Trace {
+	trace := observability.Trace{
+		TraceID:   bucket.Key,
+		SpanCount: bucket.DocCount,
+	}
+
+	// Extract startTime from the earliest span (top_hits sorted by startTime asc)
+	if len(bucket.EarliestSpan.Hits.Hits) > 0 {
+		src := bucket.EarliestSpan.Hits.Hits[0].Source
+		if src != nil {
+			if ts, ok := src["startTime"].(string); ok {
+				if parsed, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+					trace.StartTime = parsed
+				}
+			}
+		}
+	}
+
+	// Extract root span info from the root_span filter aggregation (parentSpanId == "")
+	// Falls back to the earliest span if no root span is found
+	if len(bucket.RootSpan.Hit.Hits.Hits) > 0 {
+		src := bucket.RootSpan.Hit.Hits.Hits[0].Source
+		if src != nil {
+			if spanID, ok := src["spanId"].(string); ok {
+				trace.RootSpanID = spanID
+			}
+			if name, ok := src["name"].(string); ok {
+				trace.RootSpanName = name
+				trace.TraceName = name
+			}
+		}
+	} else if len(bucket.EarliestSpan.Hits.Hits) > 0 {
+		src := bucket.EarliestSpan.Hits.Hits[0].Source
+		if src != nil {
+			if spanID, ok := src["spanId"].(string); ok {
+				trace.RootSpanID = spanID
+			}
+			if name, ok := src["name"].(string); ok {
+				trace.RootSpanName = name
+				trace.TraceName = name
+			}
+		}
+	}
+
+	// Extract endTime from the latest span (top_hits sorted by endTime desc)
+	if len(bucket.LatestSpan.Hits.Hits) > 0 {
+		src := bucket.LatestSpan.Hits.Hits[0].Source
+		if src != nil {
+			if ts, ok := src["endTime"].(string); ok {
+				if parsed, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+					trace.EndTime = parsed
+				}
+			}
+		}
+	}
+
+	// Calculate duration
+	if !trace.StartTime.IsZero() && !trace.EndTime.IsZero() {
+		trace.DurationNs = trace.EndTime.Sub(trace.StartTime).Nanoseconds()
+	}
+
+	return trace
 }
 
 // GetSpanDetails retrieves details for a specific span

--- a/internal/observer/adaptor/traces_default_test.go
+++ b/internal/observer/adaptor/traces_default_test.go
@@ -4,6 +4,7 @@
 package adaptor
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -224,4 +225,361 @@ func TestConvertToObservabilityTrace_ComplexHierarchy(t *testing.T) {
 
 	// Verify all spans are in the trace
 	assert.Len(t, trace.Spans, 4)
+}
+
+func TestParseTracesAggregation(t *testing.T) {
+	t.Run("Valid aggregation response", func(t *testing.T) {
+		raw := json.RawMessage(`{
+			"trace_count": { "value": 42 },
+			"traces": {
+				"buckets": [
+					{
+						"key": "trace-aaa",
+						"doc_count": 5,
+						"earliest_span": {
+							"hits": {
+								"hits": [
+									{
+										"_id": "hit1",
+										"_source": { "spanId": "span-root", "name": "GET /api", "parentSpanId": "", "startTime": "2024-01-01T00:00:00.123456789Z" }
+									}
+								]
+							}
+						},
+						"root_span": {
+							"doc_count": 1,
+							"hit": {
+								"hits": {
+									"hits": [
+										{
+											"_id": "hit1-root",
+											"_source": { "spanId": "span-root", "name": "GET /api" }
+										}
+									]
+								}
+							}
+						},
+						"latest_span": {
+							"hits": {
+								"hits": [
+									{
+										"_id": "hit1-end",
+										"_source": { "endTime": "2024-01-01T00:00:01.987654321Z" }
+									}
+								]
+							}
+						},
+						"min_start_time": { "value": 1704067200123 }
+					},
+					{
+						"key": "trace-bbb",
+						"doc_count": 3,
+						"earliest_span": {
+							"hits": {
+								"hits": [
+									{
+										"_id": "hit2",
+										"_source": { "spanId": "span-root-2", "name": "POST /submit", "parentSpanId": "", "startTime": "2024-01-01T00:00:02.111222333Z" }
+									}
+								]
+							}
+						},
+						"root_span": {
+							"doc_count": 1,
+							"hit": {
+								"hits": {
+									"hits": [
+										{
+											"_id": "hit2-root",
+											"_source": { "spanId": "span-root-2", "name": "POST /submit" }
+										}
+									]
+								}
+							}
+						},
+						"latest_span": {
+							"hits": {
+								"hits": [
+									{
+										"_id": "hit2-end",
+										"_source": { "endTime": "2024-01-01T00:00:03.444555666Z" }
+									}
+								]
+							}
+						},
+						"min_start_time": { "value": 1704067202111 }
+					}
+				]
+			}
+		}`)
+
+		result, err := parseTracesAggregation(raw)
+		require.NoError(t, err)
+
+		assert.Equal(t, 42, result.TraceCount.Value)
+		assert.Len(t, result.Traces.Buckets, 2)
+
+		bucket := result.Traces.Buckets[0]
+		assert.Equal(t, "trace-aaa", bucket.Key)
+		assert.Equal(t, 5, bucket.DocCount)
+
+		require.Len(t, bucket.EarliestSpan.Hits.Hits, 1)
+		earliestSource := bucket.EarliestSpan.Hits.Hits[0].Source
+		assert.Equal(t, "span-root", earliestSource["spanId"])
+		assert.Equal(t, "GET /api", earliestSource["name"])
+		assert.Equal(t, "2024-01-01T00:00:00.123456789Z", earliestSource["startTime"])
+
+		require.Len(t, bucket.LatestSpan.Hits.Hits, 1)
+		latestSource := bucket.LatestSpan.Hits.Hits[0].Source
+		assert.Equal(t, "2024-01-01T00:00:01.987654321Z", latestSource["endTime"])
+	})
+
+	t.Run("Empty aggregation", func(t *testing.T) {
+		result, err := parseTracesAggregation(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.TraceCount.Value)
+		assert.Empty(t, result.Traces.Buckets)
+	})
+}
+
+func TestParseTracesAggregation_InvalidJSON(t *testing.T) {
+	raw := json.RawMessage(`{invalid json}`)
+	_, err := parseTracesAggregation(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal aggregation result")
+}
+
+func TestBuildTraceFromBucket_EmptyBucket(t *testing.T) {
+	bucket := opensearch.TraceBucket{
+		Key:      "trace-empty",
+		DocCount: 0,
+	}
+
+	trace := buildTraceFromBucket(bucket)
+
+	assert.Equal(t, "trace-empty", trace.TraceID)
+	assert.Equal(t, 0, trace.SpanCount)
+	assert.Empty(t, trace.RootSpanID)
+	assert.Empty(t, trace.RootSpanName)
+	assert.True(t, trace.StartTime.IsZero())
+	assert.True(t, trace.EndTime.IsZero())
+	assert.Equal(t, int64(0), trace.DurationNs)
+}
+
+func TestBuildTraceFromBucket_NilSource(t *testing.T) {
+	bucket := opensearch.TraceBucket{
+		Key:      "trace-nil",
+		DocCount: 1,
+		EarliestSpan: opensearch.AggTopHitsValue{
+			Hits: struct {
+				Hits []opensearch.Hit `json:"hits"`
+			}{
+				Hits: []opensearch.Hit{
+					{ID: "hit1", Source: nil},
+				},
+			},
+		},
+		LatestSpan: opensearch.AggTopHitsValue{
+			Hits: struct {
+				Hits []opensearch.Hit `json:"hits"`
+			}{
+				Hits: []opensearch.Hit{
+					{ID: "hit2", Source: nil},
+				},
+			},
+		},
+	}
+
+	trace := buildTraceFromBucket(bucket)
+
+	assert.Equal(t, "trace-nil", trace.TraceID)
+	assert.Equal(t, 1, trace.SpanCount)
+	assert.Empty(t, trace.RootSpanID)
+	assert.True(t, trace.StartTime.IsZero())
+	assert.True(t, trace.EndTime.IsZero())
+	assert.Equal(t, int64(0), trace.DurationNs)
+}
+
+func TestBuildTraceFromBucket_InvalidTimestamps(t *testing.T) {
+	makeTopHits := func(source map[string]interface{}) opensearch.AggTopHitsValue {
+		return opensearch.AggTopHitsValue{
+			Hits: struct {
+				Hits []opensearch.Hit `json:"hits"`
+			}{
+				Hits: []opensearch.Hit{
+					{ID: "hit1", Source: source},
+				},
+			},
+		}
+	}
+
+	bucket := opensearch.TraceBucket{
+		Key:      "trace-bad-ts",
+		DocCount: 1,
+		EarliestSpan: makeTopHits(map[string]interface{}{
+			"spanId":    "span-1",
+			"name":      "test",
+			"startTime": "not-a-timestamp",
+		}),
+		LatestSpan: makeTopHits(map[string]interface{}{
+			"endTime": "also-not-a-timestamp",
+		}),
+	}
+
+	trace := buildTraceFromBucket(bucket)
+
+	assert.Equal(t, "trace-bad-ts", trace.TraceID)
+	assert.Equal(t, "span-1", trace.RootSpanID)
+	assert.Equal(t, "test", trace.RootSpanName)
+	assert.True(t, trace.StartTime.IsZero())
+	assert.True(t, trace.EndTime.IsZero())
+	assert.Equal(t, int64(0), trace.DurationNs)
+}
+
+func TestBuildTraceFromBucket_OnlyStartTime(t *testing.T) {
+	makeTopHits := func(source map[string]interface{}) opensearch.AggTopHitsValue {
+		return opensearch.AggTopHitsValue{
+			Hits: struct {
+				Hits []opensearch.Hit `json:"hits"`
+			}{
+				Hits: []opensearch.Hit{
+					{ID: "hit1", Source: source},
+				},
+			},
+		}
+	}
+
+	bucket := opensearch.TraceBucket{
+		Key:      "trace-partial",
+		DocCount: 1,
+		EarliestSpan: makeTopHits(map[string]interface{}{
+			"spanId":    "span-1",
+			"name":      "test",
+			"startTime": "2024-01-01T10:00:00Z",
+		}),
+	}
+
+	trace := buildTraceFromBucket(bucket)
+
+	assert.Equal(t, "trace-partial", trace.TraceID)
+	assert.False(t, trace.StartTime.IsZero())
+	assert.True(t, trace.EndTime.IsZero())
+	assert.Equal(t, int64(0), trace.DurationNs)
+}
+
+func TestBuildTraceFromBucket(t *testing.T) {
+	makeTopHits := func(source map[string]interface{}) opensearch.AggTopHitsValue {
+		return opensearch.AggTopHitsValue{
+			Hits: struct {
+				Hits []opensearch.Hit `json:"hits"`
+			}{
+				Hits: []opensearch.Hit{
+					{ID: "hit1", Source: source},
+				},
+			},
+		}
+	}
+
+	makeFilteredTopHits := func(source map[string]interface{}) opensearch.AggFilteredTopHits {
+		return opensearch.AggFilteredTopHits{
+			DocCount: 1,
+			Hit: opensearch.AggTopHitsValue{
+				Hits: struct {
+					Hits []opensearch.Hit `json:"hits"`
+				}{
+					Hits: []opensearch.Hit{
+						{ID: "root-hit", Source: source},
+					},
+				},
+			},
+		}
+	}
+
+	bucket := opensearch.TraceBucket{
+		Key:      "trace-123",
+		DocCount: 7,
+		EarliestSpan: makeTopHits(map[string]interface{}{
+			"spanId":       "root-span-id",
+			"name":         "GET /users",
+			"parentSpanId": "",
+			"startTime":    "2024-01-01T10:00:00.123456789Z",
+		}),
+		RootSpan: makeFilteredTopHits(map[string]interface{}{
+			"spanId": "root-span-id",
+			"name":   "GET /users",
+		}),
+		LatestSpan: makeTopHits(map[string]interface{}{
+			"endTime": "2024-01-01T10:00:02.623456789Z",
+		}),
+	}
+
+	trace := buildTraceFromBucket(bucket)
+
+	assert.Equal(t, "trace-123", trace.TraceID)
+	assert.Equal(t, 7, trace.SpanCount)
+	assert.Equal(t, "root-span-id", trace.RootSpanID)
+	assert.Equal(t, "GET /users", trace.RootSpanName)
+	assert.Equal(t, "GET /users", trace.TraceName)
+	assert.Equal(t, int64(2500000000), trace.DurationNs)
+	assert.Equal(t, "2024-01-01T10:00:00.123456789Z", trace.StartTime.Format(time.RFC3339Nano))
+	assert.Equal(t, "2024-01-01T10:00:02.623456789Z", trace.EndTime.Format(time.RFC3339Nano))
+}
+
+func TestBuildTraceFromBucket_RootSpanDiffersFromEarliestSpan(t *testing.T) {
+	makeTopHits := func(source map[string]interface{}) opensearch.AggTopHitsValue {
+		return opensearch.AggTopHitsValue{
+			Hits: struct {
+				Hits []opensearch.Hit `json:"hits"`
+			}{
+				Hits: []opensearch.Hit{
+					{ID: "hit1", Source: source},
+				},
+			},
+		}
+	}
+
+	makeFilteredTopHits := func(source map[string]interface{}) opensearch.AggFilteredTopHits {
+		return opensearch.AggFilteredTopHits{
+			DocCount: 1,
+			Hit: opensearch.AggTopHitsValue{
+				Hits: struct {
+					Hits []opensearch.Hit `json:"hits"`
+				}{
+					Hits: []opensearch.Hit{
+						{ID: "root-hit", Source: source},
+					},
+				},
+			},
+		}
+	}
+
+	bucket := opensearch.TraceBucket{
+		Key:      "trace-456",
+		DocCount: 5,
+		EarliestSpan: makeTopHits(map[string]interface{}{
+			"spanId":       "child-span-id",
+			"name":         "DB query",
+			"parentSpanId": "root-span-id",
+			"startTime":    "2024-01-01T10:00:00.000000000Z",
+		}),
+		RootSpan: makeFilteredTopHits(map[string]interface{}{
+			"spanId": "root-span-id",
+			"name":   "GET /users",
+		}),
+		LatestSpan: makeTopHits(map[string]interface{}{
+			"endTime": "2024-01-01T10:00:02.000000000Z",
+		}),
+	}
+
+	trace := buildTraceFromBucket(bucket)
+
+	assert.Equal(t, "trace-456", trace.TraceID)
+	assert.Equal(t, 5, trace.SpanCount)
+	// Root span info should come from root_span, not earliest_span
+	assert.Equal(t, "root-span-id", trace.RootSpanID)
+	assert.Equal(t, "GET /users", trace.RootSpanName)
+	assert.Equal(t, "GET /users", trace.TraceName)
+	// Start time should still come from earliest span
+	assert.Equal(t, "2024-01-01T10:00:00Z", trace.StartTime.Format(time.RFC3339Nano))
+	assert.Equal(t, int64(2000000000), trace.DurationNs)
 }

--- a/internal/observer/opensearch/queries.go
+++ b/internal/observer/opensearch/queries.go
@@ -14,6 +14,8 @@ import (
 	"github.com/openchoreo/openchoreo/internal/observer/types"
 )
 
+const sortOrderDesc = "desc"
+
 // sanitizeWildcardValue escapes OpenSearch wildcard metacharacters from user-provided values
 // to prevent wildcard injection attacks. Escaped characters: \, ", *, ?
 func sanitizeWildcardValue(s string) string {
@@ -665,14 +667,14 @@ func (qb *QueryBuilder) BuildTracesQuery(params TracesRequestParams) map[string]
 		{
 			"range": map[string]interface{}{
 				"startTime": map[string]interface{}{
-					"lte": params.EndTime,
+					"gte": params.StartTime,
 				},
 			},
 		},
 		{
 			"range": map[string]interface{}{
 				"endTime": map[string]interface{}{
-					"gte": params.StartTime,
+					"lte": params.EndTime,
 				},
 			},
 		},
@@ -732,6 +734,141 @@ func (qb *QueryBuilder) BuildTracesQuery(params TracesRequestParams) map[string]
 			{
 				"startTime": map[string]interface{}{
 					"order": params.SortOrder,
+				},
+			},
+		},
+	}
+
+	return query
+}
+
+// BuildTracesAggregationQuery builds an aggregation query that groups spans by traceId,
+// so that the limit parameter controls the number of distinct traces returned.
+func (qb *QueryBuilder) BuildTracesAggregationQuery(params TracesRequestParams) map[string]interface{} {
+	filterConditions := []map[string]interface{}{
+		{
+			"range": map[string]interface{}{
+				"startTime": map[string]interface{}{
+					"gte": params.StartTime,
+				},
+			},
+		},
+		{
+			"range": map[string]interface{}{
+				"endTime": map[string]interface{}{
+					"lte": params.EndTime,
+				},
+			},
+		},
+	}
+
+	// Add ComponentUIDs filter if present
+	if len(params.ComponentUIDs) > 0 {
+		shouldConditions := make([]map[string]interface{}, 0, len(params.ComponentUIDs))
+		for _, componentUID := range params.ComponentUIDs {
+			shouldConditions = append(shouldConditions, map[string]interface{}{
+				"term": map[string]interface{}{
+					"resource.openchoreo.dev/component-uid": componentUID,
+				},
+			})
+		}
+		filterConditions = append(filterConditions, map[string]interface{}{
+			"bool": map[string]interface{}{
+				"should": shouldConditions,
+			},
+		})
+	}
+
+	// Add EnvironmentUID filter if present
+	if params.EnvironmentUID != "" {
+		filterConditions = append(filterConditions, map[string]interface{}{
+			"term": map[string]interface{}{
+				"resource.openchoreo.dev/environment-uid": params.EnvironmentUID,
+			},
+		})
+	}
+
+	if params.ProjectUID != "" {
+		filterConditions = append(filterConditions, map[string]interface{}{
+			"term": map[string]interface{}{
+				"resource.openchoreo.dev/project-uid": params.ProjectUID,
+			},
+		})
+	}
+
+	sortOrder := params.SortOrder
+	if sortOrder == "" {
+		sortOrder = sortOrderDesc
+	}
+
+	query := map[string]interface{}{
+		"size": 0,
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"filter": filterConditions,
+			},
+		},
+		"aggs": map[string]interface{}{
+			"trace_count": map[string]interface{}{
+				"cardinality": map[string]interface{}{
+					"field": "traceId",
+				},
+			},
+			"traces": map[string]interface{}{
+				"terms": map[string]interface{}{
+					"field": "traceId",
+					"size":  params.Limit,
+					"order": map[string]interface{}{
+						"min_start_time": sortOrder,
+					},
+				},
+				"aggs": map[string]interface{}{
+					"earliest_span": map[string]interface{}{
+						"top_hits": map[string]interface{}{
+							"size": 1,
+							"sort": []map[string]interface{}{
+								{
+									"startTime": map[string]interface{}{
+										"order": "asc",
+									},
+								},
+							},
+							"_source": []string{"spanId", "name", "parentSpanId", "startTime"},
+						},
+					},
+					"root_span": map[string]interface{}{
+						"filter": map[string]interface{}{
+							"term": map[string]interface{}{
+								"parentSpanId": "",
+							},
+						},
+						"aggs": map[string]interface{}{
+							"hit": map[string]interface{}{
+								"top_hits": map[string]interface{}{
+									"size":    1,
+									"_source": []string{"spanId", "name", "startTime"},
+								},
+							},
+						},
+					},
+					"latest_span": map[string]interface{}{
+						"top_hits": map[string]interface{}{
+							"size": 1,
+							"sort": []map[string]interface{}{
+								{
+									"endTime": map[string]interface{}{
+										"order": sortOrderDesc,
+									},
+								},
+							},
+							"_source": []string{"endTime"},
+						},
+					},
+					"min_start_time": map[string]interface{}{
+						"min": map[string]interface{}{
+							"field": "startTime",
+						},
+					},
 				},
 			},
 		},
@@ -1037,7 +1174,7 @@ func (qb *QueryBuilder) BuildComponentLogsQueryV1(params ComponentLogsQueryParam
 	// Set default sort order if not specified
 	sortOrder := params.SortOrder
 	if sortOrder == "" {
-		sortOrder = "desc"
+		sortOrder = sortOrderDesc
 	}
 
 	query := map[string]interface{}{

--- a/internal/observer/opensearch/queries_test.go
+++ b/internal/observer/opensearch/queries_test.go
@@ -25,7 +25,7 @@ func TestQueryBuilder_BuildComponentLogsQuery(t *testing.T) {
 			Versions:      []string{"v1.0.0", "v1.0.1"},
 			VersionIDs:    []string{"version-id-1", "version-id-2"},
 			Limit:         100,
-			SortOrder:     "desc",
+			SortOrder:     sortOrderDesc,
 			LogType:       labels.QueryParamLogTypeRuntime,
 		},
 		BuildID:   "",
@@ -185,7 +185,7 @@ func TestQueryBuilder_BuildGatewayLogsQuery(t *testing.T) {
 			EndTime:      "2024-01-01T23:59:59Z",
 			SearchPhrase: "gateway",
 			Limit:        200,
-			SortOrder:    "desc",
+			SortOrder:    sortOrderDesc,
 		},
 		NamespaceName: "namespace-123",
 		APIIDToVersionMap: map[string]string{
@@ -355,7 +355,7 @@ func TestQueryBuilder_BuildTracesQuery(t *testing.T) {
 			StartTime: "2024-01-01T00:00:00Z",
 			EndTime:   "2024-01-01T23:59:59Z",
 			Limit:     50,
-			SortOrder: "desc",
+			SortOrder: sortOrderDesc,
 		}
 
 		got := qb.BuildTracesQuery(params)
@@ -379,7 +379,7 @@ func TestQueryBuilder_BuildTracesQuery(t *testing.T) {
 			StartTime: "2024-01-01T00:00:00Z",
 			EndTime:   "2024-01-01T23:59:59Z",
 			Limit:     50,
-			SortOrder: "desc",
+			SortOrder: sortOrderDesc,
 		}
 
 		got := qb.BuildTracesQuery(params)
@@ -414,7 +414,7 @@ func TestQueryBuilder_BuildTracesQuery(t *testing.T) {
 			StartTime:     "2024-01-01T00:00:00Z",
 			EndTime:       "2024-01-01T23:59:59Z",
 			Limit:         50,
-			SortOrder:     "desc",
+			SortOrder:     sortOrderDesc,
 		}
 
 		got := qb.BuildTracesQuery(params)
@@ -468,7 +468,7 @@ func TestQueryBuilder_BuildTracesQuery(t *testing.T) {
 			StartTime:      "2024-01-01T00:00:00Z",
 			EndTime:        "2024-01-01T23:59:59Z",
 			Limit:          50,
-			SortOrder:      "desc",
+			SortOrder:      sortOrderDesc,
 		}
 
 		got := qb.BuildTracesQuery(params)
@@ -494,6 +494,130 @@ func TestQueryBuilder_BuildTracesQuery(t *testing.T) {
 		}
 		if !envFound {
 			t.Error("EnvironmentUID filter not found")
+		}
+	})
+}
+
+func TestQueryBuilder_BuildTracesAggregationQuery(t *testing.T) {
+	qb := NewQueryBuilder("otel-v1-apm-span-")
+
+	t.Run("Basic aggregation query", func(t *testing.T) {
+		params := TracesRequestParams{
+			StartTime:  "2024-01-01T00:00:00Z",
+			EndTime:    "2024-01-01T23:59:59Z",
+			ProjectUID: "project-123",
+			Limit:      10,
+			SortOrder:  sortOrderDesc,
+		}
+
+		got := qb.BuildTracesAggregationQuery(params)
+
+		// Top-level size must be 0 (no hits, only aggregations)
+		if got["size"] != 0 {
+			t.Errorf("Expected size 0, got %v", got["size"])
+		}
+
+		// Verify query filters are preserved
+		query := got["query"].(map[string]interface{})
+		boolQuery := query["bool"].(map[string]interface{})
+		filters := boolQuery["filter"].([]map[string]interface{})
+
+		// Should have 3 filters: 2 time ranges + 1 projectUID
+		if len(filters) != 3 {
+			t.Errorf("Expected 3 filters, got %d", len(filters))
+		}
+
+		// Verify aggregation structure
+		aggs, ok := got["aggs"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected aggs not found")
+		}
+
+		// Verify trace_count cardinality aggregation
+		traceCount, ok := aggs["trace_count"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected trace_count aggregation not found")
+		}
+		cardinality, ok := traceCount["cardinality"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected cardinality in trace_count")
+		}
+		if cardinality["field"] != "traceId" {
+			t.Errorf("Expected cardinality field 'traceId', got %v", cardinality["field"])
+		}
+
+		// Verify traces terms aggregation
+		traces, ok := aggs["traces"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected traces aggregation not found")
+		}
+		terms, ok := traces["terms"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected terms in traces aggregation")
+		}
+		if terms["field"] != "traceId" {
+			t.Errorf("Expected terms field 'traceId', got %v", terms["field"])
+		}
+		if terms["size"] != 10 {
+			t.Errorf("Expected terms size 10 (matching limit), got %v", terms["size"])
+		}
+
+		// Verify sort order in terms
+		order, ok := terms["order"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected order in terms")
+		}
+		if order["min_start_time"] != sortOrderDesc {
+			t.Errorf("Expected order min_start_time 'desc', got %v", order["min_start_time"])
+		}
+
+		// Verify sub-aggregations
+		subAggs, ok := traces["aggs"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected sub-aggs in traces aggregation")
+		}
+
+		if _, ok := subAggs["earliest_span"]; !ok {
+			t.Error("Expected earliest_span sub-aggregation")
+		}
+		if _, ok := subAggs["root_span"]; !ok {
+			t.Error("Expected root_span sub-aggregation")
+		}
+		if _, ok := subAggs["latest_span"]; !ok {
+			t.Error("Expected latest_span sub-aggregation")
+		}
+		if _, ok := subAggs["min_start_time"]; !ok {
+			t.Error("Expected min_start_time sub-aggregation (used for terms ordering)")
+		}
+	})
+
+	t.Run("Aggregation query with ComponentUIDs", func(t *testing.T) {
+		params := TracesRequestParams{
+			ComponentUIDs: []string{"comp-1", "comp-2"},
+			StartTime:     "2024-01-01T00:00:00Z",
+			EndTime:       "2024-01-01T23:59:59Z",
+			Limit:         5,
+			SortOrder:     "asc",
+		}
+
+		got := qb.BuildTracesAggregationQuery(params)
+
+		query := got["query"].(map[string]interface{})
+		boolQuery := query["bool"].(map[string]interface{})
+		filters := boolQuery["filter"].([]map[string]interface{})
+
+		// Should have 3 filters: 2 time ranges + 1 bool with component should
+		if len(filters) != 3 {
+			t.Errorf("Expected 3 filters, got %d", len(filters))
+		}
+
+		// Verify sort order is "asc"
+		aggs := got["aggs"].(map[string]interface{})
+		traces := aggs["traces"].(map[string]interface{})
+		terms := traces["terms"].(map[string]interface{})
+		order := terms["order"].(map[string]interface{})
+		if order["min_start_time"] != "asc" {
+			t.Errorf("Expected order 'asc', got %v", order["min_start_time"])
 		}
 	})
 }
@@ -583,6 +707,300 @@ func verifySortOrder(t *testing.T, query map[string]interface{}) {
 
 	if timestampSort["order"] != sortOrderAsc {
 		t.Errorf("Expected ascending sort order, got %v", timestampSort["order"])
+	}
+}
+
+func TestQueryBuilder_BuildWorkflowRunLogsQuery(t *testing.T) {
+	qb := NewQueryBuilder("container-logs-")
+
+	t.Run("Basic query without stepName or namespace", func(t *testing.T) {
+		params := WorkflowRunQueryParams{
+			QueryParams: QueryParams{
+				StartTime: "2024-01-01T00:00:00Z",
+				EndTime:   "2024-01-01T23:59:59Z",
+				Limit:     100,
+				SortOrder: sortOrderDesc,
+			},
+			WorkflowRunID: "wf-run-123",
+		}
+
+		query := qb.BuildWorkflowRunLogsQuery(params)
+
+		if query["size"] != 100 {
+			t.Errorf("Expected size 100, got %v", query["size"])
+		}
+
+		boolQuery := query["query"].(map[string]interface{})["bool"].(map[string]interface{})
+		mustConditions := boolQuery["must"].([]map[string]interface{})
+
+		// Should have pod wildcard + time range = 2
+		if len(mustConditions) != 2 {
+			t.Errorf("Expected 2 must conditions, got %d", len(mustConditions))
+		}
+
+		verifyPodWildcardPattern(t, mustConditions, "wf-run-123*")
+		verifyContainerExclusions(t, boolQuery["must_not"].([]map[string]interface{}))
+	})
+
+	t.Run("Query with stepName", func(t *testing.T) {
+		params := WorkflowRunQueryParams{
+			QueryParams: QueryParams{
+				StartTime: "2024-01-01T00:00:00Z",
+				EndTime:   "2024-01-01T23:59:59Z",
+				Limit:     100,
+				SortOrder: sortOrderDesc,
+			},
+			WorkflowRunID: "wf-run-456",
+			StepName:      "build-step",
+		}
+
+		query := qb.BuildWorkflowRunLogsQuery(params)
+
+		boolQuery := query["query"].(map[string]interface{})["bool"].(map[string]interface{})
+		mustConditions := boolQuery["must"].([]map[string]interface{})
+
+		// Should have pod wildcard + step annotation + time range = 3
+		if len(mustConditions) != 3 {
+			t.Errorf("Expected 3 must conditions, got %d", len(mustConditions))
+		}
+
+		verifyStepNameWildcardPattern(t, mustConditions, "*build-step*")
+	})
+
+	t.Run("Query with namespace", func(t *testing.T) {
+		params := WorkflowRunQueryParams{
+			QueryParams: QueryParams{
+				StartTime:     "2024-01-01T00:00:00Z",
+				EndTime:       "2024-01-01T23:59:59Z",
+				NamespaceName: "my-namespace",
+				Limit:         100,
+				SortOrder:     sortOrderDesc,
+			},
+			WorkflowRunID: "wf-run-789",
+		}
+
+		query := qb.BuildWorkflowRunLogsQuery(params)
+
+		boolQuery := query["query"].(map[string]interface{})["bool"].(map[string]interface{})
+		mustConditions := boolQuery["must"].([]map[string]interface{})
+
+		// Should have pod wildcard + time range + namespace = 3
+		if len(mustConditions) != 3 {
+			t.Errorf("Expected 3 must conditions, got %d", len(mustConditions))
+		}
+
+		// Verify namespace filter uses "workflows-" prefix
+		nsFound := false
+		for _, condition := range mustConditions {
+			if term, ok := condition["term"].(map[string]interface{}); ok {
+				if val, exists := term[labels.KubernetesNamespaceName]; exists && val == "workflows-my-namespace" {
+					nsFound = true
+					break
+				}
+			}
+		}
+		if !nsFound {
+			t.Error("Expected namespace filter with 'workflows-' prefix not found")
+		}
+	})
+}
+
+func TestQueryBuilder_BuildSpanDetailsQuery(t *testing.T) {
+	qb := NewQueryBuilder("otel-v1-apm-span-")
+
+	traceID := "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+	spanID := "1a2b3c4d5e6f7a8b"
+
+	query := qb.BuildSpanDetailsQuery(traceID, spanID)
+
+	if query["size"] != 1 {
+		t.Errorf("Expected size 1, got %v", query["size"])
+	}
+
+	boolQuery := query["query"].(map[string]interface{})["bool"].(map[string]interface{})
+	filters := boolQuery["filter"].([]map[string]interface{})
+
+	if len(filters) != 2 {
+		t.Errorf("Expected 2 filters (traceId + spanId), got %d", len(filters))
+	}
+
+	traceFound, spanFound := false, false
+	for _, filter := range filters {
+		if term, ok := filter["term"].(map[string]interface{}); ok {
+			if val, exists := term["traceId"]; exists && val == traceID {
+				traceFound = true
+			}
+			if val, exists := term["spanId"]; exists && val == spanID {
+				spanFound = true
+			}
+		}
+	}
+	if !traceFound {
+		t.Error("Expected traceId filter not found")
+	}
+	if !spanFound {
+		t.Error("Expected spanId filter not found")
+	}
+}
+
+func TestQueryBuilder_BuildComponentLogsQueryV1(t *testing.T) {
+	qb := NewQueryBuilder("container-logs-")
+
+	t.Run("Error on missing required fields", func(t *testing.T) {
+		_, err := qb.BuildComponentLogsQueryV1(ComponentLogsQueryParamsV1{})
+		if err == nil {
+			t.Error("Expected error for missing required fields")
+		}
+	})
+
+	t.Run("Basic query with required fields only", func(t *testing.T) {
+		params := ComponentLogsQueryParamsV1{
+			StartTime:     "2024-01-01T00:00:00Z",
+			EndTime:       "2024-01-01T23:59:59Z",
+			NamespaceName: "test-ns",
+		}
+
+		query, err := qb.BuildComponentLogsQueryV1(params)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Default limit should be 100
+		if query["size"] != 100 {
+			t.Errorf("Expected default size 100, got %v", query["size"])
+		}
+
+		// Default sort order should be "desc"
+		sortFields := query["sort"].([]map[string]interface{})
+		timestampSort := sortFields[0]["@timestamp"].(map[string]interface{})
+		if timestampSort["order"] != "desc" {
+			t.Errorf("Expected default sort order 'desc', got %v", timestampSort["order"])
+		}
+	})
+
+	t.Run("Query with all optional filters", func(t *testing.T) {
+		params := ComponentLogsQueryParamsV1{
+			StartTime:     "2024-01-01T00:00:00Z",
+			EndTime:       "2024-01-01T23:59:59Z",
+			NamespaceName: "test-ns",
+			ProjectID:     "7b3e9a1f-4c6d-4e8f-a2b5-1d3c5e7f9a2b",
+			ComponentID:   "9f1a3b5c-7d8e-4f2a-b6c4-8e0f2a4b6c8d",
+			EnvironmentID: "c4e6a8b0-2d4f-4a6c-8e0b-2d4f6a8c0e2b",
+			SearchPhrase:  "error",
+			LogLevels:     []string{"ERROR"},
+			Limit:         50,
+			SortOrder:     "asc",
+		}
+
+		query, err := qb.BuildComponentLogsQueryV1(params)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if query["size"] != 50 {
+			t.Errorf("Expected size 50, got %v", query["size"])
+		}
+
+		boolQuery := query["query"].(map[string]interface{})["bool"].(map[string]interface{})
+		mustConditions := boolQuery["must"].([]map[string]interface{})
+
+		// time range + namespace + project + component + environment + search phrase + log level = 7
+		if len(mustConditions) != 7 {
+			t.Errorf("Expected 7 must conditions, got %d", len(mustConditions))
+		}
+	})
+}
+
+func TestQueryBuilder_BuildTracesAggregationQuery_DefaultSortOrder(t *testing.T) {
+	qb := NewQueryBuilder("otel-v1-apm-span-")
+
+	params := TracesRequestParams{
+		StartTime: "2024-01-01T00:00:00Z",
+		EndTime:   "2024-01-01T23:59:59Z",
+		Limit:     10,
+		SortOrder: "", // empty should default to "desc"
+	}
+
+	got := qb.BuildTracesAggregationQuery(params)
+
+	aggs := got["aggs"].(map[string]interface{})
+	traces := aggs["traces"].(map[string]interface{})
+	terms := traces["terms"].(map[string]interface{})
+	order := terms["order"].(map[string]interface{})
+	if order["min_start_time"] != "desc" {
+		t.Errorf("Expected default order 'desc', got %v", order["min_start_time"])
+	}
+}
+
+func TestQueryBuilder_BuildTracesAggregationQuery_WithEnvironmentUID(t *testing.T) {
+	qb := NewQueryBuilder("otel-v1-apm-span-")
+
+	params := TracesRequestParams{
+		StartTime:      "2024-01-01T00:00:00Z",
+		EndTime:        "2024-01-01T23:59:59Z",
+		EnvironmentUID: "d5f7b9c1-3e5a-4c7f-8a2d-6b8e0c2f4a6d",
+		Limit:          10,
+		SortOrder:      sortOrderDesc,
+	}
+
+	got := qb.BuildTracesAggregationQuery(params)
+
+	query := got["query"].(map[string]interface{})
+	boolQuery := query["bool"].(map[string]interface{})
+	filters := boolQuery["filter"].([]map[string]interface{})
+
+	// Should have 3 filters: 2 time ranges + 1 environmentUID
+	if len(filters) != 3 {
+		t.Errorf("Expected 3 filters, got %d", len(filters))
+	}
+
+	envFound := false
+	for _, filter := range filters {
+		if term, ok := filter["term"].(map[string]interface{}); ok {
+			if val, exists := term["resource.openchoreo.dev/environment-uid"]; exists && val == "d5f7b9c1-3e5a-4c7f-8a2d-6b8e0c2f4a6d" {
+				envFound = true
+				break
+			}
+		}
+	}
+	if !envFound {
+		t.Error("EnvironmentUID filter not found in aggregation query")
+	}
+}
+
+func TestQueryBuilder_BuildTracesQuery_WithProjectUID(t *testing.T) {
+	qb := NewQueryBuilder("otel-v1-apm-span-")
+
+	params := TracesRequestParams{
+		StartTime:  "2024-01-01T00:00:00Z",
+		EndTime:    "2024-01-01T23:59:59Z",
+		ProjectUID: "e6a8c0d2-4f6b-4e8a-9c1d-3f5a7b9e1c3d",
+		Limit:      50,
+		SortOrder:  sortOrderDesc,
+	}
+
+	got := qb.BuildTracesQuery(params)
+
+	query := got["query"].(map[string]interface{})
+	boolQuery := query["bool"].(map[string]interface{})
+	filters := boolQuery["filter"].([]map[string]interface{})
+
+	// Should have 3 filters: 2 time ranges + 1 projectUID
+	if len(filters) != 3 {
+		t.Errorf("Expected 3 filters, got %d", len(filters))
+	}
+
+	projFound := false
+	for _, filter := range filters {
+		if term, ok := filter["term"].(map[string]interface{}); ok {
+			if val, exists := term["resource.openchoreo.dev/project-uid"]; exists && val == "e6a8c0d2-4f6b-4e8a-9c1d-3f5a7b9e1c3d" {
+				projFound = true
+				break
+			}
+		}
+	}
+	if !projFound {
+		t.Error("ProjectUID filter not found")
 	}
 }
 

--- a/internal/observer/opensearch/types.go
+++ b/internal/observer/opensearch/types.go
@@ -21,8 +21,41 @@ type SearchResponse struct {
 		} `json:"total"`
 		Hits []Hit `json:"hits"`
 	} `json:"hits"`
-	Took     int  `json:"took"`
-	TimedOut bool `json:"timed_out"`
+	Aggregations json.RawMessage `json:"aggregations,omitempty"`
+	Took         int             `json:"took"`
+	TimedOut     bool            `json:"timed_out"`
+}
+
+// TracesAggregationResult represents the parsed aggregation response for traces queries
+type TracesAggregationResult struct {
+	TraceCount struct {
+		Value int `json:"value"`
+	} `json:"trace_count"`
+	Traces struct {
+		Buckets []TraceBucket `json:"buckets"`
+	} `json:"traces"`
+}
+
+// TraceBucket represents a single trace bucket from the terms aggregation
+type TraceBucket struct {
+	Key          string             `json:"key"`
+	DocCount     int                `json:"doc_count"`
+	EarliestSpan AggTopHitsValue    `json:"earliest_span"`
+	RootSpan     AggFilteredTopHits `json:"root_span"`
+	LatestSpan   AggTopHitsValue    `json:"latest_span"`
+}
+
+// AggTopHitsValue represents a top_hits aggregation result
+type AggTopHitsValue struct {
+	Hits struct {
+		Hits []Hit `json:"hits"`
+	} `json:"hits"`
+}
+
+// AggFilteredTopHits represents a filter aggregation with a nested top_hits sub-aggregation
+type AggFilteredTopHits struct {
+	DocCount int             `json:"doc_count"`
+	Hit      AggTopHitsValue `json:"hit"`
 }
 
 // Hit represents a single search result hit


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The POST /api/v1alpha1/traces/query endpoint's limit parameter was controlling the number of individual spans fetched from OpenSearch, not the number of distinct traces. After retrieval, spans were grouped by traceId client-side, resulting in fewer traces than requested (e.g., limit: 10 might return only 2 traces because those 2 traces contained 10 spans total). 


## Approach
Replaced the span-level query with an OpenSearch terms aggregation grouped by traceId when listing traces. 

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3065

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [x] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
