### PR TITLE
fix: defer cancel in observer UID resolver until body is read

### DIFF
--- a/internal/observer/service/uid_resolver.go
+++ b/internal/observer/service/uid_resolver.go
@@ -173,10 +173,15 @@ func (r *ResourceUIDResolver) fetchResourceUID(ctx context.Context, path string)
 		}
 
 		reqCtx, reqCancel := context.WithTimeout(ctx, r.config.Timeout)
+		// Defer cancel so the per-request context stays valid for the
+		// response body read. Cancelling immediately after httpClient.Do
+		// returned (which only waits for response headers) races with
+		// io.ReadAll(resp.Body) — the body reader is bound to reqCtx
+		// and reads fail with "context canceled" when cancel wins the race.
+		defer reqCancel()
 
 		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
 		if err != nil {
-			reqCancel()
 			return "", fmt.Errorf("failed to create request: %w", err)
 		}
 
@@ -186,7 +191,6 @@ func (r *ResourceUIDResolver) fetchResourceUID(ctx context.Context, path string)
 		}
 
 		resp, err := r.httpClient.Do(req)
-		reqCancel()
 		if err != nil {
 			return "", fmt.Errorf("request failed: %w", err)
 		}


### PR DESCRIPTION
## Purpose

Fix an intermittent failure in observer where scope-resolution calls in `ResourceUIDResolver` return `context canceled` mid-response. From the consumer's perspective, `/api/v1alpha1/traces/query` and `/api/v1alpha1/traces/{id}/spans/query` return 500 (errorCode `OBS-V1-T-04` from `QueryTraces`, or `OBS-V1-T-01` from `QuerySpans` since that handler currently lacks an `ErrTracesResolveSearchScope` case) even though the upstream `openchoreo-api` access log shows the dependent CR fetch returned `200 OK`.

The failure is timing-dependent and surfaces with mismatched evidence (`200` at openchoreo-api, `failed to read response body: context canceled` at observer), which makes diagnosis noisy when callers fan out parallel span queries and one canceled call cascades through fail-fast logic in the consumer.

## Approach

`ResourceUIDResolver.fetchResourceUID` (`internal/observer/service/uid_resolver.go`) wraps each attempt in a per-request context via `context.WithTimeout`, then calls `reqCancel()` immediately after `r.httpClient.Do(req)` returns:

```go
reqCtx, reqCancel := context.WithTimeout(ctx, r.config.Timeout)
// ...
resp, err := r.httpClient.Do(req)
reqCancel()  // ← bug: cancels reqCtx before the body is read
if err != nil { ... }

switch resp.StatusCode {
case http.StatusOK:
    body, err := io.ReadAll(resp.Body)  // races with the cancellation above
```

`http.Client.Do` only waits for response headers; the body reader is bound to `reqCtx`. When `reqCancel()` runs before `io.ReadAll(resp.Body)` finishes, the read fails with `context canceled`. Whether this happens depends on Go scheduler ordering, TCP segmentation, and whether the body is already buffered at that microsecond — i.e., the failure is timing-dependent and intermittent.

This change replaces the bare `reqCancel()` with `defer reqCancel()` directly after the `WithTimeout`, so:

- The context stays valid for the body read.
- It is cancelled when the function returns (covers all paths, including the 401-retry `continue` path — defers accumulate per loop iteration and fire on function return, which is acceptable for the small max-retry count).
- The pattern matches `fetchAccessToken` in the same file, which already uses `defer cancel()` correctly.

## Evidence

Reproduced against observer `v1.0.1-hotfix.1`. Captured logs from a single failed `QuerySpans` call:

```
# observer log
time=... level=ERROR msg="Failed to resolve search scope"
  component=traces-service
  error="failed to resolve component UID ...: failed to read response body: context canceled"
time=... level=DEBUG msg="HTTP request"
  method=POST path=/api/v1alpha1/traces/.../spans/query status=500 duration=60.66ms

# openchoreo-api access log for the dependent CR fetch at the same instant
"path":"/api/v1/namespaces/.../components/..." status=200 duration=~10ms
```

The CR fetch returned 200; the body read inside `fetchResourceUID` failed because `reqCtx` had already been cancelled by the bare `reqCancel()` call above.

After applying this fix and rolling out a patched observer image, the previously failing trace-export flow completes successfully across repeated reproductions.

## Related Issues

None filed yet — happy to open one if preferred.

A related (separate) bug surfaces during diagnosis: `internal/observer/api/handlers/traces.go`'s `QuerySpansForTrace` handler is missing a `case errors.Is(err, service.ErrTracesResolveSearchScope)` branch that the sibling `QueryTraces` handler has, so resolution failures from `QuerySpans` get mislabeled `OBS-V1-T-01 "Failed to retrieve spans"` instead of `OBS-V1-T-04`. Not addressed here to keep this PR minimal — happy to follow up in a separate PR if useful.

## Checklist

- [x] Tests added or updated — existing `internal/observer/service` tests pass; the bug is a timing race not currently covered by unit tests, and reliably triggering it in a unit test would require a custom `RoundTripper` that delays body reads, which felt out of scope for a minimal fix. Happy to add one if reviewers prefer.
- [ ] Samples updated — not applicable.
- [ ] Added `backport/<release-branch>` label if this should be backported — flagging for maintainer judgement; the bug is reproducible against `v1.0.1-hotfix.1`.

## Remarks

Diff is 6 / -2: move `reqCancel` from a bare call to `defer`, drop the redundant `reqCancel()` in the early-return path.

```diff
   reqCtx, reqCancel := context.WithTimeout(ctx, r.config.Timeout)
+  // Defer cancel so the per-request context stays valid for the
+  // response body read. ...
+  defer reqCancel()

   req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
   if err != nil {
-      reqCancel()
       return "", fmt.Errorf("failed to create request: %w", err)
   }
   ...
   resp, err := r.httpClient.Do(req)
-  reqCancel()
   if err != nil {
       return "", fmt.Errorf("request failed: %w", err)
   }
```