### PR TITLE
fix: add support to request scope durng token retrieval for client apps

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/rca-agent-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/ai-rca-agent/rca-agent-config.yaml
@@ -14,6 +14,9 @@ data:
   REPORT_BACKEND: {{ .Values.rca.reportBackend | quote }}
   OAUTH_TOKEN_URL: {{ .Values.security.oidc.tokenUrl | quote }}
   OAUTH_CLIENT_ID: {{ .Values.rca.oauth.clientId | quote }}
+  {{- if .Values.rca.oauth.scope }}
+  OAUTH_SCOPE: {{ .Values.rca.oauth.scope | quote }}
+  {{- end }}
   TLS_INSECURE_SKIP_VERIFY: {{ or .Values.security.oidc.jwksUrlTlsInsecureSkipVerify .Values.security.oidc.uidResolverTlsInsecureSkipVerify | quote }}
   JWT_JWKS_URL: {{ .Values.security.oidc.jwksUrl | quote }}
   JWT_ISSUER: {{ .Values.security.oidc.issuer | quote }}

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -32,6 +32,9 @@ data:
   UID_RESOLVER_OAUTH_TOKEN_URL: {{ .Values.security.oidc.tokenUrl | quote }}
   {{- end }}
   UID_RESOLVER_OAUTH_CLIENT_ID: {{ .Values.observer.oauthClientId | default "openchoreo-observer-resource-reader-client" | quote }}
+  {{- if .Values.observer.oauthScope }}
+  UID_RESOLVER_OAUTH_SCOPE: {{ .Values.observer.oauthScope | quote }}
+  {{- end }}
   {{- if .Values.security.oidc.authServerBaseUrl }}
   AUTH_SERVER_BASE_URL: {{ .Values.security.oidc.authServerBaseUrl | quote }}
   {{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1160,6 +1160,12 @@
           "title": "oauthClientId",
           "type": "string"
         },
+        "oauthScope": {
+          "default": "",
+          "description": "Optional OAuth2 scope to request in the client credentials token request",
+          "title": "oauthScope",
+          "type": "string"
+        },
         "openSearchSecretName": {
           "default": "",
           "description": "Name of an existing Secret with 'username' and 'password' keys for OpenSearch authentication. Required.",
@@ -1521,6 +1527,12 @@
               "default": "openchoreo-rca-agent",
               "description": "OAuth2 client ID registered with the IDP",
               "title": "clientId",
+              "type": "string"
+            },
+            "scope": {
+              "default": "",
+              "description": "Optional OAuth2 scope to request in the client credentials token request",
+              "title": "scope",
               "type": "string"
             }
           },

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -526,6 +526,12 @@ observer:
   oauthClientId: "openchoreo-observer-resource-reader-client"
   # @schema
   # type: string
+  # description: Optional OAuth2 scope to request in the client credentials token request
+  # default: ""
+  # @schema
+  oauthScope: ""
+  # @schema
+  # type: string
   # description: Name of an existing Secret injected via envFrom into the Observer container. Required keys - OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD, UID_RESOLVER_OAUTH_CLIENT_SECRET. Optional keys - ALERT_STORE_DSN (when alertStoreBackend is postgresql).
   # default: ""
   # @schema
@@ -1498,6 +1504,12 @@ rca:
     # default: openchoreo-rca-agent
     # @schema
     clientId: "openchoreo-rca-agent"
