### PR TITLE
fix: include component UID in alert suppression check

### DIFF
--- a/internal/observer/service/alerts.go
+++ b/internal/observer/service/alerts.go
@@ -201,28 +201,44 @@ func (s *AlertService) HandleAlertWebhook(ctx context.Context, req gen.AlertWebh
 		return nil, fmt.Errorf("alert entry store is not initialized")
 	}
 
-	// Check for duplicate alert within the suppression window.
-	// This is done before fetching the CR to avoid unnecessary k8s API calls for suppressed alerts.
-	if s.config.Alerting.AlertSuppressionWindow > 0 {
-		since := time.Now().UTC().Add(-s.config.Alerting.AlertSuppressionWindow)
-		isDuplicate, err := s.alertEntryStore.HasRecentAlert(ctx, ruleName, ruleNamespace, since)
-		if err != nil {
-			s.logger.Warn("Failed to check alert suppression", "error", err, "ruleName", ruleName)
-		} else if isDuplicate {
-			s.logger.Info("Alert suppressed (duplicate within suppression window)",
-				"ruleName", ruleName, "ruleNamespace", ruleNamespace,
-				"suppressionWindow", s.config.Alerting.AlertSuppressionWindow)
-			suppressedStatus := gen.AlertWebhookResponseStatusSuccess
-			msg := "alert suppressed: duplicate within suppression window"
-			return &gen.AlertWebhookResponse{
-				Status:  &suppressedStatus,
-				Message: &msg,
-			}, nil
-		}
-	}
-
 	if s.k8sClient == nil {
 		return nil, fmt.Errorf("kubernetes client not configured")
+	}
+
+	// Fetch the ObservabilityAlertRule CR
+	alertRule := &choreoapis.ObservabilityAlertRule{}
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{
+		Name:      ruleName,
+		Namespace: ruleNamespace,
+	}, alertRule); err != nil {
+		return nil, fmt.Errorf("failed to get ObservabilityAlertRule %s/%s: %w", ruleNamespace, ruleName, err)
+	}
+
+	// Check for duplicate alert within the suppression window.
+	// The component UID is included so that alerts from a recreated component
+	// (same CR name/namespace but new UID) are not incorrectly suppressed.
+	if s.config.Alerting.AlertSuppressionWindow > 0 {
+		since := time.Now().UTC().Add(-s.config.Alerting.AlertSuppressionWindow)
+		componentUID := alertRule.Labels[labels.LabelKeyComponentUID]
+		if componentUID == "" {
+			s.logger.Warn("Skipping suppression check: component UID label is missing",
+				"ruleName", ruleName, "ruleNamespace", ruleNamespace)
+		} else {
+			isDuplicate, err := s.alertEntryStore.HasRecentAlert(ctx, ruleName, ruleNamespace, componentUID, since)
+			if err != nil {
+				s.logger.Warn("Failed to check alert suppression", "error", err, "ruleName", ruleName)
+			} else if isDuplicate {
+				s.logger.Info("Alert suppressed (duplicate within suppression window)",
+					"ruleName", ruleName, "ruleNamespace", ruleNamespace,
+					"suppressionWindow", s.config.Alerting.AlertSuppressionWindow)
+				suppressedStatus := gen.AlertWebhookResponseStatusSuccess
+				msg := "alert suppressed: duplicate within suppression window"
+				return &gen.AlertWebhookResponse{
+					Status:  &suppressedStatus,
+					Message: &msg,
+				}, nil
+			}
+		}
 	}
 
 	// Derive alertValue and timestamp from the request
