### PR TITLE
feat: add condition check for obs APIS

### DIFF
--- a/internal/observer/authz/helpers.go
+++ b/internal/observer/authz/helpers.go
@@ -13,6 +13,19 @@ import (
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
 
+// FormatDualScopedResourceName returns the authz-engine identifier for a dual-scoped resource.
+// Namespace-scoped resources use "{namespace}/{name}"; cluster-scoped resources use plain "{name}".
+// An empty name returns "" so callers can omit the attribute when the scope is not provided.
+func FormatDualScopedResourceName(namespace, name string, isClusterScoped bool) string {
+	if name == "" {
+		return ""
+	}
+	if isClusterScoped || namespace == "" {
+		return name
+	}
+	return namespace + "/" + name
+}
+
 // ComponentScopeAuthz determines the authorization resource type, name, and hierarchy
 // from a component search scope (namespace/project/component). The most specific
 // non-empty field determines the resource type.
@@ -64,7 +77,7 @@ func LogsScopeAuthz(req *types.LogsQueryRequest) (ResourceType, string, authzcor
 	return "", "", authzcore.ResourceHierarchy{}, fmt.Errorf("invalid search scope")
 }
 
-// CheckAuthorization performs a complete authorization check for observer operations
+// CheckAuthorization performs a complete authorization check for observer operations.
 func CheckAuthorization(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -73,6 +86,7 @@ func CheckAuthorization(
 	resourceType ResourceType,
 	resourceID string,
 	hierarchy authzcore.ResourceHierarchy,
+	authzCtx authzcore.Context,
 ) error {
 	if pdp == nil {
 		logger.Debug("Authorization disabled, skipping check")
@@ -100,7 +114,7 @@ func CheckAuthorization(
 			ID:        resourceID,
 			Hierarchy: hierarchy,
 		},
-		Context: authzcore.Context{},
+		Context: authzCtx,
 	}
 
 	decision, err := pdp.Evaluate(ctx, authzReq)

--- a/internal/observer/authz/helpers_test.go
+++ b/internal/observer/authz/helpers_test.go
@@ -25,6 +25,55 @@ func noopLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+func TestFormatDualScopedResourceName(t *testing.T) {
+	tests := []struct {
+		name            string
+		namespace       string
+		resourceName    string
+		isClusterScoped bool
+		want            string
+	}{
+		{
+			name:         "namespace-scoped joins namespace and name",
+			namespace:    "acme",
+			resourceName: "dev",
+			want:         "acme/dev",
+		},
+		{
+			name:            "cluster-scoped returns plain name",
+			namespace:       "acme",
+			resourceName:    "dev",
+			isClusterScoped: true,
+			want:            "dev",
+		},
+		{
+			name:         "empty name returns empty string",
+			namespace:    "acme",
+			resourceName: "",
+			want:         "",
+		},
+		{
+			name:            "empty name with cluster scope returns empty string",
+			resourceName:    "",
+			isClusterScoped: true,
+			want:            "",
+		},
+		{
+			name:         "empty namespace falls back to plain name",
+			namespace:    "",
+			resourceName: "dev",
+			want:         "dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatDualScopedResourceName(tt.namespace, tt.resourceName, tt.isClusterScoped)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // ─────────────────────── ComponentScopeAuthz ───────────────────────
 
 func TestComponentScopeAuthz(t *testing.T) {
@@ -234,6 +283,7 @@ func TestCheckAuthorization_PDPNil(t *testing.T) {
 		ResourceTypeComponent,
 		"api",
 		authzcore.ResourceHierarchy{Namespace: "acme"},
+		authzcore.Context{},
 	)
 	assert.NoError(t, err, "nil PDP should skip authorization")
 }
@@ -249,6 +299,7 @@ func TestCheckAuthorization_NoSubjectContext(t *testing.T) {
 		ResourceTypeComponent,
 		"api",
 		authzcore.ResourceHierarchy{},
+		authzcore.Context{},
 	)
 	assert.ErrorIs(t, err, ErrAuthzUnauthorized)
 }
@@ -266,6 +317,7 @@ func TestCheckAuthorization_PDPEvaluateError(t *testing.T) {
 		ResourceTypeComponent,
 		"api",
 		authzcore.ResourceHierarchy{Namespace: "acme"},
+		authzcore.Context{},
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upstream failure")
@@ -284,6 +336,7 @@ func TestCheckAuthorization_DecisionAllowed(t *testing.T) {
 		ResourceTypeComponent,
 		"api",
 		authzcore.ResourceHierarchy{Namespace: "acme"},
+		authzcore.Context{},
 	)
 	assert.NoError(t, err)
 }
@@ -301,6 +354,7 @@ func TestCheckAuthorization_DecisionDenied(t *testing.T) {
 		ResourceTypeComponent,
 		"api",
 		authzcore.ResourceHierarchy{Namespace: "acme"},
+		authzcore.Context{},
 	)
 	assert.ErrorIs(t, err, ErrAuthzForbidden)
 }
@@ -321,6 +375,7 @@ func TestCheckAuthorization_BuildsCorrectRequest(t *testing.T) {
 		ResourceTypeComponent,
 		"api",
 		hierarchy,
+		authzcore.Context{},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, capturedReq)
@@ -332,4 +387,27 @@ func TestCheckAuthorization_BuildsCorrectRequest(t *testing.T) {
 	assert.Equal(t, "user", capturedReq.SubjectContext.Type)
 	assert.Equal(t, "groups", capturedReq.SubjectContext.EntitlementClaim)
 	assert.Equal(t, []string{"dev-team"}, capturedReq.SubjectContext.EntitlementValues)
+}
+
+func TestCheckAuthorization_ContextPropagated(t *testing.T) {
+	var capturedReq *authzcore.EvaluateRequest
+	mockPDP := coremocks.NewMockPDP(t)
+	mockPDP.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req *authzcore.EvaluateRequest) { capturedReq = req }).
+		Return(&authzcore.Decision{Decision: true}, nil)
+
+	authzCtx := authzcore.Context{Resource: authzcore.ResourceAttribute{Environment: "acme/dev"}}
+	err := CheckAuthorization(
+		ctxWithSubject(),
+		noopLogger(),
+		mockPDP,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{Namespace: "acme"},
+		authzCtx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, authzCtx, capturedReq.Context)
 }

--- a/internal/observer/service/alert_incident_authz.go
+++ b/internal/observer/service/alert_incident_authz.go
@@ -47,6 +47,7 @@ func (s *alertIncidentServiceWithAuthz) QueryAlerts(ctx context.Context, req gen
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionViewAlerts,
 		resourceType, resourceName, hierarchy,
+		authzcore.Context{},
 	); err != nil {
 		return nil, err
 	}
@@ -70,6 +71,7 @@ func (s *alertIncidentServiceWithAuthz) QueryIncidents(ctx context.Context, req 
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionViewIncidents,
 		resourceType, resourceName, hierarchy,
+		authzcore.Context{},
 	); err != nil {
 		return nil, err
 	}
@@ -83,6 +85,7 @@ func (s *alertIncidentServiceWithAuthz) UpdateIncident(ctx context.Context, inci
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionUpdateIncidents,
 		observerAuthz.ResourceTypeNamespace, "", authzcore.ResourceHierarchy{},
+		authzcore.Context{},
 	); err != nil {
 		return nil, err
 	}

--- a/internal/observer/service/logs_authz.go
+++ b/internal/observer/service/logs_authz.go
@@ -33,10 +33,20 @@ func (s *logsServiceWithAuthz) QueryLogs(ctx context.Context, req *types.LogsQue
 	if err != nil {
 		return nil, err
 	}
+	// TODO: currently the obs API is not equipped to provide cluster level environments,
+	// once that is done update false to proper isClusterScoped value.
+	authzCtx := authzcore.Context{}
+	if req.SearchScope != nil && req.SearchScope.Component != nil {
+		scope := req.SearchScope.Component
+		authzCtx.Resource = authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
+		}
+	}
 	if err := observerAuthz.CheckAuthorization(
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionViewLogs,
 		resourceType, resourceName, hierarchy,
+		authzCtx,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/observer/service/metrics_authz.go
+++ b/internal/observer/service/metrics_authz.go
@@ -35,10 +35,15 @@ func (s *metricsServiceWithAuthz) QueryMetrics(ctx context.Context, req *types.M
 	}
 	scope := req.SearchScope
 	resourceType, resourceName, hierarchy := observerAuthz.ComponentScopeAuthz(scope.Namespace, scope.Project, scope.Component)
+	// TODO: currently the obs API is not equipped to provide cluster level environments,
+	// once that is done update false to proper isClusterScoped value.
 	if err := observerAuthz.CheckAuthorization(
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionViewMetrics,
 		resourceType, resourceName, hierarchy,
+		authzcore.Context{Resource: authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
+		}},
 	); err != nil {
 		return nil, err
 	}

--- a/internal/observer/service/traces_authz.go
+++ b/internal/observer/service/traces_authz.go
@@ -31,10 +31,15 @@ func NewTracesServiceWithAuthz(s TracesQuerier, pdp authzcore.PDP, logger *slog.
 func (s *tracesServiceWithAuthz) QueryTraces(ctx context.Context, req *types.TracesQueryRequest) (*types.TracesQueryResponse, error) {
 	scope := req.SearchScope
 	resourceType, resourceName, hierarchy := observerAuthz.ComponentScopeAuthz(scope.Namespace, scope.Project, scope.Component)
+	// TODO: currently the obs API is not equipped to provide cluster level environments,
+	// once that is done update false to proper isClusterScoped value.
 	if err := observerAuthz.CheckAuthorization(
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionViewTraces,
 		resourceType, resourceName, hierarchy,
+		authzcore.Context{Resource: authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
+		}},
 	); err != nil {
 		return nil, err
 	}
@@ -44,10 +49,15 @@ func (s *tracesServiceWithAuthz) QueryTraces(ctx context.Context, req *types.Tra
 func (s *tracesServiceWithAuthz) QuerySpans(ctx context.Context, traceID string, req *types.TracesQueryRequest) (*types.SpansQueryResponse, error) {
 	scope := req.SearchScope
 	resourceType, resourceName, hierarchy := observerAuthz.ComponentScopeAuthz(scope.Namespace, scope.Project, scope.Component)
+	// TODO: currently the obs API is not equipped to provide cluster level environments,
+	// once that is done update false to proper isClusterScoped value.
 	if err := observerAuthz.CheckAuthorization(
 		ctx, s.logger, s.pdp,
 		observerAuthz.ActionViewTraces,
 		resourceType, resourceName, hierarchy,
+		authzcore.Context{Resource: authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
+		}},
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR is to add environment ABAC condition to obs API eps as well.
### changes summary
  - Pass `resource.environment` to the authz PDP for observer query actions (`logs:view`, `metrics:view`,           
  `traces:view`) so CEL conditions registered in `condition_registry.go` can scope by environment.                    
  - Add required `authzcore.Context` parameter to `observerAuthz.CheckAuthorization` and update all call sites (logs,
  metrics, traces, alerts/incidents).                                                                                 
  - Add `FormatDualScopedResourceName` helper in `internal/observer/authz` to format env as `{namespace}/{env}`,
   mirroring the releasebinding pattern without the cross-package import. 

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3229

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
