### PR TITLE
fix: update logs adapter secret name in module helm chart installation

### DIFF
--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -39,7 +39,8 @@ helm upgrade --install observability-logs-opensearch \
   --create-namespace \
   --namespace "$OP_NS" \
   --version "$LOGS_OPENSEARCH_VERSION" \
-  --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
+  --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
+  --set adapter.openSearchSecretName="opensearch-admin-credentials"
 
 step "Installing OpenSearch-based traces module..."
 helm upgrade --install observability-traces-opensearch \

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -604,6 +604,7 @@ helm upgrade --install observability-logs-opensearch \
   --version 0.4.0 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearchCluster.credentialsSecretName="opensearch-admin-credentials" \
+  --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=true
 ```
@@ -620,6 +621,7 @@ helm upgrade --install observability-logs-opensearch \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
+  --set adapter.enabled=false \
   --set fluent-bit.enabled=true \
   --set fluent-bit.openSearchHost=host.k3d.internal \
   --set fluent-bit.openSearchPort=11085 \
@@ -638,6 +640,7 @@ helm upgrade --install observability-logs-opensearch \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
+  --set adapter.enabled=false \
   --set fluent-bit.enabled=true \
   --set fluent-bit.openSearchHost=host.k3d.internal \
   --set fluent-bit.openSearchPort=11085 \

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1073,7 +1073,8 @@ install_observability_plane() {
 
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
         "--version" "0.4.0" \
-        "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials"
+        "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials" \
+        "--set" "adapter.openSearchSecretName=opensearch-admin-credentials"
 
     # Enable fluent-bit after opensearch is installed and ready
     log_info "Enabling fluent-bit for log collection..."


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Resolved following error in installation time

```
Error: Deployment.apps "logs-adapter-opensearch" is invalid: [spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name: Invalid value: "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name: Invalid value: "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]
```

Related: https://github.com/openchoreo/openchoreo/pull/3307

Tracing and Metrics module versions tested and confirmed to work with current main branch

## Approach
This pull request updates the configuration for deploying the `observability-logs-opensearch` Helm chart, ensuring that the `opensearch-admin-credentials` secret is consistently set for both the `openSearchSetup` and `adapter` components. Additionally, it introduces and documents the disabling of the `adaptor` component in certain multi-cluster deployment scenarios.

Configuration improvements for OpenSearch credentials:

* Added `--set adapter.openSearchSecretName="opensearch-admin-credentials"` to the Helm install commands in `install/k3d/k3d-observability-plane.sh`, `install/quick-start/.helpers.sh`, and the multi-cluster deployment instructions to ensure the adapter uses the correct OpenSearch credentials secret. [[1]](diffhunk://#diff-1a78983d90347c6e8a0b14d6a422d924e8394502a87ae0d2e7a3e8ef1330534eL42-R43) [[2]](diffhunk://#diff-103cddf3bc93e1c47f23b9b3ea102463fb59768db9157cb81f7268b49487dc65L1076-R1077) [[3]](diffhunk://#diff-c274cd4f3f8de8434acc449281ffd0045c7e544f095d87185c0a97353581edc0R607)

Documentation and deployment option updates:

* Documented the use of `--set adaptor.enabled=false` in multi-cluster deployment instructions to clarify how to disable the adaptor component when needed. [[1]](diffhunk://#diff-c274cd4f3f8de8434acc449281ffd0045c7e544f095d87185c0a97353581edc0R624) [[2]](diffhunk://#diff-c274cd4f3f8de8434acc449281ffd0045c7e544f095d87185c0a97353581edc0R643)

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
