### PR TITLE
test(cli): increase workload converter test coverage 

### DIFF
--- a/internal/occ/resources/workload/converter_test.go
+++ b/internal/occ/resources/workload/converter_test.go
@@ -888,7 +888,7 @@ spec:
 	t.Run("invalid params", func(t *testing.T) {
 		_, err := ConvertWorkloadDescriptorToWorkloadCR(descriptorPath, api.CreateWorkloadParams{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid conversion parameters")
+		assert.Contains(t, err.Error(), "namespace name is required")
 	})
 
 	t.Run("missing descriptor file", func(t *testing.T) {
@@ -912,7 +912,7 @@ endpoints:
 		testhelpers.WriteYAML(t, badDir, "workload.yaml", badContent)
 		_, err := ConvertWorkloadDescriptorToWorkloadCR(filepath.Join(badDir, "workload.yaml"), params)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to convert descriptor to workload CR")
+		assert.Contains(t, err.Error(), `invalid endpoint visibility "bogus" for endpoint "ep"`)
 	})
 
 	t.Run("descriptor with invalid dependency propagates error", func(t *testing.T) {
@@ -930,7 +930,7 @@ dependencies:
 		testhelpers.WriteYAML(t, badDir, "workload.yaml", badContent)
 		_, err := ConvertWorkloadDescriptorToWorkloadCR(filepath.Join(badDir, "workload.yaml"), params)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to convert descriptor to workload CR")
+		assert.Contains(t, err.Error(), "component is required")
 	})
 
 	t.Run("descriptor with missing config file propagates error", func(t *testing.T) {
@@ -948,7 +948,7 @@ configurations:
 		testhelpers.WriteYAML(t, badDir, "workload.yaml", badContent)
 		_, err := ConvertWorkloadDescriptorToWorkloadCR(filepath.Join(badDir, "workload.yaml"), params)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to convert descriptor to workload CR")
+		assert.Contains(t, err.Error(), "failed to read file")
 	})
 }
 


### PR DESCRIPTION
## Purpose

Increase test coverage for `internal/occ/resources/workload/converter.go` from 47.7% to 97.7%, covering previously untested public APIs and internal functions.

## Approach

- Add tests for `CreateBasicWorkload`, `ConvertWorkloadDescriptorToWorkloadCR`, `readWorkloadDescriptor`, `readSchemaFile`, and `addConfigurationsFromDescriptor`
- Cover endpoint schema file reading, configuration file path resolution, and all error propagation paths
- Use `testhelpers.WriteYAML` for file creation instead of raw `os.WriteFile`
- Use `testhelpers.AssertYAMLEquals` for full YAML comparison instead of `assert.Contains` spot checks

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)