### PR TITLE
fix: surface rollout failures during k3d update

### DIFF
--- a/make/k3d.mk
+++ b/make/k3d.mk
@@ -145,22 +145,22 @@ k3d.update: ## Rebuild, load, and restart all components
 	@$(MAKE) k3d.build
 	@$(MAKE) k3d.load
 	@$(call log_info, Performing rollout restarts...)
-	@kubectl rollout restart deployment/controller-manager -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) || true
-	@kubectl rollout restart deployment/openchoreo-api -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) || true
-	@kubectl rollout restart deployment/cluster-gateway -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) || true
-	@kubectl rollout restart deployment/observer -n $(K3D_OP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) || true
+	@kubectl rollout restart deployment/controller-manager -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME)
+	@kubectl rollout restart deployment/openchoreo-api -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME)
+	@kubectl rollout restart deployment/cluster-gateway -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME)
+	@kubectl rollout restart deployment/observer -n $(K3D_OP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME)
 	@for ns in $(K3D_DP_NAMESPACE) $(K3D_WP_NAMESPACE) $(K3D_OP_NAMESPACE); do \
-		dep=$$(kubectl get deployment -n $$ns --context k3d-$(K3D_CLUSTER_NAME) -l app=cluster-agent -o name 2>/dev/null); \
-		if [ -n "$$dep" ]; then kubectl rollout restart $$dep -n $$ns --context k3d-$(K3D_CLUSTER_NAME) || true; fi; \
+		dep=$$(kubectl get deployment -n $$ns --context k3d-$(K3D_CLUSTER_NAME) -l app=cluster-agent -o name) || exit $$?; \
+		if [ -n "$$dep" ]; then kubectl rollout restart $$dep -n $$ns --context k3d-$(K3D_CLUSTER_NAME); fi; \
 	done
 	@$(call log_info, Waiting for rollouts to complete...)
-	@kubectl rollout status deployment/controller-manager -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s || true
-	@kubectl rollout status deployment/openchoreo-api -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s || true
-	@kubectl rollout status deployment/cluster-gateway -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s || true
-	@kubectl rollout status deployment/observer -n $(K3D_OP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s || true
+	@kubectl rollout status deployment/controller-manager -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s
+	@kubectl rollout status deployment/openchoreo-api -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s
+	@kubectl rollout status deployment/cluster-gateway -n $(K3D_CP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s
+	@kubectl rollout status deployment/observer -n $(K3D_OP_NAMESPACE) --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s
 	@for ns in $(K3D_DP_NAMESPACE) $(K3D_WP_NAMESPACE) $(K3D_OP_NAMESPACE); do \
-		dep=$$(kubectl get deployment -n $$ns --context k3d-$(K3D_CLUSTER_NAME) -l app=cluster-agent -o name 2>/dev/null); \
-		if [ -n "$$dep" ]; then kubectl rollout status $$dep -n $$ns --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s || true; fi; \
+		dep=$$(kubectl get deployment -n $$ns --context k3d-$(K3D_CLUSTER_NAME) -l app=cluster-agent -o name) || exit $$?; \
+		if [ -n "$$dep" ]; then kubectl rollout status $$dep -n $$ns --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s; fi; \
 	done
 	@$(call log_success, All components updated!)
 
@@ -206,7 +206,7 @@ k3d.update.cluster-agent: ## Update cluster-agent: build, load, restart across a
 	@$(MAKE) k3d.build.cluster-agent
 	@$(MAKE) k3d.load.cluster-agent
 	@for ns in $(K3D_DP_NAMESPACE) $(K3D_WP_NAMESPACE) $(K3D_OP_NAMESPACE); do \
-		dep=$$(kubectl get deployment -n $$ns --context k3d-$(K3D_CLUSTER_NAME) -l app=cluster-agent -o name 2>/dev/null); \
+		dep=$$(kubectl get deployment -n $$ns --context k3d-$(K3D_CLUSTER_NAME) -l app=cluster-agent -o name) || exit $$?; \
 		if [ -n "$$dep" ]; then \
 			kubectl rollout restart $$dep -n $$ns --context k3d-$(K3D_CLUSTER_NAME); \
 			kubectl rollout status $$dep -n $$ns --context k3d-$(K3D_CLUSTER_NAME) --timeout=300s; \


### PR DESCRIPTION
## Purpose

This PR fixes a k3d development workflow reliability issue where `make k3d.update` could hide failed Kubernetes rollout restart/status commands.

## Approach

Removed `|| true` from rollout restart and rollout status commands in the all-component `k3d.update` target, so update failures are surfaced instead of reporting success incorrectly.

## Validation

- Verified the rendered dry-run commands with `make -n k3d.update`
- Confirmed rollout restart/status commands no longer suppress failures
- Confirmed only `make/k3d.mk` is changed

