### PR TITLE
feat(helm): add extraVolumes, extraVolumeMounts, extraArgs and appConfig to backstage values

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -58,6 +58,13 @@ spec:
         - "--config"
         - "app-config.csp.yaml"
         {{- end }}
+        {{- if .Values.backstage.appConfig }}
+        - "--config"
+        - "app-config.extra.yaml"
+        {{- end }}
+        {{- range .Values.backstage.extraArgs }}
+        - {{ . | quote }}
+        {{- end }}
         ports:
         - containerPort: 7007
           name: http
@@ -193,6 +200,15 @@ spec:
           subPath: app-config.csp.yaml
           readOnly: true
         {{- end }}
+        {{- if .Values.backstage.appConfig }}
+        - name: extra-app-config
+          mountPath: /app/app-config.extra.yaml
+          subPath: app-config.extra.yaml
+          readOnly: true
+        {{- end }}
+        {{- with .Values.backstage.extraVolumeMounts }}
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
       volumes:
       {{- if eq .Values.backstage.database.type "sqlite" }}
       - name: backstage-db
@@ -210,5 +226,13 @@ spec:
       - name: csp-config
         configMap:
           name: {{ include "openchoreo-control-plane.backstage.name" . }}-csp-config
+      {{- end }}
+      {{- if .Values.backstage.appConfig }}
+      - name: extra-app-config
+        configMap:
+          name: {{ include "openchoreo-control-plane.backstage.name" . }}-backstage-extra-config
+      {{- end }}
+      {{- with .Values.backstage.extraVolumes }}
+      {{- toYaml . | nindent 10 }}
       {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -230,7 +230,7 @@ spec:
       {{- if .Values.backstage.appConfig }}
       - name: extra-app-config
         configMap:
-          name: {{ include "openchoreo-control-plane.backstage.name" . }}-backstage-extra-config
+          name: {{ include "openchoreo-control-plane.backstage.name" . }}-extra-config
       {{- end }}
       {{- with .Values.backstage.extraVolumes }}
       {{- toYaml . | nindent 10 }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/extra-config-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/extra-config-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.backstage.enabled .Values.backstage.appConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openchoreo-control-plane.backstage.name" . }}-backstage-extra-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+data:
+  app-config.extra.yaml: |
+    {{- toYaml .Values.backstage.appConfig | nindent 4 }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/extra-config-configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/extra-config-configmap.yaml
@@ -2,10 +2,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "openchoreo-control-plane.backstage.name" . }}-backstage-extra-config
+  name: {{ include "openchoreo-control-plane.backstage.name" . }}-extra-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
 data:
   app-config.extra.yaml: |
     {{- toYaml .Values.backstage.appConfig | nindent 4 }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -946,6 +946,42 @@
           },
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "extraVolumes": {
+          "default": [],
+          "description": "Extra volumes to add to the Backstage Pod. Follows standard Kubernetes volume spec. Use in conjunction with extraVolumeMounts to mount them into the container.",
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "extraVolumes",
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "default": [],
+          "description": "Extra volume mounts to add to the Backstage container. Use in conjunction with extraVolumes.",
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "extraVolumeMounts",
+          "type": "array"
+        },
+        "extraArgs": {
+          "default": [],
+          "description": "Extra arguments appended to the Backstage node startup command after the built-in --config flags. Typically used to add additional --config <file> arguments for operator-provided app-config overlays.",
+          "items": {
+            "type": "string"
+          },
+          "title": "extraArgs",
+          "type": "array"
+        },
+        "appConfig": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Arbitrary Backstage app-config YAML injected as an additional config overlay. When non-empty the chart renders a ConfigMap named <release>-backstage-extra-config, mounts it at /app/app-config.extra.yaml, and appends --config app-config.extra.yaml to the startup args automatically.",
+          "title": "appConfig",
+          "type": "object"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -14,6 +14,14 @@
           "title": "affinity",
           "type": "object"
         },
+        "appConfig": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Arbitrary Backstage app-config YAML injected as an additional config overlay. When non-empty the chart renders a ConfigMap named \u003crelease\u003e-backstage-extra-config, mounts it at /app/app-config.extra.yaml, and appends --config app-config.extra.yaml to the startup args automatically. This is the preferred mechanism for operator-specific Backstage configuration (auth, integrations, etc.) without requiring a custom container image. WARNING: Do not store secrets here — this value is rendered into a ConfigMap (plaintext). Use Kubernetes Secrets or existing Secret refs (e.g. via extraEnv secretKeyRef) instead.\n",
+          "required": [],
+          "title": "appConfig",
+          "type": "object"
+        },
         "auth": {
           "additionalProperties": false,
           "description": "OAuth/OIDC authentication configuration",
@@ -394,6 +402,15 @@
           "title": "externalCI",
           "type": "object"
         },
+        "extraArgs": {
+          "default": [],
+          "description": "Extra arguments appended to the Backstage node startup command after the built-in --config flags. Typically used to add additional --config \u003cfile\u003e arguments for operator-provided app-config overlays.\n",
+          "items": {
+            "type": "string"
+          },
+          "title": "extraArgs",
+          "type": "array"
+        },
         "extraEnv": {
           "description": "Additional environment variables to merge with the default env array. Use this instead of overriding backstage.env to avoid sparse array issues with --set.",
           "items": {
@@ -411,6 +428,28 @@
             "type": "object"
           },
           "title": "extraEnv",
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "default": [],
+          "description": "Extra volume mounts to add to the Backstage container. Use in conjunction with extraVolumes.\n",
+          "items": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "title": "extraVolumeMounts",
+          "type": "array"
+        },
+        "extraVolumes": {
+          "default": [],
+          "description": "Extra volumes to add to the Backstage Pod. Follows standard Kubernetes volume spec. Use in conjunction with extraVolumeMounts to mount them into the container.\n",
+          "items": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "title": "extraVolumes",
           "type": "array"
         },
         "features": {
@@ -946,42 +985,6 @@
           },
           "title": "topologySpreadConstraints",
           "type": "array"