+    # @schema
+    # type: string
+    # description: Optional OAuth2 scope to request in the client credentials token request
+    # default: ""
+    # @schema
+    scope: ""
 
   # @schema
   # type: object

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -134,6 +134,8 @@ type UIDResolverConfig struct {
 	OAuthClientID string `koanf:"oauth.client.id"`
 	// OAuthClientSecret is the OAuth2 client secret for authentication
 	OAuthClientSecret string `koanf:"oauth.client.secret"`
+	// OAuthScope is the optional OAuth2 scope to request in the token request
+	OAuthScope string `koanf:"oauth.scope"`
 	// TLSInsecureSkipVerify skips TLS certificate verification (for development)
 	TLSInsecureSkipVerify bool `koanf:"tls.insecure.skip.verify"`
 	// Timeout is the HTTP client timeout for API calls
@@ -225,6 +227,7 @@ func Load() (*Config, error) {
 		"UID_RESOLVER_OAUTH_TOKEN_URL":          "uid_resolver.oauth.token.url",
 		"UID_RESOLVER_OAUTH_CLIENT_ID":          "uid_resolver.oauth.client.id",
 		"UID_RESOLVER_OAUTH_CLIENT_SECRET":      "uid_resolver.oauth.client.secret",
+		"UID_RESOLVER_OAUTH_SCOPE":              "uid_resolver.oauth.scope",
 		"UID_RESOLVER_TLS_INSECURE_SKIP_VERIFY": "uid_resolver.tls.insecure.skip.verify",
 		"UID_RESOLVER_TIMEOUT":                  "uid_resolver.timeout",
 		"UID_RESOLVER_MAX_AUTH_RETRY":           "uid_resolver.max.auth.retry",

--- a/internal/observer/service/uid_resolver.go
+++ b/internal/observer/service/uid_resolver.go
@@ -306,6 +306,9 @@ func (r *ResourceUIDResolver) fetchAccessToken(ctx context.Context) (string, tim
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", r.config.OAuthClientID)
 	data.Set("client_secret", r.config.OAuthClientSecret)
+	if scope := strings.TrimSpace(r.config.OAuthScope); scope != "" {
+		data.Set("scope", scope)
+	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, r.config.Timeout)
 	defer cancel()

--- a/internal/observer/service/uid_resolver_test.go
+++ b/internal/observer/service/uid_resolver_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -276,6 +277,74 @@ func TestFetchResourceUID_BadClientCredentials(t *testing.T) {
 	_, err := resolver.GetNamespaceUID(context.Background(), "my-ns")
 	if !errors.Is(err, ErrScopeAuthFailed) {
 		t.Fatalf("expected ErrScopeAuthFailed for bad client credentials, got %v", err)
+	}
+}
+
+// TestFetchAccessToken_IncludesScope verifies that when OAuthScope is configured,
+// the scope parameter is included in the token request body.
+func TestFetchAccessToken_IncludesScope(t *testing.T) {
+	t.Parallel()
+
+	var capturedScope string
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		params, _ := url.ParseQuery(string(body))
+		capturedScope = params.Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","expires_in":3600}`))
+	}))
+	defer tokenSrv.Close()
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(uidResponse("uid-1")))
+	}))
+	defer apiSrv.Close()
+
+	cfg := &config.UIDResolverConfig{OAuthScope: "api:read", MaxAuthRetry: 0}
+	resolver := newTestResolver(t, apiSrv, tokenSrv, cfg)
+
+	_, err := resolver.GetNamespaceUID(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedScope != "api:read" {
+		t.Errorf("expected scope %q in token request, got %q", "api:read", capturedScope)
+	}
+}
+
+// TestFetchAccessToken_OmitsScopeWhenEmpty verifies that when OAuthScope is empty,
+// the scope parameter is not included in the token request body.
+func TestFetchAccessToken_OmitsScopeWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var capturedScope string
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		params, _ := url.ParseQuery(string(body))
+		capturedScope = params.Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","expires_in":3600}`))
+	}))
+	defer tokenSrv.Close()
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(uidResponse("uid-1")))
+	}))
+	defer apiSrv.Close()
+
+	cfg := &config.UIDResolverConfig{OAuthScope: "", MaxAuthRetry: 0}
+	resolver := newTestResolver(t, apiSrv, tokenSrv, cfg)
+
+	_, err := resolver.GetNamespaceUID(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedScope != "" {
+		t.Errorf("expected no scope in token request, got %q", capturedScope)
 	}
 }
 

--- a/internal/occ/auth/client_credential.go
+++ b/internal/occ/auth/client_credential.go
@@ -26,6 +26,8 @@ type ClientCredentialsAuth struct {
 	TokenEndpoint string
 	ClientID      string
 	ClientSecret  string
+	// Scope is an optional OAuth2 scope to request in the token request.
+	Scope string
 }
 
 // GetToken exchanges client credentials for an access token
