### PR TITLE
feat(controller): rolling restart via ReleaseBinding annotation

### DIFF
--- a/internal/controller/annotations.go
+++ b/internal/controller/annotations.go
@@ -17,6 +17,14 @@ const (
 	AnnotationKeyDisplayName = "openchoreo.dev/display-name"
 	AnnotationKeyDescription = "openchoreo.dev/description"
 
+	// AnnotationKeyRestartedAt is set on a ReleaseBinding to trigger a rolling
+	// restart of every Deployment deployed by the binding. The ReleaseBinding
+	// controller propagates the annotation to the dataplane RenderedRelease,
+	// and the rendered release controller injects the value into
+	// kubectl.kubernetes.io/restartedAt on each Deployment's pod template at
+	// apply time. The value is opaque; any change triggers a restart.
+	AnnotationKeyRestartedAt = "openchoreo.dev/restartedAt"
+
 	// SchemaExtensionComponentParameterRepositoryPrefix is the common prefix for all openAPIV3Schema
 	// x- extension keys that mark component repository parameter fields (set to true on the property).
 	// The suffix after the prefix is used as the role key in the map returned by ExtractComponentRepositoryPaths

--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -568,6 +568,15 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 			labels.LabelKeyEnvironmentName: releaseBinding.Spec.Environment,
 		}
 
+		if v, ok := releaseBinding.Annotations[controller.AnnotationKeyRestartedAt]; ok {
+			if dataPlaneRelease.Annotations == nil {
+				dataPlaneRelease.Annotations = map[string]string{}
+			}
+			dataPlaneRelease.Annotations[controller.AnnotationKeyRestartedAt] = v
+		} else {
+			delete(dataPlaneRelease.Annotations, controller.AnnotationKeyRestartedAt)
+		}
+
 		dataPlaneRelease.Spec = openchoreov1alpha1.RenderedReleaseSpec{
 			Owner: openchoreov1alpha1.RenderedReleaseOwner{
 				ProjectName:   releaseBinding.Spec.Owner.ProjectName,

--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -264,6 +264,8 @@ func (r *Reconciler) applyResources(ctx context.Context, planeClient client.Clie
 func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRelease) ([]*unstructured.Unstructured, error) {
 	desiredObjects := make([]*unstructured.Unstructured, 0, len(release.Spec.Resources))
 
+	restartedAt := release.Annotations[controller.AnnotationKeyRestartedAt]
+
 	for _, resource := range release.Spec.Resources {
 		// Convert RawExtension to Unstructured
 		obj := &unstructured.Unstructured{}
@@ -284,10 +286,31 @@ func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRe
 
 		obj.SetLabels(resourceLabels)
 
+		if restartedAt != "" {
+			injectRestartedAt(obj, restartedAt)
+		}
+
 		desiredObjects = append(desiredObjects, obj)
 	}
 
 	return desiredObjects, nil
+}
+
+// injectRestartedAt sets kubectl.kubernetes.io/restartedAt on the pod template
+// of an apps/v1 Deployment so the data plane performs a rolling restart, the
+// same way `kubectl rollout restart deployment` does. It is a no-op for any
+// other kind.
+func injectRestartedAt(obj *unstructured.Unstructured, value string) {
+	gvk := obj.GroupVersionKind()
+	if gvk.Group != "apps" || gvk.Kind != "Deployment" {
+		return
+	}
+	annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations["kubectl.kubernetes.io/restartedAt"] = value
+	_ = unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations")
 }
 
 // makeDesiredNamespaces creates namespace objects from the desired resources with proper labels

--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -289,7 +289,9 @@ func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRe
 		obj.SetLabels(resourceLabels)
 
 		if restartedAt != "" {
-			injectRestartedAt(obj, restartedAt)
+			if err := injectRestartedAt(obj, restartedAt); err != nil {
+				return nil, fmt.Errorf("failed to inject restartedAt on resource %s: %w", resource.ID, err)
+			}
 		}
 
 		desiredObjects = append(desiredObjects, obj)
@@ -301,18 +303,26 @@ func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRe
 // injectRestartedAt sets kubectl.kubernetes.io/restartedAt on the pod template
 // of an apps/v1 Deployment so the data plane performs a rolling restart, the
 // same way `kubectl rollout restart deployment` does. It is a no-op for any
-// other kind.
-func injectRestartedAt(obj *unstructured.Unstructured, value string) {
+// other kind. Returns an error if the manifest is malformed (e.g. annotations
+// is not a string map), so the caller can surface it instead of silently
+// dropping the restart trigger.
+func injectRestartedAt(obj *unstructured.Unstructured, value string) error {
 	gvk := obj.GroupVersionKind()
 	if gvk.Group != appsAPIGroup || gvk.Kind != "Deployment" {
-		return
+		return nil
 	}
-	annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return fmt.Errorf("read pod template annotations: %w", err)
+	}
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
 	annotations["kubectl.kubernetes.io/restartedAt"] = value
-	_ = unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations")
+	if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
+		return fmt.Errorf("set pod template annotations: %w", err)
+	}
+	return nil
 }
 
 // makeDesiredNamespaces creates namespace objects from the desired resources with proper labels

--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -33,6 +33,8 @@ const (
 	targetPlaneDataPlane          = "dataplane"
 	targetPlaneObservabilityPlane = "observabilityplane"
 
+	appsAPIGroup = "apps"
+
 	// ConditionResourcesApplied indicates whether resources were successfully applied to the target plane.
 	// When False, it contains the error message from the failed apply operation.
 	ConditionResourcesApplied = "ResourcesApplied"
@@ -302,7 +304,7 @@ func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRe
 // other kind.
 func injectRestartedAt(obj *unstructured.Unstructured, value string) {
 	gvk := obj.GroupVersionKind()
-	if gvk.Group != "apps" || gvk.Kind != "Deployment" {
+	if gvk.Group != appsAPIGroup || gvk.Kind != "Deployment" {
 		return
 	}
 	annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")


### PR DESCRIPTION
## Purpose

https://github.com/openchoreo/openchoreo/issues/3291

Add a way to trigger a rolling restart of the workloads owned by a ReleaseBinding without changing any user-facing image, config, or trait. Operators can now run

```bash
kubectl annotate releasebinding <name> openchoreo.dev/restartedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
```

and the data plane Deployment is rolled, the same way `kubectl rollout restart deployment` would do it.

## Approach

- Add `openchoreo.dev/restartedAt` annotation key in `internal/controller/annotations.go`.
- ReleaseBinding controller: when the annotation is present on the ReleaseBinding, propagate it to the dataplane RenderedRelease inside the existing `CreateOrUpdate` mutator. Removing the annotation also removes it on the RenderedRelease. The observability RenderedRelease is intentionally left untouched.
- RenderedRelease controller: in `makeDesiredResources`, if the RenderedRelease carries the annotation, inject `kubectl.kubernetes.io/restartedAt` into the pod template of every `apps/v1` Deployment before applying. Other kinds (StatefulSet, DaemonSet, ConfigMap, etc.) are skipped — only Deployment is in scope for now.
- The value is treated as opaque. Any change (or first appearance) is enough to trigger a restart, since it changes `spec.template`.

Verified end-to-end on a k3d cluster with the `samples/from-image/echo-websocket-service` sample at both 1 and 3 replicas. The 3-replica run produced a normal staggered rolling update (`1 out of 3`, `2 out of 3`, `complete`), with all old pods replaced by new ones on a fresh ReplicaSet and the annotation visible at all three layers (ReleaseBinding → RenderedRelease → Deployment pod template).

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)