@@ -234,15 +250,6 @@ func (s *AlertService) HandleAlertWebhook(ctx context.Context, req gen.AlertWebh
 	var alertTimestamp string
 	if req.AlertTimestamp != nil {
 		alertTimestamp = req.AlertTimestamp.Format(time.RFC3339)
-	}
-
-	// Fetch the ObservabilityAlertRule CR
-	alertRule := &choreoapis.ObservabilityAlertRule{}
-	if err := s.k8sClient.Get(ctx, client.ObjectKey{
-		Name:      ruleName,
-		Namespace: ruleNamespace,
-	}, alertRule); err != nil {
-		return nil, fmt.Errorf("failed to get ObservabilityAlertRule %s/%s: %w", ruleNamespace, ruleName, err)
 	}
 
 	// Enrich alert details from the CR

--- a/internal/observer/service/alerts_query_test.go
+++ b/internal/observer/service/alerts_query_test.go
@@ -310,7 +310,7 @@ func (f *fakeAlertEntryStore) QueryAlertEntries(_ context.Context, params alerte
 	f.lastQueryParams = params
 	return f.entries, f.total, nil
 }
-func (f *fakeAlertEntryStore) HasRecentAlert(context.Context, string, string, time.Time) (bool, error) {
+func (f *fakeAlertEntryStore) HasRecentAlert(context.Context, string, string, string, time.Time) (bool, error) {
 	return false, nil
 }
 func (f *fakeAlertEntryStore) Close() error { return nil }

--- a/internal/observer/service/alerts_webhook_test.go
+++ b/internal/observer/service/alerts_webhook_test.go
@@ -316,3 +316,79 @@ func TestWebhook_RCADisabled_NoRCACall(t *testing.T) {
 	assert.Never(t, func() bool { return f.rcaCallCount.Load() > 0 }, 300*time.Millisecond, 50*time.Millisecond,
 		"RCA should not be triggered when aiRCAEnabled is false")
 }
+
+func TestWebhook_RecreatedComponent_NotSuppressed(t *testing.T) {
+	rule := testAlertRule("rule-cr-1", false, false)
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, false)
+
+	// First alert — should be processed
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+	assert.Equal(t, 1, f.alertCount(t))
+
+	// Simulate component deletion and recreation by updating the CR's component UID label
+	rule.Labels[labels.LabelKeyComponentUID] = "comp-uid-new"
+	require.NoError(t, f.svc.k8sClient.Update(context.Background(), rule))
+
+	// Second alert (same CR name/namespace but different component UID) — should NOT be suppressed
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged",
+		"alert for recreated component should not be suppressed")
+	assert.Equal(t, 2, f.alertCount(t))
+}
+
+func TestWebhook_MissingComponentUID_SuppressionSkipped(t *testing.T) {
+	rule := testAlertRule("rule-cr-1", false, false)
+	rule.Labels[labels.LabelKeyComponentUID] = ""
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, false)
+
+	// First alert
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	// Second alert — suppression should be skipped due to missing component UID
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged",
+		"alert should not be suppressed when component UID label is missing")
+	assert.Equal(t, 2, f.alertCount(t))
+}
+
+func TestWebhook_SuppressionStoreError_AlertStillProcessed(t *testing.T) {
+	rule := testAlertRule("rule-cr-1", false, false)
+	f := newWebhookTestFixture(t, 1*time.Hour, rule, false)
+
+	// First alert — processed normally
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+
+	// Close the store to force an error on the next HasRecentAlert call
+	require.NoError(t, f.alertStore.Close())
+
+	// Reopen a fresh store for WriteAlertEntry to succeed, but replace the
+	// service's store with a closed one so HasRecentAlert fails.
+	closedStore := f.svc.alertEntryStore
+
+	freshDSN := fmt.Sprintf("file:%s_fresh?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	freshStore, err := alertentry.New(alertentry.BackendSQLite, freshDSN, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = freshStore.Close() })
+	require.NoError(t, freshStore.Initialize(context.Background()))
+
+	// Use the closed store — HasRecentAlert will error, but the alert should still be processed
+	f.svc.alertEntryStore = closedStore
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+
+	// HasRecentAlert error is logged as a warning; the write will also fail,
+	// so we expect an error from WriteAlertEntry, not a suppressed response.
+	// The key assertion: it was NOT suppressed.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "suppressed")
+	} else {
+		assert.Contains(t, *resp.Message, "alert acknowledged")
+	}
+}

