### PR TITLE
feat: add capability to observer to use a metrics adapter

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -22,7 +22,6 @@ import (
 	observermcp "github.com/openchoreo/openchoreo/internal/observer/mcp"
 	observermiddleware "github.com/openchoreo/openchoreo/internal/observer/middleware"
 	"github.com/openchoreo/openchoreo/internal/observer/opensearch"
-	"github.com/openchoreo/openchoreo/internal/observer/prometheus"
 	"github.com/openchoreo/openchoreo/internal/observer/service"
 	"github.com/openchoreo/openchoreo/internal/observer/store/alertentry"
 	"github.com/openchoreo/openchoreo/internal/observer/store/incidententry"
@@ -67,15 +66,22 @@ func main() {
 		log.Fatalf("Failed to initialize OpenSearch client: %v", err)
 	}
 
-	// Initialize Prometheus client
-	promClient, err := prometheus.NewClient(&cfg.Prometheus, logger)
-	if err != nil {
-		log.Fatalf("Failed to initialize Prometheus client: %v", err)
-	}
+	// Initialize resource UID resolver for name-to-UID resolution
+	uidResolver := service.NewResourceUIDResolver(&cfg.UIDResolver, logger.With("component", "resource-resolver"))
 
-	// Initialize Prometheus metrics service
-	// TODO: Remove this once the metrics adapter is implemented
-	promService := prometheus.NewMetricsService(promClient, logger)
+	// Initialize metrics adapter (always enabled, forwards metrics queries to external adapter)
+	metricsAdapter := service.NewMetricsAdapter(
+		cfg.Adapters.MetricsAdapterURL,
+		cfg.Adapters.MetricsAdapterTimeout,
+		uidResolver,
+		logger.With("component", "metrics-adapter"),
+	)
+	logger.Info("Metrics adapter initialized", "adapter_url", cfg.Adapters.MetricsAdapterURL)
+
+	// Initialize metrics adapter HTTP client for alert CRUD forwarding
+	metricsAdapterClient := &http.Client{
+		Timeout: cfg.Adapters.MetricsAdapterTimeout,
+	}
 
 	// Initialize logs adapter (optional)
 	var logsAdapter observability.LogsAdapter
@@ -132,9 +138,6 @@ func main() {
 	// Initialize HTTP server
 	mux := http.NewServeMux()
 
-	// Initialize resource UID resolver for name-to-UID resolution
-	uidResolver := service.NewResourceUIDResolver(&cfg.UIDResolver, logger.With("component", "resource-resolver"))
-
 	// Initialize logs service
 	logsService, logsServiceErr := service.NewLogsService(
 		logsAdapter, uidResolver, cfg, logger.With("component", "logs-service"),
@@ -144,14 +147,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize metrics service
-	metricsService, metricsServiceErr := service.NewMetricsService(
-		promService, uidResolver, logger.With("component", "metrics-service"),
-	)
-	if metricsServiceErr != nil {
-		logger.Error("Failed to initialize metrics service", "error", metricsServiceErr)
-		os.Exit(1)
-	}
+	// Use the metrics adapter as the MetricsQuerier (forwards to external metrics-adapter service)
+	var metricsService service.MetricsQuerier = metricsAdapter
 
 	// Initialize traces service
 	tracesService, tracesServiceErr := service.NewTracesService(
@@ -217,6 +214,8 @@ func main() {
 		cfg.Alerting.AIRCAEnabled,
 		uidResolver,
 		concreteLogsAdapter,
+		cfg.Adapters.MetricsAdapterURL,
+		metricsAdapterClient,
 	)
 
 	// Wrap services with authorization checks.

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -46,6 +46,9 @@ type AdaptersConfig struct {
 	TracingAdapterEnabled bool          `koanf:"tracing.adapter.enabled"`
 	TracingAdapterURL     string        `koanf:"tracing.adapter.url"`
 	TracingAdapterTimeout time.Duration `koanf:"tracing.adapter.timeout"`
+
+	MetricsAdapterURL     string        `koanf:"metrics.adapter.url"`
+	MetricsAdapterTimeout time.Duration `koanf:"metrics.adapter.timeout"`
 }
 
 // ServerConfig holds HTTP server configuration
@@ -223,6 +226,8 @@ func Load() (*Config, error) {
 		"TRACING_ADAPTER_ENABLED":               "adapters.tracing.adapter.enabled",
 		"TRACING_ADAPTER_URL":                   "adapters.tracing.adapter.url",
 		"TRACING_ADAPTER_TIMEOUT":               "adapters.tracing.adapter.timeout",
+		"METRICS_ADAPTER_URL":                   "adapters.metrics.adapter.url",
+		"METRICS_ADAPTER_TIMEOUT":               "adapters.metrics.adapter.timeout",
 		"UID_RESOLVER_OPENCHOREO_API_URL":       "uid_resolver.openchoreo.api.url",
 		"UID_RESOLVER_OAUTH_TOKEN_URL":          "uid_resolver.oauth.token.url",
 		"UID_RESOLVER_OAUTH_CLIENT_ID":          "uid_resolver.oauth.client.id",
@@ -339,7 +344,6 @@ func getDefaults() map[string]interface{} {
 			"legacy.pattern": "choreo*",
 		},
 		"prometheus": map[string]interface{}{
-			"address": "http://localhost:9090",
 			"timeout": "30s",
 		},
 		"auth": map[string]interface{}{
@@ -373,6 +377,8 @@ func getDefaults() map[string]interface{} {
 			"tracing.adapter.enabled": false,
 			"tracing.adapter.url":     "http://tracing-adapter:9100",
 			"tracing.adapter.timeout": "30s",
+			"metrics.adapter.url":     "http://metrics-adapter:9099",
+			"metrics.adapter.timeout": "30s",
 		},
 		"uid_resolver": map[string]interface{}{
 			"openchoreo.api.url":       "http://api.openchoreo.localhost:9099",
@@ -408,12 +414,10 @@ func (c *Config) validate() error {
 		return fmt.Errorf("opensearch timeout must be positive")
 	}
 
-	if c.Prometheus.Address == "" {
-		return fmt.Errorf("prometheus address is required")
-	}
-
-	if c.Prometheus.Timeout <= 0 {
-		return fmt.Errorf("prometheus timeout must be positive")
+	// Prometheus configuration is optional when using MetricsAdapter
+	// Only validate if Prometheus address is explicitly provided
+	if c.Prometheus.Address != "" && c.Prometheus.Timeout <= 0 {
+		return fmt.Errorf("prometheus timeout must be positive when prometheus address is set")
 	}
 
 	if c.Logging.MaxLogLimit <= 0 {
@@ -459,6 +463,17 @@ func (c *Config) validate() error {
 		}
 	default:
 		return fmt.Errorf("alert.store.backend must be 'sqlite' or 'postgresql'")
+	}
+
+	// Validate and normalize MetricsAdapter configuration
+	if c.Adapters.MetricsAdapterURL == "" {
+		return fmt.Errorf("metrics adapter URL is required")
+	}
+	// Strip trailing slash to prevent double slashes in client paths
+	c.Adapters.MetricsAdapterURL = strings.TrimRight(c.Adapters.MetricsAdapterURL, "/")
+
+	if c.Adapters.MetricsAdapterTimeout <= 0 {
+		return fmt.Errorf("metrics adapter timeout must be positive")
 	}
 
 	return nil

--- a/internal/observer/config/config_test.go
+++ b/internal/observer/config/config_test.go
@@ -269,6 +269,10 @@ func TestValidate(t *testing.T) {
 					OAuthClientSecret: "test-secret",
 					Timeout:           30 * time.Second,
 				},
+				Adapters: AdaptersConfig{
+					MetricsAdapterURL:     "http://localhost:9090",
+					MetricsAdapterTimeout: 30 * time.Second,
+				},
 			},
 			expectErr: false,
 		},
@@ -376,7 +380,7 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "missing prometheus address",
+			name: "prometheus address optional - empty is valid",
 			config: Config{
 				Server: ServerConfig{
 					Port:         8080,
@@ -393,8 +397,23 @@ func TestValidate(t *testing.T) {
 				Logging: LoggingConfig{
 					MaxLogLimit: 1000,
 				},
+				Authz: AuthzConfig{
+					ServiceURL: "http://localhost:8081",
+					Timeout:    30 * time.Second,
+				},
+				UIDResolver: UIDResolverConfig{
+					OpenChoreoAPIURL:  "http://localhost:9099",
+					OAuthTokenURL:     "http://localhost:8080/oauth2/token",
+					OAuthClientID:     "test-client",
+					OAuthClientSecret: "test-secret",
+					Timeout:           30 * time.Second,
+				},
+				Adapters: AdaptersConfig{
+					MetricsAdapterURL:     "http://localhost:9090",
+					MetricsAdapterTimeout: 30 * time.Second,
+				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			name: "invalid prometheus timeout",

--- a/internal/observer/service/alerts.go
+++ b/internal/observer/service/alerts.go
@@ -68,6 +68,9 @@ type AlertService struct {
 	aiRCAEnabled       bool
 	resolver           *ResourceUIDResolver
 	logsAdapter        *LogsAdapter
+
+	metricsAdapterURL    string
+	metricsAdapterClient *http.Client
 }
 
 // NewAlertService creates a new AlertService.
@@ -83,19 +86,23 @@ func NewAlertService(
 	aiRCAEnabled bool,
 	resolver *ResourceUIDResolver,
 	logsAdapter *LogsAdapter,
+	metricsAdapterURL string,
+	metricsAdapterClient *http.Client,
 ) *AlertService {
 	return &AlertService{
-		osClient:           osClient,
-		queryBuilder:       queryBuilder,
-		alertEntryStore:    alertEntryStore,
-		incidentEntryStore: incidentEntryStore,
-		k8sClient:          k8sClient,
-		config:             cfg,
-		logger:             logger,
-		rcaServiceURL:      rcaServiceURL,
-		aiRCAEnabled:       aiRCAEnabled,
-		resolver:           resolver,
-		logsAdapter:        logsAdapter,
+		osClient:             osClient,
+		queryBuilder:         queryBuilder,
+		alertEntryStore:      alertEntryStore,
+		incidentEntryStore:   incidentEntryStore,
+		k8sClient:            k8sClient,
+		config:               cfg,
+		logger:               logger,
+		rcaServiceURL:        rcaServiceURL,
+		aiRCAEnabled:         aiRCAEnabled,
+		resolver:             resolver,
+		logsAdapter:          logsAdapter,
+		metricsAdapterURL:    metricsAdapterURL,
+		metricsAdapterClient: metricsAdapterClient,
 	}
 }
 
@@ -118,6 +125,9 @@ func (s *AlertService) CreateAlertRule(ctx context.Context, req gen.AlertRuleReq
 		}
 		return s.createOpenSearchAlertRule(ctx, req)
 	case sourceTypeMetric:
+		if s.metricsAdapterClient != nil {
+			return s.createMetricAlertRuleViaAdapter(ctx, req)
+		}
 		return s.createPrometheusAlertRule(ctx, req)
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", sourceType)
@@ -135,6 +145,9 @@ func (s *AlertService) GetAlertRule(ctx context.Context, ruleName, sourceType st
 		}
 		return s.getOpenSearchAlertRule(ctx, ruleName)
 	case sourceTypeMetric:
+		if s.metricsAdapterClient != nil {
+			return s.getMetricAlertRuleViaAdapter(ctx, ruleName)
+		}
 		return s.getPrometheusAlertRule(ctx, ruleName)
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", sourceType)
@@ -160,6 +173,9 @@ func (s *AlertService) UpdateAlertRule(ctx context.Context, ruleName string, req
 		}
 		return s.updateOpenSearchAlertRule(ctx, ruleName, req)
 	case sourceTypeMetric:
+		if s.metricsAdapterClient != nil {
+			return s.updateMetricAlertRuleViaAdapter(ctx, ruleName, req)
+		}
 		return s.updatePrometheusAlertRule(ctx, ruleName, req)
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", sourceType)
@@ -177,6 +193,9 @@ func (s *AlertService) DeleteAlertRule(ctx context.Context, ruleName, sourceType
 		}
 		return s.deleteOpenSearchAlertRule(ctx, ruleName)
 	case sourceTypeMetric:
+		if s.metricsAdapterClient != nil {
+			return s.deleteMetricAlertRuleViaAdapter(ctx, ruleName)
+		}
 		return s.deletePrometheusAlertRule(ctx, ruleName)
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", sourceType)

--- a/internal/observer/service/alerts_adapter.go
+++ b/internal/observer/service/alerts_adapter.go
@@ -27,7 +27,7 @@ func (s *AlertService) createLogAlertRuleViaAdapter(ctx context.Context, req gen
 	}
 	defer resp.Body.Close()
 
-	if err := mapAdapterHTTPError(resp); err != nil {
+	if err := mapAdapterHTTPError(resp, "logs adapter"); err != nil {
 		return nil, err
 	}
 
@@ -42,7 +42,7 @@ func (s *AlertService) getLogAlertRuleViaAdapter(ctx context.Context, ruleName s
 	}
 	defer resp.Body.Close()
 
-	if err := mapAdapterHTTPError(resp); err != nil {
+	if err := mapAdapterHTTPError(resp, "logs adapter"); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func (s *AlertService) updateLogAlertRuleViaAdapter(ctx context.Context, ruleNam
 	}
 	defer resp.Body.Close()
 
-	if err := mapAdapterHTTPError(resp); err != nil {
+	if err := mapAdapterHTTPError(resp, "logs adapter"); err != nil {
 		return nil, err
 	}
 
@@ -77,7 +77,7 @@ func (s *AlertService) deleteLogAlertRuleViaAdapter(ctx context.Context, ruleNam
 	}
 	defer resp.Body.Close()
 
-	if err := mapAdapterHTTPError(resp); err != nil {
+	if err := mapAdapterHTTPError(resp, "logs adapter"); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func toAdapterAlertRuleRequest(req gen.AlertRuleRequest) (logsadapterclientgen.A
 
 // mapAdapterHTTPError maps adapter HTTP error responses to sentinel errors.
 // Returns nil for success status codes.
-func mapAdapterHTTPError(resp *http.Response) error {
+func mapAdapterHTTPError(resp *http.Response, adapterName string) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
@@ -116,7 +116,7 @@ func mapAdapterHTTPError(resp *http.Response) error {
 	case http.StatusConflict:
 		return fmt.Errorf("%w: adapter returned 409", ErrAlertRuleAlreadyExists)
 	default:
-		return fmt.Errorf("logs adapter returned HTTP %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("%s returned HTTP %d: %s", adapterName, resp.StatusCode, string(body))
 	}
 }
 

--- a/internal/observer/service/alerts_crud_test.go
+++ b/internal/observer/service/alerts_crud_test.go
@@ -25,6 +25,7 @@ import (
 const (
 	testNamespace = "ns-1"
 	testRuleName  = "rule-1"
+	testLogQuery  = "level=error"
 )
 
 // alreadyExistsOpenSearchClient returns exists=true from SearchMonitorByName,
@@ -40,7 +41,7 @@ func (c *alreadyExistsOpenSearchClient) SearchMonitorByName(_ context.Context, _
 
 // Helper to build a valid log alert request for CRUD tests.
 func newLogAlertRequest(ruleName string) gen.AlertRuleRequest {
-	query := "level=error"
+	query := testLogQuery
 
 	return gen.AlertRuleRequest{
 		//nolint:revive,staticcheck

--- a/internal/observer/service/alerts_metrics_adapter.go
+++ b/internal/observer/service/alerts_metrics_adapter.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+)
+
+// createMetricAlertRuleViaAdapter forwards a create-alert-rule request for metric alerts to the metrics adapter.
+func (s *AlertService) createMetricAlertRuleViaAdapter(ctx context.Context, req gen.AlertRuleRequest) (*gen.AlertingRuleSyncResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal alert rule request: %w", err)
+	}
+
+	url := s.metricsAdapterURL + "/api/v1alpha1/alerts/rules"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics adapter request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.metricsAdapterClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call metrics adapter create alert rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := mapAdapterHTTPError(resp, "metrics adapter"); err != nil {
+		return nil, err
+	}
+
+	return decodeAdapterSyncResponse(resp)
+}
+
+// getMetricAlertRuleViaAdapter forwards a get-alert-rule request for metric alerts to the metrics adapter.
+func (s *AlertService) getMetricAlertRuleViaAdapter(ctx context.Context, ruleName string) (*gen.AlertRuleResponse, error) {
+	url := s.metricsAdapterURL + "/api/v1alpha1/alerts/rules/" + ruleName
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics adapter request: %w", err)
+	}
+
+	resp, err := s.metricsAdapterClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call metrics adapter get alert rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := mapAdapterHTTPError(resp, "metrics adapter"); err != nil {
+		return nil, err
+	}
+
+	return decodeAdapterAlertRuleResponse(resp)
+}
+
+// updateMetricAlertRuleViaAdapter forwards an update-alert-rule request for metric alerts to the metrics adapter.
+func (s *AlertService) updateMetricAlertRuleViaAdapter(ctx context.Context, ruleName string, req gen.AlertRuleRequest) (*gen.AlertingRuleSyncResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal alert rule request: %w", err)
+	}
+
+	url := s.metricsAdapterURL + "/api/v1alpha1/alerts/rules/" + ruleName
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics adapter request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.metricsAdapterClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call metrics adapter update alert rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := mapAdapterHTTPError(resp, "metrics adapter"); err != nil {
+		return nil, err
+	}
+
+	return decodeAdapterSyncResponse(resp)
+}
+
+// deleteMetricAlertRuleViaAdapter forwards a delete-alert-rule request for metric alerts to the metrics adapter.
+func (s *AlertService) deleteMetricAlertRuleViaAdapter(ctx context.Context, ruleName string) (*gen.AlertingRuleSyncResponse, error) {
+	url := s.metricsAdapterURL + "/api/v1alpha1/alerts/rules/" + ruleName
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics adapter request: %w", err)
+	}
+
+	resp, err := s.metricsAdapterClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call metrics adapter delete alert rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := mapAdapterHTTPError(resp, "metrics adapter"); err != nil {
+		return nil, err
+	}
+
+	return decodeAdapterSyncResponse(resp)
+}

--- a/internal/observer/service/alerts_metrics_adapter_test.go
+++ b/internal/observer/service/alerts_metrics_adapter_test.go
@@ -1,0 +1,584 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	"github.com/openchoreo/openchoreo/internal/observer/config"
+	"github.com/openchoreo/openchoreo/internal/observer/opensearch"
+)
+
+const (
+	testMetricRuleName = "test-metric-rule"
+)
+
+func TestAlertService_MetricsAdapter_CreateAlertRule(t *testing.T) {
+	t.Parallel()
+
+	ruleName := testMetricRuleName
+	metricName := gen.AlertRuleRequestSourceMetric("cpu_usage")
+
+	metricAlertReq := gen.AlertRuleRequest{
+		Source: struct {
+			Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
+			Query  *string                           `json:"query,omitempty"`
+			Type   gen.AlertRuleRequestSourceType    `json:"type"`
+		}{
+			Type:   gen.AlertRuleRequestSourceTypeMetric,
+			Metric: &metricName,
+		},
+		//nolint:revive,staticcheck // field names match generated code
+		Metadata: struct {
+			ComponentUid   openapi_types.UUID `json:"componentUid"`
+			EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+			Name           string             `json:"name"`
+			Namespace      string             `json:"namespace"`
+			ProjectUid     openapi_types.UUID `json:"projectUid"`
+		}{
+			Name:      ruleName,
+			Namespace: "test-ns",
+		},
+		Condition: struct {
+			Enabled   bool                                  `json:"enabled"`
+			Interval  string                                `json:"interval"`
+			Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+			Threshold float32                               `json:"threshold"`
+			Window    string                                `json:"window"`
+		}{
+			Enabled:   true,
+			Interval:  "1m",
+			Operator:  gen.AlertRuleRequestConditionOperatorGt,
+			Threshold: float32(10),
+			Window:    "5m",
+		},
+	}
+
+	t.Run("routes to metrics adapter when client is set", func(t *testing.T) {
+		t.Parallel()
+
+		var adapterCalled atomic.Bool
+		var capturedRequest gen.AlertRuleRequest
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			adapterCalled.Store(true)
+
+			// Verify request
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/api/v1alpha1/alerts/rules", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			// Capture request body
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(body, &capturedRequest)
+			require.NoError(t, err)
+
+			// Return success response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			status := gen.AlertingRuleSyncResponseStatus("synced")
+			action := gen.AlertingRuleSyncResponseAction("created")
+			syncResp := gen.AlertingRuleSyncResponse{
+				Status:        &status,
+				Action:        &action,
+				RuleLogicalId: &ruleName,
+			}
+			err = json.NewEncoder(w).Encode(syncResp)
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		svc := &AlertService{
+			metricsAdapterURL:    server.URL,
+			metricsAdapterClient: server.Client(),
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		resp, err := svc.CreateAlertRule(context.Background(), metricAlertReq)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, adapterCalled.Load())
+		assert.Equal(t, ruleName, capturedRequest.Metadata.Name)
+		require.NotNil(t, capturedRequest.Source.Metric)
+		assert.Equal(t, metricName, *capturedRequest.Source.Metric)
+	})
+
+	t.Run("routes to prometheus when metrics adapter client is nil", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &AlertService{
+			metricsAdapterURL:    "http://should-not-be-called",
+			metricsAdapterClient: nil, // nil client should route to Prometheus
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		// This will fail because we haven't mocked Prometheus, but we're testing routing logic
+		_, err := svc.CreateAlertRule(context.Background(), metricAlertReq)
+
+		// We expect an error since Prometheus is not mocked, but the important thing is
+		// that it attempted the Prometheus path (not the adapter path)
+		require.Error(t, err)
+	})
+}
+
+func TestAlertService_MetricsAdapter_GetAlertRule(t *testing.T) {
+	t.Parallel()
+
+	ruleName := testMetricRuleName
+
+	t.Run("routes to metrics adapter when client is set", func(t *testing.T) {
+		t.Parallel()
+
+		var adapterCalled atomic.Bool
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			adapterCalled.Store(true)
+
+			// Verify request
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/v1alpha1/alerts/rules/"+ruleName, r.URL.Path)
+
+			// Return success response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			//nolint:revive,staticcheck // field names match generated code
+			ruleResp := gen.AlertRuleResponse{
+				Metadata: &struct {
+					ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
+					EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
+					Name           *string             `json:"name,omitempty"`
+					Namespace      *string             `json:"namespace,omitempty"`
+					ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+				}{
+					Name: &ruleName,
+				},
+			}
+			err := json.NewEncoder(w).Encode(ruleResp)
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		svc := &AlertService{
+			metricsAdapterURL:    server.URL,
+			metricsAdapterClient: server.Client(),
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		resp, err := svc.GetAlertRule(context.Background(), ruleName, sourceTypeMetric)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, adapterCalled.Load())
+		require.NotNil(t, resp.Metadata)
+		require.NotNil(t, resp.Metadata.Name)
+		assert.Equal(t, ruleName, *resp.Metadata.Name)
+	})
+
+	t.Run("routes to prometheus when metrics adapter client is nil", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &AlertService{
+			metricsAdapterURL:    "http://should-not-be-called",
+			metricsAdapterClient: nil,
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		_, err := svc.GetAlertRule(context.Background(), ruleName, sourceTypeMetric)
+
+		// Should attempt Prometheus path and fail (since not mocked)
+		require.Error(t, err)
+	})
+}
+
+func TestAlertService_MetricsAdapter_UpdateAlertRule(t *testing.T) {
+	t.Parallel()
+
+	ruleName := testMetricRuleName
+	metricName := gen.AlertRuleRequestSourceMetric("cpu_usage")
+
+	metricAlertReq := gen.AlertRuleRequest{
+		Source: struct {
+			Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
+			Query  *string                           `json:"query,omitempty"`
+			Type   gen.AlertRuleRequestSourceType    `json:"type"`
+		}{
+			Type:   gen.AlertRuleRequestSourceTypeMetric,
+			Metric: &metricName,
+		},
+		//nolint:revive,staticcheck // field names match generated code
+		Metadata: struct {
+			ComponentUid   openapi_types.UUID `json:"componentUid"`
+			EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+			Name           string             `json:"name"`
+			Namespace      string             `json:"namespace"`
+			ProjectUid     openapi_types.UUID `json:"projectUid"`
+		}{
+			Name:      ruleName,
+			Namespace: "test-ns",
+		},
+		Condition: struct {
+			Enabled   bool                                  `json:"enabled"`
+			Interval  string                                `json:"interval"`
+			Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+			Threshold float32                               `json:"threshold"`
+			Window    string                                `json:"window"`
+		}{
+			Enabled:   true,
+			Interval:  "1m",
+			Operator:  gen.AlertRuleRequestConditionOperatorGt,
+			Threshold: float32(20),
+			Window:    "5m",
+		},
+	}
+
+	t.Run("routes to metrics adapter when client is set", func(t *testing.T) {
+		t.Parallel()
+
+		var adapterCalled atomic.Bool
+		var capturedRequest gen.AlertRuleRequest
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			adapterCalled.Store(true)
+
+			// Verify request
+			assert.Equal(t, http.MethodPut, r.Method)
+			assert.Equal(t, "/api/v1alpha1/alerts/rules/"+ruleName, r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			// Capture request body
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(body, &capturedRequest)
+			require.NoError(t, err)
+
+			// Return success response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			status := gen.AlertingRuleSyncResponseStatus("synced")
+			action := gen.AlertingRuleSyncResponseAction("updated")
+			syncResp := gen.AlertingRuleSyncResponse{
+				Status:        &status,
+				Action:        &action,
+				RuleLogicalId: &ruleName,
+			}
+			err = json.NewEncoder(w).Encode(syncResp)
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		svc := &AlertService{
+			metricsAdapterURL:    server.URL,
+			metricsAdapterClient: server.Client(),
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		resp, err := svc.UpdateAlertRule(context.Background(), ruleName, metricAlertReq)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, adapterCalled.Load())
+		assert.Equal(t, float32(20), capturedRequest.Condition.Threshold)
+	})
+
+	t.Run("routes to prometheus when metrics adapter client is nil", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &AlertService{
+			metricsAdapterURL:    "http://should-not-be-called",
+			metricsAdapterClient: nil,
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		_, err := svc.UpdateAlertRule(context.Background(), ruleName, metricAlertReq)
+
+		// Should attempt Prometheus path and fail (since not mocked)
+		require.Error(t, err)
+	})
+}
+
+func TestAlertService_MetricsAdapter_DeleteAlertRule(t *testing.T) {
+	t.Parallel()
+
+	ruleName := testMetricRuleName
+
+	t.Run("routes to metrics adapter when client is set", func(t *testing.T) {
+		t.Parallel()
+
+		var adapterCalled atomic.Bool
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			adapterCalled.Store(true)
+
+			// Verify request
+			assert.Equal(t, http.MethodDelete, r.Method)
+			assert.Equal(t, "/api/v1alpha1/alerts/rules/"+ruleName, r.URL.Path)
+
+			// Return success response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			status := gen.AlertingRuleSyncResponseStatus("synced")
+			action := gen.AlertingRuleSyncResponseAction("deleted")
+			syncResp := gen.AlertingRuleSyncResponse{
+				Status:        &status,
+				Action:        &action,
+				RuleLogicalId: &ruleName,
+			}
+			err := json.NewEncoder(w).Encode(syncResp)
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		svc := &AlertService{
+			metricsAdapterURL:    server.URL,
+			metricsAdapterClient: server.Client(),
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		resp, err := svc.DeleteAlertRule(context.Background(), ruleName, sourceTypeMetric)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, adapterCalled.Load())
+	})
+
+	t.Run("routes to prometheus when metrics adapter client is nil", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &AlertService{
+			metricsAdapterURL:    "http://should-not-be-called",
+			metricsAdapterClient: nil,
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		_, err := svc.DeleteAlertRule(context.Background(), ruleName, sourceTypeMetric)
+
+		// Should attempt Prometheus path and fail (since not mocked)
+		require.Error(t, err)
+	})
+}
+
+func TestAlertService_MetricsAdapter_HTTPErrors(t *testing.T) {
+	t.Parallel()
+
+	ruleName := testMetricRuleName
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectedErr    error
+		expectedErrMsg string
+	}{
+		{
+			name:           "404 not found",
+			statusCode:     http.StatusNotFound,
+			responseBody:   `{"error": "rule not found"}`,
+			expectedErr:    ErrAlertRuleNotFound,
+			expectedErrMsg: "adapter returned 404",
+		},
+		{
+			name:           "409 conflict",
+			statusCode:     http.StatusConflict,
+			responseBody:   `{"error": "rule already exists"}`,
+			expectedErr:    ErrAlertRuleAlreadyExists,
+			expectedErrMsg: "adapter returned 409",
+		},
+		{
+			name:         "500 internal server error",
+			statusCode:   http.StatusInternalServerError,
+			responseBody: `{"error": "internal error"}`,
+			// No sentinel error for 500, just check the message
+			expectedErrMsg: "metrics adapter returned HTTP 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.responseBody))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			svc := &AlertService{
+				metricsAdapterURL:    server.URL,
+				metricsAdapterClient: server.Client(),
+				logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			// Test with Get operation
+			resp, err := svc.GetAlertRule(context.Background(), ruleName, sourceTypeMetric)
+
+			assert.Nil(t, resp)
+			require.Error(t, err)
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+			}
+			assert.Contains(t, err.Error(), tt.expectedErrMsg)
+		})
+	}
+}
+
+func TestAlertService_MetricsAdapterRouting_Integration(t *testing.T) {
+	t.Parallel()
+
+	ruleName := "integration-test-rule"
+	query := "level=error"
+
+	logAlertReq := gen.AlertRuleRequest{
+		Source: struct {
+			Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
+			Query  *string                           `json:"query,omitempty"`
+			Type   gen.AlertRuleRequestSourceType    `json:"type"`
+		}{
+			Type:  gen.AlertRuleRequestSourceTypeLog,
+			Query: &query,
+		},
+		//nolint:revive,staticcheck // field names match generated code
+		Metadata: struct {
+			ComponentUid   openapi_types.UUID `json:"componentUid"`
+			EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+			Name           string             `json:"name"`
+			Namespace      string             `json:"namespace"`
+			ProjectUid     openapi_types.UUID `json:"projectUid"`
+		}{
+			Name:      ruleName,
+			Namespace: "test-ns",
+		},
+		Condition: struct {
+			Enabled   bool                                  `json:"enabled"`
+			Interval  string                                `json:"interval"`
+			Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+			Threshold float32                               `json:"threshold"`
+			Window    string                                `json:"window"`
+		}{
+			Enabled:   true,
+			Interval:  "1m",
+			Operator:  gen.AlertRuleRequestConditionOperatorGt,
+			Threshold: float32(10),
+			Window:    "5m",
+		},
+	}
+
+	metricName := gen.AlertRuleRequestSourceMetric("cpu_usage")
+	metricAlertReq := gen.AlertRuleRequest{
+		Source: struct {
+			Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
+			Query  *string                           `json:"query,omitempty"`
+			Type   gen.AlertRuleRequestSourceType    `json:"type"`
+		}{
+			Type:   gen.AlertRuleRequestSourceTypeMetric,
+			Metric: &metricName,
+		},
+		//nolint:revive,staticcheck // field names match generated code
+		Metadata: struct {
+			ComponentUid   openapi_types.UUID `json:"componentUid"`
+			EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+			Name           string             `json:"name"`
+			Namespace      string             `json:"namespace"`
+			ProjectUid     openapi_types.UUID `json:"projectUid"`
+		}{
+			Name:      ruleName,
+			Namespace: "test-ns",
+		},
+		Condition: struct {
+			Enabled   bool                                  `json:"enabled"`
+			Interval  string                                `json:"interval"`
+			Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+			Threshold float32                               `json:"threshold"`
+			Window    string                                `json:"window"`
+		}{
+			Enabled:   true,
+			Interval:  "1m",
+			Operator:  gen.AlertRuleRequestConditionOperatorGt,
+			Threshold: float32(10),
+			Window:    "5m",
+		},
+	}
+
+	t.Run("log alerts do not use metrics adapter", func(t *testing.T) {
+		t.Parallel()
+
+		var metricsAdapterCalled atomic.Bool
+
+		metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metricsAdapterCalled.Store(true)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer metricsServer.Close()
+
+		osClient := &trackingOpenSearchClient{}
+
+		svc := &AlertService{
+			osClient:             osClient,
+			queryBuilder:         &opensearch.QueryBuilder{},
+			config:               &config.Config{},
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+			metricsAdapterURL:    metricsServer.URL,
+			metricsAdapterClient: metricsServer.Client(),
+		}
+
+		_, err := svc.CreateAlertRule(context.Background(), logAlertReq)
+
+		require.NoError(t, err)
+		assert.False(t, metricsAdapterCalled.Load(), "metrics adapter should not be called for log alerts")
+		assert.Greater(t, osClient.createCalled.Load(), int32(0), "OpenSearch should be called for log alerts")
+	})
+
+	t.Run("metric alerts use metrics adapter when available", func(t *testing.T) {
+		t.Parallel()
+
+		var metricsAdapterCalled atomic.Bool
+
+		metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metricsAdapterCalled.Store(true)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			status := gen.AlertingRuleSyncResponseStatus("synced")
+			action := gen.AlertingRuleSyncResponseAction("created")
+			syncResp := gen.AlertingRuleSyncResponse{
+				Status:        &status,
+				Action:        &action,
+				RuleLogicalId: &ruleName,
+			}
+			_ = json.NewEncoder(w).Encode(syncResp)
+		}))
+		defer metricsServer.Close()
+
+		osClient := &trackingOpenSearchClient{}
+
+		svc := &AlertService{
+			osClient:             osClient,
+			queryBuilder:         &opensearch.QueryBuilder{},
+			config:               &config.Config{},
+			logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+			metricsAdapterURL:    metricsServer.URL,
+			metricsAdapterClient: metricsServer.Client(),
+		}
+
+		_, err := svc.CreateAlertRule(context.Background(), metricAlertReq)
+
+		require.NoError(t, err)
+		assert.True(t, metricsAdapterCalled.Load(), "metrics adapter should be called for metric alerts")
+		assert.Equal(t, int32(0), osClient.createCalled.Load(), "OpenSearch should not be called when using metrics adapter")
+	})
+}

--- a/internal/observer/service/metrics_adapter.go
+++ b/internal/observer/service/metrics_adapter.go
@@ -1,0 +1,159 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// metricsAdapterRequest is the request payload sent to the external metrics adapter.
+// It uses the field names expected by the adapter's OpenAPI spec (componentUid, projectUid,
+// environmentUid) rather than the Observer's API field names (component, project, environment).
+type metricsAdapterRequest struct {
+	Metric      string                    `json:"metric"`
+	StartTime   string                    `json:"startTime"`
+	EndTime     string                    `json:"endTime"`
+	Step        *string                   `json:"step,omitempty"`
+	SearchScope metricsAdapterSearchScope `json:"searchScope"`
+}
+
+// metricsAdapterSearchScope matches the adapter's ComponentSearchScope schema.
+type metricsAdapterSearchScope struct {
+	Namespace      string  `json:"namespace"`
+	ComponentUID   *string `json:"componentUid,omitempty"`
+	ProjectUID     *string `json:"projectUid,omitempty"`
+	EnvironmentUID *string `json:"environmentUid,omitempty"`
+}
+
+// MetricsAdapter forwards metrics queries to an external metrics adapter service.
+// It resolves human-readable names (project, component, environment) to UIDs before
+// forwarding, so that the adapter receives the UIDs it expects for Prometheus label filtering.
+// It implements the MetricsQuerier interface.
+type MetricsAdapter struct {
+	baseURL    string
+	httpClient *http.Client
+	resolver   *ResourceUIDResolver
+	logger     *slog.Logger
+}
+
+var _ MetricsQuerier = (*MetricsAdapter)(nil)
+
+// NewMetricsAdapter creates a new MetricsAdapter that forwards requests to the given base URL.
+// The resolver is used to convert human-readable names to UIDs before forwarding.
+func NewMetricsAdapter(baseURL string, timeout time.Duration, resolver *ResourceUIDResolver, logger *slog.Logger) *MetricsAdapter {
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	return &MetricsAdapter{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		resolver: resolver,
+		logger:   logger,
+	}
+}
+
+// QueryMetrics resolves search scope names to UIDs and forwards the metrics query
+// request to the external adapter, returning the raw JSON response.
+func (a *MetricsAdapter) QueryMetrics(ctx context.Context, req *types.MetricsQueryRequest) (any, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request must not be nil")
+	}
+
+	scope := &req.SearchScope
+
+	// Resolve human-readable names to UIDs
+	var projectUID, componentUID, environmentUID string
+	var err error
+	if scope.Project != "" {
+		projectUID, err = a.resolver.GetProjectUID(ctx, scope.Namespace, scope.Project)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to get project UID: %w", ErrMetricsResolveSearchScope, err)
+		}
+	}
+	if scope.Component != "" {
+		componentUID, err = a.resolver.GetComponentUID(ctx, scope.Namespace, scope.Project, scope.Component)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to get component UID: %w", ErrMetricsResolveSearchScope, err)
+		}
+	}
+	if scope.Environment != "" {
+		environmentUID, err = a.resolver.GetEnvironmentUID(ctx, scope.Namespace, scope.Environment)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to get environment UID: %w", ErrMetricsResolveSearchScope, err)
+		}
+	}
+
+	// Build adapter request with resolved UIDs
+	adapterReq := metricsAdapterRequest{
+		Metric:    req.Metric,
+		StartTime: req.StartTime,
+		EndTime:   req.EndTime,
+		Step:      req.Step,
+		SearchScope: metricsAdapterSearchScope{
+			Namespace: scope.Namespace,
+		},
+	}
+	if projectUID != "" {
+		adapterReq.SearchScope.ProjectUID = &projectUID
+	}
+	if componentUID != "" {
+		adapterReq.SearchScope.ComponentUID = &componentUID
+	}
+	if environmentUID != "" {
+		adapterReq.SearchScope.EnvironmentUID = &environmentUID
+	}
+
+	a.logger.Debug("Forwarding metrics query to adapter",
+		"metric", req.Metric,
+		"namespace", scope.Namespace,
+		"projectUID", projectUID,
+		"componentUID", componentUID,
+		"environmentUID", environmentUID,
+	)
+
+	body, err := json.Marshal(adapterReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metrics query request: %w", err)
+	}
+
+	url := a.baseURL + "/api/v1/metrics/query"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics adapter request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMetricsRetrieval, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metrics adapter response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%w: metrics adapter returned HTTP %d: %s", ErrMetricsRetrieval, resp.StatusCode, string(respBody))
+	}
+
+	var result json.RawMessage
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("%w: failed to decode metrics adapter response: %w", ErrMetricsRetrieval, err)
+	}
+
+	return result, nil
+}

--- a/internal/observer/service/metrics_adapter_test.go
+++ b/internal/observer/service/metrics_adapter_test.go
@@ -1,0 +1,538 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/observer/config"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// newMockUIDResolver creates a ResourceUIDResolver backed by a test HTTP server
+// that returns the specified UIDs. The returnErr function, if non-nil, is called
+// with the request path to determine whether to return an error for that path.
+func newMockUIDResolver(projectUID, componentUID, environmentUID string, returnErr func(path string) bool) (*ResourceUIDResolver, func()) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle OAuth token endpoint
+		if strings.Contains(r.URL.Path, "/token") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			tokenResp := map[string]interface{}{
+				"access_token": "test-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+			_ = json.NewEncoder(w).Encode(tokenResp)
+			return
+		}
+
+		if returnErr != nil && returnErr(r.URL.Path) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var uid string
+		// Determine which UID to return based on the URL path
+		if strings.Contains(r.URL.Path, "/projects/") {
+			uid = projectUID
+		} else if strings.Contains(r.URL.Path, "/components/") {
+			uid = componentUID
+		} else if strings.Contains(r.URL.Path, "/environments/") {
+			uid = environmentUID
+		} else {
+			uid = projectUID // default
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"uid": uid,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+
+	cfg := &config.UIDResolverConfig{
+		OpenChoreoAPIURL:      server.URL,
+		OAuthTokenURL:         server.URL + "/token",
+		OAuthClientID:         "test-client",
+		OAuthClientSecret:     "test-secret",
+		Timeout:               5 * time.Second,
+		TLSInsecureSkipVerify: true,
+	}
+
+	resolver := NewResourceUIDResolver(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return resolver, server.Close
+}
+
+func TestNewMetricsAdapter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		baseURL         string
+		timeout         time.Duration
+		expectedTimeout time.Duration
+	}{
+		{
+			name:            "default timeout",
+			baseURL:         "http://localhost:9099",
+			timeout:         0,
+			expectedTimeout: 30 * time.Second,
+		},
+		{
+			name:            "custom timeout",
+			baseURL:         "http://localhost:9099",
+			timeout:         60 * time.Second,
+			expectedTimeout: 60 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			resolver, cleanup := newMockUIDResolver("", "", "", nil)
+			defer cleanup()
+
+			adapter := NewMetricsAdapter(tt.baseURL, tt.timeout, resolver, logger)
+
+			require.NotNil(t, adapter)
+			assert.Equal(t, tt.baseURL, adapter.baseURL)
+			require.NotNil(t, adapter.httpClient)
+			assert.Equal(t, tt.expectedTimeout, adapter.httpClient.Timeout)
+			require.NotNil(t, adapter.resolver)
+			assert.Equal(t, logger, adapter.logger)
+		})
+	}
+}
+
+func TestMetricsAdapter_QueryMetrics_NilRequest(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, cleanup := newMockUIDResolver("", "", "", nil)
+	defer cleanup()
+	adapter := NewMetricsAdapter("http://localhost:9099", 30*time.Second, resolver, logger)
+
+	result, err := adapter.QueryMetrics(context.Background(), nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request must not be nil")
+}
+
+func TestMetricsAdapter_QueryMetrics_ResolverError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		req         *types.MetricsQueryRequest
+		resolverErr func(path string) bool
+		expectedErr string
+	}{
+		{
+			name: "project UID resolution failure",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: "2026-01-01T00:00:00Z",
+				EndTime:   "2026-01-01T01:00:00Z",
+				SearchScope: types.ComponentSearchScope{
+					Namespace: "test-ns",
+					Project:   "test-project",
+				},
+			},
+			resolverErr: func(path string) bool { return strings.Contains(path, "/projects/") },
+			expectedErr: "failed to get project UID",
+		},
+		{
+			name: "component UID resolution failure",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: "2026-01-01T00:00:00Z",
+				EndTime:   "2026-01-01T01:00:00Z",
+				SearchScope: types.ComponentSearchScope{
+					Namespace: "test-ns",
+					Project:   "test-project",
+					Component: "test-component",
+				},
+			},
+			resolverErr: func(path string) bool { return strings.Contains(path, "/components/") },
+			expectedErr: "failed to get component UID",
+		},
+		{
+			name: "environment UID resolution failure",
+			req: &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: "2026-01-01T00:00:00Z",
+				EndTime:   "2026-01-01T01:00:00Z",
+				SearchScope: types.ComponentSearchScope{
+					Namespace:   "test-ns",
+					Environment: "test-env",
+				},
+			},
+			resolverErr: func(path string) bool { return strings.Contains(path, "/environments/") },
+			expectedErr: "failed to get environment UID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			// Provide valid UIDs so that successful resolutions return proper values
+			resolver, cleanup := newMockUIDResolver("project-uid-123", "component-uid-456", "env-uid-789", tt.resolverErr)
+			defer cleanup()
+			adapter := NewMetricsAdapter("http://localhost:9099", 30*time.Second, resolver, logger)
+
+			result, err := adapter.QueryMetrics(context.Background(), tt.req)
+
+			assert.Nil(t, result)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrMetricsResolveSearchScope)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestMetricsAdapter_QueryMetrics_Success(t *testing.T) {
+	t.Parallel()
+
+	step := "5m"
+	expectedResponse := map[string]interface{}{
+		"cpuUsage": []map[string]interface{}{
+			{"timestamp": "2026-01-01T00:00:00Z", "value": 0.5},
+			{"timestamp": "2026-01-01T00:05:00Z", "value": 0.6},
+		},
+	}
+
+	var capturedRequest metricsAdapterRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and path
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/metrics/query", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Capture the request body
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &capturedRequest)
+		require.NoError(t, err)
+
+		// Return success response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(expectedResponse)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, resolverCleanup := newMockUIDResolver("project-uid-123", "component-uid-456", "env-uid-789", nil)
+	defer resolverCleanup()
+	adapter := NewMetricsAdapter(server.URL, 30*time.Second, resolver, logger)
+
+	req := &types.MetricsQueryRequest{
+		Metric:    "resource",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-01-01T01:00:00Z",
+		Step:      &step,
+		SearchScope: types.ComponentSearchScope{
+			Namespace:   "test-ns",
+			Project:     "test-project",
+			Component:   "test-component",
+			Environment: "test-env",
+		},
+	}
+
+	result, err := adapter.QueryMetrics(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify the captured request
+	assert.Equal(t, "resource", capturedRequest.Metric)
+	assert.Equal(t, "2026-01-01T00:00:00Z", capturedRequest.StartTime)
+	assert.Equal(t, "2026-01-01T01:00:00Z", capturedRequest.EndTime)
+	require.NotNil(t, capturedRequest.Step)
+	assert.Equal(t, "5m", *capturedRequest.Step)
+	assert.Equal(t, "test-ns", capturedRequest.SearchScope.Namespace)
+	require.NotNil(t, capturedRequest.SearchScope.ProjectUID)
+	assert.Equal(t, "project-uid-123", *capturedRequest.SearchScope.ProjectUID)
+	require.NotNil(t, capturedRequest.SearchScope.ComponentUID)
+	assert.Equal(t, "component-uid-456", *capturedRequest.SearchScope.ComponentUID)
+	require.NotNil(t, capturedRequest.SearchScope.EnvironmentUID)
+	assert.Equal(t, "env-uid-789", *capturedRequest.SearchScope.EnvironmentUID)
+
+	// Verify the response
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	expectedJSON, err := json.Marshal(expectedResponse)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expectedJSON), string(resultJSON))
+}
+
+func TestMetricsAdapter_QueryMetrics_PartialScope(t *testing.T) {
+	t.Parallel()
+
+	var capturedRequest metricsAdapterRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &capturedRequest)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(map[string]interface{}{})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, resolverCleanup := newMockUIDResolver("project-uid-123", "", "", nil)
+	defer resolverCleanup()
+	adapter := NewMetricsAdapter(server.URL, 30*time.Second, resolver, logger)
+
+	req := &types.MetricsQueryRequest{
+		Metric:    "http",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-01-01T01:00:00Z",
+		SearchScope: types.ComponentSearchScope{
+			Namespace: "test-ns",
+			Project:   "test-project",
+		},
+	}
+
+	result, err := adapter.QueryMetrics(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify only project UID is set
+	assert.Equal(t, "test-ns", capturedRequest.SearchScope.Namespace)
+	require.NotNil(t, capturedRequest.SearchScope.ProjectUID)
+	assert.Equal(t, "project-uid-123", *capturedRequest.SearchScope.ProjectUID)
+	assert.Nil(t, capturedRequest.SearchScope.ComponentUID)
+	assert.Nil(t, capturedRequest.SearchScope.EnvironmentUID)
+}
+
+func TestMetricsAdapter_QueryMetrics_EmptyScope(t *testing.T) {
+	t.Parallel()
+
+	var capturedRequest metricsAdapterRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &capturedRequest)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(map[string]interface{}{})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, cleanup := newMockUIDResolver("", "", "", nil)
+	defer cleanup()
+	adapter := NewMetricsAdapter(server.URL, 30*time.Second, resolver, logger)
+
+	req := &types.MetricsQueryRequest{
+		Metric:    "resource",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-01-01T01:00:00Z",
+		SearchScope: types.ComponentSearchScope{
+			Namespace: "test-ns",
+		},
+	}
+
+	result, err := adapter.QueryMetrics(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify no UIDs are set
+	assert.Equal(t, "test-ns", capturedRequest.SearchScope.Namespace)
+	assert.Nil(t, capturedRequest.SearchScope.ProjectUID)
+	assert.Nil(t, capturedRequest.SearchScope.ComponentUID)
+	assert.Nil(t, capturedRequest.SearchScope.EnvironmentUID)
+}
+
+func TestMetricsAdapter_QueryMetrics_HTTPErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectedErrMsg string
+	}{
+		{
+			name:           "404 not found",
+			statusCode:     http.StatusNotFound,
+			responseBody:   `{"error": "not found"}`,
+			expectedErrMsg: "metrics adapter returned HTTP 404",
+		},
+		{
+			name:           "500 internal server error",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   `{"error": "internal error"}`,
+			expectedErrMsg: "metrics adapter returned HTTP 500",
+		},
+		{
+			name:           "400 bad request",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"error": "invalid request"}`,
+			expectedErrMsg: "metrics adapter returned HTTP 400",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.responseBody))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			resolver, cleanup := newMockUIDResolver("", "", "", nil)
+			defer cleanup()
+			adapter := NewMetricsAdapter(server.URL, 30*time.Second, resolver, logger)
+
+			req := &types.MetricsQueryRequest{
+				Metric:    "resource",
+				StartTime: "2026-01-01T00:00:00Z",
+				EndTime:   "2026-01-01T01:00:00Z",
+				SearchScope: types.ComponentSearchScope{
+					Namespace: "test-ns",
+				},
+			}
+
+			result, err := adapter.QueryMetrics(context.Background(), req)
+
+			assert.Nil(t, result)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrMetricsRetrieval)
+			assert.Contains(t, err.Error(), tt.expectedErrMsg)
+		})
+	}
+}
+
+func TestMetricsAdapter_QueryMetrics_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("invalid json"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, cleanup := newMockUIDResolver("", "", "", nil)
+	defer cleanup()
+	adapter := NewMetricsAdapter(server.URL, 30*time.Second, resolver, logger)
+
+	req := &types.MetricsQueryRequest{
+		Metric:    "resource",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-01-01T01:00:00Z",
+		SearchScope: types.ComponentSearchScope{
+			Namespace: "test-ns",
+		},
+	}
+
+	result, err := adapter.QueryMetrics(context.Background(), req)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMetricsRetrieval)
+	assert.Contains(t, err.Error(), "failed to decode metrics adapter response")
+}
+
+func TestMetricsAdapter_QueryMetrics_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, cleanup := newMockUIDResolver("", "", "", nil)
+	defer cleanup()
+	// Use an invalid URL to trigger network error
+	adapter := NewMetricsAdapter("http://invalid-host-that-does-not-exist:9999", 1*time.Second, resolver, logger)
+
+	req := &types.MetricsQueryRequest{
+		Metric:    "resource",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-01-01T01:00:00Z",
+		SearchScope: types.ComponentSearchScope{
+			Namespace: "test-ns",
+		},
+	}
+
+	result, err := adapter.QueryMetrics(context.Background(), req)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMetricsRetrieval)
+}
+
+func TestMetricsAdapter_QueryMetrics_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that delays response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolver, cleanup := newMockUIDResolver("", "", "", nil)
+	defer cleanup()
+	adapter := NewMetricsAdapter(server.URL, 30*time.Second, resolver, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	req := &types.MetricsQueryRequest{
+		Metric:    "resource",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-01-01T01:00:00Z",
+		SearchScope: types.ComponentSearchScope{
+			Namespace: "test-ns",
+		},
+	}
+
+	result, err := adapter.QueryMetrics(ctx, req)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMetricsRetrieval)
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Enables the observer to delegate metrics querying and metric based alert management to an external metrics adapter service

## Approach
- Metrics Adapter: Created MetricsAdapter that implements the MetricsQuerier interface, forwarding metrics queries to an external HTTP service at a configurable URL. The adapter resolves human-readable names (project, component, environment) to UIDs before forwarding requests, ensuring the adapter receives UIDs for label filtering.
- Alert Routing: Modified AlertService to conditionally route metric-based alert operations (Create, Read, Update, Delete) to the metrics adapter when a metrics adapter client is configured. Falls back to the existing Prometheus implementation when the adapter client is nil (This is temporary and the built-in Promethus implementation will be removed in the future)
- Configuration: Added METRICS_ADAPTER_URL and METRICS_ADAPTER_TIMEOUT environment variables to configure the adapter endpoint (defaults to http://metrics-adapter:9099 with 30s timeout).
- Initialization: Replaced direct Prometheus service initialization with metrics adapter initialization in the observer's main entrypoint. The adapter is always enabled and uses the configured external service.
- Testing: Added unit tests

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2964

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
