### PR TITLE
test: add unit tests for internal/scaffold/component package

### DIFF
--- a/internal/scaffold/component/field_context_test.go
+++ b/internal/scaffold/component/field_context_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"reflect"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestFieldContext_GetValueAsMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  map[string]any
+	}{
+		{"valid map", map[string]any{"k": "v"}, map[string]any{"k": "v"}},
+		{"nil value", nil, map[string]any{}},
+		{"non-map value", "string", map[string]any{}},
+		{"int value", 42, map[string]any{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &FieldContext{Value: tt.value}
+			got := ctx.GetValueAsMap()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetValueAsMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFieldContext_GetValueAsSlice(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  []any
+	}{
+		{"valid slice", []any{"a", "b"}, []any{"a", "b"}},
+		{"nil value", nil, []any{}},
+		{"non-slice value", "string", []any{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &FieldContext{Value: tt.value}
+			got := ctx.GetValueAsSlice()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetValueAsSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFieldContext_BuildFieldOptions(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+
+	t.Run("with separator and comment", func(t *testing.T) {
+		ctx := &FieldContext{AddSeparator: true, Renderer: renderer}
+		opts := ctx.BuildFieldOptions("A comment")
+		if len(opts) != 2 {
+			t.Errorf("expected 2 options, got %d", len(opts))
+		}
+	})
+
+	t.Run("no separator, no comment", func(t *testing.T) {
+		ctx := &FieldContext{AddSeparator: false, Renderer: renderer}
+		opts := ctx.BuildFieldOptions("")
+		if len(opts) != 0 {
+			t.Errorf("expected 0 options, got %d", len(opts))
+		}
+	})
+
+	t.Run("separator only", func(t *testing.T) {
+		ctx := &FieldContext{AddSeparator: true, Renderer: renderer}
+		opts := ctx.BuildFieldOptions("")
+		if len(opts) != 1 {
+			t.Errorf("expected 1 option, got %d", len(opts))
+		}
+	})
+
+	t.Run("comment only", func(t *testing.T) {
+		ctx := &FieldContext{AddSeparator: false, Renderer: renderer}
+		opts := ctx.BuildFieldOptions("comment")
+		if len(opts) != 1 {
+			t.Errorf("expected 1 option, got %d", len(opts))
+		}
+	})
+}
+
+func TestFieldContext_DetermineRenderMode(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+
+	tests := []struct {
+		name       string
+		isRequired bool
+		hasDefault bool
+		want       RenderMode
+	}{
+		{"required without default", true, false, RenderActive},
+		{"required with default", true, true, RenderCommented},
+		{"optional without default", false, false, RenderCommented},
+		{"optional with default", false, true, RenderCommented},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &FieldContext{
+				IsRequired: tt.isRequired,
+				HasDefault: tt.hasDefault,
+				Renderer:   renderer,
+			}
+			got := ctx.DetermineRenderMode()
+			if got != tt.want {
+				t.Errorf("DetermineRenderMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFieldContext_TypeChecks(t *testing.T) {
+	tests := []struct {
+		name        string
+		schema      *extv1.JSONSchemaProps
+		wantMap     bool
+		wantObject  bool
+		wantArray   bool
+		wantPrimStr bool
+	}{
+		{
+			name: "map field",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeObject,
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			wantMap: true,
+		},
+		{
+			name: "object field",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+				},
+			},
+			wantObject: true,
+		},
+		{
+			name:      "array field",
+			schema:    &extv1.JSONSchemaProps{Type: typeArray},
+			wantArray: true,
+		},
+		{
+			name:        "string field",
+			schema:      &extv1.JSONSchemaProps{Type: typeString},
+			wantPrimStr: true,
+		},
+		{
+			name:        "integer field",
+			schema:      &extv1.JSONSchemaProps{Type: typeInteger},
+			wantPrimStr: true,
+		},
+		{
+			name:        "boolean field",
+			schema:      &extv1.JSONSchemaProps{Type: typeBoolean},
+			wantPrimStr: true,
+		},
+		{
+			name:        "number field",
+			schema:      &extv1.JSONSchemaProps{Type: typeNumber},
+			wantPrimStr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &FieldContext{Schema: tt.schema}
+			if got := ctx.IsMapField(); got != tt.wantMap {
+				t.Errorf("IsMapField() = %v, want %v", got, tt.wantMap)
+			}
+			if got := ctx.IsObjectField(); got != tt.wantObject {
+				t.Errorf("IsObjectField() = %v, want %v", got, tt.wantObject)
+			}
+			if got := ctx.IsArrayField(); got != tt.wantArray {
+				t.Errorf("IsArrayField() = %v, want %v", got, tt.wantArray)
+			}
+			if got := ctx.IsPrimitiveField(); got != tt.wantPrimStr {
+				t.Errorf("IsPrimitiveField() = %v, want %v", got, tt.wantPrimStr)
+			}
+		})
+	}
+}
+
+func TestFieldContext_GetArrayItemSchema(t *testing.T) {
+	t.Run("with items", func(t *testing.T) {
+		itemSchema := &extv1.JSONSchemaProps{Type: typeString}
+		ctx := &FieldContext{
+			Schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: itemSchema,
+				},
+			},
+		}
+		got := ctx.GetArrayItemSchema()
+		if got != itemSchema {
+			t.Errorf("GetArrayItemSchema() = %v, want %v", got, itemSchema)
+		}
+	})
+
+	t.Run("nil items", func(t *testing.T) {
+		ctx := &FieldContext{Schema: &extv1.JSONSchemaProps{Type: typeArray}}
+		if got := ctx.GetArrayItemSchema(); got != nil {
+			t.Errorf("GetArrayItemSchema() = %v, want nil", got)
+		}
+	})
+}
+
+func TestFieldContext_GetMapValueSchema(t *testing.T) {
+	t.Run("with additionalProperties", func(t *testing.T) {
+		valueSchema := &extv1.JSONSchemaProps{Type: typeString}
+		ctx := &FieldContext{
+			Schema: &extv1.JSONSchemaProps{
+				Type: typeObject,
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+					Schema: valueSchema,
+				},
+			},
+		}
+		got := ctx.GetMapValueSchema()
+		if got != valueSchema {
+			t.Errorf("GetMapValueSchema() = %v, want %v", got, valueSchema)
+		}
+	})
+
+	t.Run("nil additionalProperties", func(t *testing.T) {
+		ctx := &FieldContext{Schema: &extv1.JSONSchemaProps{Type: typeObject}}
+		if got := ctx.GetMapValueSchema(); got != nil {
+			t.Errorf("GetMapValueSchema() = %v, want nil", got)
+		}
+	})
+}
+
+func TestFieldContext_ShouldOmitOptionalField(t *testing.T) {
+	tests := []struct {
+		name             string
+		isRequired       bool
+		hasDefault       bool
+		includeAllFields bool
+		want             bool
+	}{
+		{"optional no default includeAll=false", false, false, false, true},
+		{"optional no default includeAll=true", false, false, true, false},
+		{"optional with default", false, true, false, false},
+		{"required no default", true, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer := NewFieldRenderer(false, tt.includeAllFields, false)
+			ctx := &FieldContext{
+				IsRequired: tt.isRequired,
+				HasDefault: tt.hasDefault,
+				Renderer:   renderer,
+			}
+			if got := ctx.ShouldOmitOptionalField(); got != tt.want {
+				t.Errorf("ShouldOmitOptionalField() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scaffold/component/helpers_test.go
+++ b/internal/scaffold/component/helpers_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// assertYAMLEqual performs exact string equality after stripping a trailing
+// newline. Fails the test with a unified diff when the output differs.
+func assertYAMLEqual(t *testing.T, want, got string) {
+	t.Helper()
+	got = strings.TrimRight(got, "\n")
+	want = strings.TrimRight(want, "\n")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// encodeOrFatal encodes the builder and fails the test on error.
+func encodeOrFatal(t *testing.T, b *YAMLBuilder) string {
+	t.Helper()
+	got, err := b.Encode()
+	if err != nil {
+		t.Fatalf("Encode() error: %v", err)
+	}
+	return got
+}
+
+// dedent strips the minimum common leading whitespace from every non-empty line.
+// It also strips a single leading newline and any trailing whitespace/newlines,
+// so callers can write raw-string YAML indented to match the surrounding Go code:
+//
+//	want := dedent(`
+//	    retryPolicy: {}
+//	    # retryPolicy:
+//	      # attempts: 0
+//	`)
+//
+// The example above yields "retryPolicy: {}\n# retryPolicy:\n  # attempts: 0".
+// Relative indentation within the block is preserved (the "# attempts: 0" line
+// stays indented two spaces past "# retryPolicy:").
+//
+// A leading blank line (i.e. two newlines at the start of the raw string) is
+// preserved as an intentional blank output line; only one leading newline is
+// consumed as structural.
+func dedent(s string) string {
+	s = strings.TrimPrefix(s, "\n")
+	s = strings.TrimRight(s, " \t\n")
+
+	lines := strings.Split(s, "\n")
+
+	// Compute the minimum indent across non-blank lines.
+	minIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if minIndent == -1 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+	if minIndent <= 0 {
+		return s
+	}
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			lines[i] = ""
+			continue
+		}
+		lines[i] = line[minIndent:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/scaffold/component/nested_type_renderer_test.go
+++ b/internal/scaffold/component/nested_type_renderer_test.go
@@ -1,0 +1,558 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"strings"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestNestedTypeRenderer_RenderMapOfCustomType_Commented(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	valueSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+		},
+	}
+
+	nr.RenderMapOfCustomType(b, "configs", valueSchema, nil, RenderCommented, nil)
+	// All-optional children and empty value produce empty object entries.
+	want := dedent(`
+		# configs:
+		  # key1: {}
+		  # key2: {}
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfCustomType_Active(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	valueSchema := &extv1.JSONSchemaProps{
+		Type:     typeObject,
+		Required: []string{"port"},
+		Properties: map[string]extv1.JSONSchemaProps{
+			"port": {Type: typeInteger},
+		},
+	}
+
+	nr.RenderMapOfCustomType(b, "services", valueSchema, nil, RenderActive, nil)
+	want := dedent(`
+		services:
+		  key1:
+		    port: <TODO_PORT>
+		  key2:
+		    port: <TODO_PORT>
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfCustomType_WithExistingValueForKey1(t *testing.T) {
+	// This test documents the current behavior: RenderMapOfCustomType always
+	// generates exactly two entries ("key1" and "key2"), and only the entry
+	// matching a key in the provided value map picks up that default value.
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	valueSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"host": {Type: typeString, Default: &extv1.JSON{Raw: []byte(`"localhost"`)}},
+		},
+	}
+	existingValue := map[string]any{
+		"key1": map[string]any{"host": "localhost"},
+	}
+
+	nr.RenderMapOfCustomType(b, "endpoints", valueSchema, existingValue, RenderActive, nil)
+	// key1 renders its populated default as a commented field (optional with default).
+	// key2 renders as an empty mapping because its value map is nil.
+	want := dedent(`
+		endpoints:
+		  key1:
+		    # host: localhost
+		  key2: {}
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfPrimitiveArray_Commented(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	arraySchema := &extv1.JSONSchemaProps{
+		Type: typeArray,
+		Items: &extv1.JSONSchemaPropsOrArray{
+			Schema: &extv1.JSONSchemaProps{Type: typeString},
+		},
+	}
+
+	nr.RenderMapOfPrimitiveArray(b, "tags", arraySchema, RenderCommented, nil)
+	want := dedent(`
+		# tags:
+		  # key1: [example, example]
+		  # key2: [example, example]
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfPrimitiveArray_Active(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	arraySchema := &extv1.JSONSchemaProps{
+		Type: typeArray,
+		Items: &extv1.JSONSchemaPropsOrArray{
+			Schema: &extv1.JSONSchemaProps{Type: typeInteger},
+		},
+	}
+
+	nr.RenderMapOfPrimitiveArray(b, "ports", arraySchema, RenderActive, nil)
+	want := dedent(`
+		ports:
+		  key1: [0, 0]
+		  key2: [0, 0]
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfCustomTypeArray_Commented(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	arraySchema := &extv1.JSONSchemaProps{
+		Type: typeArray,
+		Items: &extv1.JSONSchemaPropsOrArray{
+			Schema: &extv1.JSONSchemaProps{
+				Type:     typeObject,
+				Required: []string{"name"},
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+				},
+			},
+		},
+	}
+
+	nr.RenderMapOfCustomTypeArray(b, "groups", arraySchema, RenderCommented, nil)
+	want := dedent(`
+		# groups:
+		  # key1:
+		    # - name: <TODO_NAME>
+		    # - name: <TODO_NAME>
+		  # key2:
+		    # - name: <TODO_NAME>
+		    # - name: <TODO_NAME>
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfCustomTypeArray_Active(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	arraySchema := &extv1.JSONSchemaProps{
+		Type: typeArray,
+		Items: &extv1.JSONSchemaPropsOrArray{
+			Schema: &extv1.JSONSchemaProps{
+				Type:     typeObject,
+				Required: []string{"value"},
+				Properties: map[string]extv1.JSONSchemaProps{
+					"value": {Type: typeString},
+				},
+			},
+		},
+	}
+
+	nr.RenderMapOfCustomTypeArray(b, "entries", arraySchema, RenderActive, nil)
+	want := dedent(`
+		entries:
+		  key1:
+		    - value: <TODO_VALUE>
+		    - value: <TODO_VALUE>
+		  key2:
+		    - value: <TODO_VALUE>
+		    - value: <TODO_VALUE>
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfCustomTypeArray_NilItemSchema(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	arraySchema := &extv1.JSONSchemaProps{
+		Type:  typeArray,
+		Items: &extv1.JSONSchemaPropsOrArray{Schema: nil},
+	}
+
+	nr.RenderMapOfCustomTypeArray(b, "data", arraySchema, RenderActive, nil)
+	got := encodeOrFatal(t, b)
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty output for nil item schema, got:\n%s", got)
+	}
+}
+
+func TestNestedTypeRenderer_RenderMapOfPrimitives_Commented(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.RenderMapOfPrimitives(b, "labels", &extv1.JSONSchemaProps{Type: typeString}, RenderCommented, nil)
+	want := dedent(`
+		# labels:
+		  # key1: example
+		  # key2: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapOfPrimitives_Active(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.RenderMapOfPrimitives(b, "counts", &extv1.JSONSchemaProps{Type: typeInteger}, RenderActive, nil)
+	want := dedent(`
+		counts:
+		  key1: 0
+		  key2: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfMaps_EmptyValues(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+			Schema: &extv1.JSONSchemaProps{Type: typeString},
+		},
+	}
+
+	nr.RenderArrayOfMaps(b, "data", itemSchema, nil, RenderActive, nil)
+	want := dedent(`
+		data:
+		  - key1: example
+		    key2: example
+		  - key1: example
+		    key2: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfMaps_Truncation(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+			Schema: &extv1.JSONSchemaProps{Type: typeString},
+		},
+	}
+
+	values := []any{
+		map[string]any{"a": "1"},
+		map[string]any{"b": "2"},
+		map[string]any{"c": "3"},
+	}
+
+	nr.RenderArrayOfMaps(b, "envVars", itemSchema, values, RenderActive, nil)
+	// Exactly 2 items rendered; the third is dropped.
+	want := dedent(`
+		envVars:
+		  - a: 1
+		  - b: 2
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfMaps_CommentedWithValues(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+			Schema: &extv1.JSONSchemaProps{Type: typeString},
+		},
+	}
+	values := []any{map[string]any{"key": "val"}}
+
+	nr.RenderArrayOfMaps(b, "configs", itemSchema, values, RenderCommented, nil)
+	want := dedent(`
+		# configs:
+		  # - key: val
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfMaps_ActualValues(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+			Schema: &extv1.JSONSchemaProps{Type: typeString},
+		},
+	}
+	values := []any{
+		map[string]any{"host": "localhost", "port": "8080"},
+	}
+
+	nr.RenderArrayOfMaps(b, "servers", itemSchema, values, RenderActive, nil)
+	// Map keys within the item are sorted alphabetically.
+	want := dedent(`
+		servers:
+		  - host: localhost
+		    port: 8080
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfCustomType_EmptyValues(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+			"port": {Type: typeInteger},
+		},
+	}
+
+	nr.RenderArrayOfCustomType(b, "items", itemSchema, nil, RenderActive, nil)
+	// All-optional children + empty value maps produce empty "{}" items.
+	want := dedent(`
+		items:
+		  - {}
+		  - {}
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfCustomType_Truncation(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type:     typeObject,
+		Required: []string{"name"},
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+			"port": {Type: typeInteger},
+		},
+	}
+
+	values := []any{
+		map[string]any{"name": "a"},
+		map[string]any{"name": "b"},
+		map[string]any{"name": "c"},
+	}
+
+	nr.RenderArrayOfCustomType(b, "servers", itemSchema, values, RenderActive, nil)
+	// Only 2 items; "c" is dropped. In active mode, required "name" uses the TODO
+	// placeholder because ApplyDefaults hasn't been called on these values here.
+	want := dedent(`
+		servers:
+		  - name: <TODO_NAME>
+		  - name: <TODO_NAME>
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfCustomType_CommentedNoValues(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+			"port": {Type: typeInteger},
+		},
+	}
+
+	nr.RenderArrayOfCustomType(b, "servers", itemSchema, nil, RenderCommented, nil)
+	// Commented mode without values uses example values for every field.
+	// Properties are sorted alphabetically by sortedPropertyNames().
+	want := dedent(`
+		# servers:
+		  # - name: example
+		    # port: 0
+		  # - name: example
+		    # port: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfCustomType_CommentedNonMapValue(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+			"port": {Type: typeInteger},
+		},
+	}
+
+	// Non-map item value falls back to empty map, then example values are used.
+	nr.RenderArrayOfCustomType(b, "items", itemSchema, []any{"not-a-map"}, RenderCommented, nil)
+	want := dedent(`
+		# items:
+		  # - name: example
+		    # port: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderArrayOfCustomType_CommentedPartialValues(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	itemSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+			"port": {Type: typeInteger},
+		},
+	}
+
+	// Only "name" provided; "port" is missing so it uses an example value.
+	values := []any{map[string]any{"name": "myserver"}}
+
+	nr.RenderArrayOfCustomType(b, "servers", itemSchema, values, RenderCommented, nil)
+	want := dedent(`
+		# servers:
+		  # - name: myserver
+		    # port: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapEntries_NilSchema(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.renderMapEntries(b, nil)
+	want := dedent(`
+		key1: example
+		key2: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapEntries_CustomType(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	valueSchema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"host": {Type: typeString},
+		},
+	}
+
+	nr.renderMapEntries(b, valueSchema)
+	want := dedent(`
+		key1:
+		  host: example
+		key2:
+		  host: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderMapEntries_Primitive(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.renderMapEntries(b, &extv1.JSONSchemaProps{Type: typeInteger})
+	want := dedent(`
+		key1: 0
+		key2: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestNestedTypeRenderer_RenderExampleFields_NilSchema(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.renderExampleFields(b, nil)
+	got := encodeOrFatal(t, b)
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty output for nil schema, got:\n%s", got)
+	}
+}
+
+func TestNestedTypeRenderer_RenderExampleFields_EmptyProperties(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.renderExampleFields(b, &extv1.JSONSchemaProps{
+		Type:       typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{},
+	})
+	got := encodeOrFatal(t, b)
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty output for empty properties, got:\n%s", got)
+	}
+}
+
+func TestNestedTypeRenderer_RenderExampleFields_AllTypes(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	nr := NewNestedTypeRenderer(renderer)
+	b := NewYAMLBuilder()
+
+	nr.renderExampleFields(b, &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name":    {Type: typeString},
+			"count":   {Type: typeInteger},
+			"enabled": {Type: typeBoolean},
+		},
+	})
+	// Fields are sorted alphabetically by sortedPropertyNames().
+	want := dedent(`
+		count: 0
+		enabled: false
+		name: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}

--- a/internal/scaffold/component/rendering_helpers_test.go
+++ b/internal/scaffold/component/rendering_helpers_test.go
@@ -1,0 +1,485 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"reflect"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestGenerateExampleValueForType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   any
+	}{
+		{
+			name:   "string",
+			schema: &extv1.JSONSchemaProps{Type: typeString},
+			want:   "example",
+		},
+		{
+			name:   "integer",
+			schema: &extv1.JSONSchemaProps{Type: typeInteger},
+			want:   0,
+		},
+		{
+			name:   "number",
+			schema: &extv1.JSONSchemaProps{Type: typeNumber},
+			want:   0.0,
+		},
+		{
+			name:   "boolean",
+			schema: &extv1.JSONSchemaProps{Type: typeBoolean},
+			want:   false,
+		},
+		{
+			name:   "unknown type",
+			schema: &extv1.JSONSchemaProps{Type: "custom"},
+			want:   "example",
+		},
+		{
+			name: "object with properties",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+					"port": {Type: typeInteger},
+				},
+			},
+			want: map[string]any{"name": "example", "port": 0},
+		},
+		{
+			name:   "object without properties",
+			schema: &extv1.JSONSchemaProps{Type: typeObject},
+			want:   map[string]any{},
+		},
+		{
+			name: "array of objects",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{
+						Type: typeObject,
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: typeString},
+						},
+					},
+				},
+			},
+			want: []any{
+				map[string]any{"name": "example"},
+				map[string]any{"name": "example"},
+			},
+		},
+		{
+			name: "array of primitives",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			want: []any{"example", "example"},
+		},
+		{
+			name: "array with no items schema",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+			},
+			want: []any{"example", "example"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateExampleValueForType(tt.schema)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("generateExampleValueForType() = %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateExamplePrimitiveArrayForType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   []any
+	}{
+		{
+			name: "string items",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			want: []any{"example", "example"},
+		},
+		{
+			name: "integer items",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeInteger},
+				},
+			},
+			want: []any{0, 0},
+		},
+		{
+			name: "number items",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeNumber},
+				},
+			},
+			want: []any{0.0, 0.0},
+		},
+		{
+			name: "boolean items",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeBoolean},
+				},
+			},
+			want: []any{false, false},
+		},
+		{
+			name:   "nil items schema",
+			schema: &extv1.JSONSchemaProps{Type: typeArray},
+			want:   []any{"example", "example"},
+		},
+		{
+			name: "nil inner schema",
+			schema: &extv1.JSONSchemaProps{
+				Type:  typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{Schema: nil},
+			},
+			want: []any{"example", "example"},
+		},
+		{
+			name: "unknown item type",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: "custom"},
+				},
+			},
+			want: []any{"example", "example"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateExamplePrimitiveArrayForType(tt.schema)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("generateExamplePrimitiveArrayForType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetExampleValueForPrimitiveType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   string
+	}{
+		{"string", &extv1.JSONSchemaProps{Type: typeString}, "example"},
+		{"integer", &extv1.JSONSchemaProps{Type: typeInteger}, "0"},
+		{"boolean", &extv1.JSONSchemaProps{Type: typeBoolean}, "false"},
+		{"number", &extv1.JSONSchemaProps{Type: typeNumber}, "0.0"},
+		{"unknown", &extv1.JSONSchemaProps{Type: "custom"}, "example"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getExampleValueForPrimitiveType(tt.schema)
+			if got != tt.want {
+				t.Errorf("getExampleValueForPrimitiveType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMapOfCustomType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{"nil schema", nil, false},
+		{
+			"object with properties",
+			&extv1.JSONSchemaProps{
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+				},
+			},
+			true,
+		},
+		{"object without properties", &extv1.JSONSchemaProps{Type: typeObject}, false},
+		{"non-object", &extv1.JSONSchemaProps{Type: typeString}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMapOfCustomType(tt.schema); got != tt.want {
+				t.Errorf("isMapOfCustomType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMapOfArray(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{"nil schema", nil, false},
+		{"array type", &extv1.JSONSchemaProps{Type: typeArray}, true},
+		{"non-array", &extv1.JSONSchemaProps{Type: typeString}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMapOfArray(tt.schema); got != tt.want {
+				t.Errorf("isMapOfArray() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMapOfPrimitiveArray(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{"non-array", &extv1.JSONSchemaProps{Type: typeString}, false},
+		{
+			"primitive array items",
+			&extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			true,
+		},
+		{
+			"object array items",
+			&extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{
+						Type: typeObject,
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: typeString},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"nil item schema",
+			&extv1.JSONSchemaProps{
+				Type:  typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{Schema: nil},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMapOfPrimitiveArray(tt.schema); got != tt.want {
+				t.Errorf("isMapOfPrimitiveArray() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMapOfCustomTypeArray(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{"non-array", &extv1.JSONSchemaProps{Type: typeString}, false},
+		{
+			"object array items",
+			&extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{
+						Type: typeObject,
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: typeString},
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"nil item schema",
+			&extv1.JSONSchemaProps{
+				Type:  typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{Schema: nil},
+			},
+			false,
+		},
+		{
+			"primitive item schema",
+			&extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMapOfCustomTypeArray(tt.schema); got != tt.want {
+				t.Errorf("isMapOfCustomTypeArray() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsArrayOfMaps(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{"nil schema", nil, false},
+		{
+			"object with additionalProperties",
+			&extv1.JSONSchemaProps{
+				Type: typeObject,
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			true,
+		},
+		{"object without additionalProperties", &extv1.JSONSchemaProps{Type: typeObject}, false},
+		{"non-object", &extv1.JSONSchemaProps{Type: typeString}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isArrayOfMaps(tt.schema); got != tt.want {
+				t.Errorf("isArrayOfMaps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsArrayOfCustomType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{"nil schema", nil, false},
+		{
+			"object with properties",
+			&extv1.JSONSchemaProps{
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+				},
+			},
+			true,
+		},
+		{"object without properties", &extv1.JSONSchemaProps{Type: typeObject}, false},
+		{"non-object", &extv1.JSONSchemaProps{Type: typeString}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isArrayOfCustomType(tt.schema); got != tt.want {
+				t.Errorf("isArrayOfCustomType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortedPropertyNames(t *testing.T) {
+	props := map[string]extv1.JSONSchemaProps{
+		"zebra": {Type: typeString},
+		"alpha": {Type: typeString},
+		"mid":   {Type: typeString},
+	}
+
+	got := sortedPropertyNames(props)
+	want := []string{"alpha", "mid", "zebra"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortedPropertyNames() = %v, want %v", got, want)
+	}
+}
+
+func TestAllChildrenOptional(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		want   bool
+	}{
+		{
+			name: "no required fields",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "required field with default",
+			schema: &extv1.JSONSchemaProps{
+				Type:     typeObject,
+				Required: []string{"name"},
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString, Default: &extv1.JSON{Raw: []byte(`"default"`)}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "required field without default",
+			schema: &extv1.JSONSchemaProps{
+				Type:     typeObject,
+				Required: []string{"name"},
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: typeString},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allChildrenOptional(tt.schema); got != tt.want {
+				t.Errorf("allChildrenOptional() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scaffold/component/schema_defaults_test.go
+++ b/internal/scaffold/component/schema_defaults_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"reflect"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestApplyDefaultsToSchema_NilSchema(t *testing.T) {
+	result, err := applyDefaultsToSchema(nil)
+	if err != nil {
+		t.Fatalf("applyDefaultsToSchema(nil) error: %v", err)
+	}
+	if result.jsonSchema != nil {
+		t.Errorf("expected nil jsonSchema, got %v", result.jsonSchema)
+	}
+	if result.structural != nil {
+		t.Errorf("expected nil structural, got %v", result.structural)
+	}
+	if len(result.defaultedObj) != 0 {
+		t.Errorf("expected empty defaultedObj, got %v", result.defaultedObj)
+	}
+}
+
+func TestApplyDefaultsToSchema_ValidSchema(t *testing.T) {
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"replicas": {
+				Type:    typeInteger,
+				Default: &extv1.JSON{Raw: []byte(`3`)},
+			},
+			"name": {
+				Type: typeString,
+			},
+		},
+	}
+
+	result, err := applyDefaultsToSchema(schema)
+	if err != nil {
+		t.Fatalf("applyDefaultsToSchema() error: %v", err)
+	}
+	if result.jsonSchema == nil {
+		t.Fatal("expected non-nil jsonSchema")
+	}
+	if result.structural == nil {
+		t.Fatal("expected non-nil structural")
+	}
+	// The default for replicas should be applied
+	if val, ok := result.defaultedObj["replicas"]; !ok {
+		t.Error("expected replicas in defaultedObj")
+	} else if val != int64(3) {
+		t.Errorf("expected replicas=3, got %v (%T)", val, val)
+	}
+}
+
+func TestBuildEmptyStructure(t *testing.T) {
+	t.Run("nil schema", func(t *testing.T) {
+		got := buildEmptyStructure(nil)
+		if len(got) != 0 {
+			t.Errorf("expected empty map for nil schema, got %v", got)
+		}
+	})
+
+	t.Run("nil properties", func(t *testing.T) {
+		got := buildEmptyStructure(&extv1.JSONSchemaProps{Type: typeObject})
+		if len(got) != 0 {
+			t.Errorf("expected empty map for nil properties, got %v", got)
+		}
+	})
+
+	t.Run("nested object with empty default", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"nested": {
+					Type: typeObject,
+					Properties: map[string]extv1.JSONSchemaProps{
+						"inner": {Type: typeString},
+					},
+					Default: &extv1.JSON{Raw: []byte(`{}`)},
+				},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		if _, ok := got["nested"]; !ok {
+			t.Error("expected nested key in result")
+		}
+	})
+
+	t.Run("nested object with non-empty default", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"config": {
+					Type: typeObject,
+					Properties: map[string]extv1.JSONSchemaProps{
+						"mode": {Type: typeString},
+					},
+					Default: &extv1.JSON{Raw: []byte(`{"mode": "production"}`)},
+				},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		// Objects with non-empty defaults should NOT be in the empty structure
+		if _, ok := got["config"]; ok {
+			t.Error("objects with non-empty defaults should be skipped")
+		}
+	})
+
+	t.Run("nested object without default", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"nested": {
+					Type: typeObject,
+					Properties: map[string]extv1.JSONSchemaProps{
+						"inner": {Type: typeString},
+					},
+				},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		if _, ok := got["nested"]; !ok {
+			t.Error("expected nested key for object without default")
+		}
+	})
+
+	t.Run("array of objects", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"servers": {
+					Type: typeArray,
+					Items: &extv1.JSONSchemaPropsOrArray{
+						Schema: &extv1.JSONSchemaProps{
+							Type: typeObject,
+							Properties: map[string]extv1.JSONSchemaProps{
+								"name": {Type: typeString},
+							},
+						},
+					},
+				},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		arr, ok := got["servers"].([]any)
+		if !ok {
+			t.Fatal("expected servers array")
+		}
+		if len(arr) != 2 {
+			t.Errorf("expected 2 example items, got %d", len(arr))
+		}
+	})
+
+	t.Run("array without item schema", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"tags": {
+					Type: typeArray,
+				},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		arr, ok := got["tags"].([]any)
+		if !ok {
+			t.Fatal("expected tags array")
+		}
+		if len(arr) != 0 {
+			t.Errorf("expected empty array for no item schema, got %d items", len(arr))
+		}
+	})
+
+	t.Run("array with non-empty default", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"items": {
+					Type:    typeArray,
+					Default: &extv1.JSON{Raw: []byte(`["a","b"]`)},
+					Items: &extv1.JSONSchemaPropsOrArray{
+						Schema: &extv1.JSONSchemaProps{Type: typeString},
+					},
+				},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		// Arrays with non-empty defaults should NOT be in the empty structure
+		if _, ok := got["items"]; ok {
+			t.Error("arrays with non-empty defaults should be skipped")
+		}
+	})
+
+	t.Run("primitive properties are skipped", func(t *testing.T) {
+		schema := &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"name": {Type: typeString},
+				"port": {Type: typeInteger},
+			},
+		}
+		got := buildEmptyStructure(schema)
+		if len(got) != 0 {
+			t.Errorf("expected empty map for primitives only, got %v", got)
+		}
+	})
+}
+
+func TestBuildEmptyArrayStructure(t *testing.T) {
+	t.Run("nil items", func(t *testing.T) {
+		got := buildEmptyArrayStructure(&extv1.JSONSchemaProps{Type: typeArray})
+		if len(got) != 0 {
+			t.Errorf("expected empty array, got %v", got)
+		}
+	})
+
+	t.Run("nil item schema", func(t *testing.T) {
+		got := buildEmptyArrayStructure(&extv1.JSONSchemaProps{
+			Type:  typeArray,
+			Items: &extv1.JSONSchemaPropsOrArray{Schema: nil},
+		})
+		if len(got) != 0 {
+			t.Errorf("expected empty array for nil item schema, got %v", got)
+		}
+	})
+
+	t.Run("object items", func(t *testing.T) {
+		got := buildEmptyArrayStructure(&extv1.JSONSchemaProps{
+			Type: typeArray,
+			Items: &extv1.JSONSchemaPropsOrArray{
+				Schema: &extv1.JSONSchemaProps{
+					Type: typeObject,
+					Properties: map[string]extv1.JSONSchemaProps{
+						"name": {Type: typeString},
+					},
+				},
+			},
+		})
+		if len(got) != 2 {
+			t.Errorf("expected 2 example items, got %d", len(got))
+		}
+	})
+
+	t.Run("primitive items", func(t *testing.T) {
+		got := buildEmptyArrayStructure(&extv1.JSONSchemaProps{
+			Type: typeArray,
+			Items: &extv1.JSONSchemaPropsOrArray{
+				Schema: &extv1.JSONSchemaProps{Type: typeString},
+			},
+		})
+		if len(got) != 0 {
+			t.Errorf("expected empty array for primitive items, got %v", got)
+		}
+	})
+}
+
+func TestIsEmptyDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		def  *extv1.JSON
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty raw", &extv1.JSON{Raw: []byte{}}, true},
+		{"empty object", &extv1.JSON{Raw: []byte(`{}`)}, true},
+		{"null", &extv1.JSON{Raw: []byte(`null`)}, true},
+		{"empty object with spaces", &extv1.JSON{Raw: []byte(`  {}  `)}, true},
+		{"non-empty object", &extv1.JSON{Raw: []byte(`{"key": "val"}`)}, false},
+		{"string value", &extv1.JSON{Raw: []byte(`"hello"`)}, false},
+		{"number value", &extv1.JSON{Raw: []byte(`42`)}, false},
+		{"array value", &extv1.JSON{Raw: []byte(`[1,2]`)}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEmptyDefault(tt.def); got != tt.want {
+				t.Errorf("isEmptyDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSchemaToStructural_ValidSchema(t *testing.T) {
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name": {Type: typeString},
+		},
+	}
+
+	structural, err := schemaToStructural(schema)
+	if err != nil {
+		t.Fatalf("schemaToStructural() error: %v", err)
+	}
+	if structural == nil {
+		t.Fatal("expected non-nil structural schema")
+	}
+}
+
+func TestFormatDefaultValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"nil", nil, ""},
+		{"string", "hello", "hello"},
+		{"whole float64", float64(42), "42"},
+		{"decimal float64", 3.14, "3.14"},
+		{"int64", int64(99), "99"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"slice", []string{"a", "b"}, `["a","b"]`},
+		{"map", map[string]string{"k": "v"}, `{"k":"v"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDefaultValue(tt.value)
+			if got != tt.want {
+				t.Errorf("formatDefaultValue(%v) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	m := map[string]any{
+		"zebra": 1,
+		"alpha": 2,
+		"mid":   3,
+	}
+	got := sortedKeys(m)
+	want := []string{"alpha", "mid", "zebra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortedKeys() = %v, want %v", got, want)
+	}
+}

--- a/internal/scaffold/component/strategy_object_test.go
+++ b/internal/scaffold/component/strategy_object_test.go
@@ -1,0 +1,577 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"strings"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestObjectFieldStrategy_Render_OptionalOmitted(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	ctx := &FieldContext{
+		Name: "config",
+		Schema: &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"name": {Type: typeString},
+			},
+		},
+		IsRequired: false,
+		HasDefault: false,
+		Renderer:   renderer,
+	}
+
+	strategy.Render(b, ctx)
+	got := encodeOrFatal(t, b)
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty output for omitted optional object, got:\n%s", got)
+	}
+}
+
+func TestObjectFieldStrategy_Render_OptionalCommented(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	ctx := &FieldContext{
+		Name: "config",
+		Schema: &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"name": {Type: typeString},
+			},
+		},
+		Value:      map[string]any{"name": "default_val"},
+		IsRequired: false,
+		HasDefault: true,
+		Renderer:   renderer,
+	}
+
+	strategy.Render(b, ctx)
+	want := dedent(`
+		# config:
+		  # name: default_val
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_Render_RequiredAllOptionalChildren(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	ctx := &FieldContext{
+		Name: "retryPolicy",
+		Schema: &extv1.JSONSchemaProps{
+			Type: typeObject,
+			Properties: map[string]extv1.JSONSchemaProps{
+				"attempts": {Type: typeInteger},
+				"backoff":  {Type: typeInteger},
+			},
+		},
+		Value:      map[string]any{},
+		IsRequired: true,
+		HasDefault: false,
+		Renderer:   renderer,
+	}
+
+	strategy.Render(b, ctx)
+	want := dedent(`
+		retryPolicy: {}
+		# retryPolicy:
+		  # attempts: 0
+		  # backoff: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_Render_RequiredAllOptionalChildren_StructuralComments(t *testing.T) {
+	renderer := NewFieldRenderer(true, false, true)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	ctx := &FieldContext{
+		Name: "retryPolicy",
+		Schema: &extv1.JSONSchemaProps{
+			Type:        typeObject,
+			Description: "Retry configuration",
+			Properties: map[string]extv1.JSONSchemaProps{
+				"attempts": {Type: typeInteger},
+			},
+		},
+		Value:        map[string]any{},
+		IsRequired:   true,
+		HasDefault:   false,
+		AddSeparator: true,
+		Renderer:     renderer,
+	}
+
+	strategy.Render(b, ctx)
+	// Note the intentional leading blank line: the encoder emits a blank line
+	// before the "Defaults:" separator comment. We preserve it with an extra
+	// leading newline in the raw string.
+	want := dedent(`
+
+		# Defaults: Uncomment to customize
+		# Retry configuration
+
+		# Empty object, or customize:
+		retryPolicy: {}
+		# retryPolicy:
+		  # attempts: 0
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_Render_RequiredWithRequiredChildren(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	ctx := &FieldContext{
+		Name: "service",
+		Schema: &extv1.JSONSchemaProps{
+			Type:     typeObject,
+			Required: []string{"name"},
+			Properties: map[string]extv1.JSONSchemaProps{
+				"name":     {Type: typeString},
+				"protocol": {Type: typeString},
+			},
+		},
+		Value:      map[string]any{},
+		IsRequired: true,
+		HasDefault: false,
+		Renderer:   renderer,
+	}
+
+	strategy.Render(b, ctx)
+	// Required "name" renders active with TODO placeholder.
+	// Optional "protocol" has no default and IncludeAllFields is false, so it's omitted.
+	want := dedent(`
+		service:
+		  name: <TODO_NAME>
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_BuildHeadComment(t *testing.T) {
+	renderer := NewFieldRenderer(true, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+
+	tests := []struct {
+		name      string
+		separator bool
+		comment   string
+		want      string
+	}{
+		{
+			name:      "separator and comment",
+			separator: true,
+			comment:   "Some description",
+			want:      "\nDefaults: Uncomment to customize\nSome description",
+		},
+		{
+			name:      "separator only",
+			separator: true,
+			comment:   "",
+			want:      "\nDefaults: Uncomment to customize",
+		},
+		{
+			name:      "comment only",
+			separator: false,
+			comment:   "Some description",
+			want:      "Some description",
+		},
+		{
+			name:      "neither",
+			separator: false,
+			comment:   "",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &FieldContext{AddSeparator: tt.separator}
+			if got := strategy.buildHeadComment(ctx, tt.comment); got != tt.want {
+				t.Errorf("buildHeadComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectFieldStrategy_BuildEmptyObjectComment(t *testing.T) {
+	tests := []struct {
+		name                     string
+		includeStructuralComment bool
+		headComment              string
+		want                     string
+	}{
+		{
+			name:                     "structural comments with head comment",
+			includeStructuralComment: true,
+			headComment:              "Description",
+			want:                     "Description\n\nEmpty object, or customize:",
+		},
+		{
+			name:                     "structural comments without head comment",
+			includeStructuralComment: true,
+			headComment:              "",
+			want:                     "\nEmpty object, or customize:",
+		},
+		{
+			name:                     "no structural comments",
+			includeStructuralComment: false,
+			headComment:              "Description",
+			want:                     "Description",
+		},
+		{
+			name:                     "no structural comments, no head comment",
+			includeStructuralComment: false,
+			headComment:              "",
+			want:                     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer := NewFieldRenderer(false, false, tt.includeStructuralComment)
+			strategy := NewObjectFieldStrategy(renderer)
+			if got := strategy.buildEmptyObjectComment(tt.headComment); got != tt.want {
+				t.Errorf("buildEmptyObjectComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_NilSchema(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	strategy.renderFieldsCommented(b, nil, nil)
+	got := encodeOrFatal(t, b)
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty output for nil schema, got:\n%s", got)
+	}
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_NilProperties(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	strategy.renderFieldsCommented(b, &extv1.JSONSchemaProps{Type: typeObject}, nil)
+	got := encodeOrFatal(t, b)
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty output for nil properties, got:\n%s", got)
+	}
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_NestedEmptyDefault(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"nested": {
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"inner": {Type: typeString},
+				},
+				Default: &extv1.JSON{Raw: []byte(`{}`)},
+			},
+		},
+	}
+
+	strategy.renderFieldsCommented(b, schema, map[string]any{})
+	// Empty default objects collapse to "# nested: '{}'" - the "{}" is quoted
+	// because quoteIfNeeded treats "{" as a special YAML character.
+	want := `# nested: '{}'`
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_NestedNonEmptyDefault(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"nested": {
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"inner": {Type: typeString},
+				},
+				Default: &extv1.JSON{Raw: []byte(`{"inner": "val"}`)},
+			},
+		},
+	}
+
+	strategy.renderFieldsCommented(b, schema, map[string]any{
+		"nested": map[string]any{"inner": "val"},
+	})
+	want := dedent(`
+		# nested:
+		  # inner: val
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_NonMapValueFallback(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"nested": {
+				Type: typeObject,
+				Properties: map[string]extv1.JSONSchemaProps{
+					"inner": {Type: typeString},
+				},
+				Default: &extv1.JSON{Raw: []byte(`{"inner": "val"}`)},
+			},
+		},
+	}
+
+	// Value is not a map - should fallback to empty map, so "inner" uses example value
+	strategy.renderFieldsCommented(b, schema, map[string]any{
+		"nested": "not-a-map",
+	})
+	want := dedent(`
+		# nested:
+		  # inner: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_ComplexArray(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"items": {
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{
+						Type: typeObject,
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: typeString},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	strategy.renderFieldsCommented(b, schema, map[string]any{
+		"items": []any{
+			map[string]any{"name": "a"},
+			map[string]any{"name": "b"},
+		},
+	})
+	want := dedent(`
+		# items:
+		  # - name: a
+		  # - name: b
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_SimpleArray(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"tags": {
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+		},
+	}
+
+	strategy.renderFieldsCommented(b, schema, map[string]any{
+		"tags": []any{"web", "api"},
+	})
+	want := dedent(`
+		# tags:
+		  # - web
+		  # - api
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_EmptyArray(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"tags": {
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+		},
+	}
+
+	strategy.renderFieldsCommented(b, schema, map[string]any{})
+	// "[]" is quoted by quoteIfNeeded since "[" is a special YAML character.
+	want := `# tags: '[]'`
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderFieldsCommented_PrimitivesUseExamples(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	schema := &extv1.JSONSchemaProps{
+		Type: typeObject,
+		Properties: map[string]extv1.JSONSchemaProps{
+			"port":    {Type: typeInteger},
+			"enabled": {Type: typeBoolean},
+			"name":    {Type: typeString},
+		},
+	}
+
+	strategy.renderFieldsCommented(b, schema, map[string]any{})
+	// Fields are sorted by type then alphabetically: bool < int < string
+	want := dedent(`
+		# enabled: false
+		# port: 0
+		# name: example
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_IsComplexArray(t *testing.T) {
+	strategy := NewObjectFieldStrategy(NewFieldRenderer(false, false, false))
+
+	tests := []struct {
+		name   string
+		schema *extv1.JSONSchemaProps
+		values []any
+		want   bool
+	}{
+		{
+			name:   "empty values",
+			schema: &extv1.JSONSchemaProps{Type: typeArray},
+			values: []any{},
+			want:   false,
+		},
+		{
+			name:   "values contain map",
+			schema: &extv1.JSONSchemaProps{Type: typeArray},
+			values: []any{map[string]any{"key": "val"}},
+			want:   true,
+		},
+		{
+			name:   "values contain slice",
+			schema: &extv1.JSONSchemaProps{Type: typeArray},
+			values: []any{[]any{"a", "b"}},
+			want:   true,
+		},
+		{
+			name: "primitives but schema items are object",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{
+						Type: typeObject,
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: typeString},
+						},
+					},
+				},
+			},
+			values: []any{"a", "b"},
+			want:   true,
+		},
+		{
+			name: "primitives and schema items are primitive",
+			schema: &extv1.JSONSchemaProps{
+				Type: typeArray,
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: typeString},
+				},
+			},
+			values: []any{"a", "b"},
+			want:   false,
+		},
+		{
+			name:   "primitives with no items schema",
+			schema: &extv1.JSONSchemaProps{Type: typeArray},
+			values: []any{"a"},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := strategy.isComplexArray(tt.schema, tt.values); got != tt.want {
+				t.Errorf("isComplexArray() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectFieldStrategy_RenderCommentedComplexArray_ObjectItems(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	values := []any{
+		map[string]any{"name": "first", "port": float64(8080)},
+		map[string]any{"name": "second"},
+	}
+
+	strategy.renderCommentedComplexArray(b, "servers", values, "Server list")
+	// Keys within each object item are sorted alphabetically by sortedKeys().
+	// The comment is passed as LineComment on the keyNode but is not rendered
+	// by the custom encoder (it only renders value LineComments).
+	want := dedent(`
+		# servers:
+		  # - name: first
+		    # port: 8080
+		  # - name: second
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestObjectFieldStrategy_RenderCommentedComplexArray_ScalarFallback(t *testing.T) {
+	renderer := NewFieldRenderer(false, false, false)
+	strategy := NewObjectFieldStrategy(renderer)
+	b := NewYAMLBuilder()
+
+	strategy.renderCommentedComplexArray(b, "items", []any{"scalar-value", 42}, "")
+	want := dedent(`
+		# items:
+		  # - scalar-value
+		  # - 42
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}

--- a/internal/scaffold/component/yaml_builder_test.go
+++ b/internal/scaffold/component/yaml_builder_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"testing"
+)
+
+func TestYAMLBuilder_FormatScalarValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"string", "hello", "hello"},
+		{"int", 42, "42"},
+		{"int64", int64(99), "99"},
+		{"whole float64", float64(5), "5"},
+		{"decimal float64", 3.14, "3.14"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"other type", struct{}{}, "{}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatScalarValue(tt.value); got != tt.want {
+				t.Errorf("formatScalarValue(%v) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestYAMLBuilder_QuoteIfNeeded(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"normal", "hello", "hello"},
+		{"starts with [", "[array]", "'[array]'"},
+		{"starts with {", "{object}", "'{object}'"},
+		{"starts with &", "&anchor", "'&anchor'"},
+		{"starts with *", "*ref", "'*ref'"},
+		{"starts with !", "!tag", "'!tag'"},
+		{"starts with |", "|literal", "'|literal'"},
+		{"starts with >", ">folded", "'>folded'"},
+		{"starts with single quote", "'quoted'", "'''quoted'''"},
+		{"starts with double quote", "\"quoted\"", "'\"quoted\"'"},
+		{"starts with %", "%directive", "'%directive'"},
+		{"starts with @", "@at", "'@at'"},
+		{"starts with backtick", "`tick`", "'`tick`'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quoteIfNeeded(tt.input); got != tt.want {
+				t.Errorf("quoteIfNeeded(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestYAMLBuilder_AddCommentedInlineArray_Floats(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddCommentedInlineArray("ports", []any{float64(8080), float64(9090)})
+	assertYAMLEqual(t, `# ports: [8080, 9090]`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_AddCommentedInlineArray_Bools(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddCommentedInlineArray("flags", []any{true, false})
+	assertYAMLEqual(t, `# flags: [true, false]`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_AddCommentedInlineArray_Empty(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddCommentedInlineArray("empty", []any{})
+	assertYAMLEqual(t, `# empty: []`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_InCommentedMappingWithFunc(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.InCommentedMappingWithFunc("config", func(b *YAMLBuilder) {
+		b.AddField("key", "value")
+	})
+	want := dedent(`
+		# config:
+		  # key: value
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_AddSequenceScalar(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("items")
+	b.AddSequenceScalar(seq, "first")
+	b.AddSequenceScalar(seq, "second")
+	want := dedent(`
+		items:
+		  - first
+		  - second
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_AddInlineSequence(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddInlineSequence("tags", []string{"web", "api"})
+	assertYAMLEqual(t, `tags: [web, api]`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_AddCommentedInlineSequence(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddCommentedInlineSequence("tags", []string{"web", "api"})
+	assertYAMLEqual(t, `# tags: [web, api]`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_WithFootComment(t *testing.T) {
+	// WithFootComment sets FootComment on the value node, but the custom encoder
+	// does not render FootComments. This documents that the option is wired but
+	// has no output effect today.
+	b := NewYAMLBuilder()
+	b.AddField("key", "value", WithFootComment("footer"))
+	assertYAMLEqual(t, `key: value`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_MappingWithLineComment_NonEmpty(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.InMapping("config", func(b *YAMLBuilder) {
+		b.AddField("key", "value")
+	}, WithLineComment("A comment"))
+	// LineComment on a non-empty mapping is rendered on the key line.
+	want := dedent(`
+		config: # A comment
+		  key: value
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_MappingWithLineComment_Empty(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddMapping("config", WithLineComment("A comment"))
+	assertYAMLEqual(t, `config: {} # A comment`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_MappingItems(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("servers")
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {
+		b.AddField("name", "server1")
+		b.AddField("port", "8080")
+	})
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {
+		b.AddField("name", "server2")
+	})
+	// First field of each item renders on the dash line; remaining fields
+	// are indented further.
+	want := dedent(`
+		servers:
+		  - name: server1
+		    port: 8080
+		  - name: server2
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_EmptyMappingItem(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("items")
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {})
+	want := dedent(`
+		items:
+		  - {}
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_ScalarItems(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("tags")
+	b.AddSequenceScalar(seq, "web")
+	b.AddSequenceScalar(seq, "api")
+	want := dedent(`
+		tags:
+		  - web
+		  - api
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_NestedMappingValue(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("entries")
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {
+		b.InMapping("nested", func(b *YAMLBuilder) {
+			b.AddField("inner", "value")
+		})
+	})
+	want := dedent(`
+		entries:
+		  - nested:
+		      inner: value
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_EmptyMappingValue(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("entries")
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {
+		b.AddMapping("config")
+	})
+	want := dedent(`
+		entries:
+		  - config: {}
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_InlineArrayValue(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("entries")
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {
+		b.AddInlineArray("tags", []any{"a", "b"})
+	})
+	want := dedent(`
+		entries:
+		  - tags: [a, b]
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_BlockSequence_BlockArrayValue(t *testing.T) {
+	b := NewYAMLBuilder()
+	seq := b.AddSequence("entries")
+	b.AddSequenceMapping(seq, func(b *YAMLBuilder) {
+		innerSeq := b.AddSequence("items")
+		b.AddSequenceScalar(innerSeq, "x")
+		b.AddSequenceScalar(innerSeq, "y")
+	})
+	want := dedent(`
+		entries:
+		  - items:
+		      - x
+		      - y
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_CommentedBlockSequence(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddCommentedArray("items", []any{"first", "second"})
+	want := dedent(`
+		# items:
+		  # - first
+		  # - second
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_HeadComment_EmptyLines(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddField("key", "value", WithHeadComment("line1\n\nline3"))
+	// Empty lines in head comments render as blank lines, not "# ".
+	want := dedent(`
+		# line1
+
+		# line3
+		key: value
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_WithLineComment_Scalar(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddField("port", "8080", WithLineComment("Container port"))
+	assertYAMLEqual(t, `port: 8080 # Container port`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_WithLineComment_InlineArray(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddInlineArray("tags", []any{"web"}, WithLineComment("Tags"))
+	assertYAMLEqual(t, `tags: [web] # Tags`, encodeOrFatal(t, b))
+}
+
+func TestYAMLBuilder_WithLineComment_BlockArray(t *testing.T) {
+	b := NewYAMLBuilder()
+	b.AddCommentedArray("items", []any{"a"}, WithLineComment("Items list"))
+	want := dedent(`
+		# items: # Items list
+		  # - a
+	`)
+	assertYAMLEqual(t, want, encodeOrFatal(t, b))
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

Adds comprehensive unit test coverage for the internal/scaffold/component package, which is responsible for scaffolding component YAML from ComponentType/Trait schemas (used by choreoctl to generate starter component definitions).

Coverage for the package is now 92.8%.

New test files mirror the existing implementation units:
```
field_context_test.go — field path/context tracking used during rendering
helpers_test.go — shared helper utilities
nested_type_renderer_test.go — rendering of nested object/array/map types
rendering_helpers_test.go — lower-level rendering helpers (indentation, comments, value formatting)
schema_defaults_test.go — resolution of schema defaults from shorthand / OpenAPI schemas
strategy_object_test.go — object field scaffolding strategy (required vs. optional, nested properties)
yaml_builder_test.go — the final YAML assembly step
```

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
