### PR TITLE
fix(helm): guard backstage sqlite autoscaling

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-control-plane/templates/NOTES.txt
@@ -1,4 +1,5 @@
 {{- include "openchoreo-control-plane.validateHostnames" . -}}
+{{- include "openchoreo-control-plane.validateBackstageDatabase" . -}}
 OpenChoreo Control Plane installed in namespace "{{ .Release.Namespace }}".
 
 {{- if .Values.backstage.http.enabled }}

--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -231,3 +231,18 @@ Validate that placeholder .invalid hostnames have been replaced with real domain
   {{- fail (printf "Placeholder domains found. Set real hostnames for:\n  - %s" (join "\n  - " $errors)) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate Backstage database settings that can break multi-replica deployments.
+SQLite is local to the Backstage pod or PVC and is not safe for multiple
+Backstage replicas. Use PostgreSQL before enabling horizontal scale-out.
+*/}}
+{{- define "openchoreo-control-plane.validateBackstageDatabase" -}}
+{{- if and .Values.backstage.enabled (eq .Values.backstage.database.type "sqlite") -}}
+  {{- $replicas := int .Values.backstage.replicas -}}
+  {{- $maxReplicas := int .Values.backstage.autoscaling.maxReplicas -}}
+  {{- if or (gt $replicas 1) (and .Values.backstage.autoscaling.enabled (gt $maxReplicas 1)) -}}
+    {{- fail "Backstage SQLite database is only supported with a single replica. Set backstage.database.type=postgresql before using backstage.replicas > 1 or backstage.autoscaling.maxReplicas > 1." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -144,7 +144,7 @@
             },
             "enabled": {
               "default": false,
-              "description": "Enable HPA",
+              "description": "Enable HPA. Scaling Backstage beyond one replica requires database.type=postgresql.",
               "title": "enabled",
               "type": "boolean"
             },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2643,7 +2643,7 @@ backstage:
   autoscaling:
     # @schema
     # type: boolean
-    # description: Enable HPA
+    # description: Enable HPA. Scaling Backstage beyond one replica requires database.type=postgresql.
     # default: false
     # @schema
     enabled: false


### PR DESCRIPTION
## Purpose

This PR prevents unsafe Backstage horizontal scaling when the chart is configured to use SQLite.

SQLite is local to a single Backstage pod or PVC-backed filesystem and is not safe for multi-replica deployments. If HPA scales Backstage above one replica while SQLite is used, replicas can end up with inconsistent local state or storage conflicts.

## Approach

Added Helm validation to fail early when Backstage uses SQLite with more than one replica.

The chart now blocks:
- `backstage.replicas > 1` with SQLite
- `backstage.autoscaling.enabled=true` with `backstage.autoscaling.maxReplicas > 1` and SQLite

PostgreSQL remains supported for multi-replica Backstage deployments.

## Related Issues

N/A

## Remarks

Validated with `helm lint` and `helm template`.

- Default SQLite single-replica configuration renders successfully.
- SQLite with HPA maxReplicas greater than 1 fails with a clear error.
- PostgreSQL with HPA renders successfully.
