### PR TITLE
feat: add permission-based tool filtering middleware

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -199,7 +199,7 @@ func main() {
 		mcpLoggerMw := apilogger.LoggerMiddleware(mcpLogger)
 		resourceMetadataURL := cfg.Server.PublicURL + "/.well-known/oauth-protected-resource"
 		mcpAuth401Mw := mcpmiddleware.Auth401Interceptor(resourceMetadataURL)
-		mcpHandler := middleware.Chain(mcpLoggerMw, mcpAuth401Mw, jwtMiddleware)(mcp.NewHTTPServer(toolsets))
+		mcpHandler := middleware.Chain(mcpLoggerMw, mcpAuth401Mw, jwtMiddleware)(mcp.NewHTTPServer(toolsets, runtime.pdp))
 
 		baseMux.Handle("/mcp", mcpHandler)
 	}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -8,25 +8,40 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
 )
 
-func NewHTTPServer(tools *tools.Toolsets) http.Handler {
+// NewHTTPServer creates an MCP HTTP handler backed by a single shared server.
+//
+// When pdp is non-nil the server installs a receiving middleware that filters
+// tools/list results and guards tools/call invocations based on the
+// authenticated user's permissions derived from their JWT token.
+// When pdp is nil (authz disabled) all registered tools are visible and
+// callable — the service layer still enforces authz independently.
+func NewHTTPServer(toolsets *tools.Toolsets, pdp authzcore.PDP) http.Handler {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "openchoreo-api",
 		Version: "1.0.0",
 	}, nil)
-	tools.Register(server)
+	perms := toolsets.Register(server)
+	if pdp != nil {
+		server.AddReceivingMiddleware(tools.NewToolFilterMiddleware(pdp, perms))
+	}
 	return mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
 	}, nil)
 }
 
-func NewSTDIO(tools *tools.Toolsets) *mcp.Server {
+// NewSTDIO creates an MCP server for STDIO transport (local CLI usage).
+// Permission filtering is intentionally skipped for STDIO: there is no
+// HTTP request, no JWT token, and no authenticated user identity available.
+// The service layer still enforces authz for any operations that require it.
+func NewSTDIO(toolsets *tools.Toolsets) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "openchoreo-cli",
 		Version: "1.0.0",
 	}, nil)
-	tools.Register(server)
+	toolsets.Register(server)
 	return server
 }

--- a/pkg/mcp/tools/component.go
+++ b/pkg/mcp/tools/component.go
@@ -9,12 +9,16 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
 
