### PR TITLE
fix(controller): enhance GVK handling for data and observability planes

### DIFF
--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -163,7 +163,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// PHASE 2: Discover live resources that we manage in the target plane
 	// This queries both current resource types (from spec) and previous resource types (from status)
 	// to ensure we find all resources that might need cleanup, preventing resource leaks
-	gvks := findAllKnownGVKs(desiredResources, release.Status.Resources)
+	gvks := findAllKnownGVKs(desiredResources, release.Status.Resources, targetPlane)
 	liveResources, err := r.listLiveResourcesByGVKs(ctx, planeClient, release, gvks)
 	if err != nil {
 		logger.Error(err, "Failed to list live resources from target plane", "targetPlane", targetPlane)
@@ -436,6 +436,54 @@ func (r *Reconciler) deleteResources(ctx context.Context, planeClient client.Cli
 	return nil
 }
 
+// wellKnownDataPlaneGVKs is the safety-net list for data-plane rendered releases.
+// It covers common Kubernetes resource types that the data-plane agent has permission
+// to list, so orphaned resources are caught even when status update fails.
+var wellKnownDataPlaneGVKs = []schema.GroupVersionKind{
+	// Core Kubernetes Resources
+	{Group: "", Version: "v1", Kind: "Service"},
+	{Group: "", Version: "v1", Kind: "ConfigMap"},
+	{Group: "", Version: "v1", Kind: "Secret"},
+	{Group: "", Version: "v1", Kind: "ServiceAccount"},
+	{Group: "", Version: "v1", Kind: "Namespace"},
+	{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+
+	// Apps
+	{Group: "apps", Version: "v1", Kind: "Deployment"},
+	{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+
+	// Batch
+	{Group: "batch", Version: "v1", Kind: "Job"},
+	{Group: "batch", Version: "v1", Kind: "CronJob"},
+
+	// Autoscaling & Policy
+	{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
+	{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+
+	// Networking
+	{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+	{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+
+	// RBAC
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
+
+	// Gateway API
+	{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"},
+	{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"},
+}
+
+// wellKnownObservabilityPlaneGVKs is the safety-net list for observability-plane rendered
+// releases. It is intentionally narrow: only the CRDs that the observability-plane agent
+// reconciles and has RBAC permission to list. Broad Kubernetes types (Services, Deployments,
+// etc.) and control-plane-only CRDs (e.g. ObservabilityAlertsNotificationChannel) are
+// excluded because the observability-plane agent's RBAC does not cover them.
+var wellKnownObservabilityPlaneGVKs = []schema.GroupVersionKind{
+	{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
+}
+
 // findAllKnownGVKs finds all GroupVersionKinds that we should query for cleanup.
 //
 // This function is critical for preventing resource leaks during cleanup. It combines resource types
@@ -449,18 +497,17 @@ func (r *Reconciler) deleteResources(ctx context.Context, planeClient client.Cli
 //   - Handles resource types that were removed from the spec
 //   - Prevents orphaned resources when user removes entire resource types
 //
-// 3. WELL-KNOWN TYPES: Common Kubernetes resource types we typically manage
+// 3. WELL-KNOWN TYPES: Plane-specific resource types we typically manage
 //   - Handles edge cases where resources exist but status update failed
 //   - Provides safety net for orphaned resources from failed reconciliations
+//   - Scoped per target plane so only types the plane's agent can list are queried
 //
 // Example scenario:
 //   - Previous reconciliation: Applied ConfigMap + Secret
 //   - Current reconciliation: User removed ConfigMap, kept Secret
 //   - Without status: Would only query Secret, miss orphaned ConfigMap
 //   - With status: Queries both Secret + ConfigMap, finds and deletes orphaned ConfigMap
-//
-// This approach automatically supports any CRDs (Gateway, Cilium, etc.) without hardcoded lists.
-func findAllKnownGVKs(desiredResources []*unstructured.Unstructured, appliedResources []openchoreov1alpha1.ResourceStatus) []schema.GroupVersionKind {
+func findAllKnownGVKs(desiredResources []*unstructured.Unstructured, appliedResources []openchoreov1alpha1.ResourceStatus, targetPlane string) []schema.GroupVersionKind {
 	gvkSet := make(map[schema.GroupVersionKind]bool)
 
 	// Add GVKs from desired resources (current spec)
@@ -481,42 +528,12 @@ func findAllKnownGVKs(desiredResources []*unstructured.Unstructured, appliedReso
 		gvkSet[gvk] = true
 	}
 
-	// Add well-known GVKs that are commonly managed by controllers
-	// This provides a safety net for resources that might be orphaned due to failed status updates
-	wellKnownGVKs := []schema.GroupVersionKind{
-		// Core Kubernetes Resources
-		{Group: "", Version: "v1", Kind: "Service"},
-		{Group: "", Version: "v1", Kind: "ConfigMap"},
-		{Group: "", Version: "v1", Kind: "Secret"},
-		{Group: "", Version: "v1", Kind: "ServiceAccount"},
-		{Group: "", Version: "v1", Kind: "Namespace"},
-		{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
-
-		// Apps
-		{Group: "apps", Version: "v1", Kind: "Deployment"},
-		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
-
-		// Batch
-		{Group: "batch", Version: "v1", Kind: "Job"},
-		{Group: "batch", Version: "v1", Kind: "CronJob"},
-
-		// Autoscaling & Policy
-		{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
-		{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
-
-		// Networking
-		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
-		{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
-
-		// RBAC
-		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
-		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
-		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
-		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
-
-		// Gateway API
-		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"},
-		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"},
+	// Add plane-specific well-known GVKs as a safety net for orphaned resources.
+	// Using a plane-scoped list ensures we only probe types the plane agent can list,
+	// avoiding spurious RBAC errors from querying types the plane doesn't manage.
+	wellKnownGVKs := wellKnownDataPlaneGVKs
+	if targetPlane == targetPlaneObservabilityPlane {
+		wellKnownGVKs = wellKnownObservabilityPlaneGVKs
 	}
 	for _, gvk := range wellKnownGVKs {
 		gvkSet[gvk] = true

--- a/internal/controller/renderedrelease/controller_finalize.go
+++ b/internal/controller/renderedrelease/controller_finalize.go
@@ -84,7 +84,7 @@ func (r *Reconciler) finalizeDataPlane(ctx context.Context, old, release *opench
 
 	// STEP 3: List all live resources we manage (use empty desired resources since we want to delete everything)
 	var emptyDesiredResources []*unstructured.Unstructured
-	gvks := findAllKnownGVKs(emptyDesiredResources, release.Status.Resources)
+	gvks := findAllKnownGVKs(emptyDesiredResources, release.Status.Resources, targetPlaneDataPlane)
 	liveResources, err := r.listLiveResourcesByGVKs(ctx, planeClient, release, gvks)
 	if err != nil {
 		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
@@ -187,14 +187,9 @@ func (r *Reconciler) finalizeObsPlane(ctx context.Context, old, release *opencho
 	return ctrl.Result{}, nil
 }
 
-// intersectObsPlaneGVKs returns the subset of GVKs from the release status that are in the obs-plane allowlist.
+// intersectObsPlaneGVKs returns the subset of GVKs from the release status that are in
+// wellKnownObservabilityPlaneGVKs
 func (r *Reconciler) intersectObsPlaneGVKs(ctx context.Context, release *openchoreov1alpha1.RenderedRelease) []schema.GroupVersionKind {
-	// Narrow allowlist — broad cluster-scope listing would require excessive RBAC permissions
-	// for the cluster-agent service account in the observability plane.
-	var obsPlaneGVKs = []schema.GroupVersionKind{
-		{Group: "openchoreo.dev", Version: "v1alpha1", Kind: "ObservabilityAlertRule"},
-	}
-
 	seen := make(map[schema.GroupVersionKind]bool)
 	var result []schema.GroupVersionKind
 	logger := log.FromContext(ctx).WithValues("release", release.Name)
@@ -205,10 +200,10 @@ func (r *Reconciler) intersectObsPlaneGVKs(ctx context.Context, release *opencho
 			continue
 		}
 		seen[gvk] = true
-		if slices.Contains(obsPlaneGVKs, gvk) {
+		if slices.Contains(wellKnownObservabilityPlaneGVKs, gvk) {
 			result = append(result, gvk)
 		} else {
-			logger.Error(fmt.Errorf("GVK not in obsPlaneGVKs allowlist"),
+			logger.Error(fmt.Errorf("GVK not in observability plane allowlist"),
 				"resource will not be cleaned up during obs-plane finalization",
 				"group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 		}

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -217,7 +217,8 @@ func TestFindStaleResources(t *testing.T) {
 // ─────────────────────────────────────────────────────────────
 
 func TestFindAllKnownGVKs(t *testing.T) {
-	const wellKnownCount = 20 // number of well-known GVKs defined in the function
+	const dpWellKnownCount = 20 // number of well-known GVKs for the data plane
+	const opWellKnownCount = 1  // number of well-known GVKs for the observability plane
 
 	containsGVK := func(gvks []schema.GroupVersionKind, group, kind string) bool {
 		for _, gvk := range gvks {
@@ -228,15 +229,15 @@ func TestFindAllKnownGVKs(t *testing.T) {
 		return false
 	}
 
-	t.Run("empty inputs returns all well-known types", func(t *testing.T) {
-		gvks := findAllKnownGVKs(nil, nil)
-		if len(gvks) != wellKnownCount {
-			t.Errorf("expected %d well-known GVKs, got %d", wellKnownCount, len(gvks))
+	t.Run("empty inputs returns all data-plane well-known types", func(t *testing.T) {
+		gvks := findAllKnownGVKs(nil, nil, targetPlaneDataPlane)
+		if len(gvks) != dpWellKnownCount {
+			t.Errorf("expected %d well-known GVKs, got %d", dpWellKnownCount, len(gvks))
 		}
 	})
 
-	t.Run("well-known types include common Kubernetes resources", func(t *testing.T) {
-		gvks := findAllKnownGVKs(nil, nil)
+	t.Run("data-plane well-known types include common Kubernetes resources", func(t *testing.T) {
+		gvks := findAllKnownGVKs(nil, nil, targetPlaneDataPlane)
 		for _, check := range []struct{ group, kind string }{
 			{"apps", "Deployment"},
 			{"apps", "StatefulSet"},
@@ -251,12 +252,29 @@ func TestFindAllKnownGVKs(t *testing.T) {
 		}
 	})
 
+	t.Run("observability-plane well-known types contain only obs-plane CRDs", func(t *testing.T) {
+		gvks := findAllKnownGVKs(nil, nil, targetPlaneObservabilityPlane)
+		if len(gvks) != opWellKnownCount {
+			t.Errorf("expected %d well-known GVKs for obs plane, got %d", opWellKnownCount, len(gvks))
+		}
+		if !containsGVK(gvks, "openchoreo.dev", "ObservabilityAlertRule") {
+			t.Error("expected obs-plane well-known GVK openchoreo.dev/ObservabilityAlertRule to be present")
+		}
+		// Control-plane-only and data-plane types must NOT appear in the obs-plane list
+		if containsGVK(gvks, "openchoreo.dev", "ObservabilityAlertsNotificationChannel") {
+			t.Error("ObservabilityAlertsNotificationChannel is a control-plane CRD and must not appear in obs-plane list")
+		}
+		if containsGVK(gvks, "apps", "Deployment") || containsGVK(gvks, "", "Service") {
+			t.Error("data-plane GVKs must not appear in the observability-plane well-known list")
+		}
+	})
+
 	t.Run("custom desired resource GVK is included alongside well-known", func(t *testing.T) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "custom.io", Version: "v1", Kind: "Widget"})
-		gvks := findAllKnownGVKs([]*unstructured.Unstructured{obj}, nil)
-		if len(gvks) != wellKnownCount+1 {
-			t.Errorf("expected %d, got %d", wellKnownCount+1, len(gvks))
+		gvks := findAllKnownGVKs([]*unstructured.Unstructured{obj}, nil, targetPlaneDataPlane)
+		if len(gvks) != dpWellKnownCount+1 {
+			t.Errorf("expected %d, got %d", dpWellKnownCount+1, len(gvks))
 		}
 		if !containsGVK(gvks, "custom.io", "Widget") {
 			t.Error("custom GVK not found in result")
@@ -266,9 +284,9 @@ func TestFindAllKnownGVKs(t *testing.T) {
 	t.Run("desired resource matching a well-known GVK is not duplicated", func(t *testing.T) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
-		gvks := findAllKnownGVKs([]*unstructured.Unstructured{obj}, nil)
-		if len(gvks) != wellKnownCount {
-			t.Errorf("expected %d (no duplication), got %d", wellKnownCount, len(gvks))
+		gvks := findAllKnownGVKs([]*unstructured.Unstructured{obj}, nil, targetPlaneDataPlane)
+		if len(gvks) != dpWellKnownCount {
+			t.Errorf("expected %d (no duplication), got %d", dpWellKnownCount, len(gvks))
 		}
 	})
 
@@ -276,9 +294,9 @@ func TestFindAllKnownGVKs(t *testing.T) {
 		applied := []openchoreov1alpha1.ResourceStatus{
 			{Group: "legacy.io", Version: "v1", Kind: "OldThing"},
 		}
-		gvks := findAllKnownGVKs(nil, applied)
-		if len(gvks) != wellKnownCount+1 {
-			t.Errorf("expected %d, got %d", wellKnownCount+1, len(gvks))
+		gvks := findAllKnownGVKs(nil, applied, targetPlaneDataPlane)
+		if len(gvks) != dpWellKnownCount+1 {
+			t.Errorf("expected %d, got %d", dpWellKnownCount+1, len(gvks))
 		}
 		if !containsGVK(gvks, "legacy.io", "OldThing") {
 			t.Error("applied resource GVK not found in result")
@@ -292,9 +310,9 @@ func TestFindAllKnownGVKs(t *testing.T) {
 			{Group: "a.io", Version: "v1", Kind: "A"}, // duplicate of desired
 			{Group: "b.io", Version: "v1", Kind: "B"},
 		}
-		gvks := findAllKnownGVKs([]*unstructured.Unstructured{desiredObj}, applied)
-		if len(gvks) != wellKnownCount+2 {
-			t.Errorf("expected %d, got %d", wellKnownCount+2, len(gvks))
+		gvks := findAllKnownGVKs([]*unstructured.Unstructured{desiredObj}, applied, targetPlaneDataPlane)
+		if len(gvks) != dpWellKnownCount+2 {
+			t.Errorf("expected %d, got %d", dpWellKnownCount+2, len(gvks))
 		}
 	})
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Fix a regression from https://github.com/openchoreo/openchoreo/pull/3228 which causes missing observability-plane resources in the resource-tree. Fix it by ensuring the renderedrelease controller correctly populates status.resources for obs-plane releases.

## Approach
This pull request refactors how well-known Kubernetes resource types (GVKs) are handled for resource cleanup in the rendered release controller. The main improvement is making the list of well-known GVKs plane-specific, so only the resource types relevant to each plane (data plane or observability plane) are considered. This prevents unnecessary RBAC errors and better matches the permissions and responsibilities of each agent. The changes also update related logic and tests to use the new approach.

**Plane-specific well-known GVKs for resource cleanup:**

* Introduced `wellKnownDataPlaneGVKs` and `wellKnownObservabilityPlaneGVKs` as distinct lists of GVKs for the data plane and observability plane, respectively. This ensures each plane only queries for resource types it can manage and avoids RBAC errors.
* Updated the `findAllKnownGVKs` function to accept a `targetPlane` parameter and use the appropriate well-known GVK list based on the plane. This function now provides a plane-scoped safety net for orphaned resource cleanup. [[1]](diffhunk://#diff-2bd86987c8bef08758986f908c30794c8be68bc7bc3798b717bc588685849185L166-R166) [[2]](diffhunk://#diff-2bd86987c8bef08758986f908c30794c8be68bc7bc3798b717bc588685849185L452-R510) [[3]](diffhunk://#diff-2bd86987c8bef08758986f908c30794c8be68bc7bc3798b717bc588685849185L484-R536)
* Refactored calls to `findAllKnownGVKs` throughout the codebase to pass the correct `targetPlane` argument, ensuring correct behavior during reconciliation and finalization for both planes.

**Observability plane cleanup improvements:**

* Updated the logic in `intersectObsPlaneGVKs` to use the new `wellKnownObservabilityPlaneGVKs` list, ensuring only the correct CRDs are considered for cleanup in the observability plane. Improved error messages for excluded types. [[1]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L190-L197) [[2]](diffhunk://#diff-d975232e4c77cfdfa3328b83588a807b4e7337b74b9086ed207ff31b15815046L208-R206)

**Test updates:**

* Enhanced unit tests for `findAllKnownGVKs` to verify correct behavior for both data plane and observability plane, including checks for correct GVK inclusion and exclusion per plane. [[1]](diffhunk://#diff-6db74564c6924843eb6c0256b1462339faf49209f2fd24cb80b570e2a3caaacbL220-R221) [[2]](diffhunk://#diff-6db74564c6924843eb6c0256b1462339faf49209f2fd24cb80b570e2a3caaacbL231-R240) [[3]](diffhunk://#diff-6db74564c6924843eb6c0256b1462339faf49209f2fd24cb80b570e2a3caaacbR255-R277) [[4]](diffhunk://#diff-6db74564c6924843eb6c0256b1462339faf49209f2fd24cb80b570e2a3caaacbL269-R299) [[5]](diffhunk://#diff-6db74564c6924843eb6c0256b1462339faf49209f2fd24cb80b570e2a3caaacbL295-R315)

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