@@ -34,6 +36,9 @@ func (c *ClientCredentialsAuth) GetToken() (*TokenResponse, error) {
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", c.ClientID)
 	data.Set("client_secret", c.ClientSecret)
+	if c.Scope != "" {
+		data.Set("scope", c.Scope)
+	}
 
 	req, err := http.NewRequest("POST", c.TokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {

--- a/internal/occ/auth/client_credential_test.go
+++ b/internal/occ/auth/client_credential_test.go
@@ -78,4 +78,48 @@ func TestClientCredentialsGetToken(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse token response")
 	})
+
+	t.Run("includes scope in request when Scope is set", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			params, err := url.ParseQuery(string(body))
+			require.NoError(t, err)
+
+			assert.Equal(t, "openid profile", params.Get("scope"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+		}))
+		defer server.Close()
+
+		c := &ClientCredentialsAuth{
+			TokenEndpoint: server.URL,
+			ClientID:      "c",
+			ClientSecret:  "s",
+			Scope:         "openid profile",
+		}
+		resp, err := c.GetToken()
+		require.NoError(t, err)
+		assert.Equal(t, "tok", resp.AccessToken)
+	})
+
+	t.Run("omits scope from request when Scope is empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			params, err := url.ParseQuery(string(body))
+			require.NoError(t, err)
+
+			assert.Equal(t, "", params.Get("scope"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+		}))
+		defer server.Close()
+
+		c := &ClientCredentialsAuth{TokenEndpoint: server.URL, ClientID: "c", ClientSecret: "s"}
+		_, err := c.GetToken()
+		require.NoError(t, err)
+	})
 }

--- a/internal/occ/auth/token.go
+++ b/internal/occ/auth/token.go
@@ -102,6 +102,7 @@ func RefreshToken() (string, error) {
 		TokenEndpoint: oidcConfig.TokenEndpoint,
 		ClientID:      credential.ClientID,
 		ClientSecret:  credential.ClientSecret,
+		Scope:         credential.Scope,
 	}
 
 	tokenResp, err := authClient.GetToken()

