### PR TITLE
fix: enhance finalization logic for observability plane resources

### DIFF
--- a/internal/controller/renderedrelease/controller_finalize.go
+++ b/internal/controller/renderedrelease/controller_finalize.go
@@ -6,12 +6,13 @@ package renderedrelease
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -22,6 +23,8 @@ import (
 const (
 	// DataPlaneCleanupFinalizer is the finalizer that is used to clean up the data plane resources.
 	DataPlaneCleanupFinalizer = "openchoreo.dev/dataplane-cleanup"
+	// ObsPlaneCleanupFinalizer is the finalizer that is used to clean up the observability plane resources.
+	ObsPlaneCleanupFinalizer = "openchoreo.dev/obsplane-cleanup"
 )
 
 // ensureFinalizer ensures that the finalizer is added to the Release.
@@ -32,15 +35,28 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, release *openchoreov1a
 		return false, nil
 	}
 
-	if controllerutil.AddFinalizer(release, DataPlaneCleanupFinalizer) {
+	finalizer := DataPlaneCleanupFinalizer
+	if release.Spec.TargetPlane == targetPlaneObservabilityPlane {
+		finalizer = ObsPlaneCleanupFinalizer
+	}
+
+	if controllerutil.AddFinalizer(release, finalizer) {
 		return true, r.Update(ctx, release)
 	}
 
 	return false, nil
 }
 
-// finalize cleans up the target plane (dataplane or observabilityplane) resources associated with the Release.
+// finalize dispatches to the appropriate plane-specific cleanup based on targetPlane.
 func (r *Reconciler) finalize(ctx context.Context, old, release *openchoreov1alpha1.RenderedRelease) (ctrl.Result, error) {
+	if release.Spec.TargetPlane == targetPlaneObservabilityPlane {
+		return r.finalizeObsPlane(ctx, old, release)
+	}
+	return r.finalizeDataPlane(ctx, old, release)
+}
+
+// finalizeDataPlane cleans up the data plane resources associated with the Release.
+func (r *Reconciler) finalizeDataPlane(ctx context.Context, old, release *openchoreov1alpha1.RenderedRelease) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(release, DataPlaneCleanupFinalizer) {
 		// Nothing to do if the finalizer is not present
 		return ctrl.Result{}, nil
@@ -56,35 +72,14 @@ func (r *Reconciler) finalize(ctx context.Context, old, release *openchoreov1alp
 		return ctrl.Result{}, nil
 	}
 
-	// STEP 2: Get plane client (dataplane or observabilityplane) and find all managed resources
-	targetPlane := release.Spec.TargetPlane
-	if targetPlane == "" {
-		targetPlane = "dataplane" // Default to dataplane if not specified
-	}
-
-	var planeClient client.Client
-	var err error
-	switch targetPlane {
-	case "observabilityplane":
-		planeClient, err = r.getOPClient(ctx, release.Namespace, release.Spec.EnvironmentName)
-		if err != nil {
-			meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
-			if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
-				return ctrl.Result{}, updateErr
-			}
-			return ctrl.Result{}, fmt.Errorf("failed to get observability plane client for finalization: %w", err)
+	// STEP 2: Get data plane client
+	planeClient, err := r.getDPClient(ctx, release.Namespace, release.Spec.EnvironmentName)
+	if err != nil {
+		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
+		if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
+			return ctrl.Result{}, updateErr
 		}
-	case "dataplane":
-		fallthrough
-	default:
-		planeClient, err = r.getDPClient(ctx, release.Namespace, release.Spec.EnvironmentName)
-		if err != nil {
-			meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
-			if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
-				return ctrl.Result{}, updateErr
-			}
-			return ctrl.Result{}, fmt.Errorf("failed to get dataplane client for finalization: %w", err)
-		}
+		return ctrl.Result{}, fmt.Errorf("failed to get dataplane client for finalization: %w", err)
 	}
 
 	// STEP 3: List all live resources we manage (use empty desired resources since we want to delete everything)
