### PR TITLE
fix: sort rendered file-mount volumes to prevent rollout loops

### DIFF
--- a/internal/pipeline/component/context/cel_extensions.go
+++ b/internal/pipeline/component/context/cel_extensions.go
@@ -457,8 +457,15 @@ func makeVolumesList(containerConfig map[string]any, prefix string) []map[string
 		}
 	}
 
-	for _, volume := range volumes {
-		result = append(result, volume)
+	// Sort by name so the slice order is stable across renders; otherwise
+	// the Deployment's pod-template-hash flips on every reconcile.
+	names := make([]string, 0, len(volumes))
+	for name := range volumes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		result = append(result, volumes[name])
 	}
 
 	return result

--- a/internal/pipeline/component/context/cel_extensions_test.go
+++ b/internal/pipeline/component/context/cel_extensions_test.go
@@ -1165,6 +1165,72 @@ func TestConfigurationsToVolumesMacro(t *testing.T) {
 	}
 }
 
+// TestConfigurationsToVolumesMacro_DeterministicOrder guards against rollout loops
+// caused by Go's randomized map iteration. With many file mounts the rendered
+// volumes slice must be in a stable, sorted order — otherwise SSA persists a
+// different order each render, the Deployment's pod-template-hash changes, and
+// pods needlessly roll. See issue #3302.
+func TestConfigurationsToVolumesMacro_DeterministicOrder(t *testing.T) {
+	configFiles := []any{
+		map[string]any{"name": "alpha.properties", "mountPath": "/etc/alpha"},
+		map[string]any{"name": "bravo.properties", "mountPath": "/etc/bravo"},
+		map[string]any{"name": "charlie.properties", "mountPath": "/etc/charlie"},
+		map[string]any{"name": "delta.properties", "mountPath": "/etc/delta"},
+	}
+	secretFiles := []any{
+		map[string]any{"name": "echo.crt", "mountPath": "/etc/echo"},
+		map[string]any{"name": "foxtrot.crt", "mountPath": "/etc/foxtrot"},
+	}
+	inputs := map[string]any{
+		"metadata": map[string]any{
+			"componentName":   "app",
+			"environmentName": "dev",
+		},
+		"configurations": map[string]any{
+			"configs": map[string]any{"files": configFiles},
+			"secrets": map[string]any{"files": secretFiles},
+		},
+	}
+
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+
+	render := func() []map[string]any {
+		result, err := engine.Render("${configurations.toVolumes()}", inputs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got, ok := result.([]map[string]any)
+		if !ok {
+			t.Fatalf("expected []map[string]any, got %T", result)
+		}
+		return got
+	}
+
+	first := render()
+
+	if len(first) != len(configFiles)+len(secretFiles) {
+		t.Fatalf("expected %d volumes, got %d", len(configFiles)+len(secretFiles), len(first))
+	}
+
+	names := make([]string, 0, len(first))
+	for _, v := range first {
+		names = append(names, v["name"].(string))
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] >= names[i] {
+			t.Errorf("volumes not sorted by name: %v", names)
+			break
+		}
+	}
+
+	for i := 0; i < 50; i++ {
+		next := render()
+		if diff := cmp.Diff(first, next); diff != "" {
+			t.Fatalf("volume order is non-deterministic across renders (-first +iter%d):\n%s", i, diff)
+		}
+	}
+}
+
 func TestConfigurationsToConfigEnvsByContainerMacro(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Purpose

When a Component declares two or more file-mount ConfigMaps/Secrets, the controller continuously re-applies the rendered Deployment with reordered `spec.template.spec.volumes`, which changes the pod-template-hash and rolls the pods on every reconcile.

Root cause: The CEL helper makeVolumesList() (which powers configurations.toVolumes()) builds the list of volumes from a Go map. Go does not guarantee any particular order when reading entries out of a map, so every render produces the same volumes but in a different order. When the controller applies the rendered Deployment, the API server stores the volumes in the exact order it received them. The Deployment controller then computes a hash over the pod template, and that hash depends on the order of items in the list, not just their content. A different order produces a different hash; Kubernetes treats it as a new pod template, creates a new ReplicaSet, and rolls the pods.


## Approach

- Sort by volume name before appending, mirroring the existing pattern used in `workloadToServicePortsFunction()` in the same file.
- Add `TestConfigurationsToVolumesMacro_DeterministicOrder`: 6 file mounts, asserts sorted order, renders 50× and asserts every render is byte-identical. The pre-existing `TestConfigurationsToVolumesMacro` used `cmpopts.SortSlices` which masked this bug; the new test guards the contract directly.
- Audited the rest of the rendering pipeline (`internal/pipeline/`, `internal/template/`, `internal/controller/releasebinding/`) — every other map→slice conversion already sorts (`workloadToServicePorts`, `sortRenderedResources`, `addDPResourceHashAnnotation`, endpoint URL status, `foreach` keys, engine cache key). `makeVolumesList` was the only oversight.

## Related Issues

Closes #3302

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)