### PR TITLE
chore(deps): bump ai-rca-agent distroless base

### DIFF
--- a/rca-agent/Dockerfile
+++ b/rca-agent/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     echo "libz path: $LIBZ_PATH"; \
     cp "$LIBZ_PATH/libz.so.1" /lib/libz.so.1
 
-FROM gcr.io/distroless/cc@sha256:72344f7f909a8bf003c67f55687e6d51a441b49661af8f660aa7b285f00e57df
+FROM gcr.io/distroless/cc-debian12@sha256:847433844c7e04bcf07a3a0f0f5a8de554c6df6fa9e3e3ab14d3f6b73d780235
 
 COPY --from=builder --chown=12000:12000 /python /python
 WORKDIR /app


### PR DESCRIPTION
## Purpose
The ai-rca-agent image used a distroless Debian 12 base with libssl3 3.0.18, which Trivy flags for CVE-2026-31789. This PR bumps the runtime base to a fixed Debian 12 distroless digest.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
Security alert: https://github.com/openchoreo/openchoreo/security/code-scanning/198

Verified ai-rca-agent image builds for linux/arm64 and linux/amd64, and Trivy 0.70.0 reports 0 matches for CVE-2026-31789 on both local images. `make lint` passed in a clean worktree; `make test` was manually verified locally.