-        },
-        "extraVolumes": {
-          "default": [],
-          "description": "Extra volumes to add to the Backstage Pod. Follows standard Kubernetes volume spec. Use in conjunction with extraVolumeMounts to mount them into the container.",
-          "items": {
-            "additionalProperties": true,
-            "type": "object"
-          },
-          "title": "extraVolumes",
-          "type": "array"
-        },
-        "extraVolumeMounts": {
-          "default": [],
-          "description": "Extra volume mounts to add to the Backstage container. Use in conjunction with extraVolumes.",
-          "items": {
-            "additionalProperties": true,
-            "type": "object"
-          },
-          "title": "extraVolumeMounts",
-          "type": "array"
-        },
-        "extraArgs": {
-          "default": [],
-          "description": "Extra arguments appended to the Backstage node startup command after the built-in --config flags. Typically used to add additional --config <file> arguments for operator-provided app-config overlays.",
-          "items": {
-            "type": "string"
-          },
-          "title": "extraArgs",
-          "type": "array"
-        },
-        "appConfig": {
-          "additionalProperties": true,
-          "default": {},
-          "description": "Arbitrary Backstage app-config YAML injected as an additional config overlay. When non-empty the chart renders a ConfigMap named <release>-backstage-extra-config, mounts it at /app/app-config.extra.yaml, and appends --config app-config.extra.yaml to the startup args automatically.",
-          "title": "appConfig",
-          "type": "object"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2348,7 +2348,60 @@ backstage:
   #       description: Environment variable value
   # @schema
   extraEnv: []
+  # @schema
+  # type: array
+  # description: >
+  #   Extra volumes to add to the Backstage Pod. Follows standard Kubernetes
+  #   volume spec. Use in conjunction with extraVolumeMounts to mount them
+  #   into the container.
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # default: []
+  # @schema
+  extraVolumes: []
 
+  # @schema
+  # type: array
+  # description: >
+  #   Extra volume mounts to add to the Backstage container. Use in
+  #   conjunction with extraVolumes.
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # default: []
+  # @schema
+  extraVolumeMounts: []
+
+  # @schema
+  # type: array
+  # description: >
+  #   Extra arguments appended to the Backstage node startup command after
+  #   the built-in --config flags. Typically used to add additional
+  #   --config <file> arguments for operator-provided app-config overlays.
+  # items:
+  #   type: string
+  # default: []
+  # @schema
+  extraArgs: []
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: >
+  #   Arbitrary Backstage app-config YAML injected as an additional config
+  #   overlay. When non-empty the chart renders a ConfigMap named
+  #   <release>-backstage-extra-config, mounts it at
+  #   /app/app-config.extra.yaml, and appends --config app-config.extra.yaml
+  #   to the startup args automatically. This is the preferred mechanism for
+  #   operator-specific Backstage configuration (auth, integrations, etc.)
+  #   without requiring a custom container image.
+  #   WARNING: Do not store secrets here — this value is rendered into a
+  #   ConfigMap (plaintext). Use Kubernetes Secrets or existing Secret refs
+  #   (e.g. via extraEnv secretKeyRef) instead.
+  # default: {}
+  # @schema
+  appConfig: {}
   # @schema
   # type: string
   # description: Backstage public base URL


### PR DESCRIPTION
## Summary

Adds four new values to the `backstage:` section of the `openchoreo-control-plane` Helm
chart, following the pattern established by the official `backstage/backstage` chart:

| Value | Purpose |
|-------|---------|
| `backstage.extraVolumes` | Arbitrary pod volumes (default `[]`) |
| `backstage.extraVolumeMounts` | Corresponding container volume mounts (default `[]`) |
| `backstage.extraArgs` | Extra arguments appended to the node startup command (default `[]`) |
| `backstage.appConfig` | Inline app-config YAML overlay, auto-mounted and auto-wired (default `{}`) |

When `backstage.appConfig` is non-empty the chart:
1. Renders a ConfigMap named `<release>-backstage-extra-config` containing the YAML
2. Mounts it at `/app/app-config.extra.yaml`
3. Appends `--config app-config.extra.yaml` to the startup args

All four values default to empty — no existing deployment is affected unless an operator
explicitly sets one of them. The change is purely additive.

## Motivation

Operators need a GitOps-safe way to inject additional Backstage `app-config` overlays at
deploy time — for example, to configure `backend.auth.externalAccess` for external
service-to-service callers (such as the CAIPE rag-ingestor), or to add custom
integrations without building a custom container image.

Without these values the only workaround is direct Deployment patching via Kustomize on
top of the Helm release, which is brittle and makes the configuration invisible in Helm.

## Changes

- `install/helm/openchoreo-control-plane/values.yaml` — four new annotated entries after `extraEnv`
- `install/helm/openchoreo-control-plane/values.schema.json` — four new property definitions in `backstage.properties` (required by schema validation; matches the `@schema` annotations in values.yaml)
- `install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml` — three
  insertion points: args, volumeMounts, volumes
- `install/helm/openchoreo-control-plane/templates/backstage/extra-config-configmap.yaml` — new template

## Example usage

```yaml
backstage:
  extraEnv:
    - name: BACKSTAGE_INGESTOR_TOKEN
      valueFrom:
        secretKeyRef:
          name: backstage-secrets
          key: ingestor-token

  appConfig:
    backend:
      auth:
        externalAccess:
          - type: static
            options:
              token: ${BACKSTAGE_INGESTOR_TOKEN}
              subject: rag-ingestor
```

Closes #2973