### PR TITLE
fix(api): advertise OAuth scopes in WWW-Authenticate and protected-resource metadata

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -480,7 +481,7 @@ func initMCPMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 	}
 	resourceMetadataURL := observerBaseURL + "/.well-known/oauth-protected-resource"
 
-	return mcpmiddleware.Auth401Interceptor(resourceMetadataURL)
+	return mcpmiddleware.Auth401Interceptor(resourceMetadataURL, mcpOAuthScopes())
 }
 
 // oauthProtectedResourceMetadata returns a handler for OAuth 2.0 protected resource metadata
@@ -506,6 +507,23 @@ func oauthProtectedResourceMetadata(logger *slog.Logger) http.HandlerFunc {
 		AuthorizationServers: []string{
 			authServerBaseURL,
 		},
-		Logger: logger,
+		ScopesSupported: mcpOAuthScopes(),
+		Logger:          logger,
 	})
+}
+
+// mcpOAuthScopes returns the OAuth scopes to advertise for the MCP endpoint.
+// Operators can override via MCP_OAUTH_SCOPES (space-delimited) when an
+// authorization server's scopes_supported doesn't match what the app client
+// actually allows (see issue #3217).
+func mcpOAuthScopes() []string {
+	raw := os.Getenv(apiconfig.EnvMCPOAuthScopes)
+	if raw == "" {
+		return []string{"openid", "profile", "email"}
+	}
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return []string{"openid", "profile", "email"}
+	}
+	return fields
 }

--- a/cmd/openchoreo-api/config.yaml
+++ b/cmd/openchoreo-api/config.yaml
@@ -144,21 +144,22 @@ identity:
         - "profile"
         - "email"
 
+  # OAuth scopes advertised by the MCP endpoint via
+  # `.well-known/oauth-protected-resource` and the WWW-Authenticate header on
+  # 401 responses. MCP clients prefer this list over the authorization server's
+  # scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes
+  # that a specific app client doesn't allow). See issue #3217.
+  mcp_oauth_scopes:
+    - "openid"
+    - "profile"
+    - "email"
+
 secret_management:
   # Enable the Secret management API under
   # /api/v1alpha1/namespaces/{namespaceName}/secrets
   # (POST/PUT/GET/LIST/DELETE).
   # When false, all five endpoints return 501 Not Implemented.
   enabled: false
-  # OAuth scopes advertised by the MCP endpoint via
-  # `.well-known/oauth-protected-resource` and the WWW-Authenticate header on
-  # 401 responses. MCP clients prefer this list over the authorization server's
-  # scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes
-  # that a specific app client doesn't allow). See issue #3217.
-  scopes:
-    - "openid"
-    - "profile"
-    - "email"
 
 mcp:
   # Enable the Model Context Protocol (MCP) server.

--- a/cmd/openchoreo-api/config.yaml
+++ b/cmd/openchoreo-api/config.yaml
@@ -150,6 +150,15 @@ secret_management:
   # (POST/PUT/GET/LIST/DELETE).
   # When false, all five endpoints return 501 Not Implemented.
   enabled: false
