### PR TITLE
fix(helm): align selectors with pod labels

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/networkpolicy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/networkpolicy.yaml
@@ -11,8 +11,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: backstage
-      app.kubernetes.io/name: {{ include "openchoreo-control-plane.fullname" . }}
+      {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" "backstage") | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/networkpolicy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/networkpolicy.yaml
@@ -10,8 +10,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: controller-manager
-      app.kubernetes.io/name: {{ include "openchoreo-control-plane.fullname" . }}
+      {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/servicemonitor.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/servicemonitor.yaml
@@ -28,6 +28,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: controller-manager
-      app.kubernetes.io/name: {{ include "openchoreo-control-plane.fullname" . }}
+      {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 6 }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/servicemonitor.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/servicemonitor.yaml
@@ -28,6 +28,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: api-server
-      app.kubernetes.io/name: {{ include "openchoreo-control-plane.fullname" . }}
+      {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" "api-server") | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
## Purpose

This PR fixes Helm selector mismatches where PDB, NetworkPolicy, and ServiceMonitor resources could target labels that do not match the actual Deployment and Service labels.

## Approach

Updated the affected selectors to use the same stable selector labels used by the workload templates.

## Impact

This ensures reliability, security, and observability resources correctly target the intended OpenChoreo workloads.

## Validation

- Rendered the control-plane chart with PDB, NetworkPolicy, and ServiceMonitor enabled
- Verified selector labels align with Deployment and Service labels
- Ran Helm lint successfully
