### PR TITLE
fix: make branch ref and version env overridable in pre-requisite and obs plane installation scripts

### DIFF
--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -11,8 +11,8 @@ set -euo pipefail
 #   install/k3d/k3d-observability-plane.sh
 
 # -- versions (update these on release branches) --
-OPENCHOREO_REF="release-v1.0"
-OPENCHOREO_OP_VERSION="1.0.1-hotfix.1"
+OPENCHOREO_REF="${OPENCHOREO_REF:-main}"           # overridable via env; defaults to main
+OPENCHOREO_OP_VERSION="${OPENCHOREO_OP_VERSION:-0.0.0-latest-dev}"  # overridable via env
 LOGS_OPENSEARCH_VERSION="0.3.11"
 TRACES_OPENSEARCH_VERSION="0.3.11"
 METRICS_PROMETHEUS_VERSION="0.2.5"

--- a/install/k3d/k3d-prerequisites.sh
+++ b/install/k3d/k3d-prerequisites.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #   install/k3d/k3d-prerequisites.sh
 
 # -- versions (update these on release branches) --
-OPENCHOREO_REF="release-v1.0"
+OPENCHOREO_REF="${OPENCHOREO_REF:-main}"   # overridable via env; defaults to main
 GATEWAY_API_VERSION="v1.4.1"
 CERT_MANAGER_VERSION="v1.19.4"
 ESO_VERSION="2.0.1"


### PR DESCRIPTION
$subject