### PR TITLE
fix(controller): clean up trait-created secrets on deletion

### DIFF
--- a/internal/cluster-gateway/validator.go
+++ b/internal/cluster-gateway/validator.go
@@ -39,7 +39,6 @@ func NewRequestValidator() *RequestValidator {
 		},
 		blockedPaths: []string{
 			"/api/v1/namespaces/kube-system/secrets",
-			"/api/v1/secrets",          // Without namespace - cluster-wide
 			"/apis/v1/serviceaccounts", // Cluster-wide service accounts
 		},
 		allowedTargets: map[string]bool{

--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -467,12 +467,7 @@ func findAllKnownGVKs(desiredResources []*unstructured.Unstructured, appliedReso
 		// Core Kubernetes Resources
 		{Group: "", Version: "v1", Kind: "Service"},
 		{Group: "", Version: "v1", Kind: "ConfigMap"},
-		// Secret is excluded from well-known GVKs because the cluster gateway blocks
-		// cluster-wide secret listing (/api/v1/secrets) for security reasons.
-		// Secrets are tracked and cleaned up through external secrets.
-		// TODO: Switch listLiveResourcesByGVKs to namespace-scoped listing so secrets
-		// can be safely re-added here without hitting the cluster gateway block.
-		// {Group: "", Version: "v1", Kind: "Secret"},
+		{Group: "", Version: "v1", Kind: "Secret"},
 		{Group: "", Version: "v1", Kind: "ServiceAccount"},
 		{Group: "", Version: "v1", Kind: "Namespace"},
 		{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -213,7 +213,7 @@ func TestFindStaleResources(t *testing.T) {
 // ─────────────────────────────────────────────────────────────
 
 func TestFindAllKnownGVKs(t *testing.T) {
-	const wellKnownCount = 19 // number of well-known GVKs defined in the function (Secret excluded)
+	const wellKnownCount = 20 // number of well-known GVKs defined in the function
 
 	containsGVK := func(gvks []schema.GroupVersionKind, group, kind string) bool {
 		for _, gvk := range gvks {


### PR DESCRIPTION
## Purpose

Backport of #3321 to `release-v1.0`.

Trait-created Kubernetes Secrets were not cleaned up when a component was deleted, leaving orphaned secrets in the data plane namespace. The renderedrelease controller excluded `Secret` from its well-known GVK list because the cluster gateway blocked all secret paths via a `strings.Contains` match on `/api/v1/secrets`, which also matched namespaced secret URLs.

## Approach

- Remove the cluster-wide `/api/v1/secrets` entry from the gateway validator's blocked paths. The kube-system block stays in place.
- Re-add `Secret` to the well-known GVKs in `findAllKnownGVKs` so cleanup can discover and delete orphaned secrets via the managed-by label selector.
- Update the unit test count to match.

Note: `release-v1.0` does not have `internal/cluster-gateway/validator_test.go`, so the validator test changes from the main PR are not included here.

## Related Issues

Closes #3244

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)