--- a/internal/occ/cmd/config/types.go
+++ b/internal/occ/cmd/config/types.go
@@ -22,6 +22,7 @@ type Credential struct {
 	Name         string `yaml:"name"`
 	ClientID     string `yaml:"clientId,omitempty"`
 	ClientSecret string `yaml:"clientSecret,omitempty"`
+	Scope        string `yaml:"scope,omitempty"`
 	Token        string `yaml:"token,omitempty"`
 	RefreshToken string `yaml:"refreshToken,omitempty"`
 	AuthMethod   string `yaml:"authMethod,omitempty"` // "pkce" or "client_credentials"

--- a/internal/occ/cmd/login/cmd.go
+++ b/internal/occ/cmd/login/cmd.go
@@ -12,6 +12,7 @@ type LoginParams struct {
 	ClientCredentials bool
 	ClientID          string
 	ClientSecret      string
+	Scope             string
 	CredentialName    string
 }
 
@@ -24,11 +25,13 @@ func NewLoginCmd() *cobra.Command {
 			clientCreds, _ := cmd.Flags().GetBool("client-credentials")
 			clientID, _ := cmd.Flags().GetString("client-id")
 			clientSecret, _ := cmd.Flags().GetString("client-secret")
+			scope, _ := cmd.Flags().GetString("scope")
 			credentialName, _ := cmd.Flags().GetString("credential")
 			return NewAuthImpl().Login(LoginParams{
 				ClientCredentials: clientCreds,
 				ClientID:          clientID,
 				ClientSecret:      clientSecret,
+				Scope:             scope,
 				CredentialName:    credentialName,
 			})
 		},
@@ -36,6 +39,7 @@ func NewLoginCmd() *cobra.Command {
 	cmd.Flags().Bool("client-credentials", false, "Use OAuth2 client credentials flow for authentication")
 	cmd.Flags().String("client-id", "", "OAuth2 client ID for service account authentication")
 	cmd.Flags().String("client-secret", "", "OAuth2 client secret for service account authentication")
+	cmd.Flags().String("scope", "", "OAuth2 scope to request in the token request (optional, client credentials flow only)")
 	cmd.Flags().String("credential", "", "Name to save the credential as in config")
 	return cmd
 }

--- a/internal/occ/cmd/login/login.go
+++ b/internal/occ/cmd/login/login.go
@@ -81,6 +81,7 @@ func (i *AuthImpl) loginWithClientCredentials(params LoginParams) error {
 		TokenEndpoint: oidcConfig.TokenEndpoint,
 		ClientID:      clientID,
 		ClientSecret:  clientSecret,
+		Scope:         params.Scope,
 	}
 
 	tokenResp, err := authClient.GetToken()
@@ -94,6 +95,7 @@ func (i *AuthImpl) loginWithClientCredentials(params LoginParams) error {
 		if cfg.Credentials[idx].Name == credentialName {
 			cfg.Credentials[idx].ClientID = clientID
 			cfg.Credentials[idx].ClientSecret = clientSecret
+			cfg.Credentials[idx].Scope = params.Scope
 			cfg.Credentials[idx].Token = tokenResp.AccessToken
 			cfg.Credentials[idx].AuthMethod = "client_credentials"
 			credentialExists = true
@@ -106,6 +108,7 @@ func (i *AuthImpl) loginWithClientCredentials(params LoginParams) error {
 			Name:         credentialName,
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
+			Scope:        params.Scope,
 			Token:        tokenResp.AccessToken,
 			AuthMethod:   "client_credentials",
 		})

--- a/internal/occ/cmd/login/login_test.go
+++ b/internal/occ/cmd/login/login_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,6 +54,47 @@ func mockOIDCTransport(t *testing.T, securityEnabled bool, tokenStatus int) stri
 			}
 			return testutil.JSONResp(http.StatusOK, map[string]any{
 				"access_token": "test-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}), nil
+
+		default:
+			return &http.Response{StatusCode: http.StatusNotFound, Body: http.NoBody, Header: http.Header{}}, nil
+		}
+	}))
+
+	return baseURL
+}
+
+// mockOIDCTransportCapturingToken is like mockOIDCTransport but also captures the
+// parsed form values from the /token request for assertion in the calling test.
+func mockOIDCTransportCapturingToken(t *testing.T, captured *url.Values) string {
+	t.Helper()
+	const baseURL = "http://mock-control-plane"
+
+	testutil.SetTransport(t, testutil.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			return testutil.JSONResp(http.StatusOK, map[string]any{
+				"authorization_servers": []string{baseURL},
+				"openchoreo_clients": []map[string]any{
+					{"name": "cli", "client_id": "cli-id", "scopes": []string{"openid"}},
+				},
+				"openchoreo_security_enabled": true,
+			}), nil
+
+		case "/.well-known/openid-configuration":
+			return testutil.JSONResp(http.StatusOK, map[string]any{
+				"authorization_endpoint": baseURL + "/authorize",
+				"token_endpoint":         baseURL + "/token",
+			}), nil
+
+		case "/token":
+			body, _ := io.ReadAll(r.Body)
+			vals, _ := url.ParseQuery(string(body))
+			*captured = vals
+			return testutil.JSONResp(http.StatusOK, map[string]any{
+				"access_token": "scoped-token",
 				"token_type":   "Bearer",
 				"expires_in":   3600,
 			}), nil
@@ -274,6 +316,68 @@ func TestIsLoggedIn(t *testing.T) {
 		})
 
 		assert.False(t, NewAuthImpl().IsLoggedIn())
+	})
+}
+
+func TestLoginWithClientCredentials_Scope(t *testing.T) {
+	t.Run("scope is sent in token request and persisted to credential", func(t *testing.T) {
+		home := testutil.SetupTestHome(t)
+		var captured url.Values
+		baseURL := mockOIDCTransportCapturingToken(t, &captured)
+
+		testutil.WriteOCConfig(t, home, &config.StoredConfig{
+			CurrentContext: "ctx",
+			ControlPlanes:  []config.ControlPlane{{Name: "cp", URL: baseURL}},
+			Credentials:    []config.Credential{{Name: "cred"}},
+			Contexts:       []config.Context{{Name: "ctx", ControlPlane: "cp", Credentials: "cred"}},
+		})
+
+		err := NewAuthImpl().Login(LoginParams{
+			ClientCredentials: true,
+			ClientID:          "my-client",
+			ClientSecret:      "my-secret",
+			Scope:             "openid profile",
+			CredentialName:    "cred",
+		})
+		require.NoError(t, err)
+
+		// Scope must have been sent in the token request.
+		assert.Equal(t, "openid profile", captured.Get("scope"))
+
+		// Scope must be persisted to the stored credential for token refresh.
+		cfg, err := config.LoadStoredConfig()
+		require.NoError(t, err)
+		require.Len(t, cfg.Credentials, 1)
+		assert.Equal(t, "openid profile", cfg.Credentials[0].Scope)
+		assert.Equal(t, "scoped-token", cfg.Credentials[0].Token)
+	})
+
+	t.Run("scope is not sent when empty", func(t *testing.T) {
+		home := testutil.SetupTestHome(t)
+		var captured url.Values
+		baseURL := mockOIDCTransportCapturingToken(t, &captured)
+
+		testutil.WriteOCConfig(t, home, &config.StoredConfig{
+			CurrentContext: "ctx",
+			ControlPlanes:  []config.ControlPlane{{Name: "cp", URL: baseURL}},
+			Credentials:    []config.Credential{{Name: "cred"}},
+			Contexts:       []config.Context{{Name: "ctx", ControlPlane: "cp", Credentials: "cred"}},
+		})
+
+		err := NewAuthImpl().Login(LoginParams{
+			ClientCredentials: true,
+			ClientID:          "my-client",
+			ClientSecret:      "my-secret",
+			CredentialName:    "cred",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "", captured.Get("scope"))
+
+		cfg, err := config.LoadStoredConfig()
+		require.NoError(t, err)
+		require.Len(t, cfg.Credentials, 1)
+		assert.Equal(t, "", cfg.Credentials[0].Scope)
 	})
 }
 

--- a/rca-agent/src/auth/oauth_client.py
+++ b/rca-agent/src/auth/oauth_client.py
@@ -12,15 +12,19 @@ logger = logging.getLogger(__name__)
 
 
 class OAuth2ClientCredentialsAuth(httpx.Auth):
-    def __init__(self, token_url: str, client_id: str, client_secret: str):
+    def __init__(self, token_url: str, client_id: str, client_secret: str, scope: str = ""):
         self.token_url = token_url
         self.client_id = client_id
         self.client_secret = client_secret
+        self.scope = scope
         self._token: dict | None = None
 
     def _ensure_token(self, client: OAuth2Client) -> dict:
         if self._token is None or client.token.is_expired():
-            self._token = client.fetch_token(self.token_url, grant_type="client_credentials")
+            kwargs = {"grant_type": "client_credentials"}
+            if self.scope:
+                kwargs["scope"] = self.scope
+            self._token = client.fetch_token(self.token_url, **kwargs)
             if self._token is None:
                 raise RuntimeError("Failed to fetch OAuth2 token")
             logger.debug("Fetched OAuth2 token, expires in %s", self._token.get("expires_in"))
@@ -28,7 +32,10 @@ class OAuth2ClientCredentialsAuth(httpx.Auth):
 
     async def _async_ensure_token(self, client: AsyncOAuth2Client) -> dict:
         if self._token is None or client.token.is_expired():
-            self._token = await client.fetch_token(self.token_url, grant_type="client_credentials")
+            kwargs = {"grant_type": "client_credentials"}
+            if self.scope:
+                kwargs["scope"] = self.scope
+            self._token = await client.fetch_token(self.token_url, **kwargs)
             if self._token is None:
                 raise RuntimeError("Failed to fetch OAuth2 token")
             logger.debug("Fetched OAuth2 token, expires in %s", self._token.get("expires_in"))
@@ -73,6 +80,7 @@ def get_oauth2_auth() -> OAuth2ClientCredentialsAuth:
         token_url=settings.oauth_token_url,
         client_id=settings.oauth_client_id,
         client_secret=settings.oauth_client_secret,
+        scope=settings.oauth_scope,
     )
 
 