@@ -123,4 +118,100 @@ func (r *Reconciler) finalize(ctx context.Context, old, release *openchoreov1alp
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// finalizeObsPlane cleans up the observability plane resources associated with the release.
+func (r *Reconciler) finalizeObsPlane(ctx context.Context, old, release *openchoreov1alpha1.RenderedRelease) (ctrl.Result, error) {
+	// For backward compatibility, obsplane releases created before this change may still carry
+	// DataPlaneCleanupFinalizer — fall back to it so those releases are not permanently stuck.
+	activeFinalizer := ObsPlaneCleanupFinalizer
+	if !controllerutil.ContainsFinalizer(release, ObsPlaneCleanupFinalizer) {
+		if !controllerutil.ContainsFinalizer(release, DataPlaneCleanupFinalizer) {
+			return ctrl.Result{}, nil
+		}
+		activeFinalizer = DataPlaneCleanupFinalizer
+	}
+
+	// STEP 1: Set finalizing status condition and return to persist it
+	if meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseFinalizingCondition(release.Generation)) {
+		if err := controller.UpdateStatusConditions(ctx, r.Client, old, release); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// STEP 2: Get observability plane client
+	planeClient, err := r.getOPClient(ctx, release.Namespace, release.Spec.EnvironmentName)
+	if err != nil {
+		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
+		if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get observability plane client for finalization: %w", err)
+	}
+
+	// STEP 3: List the obs-plane resource types managed by this release
+	releaseResourceGVKs := r.intersectObsPlaneGVKs(ctx, release)
+	liveResources, err := r.listLiveResourcesByGVKs(ctx, planeClient, release, releaseResourceGVKs)
+	if err != nil {
+		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
+		if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to list live resources for cleanup: %w", err)
+	}
+
+	// STEP 4: Delete all live resources
+	if err := r.deleteResources(ctx, planeClient, liveResources); err != nil {
+		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
+		if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to delete resources during finalization: %w", err)
+	}
+
+	// STEP 5: Check if any resources still exist - if so, requeue for retry
+	if len(liveResources) > 0 {
+		logger := log.FromContext(ctx).WithValues("release", release.Name)
+		logger.Info("Resource deletion is still pending, retrying...", "remainingResources", len(liveResources))
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	}
+
+	// STEP 6: All resources cleaned up - remove the finalizer
+	if controllerutil.RemoveFinalizer(release, activeFinalizer) {
+		if err := r.Update(ctx, release); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// intersectObsPlaneGVKs returns the subset of GVKs from the release status that are in the obs-plane allowlist.
+func (r *Reconciler) intersectObsPlaneGVKs(ctx context.Context, release *openchoreov1alpha1.RenderedRelease) []schema.GroupVersionKind {
+	// Narrow allowlist — broad cluster-scope listing would require excessive RBAC permissions
+	// for the cluster-agent service account in the observability plane.
+	var obsPlaneGVKs = []schema.GroupVersionKind{
+		{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
+	}
+
+	seen := make(map[schema.GroupVersionKind]bool)
+	var result []schema.GroupVersionKind
+	logger := log.FromContext(ctx).WithValues("release", release.Name)
+
+	for _, rs := range release.Status.Resources {
+		gvk := schema.GroupVersionKind{Group: rs.Group, Version: rs.Version, Kind: rs.Kind}
+		if seen[gvk] {
+			continue
+		}
+		seen[gvk] = true
+		if slices.Contains(obsPlaneGVKs, gvk) {
+			result = append(result, gvk)
+		} else {
+			logger.Error(fmt.Errorf("GVK not in obsPlaneGVKs allowlist"),
+				"resource will not be cleaned up during obs-plane finalization",
+				"group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
+		}
+	}
+	return result
 }

--- a/internal/controller/renderedrelease/controller_integration_test.go
+++ b/internal/controller/renderedrelease/controller_integration_test.go
@@ -34,15 +34,16 @@ const (
 	testInterval = 250 * time.Millisecond
 )
 
-// forceDelete removes the DataPlaneCleanupFinalizer from a RenderedRelease and deletes it.
+// forceDelete removes any known cleanup finalizers from a RenderedRelease and deletes it.
 // Safe to call even if the resource does not exist.
 func forceDelete(ctx context.Context, nn types.NamespacedName) {
 	r := &openchoreov1alpha1.RenderedRelease{}
 	if err := k8sClient.Get(ctx, nn, r); err != nil {
 		return
 	}
-	if controllerutil.ContainsFinalizer(r, DataPlaneCleanupFinalizer) {
-		controllerutil.RemoveFinalizer(r, DataPlaneCleanupFinalizer)
+	dpRemoved := controllerutil.RemoveFinalizer(r, DataPlaneCleanupFinalizer)
+	opRemoved := controllerutil.RemoveFinalizer(r, ObsPlaneCleanupFinalizer)
+	if dpRemoved || opRemoved {
 		_ = k8sClient.Update(ctx, r)
 	}
 	_ = k8sClient.Delete(ctx, r)
@@ -1201,6 +1202,171 @@ var _ = Describe("RenderedRelease Controller", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 
 			By("Second finalize reconcile: no live resources, removes finalizer")
+			mustReconcile(r, reconcileRequest(releaseName))
+
+			By("Verifying the RenderedRelease is fully deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, nn, &openchoreov1alpha1.RenderedRelease{})
+				return apierrors.IsNotFound(err)
+			}, testTimeout, testInterval).Should(BeTrue())
+		})
+	})
+
+	// ─────────────────────────────────────────────────────────────
+	// Finalization: obs-plane with ObsPlaneCleanupFinalizer, no live resources
+	// ─────────────────────────────────────────────────────────────
+
+	Context("Finalization with ObsPlaneCleanupFinalizer and no live obs-plane resources", func() {
+		const (
+			releaseName = "release-finalize-op-new"
+			envName     = "env-finalize-op-new"
+			cdpName     = "cdp-finalize-op-new"
+			copName     = "cop-finalize-op-new"
+			planeID     = "plane-finalize-op-new"
+			opPlaneID   = "obs-plane-finalize-op-new"
+		)
+		nn := types.NamespacedName{Name: releaseName, Namespace: testNs}
+		envNN := types.NamespacedName{Name: envName, Namespace: testNs}
+
+		AfterEach(func() {
+			forceDelete(ctx, nn)
+			forceDeleteEnvironment(ctx, envNN)
+			forceDeleteClusterDataPlane(ctx, cdpName)
+			forceDeleteClusterObservabilityPlane(ctx, copName)
+		})
+
+		It("sets Finalizing condition then removes ObsPlaneCleanupFinalizer when no resources exist", func() {
+			By("Creating prerequisite ClusterObservabilityPlane, ClusterDataPlane, and Environment")
+			Expect(k8sClient.Create(ctx, makeClusterObservabilityPlane(copName, opPlaneID))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeClusterDataPlaneWithOPRef(cdpName, planeID, copName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeEnvironment(envName, cdpName))).To(Succeed())
+
+			By("Creating a RenderedRelease targeting the observability plane with ObsPlaneCleanupFinalizer")
+			release := makeMinimalRelease(releaseName, envName)
+			release.Spec.TargetPlane = targetPlaneObservabilityPlane
+			release.Finalizers = []string{ObsPlaneCleanupFinalizer}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			By("Using an empty fake OP client (no live resources)")
+			dpClient := fake.NewClientBuilder().Build()
+			r := testReconcilerWithDPClient(dpClient, planeID, cdpName)
+
+			By("Deleting the release (sets DeletionTimestamp; finalizer blocks removal)")
+			Expect(k8sClient.Delete(ctx, release)).To(Succeed())
+			Eventually(func() bool {
+				updated := &openchoreov1alpha1.RenderedRelease{}
+				if err := k8sClient.Get(ctx, nn, updated); err != nil {
+					return false
+				}
+				return !updated.DeletionTimestamp.IsZero()
+			}, testTimeout, testInterval).Should(BeTrue())
+
+			By("First finalize reconcile: sets the Finalizing=True condition")
+			mustReconcile(r, reconcileRequest(releaseName))
+			updated := fetchRelease(releaseName)
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, string(ConditionFinalizing))
+			Expect(cond).NotTo(BeNil(), "Finalizing condition must be present")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(string(ReasonCleanupInProgress)))
+			Expect(updated.Finalizers).To(ContainElement(ObsPlaneCleanupFinalizer))
+
+			By("Second finalize reconcile: no live resources → removes ObsPlaneCleanupFinalizer")
+			mustReconcile(r, reconcileRequest(releaseName))
+
+			By("Verifying the RenderedRelease is fully deleted after finalizer removal")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, nn, &openchoreov1alpha1.RenderedRelease{})
+				return apierrors.IsNotFound(err)
+			}, testTimeout, testInterval).Should(BeTrue())
+		})
+	})
+
+	// ─────────────────────────────────────────────────────────────
+	// Finalization: obs-plane with live ObservabilityAlertRule resources
+	// ─────────────────────────────────────────────────────────────
+
+	Context("Finalization with live ObservabilityAlertRule resources in obs plane", func() {
+		const (
+			releaseName = "release-finalize-op-live"
+			envName     = "env-finalize-op-live"
+			cdpName     = "cdp-finalize-op-live"
+			copName     = "cop-finalize-op-live"
+			planeID     = "plane-finalize-op-live"
+			opPlaneID   = "obs-plane-finalize-op-live"
+		)
+		nn := types.NamespacedName{Name: releaseName, Namespace: testNs}
+		envNN := types.NamespacedName{Name: envName, Namespace: testNs}
+
+		AfterEach(func() {
+			forceDelete(ctx, nn)
+			forceDeleteEnvironment(ctx, envNN)
+			forceDeleteClusterDataPlane(ctx, cdpName)
+			forceDeleteClusterObservabilityPlane(ctx, copName)
+		})
+
+		It("deletes live ObservabilityAlertRule, requeues, then removes finalizer on next reconcile", func() {
+			By("Creating prerequisite ClusterObservabilityPlane, ClusterDataPlane, and Environment")
+			Expect(k8sClient.Create(ctx, makeClusterObservabilityPlane(copName, opPlaneID))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeClusterDataPlaneWithOPRef(cdpName, planeID, copName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeEnvironment(envName, cdpName))).To(Succeed())
+
+			By("Creating a RenderedRelease targeting the observability plane with ObsPlaneCleanupFinalizer")
+			release := makeMinimalRelease(releaseName, envName)
+			release.Spec.TargetPlane = targetPlaneObservabilityPlane
+			release.Finalizers = []string{ObsPlaneCleanupFinalizer}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			By("Re-fetching to get server-assigned UID for tracking labels")
+			fetched := fetchRelease(releaseName)
+
+			By("Setting status.resources to include an ObservabilityAlertRule entry")
+			fetched.Status.Resources = []openchoreov1alpha1.ResourceStatus{
+				{
+					ID:      "alert-rule-1",
+					Group:   "openchoreo.dev",
+					Version: "v1alpha1",
+					Kind:    "ObservabilityAlertRule",
+					Name:    "my-alert-rule",
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, fetched)).To(Succeed())
+
+			By("Re-fetching after status update to get consistent resource version")
+			fetched = fetchRelease(releaseName)
+
+			By("Creating a fake OP client with a live ObservabilityAlertRule that has tracking labels")
+			liveAlertRule := makeLabeledUnstructured(
+				"openchoreo.dev/v1alpha1", "ObservabilityAlertRule",
+				"", "my-alert-rule", "alert-rule-1", fetched)
+			opClient := fake.NewClientBuilder().
+				WithScheme(k8sClient.Scheme()).
+				WithObjects(liveAlertRule).
+				Build()
+			r := testReconcilerWithDPClient(opClient, planeID, cdpName)
+
+			By("Deleting the release (sets DeletionTimestamp)")
+			Expect(k8sClient.Delete(ctx, release)).To(Succeed())
+			Eventually(func() bool {
+				updated := &openchoreov1alpha1.RenderedRelease{}
+				if err := k8sClient.Get(ctx, nn, updated); err != nil {
+					return false
+				}
+				return !updated.DeletionTimestamp.IsZero()
+			}, testTimeout, testInterval).Should(BeTrue())
+
+			By("First finalize reconcile: sets the Finalizing condition")
+			mustReconcile(r, reconcileRequest(releaseName))
+
+			By("Second finalize reconcile: finds live ObservabilityAlertRule, deletes it, requeues")
+			result := mustReconcile(r, reconcileRequest(releaseName))
+			Expect(result.RequeueAfter).To(Equal(5*time.Second),
+				"should requeue after 5s while live obs-plane resources exist")
+
+			By("Verifying ObsPlaneCleanupFinalizer is still present (waiting for resource deletion)")
+			updated := fetchRelease(releaseName)
+			Expect(updated.Finalizers).To(ContainElement(ObsPlaneCleanupFinalizer))
+
+			By("Third finalize reconcile: no more live resources → removes finalizer")
 			mustReconcile(r, reconcileRequest(releaseName))
 
 			By("Verifying the RenderedRelease is fully deleted")

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/labels"
@@ -1417,6 +1419,204 @@ func TestBuildResourceStatusMixedResources(t *testing.T) {
 // ─────────────────────────────────────────────────────────────
 // extractDeploymentConditions
 // ─────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────
+// ensureFinalizer
+// ─────────────────────────────────────────────────────────────
+
+func TestEnsureFinalizer(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	makeRelease := func(targetPlane string, finalizers ...string) *openchoreov1alpha1.RenderedRelease {
+		return &openchoreov1alpha1.RenderedRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-release",
+				Namespace:  "default",
+				Finalizers: finalizers,
+			},
+			Spec: openchoreov1alpha1.RenderedReleaseSpec{TargetPlane: targetPlane},
+		}
+	}
+
+	t.Run("obs-plane release gets ObsPlaneCleanupFinalizer", func(t *testing.T) {
+		release := makeRelease(targetPlaneObservabilityPlane)
+		fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(release).Build()
+		r := &Reconciler{Client: fakeClient}
+
+		added, err := r.ensureFinalizer(context.Background(), release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !added {
+			t.Error("expected finalizer to be added")
+		}
+		if !controllerutil.ContainsFinalizer(release, ObsPlaneCleanupFinalizer) {
+			t.Errorf("expected %q on obs-plane release", ObsPlaneCleanupFinalizer)
+		}
+		if controllerutil.ContainsFinalizer(release, DataPlaneCleanupFinalizer) {
+			t.Errorf("unexpected %q on obs-plane release", DataPlaneCleanupFinalizer)
+		}
+	})
+
+	t.Run("empty targetPlane gets DataPlaneCleanupFinalizer", func(t *testing.T) {
+		release := makeRelease("")
+		fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(release).Build()
+		r := &Reconciler{Client: fakeClient}
+
+		added, err := r.ensureFinalizer(context.Background(), release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !added {
+			t.Error("expected finalizer to be added")
+		}
+		if !controllerutil.ContainsFinalizer(release, DataPlaneCleanupFinalizer) {
+			t.Errorf("expected %q on data-plane release", DataPlaneCleanupFinalizer)
+		}
+	})
+
+	t.Run("does not add finalizer when release is being deleted", func(t *testing.T) {
+		now := metav1.Now()
+		// DeletionTimestamp can only be set server-side; simulate by pre-setting a finalizer
+		// so the fake client accepts it, then set the timestamp manually on the in-memory object.
+		release := makeRelease(targetPlaneObservabilityPlane, "existing-finalizer")
+		release.DeletionTimestamp = &now
+		fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(release).Build()
+		r := &Reconciler{Client: fakeClient}
+
+		added, err := r.ensureFinalizer(context.Background(), release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if added {
+			t.Error("expected no finalizer added when release is being deleted")
+		}
+	})
+
+	t.Run("no-op when correct finalizer already present", func(t *testing.T) {
+		release := makeRelease(targetPlaneObservabilityPlane, ObsPlaneCleanupFinalizer)
+		fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(release).Build()
+		r := &Reconciler{Client: fakeClient}
+
+		added, err := r.ensureFinalizer(context.Background(), release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if added {
+			t.Error("expected no-op when finalizer already present")
+		}
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// finalizeObsPlane — no-finalizer fast path
+// ─────────────────────────────────────────────────────────────
+
+func TestFinalizeObsPlane_NoFinalizersIsNoOp(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	release := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-release", Namespace: "default"},
+		Spec:       openchoreov1alpha1.RenderedReleaseSpec{TargetPlane: targetPlaneObservabilityPlane},
+		// No Finalizers
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(release).Build()
+	r := &Reconciler{Client: fakeClient}
+
+	result, err := r.finalizeObsPlane(context.Background(), release, release)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Errorf("expected empty Result for no-op path, got Requeue=%v RequeueAfter=%v", result.Requeue, result.RequeueAfter)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// intersectObsPlaneGVKs
+// ─────────────────────────────────────────────────────────────
+
+func TestIntersectObsPlaneGVKs(t *testing.T) {
+	r := &Reconciler{}
+	ctx := context.Background()
+
+	t.Run("empty status resources returns empty", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{}
+		result := r.intersectObsPlaneGVKs(ctx, release)
+		if len(result) != 0 {
+			t.Errorf("expected 0 GVKs, got %d", len(result))
+		}
+	})
+
+	t.Run("status resource in allowlist is included", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{
+			Status: openchoreov1alpha1.RenderedReleaseStatus{
+				Resources: []openchoreov1alpha1.ResourceStatus{
+					{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
+				},
+			},
+		}
+		result := r.intersectObsPlaneGVKs(ctx, release)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 GVK, got %d", len(result))
+		}
+		if result[0].Kind != "ObservabilityAlertRule" {
+			t.Errorf("expected ObservabilityAlertRule, got %s", result[0].Kind)
+		}
+	})
+
+	t.Run("status resource not in allowlist is excluded", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{
+			Status: openchoreov1alpha1.RenderedReleaseStatus{
+				Resources: []openchoreov1alpha1.ResourceStatus{
+					{Group: "other.io", Version: "v1", Kind: "SomeOtherType"},
+				},
+			},
+		}
+		result := r.intersectObsPlaneGVKs(ctx, release)
+		if len(result) != 0 {
+			t.Errorf("expected 0 GVKs (non-allowlisted excluded), got %d", len(result))
+		}
+	})
+
+	t.Run("duplicate GVKs in status are deduplicated", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{
+			Status: openchoreov1alpha1.RenderedReleaseStatus{
+				Resources: []openchoreov1alpha1.ResourceStatus{
+					{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
+					{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
+				},
+			},
+		}
+		result := r.intersectObsPlaneGVKs(ctx, release)
+		if len(result) != 1 {
+			t.Errorf("expected 1 deduplicated GVK, got %d", len(result))
+		}
+	})
+
+	t.Run("mixed: allowlisted and non-allowlisted GVKs", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{
+			Status: openchoreov1alpha1.RenderedReleaseStatus{
+				Resources: []openchoreov1alpha1.ResourceStatus{
+					{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
+					{Group: "other.io", Version: "v1", Kind: "NotAllowlisted"},
+				},
+			},
+		}
+		result := r.intersectObsPlaneGVKs(ctx, release)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 GVK, got %d", len(result))
+		}
+		if result[0].Kind != "ObservabilityAlertRule" {
+			t.Errorf("expected ObservabilityAlertRule, got %s", result[0].Kind)
+		}
+	})
+}
 
 func TestExtractDeploymentConditions(t *testing.T) {
 	makeCondition := func(condType appsv1.DeploymentConditionType, status corev1.ConditionStatus, reason string) appsv1.DeploymentCondition {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request refactors and extends the finalization logic for `RenderedRelease` resources to support both data plane and observability plane cleanups. It introduces a new finalizer for observability plane resources, ensures backward compatibility, and separates the cleanup logic for each plane to improve maintainability and clarity.

**Support for Observability Plane Finalization:**

* Introduced a new finalizer constant `ObsPlaneCleanupFinalizer` and a list of supported GVKs (`obsPlaneGVKs`) for observability plane resource cleanup.

* Refactored the `ensureFinalizer` method to add the appropriate finalizer based on the target plane (`DataPlaneCleanupFinalizer` or `ObsPlaneCleanupFinalizer`).

* Split the `finalize` method into plane-specific cleanup functions: `finalizeDataPlane` for data plane resources and `finalizeObsPlane` for observability plane resources, dispatching based on the release's target plane. [[1]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L35-R65) [[2]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L59-R160)

**Cleanup Logic Improvements:**

* In both data plane and observability plane cleanup, the code now lists and deletes all managed resources, checks for pending deletions, and removes the appropriate finalizer only when all resources are cleaned up. [[1]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L59-R160) [[2]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L102-R169) [[3]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L119-R186)

* Added backward compatibility in `finalizeObsPlane` to handle releases that may still have the old data plane finalizer, preventing them from getting stuck.

**Other Technical Improvements:**

* Updated imports to include `schema` for working with GVKs and removed unused imports.

These changes improve the reliability and clarity of the finalization process for both data and observability planes, and ensure proper cleanup and status handling for `RenderedRelease` resources.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3212

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
