### PR TITLE
feat(controller): add support for CiliumNetworkPolicy generation

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -50,6 +50,23 @@ type Reconciler struct {
 	Pipeline *componentpipeline.Pipeline
 }
 
+// networkPolicyProviderFromDataPlane reads the "openchoreo.dev/networkpolicyprovider" annotation
+// from the DataPlane or ClusterDataPlane CR and returns the matching Provider.
+// Absent annotation or any value other than "cilium" defaults to ProviderKubernetes.
+func networkPolicyProviderFromDataPlane(dp *controller.DataPlaneResult) networkpolicy.Provider {
+	var annotations map[string]string
+	switch {
+	case dp.DataPlane != nil:
+		annotations = dp.DataPlane.Annotations
+	case dp.ClusterDataPlane != nil:
+		annotations = dp.ClusterDataPlane.Annotations
+	}
+	if annotations["openchoreo.dev/networkpolicyprovider"] == string(networkpolicy.ProviderCilium) {
+		return networkpolicy.ProviderCilium
+	}
+	return networkpolicy.ProviderKubernetes
+}
+
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=releasebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=releasebindings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=releasebindings/finalizers,verbs=update
@@ -509,7 +526,8 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 		}
 	}
 
-	// Inject per-component NetworkPolicies into dataplane resources
+	// Inject per-component network policies into dataplane resources.
+	// The provider is determined by the "openchoreo.dev/networkpolicyprovider" annotation on the DataPlane CR.
 	componentNetpols := networkpolicy.MakeComponentPolicies(networkpolicy.ComponentPolicyParams{
 		Namespace:     metadataContext.Namespace,
 		CPNamespace:   metadataContext.ComponentNamespace,
@@ -517,6 +535,7 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 		ComponentName: metadataContext.ComponentName,
 		PodSelectors:  metadataContext.PodSelectors,
 		Endpoints:     snapshotWorkload.Spec.Endpoints,
+		Provider:      networkPolicyProviderFromDataPlane(dataPlaneResult),
 	})
 	dataPlaneResources = append(dataPlaneResources, componentNetpols...)
 

--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -6,10 +6,26 @@ package networkpolicy
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	dpkubernetes "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
 	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+// Provider selects which network policy API to use when generating component policies.
+type Provider string
+
+const (
+	// ProviderKubernetes generates standard Kubernetes NetworkPolicy objects (default).
+	ProviderKubernetes Provider = "kubernetes"
+	// ProviderCilium generates CiliumNetworkPolicy objects with L7 HTTP rules for
+	// HTTP-proxied endpoints, enabling Hubble flow metrics via Envoy.
+	ProviderCilium Provider = "cilium"
+
+	// KubernetesNamespaceKey is the key for Kubernetes namespace
+	// used in CiliumNetworkPolicy to allow rules based on namespace.
+	KubernetesNamespaceKey = "k8s:io.kubernetes.pod.namespace"
 )
 
 // ComponentPolicyParams holds parameters for generating per-component NetworkPolicies
@@ -21,11 +37,18 @@ type ComponentPolicyParams struct {
 	ComponentName string                                         // for naming the policy
 	PodSelectors  map[string]string                              // platform pod selectors
 	Endpoints     map[string]openchoreov1alpha1.WorkloadEndpoint // from workload spec
+	Provider      Provider                                       // network policy provider
 }
 
