### PR TITLE
feat: forward logs and tracing requests to an external adapter by default and update module versions

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -41,9 +41,9 @@ data:
   {{- if .Values.observer.cors.allowedOrigins }}
   CORS_ALLOWED_ORIGINS: {{ join "," .Values.observer.cors.allowedOrigins | quote }}
   {{- end }}
-  LOGS_ADAPTER_ENABLED: {{ .Values.observer.logsAdapter.enabled | default false | quote }}
+  LOGS_ADAPTER_ENABLED: {{ .Values.observer.logsAdapter.enabled | quote }}
   LOGS_ADAPTER_URL: {{ .Values.observer.logsAdapter.url | default "http://logs-adapter:9098" | quote }}
   LOGS_ADAPTER_TIMEOUT: {{ .Values.observer.logsAdapter.timeout | default "30s" | quote }}
-  TRACING_ADAPTER_ENABLED: {{ .Values.observer.tracingAdapter.enabled | default false | quote }}
+  TRACING_ADAPTER_ENABLED: {{ .Values.observer.tracingAdapter.enabled | quote }}
   TRACING_ADAPTER_URL: {{ .Values.observer.tracingAdapter.url | default "http://tracing-adapter:9100" | quote }}
   TRACING_ADAPTER_TIMEOUT: {{ .Values.observer.tracingAdapter.timeout | default "30s" | quote }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1132,7 +1132,7 @@
           "description": "Configurations for logs adapter connectivity",
           "properties": {
             "enabled": {
-              "default": false,
+              "default": true,
               "description": "Enable logs adapter for fetching logs from an external adapter",
               "title": "enabled",
               "type": "boolean"
@@ -1349,7 +1349,7 @@
           "description": "Configurations for tracing adapter connectivity",
           "properties": {
             "enabled": {
-              "default": false,
+              "default": true,
               "description": "Enable tracing adapter for fetching traces from an external adapter",
               "title": "enabled",
               "type": "boolean"

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -393,9 +393,9 @@ observer:
     # @schema
     # type: boolean
     # description: Enable logs adapter for fetching logs from an external adapter
-    # default: false
+    # default: true
     # @schema
-    enabled: false
+    enabled: true
     # @schema
     # type: string
     # description: URL of the logs adapter service
@@ -502,9 +502,9 @@ observer:
     # @schema
     # type: boolean
     # description: Enable tracing adapter for fetching traces from an external adapter
-    # default: false
+    # default: true
     # @schema
-    enabled: false
+    enabled: true
     # @schema
     # type: string
     # description: URL of the tracing adapter service

--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -13,9 +13,9 @@ set -euo pipefail
 # -- versions (update these on release branches) --
 OPENCHOREO_REF="main"
 OPENCHOREO_OP_VERSION="0.0.0-latest-dev"
-LOGS_OPENSEARCH_VERSION="0.3.11"
-TRACES_OPENSEARCH_VERSION="0.3.11"
-METRICS_PROMETHEUS_VERSION="0.3.0"
+LOGS_OPENSEARCH_VERSION="0.4.0"
+TRACES_OPENSEARCH_VERSION="0.4.1"
+METRICS_PROMETHEUS_VERSION="0.4.2"
 
 # -- derived constants --
 RAW_BASE="https://raw.githubusercontent.com/openchoreo/openchoreo/${OPENCHOREO_REF}"

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -601,7 +601,7 @@ helm upgrade --install observability-logs-opensearch \
   --kube-context k3d-openchoreo-op \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --version 0.4.0 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearchCluster.credentialsSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
@@ -616,7 +616,7 @@ helm upgrade --install observability-logs-opensearch \
   --kube-context k3d-openchoreo-dp \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --version 0.4.0 \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
@@ -634,7 +634,7 @@ helm upgrade --install observability-logs-opensearch \
   --kube-context k3d-openchoreo-wp \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --version 0.4.0 \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
@@ -654,7 +654,7 @@ helm upgrade --install observability-tracing-opensearch \
   --kube-context k3d-openchoreo-op \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --version 0.4.1 \
   --set global.installationMode="multiClusterReceiver" \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
@@ -669,7 +669,7 @@ helm upgrade --install observability-tracing-opensearch \
   --kube-context k3d-openchoreo-dp \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.11 \
+  --version 0.4.1 \
   --set global.installationMode="multiClusterExporter" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
@@ -689,7 +689,7 @@ helm upgrade --install observability-metrics-prometheus \
   --kube-context k3d-openchoreo-op \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.0 \
+  --version 0.4.2 \
   --set global.installationMode="multiClusterReceiver" \
   --set-json 'prometheusCustomizations.http.hostnames=["prometheus.observability.openchoreo.localhost", "host.k3d.internal"]'
 ```
@@ -702,7 +702,7 @@ helm upgrade --install observability-metrics-prometheus \
   --kube-context k3d-openchoreo-dp \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.0 \
+  --version 0.4.2 \
   --set global.installationMode="multiClusterExporter" \
   --set prometheusCustomizations.http.observabilityPlaneUrl=http://host.k3d.internal:11080/api/v1/write \
   --set kube-prometheus-stack.prometheus.enabled=false \

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1072,18 +1072,18 @@ install_observability_plane() {
     log_info "Installing observability modules..."
 
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.3.11" \
+        "--version" "0.4.0" \
         "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials"
 
     # Enable fluent-bit after opensearch is installed and ready
     log_info "Enabling fluent-bit for log collection..."
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.3.11" \
+        "--version" "0.4.0" \
         "--reuse-values" \
         "--set" "fluent-bit.enabled=true"
 
     install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.3.0"
+        "--version" "0.4.2"
 }
 
 # Apply ClusterWorkflowTemplates required by the workflow plane

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -282,6 +282,18 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// Print deprecation notices for adapter-enabled environment variables
+	if os.Getenv("LOGS_ADAPTER_ENABLED") != "" {
+		fmt.Fprintln(os.Stderr, "NOTICE: LOGS_ADAPTER_ENABLED is deprecated. "+
+			"OpenChoreo observability now uses the adapter architecture by default. "+
+			"This environment variable will be removed in a future version.")
+	}
+	if os.Getenv("TRACING_ADAPTER_ENABLED") != "" {
+		fmt.Fprintln(os.Stderr, "NOTICE: TRACING_ADAPTER_ENABLED is deprecated. "+
+			"OpenChoreo observability now uses the adapter architecture by default. "+
+			"This environment variable will be removed in a future version.")
+	}
+
 	// Load environment overrides
 	if len(envOverrides) > 0 {
 		if err := k.Load(confmap.Provider(envOverrides, "."), nil); err != nil {
@@ -371,10 +383,10 @@ func getDefaults() map[string]interface{} {
 			"alert.suppression.window": "1h",
 		},
 		"adapters": map[string]interface{}{
-			"logs.adapter.enabled":    false,
+			"logs.adapter.enabled":    true,
 			"logs.adapter.url":        "http://logs-adapter:9098",
 			"logs.adapter.timeout":    "30s",
-			"tracing.adapter.enabled": false,
+			"tracing.adapter.enabled": true,
 			"tracing.adapter.url":     "http://tracing-adapter:9100",
 			"tracing.adapter.timeout": "30s",
 			"metrics.adapter.url":     "http://metrics-adapter:9099",

--- a/internal/observer/config/config_test.go
+++ b/internal/observer/config/config_test.go
@@ -223,15 +223,15 @@ func TestLoad_BooleanEnvParsing_InvalidValues(t *testing.T) {
 }
 
 func TestLoad_BooleanEnvParsing_Unset(t *testing.T) {
-	// When env vars are not set, adapters should default to false
+	// When env vars are not set, adapters should default to true
 	os.Unsetenv("LOGS_ADAPTER_ENABLED")
 	os.Unsetenv("TRACING_ADAPTER_ENABLED")
 
 	cfg, err := Load()
 	require.NoError(t, err, "Failed to load config")
 
-	assert.False(t, cfg.Adapters.LogsAdapterEnabled)
-	assert.False(t, cfg.Adapters.TracingAdapterEnabled)
+	assert.True(t, cfg.Adapters.LogsAdapterEnabled)
+	assert.True(t, cfg.Adapters.TracingAdapterEnabled)
 }
 
 func TestValidate(t *testing.T) {

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -280,12 +280,12 @@ _e2e.install-op:
 	@$(call log_info, Installing observability modules)
 	$(E2E_HELM) upgrade --install observability-logs-opensearch \
 		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
-		--version 0.3.11 \
+		--version 0.4.0 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_HELM) upgrade --install observability-metrics-prometheus \
 		oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
-		--version 0.3.0 \
+		--version 0.4.2 \
 		--namespace $(E2E_OP_NS) \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_KUBECTL) wait -n $(E2E_OP_NS) \


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Enable the adapter architecture by default for logs and tracing in the Observer service. Previously, adapters were opt-in via LOGS_ADAPTER_ENABLED and TRACING_ADAPTER_ENABLED environment variables. This change makes the adapter path the standard

## Approach
- Changed the default value for logs.adapter.enabled and tracing.adapter.enabled from false to true in the Go config defaults, Helm chart values, and Helm template fallbacks.
- Added deprecation notices (printed to stderr at startup) when LOGS_ADAPTER_ENABLED or TRACING_ADAPTER_ENABLED environment variables are explicitly set, informing users that the adapter architecture is now the default and these variables will be removed in a future version.
- Updated the corresponding unit test to expect the new default.
- Updated the observability module helm chart versions

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2964

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
