### PR TITLE
chore(deps): bump google.golang.org/grpc to v1.79.3 for CVE-2026-33186

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 )
 
 require (
-	cel.dev/expr v0.24.0 // indirect
+	cel.dev/expr v0.25.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -147,7 +147,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
-	google.golang.org/grpc v1.78.0 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
-cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
@@ -372,8 +372,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409/go.mod h1:fl8J1IvUjCilwZzQowmw2b7HQB2eAuYBabMXzWurF+I=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 h1:H86B94AW+VfJWDqFeEbBPhEtHzJwJfTbgE2lZa54ZAQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
-google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=
-google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpWvW7U=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Purpose

Bump `google.golang.org/grpc` from `v1.78.0` to `v1.79.3` to clear Trivy code-scanning alert [#121](https://github.com/openchoreo/openchoreo/security/code-scanning/121) and the sibling Dependabot alert [#36](https://github.com/openchoreo/openchoreo/security/dependabot/36) for **CVE-2026-33186** / GHSA-p77j-4mvh-x3m3 (CRITICAL, CVSS 9.1) — gRPC-Go authorization bypass via missing leading slash in HTTP/2 `:path`.

## Reachability — false positive (hygiene bump)

The CVE is **not exploitable** in OpenChoreo, but the alert is recurring CRITICAL noise on every image rescan. Bumping is the durable fix.

Evidence the vulnerable code path is not reached:

- `govulncheck ./cmd/...` lists this CVE under `=== Package Results ===` with no call traces. Summary: *"3 vulnerabilities in packages you import [...] your code doesn't appear to call these vulnerabilities"* — grpc is one of those.
- No `grpc.NewServer` / `RegisterService` usage anywhere in non-test Go code → we don't run a gRPC server.
- No `google.golang.org/grpc/authz` import.
- No `info.FullMethod` / `grpc.Method(ctx)` usage.
- `grpc` enters the closure as a **client only**, transitively via `k8s.io/apiserver` (webhook auth, egress selector).

VEX status: `not_affected` / justification `vulnerable_code_not_in_execute_path`.

Re-evaluate if anyone:
- Adds a gRPC server endpoint to a `cmd/` binary.
- Imports `google.golang.org/grpc/authz` or wires `info.FullMethod`-based interceptors.
- Pulls in a transitive dep that calls `grpc.RegisterService`.

## Diff scope

- `google.golang.org/grpc`: `v1.78.0` → `v1.79.3` (indirect; +1 minor, +3 patches; not retracted).
- `cel.dev/expr`: `v0.24.0` → `v0.25.1` (MVS-driven transitive bump required by grpc 1.79.3).

No code changes — `go.mod` / `go.sum` only.

## Verification

- [x] `go mod tidy` — clean
- [x] `make go.build` — all 6 binaries (`manager`, `occ`, `openchoreo-api`, `observer`, `cluster-gateway`, `cluster-agent`) compile
- [x] `govulncheck ./cmd/...` rescan — GO-2026-4762 / CVE-2026-33186 no longer reported
- [ ] Trivy image rescan in CI (will close alert #121)
- [ ] Dependabot rescan post-merge (will close alert #36)

## Type of Change

- [x] Chore (dependency bump)

## How To Test

```sh
go mod tidy
make go.build
# optional, requires `go install golang.org/x/vuln/cmd/govulncheck@latest`:
govulncheck ./cmd/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)