### PR TITLE
feat: add toolset and authz query params for tool filtering

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -5,6 +5,8 @@ package mcp
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -12,25 +14,45 @@ import (
 	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
 )
 
+// HTTP query parameter names recognized by the MCP HTTP handler. Both are
+// optional and read once per session-creation request.
+const (
+	// QueryParamToolsets narrows the toolsets visible via tools/list to a
+	// comma-separated subset (e.g. ?toolsets=namespace,component,pe). Unknown
+	// or disabled toolset names are silently ignored. When the param is
+	// absent or empty, all registered toolsets are returned.
+	QueryParamToolsets = "toolsets"
+	// QueryParamFilterByAuthz controls whether MCP-layer authz filtering is
+	// applied to tools/list and tools/call (e.g. ?filterByAuthz=false).
+	// Defaults to true. The service layer enforces authz independently
+	// regardless of this flag.
+	QueryParamFilterByAuthz = "filterByAuthz"
+)
+
 // NewHTTPServer creates an MCP HTTP handler backed by a single shared server.
+//
+// All configured toolsets are registered up front. Per-session narrowing
+// happens via query parameters parsed from the initialize request:
+//   - ?toolsets=ns1,ns2     — only show tools from those toolsets in tools/list
+//   - ?filterByAuthz=false  — disable MCP-layer authz filtering for the session
 //
 // When pdp is non-nil the server installs a receiving middleware that filters
 // tools/list results and guards tools/call invocations based on the
-// authenticated user's permissions derived from their JWT token.
-// When pdp is nil (authz disabled) all registered tools are visible and
-// callable — the service layer still enforces authz independently.
+// authenticated user's permissions derived from their JWT token. When pdp is
+// nil (authz disabled) all registered tools are visible and callable — the
+// service layer still enforces authz independently. The toolset filter is
+// always applied when the client requests it, regardless of pdp.
 func NewHTTPServer(toolsets *tools.Toolsets, pdp authzcore.PDP) http.Handler {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "openchoreo-api",
 		Version: "1.0.0",
 	}, nil)
-	perms := toolsets.Register(server)
-	if pdp != nil {
-		server.AddReceivingMiddleware(tools.NewToolFilterMiddleware(pdp, perms))
-	}
-	return mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+	perms, toolToToolsets := toolsets.Register(server)
+	server.AddReceivingMiddleware(tools.NewToolFilterMiddleware(pdp, perms, toolToToolsets))
+	streamable := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
 	}, nil)
+	return withSessionQueryParams(streamable)
 }
 
 // NewSTDIO creates an MCP server for STDIO transport (local CLI usage).
@@ -44,4 +66,52 @@ func NewSTDIO(toolsets *tools.Toolsets) *mcp.Server {
 	}, nil)
 	toolsets.Register(server)
 	return server