-func (t *Toolsets) RegisterListComponents(s *mcp.Server) {
+//nolint:dupl // paginated list handlers share similar structure
+func (t *Toolsets) RegisterListComponents(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_components"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponent}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_components",
+		Name: name,
 		Description: "List all components in a project. Components are deployable units (services, jobs, etc.) " +
 			"with independent build and deployment lifecycles. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -33,9 +37,11 @@ func (t *Toolsets) RegisterListComponents(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetComponent(s *mcp.Server) {
+func (t *Toolsets) RegisterGetComponent(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponent}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component",
+		Name: name,
 		Description: "Get detailed information about a component including configuration, deployment status, " +
 			"and builds.",
 		InputSchema: createSchema(map[string]any{
@@ -51,9 +57,11 @@ func (t *Toolsets) RegisterGetComponent(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListWorkloads(s *mcp.Server) {
+func (t *Toolsets) RegisterListWorkloads(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_workloads"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkload}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_workloads",
+		Name: name,
 		Description: "List workloads for a component. Shows workload names, images, and endpoint names. " +
 			"For Kubernetes users: Similar to 'kubectl get pods'.",
 		InputSchema: createSchema(map[string]any{
@@ -69,9 +77,11 @@ func (t *Toolsets) RegisterListWorkloads(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetWorkload(s *mcp.Server) {
+func (t *Toolsets) RegisterGetWorkload(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workload"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkload}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workload",
+		Name: name,
 		Description: "Get detailed information about a specific workload including container " +
 			"configuration, endpoints, and connections.",
 		InputSchema: createSchema(map[string]any{
@@ -87,9 +97,11 @@ func (t *Toolsets) RegisterGetWorkload(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetReleaseBinding(s *mcp.Server) {
+func (t *Toolsets) RegisterGetReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_release_binding",
+		Name: name,
 		Description: "Get detailed information about a specific release binding including environment, " +
 			"release name, state, overrides, endpoints, and deployment status.",
 		InputSchema: createSchema(map[string]any{
@@ -105,9 +117,11 @@ func (t *Toolsets) RegisterGetReleaseBinding(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterCreateComponent(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateComponent(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_component"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateComponent}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_component",
+		Name: name,
 		Description: "Create a new component in a project. Components are deployable units (services, jobs, etc.) " +
 			"with independent build and deployment lifecycles. For components using the from-image approach " +
 			"(no workflow to build from source), use create_workload after creating the component to define " +
@@ -218,9 +232,12 @@ func (t *Toolsets) RegisterCreateComponent(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListReleaseBindings(s *mcp.Server) {
+//nolint:dupl // paginated list handlers share similar structure
+func (t *Toolsets) RegisterListReleaseBindings(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_release_bindings"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_release_bindings",
+		Name: name,
 		Description: "List release bindings for a component. Release bindings associate releases with " +
 			"environments and define deployment configurations. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -239,9 +256,11 @@ func (t *Toolsets) RegisterListReleaseBindings(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterCreateReleaseBinding(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_release_binding",
+		Name: name,
 		Description: "Create a new release binding to deploy a component release to a specific " +
 			"environment. Fails if a binding already exists for the component in that environment, " +
 			"use update_release_binding to deploy a new release to an environment that already has " +
@@ -315,9 +334,11 @@ func (t *Toolsets) RegisterCreateReleaseBinding(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterUpdateReleaseBinding(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_release_binding",
+		Name: name,
 		Description: "Update an existing release binding's configuration (partial update). Only provided fields are " +
 			"updated; omitted fields remain unchanged. Use this to deploy a new component release to an " +
 			"environment, or to modify environment configs and workload overrides.",
@@ -491,9 +512,11 @@ func parseFileVars(container map[string]interface{}) ([]gen.FileVar, error) {
 	return fileVars, nil
 }
 
-func (t *Toolsets) RegisterCreateWorkload(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateWorkload(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_workload"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateWorkload}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_workload",
+		Name: name,
 		Description: "Create a new workload for a component. Workloads define the runtime specification " +
 			"including container images, resource limits, and environment variables. " +
 			"Use this for components that follow the from-image approach (i.e., they do not use workflows to " +
@@ -520,9 +543,11 @@ func (t *Toolsets) RegisterCreateWorkload(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterUpdateWorkload(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateWorkload(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_workload"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateWorkload}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_workload",
+		Name: name,
 		Description: "Update an existing workload's specification for a component. Use this for components " +
 			"that use workflows to build images from source, when the source repository does not contain a " +
 			"workload descriptor (workload.yaml) and you need to modify the workload generated from the build " +
@@ -550,9 +575,11 @@ func (t *Toolsets) RegisterUpdateWorkload(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetWorkloadSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetWorkloadSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workload_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkload}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workload_schema",
+		Name: name,
 		Description: "Get the JSON schema for the workload specification. Returns the full schema showing " +
 			"all available fields (container, endpoints, connections), their types, required fields, and " +
 			"valid values. Use this before calling create_workload or update_workload to understand the " +
@@ -564,9 +591,11 @@ func (t *Toolsets) RegisterGetWorkloadSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetComponentSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetComponentSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponent}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_schema",
+		Name: name,
 		Description: "Get the schema definition for a component. Returns the JSON schema showing component " +
 			"configuration options, required fields, and their types.",
 		InputSchema: createSchema(map[string]any{
@@ -582,9 +611,11 @@ func (t *Toolsets) RegisterGetComponentSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterUpdateReleaseBindingState(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateReleaseBindingState(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_release_binding_state"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_release_binding_state",
+		Name: name,
 		Description: "Update the state of a release binding. Use this to activate, suspend, or undeploy a " +
 			"component in a specific environment. Valid states: Active, Undeploy.",
 		InputSchema: createSchema(map[string]any{
@@ -612,9 +643,11 @@ func (t *Toolsets) RegisterUpdateReleaseBindingState(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterTriggerWorkflowRun(s *mcp.Server) {
+func (t *Toolsets) RegisterTriggerWorkflowRun(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "trigger_workflow_run"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateWorkflowRun}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "trigger_workflow_run",
+		Name: name,
 		Description: "Trigger a workflow run for a component using the component's configured workflow and " +
 			"parameters. Optionally override commit SHA when the workflow supports a commit parameter mapping.",
 		InputSchema: createSchema(map[string]any{
@@ -635,9 +668,11 @@ func (t *Toolsets) RegisterTriggerWorkflowRun(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPatchComponent(s *mcp.Server) {
+func (t *Toolsets) RegisterPatchComponent(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "patch_component"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateComponent}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "patch_component",
+		Name: name,
 		Description: "Patch (partially update) a component's configuration. Only the fields provided in the request " +
 			"will be updated; omitted fields remain unchanged. Supports updating autoDeploy and parameters.",
 		InputSchema: createSchema(map[string]any{

--- a/pkg/mcp/tools/filter.go
+++ b/pkg/mcp/tools/filter.go
@@ -1,0 +1,211 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
+)
+
+const (
+	// methodCallTool is the MCP method name for tool invocation.
+	methodCallTool = "tools/call"
+	// methodListTools is the MCP method name for listing tools.
+	methodListTools = "tools/list"
+)
+
+// NewToolFilterMiddleware returns an MCP receiving middleware that filters tools/list
+// results and rejects tools/call requests based on the authenticated user's permissions.
+//
+// Design: this is a UX improvement layer, not the security boundary. The actual
+// security boundary is enforced by the service layer (NewServiceWithAuthz wrappers).
+// If pdp is nil, all tools are returned unfiltered (graceful degradation / authz disabled).
+//
+// The perms map is produced by ToolPermissions(). It maps tool name to ToolPermission,
+// which carries the required authz action for that tool.
+func NewToolFilterMiddleware(pdp authzcore.PDP, perms map[string]ToolPermission) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			// If no PDP configured, pass through unfiltered.
+			if pdp == nil {
+				return next(ctx, method, req)
+			}
+
+			switch method {
+			case methodListTools:
+				return filterListTools(ctx, next, req, pdp, perms)
+			case methodCallTool:
+				return filterCallTool(ctx, next, method, req, pdp, perms)
+			default:
+				return next(ctx, method, req)
+			}
+		}
+	}
+}
+
+// filterListTools calls the next handler, then removes tools that the user is not
+// permitted to use. Unknown tools (no permission entry) are shown by default to
+// avoid accidentally hiding tools during a rollout.
+func filterListTools(
+	ctx context.Context,
+	next mcp.MethodHandler,
+	req mcp.Request,
+	pdp authzcore.PDP,
+	perms map[string]ToolPermission,
+) (mcp.Result, error) {
+	result, err := next(ctx, methodListTools, req)
+	if err != nil {
+		return result, err
+	}
+
+	listResult, ok := result.(*mcp.ListToolsResult)
+	if !ok || listResult == nil {
+		// Unexpected type: pass through unchanged.
+		return result, nil
+	}
+
+	subjectCtx, _ := auth.GetSubjectContextFromContext(ctx)
+	if subjectCtx == nil {
+		// No authenticated user in context — return no tools.
+		listResult.Tools = []*mcp.Tool{}
+		return listResult, nil
+	}
+
+	profile, err := pdp.GetSubjectProfile(ctx, &authzcore.ProfileRequest{
+		SubjectContext: authzcore.GetAuthzSubjectContext(subjectCtx),
+	})
+	if err != nil {
+		// On PDP error, be safe: return no tools. The service layer will
+		// independently deny any calls the user makes.
+		listResult.Tools = []*mcp.Tool{}
+		return listResult, nil
+	}
+
+	filtered := listResult.Tools[:0:0]
+	for _, tool := range listResult.Tools {
+		if isAllowed(tool.Name, perms, profile) {
+			filtered = append(filtered, tool)
+		}
+	}
+	listResult.Tools = filtered
+	return listResult, nil
+}
+
+// filterCallTool checks whether the user is permitted to call the requested tool
+// before forwarding to the next handler.
+func filterCallTool(
+	ctx context.Context,
+	next mcp.MethodHandler,
+	method string,
+	req mcp.Request,
+	pdp authzcore.PDP,
+	perms map[string]ToolPermission,
+) (mcp.Result, error) {
+	toolName := callToolName(req)
+	perm, hasPerm := perms[toolName]
+	if !hasPerm {
+		// No permission entry — allow through (unknown tools pass, service layer will check).
+		return next(ctx, method, req)
+	}
+
+	subjectCtx, _ := auth.GetSubjectContextFromContext(ctx)
+	if subjectCtx == nil {
+		return nil, fmt.Errorf("not authorized to call tool %q: no authenticated user", toolName)
+	}
+
+	profile, err := pdp.GetSubjectProfile(ctx, &authzcore.ProfileRequest{
+		SubjectContext: authzcore.GetAuthzSubjectContext(subjectCtx),
+		Scope:          callToolScope(req),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("not authorized to call tool %q: could not evaluate permissions", toolName)
+	}
+
+	if !hasActionCapability(perm.Action, profile) {
+		return nil, fmt.Errorf("not authorized to call tool %q: missing permission %q", toolName, perm.Action)
+	}
+
+	return next(ctx, method, req)
+}
+
+// isAllowed returns true if the user's profile grants at least one resource for the
+// tool's required action. If the tool has no permission entry in perms, it is shown
+// by default (safe-default: don't hide tools added after a deploy).
+func isAllowed(toolName string, perms map[string]ToolPermission, profile *authzcore.UserCapabilitiesResponse) bool {
+	perm, ok := perms[toolName]
+	if !ok {
+		return true
+	}
+	return hasActionCapability(perm.Action, profile)
+}
+
+// hasActionCapability returns true if the profile has at least one allowed resource
+// for the given action.
+func hasActionCapability(action string, profile *authzcore.UserCapabilitiesResponse) bool {
+	if profile == nil {
+		return false
+	}
+	cap, ok := profile.Capabilities[action]
+	if !ok || cap == nil {
+		return false
+	}
+	return len(cap.Allowed) > 0
+}
+
+// callToolName extracts the tool name from a tools/call Request.
+// The Params field is of type *mcp.CallToolParamsRaw (server-side) which embeds Name.
+func callToolName(req mcp.Request) string {
+	if req == nil {
+		return ""
+	}
+	params := req.GetParams()
+	if params == nil {
+		return ""
+	}
+	if p, ok := params.(*mcp.CallToolParamsRaw); ok && p != nil {
+		return p.Name
+	}
+	// Fallback: try CallToolParams (client-side, shouldn't happen on server).
+	if p, ok := params.(*mcp.CallToolParams); ok && p != nil {
+		return p.Name
+	}
+	return ""
+}
+
+// callToolScope derives the resource hierarchy scope from the tools/call arguments.
+// It looks for the conventional namespace_name, project_name and component_name
+// fields used by MCP tools in this package. Missing fields remain empty, which
+// the PDP interprets as a broader scope.
+func callToolScope(req mcp.Request) authzcore.ResourceHierarchy {
+	if req == nil {
+		return authzcore.ResourceHierarchy{}
+	}
+	params := req.GetParams()
+	if params == nil {
+		return authzcore.ResourceHierarchy{}
+	}
+	p, ok := params.(*mcp.CallToolParamsRaw)
+	if !ok || p == nil || len(p.Arguments) == 0 {
+		return authzcore.ResourceHierarchy{}
+	}
+	var args struct {
+		NamespaceName string `json:"namespace_name"`
+		ProjectName   string `json:"project_name"`
+		ComponentName string `json:"component_name"`
+	}
+	if err := json.Unmarshal(p.Arguments, &args); err != nil {
+		return authzcore.ResourceHierarchy{}
+	}
+	return authzcore.ResourceHierarchy{
+		Namespace: args.NamespaceName,
+		Project:   args.ProjectName,
+		Component: args.ComponentName,
+	}
+}

--- a/pkg/mcp/tools/filter_test.go
+++ b/pkg/mcp/tools/filter_test.go
@@ -1,0 +1,411 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers / mocks
+// ---------------------------------------------------------------------------
+
+// mockPDP is a test double for authzcore.PDP.
+type mockPDP struct {
+	profile *authzcore.UserCapabilitiesResponse
+	err     error
+}
+
+func (m *mockPDP) Evaluate(_ context.Context, _ *authzcore.EvaluateRequest) (*authzcore.Decision, error) {
+	return &authzcore.Decision{Decision: true}, nil
+}
+
+func (m *mockPDP) BatchEvaluate(
+	_ context.Context, _ *authzcore.BatchEvaluateRequest,
+) (*authzcore.BatchEvaluateResponse, error) {
+	return &authzcore.BatchEvaluateResponse{}, nil
+}
+
+func (m *mockPDP) GetSubjectProfile(
+	_ context.Context, _ *authzcore.ProfileRequest,
+) (*authzcore.UserCapabilitiesResponse, error) {
+	return m.profile, m.err
+}
+
+// allowAllProfile returns a UserCapabilitiesResponse that grants every provided action.
+func allowAllProfile(actions ...string) *authzcore.UserCapabilitiesResponse {
+	caps := make(map[string]*authzcore.ActionCapability, len(actions))
+	for _, a := range actions {
+		caps[a] = &authzcore.ActionCapability{
+			Allowed: []*authzcore.CapabilityResource{
+				{Path: "namespace/test"},
+			},
+		}
+	}
+	return &authzcore.UserCapabilitiesResponse{Capabilities: caps}
+}
+
+// denyAllProfile returns a profile with no capabilities.
+func denyAllProfile() *authzcore.UserCapabilitiesResponse {
+	return &authzcore.UserCapabilitiesResponse{Capabilities: map[string]*authzcore.ActionCapability{}}
+}
+
+// ctxWithSubject injects a SubjectContext into the context, simulating the JWT middleware.
+func ctxWithSubject(ctx context.Context) context.Context {
+	return auth.SetSubjectContext(ctx, &auth.SubjectContext{
+		ID:                "user-1",
+		Type:              "user",
+		EntitlementClaim:  "groups",
+		EntitlementValues: []string{"devs"},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Middleware unit tests
+// ---------------------------------------------------------------------------
+
+// TestNewToolFilterMiddlewareNilPDP verifies that when pdp is nil all tools are
+// returned unfiltered (graceful degradation when authz is disabled).
+func TestNewToolFilterMiddlewareNilPDP(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, func(
+		ctx context.Context, req *mcp.CallToolRequest, args any,
+	) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(nil, map[string]ToolPermission{
+		"list_namespaces": {ToolName: "list_namespaces", Action: "namespace:view"},
+	}))
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(result.Tools) != 1 {
+		t.Errorf("expected 1 tool when PDP is nil, got %d", len(result.Tools))
+	}
+}
+
+// TestToolFilterMiddlewareFiltersListTools verifies that tools/list only returns
+// tools the user has permission to use.
+func TestToolFilterMiddlewareFiltersListTools(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "create_namespace"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_projects"}, nopToolHandler)
+
+	perms := map[string]ToolPermission{
+		"list_namespaces":  {ToolName: "list_namespaces", Action: "namespace:view"},
+		"create_namespace": {ToolName: "create_namespace", Action: "namespace:create"},
+		"list_projects":    {ToolName: "list_projects", Action: "project:view"},
+	}
+
+	// User can only view namespaces and projects, not create namespace.
+	pdp := &mockPDP{profile: allowAllProfile("namespace:view", "project:view")}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	ctx := ctxWithSubject(context.Background())
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	found := make(map[string]bool)
+	for _, tool := range result.Tools {
+		found[tool.Name] = true
+	}
+
+	if !found["list_namespaces"] {
+		t.Error("expected list_namespaces to be visible")
+	}
+	if !found["list_projects"] {
+		t.Error("expected list_projects to be visible")
+	}
+	if found["create_namespace"] {
+		t.Error("create_namespace should not be visible: user lacks namespace:create")
+	}
+}
+
+// TestToolFilterMiddlewareDenyAllProfile verifies that when a user has no capabilities,
+// no tools are returned.
+func TestToolFilterMiddlewareDenyAllProfile(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "create_namespace"}, nopToolHandler)
+
+	perms := map[string]ToolPermission{
+		"list_namespaces":  {ToolName: "list_namespaces", Action: "namespace:view"},
+		"create_namespace": {ToolName: "create_namespace", Action: "namespace:create"},
+	}
+
+	pdp := &mockPDP{profile: denyAllProfile()}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	ctx := ctxWithSubject(context.Background())
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	if len(result.Tools) != 0 {
+		t.Errorf("expected 0 tools for user with no capabilities, got %d", len(result.Tools))
+	}
+}
+
+// TestToolFilterMiddlewareNoSubjectInContext verifies that when there is no
+// authenticated user in context, tools/list returns an empty list.
+func TestToolFilterMiddlewareNoSubjectInContext(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+
+	perms := map[string]ToolPermission{
+		"list_namespaces": {ToolName: "list_namespaces", Action: "namespace:view"},
+	}
+
+	pdp := &mockPDP{profile: allowAllProfile("namespace:view")}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	// Context WITHOUT a subject.
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	if len(result.Tools) != 0 {
+		t.Errorf("expected 0 tools when no subject in context, got %d", len(result.Tools))
+	}
+}
+
+// TestToolFilterMiddlewarePDPError verifies graceful degradation when the PDP
+// returns an error: no tools are shown.
+func TestToolFilterMiddlewarePDPError(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+
+	perms := map[string]ToolPermission{
+		"list_namespaces": {ToolName: "list_namespaces", Action: "namespace:view"},
+	}
+
+	pdp := &mockPDP{err: errors.New("pdp unavailable")}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	ctx := ctxWithSubject(context.Background())
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	if len(result.Tools) != 0 {
+		t.Errorf("expected 0 tools when PDP errors, got %d", len(result.Tools))
+	}
+}
+
+// TestToolFilterMiddlewareCallToolAllowed verifies that an authorized user can
+// call a tool.
+func TestToolFilterMiddlewareCallToolAllowed(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	called := false
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, func(
+		ctx context.Context, req *mcp.CallToolRequest, args any,
+	) (*mcp.CallToolResult, any, error) {
+		called = true
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	perms := map[string]ToolPermission{
+		"list_namespaces": {ToolName: "list_namespaces", Action: "namespace:view"},
+	}
+
+	pdp := &mockPDP{profile: allowAllProfile("namespace:view")}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	ctx := ctxWithSubject(context.Background())
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{Name: "list_namespaces"})
+	if err != nil {
+		t.Fatalf("CallTool: expected success, got %v", err)
+	}
+	if !called {
+		t.Error("expected tool handler to be called, but it was not")
+	}
+}
+
+// TestToolFilterMiddlewareCallToolDenied verifies that an unauthorized user gets
+// an error when attempting to call a tool they lack permission for.
+func TestToolFilterMiddlewareCallToolDenied(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	called := false
+	mcp.AddTool(server, &mcp.Tool{Name: "create_namespace"}, func(
+		ctx context.Context, req *mcp.CallToolRequest, args any,
+	) (*mcp.CallToolResult, any, error) {
+		called = true
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	perms := map[string]ToolPermission{
+		"create_namespace": {ToolName: "create_namespace", Action: "namespace:create"},
+	}
+
+	// User only has view, not create.
+	pdp := &mockPDP{profile: allowAllProfile("namespace:view")}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	ctx := ctxWithSubject(context.Background())
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{Name: "create_namespace"})
+	if err == nil {
+		t.Error("expected error when calling create_namespace without permission, got nil")
+	}
+	if called {
+		t.Error("tool handler should not have been called for unauthorized user")
+	}
+}
+
+// TestToolFilterMiddlewareUnknownToolPassthrough verifies that a tool with no
+// permission entry passes through unfiltered (safe default).
+func TestToolFilterMiddlewareUnknownToolPassthrough(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "some_new_tool"}, nopToolHandler)
+
+	// Empty perms — "some_new_tool" has no entry.
+	perms := map[string]ToolPermission{}
+
+	pdp := &mockPDP{profile: denyAllProfile()}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+
+	ctx := ctxWithSubject(context.Background())
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	if len(result.Tools) != 1 {
+		t.Errorf("expected tool with no perm entry to be visible, got %d tools", len(result.Tools))
+	}
+}
+
+// nopToolHandler is a minimal tool handler used in tests.
+func nopToolHandler(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{}, nil, nil
+}

--- a/pkg/mcp/tools/namespace.go
+++ b/pkg/mcp/tools/namespace.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
 
-func (t *Toolsets) RegisterListNamespaces(s *mcp.Server) {
+func (t *Toolsets) RegisterListNamespaces(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_namespaces"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewNamespace}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_namespaces",
+		Name: name,
 		Description: "List all namespaces. Namespaces are top-level containers for organizing " +
 			"projects, components, and other resources. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{}), []string{}),
@@ -26,9 +29,11 @@ func (t *Toolsets) RegisterListNamespaces(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterCreateNamespace(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateNamespace(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_namespace"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateNamespace}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_namespace",
+		Name: name,
 		Description: "Create a new namespace. Namespaces are top-level containers for organizing " +
 			"projects, components, and other resources.",
 		InputSchema: createSchema(map[string]any{
@@ -60,9 +65,11 @@ func (t *Toolsets) RegisterCreateNamespace(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListSecretReferences(s *mcp.Server) {
+func (t *Toolsets) RegisterListSecretReferences(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_secret_references"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewSecretReference}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_secret_references",
+		Name: name,
 		Description: "List all secret references for an namespace. Secret references are " +
 			"credentials and sensitive configuration that can be used by components. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{

--- a/pkg/mcp/tools/pe.go
+++ b/pkg/mcp/tools/pe.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
 
@@ -81,9 +82,11 @@ func buildSpec[T any](specInput map[string]interface{}) (*T, error) {
 // PE Toolset — Environment management
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterPEListEnvironments(s *mcp.Server) {
+func (t *Toolsets) RegisterPEListEnvironments(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_environments"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewEnvironment}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_environments",
+		Name: name,
 		Description: "List all environments in a namespace. Environments are deployment targets representing " +
 			"pipeline stages (dev, staging, production) or isolated tenants. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -100,9 +103,11 @@ func (t *Toolsets) RegisterPEListEnvironments(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterCreateEnvironment(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateEnvironment(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_environment"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateEnvironment}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_environment",
+		Name: name,
 		Description: "Create a new environment in a namespace. Environments are deployment targets representing " +
 			"pipeline stages (dev, qa, prod) or isolated tenants.",
 		InputSchema: createSchema(map[string]any{
@@ -171,9 +176,11 @@ func (t *Toolsets) RegisterCreateEnvironment(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterUpdateEnvironment(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateEnvironment(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_environment"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateEnvironment}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_environment",
+		Name: name,
 		Description: "Update an existing environment in a namespace. Allows modifying display name, description, " +
 			"and production flag. Data plane reference is immutable after creation.",
 		InputSchema: createSchema(map[string]any{
@@ -215,9 +222,11 @@ func (t *Toolsets) RegisterUpdateEnvironment(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteEnvironment(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteEnvironment(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_environment"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteEnvironment}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "delete_environment",
+		Name: name,
 		Description: "Delete an environment from a namespace. " +
 			"This will remove the deployment target and any associated resources.",
 		InputSchema: createSchema(map[string]any{
@@ -264,9 +273,11 @@ func promotionPathsSchema(description string) map[string]any {
 }
 
 //nolint:dupl
-func (t *Toolsets) RegisterCreateDeploymentPipeline(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateDeploymentPipeline(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_deployment_pipeline"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateDeploymentPipeline}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_deployment_pipeline",
+		Name: name,
 		Description: "Create a new deployment pipeline in a namespace. Deployment pipelines define the promotion " +
 			"order between environments (e.g., dev → staging → production) with optional approval gates.",
 		InputSchema: createSchema(map[string]any{
@@ -308,9 +319,12 @@ func (t *Toolsets) RegisterCreateDeploymentPipeline(s *mcp.Server) {
 // PE Toolset — Component releases
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterPEListComponentReleases(s *mcp.Server) {
+//nolint:dupl // paginated list handlers share similar structure
+func (t *Toolsets) RegisterPEListComponentReleases(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_component_releases"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentRelease}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_component_releases",
+		Name: name,
 		Description: "List all releases for a component. Releases are immutable snapshots of a component at a " +
 			"specific build, ready for deployment to environments. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -330,9 +344,11 @@ func (t *Toolsets) RegisterPEListComponentReleases(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPECreateComponentRelease(s *mcp.Server) {
+func (t *Toolsets) RegisterPECreateComponentRelease(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_component_release"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateComponentRelease}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_component_release",
+		Name: name,
 		Description: "Create a new release from the latest build of a component. Releases are immutable " +
 			"snapshots that can be deployed to environments through release bindings. The component " +
 			"must have at least one successful build or workload. If the source repository does not " +
@@ -354,9 +370,11 @@ func (t *Toolsets) RegisterPECreateComponentRelease(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetComponentRelease(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetComponentRelease(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_release"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentRelease}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_release",
+		Name: name,
 		Description: "Get detailed information about a specific component release including build information, " +
 			"image tags, and deployment status.",
 		InputSchema: createSchema(map[string]any{
@@ -372,9 +390,11 @@ func (t *Toolsets) RegisterPEGetComponentRelease(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetComponentReleaseSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetComponentReleaseSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_release_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentRelease}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_release_schema",
+		Name: name,
 		Description: "Get the release schema for a component. Returns the JSON schema showing the configuration " +
 			"options available when creating or deploying releases for this component.",
 		InputSchema: createSchema(map[string]any{
@@ -397,9 +417,11 @@ func (t *Toolsets) RegisterPEGetComponentReleaseSchema(s *mcp.Server) {
 // PE Toolset — DataPlane read
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListDataPlanes(s *mcp.Server) {
+func (t *Toolsets) RegisterListDataPlanes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_dataplanes"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewDataPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_dataplanes",
+		Name: name,
 		Description: "List all data planes in a namespace. Data planes are Kubernetes clusters or cluster " +
 			"regions where component workloads actually execute. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -415,9 +437,11 @@ func (t *Toolsets) RegisterListDataPlanes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetDataPlane(s *mcp.Server) {
+func (t *Toolsets) RegisterGetDataPlane(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_dataplane"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewDataPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_dataplane",
+		Name: name,
 		Description: "Get detailed information about a data plane including cluster details, capacity, health " +
 			"status, associated environments, and network configuration.",
 		InputSchema: createSchema(map[string]any{
@@ -437,9 +461,11 @@ func (t *Toolsets) RegisterGetDataPlane(s *mcp.Server) {
 // PE Toolset — WorkflowPlane read
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListWorkflowPlanes(s *mcp.Server) {
+func (t *Toolsets) RegisterListWorkflowPlanes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_workflowplanes"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflowPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_workflowplanes",
+		Name: name,
 		Description: "List all workflow planes in a namespace. Workflow planes are infrastructure that handles " +
 			"continuous integration and container image building. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -456,9 +482,11 @@ func (t *Toolsets) RegisterListWorkflowPlanes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetWorkflowPlane(s *mcp.Server) {
+func (t *Toolsets) RegisterGetWorkflowPlane(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workflowplane"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflowPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workflowplane",
+		Name: name,
 		Description: "Get detailed information about a workflow plane including cluster details, health status, " +
 			"and agent connection state.",
 		InputSchema: createSchema(map[string]any{
@@ -478,9 +506,11 @@ func (t *Toolsets) RegisterGetWorkflowPlane(s *mcp.Server) {
 // PE Toolset — ObservabilityPlane read
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListObservabilityPlanes(s *mcp.Server) {
+func (t *Toolsets) RegisterListObservabilityPlanes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_observability_planes"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewObservabilityPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_observability_planes",
+		Name: name,
 		Description: "List all ObservabilityPlanes in a namespace. ObservabilityPlanes provide monitoring, " +
 			"logging, tracing, and metrics collection capabilities for deployed components. " +
 			"Supports pagination via limit and cursor.",
@@ -498,9 +528,11 @@ func (t *Toolsets) RegisterListObservabilityPlanes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetObservabilityPlane(s *mcp.Server) {
+func (t *Toolsets) RegisterGetObservabilityPlane(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_observability_plane"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewObservabilityPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_observability_plane",
+		Name: name,
 		Description: "Get detailed information about an observability plane including observer URL, " +
 			"health status, and agent connection state.",
 		InputSchema: createSchema(map[string]any{
@@ -520,9 +552,11 @@ func (t *Toolsets) RegisterGetObservabilityPlane(s *mcp.Server) {
 // PE Toolset — Cluster-scoped plane read
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListClusterDataPlanes(s *mcp.Server) {
+func (t *Toolsets) RegisterListClusterDataPlanes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_dataplanes"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterDataPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_dataplanes",
+		Name: name,
 		Description: "List all cluster-scoped data planes. These are shared infrastructure managed by " +
 			"platform admins, not scoped to any namespace. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{}), nil),
@@ -535,9 +569,11 @@ func (t *Toolsets) RegisterListClusterDataPlanes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterDataPlane(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterDataPlane(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_dataplane"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterDataPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_dataplane",
+		Name: name,
 		Description: "Get detailed information about a cluster-scoped data plane including cluster details, " +
 			"capacity, health status, and network configuration.",
 		InputSchema: createSchema(map[string]any{
@@ -551,9 +587,11 @@ func (t *Toolsets) RegisterGetClusterDataPlane(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListClusterWorkflowPlanes(s *mcp.Server) {
+func (t *Toolsets) RegisterListClusterWorkflowPlanes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_workflowplanes"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterWorkflowPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_workflowplanes",
+		Name: name,
 		Description: "List all cluster-scoped workflow planes. These are shared workflow infrastructure managed by " +
 			"platform admins, not scoped to any namespace. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{}), nil),
@@ -566,9 +604,11 @@ func (t *Toolsets) RegisterListClusterWorkflowPlanes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListClusterObservabilityPlanes(s *mcp.Server) {
+func (t *Toolsets) RegisterListClusterObservabilityPlanes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_observability_planes"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterObservabilityPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_observability_planes",
+		Name: name,
 		Description: "List all cluster-scoped observability planes. These are shared observability infrastructure " +
 			"managed by platform admins, not scoped to any namespace. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{}), nil),
@@ -585,9 +625,11 @@ func (t *Toolsets) RegisterListClusterObservabilityPlanes(s *mcp.Server) {
 // PE Toolset — Platform standards read (dual with Component toolset)
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterPEListComponentTypes(s *mcp.Server) {
+func (t *Toolsets) RegisterPEListComponentTypes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_component_types"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_component_types",
+		Name: name,
 		Description: "List all available component types in a namespace. Component types define the " +
 			"structure and capabilities of components (e.g., WebApplication, Service, ScheduledTask). " +
 			"Supports pagination via limit and cursor.",
@@ -605,9 +647,11 @@ func (t *Toolsets) RegisterPEListComponentTypes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetComponentTypeSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetComponentTypeSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_type_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_type_schema",
+		Name: name,
 		Description: "Get the parameter schema for a component type. Returns the JSON schema showing " +
 			"the parameters developers can configure when using this component type.",
 		InputSchema: createSchema(map[string]any{
@@ -623,9 +667,11 @@ func (t *Toolsets) RegisterPEGetComponentTypeSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_type",
+		Name: name,
 		Description: "Get the full definition of a component type including its complete spec. " +
 			"Use this before updating a component type to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
@@ -641,9 +687,11 @@ func (t *Toolsets) RegisterPEGetComponentType(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEListTraits(s *mcp.Server) {
+func (t *Toolsets) RegisterPEListTraits(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_traits"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_traits",
+		Name: name,
 		Description: "List all available traits in a namespace. Traits add capabilities to components " +
 			"(e.g., autoscaling, ingress, service mesh). Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -660,9 +708,11 @@ func (t *Toolsets) RegisterPEListTraits(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetTraitSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetTraitSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_trait_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_trait_schema",
+		Name: name,
 		Description: "Get the parameter schema for a trait. Returns the JSON schema showing the " +
 			"parameters developers can configure when using this trait.",
 		InputSchema: createSchema(map[string]any{
@@ -678,9 +728,11 @@ func (t *Toolsets) RegisterPEGetTraitSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_trait",
+		Name: name,
 		Description: "Get the full definition of a trait including its complete spec. " +
 			"Use this before updating a trait to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
@@ -696,9 +748,11 @@ func (t *Toolsets) RegisterPEGetTrait(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEListWorkflows(s *mcp.Server) {
+func (t *Toolsets) RegisterPEListWorkflows(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_workflows"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_workflows",
+		Name: name,
 		Description: "List all workflows in a namespace. Workflows are reusable templates that define " +
 			"automated processes such as CI/CD pipelines executed on the workflow plane. " +
 			"Use this to discover available workflow names for use with create_component or create_workflow_run. " +
@@ -717,9 +771,11 @@ func (t *Toolsets) RegisterPEListWorkflows(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetWorkflowSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetWorkflowSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workflow_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workflow_schema",
+		Name: name,
 		Description: "Get the parameter schema for a specific workflow. Use this to inspect what parameters " +
 			"a workflow accepts before configuring a component's workflow field or triggering a workflow run.",
 		InputSchema: createSchema(map[string]any{
@@ -735,9 +791,11 @@ func (t *Toolsets) RegisterPEGetWorkflowSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workflow",
+		Name: name,
 		Description: "Get the full definition of a workflow including its complete spec. " +
 			"Use this before updating a workflow to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
@@ -757,9 +815,11 @@ func (t *Toolsets) RegisterPEGetWorkflow(s *mcp.Server) {
 // PE Toolset — Diagnostics
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterGetResourceEvents(s *mcp.Server) {
+func (t *Toolsets) RegisterGetResourceEvents(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_resource_events"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_resource_events",
+		Name: name,
 		Description: "Get Kubernetes events for a specific resource in a deployment. Useful for diagnosing " +
 			"deployment issues, scheduling problems, or container startup failures.",
 		InputSchema: createSchema(map[string]any{
@@ -786,9 +846,11 @@ func (t *Toolsets) RegisterGetResourceEvents(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetResourceLogs(s *mcp.Server) {
+func (t *Toolsets) RegisterGetResourceLogs(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_resource_logs"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewLogs}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_resource_logs",
+		Name: name,
 		Description: "Get container logs from a specific pod in a deployment. Useful for debugging " +
 			"application errors, startup failures, and runtime issues.",
 		InputSchema: createSchema(map[string]any{
@@ -817,9 +879,11 @@ func (t *Toolsets) RegisterGetResourceLogs(s *mcp.Server) {
 // Deployment Toolset — Deployment pipelines (developer-facing read)
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterGetDeploymentPipeline(s *mcp.Server) {
+func (t *Toolsets) RegisterGetDeploymentPipeline(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_deployment_pipeline"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewDeploymentPipeline}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_deployment_pipeline",
+		Name: name,
 		Description: "Get detailed information about a deployment pipeline including its stages, promotion " +
 			"order, and associated environments.",
 		InputSchema: createSchema(map[string]any{
@@ -835,9 +899,11 @@ func (t *Toolsets) RegisterGetDeploymentPipeline(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListDeploymentPipelines(s *mcp.Server) {
+func (t *Toolsets) RegisterListDeploymentPipelines(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_deployment_pipelines"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewDeploymentPipeline}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_deployment_pipelines",
+		Name: name,
 		Description: "List all deployment pipelines in a namespace. Deployment pipelines define the promotion " +
 			"order between environments (e.g., dev → staging → production). Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -858,9 +924,11 @@ func (t *Toolsets) RegisterListDeploymentPipelines(s *mcp.Server) {
 // Deployment Toolset — Environments (developer-facing read)
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListEnvironments(s *mcp.Server) {
+func (t *Toolsets) RegisterListEnvironments(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_environments"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewEnvironment}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_environments",
+		Name: name,
 		Description: "List all environments in a namespace. Environments are deployment targets representing " +
 			"pipeline stages (dev, staging, production) or isolated tenants. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -881,9 +949,11 @@ func (t *Toolsets) RegisterListEnvironments(s *mcp.Server) {
 // Build Toolset — WorkflowRun operations
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterCreateWorkflowRun(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateWorkflowRun(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_workflow_run"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateWorkflowRun}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_workflow_run",
+		Name: name,
 		Description: "Create a new workflow run by specifying a workflow name and optional parameters. " +
 			"Workflows define automated processes like CI/CD pipelines that execute on the workflow plane.",
 		InputSchema: createSchema(map[string]any{
@@ -904,9 +974,11 @@ func (t *Toolsets) RegisterCreateWorkflowRun(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListWorkflowRuns(s *mcp.Server) {
+func (t *Toolsets) RegisterListWorkflowRuns(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_workflow_runs"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflowRun}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_workflow_runs",
+		Name: name,
 		Description: "List workflow runs in a namespace, optionally filtered by project and component. " +
 			"Shows execution history including status, timestamps, and workflow references. " +
 			"Supports pagination via limit and cursor.",
@@ -928,9 +1000,11 @@ func (t *Toolsets) RegisterListWorkflowRuns(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetWorkflowRun(s *mcp.Server) {
+func (t *Toolsets) RegisterGetWorkflowRun(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workflow_run"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflowRun}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workflow_run",
+		Name: name,
 		Description: "Get detailed information about a specific workflow run including its status, tasks, " +
 			"timestamps, and referenced resources.",
 		InputSchema: createSchema(map[string]any{
@@ -950,9 +1024,11 @@ func (t *Toolsets) RegisterGetWorkflowRun(s *mcp.Server) {
 // Build Toolset — Workflow read
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListWorkflows(s *mcp.Server) {
+func (t *Toolsets) RegisterListWorkflows(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_workflows"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_workflows",
+		Name: name,
 		Description: "List all workflows in a namespace. Workflows are reusable templates that define " +
 			"automated processes such as CI/CD pipelines executed on the workflow plane. " +
 			"Use this to discover available workflow names for use with create_component or create_workflow_run. " +
@@ -971,9 +1047,11 @@ func (t *Toolsets) RegisterListWorkflows(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetWorkflowSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetWorkflowSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_workflow_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_workflow_schema",
+		Name: name,
 		Description: "Get the parameter schema for a specific workflow. Use this to inspect what parameters " +
 			"a workflow accepts before configuring a component's workflow field or triggering a workflow run.",
 		InputSchema: createSchema(map[string]any{
@@ -993,9 +1071,11 @@ func (t *Toolsets) RegisterGetWorkflowSchema(s *mcp.Server) {
 // Build Toolset — Cluster-scoped workflows
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListClusterWorkflows(s *mcp.Server) {
+func (t *Toolsets) RegisterListClusterWorkflows(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_workflows"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_workflows",
+		Name: name,
 		Description: "List all cluster-scoped workflows. These are shared workflow definitions managed by platform " +
 			"admins that can be referenced by components across all namespaces via ClusterComponentType. " +
 			"Supports pagination via limit and cursor.",
@@ -1009,9 +1089,11 @@ func (t *Toolsets) RegisterListClusterWorkflows(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_workflow",
+		Name: name,
 		Description: "Get the full definition of a cluster-scoped workflow including its complete spec. " +
 			"Use this before updating a cluster workflow to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
@@ -1025,9 +1107,11 @@ func (t *Toolsets) RegisterGetClusterWorkflow(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterWorkflowSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterWorkflowSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_workflow_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_workflow_schema",
+		Name: name,
 		Description: "Get the schema definition for a cluster-scoped workflow. Returns the JSON schema " +
 			"showing workflow configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
@@ -1045,9 +1129,11 @@ func (t *Toolsets) RegisterGetClusterWorkflowSchema(s *mcp.Server) {
 // PE Toolset — Cluster-scoped platform standards
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterPEListClusterComponentTypes(s *mcp.Server) {
+func (t *Toolsets) RegisterPEListClusterComponentTypes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_component_types"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_component_types",
+		Name: name,
 		Description: "List all cluster-scoped component types. These are shared component type templates managed " +
 			"by platform admins that define the structure and capabilities of components across all namespaces. " +
 			"Supports pagination via limit and cursor.",
@@ -1061,9 +1147,11 @@ func (t *Toolsets) RegisterPEListClusterComponentTypes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetClusterComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetClusterComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_component_type",
+		Name: name,
 		Description: "Get the full definition of a cluster-scoped component type including its complete spec. " +
 			"Use this before updating a cluster component type to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
@@ -1077,9 +1165,11 @@ func (t *Toolsets) RegisterPEGetClusterComponentType(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetClusterComponentTypeSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetClusterComponentTypeSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_component_type_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_component_type_schema",
+		Name: name,
 		Description: "Get the schema definition for a cluster-scoped component type. Returns the JSON schema " +
 			"showing required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
@@ -1093,9 +1183,11 @@ func (t *Toolsets) RegisterPEGetClusterComponentTypeSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEListClusterTraits(s *mcp.Server) {
+func (t *Toolsets) RegisterPEListClusterTraits(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_traits"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_traits",
+		Name: name,
 		Description: "List all cluster-scoped traits. These are shared trait definitions managed by platform " +
 			"admins that add capabilities to components across all namespaces (e.g., autoscaling, ingress). " +
 			"Supports pagination via limit and cursor.",
@@ -1109,9 +1201,11 @@ func (t *Toolsets) RegisterPEListClusterTraits(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetClusterTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetClusterTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_trait",
+		Name: name,
 		Description: "Get the full definition of a cluster-scoped trait including its complete spec. " +
 			"Use this before updating a cluster trait to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
@@ -1125,9 +1219,11 @@ func (t *Toolsets) RegisterPEGetClusterTrait(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEGetClusterTraitSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterPEGetClusterTraitSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_trait_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_trait_schema",
+		Name: name,
 		Description: "Get the schema definition for a cluster-scoped trait. Returns the JSON schema " +
 			"showing trait configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
@@ -1145,9 +1241,11 @@ func (t *Toolsets) RegisterPEGetClusterTraitSchema(s *mcp.Server) {
 // Component Toolset — Platform standards (read-only, developer-facing)
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterListComponentTypes(s *mcp.Server) {
+func (t *Toolsets) RegisterListComponentTypes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_component_types"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_component_types",
+		Name: name,
 		Description: "List all available component types in a namespace. Component types define the " +
 			"structure and capabilities of components (e.g., WebApplication, Service, ScheduledTask). " +
 			"Supports pagination via limit and cursor.",
@@ -1165,9 +1263,11 @@ func (t *Toolsets) RegisterListComponentTypes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetComponentTypeSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetComponentTypeSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_type_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_type_schema",
+		Name: name,
 		Description: "Get the schema definition for a component type. Returns the JSON schema showing " +
 			"required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
@@ -1183,9 +1283,11 @@ func (t *Toolsets) RegisterGetComponentTypeSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListTraits(s *mcp.Server) {
+func (t *Toolsets) RegisterListTraits(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_traits"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_traits",
+		Name: name,
 		Description: "List all available traits in a namespace. Traits add capabilities to components " +
 			"(e.g., autoscaling, ingress, service mesh). Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -1202,9 +1304,11 @@ func (t *Toolsets) RegisterListTraits(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetTraitSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetTraitSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_trait_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_trait_schema",
+		Name: name,
 		Description: "Get the schema definition for a trait. Returns the JSON schema showing trait " +
 			"configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
@@ -1220,9 +1324,11 @@ func (t *Toolsets) RegisterGetTraitSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListClusterComponentTypes(s *mcp.Server) {
+func (t *Toolsets) RegisterListClusterComponentTypes(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_component_types"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_component_types",
+		Name: name,
 		Description: "List all cluster-scoped component types. These are shared component type templates managed " +
 			"by platform admins that define the structure and capabilities of components across all namespaces. " +
 			"Supports pagination via limit and cursor.",
@@ -1236,9 +1342,11 @@ func (t *Toolsets) RegisterListClusterComponentTypes(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_component_type",
+		Name: name,
 		Description: "Get detailed information about a cluster-scoped component type including workload type, " +
 			"allowed workflows, allowed traits, and description.",
 		InputSchema: createSchema(map[string]any{
@@ -1252,9 +1360,11 @@ func (t *Toolsets) RegisterGetClusterComponentType(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterComponentTypeSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterComponentTypeSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_component_type_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_component_type_schema",
+		Name: name,
 		Description: "Get the schema definition for a cluster-scoped component type. Returns the JSON schema " +
 			"showing required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
@@ -1268,9 +1378,11 @@ func (t *Toolsets) RegisterGetClusterComponentTypeSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterListClusterTraits(s *mcp.Server) {
+func (t *Toolsets) RegisterListClusterTraits(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_cluster_traits"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_cluster_traits",
+		Name: name,
 		Description: "List all cluster-scoped traits. These are shared trait definitions managed by platform " +
 			"admins that add capabilities to components across all namespaces (e.g., autoscaling, ingress). " +
 			"Supports pagination via limit and cursor.",
@@ -1284,9 +1396,11 @@ func (t *Toolsets) RegisterListClusterTraits(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_trait",
+		Name: name,
 		Description: "Get detailed information about a cluster-scoped trait including its name, " +
 			"display name, and description.",
 		InputSchema: createSchema(map[string]any{
@@ -1300,9 +1414,11 @@ func (t *Toolsets) RegisterGetClusterTrait(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterTraitSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterTraitSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_trait_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_trait_schema",
+		Name: name,
 		Description: "Get the schema definition for a cluster-scoped trait. Returns the JSON schema " +
 			"showing trait configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
@@ -1321,9 +1437,11 @@ func (t *Toolsets) RegisterGetClusterTraitSchema(s *mcp.Server) {
 // ---------------------------------------------------------------------------
 
 //nolint:dupl
-func (t *Toolsets) RegisterUpdateDeploymentPipeline(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateDeploymentPipeline(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_deployment_pipeline"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateDeploymentPipeline}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_deployment_pipeline",
+		Name: name,
 		Description: "Update an existing deployment pipeline in a namespace. Allows modifying promotion paths " +
 			"between environments and approval requirements. Use list_environments to discover valid environment names.",
 		InputSchema: createSchema(map[string]any{
@@ -1359,9 +1477,11 @@ func (t *Toolsets) RegisterUpdateDeploymentPipeline(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteDeploymentPipeline(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteDeploymentPipeline(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_deployment_pipeline"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteDeploymentPipeline}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_deployment_pipeline",
+		Name:        name,
 		Description: "Delete a deployment pipeline from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1381,9 +1501,11 @@ func (t *Toolsets) RegisterDeleteDeploymentPipeline(s *mcp.Server) {
 // PE Toolset — Cluster-scoped plane read (Get additions)
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterGetClusterWorkflowPlane(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterWorkflowPlane(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_workflowplane"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterWorkflowPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_workflowplane",
+		Name: name,
 		Description: "Get detailed information about a cluster-scoped workflow plane including cluster details, " +
 			"health status, and agent connection state.",
 		InputSchema: createSchema(map[string]any{
@@ -1397,9 +1519,11 @@ func (t *Toolsets) RegisterGetClusterWorkflowPlane(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterObservabilityPlane(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterObservabilityPlane(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_observability_plane"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewClusterObservabilityPlane}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_observability_plane",
+		Name: name,
 		Description: "Get detailed information about a cluster-scoped observability plane including " +
 			"observer URL, health status, and agent connection state.",
 		InputSchema: createSchema(map[string]any{
@@ -1418,9 +1542,11 @@ func (t *Toolsets) RegisterGetClusterObservabilityPlane(s *mcp.Server) {
 // PE Toolset — Component type creation schema tools
 // ---------------------------------------------------------------------------
 
-func (t *Toolsets) RegisterGetComponentTypeCreationSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetComponentTypeCreationSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_component_type_creation_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_component_type_creation_schema",
+		Name: name,
 		Description: "Get the spec schema for creating a namespace-scoped component type. " +
 			"Returns the full JSON schema showing all required and optional fields, their types, " +
 			"and descriptions. Call this before create_component_type to understand the spec structure.",
@@ -1431,9 +1557,11 @@ func (t *Toolsets) RegisterGetComponentTypeCreationSchema(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterGetClusterComponentTypeCreationSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetClusterComponentTypeCreationSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_cluster_component_type_creation_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_cluster_component_type_creation_schema",
+		Name: name,
 		Description: "Get the spec schema for creating a cluster-scoped component type. " +
 			"Returns the full JSON schema showing all required and optional fields, their types, " +
 			"and descriptions. Call this before create_cluster_component_type to understand the spec structure.",
@@ -1444,9 +1572,11 @@ func (t *Toolsets) RegisterGetClusterComponentTypeCreationSchema(s *mcp.Server) 
 	})
 }
 
-func (t *Toolsets) RegisterGetTraitCreationSchema(s *mcp.Server) {
+func (t *Toolsets) RegisterGetTraitCreationSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_trait_creation_schema"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_trait_creation_schema",
+		Name: name,
 		Description: "Get the spec schema for creating a namespace-scoped trait. " +
 			"Returns the full JSON schema showing all required and optional fields, their types, " +
 			"and descriptions. Call this before create_trait to understand the spec structure.",
@@ -1462,9 +1592,11 @@ func (t *Toolsets) RegisterGetTraitCreationSchema(s *mcp.Server) {
 // ---------------------------------------------------------------------------
 
 //nolint:dupl // create/update component type handlers share similar structure
-func (t *Toolsets) RegisterCreateComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_component_type",
+		Name: name,
 		Description: "Create a new component type in a namespace. Component types define the structure, " +
 			"workload type, allowed traits, and allowed workflows for components.",
 		InputSchema: createSchema(map[string]any{
@@ -1502,9 +1634,11 @@ func (t *Toolsets) RegisterCreateComponentType(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update component type handlers share similar structure
-func (t *Toolsets) RegisterUpdateComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_component_type",
+		Name:        name,
 		Description: "Update an existing component type in a namespace (full replacement).",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1542,9 +1676,11 @@ func (t *Toolsets) RegisterUpdateComponentType(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_component_type",
+		Name:        name,
 		Description: "Delete a component type from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1561,9 +1697,11 @@ func (t *Toolsets) RegisterDeleteComponentType(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update trait handlers share similar structure
-func (t *Toolsets) RegisterCreateTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_trait",
+		Name: name,
 		Description: "Create a new trait in a namespace. Traits add capabilities to components by creating " +
 			"additional Kubernetes resources or patching existing ones (e.g., autoscaling, ingress, service mesh).",
 		InputSchema: createSchema(map[string]any{
@@ -1601,9 +1739,11 @@ func (t *Toolsets) RegisterCreateTrait(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update trait handlers share similar structure
-func (t *Toolsets) RegisterUpdateTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_trait",
+		Name:        name,
 		Description: "Update an existing trait in a namespace (full replacement).",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1640,9 +1780,11 @@ func (t *Toolsets) RegisterUpdateTrait(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_trait",
+		Name:        name,
 		Description: "Delete a trait from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1658,9 +1800,11 @@ func (t *Toolsets) RegisterDeleteTrait(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update workflow handlers share similar structure
-func (t *Toolsets) RegisterPECreateWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterPECreateWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_workflow",
+		Name: name,
 		Description: "Create a new workflow in a namespace. Workflows are reusable CI/CD pipeline templates " +
 			"that execute on the workflow plane.",
 		InputSchema: createSchema(map[string]any{
@@ -1699,9 +1843,11 @@ func (t *Toolsets) RegisterPECreateWorkflow(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update workflow handlers share similar structure
-func (t *Toolsets) RegisterPEUpdateWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterPEUpdateWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_workflow",
+		Name:        name,
 		Description: "Update an existing workflow in a namespace (full replacement).",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1738,9 +1884,11 @@ func (t *Toolsets) RegisterPEUpdateWorkflow(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterPEDeleteWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterPEDeleteWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_workflow",
+		Name:        name,
 		Description: "Delete a workflow from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
@@ -1760,9 +1908,11 @@ func (t *Toolsets) RegisterPEDeleteWorkflow(s *mcp.Server) {
 // ---------------------------------------------------------------------------
 
 //nolint:dupl // create/update cluster component type handlers share similar structure
-func (t *Toolsets) RegisterCreateClusterComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateClusterComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_cluster_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_cluster_component_type",
+		Name: name,
 		Description: "Create a new cluster-scoped component type. Cluster component types are the platform-wide " +
 			"golden path templates available to all namespaces.",
 		InputSchema: createSchema(map[string]any{
@@ -1808,9 +1958,11 @@ func (t *Toolsets) RegisterCreateClusterComponentType(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update cluster component type handlers share similar structure
-func (t *Toolsets) RegisterUpdateClusterComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateClusterComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_cluster_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_cluster_component_type",
+		Name:        name,
 		Description: "Update an existing cluster-scoped component type (full replacement).",
 		InputSchema: createSchema(map[string]any{
 			"name": stringProperty(
@@ -1856,9 +2008,11 @@ func (t *Toolsets) RegisterUpdateClusterComponentType(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteClusterComponentType(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteClusterComponentType(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_cluster_component_type"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteClusterComponentType}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_cluster_component_type",
+		Name:        name,
 		Description: "Delete a cluster-scoped component type.",
 		InputSchema: createSchema(map[string]any{
 			"cct_name": stringProperty(
@@ -1873,9 +2027,11 @@ func (t *Toolsets) RegisterDeleteClusterComponentType(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update cluster trait handlers share similar structure
-func (t *Toolsets) RegisterCreateClusterTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateClusterTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_cluster_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_cluster_trait",
+		Name: name,
 		Description: "Create a new cluster-scoped trait. Cluster traits are platform-wide capability definitions " +
 			"available to all namespaces (e.g., autoscaling, ingress, service mesh).",
 		InputSchema: createSchema(map[string]any{
@@ -1922,9 +2078,11 @@ func (t *Toolsets) RegisterCreateClusterTrait(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update cluster trait handlers share similar structure
-func (t *Toolsets) RegisterUpdateClusterTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateClusterTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_cluster_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_cluster_trait",
+		Name: name,
 		Description: "Update an existing cluster-scoped trait (full replacement). " +
 			"Use get_cluster_trait to retrieve the current definition first.",
 		InputSchema: createSchema(map[string]any{
@@ -1971,9 +2129,11 @@ func (t *Toolsets) RegisterUpdateClusterTrait(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteClusterTrait(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteClusterTrait(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_cluster_trait"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteClusterTrait}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_cluster_trait",
+		Name:        name,
 		Description: "Delete a cluster-scoped trait.",
 		InputSchema: createSchema(map[string]any{
 			"ct_name": stringProperty("Name of the cluster trait to delete. Use list_cluster_traits to discover valid names"),
@@ -1987,9 +2147,11 @@ func (t *Toolsets) RegisterDeleteClusterTrait(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update cluster workflow handlers share similar structure
-func (t *Toolsets) RegisterCreateClusterWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateClusterWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_cluster_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateClusterWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_cluster_workflow",
+		Name: name,
 		Description: "Create a new cluster-scoped workflow. Cluster workflows are platform-wide CI/CD pipeline " +
 			"templates available to all namespaces.",
 		InputSchema: createSchema(map[string]any{
@@ -2026,9 +2188,11 @@ func (t *Toolsets) RegisterCreateClusterWorkflow(s *mcp.Server) {
 }
 
 //nolint:dupl // create/update cluster workflow handlers share similar structure
-func (t *Toolsets) RegisterUpdateClusterWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterUpdateClusterWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_cluster_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateClusterWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_cluster_workflow",
+		Name: name,
 		Description: "Update an existing cluster-scoped workflow (full replacement). " +
 			"Use get_cluster_workflow to retrieve the current definition first.",
 		InputSchema: createSchema(map[string]any{
@@ -2065,9 +2229,11 @@ func (t *Toolsets) RegisterUpdateClusterWorkflow(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterDeleteClusterWorkflow(s *mcp.Server) {
+func (t *Toolsets) RegisterDeleteClusterWorkflow(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_cluster_workflow"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteClusterWorkflow}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_cluster_workflow",
+		Name:        name,
 		Description: "Delete a cluster-scoped workflow.",
 		InputSchema: createSchema(map[string]any{
 			"cwf_name": stringProperty(

--- a/pkg/mcp/tools/permissions_test.go
+++ b/pkg/mcp/tools/permissions_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+)
+
+// fullToolsets returns a Toolsets with all toolsets enabled using the shared mock handler.
+func fullToolsets() *Toolsets {
+	mockHandler := NewMockCoreToolsetHandler()
+	return &Toolsets{
+		NamespaceToolset:  mockHandler,
+		ProjectToolset:    mockHandler,
+		ComponentToolset:  mockHandler,
+		DeploymentToolset: mockHandler,
+		BuildToolset:      mockHandler,
+		PEToolset:         mockHandler,
+	}
+}
+
+// TestRegisteredToolsHavePermissions verifies that every tool registered by
+// Register() has a corresponding non-empty permission entry in the returned
+// perms map. This enforces that developers declare a permission when adding a tool.
+func TestRegisteredToolsHavePermissions(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	perms := fullToolsets().Register(server)
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("Failed to connect server: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect client: %v", err)
+	}
+	defer clientSession.Close()
+
+	toolsResult, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("Failed to list tools: %v", err)
+	}
+	if len(toolsResult.Tools) == 0 {
+		t.Fatal("Register() registered no tools on the server")
+	}
+
+	for _, tool := range toolsResult.Tools {
+		name := tool.Name
+		t.Run(name, func(t *testing.T) {
+			perm, ok := perms[name]
+			if !ok {
+				t.Errorf("tool %q has no entry in the perms map returned by Register()", name)
+				return
+			}
+			if perm.Action == "" {
+				t.Errorf("tool %q has an empty Action in its ToolPermission", name)
+			}
+			if perm.ToolName != name {
+				t.Errorf("tool %q: ToolPermission.ToolName=%q mismatch", name, perm.ToolName)
+			}
+		})
+	}
+}
+
+// TestRegisteredPermissionsHaveValidActions verifies that every action string in
+// the perms map returned by Register() is a real action defined in actions.go.
+// This prevents typos in action names from silently creating incorrect mappings.
+func TestRegisteredPermissionsHaveValidActions(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	perms := fullToolsets().Register(server)
+
+	validActions := make(map[string]bool)
+	for _, action := range authzcore.AllActions() {
+		validActions[action.Name] = true
+	}
+
+	for toolName, perm := range perms {
+		if !validActions[perm.Action] {
+			t.Errorf("tool %q uses action %q which is not defined in systemActions", toolName, perm.Action)
+		}
+	}
+}

--- a/pkg/mcp/tools/project.go
+++ b/pkg/mcp/tools/project.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
 
-func (t *Toolsets) RegisterListProjects(s *mcp.Server) {
+func (t *Toolsets) RegisterListProjects(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_projects"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewProject}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "list_projects",
+		Name: name,
 		Description: "List all projects in an namespace. Projects are logical groupings of related " +
 			"components that share deployment pipelines. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
@@ -30,9 +33,11 @@ func (t *Toolsets) RegisterListProjects(s *mcp.Server) {
 	})
 }
 
-func (t *Toolsets) RegisterCreateProject(s *mcp.Server) {
+func (t *Toolsets) RegisterCreateProject(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_project"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateProject}
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_project",
+		Name: name,
 		Description: "Create a new project in an namespace. Project names must be DNS-compatible " +
 			"(lowercase, alphanumeric, hyphens only, max 63 chars).",
 		InputSchema: createSchema(map[string]any{

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -173,40 +173,48 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 	}
 }
 
-func (t *Toolsets) Register(s *mcp.Server) {
+// Register registers all enabled tools with the MCP server and returns the
+// permissions map built as a side effect of registration. Each RegisterFunc
+// declares its required authz action by writing to the perms map, so the
+// returned map is always consistent with the set of registered tools.
+func (t *Toolsets) Register(s *mcp.Server) map[string]ToolPermission {
+	perms := make(map[string]ToolPermission)
+
 	if t.NamespaceToolset != nil {
 		for _, registerFunc := range t.namespaceToolRegistrations() {
-			registerFunc(s)
+			registerFunc(s, perms)
 		}
 	}
 
 	if t.ProjectToolset != nil {
 		for _, registerFunc := range t.projectToolRegistrations() {
-			registerFunc(s)
+			registerFunc(s, perms)
 		}
 	}
 
 	if t.ComponentToolset != nil {
 		for _, registerFunc := range t.componentToolRegistrations() {
-			registerFunc(s)
+			registerFunc(s, perms)
 		}
 	}
 
 	if t.DeploymentToolset != nil {
 		for _, registerFunc := range t.deploymentToolRegistrations() {
-			registerFunc(s)
+			registerFunc(s, perms)
 		}
 	}
 
 	if t.BuildToolset != nil {
 		for _, registerFunc := range t.buildToolRegistrations() {
-			registerFunc(s)
+			registerFunc(s, perms)
 		}
 	}
 
 	if t.PEToolset != nil {
 		for _, registerFunc := range t.peToolRegistrations() {
-			registerFunc(s)
+			registerFunc(s, perms)
 		}
 	}
+
+	return perms
 }

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -178,10 +178,10 @@ type ComponentToolsetHandler interface {
 	ListWorkloads(ctx context.Context, namespaceName, componentName string) (any, error)
 	GetWorkload(ctx context.Context, namespaceName, workloadName string) (any, error)
 	CreateWorkload(
-		ctx context.Context, namespaceName, componentName string, workloadSpec interface{},
+		ctx context.Context, namespaceName, componentName string, workloadSpec any,
 	) (any, error)
 	UpdateWorkload(
-		ctx context.Context, namespaceName, workloadName string, workloadSpec interface{},
+		ctx context.Context, namespaceName, workloadName string, workloadSpec any,
 	) (any, error)
 	GetWorkloadSchema(ctx context.Context) (any, error)
 	GetComponentSchema(ctx context.Context, namespaceName, componentName string) (any, error)
@@ -235,7 +235,7 @@ type BuildToolsetHandler interface {
 	) (any, error)
 	CreateWorkflowRun(
 		ctx context.Context, namespaceName, workflowName string,
-		parameters map[string]interface{},
+		parameters map[string]any,
 	) (any, error)
 	ListWorkflowRuns(
 		ctx context.Context, namespaceName, projectName, componentName string,
@@ -249,5 +249,15 @@ type BuildToolsetHandler interface {
 	GetClusterWorkflowSchema(ctx context.Context, cwfName string) (any, error)
 }
 
-// RegisterFunc is a function type for registering MCP tools
-type RegisterFunc func(s *mcp.Server)
+// RegisterFunc is a function type for registering MCP tools.
+// Each RegisterFunc must declare its required permission by writing to the perms map.
+type RegisterFunc func(s *mcp.Server, perms map[string]ToolPermission)
+
+// ToolPermission associates an MCP tool with the authz action required to use it.
+// Action must be one of the action constants defined in internal/authz/core/actions.go.
+type ToolPermission struct {
+	// ToolName is the MCP tool name (first arg to mcp.AddTool).
+	ToolName string
+	// Action is the required authz action (e.g. "namespace:view", "component:create").
+	Action string
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds permission-based tool filtering middleware for the openchoreo controlplane MCP server.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2742

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)