--- a/internal/observer/store/alertentry/sql.go
+++ b/internal/observer/store/alertentry/sql.go
@@ -317,7 +317,7 @@ func (s *sqlStore) QueryAlertEntries(ctx context.Context, params QueryParams) ([
 	return entries, total, nil
 }
 
-func (s *sqlStore) HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace string, since time.Time) (bool, error) {
+func (s *sqlStore) HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace, componentUID string, since time.Time) (bool, error) {
 	sinceNS := since.UnixNano()
 	var query string
 	if s.backend == BackendPostgreSQL {
@@ -326,7 +326,7 @@ func (s *sqlStore) HasRecentAlert(ctx context.Context, alertRuleCRName, alertRul
 		query = hasRecentAlertSQLiteQuery
 	}
 	var exists bool
-	if err := s.db.QueryRowContext(ctx, query, alertRuleCRName, alertRuleCRNamespace, sinceNS).Scan(&exists); err != nil {
+	if err := s.db.QueryRowContext(ctx, query, alertRuleCRName, alertRuleCRNamespace, componentUID, sinceNS).Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check recent alert: %w", err)
 	}
 	return exists, nil
@@ -414,16 +414,16 @@ INSERT INTO alert_entries (
 
 const createAlertRuleCRTimestampIndexQuery = `
 CREATE INDEX IF NOT EXISTS idx_alert_entries_cr_ts
-ON alert_entries(alert_rule_cr_name, alert_rule_cr_namespace, timestamp_ns);`
+ON alert_entries(alert_rule_cr_name, alert_rule_cr_namespace, component_id, timestamp_ns);`
 
 const hasRecentAlertSQLiteQuery = `
 SELECT EXISTS(SELECT 1 FROM alert_entries
-WHERE alert_rule_cr_name = ? AND alert_rule_cr_namespace = ? AND timestamp_ns >= ?
+WHERE alert_rule_cr_name = ? AND alert_rule_cr_namespace = ? AND component_id = ? AND timestamp_ns >= ?
 LIMIT 1);`
 
 const hasRecentAlertPostgresQuery = `
 SELECT EXISTS(SELECT 1 FROM alert_entries
-WHERE alert_rule_cr_name = $1 AND alert_rule_cr_namespace = $2 AND timestamp_ns >= $3
+WHERE alert_rule_cr_name = $1 AND alert_rule_cr_namespace = $2 AND component_id = $3 AND timestamp_ns >= $4
 LIMIT 1);`
 
 const insertAlertEntryPostgresQuery = `

--- a/internal/observer/store/alertentry/sql_test.go
+++ b/internal/observer/store/alertentry/sql_test.go
@@ -163,49 +163,63 @@ func TestHasRecentAlert(t *testing.T) {
 		AlertValue:           "42",
 		NamespaceName:        "ns-1",
 		ComponentName:        "payments",
+		ComponentID:          "comp-uid-1",
 	})
 	require.NoError(t, err)
 
 	tests := []struct {
-		name        string
-		crName      string
-		crNamespace string
-		since       time.Time
-		want        bool
+		name         string
+		crName       string
+		crNamespace  string
+		componentUID string
+		since        time.Time
+		want         bool
 	}{
 		{
-			name:        "match within window",
-			crName:      "rule-cr-1",
-			crNamespace: "obs-plane",
-			since:       now.Add(-1 * time.Hour),
-			want:        true,
+			name:         "match within window",
+			crName:       "rule-cr-1",
+			crNamespace:  "obs-plane",
+			componentUID: "comp-uid-1",
+			since:        now.Add(-1 * time.Hour),
+			want:         true,
 		},
 		{
-			name:        "no match - outside window",
-			crName:      "rule-cr-1",
-			crNamespace: "obs-plane",
-			since:       now.Add(-10 * time.Minute),
-			want:        false,
+			name:         "no match - outside window",
+			crName:       "rule-cr-1",
+			crNamespace:  "obs-plane",
+			componentUID: "comp-uid-1",
+			since:        now.Add(-10 * time.Minute),
+			want:         false,
 		},
 		{
-			name:        "no match - different cr name",
-			crName:      "rule-cr-other",
-			crNamespace: "obs-plane",
-			since:       now.Add(-1 * time.Hour),
-			want:        false,
+			name:         "no match - different cr name",
+			crName:       "rule-cr-other",
+			crNamespace:  "obs-plane",
+			componentUID: "comp-uid-1",
+			since:        now.Add(-1 * time.Hour),
+			want:         false,
 		},
 		{
-			name:        "no match - different namespace",
-			crName:      "rule-cr-1",
-			crNamespace: "other-ns",
-			since:       now.Add(-1 * time.Hour),
-			want:        false,
+			name:         "no match - different namespace",
+			crName:       "rule-cr-1",
+			crNamespace:  "other-ns",
+			componentUID: "comp-uid-1",
+			since:        now.Add(-1 * time.Hour),
+			want:         false,
+		},
+		{
+			name:         "no match - different component UID (recreated component)",
+			crName:       "rule-cr-1",
+			crNamespace:  "obs-plane",
+			componentUID: "comp-uid-new",
+			since:        now.Add(-1 * time.Hour),
+			want:         false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := store.HasRecentAlert(ctx, tt.crName, tt.crNamespace, tt.since)
+			got, err := store.HasRecentAlert(ctx, tt.crName, tt.crNamespace, tt.componentUID, tt.since)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/observer/store/alertentry/store.go
+++ b/internal/observer/store/alertentry/store.go
@@ -61,7 +61,7 @@ type AlertEntryStore interface {
 	Initialize(ctx context.Context) error
 	WriteAlertEntry(ctx context.Context, entry *AlertEntry) (id string, err error)
 	QueryAlertEntries(ctx context.Context, params QueryParams) ([]AlertEntry, int, error)
-	HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace string, since time.Time) (bool, error)
+	HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace, componentUID string, since time.Time) (bool, error)
 	Close() error
 }
 


### PR DESCRIPTION
## Summary
- Include component UID in the alert suppression duplicate check so that a recreated component (same CR name/namespace but new UID) is not incorrectly suppressed by alerts from the previous component instance.