+  # OAuth scopes advertised by the MCP endpoint via
+  # `.well-known/oauth-protected-resource` and the WWW-Authenticate header on
+  # 401 responses. MCP clients prefer this list over the authorization server's
+  # scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes
+  # that a specific app client doesn't allow). See issue #3217.
+  scopes:
+    - "openid"
+    - "profile"
+    - "email"
 
 mcp:
   # Enable the Model Context Protocol (MCP) server.

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -211,7 +211,7 @@ func main() {
 		// MCP middleware chain: logger → auth401 interceptor → JWT auth → handler
 		mcpLoggerMw := apilogger.LoggerMiddleware(mcpLogger)
 		resourceMetadataURL := cfg.Server.PublicURL + "/.well-known/oauth-protected-resource"
-		mcpAuth401Mw := mcpmiddleware.Auth401Interceptor(resourceMetadataURL, cfg.Identity.Scopes)
+		mcpAuth401Mw := mcpmiddleware.Auth401Interceptor(resourceMetadataURL, cfg.Identity.MCPOAuthScopes)
 		mcpHandler := middleware.Chain(mcpLoggerMw, mcpAuth401Mw, jwtMiddleware)(mcp.NewHTTPServer(toolsets, runtime.pdp))
 
 		baseMux.Handle("/mcp", mcpHandler)

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -211,7 +211,7 @@ func main() {
 		// MCP middleware chain: logger → auth401 interceptor → JWT auth → handler
 		mcpLoggerMw := apilogger.LoggerMiddleware(mcpLogger)
 		resourceMetadataURL := cfg.Server.PublicURL + "/.well-known/oauth-protected-resource"
-		mcpAuth401Mw := mcpmiddleware.Auth401Interceptor(resourceMetadataURL)
+		mcpAuth401Mw := mcpmiddleware.Auth401Interceptor(resourceMetadataURL, cfg.Identity.Scopes)
 		mcpHandler := middleware.Chain(mcpLoggerMw, mcpAuth401Mw, jwtMiddleware)(mcp.NewHTTPServer(toolsets, runtime.pdp))
 
 		baseMux.Handle("/mcp", mcpHandler)

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -54,6 +54,8 @@ data:
           scopes:
             {{- toYaml .scopes | nindent 12 }}
         {{- end }}
+      scopes:
+        {{- toYaml .Values.security.oidc.scopes | nindent 8 }}
 
     mcp:
       enabled: {{ .Values.openchoreoApi.config.mcp.enabled }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -54,8 +54,8 @@ data:
           scopes:
             {{- toYaml .scopes | nindent 12 }}
         {{- end }}
-      scopes:
-        {{- toYaml .Values.security.oidc.scopes | nindent 8 }}
+      mcp_oauth_scopes:
+        {{- toYaml .Values.security.oidc.mcpOAuthScopes | nindent 8 }}
 
     mcp:
       enabled: {{ .Values.openchoreoApi.config.mcp.enabled }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -4503,7 +4503,7 @@
               "title": "jwksUrlTlsInsecureSkipVerify",
               "type": "boolean"
             },
-            "scopes": {
+            "mcpOAuthScopes": {
               "description": "OAuth scopes advertised by the MCP endpoint via the protected-resource metadata (RFC 9728) and the WWW-Authenticate 401 challenge. MCP clients prefer this list over the authorization server's scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes).",
               "items": {
                 "anyOf": [
@@ -4519,7 +4519,7 @@
                 ],
                 "required": []
               },
-              "title": "scopes",
+              "title": "mcpOAuthScopes",
               "type": "array"
             },
             "tokenUrl": {

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -4503,6 +4503,25 @@
               "title": "jwksUrlTlsInsecureSkipVerify",
               "type": "boolean"
             },
+            "scopes": {
+              "description": "OAuth scopes advertised by the MCP endpoint via the protected-resource metadata (RFC 9728) and the WWW-Authenticate 401 challenge. MCP clients prefer this list over the authorization server's scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes).",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "scopes",
+              "type": "array"
+            },
             "tokenUrl": {
               "default": "http://thunder.openchoreo.invalid/oauth2/token",
               "description": "OIDC token endpoint URL",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -102,7 +102,7 @@ security:
     # type: array
     # description: OAuth scopes advertised by the MCP endpoint via the protected-resource metadata (RFC 9728) and the WWW-Authenticate 401 challenge. MCP clients prefer this list over the authorization server's scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes).
     # @schema
-    scopes:
+    mcpOAuthScopes:
       - "openid"
       - "profile"
       - "email"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -98,6 +98,15 @@ security:
           - "profile"
           - "email"
 
+    # @schema
+    # type: array
+    # description: OAuth scopes advertised by the MCP endpoint via the protected-resource metadata (RFC 9728) and the WWW-Authenticate 401 challenge. MCP clients prefer this list over the authorization server's scopes_supported, which can be over-broad (e.g. Cognito pool-level scopes).
+    # @schema
+    scopes:
+      - "openid"
+      - "profile"
+      - "email"
+
   # @schema
   # type: object
   # description: JWT token configuration

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -38,6 +38,9 @@ data:
   {{- if .Values.security.oidc.authServerBaseUrl }}
   AUTH_SERVER_BASE_URL: {{ .Values.security.oidc.authServerBaseUrl | quote }}
   {{- end }}
+  {{- if .Values.security.oidc.mcpOAuthScopes }}
+  MCP_OAUTH_SCOPES: {{ join " " .Values.security.oidc.mcpOAuthScopes | quote }}
+  {{- end }}
   {{- if .Values.observer.cors.allowedOrigins }}
   CORS_ALLOWED_ORIGINS: {{ join "," .Values.observer.cors.allowedOrigins | quote }}
   {{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1967,6 +1967,14 @@
               "title": "jwksUrlTlsInsecureSkipVerify",
               "type": "string"
             },
+            "mcpOAuthScopes": {
+              "description": "OAuth scopes advertised by the observer's MCP endpoint via the protected-resource metadata (RFC 9728) and WWW-Authenticate 401 challenge. Leave empty to use the default (openid profile email).",
+              "items": {
+                "required": []
+              },
+              "title": "mcpOAuthScopes",
+              "type": "array"
+            },
             "tokenUrl": {
               "default": "",
               "description": "OIDC token endpoint URL",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1201,6 +1201,11 @@ security:
     # default: ""
     # @schema
     authServerBaseUrl: ""
+    # @schema
+    # type: array
+    # description: OAuth scopes advertised by the observer's MCP endpoint via the protected-resource metadata (RFC 9728) and WWW-Authenticate 401 challenge. Leave empty to use the default (openid profile email).
+    # @schema
+    mcpOAuthScopes: []
   # @schema
   # type: object
   # description: JWT configuration

--- a/internal/openchoreo-api/api/handlers/oauth_metadata.go
+++ b/internal/openchoreo-api/api/handlers/oauth_metadata.go
@@ -32,7 +32,7 @@ func (h *Handler) GetOAuthProtectedResourceMetadata(
 	securityEnabled := h.Config.Security.Enabled
 	resource := strings.TrimSuffix(h.Config.Server.PublicURL, "/") + "/mcp"
 
-	scopesSupported := h.Config.Identity.Scopes
+	scopesSupported := h.Config.Identity.MCPOAuthScopes
 	if scopesSupported == nil {
 		scopesSupported = []string{}
 	}

--- a/internal/openchoreo-api/api/handlers/oauth_metadata.go
+++ b/internal/openchoreo-api/api/handlers/oauth_metadata.go
@@ -32,6 +32,11 @@ func (h *Handler) GetOAuthProtectedResourceMetadata(
 	securityEnabled := h.Config.Security.Enabled
 	resource := strings.TrimSuffix(h.Config.Server.PublicURL, "/") + "/mcp"
 
+	scopesSupported := h.Config.Identity.Scopes
+	if scopesSupported == nil {
+		scopesSupported = []string{}
+	}
+
 	response := gen.GetOAuthProtectedResourceMetadata200JSONResponse{
 		ResourceName:         "OpenChoreo MCP Server",
 		Resource:             resource,
@@ -39,7 +44,7 @@ func (h *Handler) GetOAuthProtectedResourceMetadata(
 		BearerMethodsSupported: []string{
 			"header",
 		},
-		ScopesSupported:           []string{},
+		ScopesSupported:           scopesSupported,
 		OpenchoreoSecurityEnabled: &securityEnabled,
 	}
 

--- a/internal/openchoreo-api/api/handlers/oauth_metadata_test.go
+++ b/internal/openchoreo-api/api/handlers/oauth_metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package handlers

--- a/internal/openchoreo-api/api/handlers/oauth_metadata_test.go
+++ b/internal/openchoreo-api/api/handlers/oauth_metadata_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
+)
+
+func TestGetOAuthProtectedResourceMetadata(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfgScopes  []string
+		wantScopes []string
+	}{
+		{
+			name:       "scopes from config are advertised",
+			cfgScopes:  []string{"openid", "profile", "email"},
+			wantScopes: []string{"openid", "profile", "email"},
+		},
+		{
+			name:       "nil config scopes yields empty list, never null",
+			cfgScopes:  nil,
+			wantScopes: []string{},
+		},
+		{
+			name:       "custom scope set is preserved in order",
+			cfgScopes:  []string{"api.read", "api.write"},
+			wantScopes: []string{"api.read", "api.write"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{
+				Config: &config.Config{
+					Server: config.ServerConfig{
+						PublicURL: "http://api.openchoreo.localhost",
+					},
+					Identity: config.IdentityConfig{
+						OIDC: config.OIDCConfig{
+							Issuer: "http://sts.openchoreo.localhost",
+						},
+						Scopes: tt.cfgScopes,
+					},
+				},
+			}
+
+			resp, err := h.GetOAuthProtectedResourceMetadata(
+				context.Background(),
+				gen.GetOAuthProtectedResourceMetadataRequestObject{},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			metadata, ok := resp.(gen.GetOAuthProtectedResourceMetadata200JSONResponse)
+			if !ok {
+				t.Fatalf("unexpected response type: %T", resp)
+			}
+
+			if metadata.Resource != "http://api.openchoreo.localhost/mcp" {
+				t.Errorf("Resource: got %q, want %q", metadata.Resource, "http://api.openchoreo.localhost/mcp")
+			}
+
+			if len(metadata.AuthorizationServers) != 1 || metadata.AuthorizationServers[0] != "http://sts.openchoreo.localhost" {
+				t.Errorf("AuthorizationServers: got %v, want [\"http://sts.openchoreo.localhost\"]", metadata.AuthorizationServers)
+			}
+
+			if len(metadata.ScopesSupported) != len(tt.wantScopes) {
+				t.Fatalf("ScopesSupported length: got %d, want %d", len(metadata.ScopesSupported), len(tt.wantScopes))
+			}
+			for i, scope := range tt.wantScopes {
+				if metadata.ScopesSupported[i] != scope {
+					t.Errorf("ScopesSupported[%d]: got %q, want %q", i, metadata.ScopesSupported[i], scope)
+				}
+			}
+
+			// The OpenAPI contract marks scopes_supported as required, so the
+			// field must serialize as [] rather than null when no scopes are
+			// configured. Asserting non-nil protects that JSON encoding.
+			if metadata.ScopesSupported == nil {
+				t.Error("ScopesSupported must not be nil (required field in RFC 9728 metadata)")
+			}
+		})
+	}
+}

--- a/internal/openchoreo-api/api/handlers/oauth_metadata_test.go
+++ b/internal/openchoreo-api/api/handlers/oauth_metadata_test.go
@@ -45,7 +45,7 @@ func TestGetOAuthProtectedResourceMetadata(t *testing.T) {
 						OIDC: config.OIDCConfig{
 							Issuer: "http://sts.openchoreo.localhost",
 						},
-						Scopes: tt.cfgScopes,
+						MCPOAuthScopes: tt.cfgScopes,
 					},
 				},
 			}

--- a/internal/openchoreo-api/config/env.go
+++ b/internal/openchoreo-api/config/env.go
@@ -23,6 +23,12 @@ const (
 	// EnvMCPToolsets is the comma-separated list of enabled MCP toolsets
 	EnvMCPToolsets = "MCP_TOOLSETS"
 
+	// EnvMCPOAuthScopes is the space-delimited list of OAuth scopes advertised
+	// in the MCP endpoint's protected-resource metadata and WWW-Authenticate
+	// challenge. Lets operators override the default so MCP clients don't fall
+	// back to the authorization server's (possibly over-broad) scopes_supported.
+	EnvMCPOAuthScopes = "MCP_OAUTH_SCOPES"
+
 	// EnvJWTDisabled is the flag to disable JWT authentication
 	EnvJWTDisabled = "JWT_DISABLED"
 

--- a/internal/openchoreo-api/config/identity.go
+++ b/internal/openchoreo-api/config/identity.go
@@ -14,6 +14,12 @@ type IdentityConfig struct {
 	// Clients defines OAuth client configurations for external integrations.
 	// Keys are client identifiers (e.g., "cli", "ci").
 	Clients map[string]ClientConfig `koanf:"clients"`
+	// Scopes is the list of OAuth scopes supported by this resource server.
+	// Advertised via the protected-resource metadata (RFC 9728) and the
+	// WWW-Authenticate header on 401 responses so MCP clients can pick a
+	// scope set without falling back to the authorization server's
+	// (potentially over-broad) scopes_supported.
+	Scopes []string `koanf:"scopes"`
 }
 
 // IdentityDefaults returns the default identity configuration.
@@ -21,6 +27,7 @@ func IdentityDefaults() IdentityConfig {
 	return IdentityConfig{
 		OIDC:    OIDCDefaults(),
 		Clients: nil,
+		Scopes:  []string{"openid", "profile", "email"},
 	}
 }
 

--- a/internal/openchoreo-api/config/identity.go
+++ b/internal/openchoreo-api/config/identity.go
@@ -14,20 +14,20 @@ type IdentityConfig struct {
 	// Clients defines OAuth client configurations for external integrations.
 	// Keys are client identifiers (e.g., "cli", "ci").
 	Clients map[string]ClientConfig `koanf:"clients"`
-	// Scopes is the list of OAuth scopes supported by this resource server.
-	// Advertised via the protected-resource metadata (RFC 9728) and the
-	// WWW-Authenticate header on 401 responses so MCP clients can pick a
+	// MCPOAuthScopes is the list of OAuth scopes advertised by the MCP
+	// endpoint. Advertised via the protected-resource metadata (RFC 9728) and
+	// the WWW-Authenticate header on 401 responses so MCP clients can pick a
 	// scope set without falling back to the authorization server's
 	// (potentially over-broad) scopes_supported.
-	Scopes []string `koanf:"scopes"`
+	MCPOAuthScopes []string `koanf:"mcp_oauth_scopes"`
 }
 
 // IdentityDefaults returns the default identity configuration.
 func IdentityDefaults() IdentityConfig {
 	return IdentityConfig{
-		OIDC:    OIDCDefaults(),
-		Clients: nil,
-		Scopes:  []string{"openid", "profile", "email"},
+		OIDC:           OIDCDefaults(),
+		Clients:        nil,
+		MCPOAuthScopes: []string{"openid", "profile", "email"},
 	}
 }
 

--- a/internal/server/middleware/mcp/auth401.go
+++ b/internal/server/middleware/mcp/auth401.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/openchoreo/openchoreo/internal/server/middleware"
 )
@@ -12,9 +13,9 @@ import (
 // responseWriter401Interceptor wraps http.ResponseWriter to intercept 401 status codes
 type responseWriter401Interceptor struct {
 	http.ResponseWriter
-	statusCode          int
-	headerWritten       bool
-	resourceMetadataURL string
+	statusCode      int
+	headerWritten   bool
+	challengeHeader string
 }
 
 // WriteHeader intercepts the status code and adds WWW-Authenticate header on 401
@@ -28,7 +29,7 @@ func (rw *responseWriter401Interceptor) WriteHeader(statusCode int) {
 
 	// Add WWW-Authenticate header if status is 401
 	if statusCode == http.StatusUnauthorized {
-		rw.ResponseWriter.Header().Set("WWW-Authenticate", "Bearer resource_metadata=\""+rw.resourceMetadataURL+"\"")
+		rw.ResponseWriter.Header().Set("WWW-Authenticate", rw.challengeHeader)
 	}
 
 	rw.ResponseWriter.WriteHeader(statusCode)
@@ -44,21 +45,38 @@ func (rw *responseWriter401Interceptor) Write(b []byte) (int, error) {
 	return rw.ResponseWriter.Write(b)
 }
 
-// Auth401Interceptor creates a middleware that adds WWW-Authenticate header on 401 responses
-// resourceMetadataURL is the URL to the OAuth protected resource metadata endpoint
-func Auth401Interceptor(resourceMetadataURL string) middleware.Middleware {
+// Auth401Interceptor creates a middleware that adds WWW-Authenticate header on 401 responses.
+// resourceMetadataURL is the URL to the OAuth protected resource metadata endpoint.
+// scopes is the space-delimited scope list advertised in the challenge so MCP clients
+// pick the resource's required scopes (MCP 2025-06-18 §Authorization scope selection)
+// instead of falling back to the authorization server's scopes_supported.
+func Auth401Interceptor(resourceMetadataURL string, scopes []string) middleware.Middleware {
+	challenge := buildChallengeHeader(resourceMetadataURL, scopes)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Wrap the response writer to intercept status codes
 			interceptor := &responseWriter401Interceptor{
-				ResponseWriter:      w,
-				statusCode:          http.StatusOK,
-				headerWritten:       false,
-				resourceMetadataURL: resourceMetadataURL,
+				ResponseWriter:  w,
+				statusCode:      http.StatusOK,
+				headerWritten:   false,
+				challengeHeader: challenge,
 			}
 
 			// Call the next handler with our wrapped response writer
 			next.ServeHTTP(interceptor, r)
 		})
 	}
+}
+
+func buildChallengeHeader(resourceMetadataURL string, scopes []string) string {
+	var b strings.Builder
+	b.WriteString(`Bearer resource_metadata="`)
+	b.WriteString(resourceMetadataURL)
+	b.WriteString(`"`)
+	if scope := strings.TrimSpace(strings.Join(scopes, " ")); scope != "" {
+		b.WriteString(`, scope="`)
+		b.WriteString(scope)
+		b.WriteString(`"`)
+	}
+	return b.String()
 }

--- a/internal/server/middleware/mcp/auth401_test.go
+++ b/internal/server/middleware/mcp/auth401_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 )
 
+const testResourceMetadataURL = "http://api.openchoreo.localhost/.well-known/oauth-protected-resource"
+
 func TestAuth401Interceptor(t *testing.T) {
-	resourceMetadataURL := "http://api.openchoreo.localhost/.well-known/oauth-protected-resource"
-	expectedHeader := "Bearer resource_metadata=\"http://api.openchoreo.localhost/.well-known/oauth-protected-resource\""
+	resourceMetadataURL := testResourceMetadataURL
+	scopes := []string{"openid", "profile", "email"}
+	expectedHeader := `Bearer resource_metadata="http://api.openchoreo.localhost/.well-known/oauth-protected-resource", scope="openid profile email"`
 
 	tests := []struct {
 		name             string
@@ -48,7 +51,7 @@ func TestAuth401Interceptor(t *testing.T) {
 			})
 
 			// Wrap the handler with the middleware
-			middleware := Auth401Interceptor(resourceMetadataURL)
+			middleware := Auth401Interceptor(resourceMetadataURL, scopes)
 			wrappedHandler := middleware(testHandler)
 
 			// Create a test request and response recorder
@@ -82,8 +85,9 @@ func TestAuth401Interceptor(t *testing.T) {
 }
 
 func TestAuth401Interceptor_WithWrite(t *testing.T) {
-	resourceMetadataURL := "http://api.openchoreo.localhost/.well-known/oauth-protected-resource"
-	expectedHeader := "Bearer resource_metadata=\"http://api.openchoreo.localhost/.well-known/oauth-protected-resource\""
+	resourceMetadataURL := testResourceMetadataURL
+	scopes := []string{"openid", "profile", "email"}
+	expectedHeader := `Bearer resource_metadata="http://api.openchoreo.localhost/.well-known/oauth-protected-resource", scope="openid profile email"`
 
 	// Test handler that writes without explicitly calling WriteHeader
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -91,7 +95,7 @@ func TestAuth401Interceptor_WithWrite(t *testing.T) {
 		_, _ = w.Write([]byte("OK"))
 	})
 
-	middleware := Auth401Interceptor(resourceMetadataURL)
+	middleware := Auth401Interceptor(resourceMetadataURL, scopes)
 	wrappedHandler := middleware(testHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -133,5 +137,37 @@ func TestAuth401Interceptor_WithWrite(t *testing.T) {
 	}
 	if wwwAuth401 != expectedHeader {
 		t.Errorf("expected WWW-Authenticate header to be %q, got %q", expectedHeader, wwwAuth401)
+	}
+}
+
+func TestAuth401Interceptor_NoScopes(t *testing.T) {
+	resourceMetadataURL := testResourceMetadataURL
+	expectedHeader := `Bearer resource_metadata="` + testResourceMetadataURL + `"`
+
+	tests := []struct {
+		name   string
+		scopes []string
+	}{
+		{name: "nil scopes", scopes: nil},
+		{name: "empty scopes", scopes: []string{}},
+		{name: "whitespace-only scopes", scopes: []string{"", "  "}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})
+
+			wrappedHandler := Auth401Interceptor(resourceMetadataURL, tt.scopes)(testHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rec := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("WWW-Authenticate"); got != expectedHeader {
+				t.Errorf("expected WWW-Authenticate header to be %q, got %q", expectedHeader, got)
+			}
+		})
 	}
 }

--- a/internal/server/oauth/metadata.go
+++ b/internal/server/oauth/metadata.go
@@ -34,14 +34,23 @@ type MetadataHandlerConfig struct {
 	ResourceName         string
 	ResourceURL          string
 	AuthorizationServers []string
-	Clients              []ClientInfo
-	SecurityEnabled      bool
-	Logger               *slog.Logger
+	// ScopesSupported is advertised as scopes_supported in the protected-resource
+	// metadata (RFC 9728). MCP clients prefer this list over the authorization
+	// server's scopes_supported — critical when the AS (e.g. Cognito) advertises
+	// pool-level scopes that a specific app client doesn't allow.
+	ScopesSupported []string
+	Clients         []ClientInfo
+	SecurityEnabled bool
+	Logger          *slog.Logger
 }
 
 // NewMetadataHandler creates an HTTP handler that serves OAuth 2.0 protected resource metadata
 func NewMetadataHandler(config MetadataHandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		scopesSupported := config.ScopesSupported
+		if scopesSupported == nil {
+			scopesSupported = []string{}
+		}
 		metadata := ProtectedResourceMetadata{
 			ResourceName:         config.ResourceName,
 			Resource:             config.ResourceURL,
@@ -49,7 +58,7 @@ func NewMetadataHandler(config MetadataHandlerConfig) http.HandlerFunc {
 			BearerMethodsSupported: []string{
 				"header",
 			},
-			ScopesSupported:           []string{},
+			ScopesSupported:           scopesSupported,
 			OpenChoreoClients:         config.Clients,
 			OpenChoreoSecurityEnabled: config.SecurityEnabled,
 		}

--- a/internal/server/oauth/metadata_test.go
+++ b/internal/server/oauth/metadata_test.go
@@ -83,6 +83,27 @@ func TestNewMetadataHandler(t *testing.T) {
 				OpenChoreoSecurityEnabled: true,
 			},
 		},
+		{
+			name: "metadata advertises configured scopes_supported",
+			config: MetadataHandlerConfig{
+				ResourceName: "OpenChoreo MCP Server",
+				ResourceURL:  "http://api.openchoreo.localhost/mcp",
+				AuthorizationServers: []string{
+					"http://sts.openchoreo.localhost",
+				},
+				ScopesSupported: []string{"openid", "profile", "email"},
+			},
+			want: ProtectedResourceMetadata{
+				ResourceName: "OpenChoreo MCP Server",
+				Resource:     "http://api.openchoreo.localhost/mcp",
+				AuthorizationServers: []string{
+					"http://sts.openchoreo.localhost",
+				},
+				BearerMethodsSupported:    []string{"header"},
+				ScopesSupported:           []string{"openid", "profile", "email"},
+				OpenChoreoSecurityEnabled: false,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Purpose

MCP clients select OAuth scopes from the `WWW-Authenticate` challenge or protected-resource metadata before falling back to the authorization server's full scope list. With AWS Cognito, the fallback includes pool-level scopes the app client does not allow, causing `/authorize` to fail with `invalid_scope`. This PR advertises the configured OAuth scopes in both the challenge header and the protected-resource metadata.

## Related Issues

https://github.com/openchoreo/openchoreo/issues/3217

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)