### PR TITLE
chore(deps): bump go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openchoreo/openchoreo
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/casbin/casbin/v2 v2.135.0

--- a/tools/licenser/go.mod
+++ b/tools/licenser/go.mod
@@ -1,6 +1,6 @@
 module licenser
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/onsi/ginkgo/v2 v2.23.4


### PR DESCRIPTION
## Purpose

Bump the Go toolchain from 1.26.1 to 1.26.2 to pick up upstream stdlib and
compiler security fixes released on 2026-04-07.

Go 1.26.2 includes security fixes in `crypto/tls`, `crypto/x509`,
`html/template`, `archive/tar`, `os`, the `go` command, and the compiler
(including memory-safety issues). See the
[Go release notes](https://go.dev/doc/devel/release#go1.26.2).

## Approach

- Update `go` directive in `go.mod` from `1.26.1` to `1.26.2`
- Update `go` directive in `tools/licenser/go.mod` from `1.26.1` to `1.26.2`
- `go mod tidy` reports no dependency drift in either module
- `go build ./...` passes in both modules under `go1.26.2`
- CI picks up the new version automatically via `go-version-file: go.mod`
  in `.github/actions/setup-go/action.yml`

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)