### PR TITLE
fix: update adapter image tag for observability metrics module

### DIFF
--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -55,7 +55,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace "$OP_NS" \
-  --version "$METRICS_PROMETHEUS_VERSION"
+  --version "$METRICS_PROMETHEUS_VERSION" --set adapter.image.tag="$METRICS_PROMETHEUS_VERSION"
 
 step "Enabling logs collection in the configured logs module..."
 helm upgrade observability-logs-opensearch \

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -687,7 +687,8 @@ helm upgrade --install observability-metrics-prometheus \
   --kube-context k3d-openchoreo-op \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.5
+  --version 0.2.5 \
+  --set adapter.image.tag="0.2.5"
 ```
 
 ### Register Observability Plane

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1083,7 +1083,8 @@ install_observability_plane() {
         "--set" "fluent-bit.enabled=true"
 
     install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.2.5"
+        "--version" "0.2.5" \
+        "--set" "adapter.image.tag=0.2.5"
 }
 
 # Apply ClusterWorkflowTemplates required by the workflow plane

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -287,6 +287,7 @@ _e2e.install-op:
 		oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
 		--version 0.2.5 \
 		--namespace $(E2E_OP_NS) \
+		--set adapter.image.tag="0.2.5" \
 		--wait --timeout $(E2E_SETUP_TIMEOUT)
 	$(E2E_KUBECTL) wait -n $(E2E_OP_NS) \
 		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request ensures that the `adapter.image.tag` for the `observability-metrics-prometheus` Helm chart is explicitly set to match the chart version (`0.2.5`) across all installation scripts and documentation. Due to existing issue in the Helm Chart version 0.2.5, adaptor image tag always being set as 'latest' which might not always be compatible with OpenChoreo 1.0.0 release.

Pinning the image tag here as the community module fix is done in a later Helm Chart version (https://github.com/openchoreo/community-modules/pull/82)

## Approach

**Helm chart installation updates:**

* Explicitly set `adapter.image.tag` to match the chart version (`0.2.5`) in the following scripts:
  - `install/k3d/k3d-observability-plane.sh`
  - `install/quick-start/.helpers.sh`
  - `make/e2e.mk`

**Documentation update:**

* Updated the multi-cluster installation instructions in `install/k3d/multi-cluster/README.md` to include `--set adapter.image.tag="0.2.5"` in the Helm command example.


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