+}
+
+// withSessionQueryParams returns an http.Handler that extracts the optional
+// MCP session-scoping query parameters (toolsets, filterByAuthz) from the
+// request URL and stores them on the request context. The MCP SDK propagates
+// the initialize request's context into the long-lived session, so the values
+// set here become the per-session scope used by the tool-filter middleware.
+//
+// Subsequent requests in a stateful session do not re-read these params — the
+// session is bound to the values supplied at session creation. In stateless
+// mode the params are honored on every request because each request creates a
+// fresh session.
+func withSessionQueryParams(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		ctx := r.Context()
+
+		if raw := q.Get(QueryParamToolsets); raw != "" {
+			if requested := parseRequestedToolsets(raw); len(requested) > 0 {
+				ctx = tools.WithRequestedToolsets(ctx, requested)
+			}
+		}
+
+		if raw := q.Get(QueryParamFilterByAuthz); raw != "" {
+			if v, err := strconv.ParseBool(raw); err == nil {
+				ctx = tools.WithFilterByAuthz(ctx, v)
+			}
+		}
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// parseRequestedToolsets parses a comma-separated list of toolset names into a
+// set. Empty entries (from `,,` or trailing commas) are skipped. Unknown
+// toolset names are kept in the set as-is — the filter middleware silently
+// ignores them when none of the registered tools belong to that toolset, so an
+// unknown name simply matches nothing.
+func parseRequestedToolsets(raw string) map[tools.ToolsetType]bool {
+	out := map[tools.ToolsetType]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		out[tools.ToolsetType(name)] = true
+	}
+	return out
 }

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,162 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+// captureHandler is a tiny http.Handler that records the request context it
+// observed, so tests can assert that withSessionQueryParams populated it
+// correctly.
+type captureHandler struct {
+	requestedToolsets map[tools.ToolsetType]bool
+	hasRequested      bool
+	filterByAuthz     bool
+	hasFilter         bool
+}
+
+func (h *captureHandler) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	h.requestedToolsets, h.hasRequested = tools.RequestedToolsetsFromContext(r.Context())
+	h.filterByAuthz, h.hasFilter = tools.FilterByAuthzFromContext(r.Context())
+}
+
+func TestWithSessionQueryParamsParsesToolsets(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want map[tools.ToolsetType]bool
+	}{
+		{
+			name: "single toolset",
+			url:  "/mcp?toolsets=namespace",
+			want: map[tools.ToolsetType]bool{tools.ToolsetNamespace: true},
+		},
+		{
+			name: "multiple toolsets from issue example",
+			url:  "/mcp?toolsets=namespace,component,pe",
+			want: map[tools.ToolsetType]bool{
+				tools.ToolsetNamespace: true,
+				tools.ToolsetComponent: true,
+				tools.ToolsetPE:        true,
+			},
+		},
+		{
+			name: "whitespace and empty entries ignored",
+			url:  "/mcp?toolsets=namespace,%20,component,",
+			want: map[tools.ToolsetType]bool{
+				tools.ToolsetNamespace: true,
+				tools.ToolsetComponent: true,
+			},
+		},
+		{
+			name: "unknown toolset preserved (silently matches no tools downstream)",
+			url:  "/mcp?toolsets=foo",
+			want: map[tools.ToolsetType]bool{tools.ToolsetType("foo"): true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cap := &captureHandler{}
+			h := withSessionQueryParams(cap)
+
+			req := httptest.NewRequest(http.MethodPost, tt.url, http.NoBody)
+			h.ServeHTTP(httptest.NewRecorder(), req)
+
+			if !cap.hasRequested {
+				t.Fatalf("expected requested toolsets to be set on context")
+			}
+			if !reflect.DeepEqual(cap.requestedToolsets, tt.want) {
+				t.Errorf("requested toolsets = %v, want %v", cap.requestedToolsets, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithSessionQueryParamsAbsentToolsets(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "no query string", url: "/mcp"},
+		{name: "param present but empty", url: "/mcp?toolsets="},
+		{name: "param all whitespace and commas", url: "/mcp?toolsets=,,,%20,"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cap := &captureHandler{}
+			h := withSessionQueryParams(cap)
+			req := httptest.NewRequest(http.MethodPost, tt.url, http.NoBody)
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			if cap.hasRequested {
+				t.Errorf("expected no narrowing, got %v", cap.requestedToolsets)
+			}
+		})
+	}
+}
+
+func TestWithSessionQueryParamsParsesFilterByAuthz(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantSet   bool
+		wantValue bool
+	}{
+		{name: "false", url: "/mcp?filterByAuthz=false", wantSet: true, wantValue: false},
+		{name: "true", url: "/mcp?filterByAuthz=true", wantSet: true, wantValue: true},
+		{name: "0", url: "/mcp?filterByAuthz=0", wantSet: true, wantValue: false},
+		{name: "1", url: "/mcp?filterByAuthz=1", wantSet: true, wantValue: true},
+		{name: "absent", url: "/mcp", wantSet: false},
+		{name: "empty", url: "/mcp?filterByAuthz=", wantSet: false},
+		{name: "invalid value treated as absent", url: "/mcp?filterByAuthz=maybe", wantSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cap := &captureHandler{}
+			h := withSessionQueryParams(cap)
+			req := httptest.NewRequest(http.MethodPost, tt.url, http.NoBody)
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			if cap.hasFilter != tt.wantSet {
+				t.Fatalf("hasFilter = %v, want %v", cap.hasFilter, tt.wantSet)
+			}
+			if tt.wantSet && cap.filterByAuthz != tt.wantValue {
+				t.Errorf("filterByAuthz = %v, want %v", cap.filterByAuthz, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestWithSessionQueryParamsCombined(t *testing.T) {
+	cap := &captureHandler{}
+	h := withSessionQueryParams(cap)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/mcp?toolsets=namespace,component,pe&filterByAuthz=false",
+		http.NoBody,
+	)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !cap.hasRequested {
+		t.Error("expected requested toolsets to be set")
+	}
+	if !cap.hasFilter || cap.filterByAuthz {
+		t.Errorf("expected filterByAuthz=false, got hasFilter=%v value=%v", cap.hasFilter, cap.filterByAuthz)
+	}
+	want := map[tools.ToolsetType]bool{
+		tools.ToolsetNamespace: true,
+		tools.ToolsetComponent: true,
+		tools.ToolsetPE:        true,
+	}
+	if !reflect.DeepEqual(cap.requestedToolsets, want) {
+		t.Errorf("requested toolsets = %v, want %v", cap.requestedToolsets, want)
+	}
+}

--- a/pkg/mcp/tools/filter.go
+++ b/pkg/mcp/tools/filter.go
@@ -21,26 +21,36 @@ const (
 	methodListTools = "tools/list"
 )
 
-// NewToolFilterMiddleware returns an MCP receiving middleware that filters tools/list
-// results and rejects tools/call requests based on the authenticated user's permissions.
+// NewToolFilterMiddleware returns an MCP receiving middleware that filters
+// tools/list and tools/call results along two independent axes:
 //
-// Design: this is a UX improvement layer, not the security boundary. The actual
-// security boundary is enforced by the service layer (NewServiceWithAuthz wrappers).
-// If pdp is nil, all tools are returned unfiltered (graceful degradation / authz disabled).
+//  1. Toolset narrowing — when the client requested a specific subset of
+//     toolsets via ?toolsets= on the initialize request, tools/list returns
+//     only tools whose registered toolsets intersect the requested set. This
+//     filter is purely a tools/list visibility helper; tools/call is not
+//     gated by it (clients that bypass tools/list can still call any
+//     registered tool).
 //
-// The perms map is produced by ToolPermissions(). It maps tool name to ToolPermission,
-// which carries the required authz action for that tool.
-func NewToolFilterMiddleware(pdp authzcore.PDP, perms map[string]ToolPermission) mcp.Middleware {
+//  2. Authz filtering — when filterByAuthz is true (the default) and a PDP
+//     is configured, tools/list hides tools the user lacks permission for and
+//     tools/call rejects unauthorized calls. When filterByAuthz is false, or
+//     pdp is nil, the MCP server is permissive at the protocol layer; the
+//     service layer still enforces authz independently.
+//
+// The perms map is produced by Register(); it maps tool name to ToolPermission
+// (carrying the required authz action). The toolToToolsets map is also
+// produced by Register(); it maps each tool name to the set of toolsets it
+// belongs to.
+func NewToolFilterMiddleware(
+	pdp authzcore.PDP,
+	perms map[string]ToolPermission,
+	toolToToolsets map[string]map[ToolsetType]bool,
+) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-			// If no PDP configured, pass through unfiltered.
-			if pdp == nil {
-				return next(ctx, method, req)
-			}
-
 			switch method {
 			case methodListTools:
-				return filterListTools(ctx, next, req, pdp, perms)
+				return filterListTools(ctx, next, req, pdp, perms, toolToToolsets)
 			case methodCallTool:
 				return filterCallTool(ctx, next, method, req, pdp, perms)
 			default:
@@ -50,15 +60,16 @@ func NewToolFilterMiddleware(pdp authzcore.PDP, perms map[string]ToolPermission)
 	}
 }
 
-// filterListTools calls the next handler, then removes tools that the user is not
-// permitted to use. Unknown tools (no permission entry) are shown by default to
-// avoid accidentally hiding tools during a rollout.
+// filterListTools calls the next handler, then narrows the returned tool list
+// by the per-session toolset request and (when enabled) the user's authz
+// capabilities.
 func filterListTools(
 	ctx context.Context,
 	next mcp.MethodHandler,
 	req mcp.Request,
 	pdp authzcore.PDP,
 	perms map[string]ToolPermission,
+	toolToToolsets map[string]map[ToolsetType]bool,
 ) (mcp.Result, error) {
 	result, err := next(ctx, methodListTools, req)
 	if err != nil {
@@ -71,35 +82,51 @@ func filterListTools(
 		return result, nil
 	}
 
-	subjectCtx, _ := auth.GetSubjectContextFromContext(ctx)
-	if subjectCtx == nil {
-		// No authenticated user in context — return no tools.
-		listResult.Tools = []*mcp.Tool{}
+	requested, hasRequested := RequestedToolsetsFromContext(ctx)
+	authzActive := authzFilteringActive(ctx, pdp)
+
+	if !hasRequested && !authzActive {
+		// Nothing to filter on — return the result as-is.
 		return listResult, nil
 	}
 
-	profile, err := pdp.GetSubjectProfile(ctx, &authzcore.ProfileRequest{
-		SubjectContext: authzcore.GetAuthzSubjectContext(subjectCtx),
-	})
-	if err != nil {
-		// On PDP error, be safe: return no tools. The service layer will
-		// independently deny any calls the user makes.
-		listResult.Tools = []*mcp.Tool{}
-		return listResult, nil
+	var profile *authzcore.UserCapabilitiesResponse
+	if authzActive {
+		subjectCtx, _ := auth.GetSubjectContextFromContext(ctx)
+		if subjectCtx == nil {
+			// No authenticated user in context — return no tools.
+			listResult.Tools = []*mcp.Tool{}
+			return listResult, nil
+		}
+		profile, err = pdp.GetSubjectProfile(ctx, &authzcore.ProfileRequest{
+			SubjectContext: authzcore.GetAuthzSubjectContext(subjectCtx),
+		})
+		if err != nil {
+			// On PDP error, be safe: return no tools. The service layer will
+			// independently deny any calls the user makes.
+			listResult.Tools = []*mcp.Tool{}
+			return listResult, nil
+		}
 	}
 
 	filtered := listResult.Tools[:0:0]
 	for _, tool := range listResult.Tools {
-		if isAllowed(tool.Name, perms, profile) {
-			filtered = append(filtered, tool)
+		if hasRequested && !toolInRequestedToolsets(tool.Name, toolToToolsets, requested) {
+			continue
 		}
+		if authzActive && !isAllowed(tool.Name, perms, profile) {
+			continue
+		}
+		filtered = append(filtered, tool)
 	}
 	listResult.Tools = filtered
 	return listResult, nil
 }
 
 // filterCallTool checks whether the user is permitted to call the requested tool
-// before forwarding to the next handler.
+// before forwarding to the next handler. Authz checks are skipped when the
+// per-session filterByAuthz flag is false or no PDP is configured; the service
+// layer enforces authz independently in those cases.
 func filterCallTool(
 	ctx context.Context,
 	next mcp.MethodHandler,
@@ -108,6 +135,10 @@ func filterCallTool(
 	pdp authzcore.PDP,
 	perms map[string]ToolPermission,
 ) (mcp.Result, error) {
+	if !authzFilteringActive(ctx, pdp) {
+		return next(ctx, method, req)
+	}
+
 	toolName := callToolName(req)
 	perm, hasPerm := perms[toolName]
 	if !hasPerm {
@@ -133,6 +164,40 @@ func filterCallTool(
 	}
 
 	return next(ctx, method, req)
+}
+
+// authzFilteringActive reports whether MCP-layer authz filtering should be
+// applied for this request. It is active only when a PDP is configured and the
+// per-session filterByAuthz flag has not been explicitly set to false.
+func authzFilteringActive(ctx context.Context, pdp authzcore.PDP) bool {
+	if pdp == nil {
+		return false
+	}
+	if filter, set := FilterByAuthzFromContext(ctx); set && !filter {
+		return false
+	}
+	return true
+}
+
+// toolInRequestedToolsets returns true if the named tool belongs to at least
+// one of the toolsets the client requested. Tools without a toolset entry
+// (an unexpected condition since Register always indexes registered tools)
+// are returned by default to avoid hiding tools after a rollout.
+func toolInRequestedToolsets(
+	toolName string,
+	toolToToolsets map[string]map[ToolsetType]bool,
+	requested map[ToolsetType]bool,
+) bool {
+	owned, ok := toolToToolsets[toolName]
+	if !ok || len(owned) == 0 {
+		return true
+	}
+	for ts := range owned {
+		if requested[ts] {
+			return true
+		}
+	}
+	return false
 }
 
 // isAllowed returns true if the user's profile grants at least one resource for the

--- a/pkg/mcp/tools/filter_test.go
+++ b/pkg/mcp/tools/filter_test.go
@@ -84,7 +84,7 @@ func TestNewToolFilterMiddlewareNilPDP(t *testing.T) {
 
 	server.AddReceivingMiddleware(NewToolFilterMiddleware(nil, map[string]ToolPermission{
 		"list_namespaces": {ToolName: "list_namespaces", Action: "namespace:view"},
-	}))
+	}, nil))
 
 	ctx := context.Background()
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -126,7 +126,7 @@ func TestToolFilterMiddlewareFiltersListTools(t *testing.T) {
 
 	// User can only view namespaces and projects, not create namespace.
 	pdp := &mockPDP{profile: allowAllProfile("namespace:view", "project:view")}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	ctx := ctxWithSubject(context.Background())
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -177,7 +177,7 @@ func TestToolFilterMiddlewareDenyAllProfile(t *testing.T) {
 	}
 
 	pdp := &mockPDP{profile: denyAllProfile()}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	ctx := ctxWithSubject(context.Background())
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -215,7 +215,7 @@ func TestToolFilterMiddlewareNoSubjectInContext(t *testing.T) {
 	}
 
 	pdp := &mockPDP{profile: allowAllProfile("namespace:view")}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	// Context WITHOUT a subject.
 	ctx := context.Background()
@@ -254,7 +254,7 @@ func TestToolFilterMiddlewarePDPError(t *testing.T) {
 	}
 
 	pdp := &mockPDP{err: errors.New("pdp unavailable")}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	ctx := ctxWithSubject(context.Background())
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -298,7 +298,7 @@ func TestToolFilterMiddlewareCallToolAllowed(t *testing.T) {
 	}
 
 	pdp := &mockPDP{profile: allowAllProfile("namespace:view")}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	ctx := ctxWithSubject(context.Background())
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -342,7 +342,7 @@ func TestToolFilterMiddlewareCallToolDenied(t *testing.T) {
 
 	// User only has view, not create.
 	pdp := &mockPDP{profile: allowAllProfile("namespace:view")}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	ctx := ctxWithSubject(context.Background())
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -378,7 +378,7 @@ func TestToolFilterMiddlewareUnknownToolPassthrough(t *testing.T) {
 	perms := map[string]ToolPermission{}
 
 	pdp := &mockPDP{profile: denyAllProfile()}
-	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms))
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
 
 	ctx := ctxWithSubject(context.Background())
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -408,4 +408,321 @@ func TestToolFilterMiddlewareUnknownToolPassthrough(t *testing.T) {
 // nopToolHandler is a minimal tool handler used in tests.
 func nopToolHandler(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
 	return &mcp.CallToolResult{}, nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// Toolset narrowing — ?toolsets= behavior
+// ---------------------------------------------------------------------------
+
+// TestToolFilterMiddlewareToolsetNarrowing verifies that when the client
+// requests a subset of toolsets via context, tools/list returns only tools
+// whose toolset is in the requested set.
+func TestToolFilterMiddlewareToolsetNarrowing(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_components"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "create_environment"}, nopToolHandler)
+
+	toolToToolsets := map[string]map[ToolsetType]bool{
+		"list_namespaces":    {ToolsetNamespace: true},
+		"list_components":    {ToolsetComponent: true},
+		"create_environment": {ToolsetPE: true},
+	}
+
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(nil, nil, toolToToolsets))
+
+	// Client requested only the namespace and pe toolsets.
+	ctx := WithRequestedToolsets(context.Background(), map[ToolsetType]bool{
+		ToolsetNamespace: true,
+		ToolsetPE:        true,
+	})
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, tool := range result.Tools {
+		got[tool.Name] = true
+	}
+	if !got["list_namespaces"] {
+		t.Error("expected list_namespaces (namespace toolset) to be visible")
+	}
+	if !got["create_environment"] {
+		t.Error("expected create_environment (pe toolset) to be visible")
+	}
+	if got["list_components"] {
+		t.Error("list_components (component toolset) should be hidden when narrowed to namespace+pe")
+	}
+}
+
+// TestToolFilterMiddlewareToolsetNarrowingMultiOwner verifies that a tool
+// registered by more than one toolset (such as list_component_types, which is
+// shared between component and pe) is visible when *any* of its owning
+// toolsets is requested.
+func TestToolFilterMiddlewareToolsetNarrowingMultiOwner(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_component_types"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+
+	toolToToolsets := map[string]map[ToolsetType]bool{
+		"list_component_types": {ToolsetComponent: true, ToolsetPE: true},
+		"list_namespaces":      {ToolsetNamespace: true},
+	}
+
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(nil, nil, toolToToolsets))
+
+	// Narrow to pe only — list_component_types is co-owned by pe so it should still appear.
+	ctx := WithRequestedToolsets(context.Background(), map[ToolsetType]bool{ToolsetPE: true})
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, tool := range result.Tools {
+		got[tool.Name] = true
+	}
+	if !got["list_component_types"] {
+		t.Error("expected list_component_types (co-owned by pe) to be visible when narrowed to pe")
+	}
+	if got["list_namespaces"] {
+		t.Error("list_namespaces (namespace toolset only) should be hidden when narrowed to pe")
+	}
+}
+
+// TestToolFilterMiddlewareToolsetNarrowingUnknownIgnored verifies that an
+// unknown toolset name in the requested set silently matches no tools rather
+// than returning an error or hiding everything spuriously.
+func TestToolFilterMiddlewareToolsetNarrowingUnknownIgnored(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+
+	toolToToolsets := map[string]map[ToolsetType]bool{
+		"list_namespaces": {ToolsetNamespace: true},
+	}
+
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(nil, nil, toolToToolsets))
+
+	// Request a toolset name that no registered tool belongs to.
+	ctx := WithRequestedToolsets(context.Background(), map[ToolsetType]bool{ToolsetType("does-not-exist"): true})
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(result.Tools) != 0 {
+		t.Errorf("expected no tools when only an unknown toolset is requested, got %d", len(result.Tools))
+	}
+}
+
+// TestToolFilterMiddlewareToolsetAndAuthzCombined verifies that toolset
+// narrowing and authz filtering compose: the visible set is the intersection
+// of the two filters.
+func TestToolFilterMiddlewareToolsetAndAuthzCombined(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "create_namespace"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_components"}, nopToolHandler)
+
+	perms := map[string]ToolPermission{
+		"list_namespaces":  {ToolName: "list_namespaces", Action: "namespace:view"},
+		"create_namespace": {ToolName: "create_namespace", Action: "namespace:create"},
+		"list_components":  {ToolName: "list_components", Action: "component:view"},
+	}
+	toolToToolsets := map[string]map[ToolsetType]bool{
+		"list_namespaces":  {ToolsetNamespace: true},
+		"create_namespace": {ToolsetNamespace: true},
+		"list_components":  {ToolsetComponent: true},
+	}
+
+	pdp := &mockPDP{profile: allowAllProfile("namespace:view", "component:view")}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, toolToToolsets))
+
+	// Narrow to namespace only — list_components must be hidden by toolset filter,
+	// and create_namespace must be hidden by authz filter.
+	ctx := WithRequestedToolsets(ctxWithSubject(context.Background()), map[ToolsetType]bool{ToolsetNamespace: true})
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	got := map[string]bool{}
+	for _, tool := range result.Tools {
+		got[tool.Name] = true
+	}
+	if !got["list_namespaces"] {
+		t.Error("expected list_namespaces to be visible (in namespace toolset and user has namespace:view)")
+	}
+	if got["list_components"] {
+		t.Error("list_components should be hidden by toolset narrowing")
+	}
+	if got["create_namespace"] {
+		t.Error("create_namespace should be hidden by authz (user lacks namespace:create)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// filterByAuthz=false bypass
+// ---------------------------------------------------------------------------
+
+// TestToolFilterMiddlewareFilterByAuthzFalseListTools verifies that when the
+// client opts out of MCP-layer authz filtering, all tools are returned via
+// tools/list regardless of the user's permissions.
+func TestToolFilterMiddlewareFilterByAuthzFalseListTools(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "list_namespaces"}, nopToolHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "create_namespace"}, nopToolHandler)
+
+	perms := map[string]ToolPermission{
+		"list_namespaces":  {ToolName: "list_namespaces", Action: "namespace:view"},
+		"create_namespace": {ToolName: "create_namespace", Action: "namespace:create"},
+	}
+
+	pdp := &mockPDP{profile: denyAllProfile()}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
+
+	ctx := WithFilterByAuthz(ctxWithSubject(context.Background()), false)
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(result.Tools) != 2 {
+		t.Errorf("expected 2 tools when filterByAuthz=false bypasses authz, got %d", len(result.Tools))
+	}
+}
+
+// TestToolFilterMiddlewareFilterByAuthzFalseAllowsCall verifies that when the
+// client opts out of MCP-layer authz filtering, tools/call is allowed without
+// the middleware checking the user's permissions. The service layer is still
+// expected to enforce authz independently.
+func TestToolFilterMiddlewareFilterByAuthzFalseAllowsCall(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	called := false
+	mcp.AddTool(server, &mcp.Tool{Name: "create_namespace"}, func(
+		ctx context.Context, req *mcp.CallToolRequest, args any,
+	) (*mcp.CallToolResult, any, error) {
+		called = true
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	perms := map[string]ToolPermission{
+		"create_namespace": {ToolName: "create_namespace", Action: "namespace:create"},
+	}
+	pdp := &mockPDP{profile: denyAllProfile()}
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(pdp, perms, nil))
+
+	ctx := WithFilterByAuthz(ctxWithSubject(context.Background()), false)
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	if _, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: "create_namespace"}); err != nil {
+		t.Fatalf("CallTool: expected success when filterByAuthz=false, got %v", err)
+	}
+	if !called {
+		t.Error("expected tool handler to be called when filterByAuthz=false")
+	}
+}
+
+// TestToolFilterMiddlewareToolsetNarrowingDoesNotGateCall verifies that
+// requesting a narrow toolset does not gate tools/call: a client that knows
+// the tool name can still invoke any registered tool. (The filter is a
+// tools/list visibility helper only.)
+func TestToolFilterMiddlewareToolsetNarrowingDoesNotGateCall(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	called := false
+	mcp.AddTool(server, &mcp.Tool{Name: "list_components"}, func(
+		ctx context.Context, req *mcp.CallToolRequest, args any,
+	) (*mcp.CallToolResult, any, error) {
+		called = true
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	toolToToolsets := map[string]map[ToolsetType]bool{
+		"list_components": {ToolsetComponent: true},
+	}
+
+	server.AddReceivingMiddleware(NewToolFilterMiddleware(nil, nil, toolToToolsets))
+
+	// Narrow to namespace toolset — list_components is component, but call should still succeed.
+	ctx := WithRequestedToolsets(context.Background(), map[ToolsetType]bool{ToolsetNamespace: true})
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	if _, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: "list_components"}); err != nil {
+		t.Fatalf("CallTool: expected success despite toolset narrowing, got %v", err)
+	}
+	if !called {
+		t.Error("expected tool handler to be called — toolset narrowing only applies to tools/list")
+	}
 }

--- a/pkg/mcp/tools/permissions_test.go
+++ b/pkg/mcp/tools/permissions_test.go
@@ -30,7 +30,7 @@ func fullToolsets() *Toolsets {
 // perms map. This enforces that developers declare a permission when adding a tool.
 func TestRegisteredToolsHavePermissions(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
-	perms := fullToolsets().Register(server)
+	perms, _ := fullToolsets().Register(server)
 
 	ctx := context.Background()
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
@@ -75,7 +75,7 @@ func TestRegisteredToolsHavePermissions(t *testing.T) {
 // This prevents typos in action names from silently creating incorrect mappings.
 func TestRegisteredPermissionsHaveValidActions(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
-	perms := fullToolsets().Register(server)
+	perms, _ := fullToolsets().Register(server)
 
 	validActions := make(map[string]bool)
 	for _, action := range authzcore.AllActions() {

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -176,48 +176,61 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 	}
 }
 
-// Register registers all enabled tools with the MCP server and returns the
-// permissions map built as a side effect of registration. Each RegisterFunc
-// declares its required authz action by writing to the perms map, so the
-// returned map is always consistent with the set of registered tools.
-func (t *Toolsets) Register(s *mcp.Server) map[string]ToolPermission {
-	perms := make(map[string]ToolPermission)
+// Register registers all enabled tools with the MCP server and returns:
+//   - perms: maps each registered tool name to its required authz action.
+//     Each RegisterFunc declares its required action by writing to a perms map,
+//     so this is always consistent with the set of registered tools.
+//   - toolToToolsets: maps each registered tool name to the set of toolsets
+//     that contain it. A tool can belong to more than one toolset (for example,
+//     `list_component_types` is registered by both the component and pe
+//     toolsets); this index records every toolset it appears in.
+func (t *Toolsets) Register(s *mcp.Server) (
+	perms map[string]ToolPermission,
+	toolToToolsets map[string]map[ToolsetType]bool,
+) {
+	perms = make(map[string]ToolPermission)
+	toolToToolsets = make(map[string]map[ToolsetType]bool)
+
+	registerGroup := func(toolset ToolsetType, regs []RegisterFunc) {
+		for _, registerFunc := range regs {
+			// Use a fresh map per RegisterFunc so we can identify exactly
+			// which tools it registered, even when multiple RegisterFuncs
+			// share a tool name across toolsets.
+			local := make(map[string]ToolPermission)
+			registerFunc(s, local)
+			for name, perm := range local {
+				perms[name] = perm
+				if toolToToolsets[name] == nil {
+					toolToToolsets[name] = make(map[ToolsetType]bool)
+				}
+				toolToToolsets[name][toolset] = true
+			}
+		}
+	}
 
 	if t.NamespaceToolset != nil {
-		for _, registerFunc := range t.namespaceToolRegistrations() {
-			registerFunc(s, perms)
-		}
+		registerGroup(ToolsetNamespace, t.namespaceToolRegistrations())
 	}
 
 	if t.ProjectToolset != nil {
-		for _, registerFunc := range t.projectToolRegistrations() {
-			registerFunc(s, perms)
-		}
+		registerGroup(ToolsetProject, t.projectToolRegistrations())
 	}
 
 	if t.ComponentToolset != nil {
-		for _, registerFunc := range t.componentToolRegistrations() {
-			registerFunc(s, perms)
-		}
+		registerGroup(ToolsetComponent, t.componentToolRegistrations())
 	}
 
 	if t.DeploymentToolset != nil {
-		for _, registerFunc := range t.deploymentToolRegistrations() {
-			registerFunc(s, perms)
-		}
+		registerGroup(ToolsetDeployment, t.deploymentToolRegistrations())
 	}
 
 	if t.BuildToolset != nil {
-		for _, registerFunc := range t.buildToolRegistrations() {
-			registerFunc(s, perms)
-		}
+		registerGroup(ToolsetBuild, t.buildToolRegistrations())
 	}
 
 	if t.PEToolset != nil {
-		for _, registerFunc := range t.peToolRegistrations() {
-			registerFunc(s, perms)
-		}
+		registerGroup(ToolsetPE, t.peToolRegistrations())
 	}
 
-	return perms
+	return perms, toolToToolsets
 }

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -23,6 +23,47 @@ const (
 	ToolsetPE         ToolsetType = "pe"
 )
 
+// requestedToolsetsCtxKey is the context key used to carry the set of toolsets
+// the client requested via the ?toolsets= query param.
+type requestedToolsetsCtxKey struct{}
+
+// filterByAuthzCtxKey is the context key used to carry the per-session
+// filterByAuthz flag from the ?filterByAuthz= query param.
+type filterByAuthzCtxKey struct{}
+
+// WithRequestedToolsets returns a copy of ctx that carries the set of toolsets
+// the client requested. Empty or nil set means "no narrowing" — the middleware
+// will not apply a toolset filter.
+func WithRequestedToolsets(ctx context.Context, requested map[ToolsetType]bool) context.Context {
+	if len(requested) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, requestedToolsetsCtxKey{}, requested)
+}
+
+// RequestedToolsetsFromContext returns the set of toolsets the client requested
+// for this session, if any. The second return value reports whether the client
+// supplied any narrowing.
+func RequestedToolsetsFromContext(ctx context.Context) (map[ToolsetType]bool, bool) {
+	v, ok := ctx.Value(requestedToolsetsCtxKey{}).(map[ToolsetType]bool)
+	return v, ok && len(v) > 0
+}
+
+// WithFilterByAuthz returns a copy of ctx carrying the per-session decision of
+// whether to apply MCP-layer authz filtering. The default (no value in ctx) is
+// true.
+func WithFilterByAuthz(ctx context.Context, filter bool) context.Context {
+	return context.WithValue(ctx, filterByAuthzCtxKey{}, filter)
+}
+
+// FilterByAuthzFromContext returns the per-session filterByAuthz flag if the
+// client explicitly supplied one. The second return value reports whether a
+// value was set; callers should default to true when not set.
+func FilterByAuthzFromContext(ctx context.Context) (bool, bool) {
+	v, ok := ctx.Value(filterByAuthzCtxKey{}).(bool)
+	return v, ok
+}
+
 // DefaultPageSize is the default number of items per page for MCP list operations.
 const DefaultPageSize = 100
 


### PR DESCRIPTION
## Purpose

Adds the ability for MCP clients to request a specific subset of toolsets and to opt out of MCP-layer authz filtering on a per-session basis. Resolves #3272.

## Approach

Two optional URL query parameters are read once on the session-creation HTTP request:

- `?toolsets=namespace,component,pe` narrows `tools/list` to the requested toolsets. Tools registered by multiple toolsets (e.g. `list_component_types`, owned by both `component` and `pe`) appear when *any* of their owning toolsets is requested. Unknown or disabled toolset names silently match nothing. Defaults to all configured toolsets.
- `?filterByAuthz=false` disables MCP-layer authz filtering on `tools/list` and `tools/call` for the session. The service layer still enforces authz independently regardless of this flag. Defaults to `true`.

Toolset narrowing is a `tools/list` visibility helper only — `tools/call` is not gated by the requested-toolset set. The MCP SDK propagates the initialize request's context into the long-lived session, so per-session params live on `context.Context` rather than a per-server cache.

Implementation:
- `pkg/mcp/server.go` — wraps the streamable handler with `withSessionQueryParams`, which parses the params into the request context.
- `pkg/mcp/tools/register.go` — `Register` now also returns a `tool name → set of owning toolsets` index, built via fresh per-`RegisterFunc` maps so multi-owner tools are tracked correctly.
- `pkg/mcp/tools/filter.go` — middleware applies toolset narrowing on `tools/list` and gates authz checks on the per-session `filterByAuthz` flag.
- `pkg/mcp/tools/types.go` — context helpers for the two new keys.

## Related Issues

Closes #3272

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)

## Remarks

- The session is bound to the values supplied at session-creation time. In stateful mode, query params on subsequent requests are ignored. In stateless mode, every request creates a fresh session and re-reads the params.
- STDIO is unaffected; the new behavior is HTTP-only.