### PR TITLE
feat(cli): add -o shorthand to --output-path flag

### DIFF
--- a/internal/occ/flags/flags.go
+++ b/internal/occ/flags/flags.go
@@ -115,7 +115,7 @@ func GetRootDir(cmd *cobra.Command) string {
 // --- OutputPath ---
 
 func AddOutputPath(cmd *cobra.Command) {
-	cmd.Flags().String("output-path", "", "Custom output directory path")
+	cmd.Flags().StringP("output-path", "o", "", "Custom output directory path")
 }
 
 func GetOutputPath(cmd *cobra.Command) string {

--- a/internal/occ/flags/flags_test.go
+++ b/internal/occ/flags/flags_test.go
@@ -120,6 +120,14 @@ func TestOutputPath_DefaultAndSet(t *testing.T) {
 	assert.Equal(t, "/tmp/out", GetOutputPath(cmd))
 }
 
+func TestOutputPath_HasShorthand(t *testing.T) {
+	cmd := newTestCmd()
+	AddOutputPath(cmd)
+
+	f := cmd.Flags().Lookup("output-path")
+	assert.Equal(t, "o", f.Shorthand)
+}
+
 func TestRelease_DefaultAndSet(t *testing.T) {
 	cmd := newTestCmd()
 	AddRelease(cmd)


### PR DESCRIPTION
## Purpose

The `--output-path` flag lacked a shorthand, making it more verbose to use compared to other flags. This adds `-o` as a shorthand for `--output-path`.

## Approach

- Changed `AddOutputPath` to use `StringP` with `-o` shorthand in `internal/occ/flags/flags.go`
- Added `TestOutputPath_HasShorthand` test to verify the shorthand is registered correctly

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)