@@ -92,7 +100,10 @@ async def check_oauth2_connection() -> bool:
     )
 
     try:
-        token = await client.fetch_token(settings.oauth_token_url, grant_type="client_credentials")
+        kwargs = {"grant_type": "client_credentials"}
+        if settings.oauth_scope:
+            kwargs["scope"] = settings.oauth_scope
+        token = await client.fetch_token(settings.oauth_token_url, **kwargs)
         logger.debug("OAuth2 token fetch successful, expires in %s", token.get("expires_in"))
         return True
     except Exception as e:

--- a/rca-agent/src/config.py
+++ b/rca-agent/src/config.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
     oauth_token_url: str = ""
     oauth_client_id: str = ""
     oauth_client_secret: str = ""
+    oauth_scope: str = ""
     jwt_jwks_url: str = ""
     jwt_issuer: str = ""
     jwt_audience: str = ""

--- a/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
@@ -20,6 +20,8 @@ spec:
           # TODO: Mount the client secret from a Kubernetes secret instead of using a default value.
           - name: oauth-client-secret
             default: "openchoreo-workload-publisher-secret"
+          - name: oauth-scope
+            default: ""
           # --- OpenChoreo API Server Configuration ---
           # Update these when the API server URL or host changes.
           - name: api-server-url
@@ -120,13 +122,25 @@ spec:
             OAUTH_HOST="{{inputs.parameters.oauth-host-header}}"
             CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
             CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
