### PR TITLE
fix(helm): avoid rendering replicas when HPA is enabled

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: backstage
 spec:
+  {{- if not .Values.backstage.autoscaling.enabled }}
   replicas: {{ .Values.backstage.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: backstage

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.componentLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 4 }}
 spec:
+  {{- if not .Values.controllerManager.autoscaling.enabled }}
   replicas: {{ .Values.controllerManager.replicas }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     # Trigger rollout when config changes
     checksum/config: {{ include (print $.Template.BasePath "/openchoreo-api/configmap.yaml") . | sha256sum }}
 spec:
+  {{- if not .Values.openchoreoApi.autoscaling.enabled }}
   replicas: {{ .Values.openchoreoApi.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: api-server


### PR DESCRIPTION
## Purpose
This PR fixes a Helm/Kubernetes autoscaling reliability issue in the OpenChoreo control-plane chart.

When HPA is enabled, Helm should not render `Deployment.spec.replicas`, because the Horizontal Pod Autoscaler should manage replica count.

## Approach
Updated the controller-manager, openchoreo-api, and Backstage Deployment templates to render `replicas` only when autoscaling is disabled.

## Related Issues
N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
Validation performed with `helm template` and `helm lint`.

- Autoscaling disabled: Deployment `replicas` fields are rendered.
- Autoscaling enabled: Deployment `replicas` fields are not rendered.
- Autoscaling enabled: HPA resources are still rendered.