-// MakeComponentPolicies returns a NetworkPolicy for a component with ingress rules
-// based on declared endpoint visibility. Egress is unrestricted.
+// MakeComponentPolicies returns a policy for a component with ingress rules based on
+// declared endpoint visibility. Egress is unrestricted.
+// When Provider is ProviderCilium a CiliumNetworkPolicy is returned with L7 HTTP rules
+// for HTTP-proxied endpoints; otherwise a standard Kubernetes NetworkPolicy is returned.
 func MakeComponentPolicies(params ComponentPolicyParams) []map[string]any {
+	if params.Provider == ProviderCilium {
+		return makeCiliumComponentPolicies(params)
+	}
+
 	// Build ingress rules from endpoints
 	ingressRules := makeIngressRules(params)
 
@@ -167,6 +190,168 @@ func makeIngressRules(params ComponentPolicyParams) []any {
 	}
 
 	return ingressRules
+}
+
+// ciliumPortEntry holds per-endpoint data for Cilium CNP generation.
+type ciliumPortEntry struct {
+	port       string
+	proto      string
+	isL7       bool
+	visibility []openchoreov1alpha1.EndpointVisibility
+}
+
+// makeCiliumComponentPolicies returns a CiliumNetworkPolicy for a component.
+// HTTP-proxied endpoint types (HTTP, GraphQL, Websocket, gRPC) get L7 HTTP rules
+// so Cilium redirects traffic through Envoy and Hubble emits flow metrics.
+// Non-proxied types (TCP, UDP) get L4-only rules.
+func makeCiliumComponentPolicies(params ComponentPolicyParams) []map[string]any {
+	entries := make([]ciliumPortEntry, 0, len(params.Endpoints))
+	for _, ep := range params.Endpoints {
+		proto := "TCP"
+		if ep.Type == openchoreov1alpha1.EndpointTypeUDP {
+			proto = "UDP"
+		}
+		entries = append(entries, ciliumPortEntry{
+			port:       strconv.Itoa(int(ep.Port)),
+			proto:      proto,
+			isL7:       isL7Proxied(ep.Type),
+			visibility: ep.Visibility,
+		})
+	}
+	// Sort by port for deterministic output.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].port < entries[j].port
+	})
+
+	projectPorts := make([]ciliumPortEntry, 0, len(entries))
+	var namespacePorts, broadPorts []ciliumPortEntry
+	for _, e := range entries {
+		projectPorts = append(projectPorts, e)
+		for _, vis := range e.visibility {
+			switch vis {
+			case openchoreov1alpha1.EndpointVisibilityNamespace:
+				namespacePorts = append(namespacePorts, e)
+			case openchoreov1alpha1.EndpointVisibilityInternal, openchoreov1alpha1.EndpointVisibilityExternal:
+				broadPorts = append(broadPorts, e)
+			}
+		}
+	}
+
+	ingressRules := make([]any, 0)
+
+	// Rule 1: intra-namespace (project visibility) — all pods in the data-plane namespace
+	if len(projectPorts) > 0 {
+		ingressRules = append(ingressRules, map[string]any{
+			"fromEndpoints": []any{
+				map[string]any{},
+			},
+			"toPorts": ciliumToPorts(projectPorts),
+		})
+	}
+
+	// Rule 2: cross-project, same CP namespace and environment (namespace visibility)
+	if len(namespacePorts) > 0 {
+		ingressRules = append(ingressRules, map[string]any{
+			"fromEndpoints": []any{
+				map[string]any{
+					"matchLabels": map[string]any{
+						labels.LabelKeyNamespaceName:   params.CPNamespace,
+						labels.LabelKeyEnvironmentName: params.Environment,
+					},
+					"matchExpressions": []any{
+						map[string]any{ // Explicitly allow from any namespace
+							"key":      KubernetesNamespaceKey,
+							"operator": "Exists",
+						},
+					},
+				},
+			},
+			"toPorts": ciliumToPorts(namespacePorts),
+		})
+	}
+
+	// Rule 3: system components (e.g., gateway) from any namespace (internal or external visibility)
+	if len(broadPorts) > 0 {
+		ingressRules = append(ingressRules, map[string]any{
+			"fromEndpoints": []any{
+				map[string]any{"matchExpressions": []any{
+					map[string]any{
+						"key":      labels.LabelKeySystemComponent,
+						"operator": "Exists",
+					},
+					map[string]any{ // Explicitly allow from any namespace
+						"key":      KubernetesNamespaceKey,
+						"operator": "Exists",
+					},
+				}},
+			},
+			"toPorts": ciliumToPorts(broadPorts),
+		})
+	}
+
+	policyName := fmt.Sprintf("openchoreo-%s", params.ComponentName)
+	if len(policyName) > dpkubernetes.MaxResourceNameLength {
+		policyName = dpkubernetes.GenerateK8sNameWithLengthLimit(
+			dpkubernetes.MaxResourceNameLength,
+			"openchoreo", params.ComponentName,
+		)
+	}
+
+	spec := map[string]any{
+		"endpointSelector": map[string]any{
+			"matchLabels": toAnyMap(params.PodSelectors),
+		},
+		"ingress": ingressRules,
+	}
+
+	return []map[string]any{{
+		"apiVersion": "cilium.io/v2",
+		"kind":       "CiliumNetworkPolicy",
+		"metadata": map[string]any{
+			"name":      policyName,
+			"namespace": params.Namespace,
+		},
+		"spec": spec,
+	}}
+}
+
+// ciliumToPorts builds the toPorts slice for a CNP ingress rule, grouping L7-proxied
+// ports (with rules.http) separately from L4-only ports.
+func ciliumToPorts(entries []ciliumPortEntry) []any {
+	var l7Ports, l4Ports []any
+	for _, e := range entries {
+		p := map[string]any{"port": e.port, "protocol": e.proto}
+		if e.isL7 {
+			l7Ports = append(l7Ports, p)
+		} else {
+			l4Ports = append(l4Ports, p)
+		}
+	}
+	var toPorts []any
+	if len(l7Ports) > 0 {
+		toPorts = append(toPorts, map[string]any{
+			"ports": l7Ports,
+			"rules": map[string]any{"http": []any{
+				map[string]any{},
+			}},
+		})
+	}
+	if len(l4Ports) > 0 {
+		toPorts = append(toPorts, map[string]any{"ports": l4Ports})
+	}
+	return toPorts
+}
+
+// isL7Proxied reports whether the endpoint type is proxied through Envoy for L7 inspection.
+func isL7Proxied(t openchoreov1alpha1.EndpointType) bool {
+	switch t {
+	case openchoreov1alpha1.EndpointTypeHTTP,
+		openchoreov1alpha1.EndpointTypeGraphQL,
+		openchoreov1alpha1.EndpointTypeWebsocket,
+		openchoreov1alpha1.EndpointTypeGRPC:
+		return true
+	}
+	return false
 }
 
 // toAnyMap converts map[string]string to map[string]any for use in unstructured maps.

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -376,6 +376,294 @@ spec:
 `)
 }
 
+// --- Cilium CNP tests ---
+
+func TestMakeComponentPolicies_Cilium_NoEndpoints(t *testing.T) {
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: "my-comp",
+		PodSelectors:  map[string]string{"app": "test"},
+		Endpoints:     nil,
+		Provider:      ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	assertYAMLEqual(t, "cilium-no-endpoints", policies[0], `
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openchoreo-my-comp
+  namespace: dp-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: test
+  ingress: []
+`)
+}
+
+func TestMakeComponentPolicies_Cilium_HTTPEndpoint(t *testing.T) {
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: "web-app",
+		PodSelectors: map[string]string{
+			labels.LabelKeyComponentName: "web-app",
+			labels.LabelKeyProjectName:   "my-project",
+		},
+		Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+			"http": {Type: openchoreov1alpha1.EndpointTypeHTTP, Port: 8080},
+		},
+		Provider: ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	assertYAMLEqual(t, "cilium-http-endpoint", policies[0], `
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openchoreo-web-app
+  namespace: dp-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      openchoreo.dev/component: web-app
+      openchoreo.dev/project: my-project
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - {}
+`)
+}
+
+func TestMakeComponentPolicies_Cilium_TCPEndpoint(t *testing.T) {
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: "db",
+		PodSelectors:  map[string]string{"app": "db"},
+		Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+			"tcp": {Type: openchoreov1alpha1.EndpointTypeTCP, Port: 5432},
+		},
+		Provider: ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	assertYAMLEqual(t, "cilium-tcp-endpoint", policies[0], `
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openchoreo-db
+  namespace: dp-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: db
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "5432"
+        protocol: TCP
+`)
+}
+
+func TestMakeComponentPolicies_Cilium_MixedL7L4Endpoints(t *testing.T) {
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: "mixed-svc",
+		PodSelectors:  map[string]string{"app": "mixed-svc"},
+		Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+			"http": {Type: openchoreov1alpha1.EndpointTypeHTTP, Port: 8080},
+			"tcp":  {Type: openchoreov1alpha1.EndpointTypeTCP, Port: 5432},
+		},
+		Provider: ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	assertYAMLEqual(t, "cilium-mixed-l7-l4", policies[0], `
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openchoreo-mixed-svc
+  namespace: dp-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mixed-svc
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - {}
+    - ports:
+      - port: "5432"
+        protocol: TCP
+`)
+}
+
+func TestMakeComponentPolicies_Cilium_ExternalVisibility(t *testing.T) {
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: "public-api",
+		PodSelectors:  map[string]string{"app": "public-api"},
+		Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+			"http": {
+				Type:       openchoreov1alpha1.EndpointTypeHTTP,
+				Port:       8080,
+				Visibility: []openchoreov1alpha1.EndpointVisibility{openchoreov1alpha1.EndpointVisibilityExternal},
+			},
+		},
+		Provider: ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	assertYAMLEqual(t, "cilium-external-visibility", policies[0], `
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openchoreo-public-api
+  namespace: dp-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: public-api
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - {}
+  - fromEndpoints:
+    - matchExpressions:
+      - key: openchoreo.dev/system-component
+        operator: Exists
+      - key: k8s:io.kubernetes.pod.namespace
+        operator: Exists
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - {}
+`)
+}
+
+func TestMakeComponentPolicies_Cilium_NamespaceVisibility(t *testing.T) {
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: "grpc-svc",
+		PodSelectors:  map[string]string{"app": "grpc-svc"},
+		Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+			"grpc": {
+				Type:       openchoreov1alpha1.EndpointTypeGRPC,
+				Port:       9090,
+				Visibility: []openchoreov1alpha1.EndpointVisibility{openchoreov1alpha1.EndpointVisibilityNamespace},
+			},
+		},
+		Provider: ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	assertYAMLEqual(t, "cilium-namespace-visibility", policies[0], `
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openchoreo-grpc-svc
+  namespace: dp-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: grpc-svc
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "9090"
+        protocol: TCP
+      rules:
+        http:
+        - {}
+  - fromEndpoints:
+    - matchExpressions:
+      - key: k8s:io.kubernetes.pod.namespace
+        operator: Exists
+      matchLabels:
+        openchoreo.dev/namespace: cp-ns
+        openchoreo.dev/environment: development
+    toPorts:
+    - ports:
+      - port: "9090"
+        protocol: TCP
+      rules:
+        http:
+        - {}
+`)
+}
+
+func TestMakeComponentPolicies_Cilium_NameTruncation(t *testing.T) {
+	longName := strings.Repeat("a", 250)
+	policies := MakeComponentPolicies(ComponentPolicyParams{
+		Namespace:     "dp-ns",
+		CPNamespace:   "cp-ns",
+		Environment:   "development",
+		ComponentName: longName,
+		PodSelectors:  map[string]string{"app": "test"},
+		Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+			"http": {Type: openchoreov1alpha1.EndpointTypeHTTP, Port: 8080},
+		},
+		Provider: ProviderCilium,
+	})
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	meta := policies[0]["metadata"].(map[string]any)
+	name := meta["name"].(string)
+	if len(name) > 253 {
+		t.Errorf("policy name exceeds 253 chars: %d", len(name))
+	}
+}
+
 func TestMakeComponentPolicies_NameTruncation(t *testing.T) {
 	longName := strings.Repeat("a", 250)
 	policies := MakeComponentPolicies(ComponentPolicyParams{


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request adds support for generating CiliumNetworkPolicy (CNP) resources with L7 HTTP rules for per-component network policies, in addition to the existing Kubernetes NetworkPolicy support. The network policy provider can now be configured via an environment variable, and Helm chart options have been added to make this configurable. The codebase is updated to generate the correct policy type based on the provider, and comprehensive unit tests are included for the new Cilium policy logic.

**Network Policy Provider Support:**

* Introduced a `Provider` type in `internal/networkpolicy` to select between standard Kubernetes NetworkPolicy and CiliumNetworkPolicy with L7 HTTP rules. The provider is configurable via the `NETWORK_POLICY_PROVIDER` environment variable. [[1]](diffhunk://#diff-195fe80ecf9f4af12a9ba13c2b9892ccf556b7cd73fd63334159dd6e24832b5aR9-R30) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R57) [[3]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R218-R227) [[4]](diffhunk://#diff-440c67a69f0874087394cbd13c783e3bfd5465ecbac9df9f2dce3cf2dbd95fbeR51-R54) [[5]](diffhunk://#diff-440c67a69f0874087394cbd13c783e3bfd5465ecbac9df9f2dce3cf2dbd95fbeL512-R524)
* Updated the `MakeComponentPolicies` function to generate either a standard NetworkPolicy or a CiliumNetworkPolicy based on the selected provider. Added logic for CNP generation, including L7/L4 port grouping and visibility rules. [[1]](diffhunk://#diff-195fe80ecf9f4af12a9ba13c2b9892ccf556b7cd73fd63334159dd6e24832b5aR40-R51) [[2]](diffhunk://#diff-195fe80ecf9f4af12a9ba13c2b9892ccf556b7cd73fd63334159dd6e24832b5aR195-R346)
* NetworkPolicyProvider is determined at policy generation time based on an annotation in the DataPlane CR.


**Testing:**

* Added comprehensive unit tests in `internal/networkpolicy/networkpolicy_test.go` to verify CiliumNetworkPolicy generation for various endpoint types, visibilities, and edge cases (such as name truncation).

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3103

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