+            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
 
             echo ">> Requesting OAuth token from ${OAUTH_URL}"
-            TOKEN_RESPONSE=$(curl -s --fail-with-body \
-              -X POST "${OAUTH_URL}" \
-              -H "Host: ${OAUTH_HOST}" \
-              -H "Content-Type: application/x-www-form-urlencoded" \
-              -d "grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}")
+            if [ -n "${OAUTH_SCOPE}" ]; then
+              TOKEN_RESPONSE=$(curl -s --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                -H "Host: ${OAUTH_HOST}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}" \
+                --data-urlencode "scope=${OAUTH_SCOPE}")
+            else
+              TOKEN_RESPONSE=$(curl -s --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                -H "Host: ${OAUTH_HOST}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}")
+            fi
 
             ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
 

--- a/samples/getting-started/workflow-templates/generate-workload.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload.yaml
@@ -18,6 +18,8 @@ spec:
           # TODO: Mount the client secret from a Kubernetes secret instead of using a default value.
           - name: oauth-client-secret
             default: "openchoreo-workload-publisher-secret"
+          - name: oauth-scope
+            default: ""
           # --- OpenChoreo API Server Configuration ---
           # Update these when the API server URL or host changes.
           - name: api-server-url
@@ -115,12 +117,23 @@ spec:
             OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
             CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
             CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
+            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
 
             echo ">> Requesting OAuth token from ${OAUTH_URL}"
-            TOKEN_RESPONSE=$(curl -sk --fail-with-body \
-              -X POST "${OAUTH_URL}" \
-              -H "Content-Type: application/x-www-form-urlencoded" \
-              -d "grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}")
+            if [ -n "${OAUTH_SCOPE}" ]; then
+              TOKEN_RESPONSE=$(curl -sk --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}" \
+                --data-urlencode "scope=${OAUTH_SCOPE}")
+            else
+              TOKEN_RESPONSE=$(curl -sk --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}")
+            fi
 
             ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
 


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/3199

This pull request adds support for specifying an optional OAuth2 scope parameter in the client credentials token request throughout the OpenChoreo observability plane, including the Helm charts, configuration schemas, Go and Python service code, CLI, and sample workflow templates. This enables users to request specific OAuth2 scopes when authenticating services, improving compatibility with OAuth2 providers that require or support scoped access tokens.

The most important changes are:

