### PR TITLE
fix: update op version in k3d obs plane quick install script

### DIFF
--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # -- versions (update these on release branches) --
 OPENCHOREO_REF="release-v1.0"
-OPENCHOREO_OP_VERSION="1.0.0"
+OPENCHOREO_OP_VERSION="1.0.1-hotfix.1"
 LOGS_OPENSEARCH_VERSION="0.3.11"
 TRACES_OPENSEARCH_VERSION="0.3.11"
 METRICS_PROMETHEUS_VERSION="0.2.5"


### PR DESCRIPTION
This pull request updates the version of the `OPENCHOREO_OP` component in the `k3d-observability-plane.sh` installation script to apply a hotfix release.

Version update:

* Bumped `OPENCHOREO_OP_VERSION` from `1.0.0` to `1.0.1-hotfix.1` in `install/k3d/k3d-observability-plane.sh` to include the latest hotfix.