### PR TITLE
chore: exclude CLI testhelpers from codecov coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,6 +23,7 @@ ignore:
   - "test"                                                     # Test helpers and utilities
   - "internal/openchoreo-api/services/testutil"
   - "internal/controller/testutils"
+  - "internal/occ/cmd/testhelpers"                             # CLI test helpers
 
 comment:
   hide_project_coverage: false


### PR DESCRIPTION
## Purpose

Exclude the CLI test helpers package from codecov coverage reporting, consistent with other test utility directories already ignored.

## Approach

- Add `internal/occ/cmd/testhelpers` to the `ignore` list in `.github/codecov.yml`

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)