### PR TITLE
feat: add event-forwarder for event-driven Backstage catalog sync

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,6 +110,12 @@ jobs:
           name: observer
           path: bin/dist/**/observer
 
+      - name: Upload event-forwarder binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: event-forwarder
+          path: bin/dist/**/event-forwarder
+
       - name: Upload cluster-gateway binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -157,6 +163,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: observer
+          path: bin/dist
+
+      - name: Download event-forwarder binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: event-forwarder
           path: bin/dist
 
       - name: Download cluster-gateway binaries

--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -29,6 +29,7 @@ jobs:
           - cluster-agent
           - openchoreo-api
           - observer
+          - event-forwarder
           - openchoreo-cli
           - quick-start
           - init-observability-opensearch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
             init-observability-opensearch
             openchoreo-api
             observer
+            event-forwarder
             ai-rca-agent
             openchoreo-cli
             cluster-gateway

--- a/.github/workflows/trivy-image-scan.yaml
+++ b/.github/workflows/trivy-image-scan.yaml
@@ -18,6 +18,7 @@ jobs:
           - controller
           - openchoreo-api
           - observer
+          - event-forwarder
           - cluster-gateway
           - cluster-agent
           - ai-rca-agent

--- a/cmd/event-forwarder/Dockerfile
+++ b/cmd/event-forwarder/Dockerfile
@@ -1,0 +1,27 @@
+# Use distroless as minimal base image to package the event-forwarder binary.
+# The event-forwarder watches OpenChoreo CRDs via K8s informers and
+# forwards lightweight change-notification webhooks to Backstage.
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot@sha256:f512d819b8f109f2375e8b51d8cfd8aafe81034bc3e319740128b7d7f70d5036
+
+ARG TARGETOS
+ARG TARGETARCH
+
+LABEL org.opencontainers.image.source="https://github.com/openchoreo/openchoreo"
+LABEL org.opencontainers.image.description="OpenChoreo CRD event-forwarder"
+LABEL org.opencontainers.image.license="Apache-2.0"
+
+# Set working directory in the container
+WORKDIR /
+
+# Copy the pre-built binary produced by the Makefile into the image
+COPY bin/dist/${TARGETOS}/${TARGETARCH}/event-forwarder .
+
+# Use non-root user for security (65532 is 'nonroot' user in distroless)
+USER 65532:65532
+
+# Expose the HTTP port
+EXPOSE 8080
+
+# Entrypoint: run the binary
+ENTRYPOINT ["/event-forwarder"]

--- a/cmd/event-forwarder/Dockerfile
+++ b/cmd/event-forwarder/Dockerfile
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the event-forwarder binary.
-# The event-forwarder watches OpenChoreo CRDs via K8s informers and
-# forwards lightweight change-notification webhooks to Backstage.
+# The event-forwarder watches OpenChoreo Kubernetes resources via informers
+# and forwards lightweight change-notification webhooks to subscribers.
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot@sha256:f512d819b8f109f2375e8b51d8cfd8aafe81034bc3e319740128b7d7f70d5036
 
@@ -8,7 +8,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.source="https://github.com/openchoreo/openchoreo"
-LABEL org.opencontainers.image.description="OpenChoreo CRD event-forwarder"
+LABEL org.opencontainers.image.description="OpenChoreo event-forwarder"
 LABEL org.opencontainers.image.license="Apache-2.0"
 
 # Set working directory in the container

--- a/cmd/event-forwarder/main.go
+++ b/cmd/event-forwarder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main
@@ -14,41 +14,51 @@ import (
 	"syscall"
 
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/openchoreo/openchoreo/internal/eventforwarder"
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/dispatcher"
+	"github.com/openchoreo/openchoreo/internal/logging"
+	"github.com/openchoreo/openchoreo/internal/version"
 )
 
 func main() {
 	configPath := flag.String("config", "/etc/openchoreo/config.yaml", "Path to configuration file")
 	flag.Parse()
 
-	// Bootstrap logger
-	bootstrapLogger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Bootstrap logger for pre-configuration errors. Component name is
+	// baked into the binary by the build's -X linker flag (see
+	// make/golang.mk → GO_LDFLAGS_BUILD_DATA).
+	bootstrapLogger := logging.Bootstrap(version.Get().Name)
 
-	// Load configuration
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		bootstrapLogger.Error("Failed to load configuration", "error", err)
 		os.Exit(1)
 	}
 
-	// Initialize logger
-	logger := initLogger(cfg.Logging.Level)
-	logger.Info("Configuration loaded successfully", "logLevel", cfg.Logging.Level)
+	// Set up runtime logger from configuration. Same shape as every
+	// other OpenChoreo binary so log fields and formats stay consistent
+	// across components.
+	logger := logging.NewWithComponent(cfg.Logging.ToLoggingConfig(), version.Get().Name)
+	logger.Info("Starting", version.GetLogKeyValues()...)
+	logger.Info("Configuration loaded", "logLevel", cfg.Logging.Level)
 
-	// Initialize Kubernetes client
-	restConfig, err := rest.InClusterConfig()
+	// Resolve the Kubernetes REST config via controller-runtime so the
+	// binary works both in-cluster (uses the pod's service account
+	// token) and locally (falls back to KUBECONFIG / ~/.kube/config).
+	// `rest.InClusterConfig()` would have forced an in-cluster-only
+	// flow, breaking local testing.
+	restConfig, err := ctrl.GetConfig()
 	if err != nil {
-		logger.Error("Failed to create in-cluster config", "error", err)
+		logger.Error("Failed to obtain Kubernetes REST config", slog.Any("error", err))
 		os.Exit(1)
 	}
 
 	dynamicClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
-		logger.Error("Failed to create dynamic Kubernetes client", "error", err)
+		logger.Error("Failed to create dynamic Kubernetes client", slog.Any("error", err))
 		os.Exit(1)
 	}
 