**Helm Charts and Configuration:**
* Added `oauthScope` (for observer) and `scope` (for rca) fields to the Helm chart values and schemas, allowing users to specify an OAuth2 scope for service authentication. These values are now passed as environment variables to the relevant containers. [[1]](diffhunk://#diff-94d6c293793c60fc65baa0fcff151f7d1c0b5127349cc1b09a01d232e1d6ffefR529-R534) [[2]](diffhunk://#diff-94d6c293793c60fc65baa0fcff151f7d1c0b5127349cc1b09a01d232e1d6ffefR1507-R1512) [[3]](diffhunk://#diff-bd387735a71f5cea83c08ae06006319e4b0b7a64ca0ca19f6de73c62a2bcb959R1163-R1168) [[4]](diffhunk://#diff-bd387735a71f5cea83c08ae06006319e4b0b7a64ca0ca19f6de73c62a2bcb959R1531-R1536) [[5]](diffhunk://#diff-8d10f7347800b25bfd998b73c56048b68db808d1d08452d64666504fe92700f2R17-R19) [[6]](diffhunk://#diff-e18bb19b1d266d29fca4d3da2e429bb4acdcf6392fe4f41d50d6cdd5f0954368R35-R37)

**Go Backend Services:**
* Updated the observer service and authentication logic to accept and use the OAuth2 scope parameter when requesting tokens, including updates to configuration structs, environment variable mapping, and token request logic. [[1]](diffhunk://#diff-32af72bec430d0d5ec2e02774b58b675aa9a29b8b660762f1f12980fabc315acR137-R138) [[2]](diffhunk://#diff-32af72bec430d0d5ec2e02774b58b675aa9a29b8b660762f1f12980fabc315acR230) [[3]](diffhunk://#diff-fd350c9a8d9d7b54f35d9d98c85d943bf96b0cdf3c40c876dcd2a5245b7134f8R309-R311) [[4]](diffhunk://#diff-63eaecc72ac0af508572f767cd7eaac64c9b08941ffa16659deb696149e1326dR29-R30) [[5]](diffhunk://#diff-63eaecc72ac0af508572f767cd7eaac64c9b08941ffa16659deb696149e1326dR39-R41) [[6]](diffhunk://#diff-05e4a5a309dff366627c11ec73a01dc4d0f5dc4d887570dc71316485fc801023R105) [[7]](diffhunk://#diff-19826f974c2b7964927b54d34d7475c0271a8e6aa3a54c09cd7280dad204118eR25)

**CLI (occ):**
* Enhanced the CLI login command to support specifying an OAuth2 scope via a new `--scope` flag, and ensured the scope is persisted in credentials and used during token requests. [[1]](diffhunk://#diff-057e8e8d0cdc753cda70085f9bfeaa112ae4638b2838c743b1841a93ef6cbd96R15) [[2]](diffhunk://#diff-057e8e8d0cdc753cda70085f9bfeaa112ae4638b2838c743b1841a93ef6cbd96R28-R42) [[3]](diffhunk://#diff-16feb7ba6486c01e5dbf625cf901baf62b558ae82b35b893a818861e3e5dc3c7R84) [[4]](diffhunk://#diff-16feb7ba6486c01e5dbf625cf901baf62b558ae82b35b893a818861e3e5dc3c7R98) [[5]](diffhunk://#diff-16feb7ba6486c01e5dbf625cf901baf62b558ae82b35b893a818861e3e5dc3c7R111)

**Python RCA Agent:**
* Modified the RCA agent's OAuth2 authentication logic to accept and pass the scope parameter when fetching tokens, including updates to the config and token fetch routines. [[1]](diffhunk://#diff-4f2d9bccf4dde01c8253ea3e9213818468b0384b65ff10030a8ce59ed1dc32a4L15-R38) [[2]](diffhunk://#diff-4f2d9bccf4dde01c8253ea3e9213818468b0384b65ff10030a8ce59ed1dc32a4R83) [[3]](diffhunk://#diff-4f2d9bccf4dde01c8253ea3e9213818468b0384b65ff10030a8ce59ed1dc32a4L95-R106) [[4]](diffhunk://#diff-c7bb07f6e07b5e0f7f79e17fd73c902cea29282ea14d17407bc6112ec2fe88f2R38)

**Sample Workflow Templates:**
* Updated sample Argo workflow templates to allow passing the OAuth2 scope as a parameter and include it in token requests if specified. [[1]](diffhunk://#diff-ea9de76dd2e966ca9e4f71a982bf693c64f2238700bb1096a4ecb038662a19fdR23-R24) [[2]](diffhunk://#diff-ea9de76dd2e966ca9e4f71a982bf693c64f2238700bb1096a4ecb038662a19fdR125-R136) [[3]](diffhunk://#diff-ebe81acebe2bc9d019422744cac2a62a68940458bc2047680d855b2c47dd520aR21-R22) [[4]](diffhunk://#diff-ebe81acebe2bc9d019422744cac2a62a68940458bc2047680d855b2c47dd520aR120-R130)