### PR TITLE
fix: defer cancel in observer UID resolver until body is read

### DIFF
--- a/internal/observer/service/uid_resolver.go
+++ b/internal/observer/service/uid_resolver.go
@@ -167,95 +167,99 @@ func (r *ResourceUIDResolver) fetchResourceUID(ctx context.Context, path string)
 	// Build request URL
 	reqURL := strings.TrimSuffix(r.config.OpenChoreoAPIURL, "/") + path
 	for attempt := 0; attempt < (r.config.MaxAuthRetry + 1); attempt++ {
-		token, err := r.getAccessToken(ctx)
-		if err != nil {
-			return "", fmt.Errorf("%w: failed to obtain access token: %w", ErrScopeAuthFailed, err)
+		uid, err, retry := r.doFetchResourceUID(ctx, reqURL, path, attempt)
+		if retry {
+			continue
 		}
-
-		reqCtx, reqCancel := context.WithTimeout(ctx, r.config.Timeout)
-
-		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
-		if err != nil {
-			reqCancel()
-			return "", fmt.Errorf("failed to create request: %w", err)
-		}
-
-		req.Header.Set("Accept", "application/json")
-		if token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
-
-		resp, err := r.httpClient.Do(req)
-		reqCancel()
-		if err != nil {
-			return "", fmt.Errorf("request failed: %w", err)
-		}
-
-		switch resp.StatusCode {
-		case http.StatusOK:
-			// Parse response to extract metadata.uid
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				resp.Body.Close()
-				return "", fmt.Errorf("failed to read response body: %w", err)
-			}
-			resp.Body.Close()
-
-			r.logger.Debug("Raw UID resolver response", "path", path, "status", resp.StatusCode, "body", string(body))
-
-			var response struct {
-				Metadata struct {
-					UID string `json:"uid"`
-				} `json:"metadata"`
-			}
-
-			if err := json.Unmarshal(body, &response); err != nil {
-				return "", fmt.Errorf("failed to decode response: %w", err)
-			}
-
-			if response.Metadata.UID == "" {
-				return "", fmt.Errorf("uid not found in response")
-			}
-
-			r.logger.Debug("Resolved resource UID",
-				"path", path,
-				"uid", response.Metadata.UID)
-
-			return response.Metadata.UID, nil
-
-		case http.StatusNotFound:
-			_, _ = io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
-			return "", fmt.Errorf("%w: %s", ErrResourceNotFound, path)
-
-		case http.StatusUnauthorized:
-			_, _ = io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
-
-			r.tokenMu.Lock()
-			r.tokenEntry = nil
-			r.tokenMu.Unlock()
-
-			remaining := r.config.MaxAuthRetry - attempt
-			if remaining > 0 {
-				r.logger.Debug("Received 401 from openchoreo-api; invalidating cached token and retrying",
-					"path", path, "attempt", attempt+1, "remaining_retries", remaining)
-				continue
-			}
-
-			r.logger.Error("Received 401 from openchoreo-api and retries are exhausted",
-				"path", path, "max_auth_retry", r.config.MaxAuthRetry)
-			return "", fmt.Errorf("%w: received 401 after %d attempt(s)", ErrScopeAuthFailed, r.config.MaxAuthRetry+1)
-
-		default:
-			_, _ = io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
-			return "", fmt.Errorf("API returned status %d", resp.StatusCode)
-		}
+		return uid, err
 	}
 	// Unreachable: every loop iteration either returns or continues (401 retry path).
 	// Kept as a defensive fallback.
 	return "", fmt.Errorf("%w: retry loop exhausted", ErrScopeAuthFailed)
+}
+
+// doFetchResourceUID performs a single HTTP attempt to fetch a resource UID.
+// It returns (uid, err, retry) where retry=true signals the caller to retry (401 case).
+func (r *ResourceUIDResolver) doFetchResourceUID(ctx context.Context, reqURL, path string, attempt int) (string, error, bool) {
+	token, err := r.getAccessToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to obtain access token: %w", ErrScopeAuthFailed, err), false
+	}
+
+	reqCtx, reqCancel := context.WithTimeout(ctx, r.config.Timeout)
+	defer reqCancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err), false
+	}
+
+	req.Header.Set("Accept", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err), false
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("failed to read response body: %w", err), false
+		}
+
+		r.logger.Debug("Raw UID resolver response", "path", path, "status", resp.StatusCode, "body", string(body))
+
+		var response struct {
+			Metadata struct {
+				UID string `json:"uid"`
+			} `json:"metadata"`
+		}
+
+		if err := json.Unmarshal(body, &response); err != nil {
+			return "", fmt.Errorf("failed to decode response: %w", err), false
+		}
+
+		if response.Metadata.UID == "" {
+			return "", fmt.Errorf("uid not found in response"), false
+		}
+
+		r.logger.Debug("Resolved resource UID",
+			"path", path,
+			"uid", response.Metadata.UID)
+
+		return response.Metadata.UID, nil, false
+
+	case http.StatusNotFound:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("%w: %s", ErrResourceNotFound, path), false
+
+	case http.StatusUnauthorized:
+		_, _ = io.Copy(io.Discard, resp.Body)
+
+		r.tokenMu.Lock()
+		r.tokenEntry = nil
+		r.tokenMu.Unlock()
+
+		remaining := r.config.MaxAuthRetry - attempt
+		if remaining > 0 {
+			r.logger.Debug("Received 401 from openchoreo-api; invalidating cached token and retrying",
+				"path", path, "attempt", attempt+1, "remaining_retries", remaining)
+			return "", nil, true
+		}
+
+		r.logger.Error("Received 401 from openchoreo-api and retries are exhausted",
+			"path", path, "max_auth_retry", r.config.MaxAuthRetry)
+		return "", fmt.Errorf("%w: received 401 after %d attempt(s)", ErrScopeAuthFailed, r.config.MaxAuthRetry+1), false
+
+	default:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("API returned status %d", resp.StatusCode), false
+	}
 }
 
 // getAccessToken returns a valid OAuth2 access token, fetching a new one if needed


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose


Supersedes #3271


Fix an intermittent failure in observer where scope-resolution calls in `ResourceUIDResolver` return `context canceled` mid-response. From the consumer's perspective, `/api/v1alpha1/traces/query` and `/api/v1alpha1/traces/{id}/spans/query` return 500 (errorCode `OBS-V1-T-04` from `QueryTraces`, or `OBS-V1-T-01` from `QuerySpans` since that handler currently lacks an `ErrTracesResolveSearchScope` case) even though the upstream `openchoreo-api` access log shows the dependent CR fetch returned `200 OK`.

The failure is timing-dependent and surfaces with mismatched evidence (`200` at openchoreo-api, `failed to read response body: context canceled` at observer), which makes diagnosis noisy when callers fan out parallel span queries and one canceled call cascades through fail-fast logic in the consumer.

## Approach

`ResourceUIDResolver.fetchResourceUID` (`internal/observer/service/uid_resolver.go`) wraps each attempt in a per-request context via `context.WithTimeout`, then calls `reqCancel()` immediately after `r.httpClient.Do(req)` returns:                                                                                                         

```go
  reqCtx, reqCancel := context.WithTimeout(ctx, r.config.Timeout)                                                                                                       
  // ...                                      
  resp, err := r.httpClient.Do(req)                                                                                                                                     
  reqCancel()  // ← bug: cancels reqCtx before the body is read                                                                                                       
  if err != nil { ... }                                                                                                                                                 
  
  switch resp.StatusCode {                                                                                                                                              
  case http.StatusOK:                                                                                                                                                 
      body, err := io.ReadAll(resp.Body)  // races with the cancellation above
```      
                                                                                                                                                            
  `http.Client.Do` only waits for response headers; the body reader is bound to reqCtx. When `reqCancel()` runs before `io.ReadAll(resp.Body)` finishes, the read fails with context canceled. Whether this happens depends on Go scheduler ordering, TCP segmentation, and whether the body is already buffered at that microsecond — i.e., the  failure is timing-dependent and intermittent.                                                                                                                       
                                                                                                                                                                        
  This change extracts the per-attempt logic into a helper method `doFetchResourceUID,` which allows `defer reqCancel()` to fire at the end of each attempt rather than piling up until the outer function returns. This avoids the deferInLoop lint warning from gocritic while keeping the context alive for the full body read.            
                                                                                                                                                                      
  Additionally, `defer resp.Body.Close()` replaces the manual `resp.Body.Close()` calls in each switch branch, since the helper method's scope guarantees cleanup on all paths.  
  
## Evidence

Reproduced against observer `v1.0.1-hotfix.1`. Captured logs from a single failed `QuerySpans` call:

```
# observer log
time=... level=ERROR msg="Failed to resolve search scope"
  component=traces-service
  error="failed to resolve component UID ...: failed to read response body: context canceled"
time=... level=DEBUG msg="HTTP request"
  method=POST path=/api/v1alpha1/traces/.../spans/query status=500 duration=60.66ms

# openchoreo-api access log for the dependent CR fetch at the same instant
"path":"/api/v1/namespaces/.../components/..." status=200 duration=~10ms
```

The CR fetch returned 200; the body read inside `fetchResourceUID` failed because `reqCtx` had already been cancelled by the bare `reqCancel()` call above.

After applying this fix and rolling out a patched observer image, the previously failing trace-export flow completes successfully across repeated reproductions.

## Related Issues

None filed yet

A related (separate) bug surfaces during diagnosis: `internal/observer/api/handlers/traces.go`'s `QuerySpansForTrace` handler is missing a `case errors.Is(err, service.ErrTracesResolveSearchScope)` branch that the sibling `QueryTraces` handler has, so resolution failures from `QuerySpans` get mislabeled `OBS-V1-T-01 "Failed to retrieve spans"` instead of `OBS-V1-T-04`. Not addressed here to keep this PR minimal.

## Checklist

- [x] Tests added or updated — existing `internal/observer/service` tests pass; the bug is a timing race not currently covered by unit tests, and reliably triggering it in a unit test would require a custom `RoundTripper` that delays body reads, which felt out of scope for a minimal fix. Happy to add one if reviewers prefer.
- [ ] Samples updated — not applicable.
- [ ] Added `backport/<release-branch>` label if this should be backported — flagging for maintainer judgement; the bug is reproducible against `v1.0.1-hotfix.1`.


## Remarks

The original approach (PR #3271) used defer reqCancel() directly in the loop, which triggers a deferInLoop lint warning from gocritic. Extracting to a helper method resolves both the race condition and the lint issue cleanly.