@@ -61,7 +71,9 @@ func main() {
 	// Initialize health server
 	healthSrv := eventforwarder.NewHealthServer(logger.With("component", "health"))
 
-	// Start health server
+	// Start health server (note: /ready stays NotReady until Forwarder
+	// signals onReady below, so rolling-update traffic isn't routed to
+	// this pod before its informer caches have synced).
 	go func() {
 		if err := healthSrv.ListenAndServe(cfg.Server.Port); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("Health server failed", "error", err)
@@ -75,46 +87,17 @@ func main() {
 
 	// Start the dispatcher worker pool before any events can be queued
 	// — Forwarder.Start triggers an initial replay of "create" events
-	// for every existing CR as informer caches sync, so workers must be
-	// running by then.
+	// for every existing resource as informer caches sync, so workers
+	// must be running by then.
 	d.Start(ctx)
 
-	// Start event-forwarder (blocks until context is cancelled)
-	logger.Info("Starting CRD event-forwarder")
-	healthSrv.SetReady()
-
-	if err := f.Start(ctx); err != nil {
+	logger.Info("Starting event-forwarder")
+	// SetReady fires only after every informer cache has finished its
+	// initial list — see Forwarder.Start for the synchronisation point.
+	if err := f.Start(ctx, healthSrv.SetReady); err != nil {
 		logger.Error("Event-forwarder exited with error", "error", err)
 		os.Exit(1)
 	}
 
 	logger.Info("Event-forwarder shutdown complete")
-}
-
-func initLogger(level string) *slog.Logger {
-	var logLevel slog.Level
-
-	switch level {
-	case "debug":
-		logLevel = slog.LevelDebug
-	case "info":
-		logLevel = slog.LevelInfo
-	case "warn":
-		logLevel = slog.LevelWarn
-	case "error":
-		logLevel = slog.LevelError
-	default:
-		logLevel = slog.LevelInfo
-	}
-
-	opts := &slog.HandlerOptions{Level: logLevel}
-
-	var handler slog.Handler
-	if level == "debug" {
-		handler = slog.NewTextHandler(os.Stdout, opts)
-	} else {
-		handler = slog.NewJSONHandler(os.Stdout, opts)
-	}
-
-	return slog.New(handler)
 }

--- a/cmd/event-forwarder/main.go
+++ b/cmd/event-forwarder/main.go
@@ -73,6 +73,12 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Start the dispatcher worker pool before any events can be queued
+	// — Forwarder.Start triggers an initial replay of "create" events
+	// for every existing CR as informer caches sync, so workers must be
+	// running by then.
+	d.Start(ctx)
+
 	// Start event-forwarder (blocks until context is cancelled)
 	logger.Info("Starting CRD event-forwarder")
 	healthSrv.SetReady()

--- a/cmd/event-forwarder/main.go
+++ b/cmd/event-forwarder/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	logger.Info("Starting event-forwarder")
 	// SetReady fires only after every informer cache has finished its
-	// initial list — see Forwarder.Start for the synchronisation point.
+	// initial list — see Forwarder.Start for the synchronization point.
 	if err := f.Start(ctx, healthSrv.SetReady); err != nil {
 		logger.Error("Event-forwarder exited with error", "error", err)
 		os.Exit(1)

--- a/cmd/event-forwarder/main.go
+++ b/cmd/event-forwarder/main.go
@@ -1,0 +1,114 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/openchoreo/openchoreo/internal/eventforwarder"
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/dispatcher"
+)
+
+func main() {
+	configPath := flag.String("config", "/etc/openchoreo/config.yaml", "Path to configuration file")
+	flag.Parse()
+
+	// Bootstrap logger
+	bootstrapLogger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// Load configuration
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		bootstrapLogger.Error("Failed to load configuration", "error", err)
+		os.Exit(1)
+	}
+
+	// Initialize logger
+	logger := initLogger(cfg.Logging.Level)
+	logger.Info("Configuration loaded successfully", "logLevel", cfg.Logging.Level)
+
+	// Initialize Kubernetes client
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Error("Failed to create in-cluster config", "error", err)
+		os.Exit(1)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		logger.Error("Failed to create dynamic Kubernetes client", "error", err)
+		os.Exit(1)
+	}
+
+	// Initialize dispatcher
+	d := dispatcher.New(cfg.Webhooks, logger.With("component", "dispatcher"))
+
+	// Initialize event-forwarder
+	f := eventforwarder.New(dynamicClient, d, logger.With("component", "event-forwarder"))
+
+	// Initialize health server
+	healthSrv := eventforwarder.NewHealthServer(logger.With("component", "health"))
+
+	// Start health server
+	go func() {
+		if err := healthSrv.ListenAndServe(cfg.Server.Port); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("Health server failed", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Graceful shutdown
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Start event-forwarder (blocks until context is cancelled)
+	logger.Info("Starting CRD event-forwarder")
+	healthSrv.SetReady()
+
+	if err := f.Start(ctx); err != nil {
+		logger.Error("Event-forwarder exited with error", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("Event-forwarder shutdown complete")
+}
+
+func initLogger(level string) *slog.Logger {
+	var logLevel slog.Level
+
+	switch level {
+	case "debug":
+		logLevel = slog.LevelDebug
+	case "info":
+		logLevel = slog.LevelInfo
+	case "warn":
+		logLevel = slog.LevelWarn
+	case "error":
+		logLevel = slog.LevelError
+	default:
+		logLevel = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{Level: logLevel}
+
+	var handler slog.Handler
+	if level == "debug" {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	}
+
+	return slog.New(handler)
+}

--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -173,6 +173,24 @@ Cluster Gateway service account name
 {{- end }}
 
 {{/*
+Event-forwarder resource name
+*/}}
+{{- define "openchoreo-control-plane.event-forwarder.name" -}}
+{{- default "event-forwarder" .Values.eventForwarder.name }}
+{{- end }}
+
+{{/*
+Event-forwarder service account name
+*/}}
+{{- define "openchoreo-control-plane.event-forwarder.serviceAccountName" -}}
+{{- if .Values.eventForwarder.serviceAccount.create }}
+{{- default "event-forwarder" .Values.eventForwarder.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.eventForwarder.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Validate that placeholder .invalid hostnames have been replaced with real domains.
 */}}
 {{- define "openchoreo-control-plane.validateHostnames" -}}

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -117,6 +117,18 @@ spec:
           value: {{ .Values.security.authz.enabled | quote }}
         - name: OPENCHOREO_FEATURES_AUTH_REDIRECT_FLOW_ENABLED
           value: {{ .Values.backstage.features.auth.redirectFlow.enabled | quote }}
+        # Catalog sync — periodic full sync acts as a safety net behind
+        # the event-forwarder's real-time event-driven path. When the
+        # event-forwarder is disabled, this becomes the sole sync
+        # mechanism.
+        - name: OPENCHOREO_CATALOG_SYNC_FREQUENCY
+          value: {{ .Values.backstage.catalogSync.frequency | default 300 | quote }}
+        # Whether to wire the OpenChoreo events flow on the Backstage
+        # side. Mirrors `eventForwarder.enabled`: with the forwarder
+        # off, the event router and entity-provider subscriptions are
+        # skipped so the system runs in poll-only mode.
+        - name: OPENCHOREO_EVENTS_ENABLED
+          value: {{ .Values.eventForwarder.enabled | quote }}
         # External CI Platform Integrations
         # Jenkins: requires jenkins.io/job-full-name annotation on entity
         - name: JENKINS_BASE_URL

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.eventForwarder.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openchoreo-control-plane.event-forwarder.name" . }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: event-forwarder
+rules:
+- apiGroups:
+  - openchoreo.dev
+  resources:
+  - projects
+  - components
+  - workloads
+  - environments
+  - dataplanes
+  - deploymentpipelines
+  - componenttypes
+  - traits
+  - workflows
+  - workflowplanes
+  - observabilityplanes
+  - clustercomponenttypes
+  - clustertraits
+  - clusterworkflows
+  - clusterdataplanes
+  - clusterobservabilityplanes
+  - clusterworkflowplanes
+  verbs:
+  - get
+  - list
+  - watch
+# Core Kubernetes Namespace read access — needed because OpenChoreo
+# Organizations are represented as Kubernetes namespaces (marked with
+# the `openchoreo.dev/control-plane=true` label). The event-forwarder
+# applies this label as a server-side selector on the informer, so it
+# only observes OC-managed namespaces despite holding cluster-wide
+# read permission.
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrolebinding.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.eventForwarder.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "openchoreo-control-plane.event-forwarder.name" . }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: event-forwarder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "openchoreo-control-plane.event-forwarder.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-control-plane.event-forwarder.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/configmap.yaml
@@ -15,9 +15,6 @@ data:
     webhooks:
       endpoints:
         {{- toYaml .Values.eventForwarder.config.webhooks.endpoints | nindent 8 }}
-      retry:
-        maxAttempts: {{ .Values.eventForwarder.config.webhooks.retry.maxAttempts }}
-        backoffMs: {{ .Values.eventForwarder.config.webhooks.retry.backoffMs }}
 
     logging:
       level: {{ .Values.eventForwarder.config.logging.level | quote }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.eventForwarder.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openchoreo-control-plane.event-forwarder.name" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: event-forwarder
+data:
+  config.yaml: |
+    server:
+      port: {{ .Values.eventForwarder.config.server.port }}
+
+    webhooks:
+      endpoints:
+        {{- toYaml .Values.eventForwarder.config.webhooks.endpoints | nindent 8 }}
+      retry:
+        maxAttempts: {{ .Values.eventForwarder.config.webhooks.retry.maxAttempts }}
+        backoffMs: {{ .Values.eventForwarder.config.webhooks.retry.backoffMs }}
+
+    logging:
+      level: {{ .Values.eventForwarder.config.logging.level | quote }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.eventForwarder.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openchoreo-control-plane.event-forwarder.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: event-forwarder
+  annotations:
+    # Trigger rollout when config changes
+    checksum/config: {{ include (print $.Template.BasePath "/event-forwarder/configmap.yaml") . | sha256sum }}
+spec:
+  # Hardcoded to 1: the event-forwarder is stateless but each replica's
+  # informers would independently dispatch the same events,
+  # causing duplicate webhook deliveries. Not configurable.
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: event-forwarder
+      {{- include "openchoreo-control-plane.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: event-forwarder
+        {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Trigger pod restart when config changes
+        checksum/config: {{ include (print $.Template.BasePath "/event-forwarder/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "openchoreo-control-plane.event-forwarder.serviceAccountName" . }}
+      {{- with .Values.eventForwarder.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: event-forwarder
+        image: "{{ .Values.eventForwarder.image.repository }}:{{ .Values.eventForwarder.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.eventForwarder.image.pullPolicy }}
+        args:
+          - --config=/etc/openchoreo/config.yaml
+        ports:
+        - containerPort: {{ .Values.eventForwarder.config.server.port | default 8080 }}
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/openchoreo
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.eventForwarder.resources | nindent 12 }}
+        {{- with .Values.eventForwarder.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "openchoreo-control-plane.event-forwarder.name" . }}-config
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/serviceaccount.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.eventForwarder.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openchoreo-control-plane.event-forwarder.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: event-forwarder
+  {{- with .Values.eventForwarder.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true
+{{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -177,6 +177,21 @@
           "title": "baseUrl",
           "type": "string"
         },
+        "catalogSync": {
+          "additionalProperties": false,
+          "description": "Catalog sync configuration — controls how often the OpenChoreo entity provider runs the periodic full sync as a safety net behind the event-driven path. Lower values converge faster after missed events but cost more CRUD calls; higher values are cheaper but slower to recover. The event-forwarder (when enabled via eventForwarder.enabled) handles real-time delta updates between syncs.",
+          "properties": {
+            "frequency": {
+              "default": 300,
+              "description": "Frequency in seconds between periodic full syncs of the OpenChoreo catalog provider. With the event-forwarder enabled, this acts as a safety net for any events missed; with it disabled, this is the only sync mechanism and you may want a much smaller value (e.g. 60).",
+              "title": "frequency",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "catalogSync",
+          "type": "object"
+        },
         "containerSecurityContext": {
           "additionalProperties": false,
           "description": "Container security context",
@@ -365,20 +380,6 @@
           },
           "title": "env",
           "type": "array"
-        },
-        "catalogSync": {
-          "additionalProperties": false,
-          "description": "Catalog sync configuration — controls how often the OpenChoreo entity provider runs the periodic full sync",
-          "properties": {
-            "frequency": {
-              "default": 300,
-              "description": "Frequency in seconds between periodic full syncs of the OpenChoreo catalog provider",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "catalogSync",
-          "type": "object"
         },
         "externalCI": {
           "additionalProperties": false,
@@ -2206,6 +2207,265 @@
       "title": "controllerManager",
       "type": "object"
     },
+    "eventForwarder": {
+      "additionalProperties": false,
+      "description": "Event-forwarder configuration — watches OpenChoreo CRDs via K8s informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.",
+      "properties": {
+        "config": {
+          "additionalProperties": false,
+          "properties": {
+            "logging": {
+              "additionalProperties": false,
+              "properties": {
+                "level": {
+                  "default": "info",
+                  "title": "level",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "level"
+              ],
+              "title": "logging",
+              "type": "object"
+            },
+            "server": {
+              "additionalProperties": false,
+              "properties": {
+                "port": {
+                  "default": 8080,
+                  "title": "port",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "title": "server",
+              "type": "object"
+            },
+            "webhooks": {
+              "additionalProperties": false,
+              "properties": {
+                "endpoints": {
+                  "items": {
+                    "required": []
+                  },
+                  "title": "endpoints",
+                  "type": "array"
+                },
+                "retry": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "backoffMs": {
+                      "default": 1000,
+                      "title": "backoffMs",
+                      "type": "integer"
+                    },
+                    "maxAttempts": {
+                      "default": 3,
+                      "title": "maxAttempts",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "maxAttempts",
+                    "backoffMs"
+                  ],
+                  "title": "retry",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "endpoints",
+                "retry"
+              ],
+              "title": "webhooks",
+              "type": "object"
+            }
+          },
+          "required": [
+            "server",
+            "webhooks",
+            "logging"
+          ],
+          "title": "config",
+          "type": "object"
+        },
+        "containerSecurityContext": {
+          "additionalProperties": false,
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "default": false,
+              "title": "allowPrivilegeEscalation",
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "default": true,
+              "title": "readOnlyRootFilesystem",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "readOnlyRootFilesystem",
+            "allowPrivilegeEscalation"
+          ],
+          "title": "containerSecurityContext",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable the event-forwarder component. Disabling it stops the event-forwarder pod from being deployed and signals Backstage to skip its event subscriptions, falling back to poll-only catalog sync.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/openchoreo/event-forwarder",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "name": {
+          "default": "event-forwarder",
+          "description": "Name of the event-forwarder Deployment / ServiceAccount / ClusterRole resources",
+          "title": "name",
+          "type": "string"
+        },
+        "podSecurityContext": {
+          "additionalProperties": false,
+          "properties": {
+            "runAsNonRoot": {
+              "default": true,
+              "title": "runAsNonRoot",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "default": 65532,
+              "title": "runAsUser",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "runAsNonRoot",
+            "runAsUser"
+          ],
+          "title": "podSecurityContext",
+          "type": "object"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "200m",
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "256Mi",
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cpu",
+                "memory"
+              ],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "50m",
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "64Mi",
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cpu",
+                "memory"
+              ],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [
+            "limits",
+            "requests"
+          ],
+          "title": "resources",
+          "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "additionalProperties": false,
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "create": {
+              "default": true,
+              "title": "create",
+              "type": "boolean"
+            },
+            "name": {
+              "default": "",
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
+        }
+      },
+      "required": [
+        "image",
+        "config",
+        "serviceAccount",
+        "resources",
+        "podSecurityContext",
+        "containerSecurityContext"
+      ],
+      "title": "eventForwarder",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "openchoreo",
       "description": "Override the full name of the chart release",
@@ -3782,172 +4042,6 @@
       },
       "required": [],
       "title": "webhookService",
-      "type": "object"
-    },
-    "eventForwarder": {
-      "additionalProperties": false,
-      "description": "Event-forwarder configuration — watches OpenChoreo CRDs via K8s informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.",
-      "properties": {
-        "enabled": {
-          "default": true,
-          "description": "Enable the event-forwarder component. Disabling it stops the pod from being deployed and signals Backstage to skip its event subscriptions, falling back to poll-only catalog sync.",
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "name": {
-          "default": "event-forwarder",
-          "description": "Name of the event-forwarder Deployment / ServiceAccount / ClusterRole resources",
-          "required": [],
-          "title": "name",
-          "type": "string"
-        },
-        "image": {
-          "description": "Container image configuration",
-          "properties": {
-            "repository": {
-              "default": "ghcr.io/openchoreo/event-forwarder",
-              "description": "Docker image repository",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "",
-              "description": "Image tag. If empty, uses Chart.AppVersion",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            },
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "description": "Image pull policy",
-              "enum": ["Always", "IfNotPresent", "Never"],
-              "required": [],
-              "title": "pullPolicy"
-            }
-          },
-          "required": [],
-          "title": "image",
-          "type": "object"
-        },
-        "config": {
-          "description": "Event-forwarder runtime configuration",
-          "properties": {
-            "server": {
-              "properties": {
-                "port": {
-                  "default": 8080,
-                  "type": "integer"
-                }
-              },
-              "required": [],
-              "type": "object"
-            },
-            "webhooks": {
-              "properties": {
-                "endpoints": {
-                  "items": {
-                    "properties": {
-                      "url": {
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "type": "array"
-                },
-                "retry": {
-                  "properties": {
-                    "maxAttempts": {
-                      "default": 3,
-                      "type": "integer"
-                    },
-                    "backoffMs": {
-                      "default": 1000,
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "type": "object"
-                }
-              },
-              "required": [],
-              "type": "object"
-            },
-            "logging": {
-              "properties": {
-                "level": {
-                  "default": "info",
-                  "type": "string"
-                }
-              },
-              "required": [],
-              "type": "object"
-            }
-          },
-          "required": [],
-          "title": "config",
-          "type": "object"
-        },
-        "serviceAccount": {
-          "properties": {
-            "create": {
-              "default": true,
-              "type": "boolean"
-            },
-            "name": {
-              "default": "",
-              "type": "string"
-            },
-            "annotations": {
-              "type": "object"
-            }
-          },
-          "required": [],
-          "type": "object"
-        },
-        "resources": {
-          "properties": {
-            "limits": {
-              "properties": {
-                "cpu": { "default": "200m", "type": "string" },
-                "memory": { "default": "256Mi", "type": "string" }
-              },
-              "required": [],
-              "type": "object"
-            },
-            "requests": {
-              "properties": {
-                "cpu": { "default": "50m", "type": "string" },
-                "memory": { "default": "64Mi", "type": "string" }
-              },
-              "required": [],
-              "type": "object"
-            }
-          },
-          "required": [],
-          "type": "object"
-        },
-        "podSecurityContext": {
-          "properties": {
-            "runAsNonRoot": { "default": true, "type": "boolean" },
-            "runAsUser": { "default": 65532, "type": "integer" }
-          },
-          "required": [],
-          "type": "object"
-        },
-        "containerSecurityContext": {
-          "properties": {
-            "readOnlyRootFilesystem": { "default": true, "type": "boolean" },
-            "allowPrivilegeEscalation": { "default": false, "type": "boolean" }
-          },
-          "required": [],
-          "type": "object"
-        }
-      },
-      "required": [],
-      "title": "eventForwarder",
       "type": "object"
     }
   },

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -366,6 +366,20 @@
           "title": "env",
           "type": "array"
         },
+        "catalogSync": {
+          "additionalProperties": false,
+          "description": "Catalog sync configuration — controls how often the OpenChoreo entity provider runs the periodic full sync",
+          "properties": {
+            "frequency": {
+              "default": 300,
+              "description": "Frequency in seconds between periodic full syncs of the OpenChoreo catalog provider",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "catalogSync",
+          "type": "object"
+        },
         "externalCI": {
           "additionalProperties": false,
           "description": "External CI platform integrations (Jenkins). GitHub Actions and GitLab support coming soon.",
@@ -3768,6 +3782,172 @@
       },
       "required": [],
       "title": "webhookService",
+      "type": "object"
+    },
+    "eventForwarder": {
+      "additionalProperties": false,
+      "description": "Event-forwarder configuration — watches OpenChoreo CRDs via K8s informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enable the event-forwarder component. Disabling it stops the pod from being deployed and signals Backstage to skip its event subscriptions, falling back to poll-only catalog sync.",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "event-forwarder",
+          "description": "Name of the event-forwarder Deployment / ServiceAccount / ClusterRole resources",
+          "required": [],
+          "title": "name",
+          "type": "string"
+        },
+        "image": {
+          "description": "Container image configuration",
+          "properties": {
+            "repository": {
+              "default": "ghcr.io/openchoreo/event-forwarder",
+              "description": "Docker image repository",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "",
+              "description": "Image tag. If empty, uses Chart.AppVersion",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "description": "Image pull policy",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "required": [],
+              "title": "pullPolicy"
+            }
+          },
+          "required": [],
+          "title": "image",
+          "type": "object"
+        },
+        "config": {
+          "description": "Event-forwarder runtime configuration",
+          "properties": {
+            "server": {
+              "properties": {
+                "port": {
+                  "default": 8080,
+                  "type": "integer"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "webhooks": {
+              "properties": {
+                "endpoints": {
+                  "items": {
+                    "properties": {
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "retry": {
+                  "properties": {
+                    "maxAttempts": {
+                      "default": 3,
+                      "type": "integer"
+                    },
+                    "backoffMs": {
+                      "default": 1000,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "logging": {
+              "properties": {
+                "level": {
+                  "default": "info",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "serviceAccount": {
+          "properties": {
+            "create": {
+              "default": true,
+              "type": "boolean"
+            },
+            "name": {
+              "default": "",
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "resources": {
+          "properties": {
+            "limits": {
+              "properties": {
+                "cpu": { "default": "200m", "type": "string" },
+                "memory": { "default": "256Mi", "type": "string" }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "requests": {
+              "properties": {
+                "cpu": { "default": "50m", "type": "string" },
+                "memory": { "default": "64Mi", "type": "string" }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "properties": {
+            "runAsNonRoot": { "default": true, "type": "boolean" },
+            "runAsUser": { "default": 65532, "type": "integer" }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "containerSecurityContext": {
+          "properties": {
+            "readOnlyRootFilesystem": { "default": true, "type": "boolean" },
+            "allowPrivilegeEscalation": { "default": false, "type": "boolean" }
+          },
+          "required": [],
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "eventForwarder",
       "type": "object"
     }
   },

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -184,6 +184,7 @@
             "frequency": {
               "default": 300,
               "description": "Frequency in seconds between periodic full syncs of the OpenChoreo catalog provider. With the event-forwarder enabled, this acts as a safety net for any events missed; with it disabled, this is the only sync mechanism and you may want a much smaller value (e.g. 60).",
+              "minimum": 1,
               "title": "frequency",
               "type": "integer"
             }
@@ -2249,7 +2250,19 @@
               "properties": {
                 "endpoints": {
                   "items": {
-                    "required": []
+                    "additionalProperties": false,
+                    "properties": {
+                      "url": {
+                        "format": "uri",
+                        "minLength": 1,
+                        "title": "url",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object"
                   },
                   "title": "endpoints",
                   "type": "array"

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2255,7 +2255,6 @@
                       "url": {
                         "format": "uri",
                         "minLength": 1,
-                        "title": "url",
                         "type": "string"
                       }
                     },
@@ -2290,7 +2289,6 @@
                 }
               },
               "required": [
-                "endpoints",
                 "retry"
               ],
               "title": "webhooks",

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2210,7 +2210,7 @@
     },
     "eventForwarder": {
       "additionalProperties": false,
-      "description": "Event-forwarder configuration — watches OpenChoreo CRDs via K8s informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.",
+      "description": "Event-forwarder configuration — watches OpenChoreo Kubernetes resources via informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.",
       "properties": {
         "config": {
           "additionalProperties": false,
@@ -2249,7 +2249,7 @@
               "additionalProperties": false,
               "properties": {
                 "endpoints": {
-                  "description": "Webhook endpoints that receive CRD change notifications.\nDefault targets the in-cluster Backstage Service (same namespace,\ndefault service name \"backstage\" on port 7007). Override for\nexternal consumers, a renamed Backstage Service, or to fan out\nto multiple subscribers.\n\nEach endpoint may define its own optional `retry` block:\n  - url: https://example.com/hook\n    retry:\n      maxAttempts: 3\n      backoffMs: 500\nWhen omitted (the default for the Backstage entry below), the\nforwarder makes a single attempt per event and gives up on\nfailure — Backstage's periodic full sync reconciles missed\nevents. Add `retry` only for endpoints that have no equivalent\nreconciliation mechanism of their own.",
+                  "description": "Webhook endpoints that receive resource change notifications.\nDefault targets the in-cluster Backstage Service (same namespace,\ndefault service name \"backstage\" on port 7007). Override for\nexternal consumers, a renamed Backstage Service, or to fan out\nto multiple subscribers.\n\nEach endpoint may define its own optional `retry` block:\n  - url: https://example.com/hook\n    retry:\n      maxAttempts: 3\n      backoffMs: 500\nWhen omitted (the default for the Backstage entry below), the\nforwarder makes a single attempt per event and gives up on\nfailure — Backstage's periodic full sync reconciles missed\nevents. Add `retry` only for endpoints that have no equivalent\nreconciliation mechanism of their own.",
                   "items": {
                     "additionalProperties": false,
                     "properties": {

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2249,9 +2249,28 @@
               "additionalProperties": false,
               "properties": {
                 "endpoints": {
+                  "description": "Webhook endpoints that receive CRD change notifications.\nDefault targets the in-cluster Backstage Service (same namespace,\ndefault service name \"backstage\" on port 7007). Override for\nexternal consumers, a renamed Backstage Service, or to fan out\nto multiple subscribers.\n\nEach endpoint may define its own optional `retry` block:\n  - url: https://example.com/hook\n    retry:\n      maxAttempts: 3\n      backoffMs: 500\nWhen omitted (the default for the Backstage entry below), the\nforwarder makes a single attempt per event and gives up on\nfailure — Backstage's periodic full sync reconciles missed\nevents. Add `retry` only for endpoints that have no equivalent\nreconciliation mechanism of their own.",
                   "items": {
                     "additionalProperties": false,
                     "properties": {
+                      "retry": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "backoffMs": {
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "maxAttempts": {
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "maxAttempts",
+                          "backoffMs"
+                        ],
+                        "type": "object"
+                      },
                       "url": {
                         "format": "uri",
                         "minLength": 1,
@@ -2265,31 +2284,9 @@
                   },
                   "title": "endpoints",
                   "type": "array"
-                },
-                "retry": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "backoffMs": {
-                      "default": 1000,
-                      "minimum": 1,
-                      "title": "backoffMs",
-                      "type": "integer"
-                    },
-                    "maxAttempts": {
-                      "default": 3,
-                      "minimum": 1,
-                      "title": "maxAttempts",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "retry",
-                  "type": "object"
                 }
               },
-              "required": [
-                "retry"
-              ],
+              "required": [],
               "title": "webhooks",
               "type": "object"
             }

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2282,10 +2282,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "maxAttempts",
-                    "backoffMs"
-                  ],
+                  "required": [],
                   "title": "retry",
                   "type": "object"
                 }
@@ -2447,6 +2444,7 @@
                 "type": "string"
               },
               "default": {},
+              "description": "Annotations to add to the service account",
               "required": [],
               "title": "annotations",
               "type": "object"
@@ -2464,8 +2462,7 @@
           },
           "required": [
             "create",
-            "name",
-            "annotations"
+            "name"
           ],
           "title": "serviceAccount",
           "type": "object"

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2271,11 +2271,13 @@
                   "properties": {
                     "backoffMs": {
                       "default": 1000,
+                      "minimum": 1,
                       "title": "backoffMs",
                       "type": "integer"
                     },
                     "maxAttempts": {
                       "default": 3,
+                      "minimum": 1,
                       "title": "maxAttempts",
                       "type": "integer"
                     }
@@ -2441,7 +2443,10 @@
           "additionalProperties": false,
           "properties": {
             "annotations": {
-              "additionalProperties": false,
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {},
               "required": [],
               "title": "annotations",
               "type": "object"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2242,6 +2242,18 @@ backstage:
 
   # @schema
   # type: object
+  # description: Catalog sync configuration — controls how often the OpenChoreo entity provider runs the periodic full sync as a safety net behind the event-driven path. Lower values converge faster after missed events but cost more CRUD calls; higher values are cheaper but slower to recover. The event-forwarder (when enabled via eventForwarder.enabled) handles real-time delta updates between syncs.
+  # @schema
+  catalogSync:
+    # @schema
+    # type: integer
+    # description: Frequency in seconds between periodic full syncs of the OpenChoreo catalog provider. With the event-forwarder enabled, this acts as a safety net for any events missed; with it disabled, this is the only sync mechanism and you may want a much smaller value (e.g. 60).
+    # default: 300
+    # @schema
+    frequency: 300
+
+  # @schema
+  # type: object
   # description: Feature flags for enabling/disabling OpenChoreo features in Backstage
   # @schema
   features:
@@ -3490,3 +3502,59 @@ gateway:
     #       description: Secret name containing the TLS certificate
     # @schema
     certificateRefs: []
+
+# @schema
+# type: object
+# description: Event-forwarder configuration — watches OpenChoreo CRDs via K8s informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.
+# @schema
+eventForwarder:
+  # @schema
+  # type: boolean
+  # description: Enable the event-forwarder component. Disabling it stops the event-forwarder pod from being deployed and signals Backstage to skip its event subscriptions, falling back to poll-only catalog sync.
+  # default: true
+  # @schema
+  enabled: true
+
+  # @schema
+  # type: string
+  # description: Name of the event-forwarder Deployment / ServiceAccount / ClusterRole resources
+  # default: event-forwarder
+  # @schema
+  name: event-forwarder
+
+  image:
+    repository: ghcr.io/openchoreo/event-forwarder
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  config:
+    server:
+      port: 8080
+    webhooks:
+      endpoints: []
+      retry:
+        maxAttempts: 3
+        backoffMs: 1000
+    logging:
+      level: info
+
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3506,7 +3506,7 @@ gateway:
 
 # @schema
 # type: object
-# description: Event-forwarder configuration — watches OpenChoreo CRDs via K8s informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.
+# description: Event-forwarder configuration — watches OpenChoreo Kubernetes resources via informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.
 # @schema
 eventForwarder:
   # @schema
@@ -3532,7 +3532,7 @@ eventForwarder:
     server:
       port: 8080
     webhooks:
-      # Webhook endpoints that receive CRD change notifications.
+      # Webhook endpoints that receive resource change notifications.
       # Default targets the in-cluster Backstage Service (same namespace,
       # default service name "backstage" on port 7007). Override for
       # external consumers, a renamed Backstage Service, or to fan out

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2249,6 +2249,7 @@ backstage:
     # type: integer
     # description: Frequency in seconds between periodic full syncs of the OpenChoreo catalog provider. With the event-forwarder enabled, this acts as a safety net for any events missed; with it disabled, this is the only sync mechanism and you may want a much smaller value (e.g. 60).
     # default: 300
+    # minimum: 1
     # @schema
     frequency: 300
 
@@ -3531,6 +3532,18 @@ eventForwarder:
     server:
       port: 8080
     webhooks:
+      # @schema
+      # type: array
+      # items:
+      #   type: object
+      #   additionalProperties: false
+      #   required: [url]
+      #   properties:
+      #     url:
+      #       type: string
+      #       format: uri
+      #       minLength: 1
+      # @schema
       endpoints: []
       retry:
         maxAttempts: 3

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3546,7 +3546,17 @@ eventForwarder:
       # @schema
       endpoints: []
       retry:
+        # @schema
+        # type: integer
+        # minimum: 1
+        # default: 3
+        # @schema
         maxAttempts: 3
+        # @schema
+        # type: integer
+        # minimum: 1
+        # default: 1000
+        # @schema
         backoffMs: 1000
     logging:
       level: info
@@ -3554,6 +3564,13 @@ eventForwarder:
   serviceAccount:
     create: true
     name: ""
+    # @schema
+    # type: object
+    # description: Annotations to add to the service account
+    # additionalProperties:
+    #   type: string
+    # default: {}
+    # @schema
     annotations: {}
 
   resources:

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3532,6 +3532,22 @@ eventForwarder:
     server:
       port: 8080
     webhooks:
+      # Webhook endpoints that receive CRD change notifications.
+      # Default targets the in-cluster Backstage Service (same namespace,
+      # default service name "backstage" on port 7007). Override for
+      # external consumers, a renamed Backstage Service, or to fan out
+      # to multiple subscribers.
+      #
+      # Each endpoint may define its own optional `retry` block:
+      #   - url: https://example.com/hook
+      #     retry:
+      #       maxAttempts: 3
+      #       backoffMs: 500
+      # When omitted (the default for the Backstage entry below), the
+      # forwarder makes a single attempt per event and gives up on
+      # failure — Backstage's periodic full sync reconciles missed
+      # events. Add `retry` only for endpoints that have no equivalent
+      # reconciliation mechanism of their own.
       # @schema
       # type: array
       # items:
@@ -3543,21 +3559,20 @@ eventForwarder:
       #       type: string
       #       format: uri
       #       minLength: 1
+      #     retry:
+      #       type: object
+      #       additionalProperties: false
+      #       required: [maxAttempts, backoffMs]
+      #       properties:
+      #         maxAttempts:
+      #           type: integer
+      #           minimum: 1
+      #         backoffMs:
+      #           type: integer
+      #           minimum: 0
       # @schema
-      endpoints: []
-      retry:
-        # @schema
-        # type: integer
-        # minimum: 1
-        # default: 3
-        # @schema
-        maxAttempts: 3
-        # @schema
-        # type: integer
-        # minimum: 1
-        # default: 1000
-        # @schema
-        backoffMs: 1000
+      endpoints:
+        - url: http://backstage:7007/api/events/http/openchoreo
     logging:
       level: info
 

--- a/internal/eventforwarder/config/config.go
+++ b/internal/eventforwarder/config/config.go
@@ -27,15 +27,20 @@ type ServerConfig struct {
 // WebhooksConfig holds webhook dispatch settings.
 type WebhooksConfig struct {
 	Endpoints []EndpointConfig `yaml:"endpoints"`
-	Retry     RetryConfig      `yaml:"retry"`
 }
 
-// EndpointConfig holds a single webhook endpoint URL.
+// EndpointConfig holds a single webhook endpoint and its (optional)
+// retry policy. When `Retry` is nil, the dispatcher tries exactly once
+// and gives up on failure — the typical Backstage consumer reconciles
+// missed events via its periodic full-sync, so retry isn't needed for
+// the default case. Set this for endpoints that have no equivalent
+// reconciliation mechanism.
 type EndpointConfig struct {
-	URL string `yaml:"url"`
+	URL   string       `yaml:"url"`
+	Retry *RetryConfig `yaml:"retry,omitempty"`
 }
 
-// RetryConfig holds retry settings for webhook dispatch.
+// RetryConfig holds retry settings for a single webhook endpoint.
 type RetryConfig struct {
 	MaxAttempts int `yaml:"maxAttempts"`
 	BackoffMs   int `yaml:"backoffMs"`
@@ -54,13 +59,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		Server: ServerConfig{Port: 8080},
-		Webhooks: WebhooksConfig{
-			Retry: RetryConfig{
-				MaxAttempts: 3,
-				BackoffMs:   1000,
-			},
-		},
+		Server:  ServerConfig{Port: 8080},
 		Logging: LoggingConfig{Level: "info"},
 	}
 
@@ -79,6 +78,14 @@ func Load(path string) (*Config, error) {
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
 			return nil, fmt.Errorf("webhooks.endpoints[%d]: unsupported scheme %q (want http or https)", i, u.Scheme)
+		}
+		if ep.Retry != nil {
+			if ep.Retry.MaxAttempts < 1 {
+				return nil, fmt.Errorf("webhooks.endpoints[%d].retry.maxAttempts must be >= 1", i)
+			}
+			if ep.Retry.BackoffMs < 0 {
+				return nil, fmt.Errorf("webhooks.endpoints[%d].retry.backoffMs must be >= 0", i)
+			}
 		}
 	}
 

--- a/internal/eventforwarder/config/config.go
+++ b/internal/eventforwarder/config/config.go
@@ -5,7 +5,9 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -64,6 +66,20 @@ func Load(path string) (*Config, error) {
 
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+
+	for i, ep := range cfg.Webhooks.Endpoints {
+		trimmed := strings.TrimSpace(ep.URL)
+		if trimmed == "" {
+			return nil, fmt.Errorf("webhooks.endpoints[%d]: url is required", i)
+		}
+		u, err := url.Parse(trimmed)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("webhooks.endpoints[%d]: invalid url %q", i, ep.URL)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("webhooks.endpoints[%d]: unsupported scheme %q (want http or https)", i, u.Scheme)
+		}
 	}
 
 	return cfg, nil

--- a/internal/eventforwarder/config/config.go
+++ b/internal/eventforwarder/config/config.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds the event-forwarder configuration.
+type Config struct {
+	Server   ServerConfig   `yaml:"server"`
+	Webhooks WebhooksConfig `yaml:"webhooks"`
+	Logging  LoggingConfig  `yaml:"logging"`
+}
+
+// ServerConfig holds HTTP server settings.
+type ServerConfig struct {
+	Port int `yaml:"port"`
+}
+
+// WebhooksConfig holds webhook dispatch settings.
+type WebhooksConfig struct {
+	Endpoints []EndpointConfig `yaml:"endpoints"`
+	Retry     RetryConfig      `yaml:"retry"`
+}
+
+// EndpointConfig holds a single webhook endpoint URL.
+type EndpointConfig struct {
+	URL string `yaml:"url"`
+}
+
+// RetryConfig holds retry settings for webhook dispatch.
+type RetryConfig struct {
+	MaxAttempts int `yaml:"maxAttempts"`
+	BackoffMs   int `yaml:"backoffMs"`
+}
+
+// LoggingConfig holds logging settings.
+type LoggingConfig struct {
+	Level string `yaml:"level"`
+}
+
+// Load reads config from a YAML file at the given path.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file %s: %w", path, err)
+	}
+
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Webhooks: WebhooksConfig{
+			Retry: RetryConfig{
+				MaxAttempts: 3,
+				BackoffMs:   1000,
+			},
+		},
+		Logging: LoggingConfig{Level: "info"},
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+
+	return cfg, nil
+}

--- a/internal/eventforwarder/config/config.go
+++ b/internal/eventforwarder/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package config
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/openchoreo/openchoreo/internal/logging"
 )
 
 // Config holds the event-forwarder configuration.
@@ -48,7 +50,15 @@ type RetryConfig struct {
 
 // LoggingConfig holds logging settings.
 type LoggingConfig struct {
-	Level string `yaml:"level"`
+	Level  string `yaml:"level"`
+	Format string `yaml:"format"`
+}
+
+// ToLoggingConfig converts the YAML-shaped LoggingConfig into the
+// shared logging package's Config so the event-forwarder uses the same
+// logger construction as every other OpenChoreo binary.
+func (l LoggingConfig) ToLoggingConfig() logging.Config {
+	return logging.Config{Level: l.Level, Format: l.Format}
 }
 
 // Load reads config from a YAML file at the given path.

--- a/internal/eventforwarder/config/config_test.go
+++ b/internal/eventforwarder/config/config_test.go
@@ -16,7 +16,7 @@ func writeTempConfig(t *testing.T, body string) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
 	return path
 }
 

--- a/internal/eventforwarder/config/config_test.go
+++ b/internal/eventforwarder/config/config_test.go
@@ -85,6 +85,50 @@ func TestLoad_FileNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "reading config file")
 }
 
+func TestLoad_RejectsInvalidWebhookURLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "empty url",
+			body: `
+webhooks:
+  endpoints:
+    - url: ""
+`,
+			wantErr: "url is required",
+		},
+		{
+			name: "no scheme",
+			body: `
+webhooks:
+  endpoints:
+    - url: "example.com/webhook"
+`,
+			wantErr: "invalid url",
+		},
+		{
+			name: "unsupported scheme",
+			body: `
+webhooks:
+  endpoints:
+    - url: "ftp://example.com/webhook"
+`,
+			wantErr: "unsupported scheme",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTempConfig(t, tt.body)
+			_, err := Load(path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestLoad_InvalidYAML(t *testing.T) {
 	// Tabs are not valid YAML indentation.
 	path := writeTempConfig(t, "\tnot: valid\n")

--- a/internal/eventforwarder/config/config_test.go
+++ b/internal/eventforwarder/config/config_test.go
@@ -28,9 +28,9 @@ webhooks:
   endpoints:
     - url: http://example.com/webhook-a
     - url: http://example.com/webhook-b
-  retry:
-    maxAttempts: 5
-    backoffMs: 500
+      retry:
+        maxAttempts: 5
+        backoffMs: 500
 logging:
   level: debug
 `)
@@ -41,9 +41,12 @@ logging:
 	assert.Equal(t, 9090, cfg.Server.Port)
 	require.Len(t, cfg.Webhooks.Endpoints, 2)
 	assert.Equal(t, "http://example.com/webhook-a", cfg.Webhooks.Endpoints[0].URL)
+	assert.Nil(t, cfg.Webhooks.Endpoints[0].Retry,
+		"endpoint without retry block must keep nil retry (try-once default)")
 	assert.Equal(t, "http://example.com/webhook-b", cfg.Webhooks.Endpoints[1].URL)
-	assert.Equal(t, 5, cfg.Webhooks.Retry.MaxAttempts)
-	assert.Equal(t, 500, cfg.Webhooks.Retry.BackoffMs)
+	require.NotNil(t, cfg.Webhooks.Endpoints[1].Retry)
+	assert.Equal(t, 5, cfg.Webhooks.Endpoints[1].Retry.MaxAttempts)
+	assert.Equal(t, 500, cfg.Webhooks.Endpoints[1].Retry.BackoffMs)
 	assert.Equal(t, "debug", cfg.Logging.Level)
 }
 
@@ -60,8 +63,8 @@ webhooks:
 	require.NoError(t, err)
 
 	assert.Equal(t, 8080, cfg.Server.Port, "default server port")
-	assert.Equal(t, 3, cfg.Webhooks.Retry.MaxAttempts, "default retry max attempts")
-	assert.Equal(t, 1000, cfg.Webhooks.Retry.BackoffMs, "default retry backoff")
+	assert.Nil(t, cfg.Webhooks.Endpoints[0].Retry,
+		"endpoints default to no retry — consumers reconcile via their own full sync")
 	assert.Equal(t, "info", cfg.Logging.Level, "default log level")
 }
 
@@ -73,10 +76,38 @@ func TestLoad_EmptyFile(t *testing.T) {
 
 	// Every default should be present.
 	assert.Equal(t, 8080, cfg.Server.Port)
-	assert.Equal(t, 3, cfg.Webhooks.Retry.MaxAttempts)
-	assert.Equal(t, 1000, cfg.Webhooks.Retry.BackoffMs)
 	assert.Equal(t, "info", cfg.Logging.Level)
 	assert.Empty(t, cfg.Webhooks.Endpoints, "no endpoints configured")
+}
+
+func TestLoad_RejectsInvalidRetryConfig(t *testing.T) {
+	t.Run("zero maxAttempts", func(t *testing.T) {
+		path := writeTempConfig(t, `
+webhooks:
+  endpoints:
+    - url: http://example.com/webhook
+      retry:
+        maxAttempts: 0
+        backoffMs: 100
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maxAttempts must be >= 1")
+	})
+
+	t.Run("negative backoffMs", func(t *testing.T) {
+		path := writeTempConfig(t, `
+webhooks:
+  endpoints:
+    - url: http://example.com/webhook
+      retry:
+        maxAttempts: 3
+        backoffMs: -100
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backoffMs must be >= 0")
+	})
 }
 
 func TestLoad_FileNotFound(t *testing.T) {

--- a/internal/eventforwarder/config/config_test.go
+++ b/internal/eventforwarder/config/config_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return path
+}
+
+func TestLoad_FullConfig(t *testing.T) {
+	path := writeTempConfig(t, `
+server:
+  port: 9090
+webhooks:
+  endpoints:
+    - url: http://example.com/webhook-a
+    - url: http://example.com/webhook-b
+  retry:
+    maxAttempts: 5
+    backoffMs: 500
+logging:
+  level: debug
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, 9090, cfg.Server.Port)
+	require.Len(t, cfg.Webhooks.Endpoints, 2)
+	assert.Equal(t, "http://example.com/webhook-a", cfg.Webhooks.Endpoints[0].URL)
+	assert.Equal(t, "http://example.com/webhook-b", cfg.Webhooks.Endpoints[1].URL)
+	assert.Equal(t, 5, cfg.Webhooks.Retry.MaxAttempts)
+	assert.Equal(t, 500, cfg.Webhooks.Retry.BackoffMs)
+	assert.Equal(t, "debug", cfg.Logging.Level)
+}
+
+func TestLoad_AppliesDefaultsWhenFieldsMissing(t *testing.T) {
+	// An almost-empty config should still produce sensible defaults that
+	// match what the production Load() seeds before YAML unmarshal.
+	path := writeTempConfig(t, `
+webhooks:
+  endpoints:
+    - url: http://example.com/webhook
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, 8080, cfg.Server.Port, "default server port")
+	assert.Equal(t, 3, cfg.Webhooks.Retry.MaxAttempts, "default retry max attempts")
+	assert.Equal(t, 1000, cfg.Webhooks.Retry.BackoffMs, "default retry backoff")
+	assert.Equal(t, "info", cfg.Logging.Level, "default log level")
+}
+
+func TestLoad_EmptyFile(t *testing.T) {
+	path := writeTempConfig(t, "")
+
+	cfg, err := Load(path)
+	require.NoError(t, err, "empty file should not error; defaults are applied")
+
+	// Every default should be present.
+	assert.Equal(t, 8080, cfg.Server.Port)
+	assert.Equal(t, 3, cfg.Webhooks.Retry.MaxAttempts)
+	assert.Equal(t, 1000, cfg.Webhooks.Retry.BackoffMs)
+	assert.Equal(t, "info", cfg.Logging.Level)
+	assert.Empty(t, cfg.Webhooks.Endpoints, "no endpoints configured")
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load("/this/path/does/not/exist.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading config file")
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	// Tabs are not valid YAML indentation.
+	path := writeTempConfig(t, "\tnot: valid\n")
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing config file")
+}

--- a/internal/eventforwarder/config/config_test.go
+++ b/internal/eventforwarder/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/internal/eventforwarder/dispatcher/dispatcher.go
+++ b/internal/eventforwarder/dispatcher/dispatcher.go
@@ -5,11 +5,14 @@ package dispatcher
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
@@ -26,7 +29,6 @@ type Event struct {
 // Dispatcher sends webhook notifications to configured HTTP endpoints.
 type Dispatcher struct {
 	endpoints []config.EndpointConfig
-	retry     config.RetryConfig
 	client    *http.Client
 	logger    *slog.Logger
 }
@@ -35,7 +37,6 @@ type Dispatcher struct {
 func New(cfg config.WebhooksConfig, logger *slog.Logger) *Dispatcher {
 	return &Dispatcher{
 		endpoints: cfg.Endpoints,
-		retry:     cfg.Retry,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -44,7 +45,19 @@ func New(cfg config.WebhooksConfig, logger *slog.Logger) *Dispatcher {
 }
 
 // Dispatch sends an event to all configured endpoints.
-func (d *Dispatcher) Dispatch(event Event) {
+//
+// Lifecycle: spawns one parent goroutine per call, which in turn spawns
+// one child goroutine per configured endpoint and waits for all of them
+// via a WaitGroup. The caller (informer event handler) does NOT wait on
+// the parent — blocking the informer would stall every CRD event in the
+// process. The parent is "fire-and-forget at the informer boundary" but
+// owns a clean per-event lifecycle internally, so when ctx is cancelled
+// (SIGTERM) all in-flight retry sleeps and HTTP calls abort together
+// instead of running detached past process shutdown.
+//
+// Note: this does NOT bound peak goroutine count under burst load — that
+// requires a worker pool. Tracked separately as a follow-up.
+func (d *Dispatcher) Dispatch(ctx context.Context, event Event) {
 	if len(d.endpoints) == 0 {
 		d.logger.Debug("No webhook endpoints configured, skipping dispatch",
 			"kind", event.Kind,
@@ -59,19 +72,58 @@ func (d *Dispatcher) Dispatch(event Event) {
 		return
 	}
 
-	for _, ep := range d.endpoints {
-		go d.sendWithRetry(ep.URL, payload, event)
-	}
+	go d.dispatchAll(ctx, payload, event)
 }
 
-func (d *Dispatcher) sendWithRetry(url string, payload []byte, event Event) {
-	maxAttempts := d.retry.MaxAttempts
-	if maxAttempts < 1 {
-		maxAttempts = 1
+// dispatchAll fans out one HTTP delivery per configured endpoint and
+// waits for all of them to finish (or for ctx to cancel them).
+func (d *Dispatcher) dispatchAll(ctx context.Context, payload []byte, event Event) {
+	var wg sync.WaitGroup
+	for _, ep := range d.endpoints {
+		wg.Add(1)
+		go func(ep config.EndpointConfig) {
+			defer wg.Done()
+			d.sendWithRetry(ctx, ep, payload, event)
+		}(ep)
+	}
+	wg.Wait()
+	d.logger.Debug("All endpoint dispatches complete for event",
+		"kind", event.Kind,
+		"name", event.Name,
+		"action", event.Action,
+	)
+}
+
+func (d *Dispatcher) sendWithRetry(ctx context.Context, ep config.EndpointConfig, payload []byte, event Event) {
+	url := ep.URL
+	// Default behaviour is "try once and give up" — Backstage and similar
+	// catalog consumers reconcile missed events via their own periodic
+	// full sync, so the forwarder doesn't need delivery guarantees by
+	// default. Endpoints that have no equivalent reconciliation can opt
+	// in to retry by setting `retry` in their config block.
+	maxAttempts := 1
+	backoffMs := 0
+	if ep.Retry != nil {
+		maxAttempts = ep.Retry.MaxAttempts
+		if maxAttempts < 1 {
+			maxAttempts = 1
+		}
+		backoffMs = ep.Retry.BackoffMs
 	}
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := d.send(url, payload)
+		if ctx.Err() != nil {
+			d.logger.Info("Dispatch cancelled before attempt",
+				"url", url,
+				"kind", event.Kind,
+				"name", event.Name,
+				"attempt", attempt,
+				"error", ctx.Err(),
+			)
+			return
+		}
+
+		err := d.send(ctx, url, payload)
 		if err == nil {
 			d.logger.Debug("Webhook dispatched successfully",
 				"url", url,
@@ -79,6 +131,19 @@ func (d *Dispatcher) sendWithRetry(url string, payload []byte, event Event) {
 				"name", event.Name,
 				"action", event.Action,
 				"attempt", attempt,
+			)
+			return
+		}
+
+		// If the failure was caused by ctx cancellation, don't bother
+		// retrying or escalating — log at info and return cleanly.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			d.logger.Info("Dispatch cancelled during attempt",
+				"url", url,
+				"kind", event.Kind,
+				"name", event.Name,
+				"attempt", attempt,
+				"error", err,
 			)
 			return
 		}
@@ -93,8 +158,20 @@ func (d *Dispatcher) sendWithRetry(url string, payload []byte, event Event) {
 		)
 
 		if attempt < maxAttempts {
-			backoff := time.Duration(d.retry.BackoffMs) * time.Millisecond * time.Duration(math.Pow(2, float64(attempt-1)))
-			time.Sleep(backoff)
+			backoff := time.Duration(backoffMs) * time.Millisecond * time.Duration(math.Pow(2, float64(attempt-1)))
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				d.logger.Info("Dispatch cancelled during backoff",
+					"url", url,
+					"kind", event.Kind,
+					"name", event.Name,
+					"error", ctx.Err(),
+				)
+				return
+			case <-timer.C:
+			}
 		}
 	}
 
@@ -106,8 +183,8 @@ func (d *Dispatcher) sendWithRetry(url string, payload []byte, event Event) {
 	)
 }
 
-func (d *Dispatcher) send(url string, payload []byte) error {
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+func (d *Dispatcher) send(ctx context.Context, url string, payload []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/eventforwarder/dispatcher/dispatcher.go
+++ b/internal/eventforwarder/dispatcher/dispatcher.go
@@ -33,14 +33,14 @@ type Event struct {
 // responses) and the periodic full sync acting as the reconciliation
 // safety net, modest values are sufficient — there's no benefit to
 // over-provisioning, and dropping under sustained overload is honest
-// behaviour given the safety net.
+// behavior given the safety net.
 const (
 	defaultWorkers   = 4
 	defaultQueueSize = 1024
 )
 
 // dispatchJob is the unit of work consumed by the worker pool. The
-// payload is pre-marshalled at enqueue time so workers don't redo the
+// payload is pre-marshaled at enqueue time so workers don't redo the
 // JSON serialization, and ctx is captured at enqueue time so each
 // in-flight job carries the producer's context for cancellation.
 type dispatchJob struct {

--- a/internal/eventforwarder/dispatcher/dispatcher.go
+++ b/internal/eventforwarder/dispatcher/dispatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dispatcher
@@ -9,9 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,7 +21,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
 )
 
-// Event represents a lightweight CRD change notification.
+// Event represents a lightweight Kubernetes resource change notification.
 type Event struct {
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
@@ -87,7 +89,7 @@ func New(cfg config.WebhooksConfig, logger *slog.Logger) *Dispatcher {
 }
 
 // Start launches the worker pool. The workers consume from the dispatch
-// queue until ctx is cancelled, at which point they drain any in-flight
+// queue until ctx is canceled, at which point they drain any in-flight
 // HTTP attempts (via the per-job ctx) and exit. Safe to call multiple
 // times — only the first call has any effect.
 func (d *Dispatcher) Start(ctx context.Context) {
@@ -196,7 +198,7 @@ func (d *Dispatcher) sendWithRetry(ctx context.Context, ep config.EndpointConfig
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if ctx.Err() != nil {
-			d.logger.Info("Dispatch cancelled before attempt",
+			d.logger.Info("Dispatch canceled before attempt",
 				"url", url,
 				"kind", event.Kind,
 				"name", event.Name,
@@ -221,7 +223,7 @@ func (d *Dispatcher) sendWithRetry(ctx context.Context, ep config.EndpointConfig
 		// If the failure was caused by ctx cancellation, don't bother
 		// retrying or escalating — log at info and return cleanly.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			d.logger.Info("Dispatch cancelled during attempt",
+			d.logger.Info("Dispatch canceled during attempt",
 				"url", url,
 				"kind", event.Kind,
 				"name", event.Name,
@@ -246,7 +248,7 @@ func (d *Dispatcher) sendWithRetry(ctx context.Context, ep config.EndpointConfig
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				d.logger.Info("Dispatch cancelled during backoff",
+				d.logger.Info("Dispatch canceled during backoff",
 					"url", url,
 					"kind", event.Kind,
 					"name", event.Name,
@@ -283,5 +285,13 @@ func (d *Dispatcher) send(ctx context.Context, url string, payload []byte) error
 		return nil
 	}
 
-	return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	// Include a snippet of the response body in the error so the warn
+	// log is actionable for troubleshooting (e.g. "404 Not Found", an
+	// auth-rejection JSON, or a server-side stack trace excerpt). Cap
+	// at maxBodySnippetBytes to keep log lines bounded regardless of
+	// what the server returns.
+	const maxBodySnippetBytes = 256
+	bodySnippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodySnippetBytes))
+	return fmt.Errorf("unexpected status code %d: %s",
+		resp.StatusCode, strings.TrimSpace(string(bodySnippet)))
 }

--- a/internal/eventforwarder/dispatcher/dispatcher.go
+++ b/internal/eventforwarder/dispatcher/dispatcher.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
@@ -26,37 +27,106 @@ type Event struct {
 	Action    string `json:"action"`
 }
 
+// Default sizes for the worker pool. Worker count caps peak in-flight
+// dispatches; queue size caps memory under burst when downstream is
+// slow. With Backstage as the typical single consumer (sub-100ms
+// responses) and the periodic full sync acting as the reconciliation
+// safety net, modest values are sufficient — there's no benefit to
+// over-provisioning, and dropping under sustained overload is honest
+// behaviour given the safety net.
+const (
+	defaultWorkers   = 4
+	defaultQueueSize = 1024
+)
+
+// dispatchJob is the unit of work consumed by the worker pool. The
+// payload is pre-marshalled at enqueue time so workers don't redo the
+// JSON serialization, and ctx is captured at enqueue time so each
+// in-flight job carries the producer's context for cancellation.
+type dispatchJob struct {
+	ctx     context.Context
+	event   Event
+	payload []byte
+}
+
 // Dispatcher sends webhook notifications to configured HTTP endpoints.
+//
+// Concurrency model: a fixed-size pool of worker goroutines consumes
+// dispatch jobs from a buffered channel. The producer (`Dispatch`) is
+// non-blocking — it never stalls the informer thread that's calling it,
+// even under sustained downstream slowness. When the queue is full,
+// new events are dropped with a warning; the consumer's periodic full
+// sync is the reconciliation mechanism for any drops.
+//
+// This deliberately *does* bound peak goroutine count under burst load,
+// at the cost of dropping events when the queue overflows. The
+// previous design (one goroutine per event) had no such bound and could
+// pile up arbitrarily during downstream outages.
 type Dispatcher struct {
 	endpoints []config.EndpointConfig
 	client    *http.Client
 	logger    *slog.Logger
+
+	jobs    chan dispatchJob
+	workers int
+	started atomic.Bool
 }
 
-// New creates a new Dispatcher.
+// New creates a new Dispatcher. Call Start to launch the worker pool
+// before dispatching any events.
 func New(cfg config.WebhooksConfig, logger *slog.Logger) *Dispatcher {
 	return &Dispatcher{
 		endpoints: cfg.Endpoints,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		logger: logger,
+		logger:  logger,
+		jobs:    make(chan dispatchJob, defaultQueueSize),
+		workers: defaultWorkers,
 	}
 }
 
-// Dispatch sends an event to all configured endpoints.
-//
-// Lifecycle: spawns one parent goroutine per call, which in turn spawns
-// one child goroutine per configured endpoint and waits for all of them
-// via a WaitGroup. The caller (informer event handler) does NOT wait on
-// the parent — blocking the informer would stall every CRD event in the
-// process. The parent is "fire-and-forget at the informer boundary" but
-// owns a clean per-event lifecycle internally, so when ctx is cancelled
-// (SIGTERM) all in-flight retry sleeps and HTTP calls abort together
-// instead of running detached past process shutdown.
-//
-// Note: this does NOT bound peak goroutine count under burst load — that
-// requires a worker pool. Tracked separately as a follow-up.
+// Start launches the worker pool. The workers consume from the dispatch
+// queue until ctx is cancelled, at which point they drain any in-flight
+// HTTP attempts (via the per-job ctx) and exit. Safe to call multiple
+// times — only the first call has any effect.
+func (d *Dispatcher) Start(ctx context.Context) {
+	if !d.started.CompareAndSwap(false, true) {
+		return
+	}
+	for i := 0; i < d.workers; i++ {
+		go d.worker(ctx, i)
+	}
+	d.logger.Info("Dispatcher worker pool started",
+		"workers", d.workers,
+		"queueSize", cap(d.jobs),
+	)
+}
+
+func (d *Dispatcher) worker(ctx context.Context, id int) {
+	d.logger.Debug("Dispatcher worker started", "id", id)
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.Debug("Dispatcher worker stopping", "id", id, "reason", ctx.Err())
+			return
+		case job, ok := <-d.jobs:
+			if !ok {
+				return
+			}
+			d.dispatchAll(job)
+		}
+	}
+}
+
+// Dispatch enqueues an event for delivery. Returns immediately:
+//   - If endpoints are empty, no-op.
+//   - If the queue has capacity, the event is queued and the workers
+//     will pick it up. The caller (informer event handler) is never
+//     blocked.
+//   - If the queue is full, the event is dropped with a warning. This
+//     means the consumer is sustainedly slower than the event rate;
+//     the periodic full sync will reconcile missed state.
 func (d *Dispatcher) Dispatch(ctx context.Context, event Event) {
 	if len(d.endpoints) == 0 {
 		d.logger.Debug("No webhook endpoints configured, skipping dispatch",
@@ -72,31 +142,44 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event Event) {
 		return
 	}
 
-	go d.dispatchAll(ctx, payload, event)
+	select {
+	case d.jobs <- dispatchJob{ctx: ctx, event: event, payload: payload}:
+		// queued; worker will pick it up
+	default:
+		d.logger.Warn("Dispatch queue full, dropping event — consumer too slow; periodic full sync will reconcile",
+			"kind", event.Kind,
+			"name", event.Name,
+			"namespace", event.Namespace,
+			"action", event.Action,
+			"queueCapacity", cap(d.jobs),
+		)
+	}
 }
 
 // dispatchAll fans out one HTTP delivery per configured endpoint and
-// waits for all of them to finish (or for ctx to cancel them).
-func (d *Dispatcher) dispatchAll(ctx context.Context, payload []byte, event Event) {
+// waits for all of them to finish (or for ctx to cancel them). Runs on
+// a worker goroutine; per-endpoint sub-goroutines preserve concurrent
+// fan-out for events with multiple endpoints.
+func (d *Dispatcher) dispatchAll(job dispatchJob) {
 	var wg sync.WaitGroup
 	for _, ep := range d.endpoints {
 		wg.Add(1)
 		go func(ep config.EndpointConfig) {
 			defer wg.Done()
-			d.sendWithRetry(ctx, ep, payload, event)
+			d.sendWithRetry(job.ctx, ep, job.payload, job.event)
 		}(ep)
 	}
 	wg.Wait()
 	d.logger.Debug("All endpoint dispatches complete for event",
-		"kind", event.Kind,
-		"name", event.Name,
-		"action", event.Action,
+		"kind", job.event.Kind,
+		"name", job.event.Name,
+		"action", job.event.Action,
 	)
 }
 
 func (d *Dispatcher) sendWithRetry(ctx context.Context, ep config.EndpointConfig, payload []byte, event Event) {
 	url := ep.URL
-	// Default behaviour is "try once and give up" — Backstage and similar
+	// Default behavior is "try once and give up" — Backstage and similar
 	// catalog consumers reconcile missed events via their own periodic
 	// full sync, so the forwarder doesn't need delivery guarantees by
 	// default. Endpoints that have no equivalent reconciliation can opt

--- a/internal/eventforwarder/dispatcher/dispatcher.go
+++ b/internal/eventforwarder/dispatcher/dispatcher.go
@@ -1,0 +1,127 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
+)
+
+// Event represents a lightweight CRD change notification.
+type Event struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Action    string `json:"action"`
+}
+
+// Dispatcher sends webhook notifications to configured HTTP endpoints.
+type Dispatcher struct {
+	endpoints []config.EndpointConfig
+	retry     config.RetryConfig
+	client    *http.Client
+	logger    *slog.Logger
+}
+
+// New creates a new Dispatcher.
+func New(cfg config.WebhooksConfig, logger *slog.Logger) *Dispatcher {
+	return &Dispatcher{
+		endpoints: cfg.Endpoints,
+		retry:     cfg.Retry,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// Dispatch sends an event to all configured endpoints.
+func (d *Dispatcher) Dispatch(event Event) {
+	if len(d.endpoints) == 0 {
+		d.logger.Debug("No webhook endpoints configured, skipping dispatch",
+			"kind", event.Kind,
+			"name", event.Name,
+		)
+		return
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		d.logger.Error("Failed to marshal event", "error", err)
+		return
+	}
+
+	for _, ep := range d.endpoints {
+		go d.sendWithRetry(ep.URL, payload, event)
+	}
+}
+
+func (d *Dispatcher) sendWithRetry(url string, payload []byte, event Event) {
+	maxAttempts := d.retry.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err := d.send(url, payload)
+		if err == nil {
+			d.logger.Debug("Webhook dispatched successfully",
+				"url", url,
+				"kind", event.Kind,
+				"name", event.Name,
+				"action", event.Action,
+				"attempt", attempt,
+			)
+			return
+		}
+
+		d.logger.Warn("Webhook dispatch failed",
+			"url", url,
+			"kind", event.Kind,
+			"name", event.Name,
+			"attempt", attempt,
+			"maxAttempts", maxAttempts,
+			"error", err,
+		)
+
+		if attempt < maxAttempts {
+			backoff := time.Duration(d.retry.BackoffMs) * time.Millisecond * time.Duration(math.Pow(2, float64(attempt-1)))
+			time.Sleep(backoff)
+		}
+	}
+
+	d.logger.Error("Webhook dispatch failed after all retries",
+		"url", url,
+		"kind", event.Kind,
+		"name", event.Name,
+		"action", event.Action,
+	)
+}
+
+func (d *Dispatcher) send(url string, payload []byte) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+}

--- a/internal/eventforwarder/dispatcher/dispatcher_test.go
+++ b/internal/eventforwarder/dispatcher/dispatcher_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
 )
 
-// newTestDispatcher builds a Dispatcher pointed at one or more URLs.
+// newTestDispatcher builds a Dispatcher pointed at one or more URLs
+// and starts its worker pool against the test's lifetime context.
 // When maxAttempts > 1, each endpoint is configured with that retry
 // policy and a 1ms backoff so retry tests stay fast. When maxAttempts
 // is 1, no retry block is set — exercising the default "try once" path.
-func newTestDispatcher(urls []string, maxAttempts int) *Dispatcher {
+func newTestDispatcher(t *testing.T, urls []string, maxAttempts int) *Dispatcher {
+	t.Helper()
 	endpoints := make([]config.EndpointConfig, len(urls))
 	for i, u := range urls {
 		ep := config.EndpointConfig{URL: u}
@@ -36,7 +38,11 @@ func newTestDispatcher(urls []string, maxAttempts int) *Dispatcher {
 		}
 		endpoints[i] = ep
 	}
-	return New(config.WebhooksConfig{Endpoints: endpoints}, slog.Default())
+	d := New(config.WebhooksConfig{Endpoints: endpoints}, slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	d.Start(ctx)
+	return d
 }
 
 // waitForBody reads a single delivery from the channel with a generous
@@ -62,7 +68,7 @@ func TestDispatch_DeliversJSONEventOnSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	d := newTestDispatcher([]string{ts.URL}, 1)
+	d := newTestDispatcher(t, []string{ts.URL}, 1)
 	d.Dispatch(context.Background(), Event{
 		Kind:      "Project",
 		Name:      "url-shortener",
@@ -93,7 +99,7 @@ func TestDispatch_RetriesUntilSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	d := newTestDispatcher([]string{ts.URL}, 5)
+	d := newTestDispatcher(t, []string{ts.URL}, 5)
 	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	assert.Eventually(t, func() bool { return attempts.Load() == 3 },
@@ -109,7 +115,7 @@ func TestDispatch_GivesUpAfterMaxAttempts(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	d := newTestDispatcher([]string{ts.URL}, 3)
+	d := newTestDispatcher(t, []string{ts.URL}, 3)
 	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	// Wait long enough for all retries to elapse (backoff 1ms × 2^n,
@@ -144,7 +150,7 @@ func TestDispatch_FansOutToAllEndpoints(t *testing.T) {
 	}))
 	defer tsB.Close()
 
-	d := newTestDispatcher([]string{tsA.URL, tsB.URL}, 1)
+	d := newTestDispatcher(t, []string{tsA.URL, tsB.URL}, 1)
 	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	assert.Eventually(t, func() bool {
@@ -177,6 +183,7 @@ func TestDispatch_CancellationStopsRetries(t *testing.T) {
 	}, slog.Default())
 
 	ctx, cancel := context.WithCancel(context.Background())
+	d.Start(ctx)
 	d.Dispatch(ctx, Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	// Wait for the first failed attempt to land, confirming we're now in the backoff.
@@ -193,7 +200,7 @@ func TestDispatch_CancellationStopsRetries(t *testing.T) {
 }
 
 func TestDispatch_FanOutRunsEndpointsConcurrently(t *testing.T) {
-	// Both endpoints sleep 200ms. If the dispatcher serialised them, the
+	// Both endpoints sleep 200ms. If the dispatcher serialized them, the
 	// total wall-clock would be ~400ms; with concurrent fan-out it's ~200ms.
 	const handlerDelay = 200 * time.Millisecond
 	makeServer := func(hits *atomic.Int32) *httptest.Server {
@@ -209,7 +216,7 @@ func TestDispatch_FanOutRunsEndpointsConcurrently(t *testing.T) {
 	tsB := makeServer(&bHits)
 	defer tsB.Close()
 
-	d := newTestDispatcher([]string{tsA.URL, tsB.URL}, 1)
+	d := newTestDispatcher(t, []string{tsA.URL, tsB.URL}, 1)
 
 	start := time.Now()
 	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
@@ -239,10 +246,57 @@ func TestDispatch_MaxAttemptsZeroTreatedAsOne(t *testing.T) {
 			Retry: &config.RetryConfig{MaxAttempts: 0, BackoffMs: 1},
 		}},
 	}, slog.Default())
-	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	d.Dispatch(ctx, Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	assert.Eventually(t, func() bool { return attempts.Load() == 1 },
 		2*time.Second, 10*time.Millisecond)
+}
+
+func TestDispatch_DropsEventsWhenQueueFull(t *testing.T) {
+	// Hold every dispatch open until the test is ready to release them.
+	// With a tiny channel and stalled workers, the next Dispatch call
+	// should hit the `default:` branch and drop the event rather than
+	// block the producer (informer thread).
+	release := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	d := New(config.WebhooksConfig{
+		Endpoints: []config.EndpointConfig{{URL: ts.URL}},
+	}, slog.Default())
+	// Shrink the worker pool and queue to make overflow trivially
+	// reproducible. With workers=1 + queueSize=1, only the second
+	// in-flight dispatch (worker busy + queue holds 1) can be queued;
+	// the third must drop.
+	d.workers = 1
+	d.jobs = make(chan dispatchJob, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+
+	// First dispatch lands on the worker (which is now blocked in the
+	// httptest handler). Second dispatch fits in the buffered queue.
+	// Third must be dropped.
+	for i := 0; i < 3; i++ {
+		d.Dispatch(ctx, Event{
+			Kind:      "Project",
+			Name:      "p" + string(rune('0'+i)),
+			Namespace: "default",
+			Action:    "updated",
+		})
+	}
+
+	// Verify only 2 of the 3 are queued/in-flight (the third was
+	// dropped). Channel still holds the second job, worker is in
+	// httptest handler with the first.
+	assert.Equal(t, 1, len(d.jobs), "queued job count after overflow")
 }
 
 func TestDispatch_DefaultsToSingleAttemptWhenNoRetryConfigured(t *testing.T) {
@@ -259,7 +313,10 @@ func TestDispatch_DefaultsToSingleAttemptWhenNoRetryConfigured(t *testing.T) {
 	d := New(config.WebhooksConfig{
 		Endpoints: []config.EndpointConfig{{URL: ts.URL}}, // no Retry
 	}, slog.Default())
-	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	d.Dispatch(ctx, Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	// Wait long enough that any retry would have landed.
 	assert.Eventually(t, func() bool { return attempts.Load() == 1 },

--- a/internal/eventforwarder/dispatcher/dispatcher_test.go
+++ b/internal/eventforwarder/dispatcher/dispatcher_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dispatcher
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
+)
+
+// newTestDispatcher builds a Dispatcher pointed at one or more URLs with
+// fast retry settings so tests don't sleep on backoff.
+func newTestDispatcher(urls []string, maxAttempts int) *Dispatcher {
+	endpoints := make([]config.EndpointConfig, len(urls))
+	for i, u := range urls {
+		endpoints[i] = config.EndpointConfig{URL: u}
+	}
+	return New(config.WebhooksConfig{
+		Endpoints: endpoints,
+		Retry: config.RetryConfig{
+			MaxAttempts: maxAttempts,
+			BackoffMs:   1, // 1ms backoff keeps retry tests fast
+		},
+	}, slog.Default())
+}
+
+// waitForBody reads a single delivery from the channel with a generous
+// timeout, failing the test if nothing arrives.
+func waitForBody(t *testing.T, ch <-chan []byte) []byte {
+	t.Helper()
+	select {
+	case body := <-ch:
+		return body
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook delivery")
+		return nil
+	}
+}
+
+func TestDispatch_DeliversJSONEventOnSuccess(t *testing.T) {
+	received := make(chan []byte, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		received <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	d := newTestDispatcher([]string{ts.URL}, 1)
+	d.Dispatch(Event{
+		Kind:      "Project",
+		Name:      "url-shortener",
+		Namespace: "default",
+		Action:    "updated",
+	})
+
+	body := waitForBody(t, received)
+
+	var got Event
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, "Project", got.Kind)
+	assert.Equal(t, "url-shortener", got.Name)
+	assert.Equal(t, "default", got.Namespace)
+	assert.Equal(t, "updated", got.Action)
+}
+
+func TestDispatch_RetriesUntilSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Fail twice, succeed on the third attempt.
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	d := newTestDispatcher([]string{ts.URL}, 5)
+	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+
+	assert.Eventually(t, func() bool { return attempts.Load() == 3 },
+		2*time.Second, 10*time.Millisecond,
+		"expected exactly 3 attempts (2 failures + 1 success)")
+}
+
+func TestDispatch_GivesUpAfterMaxAttempts(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	d := newTestDispatcher([]string{ts.URL}, 3)
+	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+
+	// Wait long enough for all retries to elapse (backoff 1ms × 2^n,
+	// negligible for this test).
+	assert.Eventually(t, func() bool { return attempts.Load() == 3 },
+		2*time.Second, 10*time.Millisecond,
+		"expected exactly MaxAttempts attempts after persistent failure")
+
+	// Give the goroutine a moment to settle, then assert no further
+	// attempts happen.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(3), attempts.Load(), "no further attempts after MaxAttempts")
+}
+
+func TestDispatch_NoEndpointsIsNoOp(t *testing.T) {
+	d := New(config.WebhooksConfig{
+		Endpoints: nil,
+		Retry:     config.RetryConfig{MaxAttempts: 3, BackoffMs: 1},
+	}, slog.Default())
+
+	// Should return without panicking and without any side effects.
+	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+}
+
+func TestDispatch_FansOutToAllEndpoints(t *testing.T) {
+	var aHits, bHits atomic.Int32
+	tsA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		aHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer tsA.Close()
+	tsB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		bHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer tsB.Close()
+
+	d := newTestDispatcher([]string{tsA.URL, tsB.URL}, 1)
+	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+
+	assert.Eventually(t, func() bool {
+		return aHits.Load() == 1 && bHits.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected exactly one delivery to each configured endpoint")
+}
+
+func TestDispatch_MaxAttemptsZeroTreatedAsOne(t *testing.T) {
+	// Defensive: misconfigured retry.maxAttempts of 0 must still produce
+	// at least one attempt (the production code clamps to 1).
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	d := newTestDispatcher([]string{ts.URL}, 0)
+	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+
+	assert.Eventually(t, func() bool { return attempts.Load() == 1 },
+		2*time.Second, 10*time.Millisecond)
+}

--- a/internal/eventforwarder/dispatcher/dispatcher_test.go
+++ b/internal/eventforwarder/dispatcher/dispatcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dispatcher

--- a/internal/eventforwarder/dispatcher/dispatcher_test.go
+++ b/internal/eventforwarder/dispatcher/dispatcher_test.go
@@ -4,6 +4,7 @@
 package dispatcher
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -19,20 +20,23 @@ import (
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
 )
 
-// newTestDispatcher builds a Dispatcher pointed at one or more URLs with
-// fast retry settings so tests don't sleep on backoff.
+// newTestDispatcher builds a Dispatcher pointed at one or more URLs.
+// When maxAttempts > 1, each endpoint is configured with that retry
+// policy and a 1ms backoff so retry tests stay fast. When maxAttempts
+// is 1, no retry block is set — exercising the default "try once" path.
 func newTestDispatcher(urls []string, maxAttempts int) *Dispatcher {
 	endpoints := make([]config.EndpointConfig, len(urls))
 	for i, u := range urls {
-		endpoints[i] = config.EndpointConfig{URL: u}
+		ep := config.EndpointConfig{URL: u}
+		if maxAttempts > 1 {
+			ep.Retry = &config.RetryConfig{
+				MaxAttempts: maxAttempts,
+				BackoffMs:   1,
+			}
+		}
+		endpoints[i] = ep
 	}
-	return New(config.WebhooksConfig{
-		Endpoints: endpoints,
-		Retry: config.RetryConfig{
-			MaxAttempts: maxAttempts,
-			BackoffMs:   1, // 1ms backoff keeps retry tests fast
-		},
-	}, slog.Default())
+	return New(config.WebhooksConfig{Endpoints: endpoints}, slog.Default())
 }
 
 // waitForBody reads a single delivery from the channel with a generous
@@ -59,7 +63,7 @@ func TestDispatch_DeliversJSONEventOnSuccess(t *testing.T) {
 	defer ts.Close()
 
 	d := newTestDispatcher([]string{ts.URL}, 1)
-	d.Dispatch(Event{
+	d.Dispatch(context.Background(), Event{
 		Kind:      "Project",
 		Name:      "url-shortener",
 		Namespace: "default",
@@ -90,7 +94,7 @@ func TestDispatch_RetriesUntilSuccess(t *testing.T) {
 	defer ts.Close()
 
 	d := newTestDispatcher([]string{ts.URL}, 5)
-	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	assert.Eventually(t, func() bool { return attempts.Load() == 3 },
 		2*time.Second, 10*time.Millisecond,
@@ -106,7 +110,7 @@ func TestDispatch_GivesUpAfterMaxAttempts(t *testing.T) {
 	defer ts.Close()
 
 	d := newTestDispatcher([]string{ts.URL}, 3)
-	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	// Wait long enough for all retries to elapse (backoff 1ms × 2^n,
 	// negligible for this test).
@@ -121,13 +125,10 @@ func TestDispatch_GivesUpAfterMaxAttempts(t *testing.T) {
 }
 
 func TestDispatch_NoEndpointsIsNoOp(t *testing.T) {
-	d := New(config.WebhooksConfig{
-		Endpoints: nil,
-		Retry:     config.RetryConfig{MaxAttempts: 3, BackoffMs: 1},
-	}, slog.Default())
+	d := New(config.WebhooksConfig{Endpoints: nil}, slog.Default())
 
 	// Should return without panicking and without any side effects.
-	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 }
 
 func TestDispatch_FansOutToAllEndpoints(t *testing.T) {
@@ -144,12 +145,82 @@ func TestDispatch_FansOutToAllEndpoints(t *testing.T) {
 	defer tsB.Close()
 
 	d := newTestDispatcher([]string{tsA.URL, tsB.URL}, 1)
-	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	assert.Eventually(t, func() bool {
 		return aHits.Load() == 1 && bHits.Load() == 1
 	}, 2*time.Second, 10*time.Millisecond,
 		"expected exactly one delivery to each configured endpoint")
+}
+
+func TestDispatch_CancellationStopsRetries(t *testing.T) {
+	// Server that always 500s, forcing the dispatcher into the retry loop.
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	// Long backoff (500ms) and many attempts so the retry loop will be
+	// sleeping when we cancel. If cancellation is wired correctly, the
+	// goroutine should exit immediately rather than waiting out the full
+	// backoff.
+	d := New(config.WebhooksConfig{
+		Endpoints: []config.EndpointConfig{{
+			URL: ts.URL,
+			Retry: &config.RetryConfig{
+				MaxAttempts: 10,
+				BackoffMs:   500,
+			},
+		}},
+	}, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d.Dispatch(ctx, Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+
+	// Wait for the first failed attempt to land, confirming we're now in the backoff.
+	assert.Eventually(t, func() bool { return attempts.Load() >= 1 },
+		2*time.Second, 10*time.Millisecond, "expected at least one attempt before cancel")
+
+	// Cancel and confirm no further attempts arrive — proves the backoff
+	// timer is observing ctx.Done() rather than waiting out time.Sleep.
+	before := attempts.Load()
+	cancel()
+	time.Sleep(200 * time.Millisecond)
+	assert.LessOrEqual(t, attempts.Load(), before+1,
+		"no meaningful retry should occur after cancel")
+}
+
+func TestDispatch_FanOutRunsEndpointsConcurrently(t *testing.T) {
+	// Both endpoints sleep 200ms. If the dispatcher serialised them, the
+	// total wall-clock would be ~400ms; with concurrent fan-out it's ~200ms.
+	const handlerDelay = 200 * time.Millisecond
+	makeServer := func(hits *atomic.Int32) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(handlerDelay)
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+	var aHits, bHits atomic.Int32
+	tsA := makeServer(&aHits)
+	defer tsA.Close()
+	tsB := makeServer(&bHits)
+	defer tsB.Close()
+
+	d := newTestDispatcher([]string{tsA.URL, tsB.URL}, 1)
+
+	start := time.Now()
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	assert.Eventually(t, func() bool { return aHits.Load() == 1 && bHits.Load() == 1 },
+		2*time.Second, 10*time.Millisecond)
+	elapsed := time.Since(start)
+
+	// Allow generous slack for scheduling jitter, but well short of
+	// 2×handlerDelay (which would mean serial execution).
+	assert.Less(t, elapsed, 2*handlerDelay-50*time.Millisecond,
+		"endpoints should be dispatched concurrently, not serially (took %s)", elapsed)
 }
 
 func TestDispatch_MaxAttemptsZeroTreatedAsOne(t *testing.T) {
@@ -162,9 +233,40 @@ func TestDispatch_MaxAttemptsZeroTreatedAsOne(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	d := newTestDispatcher([]string{ts.URL}, 0)
-	d.Dispatch(Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+	d := New(config.WebhooksConfig{
+		Endpoints: []config.EndpointConfig{{
+			URL:   ts.URL,
+			Retry: &config.RetryConfig{MaxAttempts: 0, BackoffMs: 1},
+		}},
+	}, slog.Default())
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
 
 	assert.Eventually(t, func() bool { return attempts.Load() == 1 },
 		2*time.Second, 10*time.Millisecond)
+}
+
+func TestDispatch_DefaultsToSingleAttemptWhenNoRetryConfigured(t *testing.T) {
+	// Endpoint with no `retry` block must try exactly once and not retry
+	// on failure — the periodic full sync on the consumer side is the
+	// reconciliation mechanism by default.
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	d := New(config.WebhooksConfig{
+		Endpoints: []config.EndpointConfig{{URL: ts.URL}}, // no Retry
+	}, slog.Default())
+	d.Dispatch(context.Background(), Event{Kind: "Project", Name: "foo", Namespace: "default", Action: "updated"})
+
+	// Wait long enough that any retry would have landed.
+	assert.Eventually(t, func() bool { return attempts.Load() == 1 },
+		1*time.Second, 10*time.Millisecond,
+		"expected exactly one attempt with no retry config")
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(1), attempts.Load(),
+		"no retries should be attempted when retry config is absent")
 }

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -5,6 +5,7 @@ package eventforwarder
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"reflect"
 	"sync"
@@ -39,6 +40,11 @@ var namespaceGVR = schema.GroupVersionResource{
 // debounceWindow is the duration to wait before dispatching an event
 // for the same resource, to avoid flooding on rapid successive updates.
 const debounceWindow = 1 * time.Second
+
+// debounceCleanupInterval is how often we sweep stale entries out of the
+// debounce map. Without this, a long-lived process that sees many distinct
+// resources over time would accumulate keys forever.
+const debounceCleanupInterval = 5 * time.Minute
 
 // Forwarder watches OpenChoreo CRDs and forwards change-notification
 // webhooks to configured subscribers (typically the Backstage events
@@ -131,7 +137,7 @@ func (f *Forwarder) Start(ctx context.Context) error {
 			},
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("adding event handler for %s: %w", gvrCopy.Resource, err)
 		}
 
 		f.logger.Info("Watching CRD", "resource", gvr.Resource, "group", gvr.Group)
@@ -165,20 +171,52 @@ func (f *Forwarder) Start(ctx context.Context) error {
 		},
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("adding event handler for %s: %w", namespaceGVR.Resource, err)
 	}
 	f.logger.Info("Watching Namespaces", "labelSelector", ocControlPlaneLabelSelector)
 
 	crdFactory.Start(ctx.Done())
 	nsFactory.Start(ctx.Done())
-	crdFactory.WaitForCacheSync(ctx.Done())
-	nsFactory.WaitForCacheSync(ctx.Done())
+	for gvr, ok := range crdFactory.WaitForCacheSync(ctx.Done()) {
+		if !ok {
+			return fmt.Errorf("informer cache failed to sync for %s", gvr.Resource)
+		}
+	}
+	for gvr, ok := range nsFactory.WaitForCacheSync(ctx.Done()) {
+		if !ok {
+			return fmt.Errorf("informer cache failed to sync for %s", gvr.Resource)
+		}
+	}
 
 	f.logger.Info("All informers synced, event-forwarder is ready")
+
+	go f.cleanupDebounceLoop(ctx)
 
 	// Block until context is cancelled
 	<-ctx.Done()
 	return nil
+}
+
+// cleanupDebounceLoop periodically evicts entries from the debounce map
+// whose last-event time is older than the debounce window — they can no
+// longer suppress anything, so keeping them around just leaks memory.
+func (f *Forwarder) cleanupDebounceLoop(ctx context.Context) {
+	ticker := time.NewTicker(debounceCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			f.mu.Lock()
+			for key, last := range f.lastEvent {
+				if now.Sub(last) > debounceWindow {
+					delete(f.lastEvent, key)
+				}
+			}
+			f.mu.Unlock()
+		}
+	}
 }
 
 func (f *Forwarder) handleEvent(obj interface{}, action string, gvr schema.GroupVersionResource) {

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -247,19 +247,21 @@ func (f *Forwarder) handleEvent(obj interface{}, action string, gvr schema.Group
 	namespace := u.GetNamespace()
 	kind := u.GetKind()
 
-	// Debounce same-resource bursts to avoid flooding subscribers with
-	// rapid successive updates (e.g. a controller patching labels then
-	// annotations on the same CR within the reconcile loop).
+	// Debounce only "updated" events. Updates are the chatty case — a
+	// controller patching labels then annotations on the same CR within
+	// a single reconcile produces a burst of meaningful changes, and
+	// collapsing them into one dispatch saves the consumer redundant
+	// re-fetches without losing useful information (the consumer
+	// re-fetches on each event and gets the latest committed state
+	// anyway).
 	//
-	// Deletes are explicitly NOT debounced: a delete is terminal and
-	// non-fungible, so missing it leaves the consumer with an orphan
-	// entity until the next periodic full sync. The common bug this
-	// guards against is "create-then-delete-immediately" of a fresh
-	// resource, where the deletionTimestamp UPDATE is dispatched, the
-	// finalizer cleanup completes within 1s (because there's nothing
-	// to clean), and the trailing DELETE then collides with the
-	// debounce window and gets dropped.
-	if action != "deleted" {
+	// "created" and "deleted" events are non-fungible — you can't merge
+	// a create with a later create, and dropping a delete leaves the
+	// consumer with an orphan entity until the next periodic full sync.
+	// The common bug this guards against is "create-then-delete-
+	// immediately" of a fresh resource, where the trailing DELETE
+	// arrives within 1s of an earlier UPDATE for the same key.
+	if action == "updated" {
 		key := gvr.Resource + "/" + namespace + "/" + name
 		now := time.Now()
 		f.mu.Lock()

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package eventforwarder
@@ -28,9 +28,9 @@ import (
 const ocControlPlaneLabelSelector = "openchoreo.dev/control-plane=true"
 
 // namespaceGVR identifies the cluster-scoped Kubernetes Namespace
-// resource. Watched separately from the OC CRDs because (a) it lives in
-// the core API group and (b) we apply a label selector to scope to OC
-// Organizations only.
+// resource. Watched separately from the OC custom resources because
+// (a) it lives in the core API group and (b) we apply a label selector
+// to scope to OC Organizations only.
 var namespaceGVR = schema.GroupVersionResource{
 	Group:    "",
 	Version:  "v1",
@@ -46,13 +46,13 @@ const debounceWindow = 1 * time.Second
 // resources over time would accumulate keys forever.
 const debounceCleanupInterval = 5 * time.Minute
 
-// Forwarder watches OpenChoreo CRDs and forwards change-notification
-// webhooks to configured subscribers (typically the Backstage events
-// plugin). It uses Kubernetes informers internally — the K8s "watch"
-// terminology refers to the informer mechanism, while this component
-// itself is named "event-forwarder" to describe its outward role:
-// turning K8s events into HTTP webhooks that drive downstream catalog
-// updates.
+// Forwarder watches OpenChoreo Kubernetes resources and forwards
+// change-notification webhooks to configured subscribers (typically the
+// Backstage events plugin). It uses Kubernetes informers internally —
+// the K8s "watch" terminology refers to the informer mechanism, while
+// this component itself is named "event-forwarder" to describe its
+// outward role: turning K8s events into HTTP webhooks that drive
+// downstream catalog updates.
 type Forwarder struct {
 	client     dynamic.Interface
 	dispatcher *dispatcher.Dispatcher
@@ -117,13 +117,20 @@ func gvrList() []schema.GroupVersionResource {
 	return gvrs
 }
 
-// Start begins watching all OpenChoreo CRDs (and OC-labeled core
-// Namespaces) and blocks until the context is cancelled.
-func (f *Forwarder) Start(ctx context.Context) error {
+// Start begins watching all OpenChoreo resources (and OC-labeled core
+// Namespaces) and blocks until the context is canceled.
+//
+// `onReady`, if non-nil, is invoked exactly once after every informer
+// cache has finished its initial list — the moment the forwarder will
+// start delivering events. Callers use this to flip readiness probes
+// to "ready" so a rolling-update doesn't route traffic to this pod
+// before it can actually consume events.
+func (f *Forwarder) Start(ctx context.Context, onReady func()) error {
 	f.dispatchCtx = ctx
 
-	// CRD informers — unfiltered. Each OC CRD has its own informer so
-	// we receive events for every Project, Component, Workload, etc.
+	// Resource informers — unfiltered. Each watched OC resource has its
+	// own informer so we receive events for every Project, Component,
+	// Workload, etc.
 	crdFactory := dynamicinformer.NewDynamicSharedInformerFactory(f.client, 0)
 
 	for _, gvr := range gvrList() {
@@ -148,7 +155,7 @@ func (f *Forwarder) Start(ctx context.Context) error {
 			return fmt.Errorf("adding event handler for %s: %w", gvrCopy.Resource, err)
 		}
 
-		f.logger.Info("Watching CRD", "resource", gvr.Resource, "group", gvr.Group)
+		f.logger.Info("Watching resource", "resource", gvr.Resource, "group", gvr.Group)
 	}
 
 	// Namespace informer — filtered to OC-managed namespaces only via a
@@ -197,10 +204,13 @@ func (f *Forwarder) Start(ctx context.Context) error {
 	}
 
 	f.logger.Info("All informers synced, event-forwarder is ready")
+	if onReady != nil {
+		onReady()
+	}
 
 	go f.cleanupDebounceLoop(ctx)
 
-	// Block until context is cancelled
+	// Block until context is canceled
 	<-ctx.Done()
 	return nil
 }
@@ -273,7 +283,7 @@ func (f *Forwarder) handleEvent(obj interface{}, action string, gvr schema.Group
 		f.mu.Unlock()
 	}
 
-	f.logger.Info("CRD event detected",
+	f.logger.Debug("Resource event detected",
 		"action", action,
 		"kind", kind,
 		"name", name,
@@ -321,8 +331,11 @@ func isStatusOnlyChange(oldObj, newObj interface{}) bool {
 		return false
 	}
 	// Treat finalizer / deletion timestamp changes as meaningful — the
-	// catalog cares about the resource being on the way out.
-	if oldU.GetDeletionTimestamp() != newU.GetDeletionTimestamp() {
+	// catalog cares about the resource being on the way out. Use
+	// metav1.Time.Equal which handles nil + time-value comparison
+	// correctly; the raw `!=` would compare *metav1.Time pointers and
+	// see every reconciler write of the resource as a "change."
+	if !oldU.GetDeletionTimestamp().Equal(newU.GetDeletionTimestamp()) {
 		return false
 	}
 	if !reflect.DeepEqual(oldU.GetFinalizers(), newU.GetFinalizers()) {

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -58,6 +58,12 @@ type Forwarder struct {
 	dispatcher *dispatcher.Dispatcher
 	logger     *slog.Logger
 
+	// dispatchCtx is captured from Start() and passed to Dispatch so that
+	// in-flight HTTP retries and backoffs abort cleanly on shutdown.
+	// Informer event-handler callbacks don't carry their own context, so
+	// we hang on to the one from Start.
+	dispatchCtx context.Context
+
 	// debounce tracks the last dispatch time per resource key
 	mu        sync.Mutex
 	lastEvent map[string]time.Time
@@ -114,6 +120,8 @@ func gvrList() []schema.GroupVersionResource {
 // Start begins watching all OpenChoreo CRDs (and OC-labeled core
 // Namespaces) and blocks until the context is cancelled.
 func (f *Forwarder) Start(ctx context.Context) error {
+	f.dispatchCtx = ctx
+
 	// CRD informers — unfiltered. Each OC CRD has its own informer so
 	// we receive events for every Project, Component, Workload, etc.
 	crdFactory := dynamicinformer.NewDynamicSharedInformerFactory(f.client, 0)
@@ -239,16 +247,29 @@ func (f *Forwarder) handleEvent(obj interface{}, action string, gvr schema.Group
 	namespace := u.GetNamespace()
 	kind := u.GetKind()
 
-	// Debounce: skip if we dispatched for this resource within the window
-	key := gvr.Resource + "/" + namespace + "/" + name
-	now := time.Now()
-	f.mu.Lock()
-	if last, exists := f.lastEvent[key]; exists && now.Sub(last) < debounceWindow {
+	// Debounce same-resource bursts to avoid flooding subscribers with
+	// rapid successive updates (e.g. a controller patching labels then
+	// annotations on the same CR within the reconcile loop).
+	//
+	// Deletes are explicitly NOT debounced: a delete is terminal and
+	// non-fungible, so missing it leaves the consumer with an orphan
+	// entity until the next periodic full sync. The common bug this
+	// guards against is "create-then-delete-immediately" of a fresh
+	// resource, where the deletionTimestamp UPDATE is dispatched, the
+	// finalizer cleanup completes within 1s (because there's nothing
+	// to clean), and the trailing DELETE then collides with the
+	// debounce window and gets dropped.
+	if action != "deleted" {
+		key := gvr.Resource + "/" + namespace + "/" + name
+		now := time.Now()
+		f.mu.Lock()
+		if last, exists := f.lastEvent[key]; exists && now.Sub(last) < debounceWindow {
+			f.mu.Unlock()
+			return
+		}
+		f.lastEvent[key] = now
 		f.mu.Unlock()
-		return
 	}
-	f.lastEvent[key] = now
-	f.mu.Unlock()
 
 	f.logger.Info("CRD event detected",
 		"action", action,
@@ -257,7 +278,14 @@ func (f *Forwarder) handleEvent(obj interface{}, action string, gvr schema.Group
 		"namespace", namespace,
 	)
 
-	f.dispatcher.Dispatch(dispatcher.Event{
+	ctx := f.dispatchCtx
+	if ctx == nil {
+		// Defensive: if handleEvent fires before Start() captures the
+		// context (shouldn't happen — informers are only started inside
+		// Start), fall back to Background so we don't panic.
+		ctx = context.Background()
+	}
+	f.dispatcher.Dispatch(ctx, dispatcher.Event{
 		Kind:      kind,
 		Name:      name,
 		Namespace: namespace,

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -105,7 +105,7 @@ func gvrList() []schema.GroupVersionResource {
 	return gvrs
 }
 
-// Start begins watching all OpenChoreo CRDs (and OC-labelled core
+// Start begins watching all OpenChoreo CRDs (and OC-labeled core
 // Namespaces) and blocks until the context is cancelled.
 func (f *Forwarder) Start(ctx context.Context) error {
 	// CRD informers — unfiltered. Each OC CRD has its own informer so

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -1,0 +1,265 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package eventforwarder
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/dispatcher"
+)
+
+// ocControlPlaneLabelSelector matches namespaces marked as OpenChoreo
+// Organizations (control-plane namespaces). The OC API server itself
+// uses the same label to distinguish OC-managed namespaces from system
+// namespaces (kube-system, etc.) and unrelated namespaces.
+const ocControlPlaneLabelSelector = "openchoreo.dev/control-plane=true"
+
+// namespaceGVR identifies the cluster-scoped Kubernetes Namespace
+// resource. Watched separately from the OC CRDs because (a) it lives in
+// the core API group and (b) we apply a label selector to scope to OC
+// Organizations only.
+var namespaceGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "namespaces",
+}
+
+// debounceWindow is the duration to wait before dispatching an event
+// for the same resource, to avoid flooding on rapid successive updates.
+const debounceWindow = 1 * time.Second
+
+// Forwarder watches OpenChoreo CRDs and forwards change-notification
+// webhooks to configured subscribers (typically the Backstage events
+// plugin). It uses Kubernetes informers internally — the K8s "watch"
+// terminology refers to the informer mechanism, while this component
+// itself is named "event-forwarder" to describe its outward role:
+// turning K8s events into HTTP webhooks that drive downstream catalog
+// updates.
+type Forwarder struct {
+	client     dynamic.Interface
+	dispatcher *dispatcher.Dispatcher
+	logger     *slog.Logger
+
+	// debounce tracks the last dispatch time per resource key
+	mu        sync.Mutex
+	lastEvent map[string]time.Time
+}
+
+// New creates a new Forwarder.
+func New(client dynamic.Interface, d *dispatcher.Dispatcher, logger *slog.Logger) *Forwarder {
+	return &Forwarder{
+		client:     client,
+		dispatcher: d,
+		logger:     logger,
+		lastEvent:  make(map[string]time.Time),
+	}
+}
+
+// gvrList returns the GroupVersionResources to watch.
+func gvrList() []schema.GroupVersionResource {
+	group := "openchoreo.dev"
+	version := "v1alpha1"
+
+	resources := []string{
+		// Namespaced
+		"projects",
+		"components",
+		"workloads",
+		"environments",
+		"dataplanes",
+		"deploymentpipelines",
+		"componenttypes",
+		"traits",
+		"workflows",
+		"workflowplanes",
+		"observabilityplanes",
+		// Cluster-scoped
+		"clustercomponenttypes",
+		"clustertraits",
+		"clusterworkflows",
+		"clusterdataplanes",
+		"clusterobservabilityplanes",
+		"clusterworkflowplanes",
+	}
+
+	gvrs := make([]schema.GroupVersionResource, 0, len(resources))
+	for _, r := range resources {
+		gvrs = append(gvrs, schema.GroupVersionResource{
+			Group:    group,
+			Version:  version,
+			Resource: r,
+		})
+	}
+	return gvrs
+}
+
+// Start begins watching all OpenChoreo CRDs (and OC-labelled core
+// Namespaces) and blocks until the context is cancelled.
+func (f *Forwarder) Start(ctx context.Context) error {
+	// CRD informers — unfiltered. Each OC CRD has its own informer so
+	// we receive events for every Project, Component, Workload, etc.
+	crdFactory := dynamicinformer.NewDynamicSharedInformerFactory(f.client, 0)
+
+	for _, gvr := range gvrList() {
+		informer := crdFactory.ForResource(gvr).Informer()
+
+		gvrCopy := gvr // capture for closures
+		_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				f.handleEvent(obj, "created", gvrCopy)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				if isStatusOnlyChange(oldObj, newObj) {
+					return
+				}
+				f.handleEvent(newObj, "updated", gvrCopy)
+			},
+			DeleteFunc: func(obj interface{}) {
+				f.handleEvent(obj, "deleted", gvrCopy)
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		f.logger.Info("Watching CRD", "resource", gvr.Resource, "group", gvr.Group)
+	}
+
+	// Namespace informer — filtered to OC-managed namespaces only via a
+	// label selector. The Kubernetes API server applies the selector
+	// server-side, so the informer's cache holds only OC Organization
+	// namespaces and we never receive events for kube-system,
+	// cert-manager, dp-* data-plane namespaces, or any other ambient
+	// cluster activity.
+	nsFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
+		f.client, 0, metav1.NamespaceAll,
+		func(opts *metav1.ListOptions) {
+			opts.LabelSelector = ocControlPlaneLabelSelector
+		},
+	)
+	nsInformer := nsFactory.ForResource(namespaceGVR).Informer()
+	_, err := nsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			f.handleEvent(obj, "created", namespaceGVR)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if isStatusOnlyChange(oldObj, newObj) {
+				return
+			}
+			f.handleEvent(newObj, "updated", namespaceGVR)
+		},
+		DeleteFunc: func(obj interface{}) {
+			f.handleEvent(obj, "deleted", namespaceGVR)
+		},
+	})
+	if err != nil {
+		return err
+	}
+	f.logger.Info("Watching Namespaces", "labelSelector", ocControlPlaneLabelSelector)
+
+	crdFactory.Start(ctx.Done())
+	nsFactory.Start(ctx.Done())
+	crdFactory.WaitForCacheSync(ctx.Done())
+	nsFactory.WaitForCacheSync(ctx.Done())
+
+	f.logger.Info("All informers synced, event-forwarder is ready")
+
+	// Block until context is cancelled
+	<-ctx.Done()
+	return nil
+}
+
+func (f *Forwarder) handleEvent(obj interface{}, action string, gvr schema.GroupVersionResource) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		// Handle DeletedFinalStateUnknown
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			f.logger.Warn("Unexpected object type in event handler")
+			return
+		}
+		u, ok = tombstone.Obj.(*unstructured.Unstructured)
+		if !ok {
+			f.logger.Warn("Unexpected object type in tombstone")
+			return
+		}
+	}
+
+	name := u.GetName()
+	namespace := u.GetNamespace()
+	kind := u.GetKind()
+
+	// Debounce: skip if we dispatched for this resource within the window
+	key := gvr.Resource + "/" + namespace + "/" + name
+	now := time.Now()
+	f.mu.Lock()
+	if last, exists := f.lastEvent[key]; exists && now.Sub(last) < debounceWindow {
+		f.mu.Unlock()
+		return
+	}
+	f.lastEvent[key] = now
+	f.mu.Unlock()
+
+	f.logger.Info("CRD event detected",
+		"action", action,
+		"kind", kind,
+		"name", name,
+		"namespace", namespace,
+	)
+
+	f.dispatcher.Dispatch(dispatcher.Event{
+		Kind:      kind,
+		Name:      name,
+		Namespace: namespace,
+		Action:    action,
+	})
+}
+
+// isStatusOnlyChange returns true when the only differences between the old
+// and new objects are inside `status` (and metadata fields the catalog
+// doesn't care about, like resourceVersion / generation timestamps). When
+// spec, labels, and annotations are all unchanged, the catalog has no
+// reason to refresh — typical sources are controller reconcile loops
+// updating status conditions and agent-heartbeat timestamps.
+func isStatusOnlyChange(oldObj, newObj interface{}) bool {
+	oldU, ok1 := oldObj.(*unstructured.Unstructured)
+	newU, ok2 := newObj.(*unstructured.Unstructured)
+	if !ok1 || !ok2 {
+		// If we can't compare, fall through and dispatch — safer than silently dropping.
+		return false
+	}
+
+	oldSpec, _, _ := unstructured.NestedFieldCopy(oldU.UnstructuredContent(), "spec")
+	newSpec, _, _ := unstructured.NestedFieldCopy(newU.UnstructuredContent(), "spec")
+	if !reflect.DeepEqual(oldSpec, newSpec) {
+		return false
+	}
+	if !reflect.DeepEqual(oldU.GetLabels(), newU.GetLabels()) {
+		return false
+	}
+	if !reflect.DeepEqual(oldU.GetAnnotations(), newU.GetAnnotations()) {
+		return false
+	}
+	// Treat finalizer / deletion timestamp changes as meaningful — the
+	// catalog cares about the resource being on the way out.
+	if oldU.GetDeletionTimestamp() != newU.GetDeletionTimestamp() {
+		return false
+	}
+	if !reflect.DeepEqual(oldU.GetFinalizers(), newU.GetFinalizers()) {
+		return false
+	}
+
+	return true
+}

--- a/internal/eventforwarder/forwarder_test.go
+++ b/internal/eventforwarder/forwarder_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,15 +32,16 @@ var projectGVR = schema.GroupVersionResource{
 }
 
 // newProject constructs a minimal *unstructured.Unstructured shaped like an
-// OpenChoreo Project. Callers can override sub-trees via the optional
-// `mutate` callback to test specific diff scenarios.
-func newProject(name, namespace string, mutate ...func(map[string]interface{})) *unstructured.Unstructured {
+// OpenChoreo Project under the "default" namespace. Callers can override
+// sub-trees via the optional `mutate` callback to test specific diff
+// scenarios.
+func newProject(name string, mutate ...func(map[string]interface{})) *unstructured.Unstructured {
 	obj := map[string]interface{}{
 		"apiVersion": "openchoreo.dev/v1alpha1",
 		"kind":       "Project",
 		"metadata": map[string]interface{}{
 			"name":      name,
-			"namespace": namespace,
+			"namespace": "default",
 			"labels": map[string]interface{}{
 				"openchoreo.dev/managed": "true",
 			},
@@ -82,14 +82,14 @@ func TestIsStatusOnlyChange(t *testing.T) {
 	}{
 		{
 			name: "identical objects → status-only (no change at all)",
-			old:  newProject("p", "default"),
-			new:  newProject("p", "default"),
+			old:  newProject("p"),
+			new:  newProject("p"),
 			want: true,
 		},
 		{
 			name: "only status differs → status-only",
-			old:  newProject("p", "default"),
-			new: newProject("p", "default", func(o map[string]interface{}) {
+			old:  newProject("p"),
+			new: newProject("p", func(o map[string]interface{}) {
 				// Replace status conditions
 				o["status"] = map[string]interface{}{
 					"conditions": []interface{}{
@@ -104,8 +104,8 @@ func TestIsStatusOnlyChange(t *testing.T) {
 		},
 		{
 			name: "spec differs → not status-only",
-			old:  newProject("p", "default"),
-			new: newProject("p", "default", func(o map[string]interface{}) {
+			old:  newProject("p"),
+			new: newProject("p", func(o map[string]interface{}) {
 				spec := o["spec"].(map[string]interface{})
 				spec["deploymentPipelineRef"] = map[string]interface{}{
 					"name": "promote-fast",
@@ -115,8 +115,8 @@ func TestIsStatusOnlyChange(t *testing.T) {
 		},
 		{
 			name: "labels differ → not status-only",
-			old:  newProject("p", "default"),
-			new: newProject("p", "default", func(o map[string]interface{}) {
+			old:  newProject("p"),
+			new: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
 				meta["labels"] = map[string]interface{}{
 					"openchoreo.dev/managed": "true",
@@ -127,8 +127,8 @@ func TestIsStatusOnlyChange(t *testing.T) {
 		},
 		{
 			name: "annotations differ → not status-only",
-			old:  newProject("p", "default"),
-			new: newProject("p", "default", func(o map[string]interface{}) {
+			old:  newProject("p"),
+			new: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
 				meta["annotations"] = map[string]interface{}{
 					"openchoreo.dev/display-name": "Updated Display Name",
@@ -138,8 +138,8 @@ func TestIsStatusOnlyChange(t *testing.T) {
 		},
 		{
 			name: "deletionTimestamp added → not status-only",
-			old:  newProject("p", "default"),
-			new: newProject("p", "default", func(o map[string]interface{}) {
+			old:  newProject("p"),
+			new: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
 				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
 			}),
@@ -147,8 +147,8 @@ func TestIsStatusOnlyChange(t *testing.T) {
 		},
 		{
 			name: "finalizers changed → not status-only",
-			old:  newProject("p", "default"),
-			new: newProject("p", "default", func(o map[string]interface{}) {
+			old:  newProject("p"),
+			new: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
 				meta["finalizers"] = []interface{}{"openchoreo.dev/cleanup"}
 			}),
@@ -156,11 +156,11 @@ func TestIsStatusOnlyChange(t *testing.T) {
 		},
 		{
 			name: "old missing labels but new has them → not status-only",
-			old: newProject("p", "default", func(o map[string]interface{}) {
+			old: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
 				delete(meta, "labels")
 			}),
-			new:  newProject("p", "default"),
+			new:  newProject("p"),
 			want: false,
 		},
 		{
@@ -245,7 +245,7 @@ func TestHandleEvent_DispatchesObservedFields(t *testing.T) {
 	f, cs, cleanup := newForwarderWithCapture(t)
 	defer cleanup()
 
-	obj := newProject("url-shortener", "default")
+	obj := newProject("url-shortener")
 	f.handleEvent(obj, "updated", projectGVR)
 
 	got := waitForEvent(t, cs)
@@ -259,7 +259,7 @@ func TestHandleEvent_DebounceCollapsesRapidDuplicates(t *testing.T) {
 	f, cs, cleanup := newForwarderWithCapture(t)
 	defer cleanup()
 
-	obj := newProject("p1", "default")
+	obj := newProject("p1")
 
 	// Two calls within the debounce window should produce exactly one
 	// dispatch.
@@ -287,8 +287,8 @@ func TestHandleEvent_DebounceIsPerKey(t *testing.T) {
 
 	// Two different projects in the same window should both dispatch —
 	// the debounce key includes name/namespace.
-	f.handleEvent(newProject("p1", "default"), "updated", projectGVR)
-	f.handleEvent(newProject("p2", "default"), "updated", projectGVR)
+	f.handleEvent(newProject("p1"), "updated", projectGVR)
+	f.handleEvent(newProject("p2"), "updated", projectGVR)
 
 	got1 := waitForEvent(t, cs)
 	got2 := waitForEvent(t, cs)
@@ -302,7 +302,7 @@ func TestHandleEvent_DebounceExpiresAfterWindow(t *testing.T) {
 	f, cs, cleanup := newForwarderWithCapture(t)
 	defer cleanup()
 
-	obj := newProject("p1", "default")
+	obj := newProject("p1")
 
 	// First call — dispatches normally.
 	f.handleEvent(obj, "updated", projectGVR)
@@ -331,7 +331,7 @@ func TestHandleEvent_TombstoneIsUnwrapped(t *testing.T) {
 	// unwrap and dispatch the inner object's identity.
 	tombstone := cache.DeletedFinalStateUnknown{
 		Key: "default/p-deleted",
-		Obj: newProject("p-deleted", "default"),
+		Obj: newProject("p-deleted"),
 	}
 	f.handleEvent(tombstone, "deleted", projectGVR)
 
@@ -382,7 +382,7 @@ func TestHandleEvent_ClusterScopedHasEmptyNamespace(t *testing.T) {
 }
 
 // =====================================================================
-// gvrList — basic sanity check (no behavioural test; the list is static)
+// gvrList — basic sanity check (no behavioral test; the list is static)
 // =====================================================================
 
 func TestGVRList_AllOpenChoreoGroup(t *testing.T) {

--- a/internal/eventforwarder/forwarder_test.go
+++ b/internal/eventforwarder/forwarder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package eventforwarder
@@ -145,6 +145,25 @@ func TestIsStatusOnlyChange(t *testing.T) {
 				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
 			}),
 			want: false,
+		},
+		{
+			// Locks in the metav1.Time.Equal fix: two objects with the
+			// same deletionTimestamp value will produce *different*
+			// metav1.Time pointers when GetDeletionTimestamp() is
+			// called. The earlier pointer-equality check would have
+			// reported these as "not status-only" on every reconciler
+			// write of a deleting resource. The value-equality check
+			// correctly recognizes them as the same moment in time.
+			name: "same deletionTimestamp value but distinct pointers → status-only",
+			old: newProject("p", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
+			}),
+			new: newProject("p", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
+			}),
+			want: true,
 		},
 		{
 			name: "finalizers changed → not status-only",

--- a/internal/eventforwarder/forwarder_test.go
+++ b/internal/eventforwarder/forwarder_test.go
@@ -220,7 +220,6 @@ func newForwarderWithCapture(t *testing.T) (*Forwarder, *captureServer, func()) 
 	cs := newCaptureServer(t)
 	d := dispatcher.New(config.WebhooksConfig{
 		Endpoints: []config.EndpointConfig{{URL: cs.URL}},
-		Retry:     config.RetryConfig{MaxAttempts: 1, BackoffMs: 1},
 	}, slog.Default())
 	f := &Forwarder{
 		dispatcher: d,
@@ -296,6 +295,32 @@ func TestHandleEvent_DebounceIsPerKey(t *testing.T) {
 	names := []string{got1.Name, got2.Name}
 	assert.ElementsMatch(t, []string{"p1", "p2"}, names,
 		"both events should be dispatched because the debounce key differs")
+}
+
+func TestHandleEvent_DeletedActionBypassesDebounce(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	obj := newProject("p1")
+
+	// Sequence emulates "create-then-delete-immediately" of a fresh
+	// resource: the deletionTimestamp UPDATE lands first, finalizer
+	// cleanup completes within the debounce window, and the trailing
+	// DELETE arrives while the window is still active. The delete must
+	// bypass the debounce — losing it would leave an orphan entity in
+	// the consumer's catalog until the next periodic full sync.
+	f.handleEvent(obj, "updated", projectGVR)
+	first := waitForEvent(t, cs)
+	assert.Equal(t, "updated", first.Action)
+
+	// Same key, well within the 1s debounce window. Update would be
+	// suppressed; delete must still go through.
+	f.handleEvent(obj, "deleted", projectGVR)
+	second := waitForEvent(t, cs)
+	assert.Equal(t, "p1", second.Name)
+	assert.Equal(t, "deleted", second.Action)
+	assert.Equal(t, int32(2), cs.hits.Load(),
+		"both update and following delete must be dispatched")
 }
 
 func TestHandleEvent_DebounceExpiresAfterWindow(t *testing.T) {

--- a/internal/eventforwarder/forwarder_test.go
+++ b/internal/eventforwarder/forwarder_test.go
@@ -4,6 +4,7 @@
 package eventforwarder
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -221,12 +222,18 @@ func newForwarderWithCapture(t *testing.T) (*Forwarder, *captureServer, func()) 
 	d := dispatcher.New(config.WebhooksConfig{
 		Endpoints: []config.EndpointConfig{{URL: cs.URL}},
 	}, slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+	d.Start(ctx)
 	f := &Forwarder{
-		dispatcher: d,
-		logger:     slog.Default(),
-		lastEvent:  make(map[string]time.Time),
+		dispatcher:  d,
+		logger:      slog.Default(),
+		lastEvent:   make(map[string]time.Time),
+		dispatchCtx: ctx,
 	}
-	return f, cs, cs.Close
+	return f, cs, func() {
+		cancel()
+		cs.Close()
+	}
 }
 
 func waitForEvent(t *testing.T, cs *captureServer) dispatcher.Event {
@@ -295,6 +302,29 @@ func TestHandleEvent_DebounceIsPerKey(t *testing.T) {
 	names := []string{got1.Name, got2.Name}
 	assert.ElementsMatch(t, []string{"p1", "p2"}, names,
 		"both events should be dispatched because the debounce key differs")
+}
+
+func TestHandleEvent_CreatedActionBypassesDebounce(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	// Create-then-recreate of the same name (e.g. user deletes a CR
+	// then immediately recreates it before the cleanup goroutine
+	// evicts the debounce key, or two name collisions across a
+	// namespace boundary): the second `created` must NOT be dropped.
+	// Creates are non-fungible — collapsing them risks dropping a
+	// fresh resource entirely.
+	f.handleEvent(newProject("p1"), "created", projectGVR)
+	first := waitForEvent(t, cs)
+	assert.Equal(t, "created", first.Action)
+
+	// Same key, well within the 1s debounce window. Bypass for
+	// `created` must keep this dispatch alive.
+	f.handleEvent(newProject("p1"), "created", projectGVR)
+	second := waitForEvent(t, cs)
+	assert.Equal(t, "created", second.Action)
+	assert.Equal(t, int32(2), cs.hits.Load(),
+		"both creates must be dispatched even within the debounce window")
 }
 
 func TestHandleEvent_DeletedActionBypassesDebounce(t *testing.T) {

--- a/internal/eventforwarder/forwarder_test.go
+++ b/internal/eventforwarder/forwarder_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/openchoreo/openchoreo/internal/eventforwarder/dispatcher"
 )
 
+// testDeletionTimestamp is a fixed RFC3339 timestamp shared by every
+// test that injects a deletionTimestamp into the fixture; the exact
+// value isn't significant beyond being a valid timestamp.
+const testDeletionTimestamp = "2026-01-01T00:00:00Z"
+
 // projectGVR is the canonical GVR used in handler tests.
 var projectGVR = schema.GroupVersionResource{
 	Group:    "openchoreo.dev",
@@ -142,7 +147,7 @@ func TestIsStatusOnlyChange(t *testing.T) {
 			old:  newProject("p"),
 			new: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
-				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
+				meta["deletionTimestamp"] = testDeletionTimestamp
 			}),
 			want: false,
 		},
@@ -157,11 +162,11 @@ func TestIsStatusOnlyChange(t *testing.T) {
 			name: "same deletionTimestamp value but distinct pointers → status-only",
 			old: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
-				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
+				meta["deletionTimestamp"] = testDeletionTimestamp
 			}),
 			new: newProject("p", func(o map[string]interface{}) {
 				meta := o["metadata"].(map[string]interface{})
-				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
+				meta["deletionTimestamp"] = testDeletionTimestamp
 			}),
 			want: true,
 		},

--- a/internal/eventforwarder/forwarder_test.go
+++ b/internal/eventforwarder/forwarder_test.go
@@ -1,0 +1,395 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package eventforwarder
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/config"
+	"github.com/openchoreo/openchoreo/internal/eventforwarder/dispatcher"
+)
+
+// projectGVR is the canonical GVR used in handler tests.
+var projectGVR = schema.GroupVersionResource{
+	Group:    "openchoreo.dev",
+	Version:  "v1alpha1",
+	Resource: "projects",
+}
+
+// newProject constructs a minimal *unstructured.Unstructured shaped like an
+// OpenChoreo Project. Callers can override sub-trees via the optional
+// `mutate` callback to test specific diff scenarios.
+func newProject(name, namespace string, mutate ...func(map[string]interface{})) *unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "openchoreo.dev/v1alpha1",
+		"kind":       "Project",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"labels": map[string]interface{}{
+				"openchoreo.dev/managed": "true",
+			},
+			"annotations": map[string]interface{}{
+				"openchoreo.dev/display-name": name,
+			},
+		},
+		"spec": map[string]interface{}{
+			"deploymentPipelineRef": map[string]interface{}{
+				"name": "default",
+			},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	}
+	for _, f := range mutate {
+		f(obj)
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// =====================================================================
+// isStatusOnlyChange
+// =====================================================================
+
+func TestIsStatusOnlyChange(t *testing.T) {
+	tests := []struct {
+		name string
+		old  interface{}
+		new  interface{}
+		want bool
+	}{
+		{
+			name: "identical objects → status-only (no change at all)",
+			old:  newProject("p", "default"),
+			new:  newProject("p", "default"),
+			want: true,
+		},
+		{
+			name: "only status differs → status-only",
+			old:  newProject("p", "default"),
+			new: newProject("p", "default", func(o map[string]interface{}) {
+				// Replace status conditions
+				o["status"] = map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Ready",
+							"status": "False",
+						},
+					},
+				}
+			}),
+			want: true,
+		},
+		{
+			name: "spec differs → not status-only",
+			old:  newProject("p", "default"),
+			new: newProject("p", "default", func(o map[string]interface{}) {
+				spec := o["spec"].(map[string]interface{})
+				spec["deploymentPipelineRef"] = map[string]interface{}{
+					"name": "promote-fast",
+				}
+			}),
+			want: false,
+		},
+		{
+			name: "labels differ → not status-only",
+			old:  newProject("p", "default"),
+			new: newProject("p", "default", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				meta["labels"] = map[string]interface{}{
+					"openchoreo.dev/managed": "true",
+					"team":                   "platform",
+				}
+			}),
+			want: false,
+		},
+		{
+			name: "annotations differ → not status-only",
+			old:  newProject("p", "default"),
+			new: newProject("p", "default", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				meta["annotations"] = map[string]interface{}{
+					"openchoreo.dev/display-name": "Updated Display Name",
+				}
+			}),
+			want: false,
+		},
+		{
+			name: "deletionTimestamp added → not status-only",
+			old:  newProject("p", "default"),
+			new: newProject("p", "default", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				meta["deletionTimestamp"] = "2026-01-01T00:00:00Z"
+			}),
+			want: false,
+		},
+		{
+			name: "finalizers changed → not status-only",
+			old:  newProject("p", "default"),
+			new: newProject("p", "default", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				meta["finalizers"] = []interface{}{"openchoreo.dev/cleanup"}
+			}),
+			want: false,
+		},
+		{
+			name: "old missing labels but new has them → not status-only",
+			old: newProject("p", "default", func(o map[string]interface{}) {
+				meta := o["metadata"].(map[string]interface{})
+				delete(meta, "labels")
+			}),
+			new:  newProject("p", "default"),
+			want: false,
+		},
+		{
+			name: "non-unstructured input → fail-open (returns false)",
+			old:  "not an unstructured object",
+			new:  "still not one",
+			want: false,
+		},
+		{
+			name: "nil inputs → fail-open (returns false)",
+			old:  nil,
+			new:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isStatusOnlyChange(tt.old, tt.new)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// =====================================================================
+// Forwarder.handleEvent
+// =====================================================================
+
+// captureServer is an httptest.Server that records every webhook payload
+// it receives onto a channel.
+type captureServer struct {
+	*httptest.Server
+	delivered chan dispatcher.Event
+	hits      *atomic.Int32
+}
+
+func newCaptureServer(t *testing.T) *captureServer {
+	t.Helper()
+	delivered := make(chan dispatcher.Event, 16)
+	hits := &atomic.Int32{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var ev dispatcher.Event
+		_ = json.Unmarshal(body, &ev)
+		delivered <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	return &captureServer{Server: ts, delivered: delivered, hits: hits}
+}
+
+// newForwarderWithCapture wires a Forwarder to a real Dispatcher pointed
+// at an httptest.Server. Returns the forwarder, the capture server, and a
+// cleanup func.
+func newForwarderWithCapture(t *testing.T) (*Forwarder, *captureServer, func()) {
+	t.Helper()
+	cs := newCaptureServer(t)
+	d := dispatcher.New(config.WebhooksConfig{
+		Endpoints: []config.EndpointConfig{{URL: cs.URL}},
+		Retry:     config.RetryConfig{MaxAttempts: 1, BackoffMs: 1},
+	}, slog.Default())
+	f := &Forwarder{
+		dispatcher: d,
+		logger:     slog.Default(),
+		lastEvent:  make(map[string]time.Time),
+	}
+	return f, cs, cs.Close
+}
+
+func waitForEvent(t *testing.T, cs *captureServer) dispatcher.Event {
+	t.Helper()
+	select {
+	case ev := <-cs.delivered:
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook delivery")
+		return dispatcher.Event{}
+	}
+}
+
+func TestHandleEvent_DispatchesObservedFields(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	obj := newProject("url-shortener", "default")
+	f.handleEvent(obj, "updated", projectGVR)
+
+	got := waitForEvent(t, cs)
+	assert.Equal(t, "Project", got.Kind, "kind should come from object metadata, not GVR")
+	assert.Equal(t, "url-shortener", got.Name)
+	assert.Equal(t, "default", got.Namespace)
+	assert.Equal(t, "updated", got.Action)
+}
+
+func TestHandleEvent_DebounceCollapsesRapidDuplicates(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	obj := newProject("p1", "default")
+
+	// Two calls within the debounce window should produce exactly one
+	// dispatch.
+	f.handleEvent(obj, "updated", projectGVR)
+	f.handleEvent(obj, "updated", projectGVR)
+
+	// First call should land.
+	first := waitForEvent(t, cs)
+	assert.Equal(t, "p1", first.Name)
+
+	// Wait briefly to confirm no second delivery arrives.
+	select {
+	case extra := <-cs.delivered:
+		t.Fatalf("expected debounce to suppress second dispatch; got %+v", extra)
+	case <-time.After(150 * time.Millisecond):
+		// good — no second event arrived
+	}
+
+	assert.Equal(t, int32(1), cs.hits.Load(), "exactly one HTTP delivery")
+}
+
+func TestHandleEvent_DebounceIsPerKey(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	// Two different projects in the same window should both dispatch —
+	// the debounce key includes name/namespace.
+	f.handleEvent(newProject("p1", "default"), "updated", projectGVR)
+	f.handleEvent(newProject("p2", "default"), "updated", projectGVR)
+
+	got1 := waitForEvent(t, cs)
+	got2 := waitForEvent(t, cs)
+
+	names := []string{got1.Name, got2.Name}
+	assert.ElementsMatch(t, []string{"p1", "p2"}, names,
+		"both events should be dispatched because the debounce key differs")
+}
+
+func TestHandleEvent_DebounceExpiresAfterWindow(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	obj := newProject("p1", "default")
+
+	// First call — dispatches normally.
+	f.handleEvent(obj, "updated", projectGVR)
+	first := waitForEvent(t, cs)
+	assert.Equal(t, "p1", first.Name)
+
+	// Force the lastEvent timestamp to be older than the window so the
+	// next call is no longer debounced. Avoids real-time sleeps.
+	key := projectGVR.Resource + "/default/p1"
+	f.mu.Lock()
+	f.lastEvent[key] = time.Now().Add(-2 * debounceWindow)
+	f.mu.Unlock()
+
+	// Second call — should dispatch because the window has passed.
+	f.handleEvent(obj, "updated", projectGVR)
+	second := waitForEvent(t, cs)
+	assert.Equal(t, "p1", second.Name)
+}
+
+func TestHandleEvent_TombstoneIsUnwrapped(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	// On informer relist after a long disconnect, deletes can arrive
+	// wrapped in cache.DeletedFinalStateUnknown. The handler must
+	// unwrap and dispatch the inner object's identity.
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "default/p-deleted",
+		Obj: newProject("p-deleted", "default"),
+	}
+	f.handleEvent(tombstone, "deleted", projectGVR)
+
+	got := waitForEvent(t, cs)
+	assert.Equal(t, "Project", got.Kind)
+	assert.Equal(t, "p-deleted", got.Name)
+	assert.Equal(t, "default", got.Namespace)
+	assert.Equal(t, "deleted", got.Action)
+}
+
+func TestHandleEvent_UnknownObjectTypeIsSilentlyIgnored(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	// Pass something neither *unstructured.Unstructured nor a tombstone.
+	// The handler must log and return without dispatching.
+	f.handleEvent("a string", "updated", projectGVR)
+
+	select {
+	case ev := <-cs.delivered:
+		t.Fatalf("expected no dispatch; got %+v", ev)
+	case <-time.After(150 * time.Millisecond):
+		// good — handler dropped the bad input without crashing
+	}
+	assert.Equal(t, int32(0), cs.hits.Load())
+}
+
+func TestHandleEvent_ClusterScopedHasEmptyNamespace(t *testing.T) {
+	f, cs, cleanup := newForwarderWithCapture(t)
+	defer cleanup()
+
+	cct := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "openchoreo.dev/v1alpha1",
+		"kind":       "ClusterComponentType",
+		"metadata": map[string]interface{}{
+			"name":              "service",
+			"creationTimestamp": metav1.Now().Format(time.RFC3339),
+		},
+	}}
+	f.handleEvent(cct, "created", schema.GroupVersionResource{
+		Group: "openchoreo.dev", Version: "v1alpha1", Resource: "clustercomponenttypes",
+	})
+
+	got := waitForEvent(t, cs)
+	assert.Equal(t, "ClusterComponentType", got.Kind)
+	assert.Equal(t, "service", got.Name)
+	assert.Equal(t, "", got.Namespace, "cluster-scoped resources have empty namespace")
+}
+
+// =====================================================================
+// gvrList — basic sanity check (no behavioural test; the list is static)
+// =====================================================================
+
+func TestGVRList_AllOpenChoreoGroup(t *testing.T) {
+	for _, gvr := range gvrList() {
+		assert.Equal(t, "openchoreo.dev", gvr.Group, "every CRD watched should be in the openchoreo.dev API group")
+		assert.Equal(t, "v1alpha1", gvr.Version)
+		assert.NotEmpty(t, gvr.Resource)
+	}
+	require.NotEmpty(t, gvrList(), "watched-resource list must not be empty")
+}

--- a/internal/eventforwarder/server.go
+++ b/internal/eventforwarder/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package eventforwarder

--- a/internal/eventforwarder/server.go
+++ b/internal/eventforwarder/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync/atomic"
+	"time"
 )
 
 // HealthServer provides /health and /ready endpoints.
@@ -41,22 +42,36 @@ func (s *HealthServer) Handler() http.Handler {
 func (s *HealthServer) ListenAndServe(port int) error {
 	addr := fmt.Sprintf(":%d", port)
 	s.logger.Info("Starting health server", "address", addr)
-	return http.ListenAndServe(addr, s.Handler())
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	return srv.ListenAndServe()
 }
 
 func (s *HealthServer) healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+		s.logger.Warn("Failed to encode health response", "error", err)
+	}
 }
 
 func (s *HealthServer) readyHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	var payload map[string]string
 	if s.ready.Load() {
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+		payload = map[string]string{"status": "ready"}
 	} else {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
+		payload = map[string]string{"status": "not ready"}
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		s.logger.Warn("Failed to encode readiness response", "error", err)
 	}
 }

--- a/internal/eventforwarder/server.go
+++ b/internal/eventforwarder/server.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package eventforwarder
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+)
+
+// HealthServer provides /health and /ready endpoints.
+type HealthServer struct {
+	logger *slog.Logger
+	ready  atomic.Bool
+}
+
+// NewHealthServer creates a new HealthServer.
+func NewHealthServer(logger *slog.Logger) *HealthServer {
+	return &HealthServer{
+		logger: logger,
+	}
+}
+
+// SetReady marks the server as ready to receive traffic.
+func (s *HealthServer) SetReady() {
+	s.ready.Store(true)
+}
+
+// Handler returns an http.Handler with /health and /ready routes.
+func (s *HealthServer) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", s.healthHandler)
+	mux.HandleFunc("GET /ready", s.readyHandler)
+	return mux
+}
+
+// ListenAndServe starts the health server on the given port.
+func (s *HealthServer) ListenAndServe(port int) error {
+	addr := fmt.Sprintf(":%d", port)
+	s.logger.Info("Starting health server", "address", addr)
+	return http.ListenAndServe(addr, s.Handler())
+}
+
+func (s *HealthServer) healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *HealthServer) readyHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.ready.Load() {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
+	}
+}

--- a/internal/eventforwarder/server_test.go
+++ b/internal/eventforwarder/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The OpenChoreo Authors
+// Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package eventforwarder

--- a/internal/eventforwarder/server_test.go
+++ b/internal/eventforwarder/server_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package eventforwarder
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestHealthServer builds a HealthServer wired to an httptest server and
+// returns both the HealthServer (so the test can flip readiness) and a base
+// URL for sending requests.
+func newTestHealthServer(t *testing.T) (*HealthServer, string, func()) {
+	t.Helper()
+	hs := NewHealthServer(slog.Default())
+	ts := httptest.NewServer(hs.Handler())
+	return hs, ts.URL, ts.Close
+}
+
+func TestHealthServer_HealthAlwaysOK(t *testing.T) {
+	_, url, cleanup := newTestHealthServer(t)
+	defer cleanup()
+
+	res, err := http.Get(url + "/health")
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+
+	body, _ := io.ReadAll(res.Body)
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(body, &payload))
+	assert.Equal(t, "ok", payload["status"])
+}
+
+func TestHealthServer_ReadyReflectsState(t *testing.T) {
+	hs, url, cleanup := newTestHealthServer(t)
+	defer cleanup()
+
+	// Before SetReady: 503 with "not ready" body
+	res, err := http.Get(url + "/ready")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(body, &payload))
+	assert.Equal(t, "not ready", payload["status"])
+
+	// After SetReady: 200 with "ready" body
+	hs.SetReady()
+	res, err = http.Get(url + "/ready")
+	require.NoError(t, err)
+	body, _ = io.ReadAll(res.Body)
+	res.Body.Close()
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	require.NoError(t, json.Unmarshal(body, &payload))
+	assert.Equal(t, "ready", payload["status"])
+}
+
+func TestHealthServer_NonGetMethodsRejected(t *testing.T) {
+	_, url, cleanup := newTestHealthServer(t)
+	defer cleanup()
+
+	// http.NewServeMux + "GET /health" pattern returns 405 for non-GET.
+	res, err := http.Post(url+"/health", "application/json", nil)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+}

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -31,6 +31,7 @@ DOCKER_BUILD_IMAGES := \
 	init-observability-opensearch:$(PROJECT_DIR)/install/init/observability/opensearch/Dockerfile:$(PROJECT_DIR) \
 	openchoreo-api:$(PROJECT_DIR)/cmd/openchoreo-api/Dockerfile:$(PROJECT_DIR) \
 	observer:$(PROJECT_DIR)/cmd/observer/Dockerfile:$(PROJECT_DIR) \
+	event-forwarder:$(PROJECT_DIR)/cmd/event-forwarder/Dockerfile:$(PROJECT_DIR) \
 	ai-rca-agent:$(PROJECT_DIR)/rca-agent/Dockerfile:$(PROJECT_DIR)/rca-agent \
 	openchoreo-cli:$(PROJECT_DIR)/cmd/occ/Dockerfile:$(PROJECT_DIR) \
 	cluster-gateway:$(PROJECT_DIR)/cmd/cluster-gateway/Dockerfile:$(PROJECT_DIR) \
@@ -75,6 +76,7 @@ docker.build.controller: go.build-multiarch.manager
 docker.build.quick-start: go.build-multiarch.occ
 docker.build.openchoreo-api: go.build-multiarch.openchoreo-api
 docker.build.observer: go.build-multiarch.observer
+docker.build.event-forwarder: go.build-multiarch.event-forwarder
 docker.build.ai-rca-agent:  # Python project - no Go build dependency
 docker.build.cluster-gateway: go.build-multiarch.cluster-gateway
 docker.build.cluster-agent: go.build-multiarch.cluster-agent

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -16,6 +16,7 @@ GO_BUILD_BINARIES := \
 	occ:$(PROJECT_DIR)/cmd/occ/main.go \
 	openchoreo-api:$(PROJECT_DIR)/cmd/openchoreo-api/main.go \
 	observer:$(PROJECT_DIR)/cmd/observer/main.go \
+	event-forwarder:$(PROJECT_DIR)/cmd/event-forwarder/main.go \
 	cluster-gateway:$(PROJECT_DIR)/cmd/cluster-gateway \
 	cluster-agent:$(PROJECT_DIR)/cmd/cluster-agent
 


### PR DESCRIPTION
## Purpose

OpenChoreo currently has no way for external systems to react to CRD changes in near-real-time — consumers (catalogs, dashboards, audit tools, integrations) must poll the REST API and re-fetch everything on each tick. 
                                                                                                                                                                                                                                                     
This PR introduces a generic event-forwarder component in the OpenChoreo control plane that watches OpenChoreo CRDs and pushes lightweight change notifications to configurable HTTP webhook endpoints, enabling any downstream consumer to subscribe to OC state changes .     

## Approach

A new standalone component, `event-forwarder`, runs in the OpenChoreo control plane. It watches OpenChoreo CRDs via Kubernetes informers and pushes lightweight change notifications ({kind, name, namespace, action}) to one or more configurable  HTTP webhook endpoints.

 Key design choices:                                                                                                                                                                                                                                
   
  - **Standalone component**, not bolted into the controller manager — independent lifecycle, can be disabled via Helm values.                                                                                                                           
  - **Lightweight notifications only** — consumers re-fetch canonical state from the REST API, keeping the forwarder stateless and consumer-agnostic.                                                                                                  
  - Server-side label selector on the Namespace informer (openchoreo.dev/control-plane=true) so kube-system, cert-manager, and data-plane namespaces never enter the cache.
  - Per-resource 1s debounce + status-only diff filter to drop reconcile-loop chatter (heartbeat status writes, controller-only changes).                                                                                                            
  - Retry with exponential backoff for webhook delivery; webhook URLs validated at startup so misconfiguration fails fast.

New configurations added

```
eventForwarder:                                                                                                                                                                                                                                  
    enabled: true                                                                                                                                                                                                                                    
    config:                                                                                                                                                                                                                                        
      webhooks:
        endpoints:                                                                                                                                                                                                                                   
          - url: http://backstage:7007/api/events/http/openchoreo
        retry:                                                                                                                                                                                                                                       
          maxAttempts: 3                                                                                                                                                                                                                           
          backoffMs: 1000                 
                                                                                                                                                                                                                                                     
  backstage:                                                                                                                                                                                                                                         
    catalogSync:                                                                                                                                                                                                                                     
      frequency: 300   # full-sync safety net interval
```
## Related Issues

https://github.com/openchoreo/openchoreo/issues/3289

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
