### PR TITLE
fix: replace hardcoded InsecureSkipVerify with CA cert validation for OpenSearch

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -47,3 +47,6 @@ data:
   TRACING_ADAPTER_ENABLED: {{ .Values.observer.tracingAdapter.enabled | quote }}
   TRACING_ADAPTER_URL: {{ .Values.observer.tracingAdapter.url | default "http://tracing-adapter:9100" | quote }}
   TRACING_ADAPTER_TIMEOUT: {{ .Values.observer.tracingAdapter.timeout | default "30s" | quote }}
+  {{- if dig "opensearch" "caCertSecretName" "" .Values.observer }}
+  OPENSEARCH_TLS_CA_CERT_PATH: {{ (printf "/etc/opensearch-ca/%s" (dig "opensearch" "caCertKey" "ca.crt" .Values.observer)) | quote }}
+  {{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -55,6 +55,11 @@ spec:
         - name: auth-config
           mountPath: /etc/openchoreo
           readOnly: true
+        {{- if dig "opensearch" "caCertSecretName" "" .Values.observer }}
+        - name: opensearch-ca
+          mountPath: /etc/opensearch-ca
+          readOnly: true
+        {{- end }}
         {{- if eq (.Values.observer.alertStoreBackend | default "sqlite") "sqlite" }}
         - name: alert-store-data
           mountPath: /data
@@ -98,6 +103,11 @@ spec:
       - name: auth-config
         configMap:
           name: observer-auth-config
+      {{- if dig "opensearch" "caCertSecretName" "" .Values.observer }}
+      - name: opensearch-ca
+        secret:
+          secretName: {{ dig "opensearch" "caCertSecretName" "" .Values.observer }}
+      {{- end }}
       {{- if eq (.Values.observer.alertStoreBackend | default "sqlite") "sqlite" }}
       - name: alert-store-data
         persistentVolumeClaim:

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1172,6 +1172,27 @@
           "title": "openSearchSecretName",
           "type": "string"
         },
+        "opensearch": {
+          "additionalProperties": false,
+          "description": "OpenSearch TLS configuration for the Observer",
+          "properties": {
+            "caCertKey": {
+              "default": "ca.crt",
+              "description": "Key within the Secret that holds the PEM-encoded CA certificate.",
+              "title": "caCertKey",
+              "type": "string"
+            },
+            "caCertSecretName": {
+              "default": "",
+              "description": "Name of an existing Secret containing the OpenSearch CA certificate. When set, the CA cert is mounted at /etc/opensearch-ca and used to verify the OpenSearch server's TLS certificate instead of skipping verification. Required when OpenSearch uses a self-signed certificate.",
+              "title": "caCertSecretName",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "opensearch",
+          "type": "object"
+        },
         "prometheus": {
           "additionalProperties": false,
           "description": "Prometheus connection configuration",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -707,6 +707,26 @@ observer:
 
   # @schema
   # type: object
+  # description: OpenSearch TLS configuration for the Observer
+  # @schema
+  opensearch:
+    # @schema
+    # type: string
+    # description: Name of an existing Secret containing the OpenSearch CA certificate. When set, the CA cert
+    #   is mounted at /etc/opensearch-ca and used to verify the OpenSearch server's TLS certificate instead of
+    #   skipping verification. Required when OpenSearch uses a self-signed certificate.
+    # default: ""
+    # @schema
+    caCertSecretName: ""
+    # @schema
+    # type: string
+    # description: Key within the Secret that holds the PEM-encoded CA certificate.
+    # default: ca.crt
+    # @schema
+    caCertKey: "ca.crt"
+
+  # @schema
+  # type: object
   # description: HTTPRoute configuration for the Observer service
   # @schema
   http:

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -75,6 +75,9 @@ type OpenSearchConfig struct {
 	IndexPrefix   string        `koanf:"index.prefix"`
 	IndexPattern  string        `koanf:"index.pattern"`
 	LegacyPattern string        `koanf:"legacy.pattern"`
+	// TLSCACertPath is the path to a PEM-encoded CA certificate used to verify the OpenSearch server's TLS certificate.
+	// When empty the system CA pool is used. Required when OpenSearch uses a self-signed certificate.
+	TLSCACertPath string `koanf:"tls.ca.cert.path"`
 }
 
 // PrometheusConfig holds Prometheus connection configuration
@@ -196,6 +199,7 @@ func Load() (*Config, error) {
 		"OPENSEARCH_INDEX_PREFIX":               "opensearch.index.prefix",
 		"OPENSEARCH_INDEX_PATTERN":              "opensearch.index.pattern",
 		"OPENSEARCH_LEGACY_PATTERN":             "opensearch.legacy.pattern",
+		"OPENSEARCH_TLS_CA_CERT_PATH":           "opensearch.tls.ca.cert.path",
 		"PROMETHEUS_ADDRESS":                    "prometheus.address",
 		"PROMETHEUS_TIMEOUT":                    "prometheus.timeout",
 		"AUTH_JWT_SECRET":                       "auth.jwt.secret",

--- a/internal/observer/config/config_test.go
+++ b/internal/observer/config/config_test.go
@@ -70,6 +70,16 @@ func TestLoad_WithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, 5000, cfg.Logging.MaxLogLimit)
 }
 
+func TestLoad_OpensearchTLSCACertPath(t *testing.T) {
+	certPath := "/etc/opensearch/tls/ca.crt"
+	t.Setenv("OPENSEARCH_TLS_CA_CERT_PATH", certPath)
+
+	cfg, err := Load()
+	require.NoError(t, err, "Failed to load config")
+
+	assert.Equal(t, certPath, cfg.OpenSearch.TLSCACertPath)
+}
+
 func TestLoad_CORSAllowedOrigins(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/observer/opensearch/client.go
+++ b/internal/observer/opensearch/client.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/opensearch-project/opensearch-go"
@@ -22,6 +24,35 @@ import (
 
 const alertsIndexName = "openchoreo-alerts"
 
+// buildTLSTransport returns an HTTP transport for OpenSearch.
+// When caCertPath is non-empty it loads that PEM file and pins the CA so the
+// self-signed OpenSearch certificate is validated without skipping verification.
+// When caCertPath is empty the system CA pool is used (suitable for publicly
+// signed certificates).
+func buildTLSTransport(caCertPath string) (*http.Transport, error) {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+
+	if caCertPath == "" {
+		return base, nil
+	}
+
+	caCert, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("read CA cert %s: %w", caCertPath, err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("no valid PEM certificates found in %s", caCertPath)
+	}
+
+	base.TLSClientConfig = &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}
+	return base, nil
+}
+
 // Client wraps the OpenSearch client with logging and configuration
 type Client struct {
 	client *opensearch.Client
@@ -31,15 +62,16 @@ type Client struct {
 
 // NewClient creates a new OpenSearch client with the provided configuration
 func NewClient(cfg *config.OpenSearchConfig, logger *slog.Logger) (*Client, error) {
+	transport, err := buildTLSTransport(cfg.TLSCACertPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS transport: %w", err)
+	}
+
 	opensearchConfig := opensearch.Config{
 		Addresses: []string{cfg.Address},
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // G402: Using self-signed cert
-			},
-		},
-		Username: cfg.Username,
-		Password: cfg.Password,
+		Transport: transport,
+		Username:  cfg.Username,
+		Password:  cfg.Password,
 	}
 
 	client, err := opensearch.NewClient(opensearchConfig)

--- a/internal/observer/opensearch/client_test.go
+++ b/internal/observer/opensearch/client_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opensearch
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTempPEM writes DER-encoded certificate bytes as a PEM CERTIFICATE block
+// to a temp file and returns the path.
+func writeTempPEM(t *testing.T, data []byte) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "ca-*.pem")
+	require.NoError(t, err)
+	err = pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: data})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+// generateSelfSignedCertDER returns the DER-encoded bytes of a fresh self-signed
+// ECDSA certificate. Because httptest.NewTLSServer() always reuses the same
+// internal test cert, this helper is needed to produce a cert that is
+// genuinely different from the httptest one.
+func generateSelfSignedCertDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
+}
+
+func TestBuildTLSTransport_EmptyPath(t *testing.T) {
+	tr, err := buildTLSTransport("")
+	require.NoError(t, err)
+	require.NotNil(t, tr)
+	// Cloned from DefaultTransport — no custom CA pinned, no InsecureSkipVerify.
+	if tr.TLSClientConfig != nil {
+		assert.Nil(t, tr.TLSClientConfig.RootCAs)
+		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
+	}
+}
+
+func TestBuildTLSTransport_ValidCACert(t *testing.T) {
+	// httptest.NewTLSServer generates a self-signed cert; grab its raw DER bytes.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rawCert := srv.TLS.Certificates[0].Certificate[0]
+	caPath := writeTempPEM(t, rawCert)
+
+	tr, err := buildTLSTransport(caPath)
+	require.NoError(t, err)
+	require.NotNil(t, tr)
+	require.NotNil(t, tr.TLSClientConfig)
+	assert.NotNil(t, tr.TLSClientConfig.RootCAs, "RootCAs should be set from the provided CA cert")
+	assert.False(t, tr.TLSClientConfig.InsecureSkipVerify, "InsecureSkipVerify must remain false")
+}
+
+func TestBuildTLSTransport_ConnectsWithPinnedCA(t *testing.T) {
+	// Full round-trip: build a transport from the server's own cert as CA,
+	// then make a real HTTPS request through it.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	rawCert := srv.TLS.Certificates[0].Certificate[0]
+	caPath := writeTempPEM(t, rawCert)
+
+	tr, err := buildTLSTransport(caPath)
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err, "should connect successfully with the pinned CA cert")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestBuildTLSTransport_RejectsUnknownCA(t *testing.T) {
+	// Transport built with a *different* CA should reject the server's cert.
+	// Note: httptest.NewTLSServer always reuses the same internal test cert, so
+	// we generate a fresh self-signed cert to guarantee a distinct CA.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	caPath := writeTempPEM(t, generateSelfSignedCertDER(t))
+
+	tr, err := buildTLSTransport(caPath)
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: tr}
+	_, err = client.Get(srv.URL)
+	require.Error(t, err, "should fail TLS verification when CA does not match")
+	assert.Contains(t, err.Error(), "certificate")
+}
+
+func TestBuildTLSTransport_NonExistentFile(t *testing.T) {
+	_, err := buildTLSTransport(filepath.Join(t.TempDir(), "does-not-exist.pem"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read CA cert")
+}
+
+func TestBuildTLSTransport_InvalidPEM(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "bad-*.pem")
+	require.NoError(t, err)
+	_, err = f.WriteString("this is not valid PEM data")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, err = buildTLSTransport(f.Name())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid PEM certificates found")
+}
+
+func TestBuildTLSTransport_DoesNotSetInsecureSkipVerify(t *testing.T) {
+	// Paranoia check: ensure InsecureSkipVerify is never set regardless of input.
+	srv := httptest.NewTLSServer(nil)
+	defer srv.Close()
+	rawCert := srv.TLS.Certificates[0].Certificate[0]
+	caPath := writeTempPEM(t, rawCert)
+
+	for _, path := range []string{"", caPath} {
+		tr, err := buildTLSTransport(path)
+		require.NoError(t, err)
+		if tr.TLSClientConfig != nil {
+			assert.False(t, tr.TLSClientConfig.InsecureSkipVerify,
+				"InsecureSkipVerify must never be set (path=%q)", path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Removes the hardcoded `InsecureSkipVerify: true` in the observer's OpenSearch client (flagged by CodeQL alert [go/disabled-certificate-check #74](https://github.com/openchoreo/openchoreo/security/code-scanning/74))
- Adds `buildTLSTransport` which loads a PEM CA cert file and pins it via `RootCAs`, so self-signed OpenSearch certificates are validated rather than skipped
- Exposes `OPENSEARCH_TLS_CA_CERT_PATH` config and a Helm value (`observer.opensearch.caCertSecretName`) to mount the CA cert Secret into the observer pod
- When `caCertSecretName` is unset the transport falls back to the system CA pool with no `InsecureSkipVerify`

## Test plan

- [ ] Unit tests added for `buildTLSTransport` covering: empty path (system CA pool), valid CA cert (RootCAs set), successful connection with pinned CA, rejection of unknown CA, missing file, invalid PEM, and `InsecureSkipVerify` never set
- [ ] Verify observer pod starts and TLS verification is active (`tls: failed to verify certificate` in logs confirms verification runs rather than being skipped)
- [ ] For deployments using a self-signed OpenSearch cert: create a Secret with the CA cert and set `observer.opensearch.caCertSecretName` in Helm values

🤖 Generated with [Claude Code](https://claude.com/claude-code)