### PR TITLE
fix(helm): make gateway allowed routes configurable

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
@@ -20,7 +20,7 @@ spec:
       port: {{ .Values.gateway.httpPort | default 80 }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
 {{- if .Values.gateway.tls.enabled }}
     - name: https
       protocol: HTTPS
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
       tls:
         mode: Terminate
         certificateRefs:
@@ -49,7 +49,7 @@ spec:
       hostname: {{ (index .Values.clusterGateway.tlsRoute.hosts 0).host | quote }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
       tls:
         mode: Passthrough
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2549,34 +2549,6 @@
       "additionalProperties": true,
       "description": "KGateway (Gateway API) configuration. kgateway is installed separately; these values configure the Gateway CR created by this chart.",
       "properties": {
-        "annotations": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "description": "Annotations added to the Gateway resource. Use this to configure cert-manager, external-dns, or other integrations.",
-          "required": [],
-          "title": "annotations",
-          "type": "object"
-        },
-        "enabled": {
-          "default": true,
-          "description": "Enable Gateway CR creation",
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "httpPort": {
-          "default": 80,
-          "description": "HTTP listener port",
-          "title": "httpPort",
-          "type": "integer"
-        },
-        "httpsPort": {
-          "default": 443,
-          "description": "HTTPS listener port",
-          "title": "httpsPort",
-          "type": "integer"
-        },
         "allowedRoutes": {
           "additionalProperties": false,
           "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
@@ -2604,6 +2576,34 @@
           "required": [],
           "title": "allowedRoutes",
           "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Annotations added to the Gateway resource. Use this to configure cert-manager, external-dns, or other integrations.",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable Gateway CR creation",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "httpPort": {
+          "default": 80,
+          "description": "HTTP listener port",
+          "title": "httpPort",
+          "type": "integer"
+        },
+        "httpsPort": {
+          "default": 443,
+          "description": "HTTPS listener port",
+          "title": "httpsPort",
+          "type": "integer"
         },
         "infrastructure": {
           "additionalProperties": true,

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2577,6 +2577,34 @@
           "title": "httpsPort",
           "type": "integer"
         },
+        "allowedRoutes": {
+          "additionalProperties": false,
+          "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
+          "properties": {
+            "namespaces": {
+              "additionalProperties": false,
+              "description": "Namespace policy for routes that attach to Gateway listeners",
+              "properties": {
+                "from": {
+                  "default": "Same",
+                  "description": "Gateway API allowedRoutes.namespaces.from value",
+                  "enum": [
+                    "All",
+                    "Same"
+                  ],
+                  "required": [],
+                  "title": "from"
+                }
+              },
+              "required": [],
+              "title": "namespaces",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "allowedRoutes",
+          "type": "object"
+        },
         "infrastructure": {
           "additionalProperties": true,
           "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"",

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2558,7 +2558,7 @@
               "description": "Namespace policy for routes that attach to Gateway listeners",
               "properties": {
                 "from": {
-                  "default": "Same",
+                  "default": "All",
                   "description": "Gateway API allowedRoutes.namespaces.from value",
                   "enum": [
                     "All",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3657,6 +3657,23 @@ gateway:
 
   # @schema
   # type: object
+  # description: Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.
+  # @schema
+  allowedRoutes:
+    # @schema
+    # type: object
+    # description: Namespace policy for routes that attach to Gateway listeners
+    # @schema
+    namespaces:
+      # @schema
+      # description: Gateway API allowedRoutes.namespaces.from value
+      # enum: [All, Same]
+      # default: Same
+      # @schema
+      from: Same
+
+  # @schema
+  # type: object
   # description: TLS configuration for the HTTPS listener
   # @schema
   tls:

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3668,9 +3668,9 @@ gateway:
       # @schema
       # description: Gateway API allowedRoutes.namespaces.from value
       # enum: [All, Same]
-      # default: Same
+      # default: All
       # @schema
-      from: Same
+      from: All
 
   # @schema
   # type: object

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -22,7 +22,7 @@ spec:
       port: {{ .Values.gateway.httpPort | default 80 }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
 {{- if .Values.gateway.tls.enabled }}
     - name: https
       protocol: HTTPS
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
       tls:
         mode: Terminate
         certificateRefs:

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -466,6 +466,34 @@
           "title": "agentgateway",
           "type": "object"
         },
+        "allowedRoutes": {
+          "additionalProperties": false,
+          "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
+          "properties": {
+            "namespaces": {
+              "additionalProperties": false,
+              "description": "Namespace policy for routes that attach to Gateway listeners",
+              "properties": {
+                "from": {
+                  "default": "All",
+                  "description": "Gateway API allowedRoutes.namespaces.from value",
+                  "enum": [
+                    "All",
+                    "Same"
+                  ],
+                  "required": [],
+                  "title": "from"
+                }
+              },
+              "required": [],
+              "title": "namespaces",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "allowedRoutes",
+          "type": "object"
+        },
         "annotations": {
           "additionalProperties": {
             "type": "string"
@@ -674,34 +702,6 @@
           "minimum": 1,
           "title": "httpsPort",
           "type": "integer"
-        },
-        "allowedRoutes": {
-          "additionalProperties": false,
-          "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
-          "properties": {
-            "namespaces": {
-              "additionalProperties": false,
-              "description": "Namespace policy for routes that attach to Gateway listeners",
-              "properties": {
-                "from": {
-                  "default": "All",
-                  "description": "Gateway API allowedRoutes.namespaces.from value",
-                  "enum": [
-                    "All",
-                    "Same"
-                  ],
-                  "required": [],
-                  "title": "from"
-                }
-              },
-              "required": [],
-              "title": "namespaces",
-              "type": "object"
-            }
-          },
-          "required": [],
-          "title": "allowedRoutes",
-          "type": "object"
         },
         "infrastructure": {
           "additionalProperties": true,

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -675,6 +675,34 @@
           "title": "httpsPort",
           "type": "integer"
         },
+        "allowedRoutes": {
+          "additionalProperties": false,
+          "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
+          "properties": {
+            "namespaces": {
+              "additionalProperties": false,
+              "description": "Namespace policy for routes that attach to Gateway listeners",
+              "properties": {
+                "from": {
+                  "default": "All",
+                  "description": "Gateway API allowedRoutes.namespaces.from value",
+                  "enum": [
+                    "All",
+                    "Same"
+                  ],
+                  "required": [],
+                  "title": "from"
+                }
+              },
+              "required": [],
+              "title": "namespaces",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "allowedRoutes",
+          "type": "object"
+        },
         "infrastructure": {
           "additionalProperties": true,
           "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"",

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -101,6 +101,23 @@ gateway:
 
   # @schema
   # type: object
+  # description: Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.
+  # @schema
+  allowedRoutes:
+    # @schema
+    # type: object
+    # description: Namespace policy for routes that attach to Gateway listeners
+    # @schema
+    namespaces:
+      # @schema
+      # description: Gateway API allowedRoutes.namespaces.from value
+      # enum: [All, Same]
+      # default: All
+      # @schema
+      from: All
+
+  # @schema
+  # type: object
   # description: TLS configuration for the HTTPS listener
   # @schema
   tls:

--- a/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
@@ -20,7 +20,7 @@ spec:
       port: {{ .Values.gateway.httpPort | default 80 }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
 {{- if .Values.gateway.tls.enabled }}
     - name: https
       protocol: HTTPS
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
       tls:
         mode: Terminate
         certificateRefs:
@@ -51,7 +51,7 @@ spec:
       hostname: {{ .Values.gateway.tlsPassthrough.hostname | quote }}
       allowedRoutes:
         namespaces:
-          from: All
+          from: {{ .Values.gateway.allowedRoutes.namespaces.from }}
       tls:
         mode: Passthrough
       port: {{ .Values.gateway.tlsPassthrough.port | default 11443 }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1145,7 +1145,7 @@
               "description": "Namespace policy for routes that attach to Gateway listeners",
               "properties": {
                 "from": {
-                  "default": "Same",
+                  "default": "All",
                   "description": "Gateway API allowedRoutes.namespaces.from value",
                   "enum": [
                     "All",

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1164,6 +1164,34 @@
           "title": "httpsPort",
           "type": "integer"
         },
+        "allowedRoutes": {
+          "additionalProperties": false,
+          "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
+          "properties": {
+            "namespaces": {
+              "additionalProperties": false,
+              "description": "Namespace policy for routes that attach to Gateway listeners",
+              "properties": {
+                "from": {
+                  "default": "Same",
+                  "description": "Gateway API allowedRoutes.namespaces.from value",
+                  "enum": [
+                    "All",
+                    "Same"
+                  ],
+                  "required": [],
+                  "title": "from"
+                }
+              },
+              "required": [],
+              "title": "namespaces",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "allowedRoutes",
+          "type": "object"
+        },
         "infrastructure": {
           "additionalProperties": true,
           "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"",

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1136,34 +1136,6 @@
       "additionalProperties": false,
       "description": "Gateway resource configuration for observability plane routing",
       "properties": {
-        "annotations": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "description": "Annotations added to the Gateway resource. Use this to configure cert-manager, external-dns, or other integrations.",
-          "required": [],
-          "title": "annotations",
-          "type": "object"
-        },
-        "enabled": {
-          "default": true,
-          "description": "Enable Gateway CR creation",
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "httpPort": {
-          "default": 80,
-          "description": "HTTP listener port",
-          "title": "httpPort",
-          "type": "integer"
-        },
-        "httpsPort": {
-          "default": 443,
-          "description": "HTTPS listener port",
-          "title": "httpsPort",
-          "type": "integer"
-        },
         "allowedRoutes": {
           "additionalProperties": false,
           "description": "Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.",
@@ -1191,6 +1163,34 @@
           "required": [],
           "title": "allowedRoutes",
           "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Annotations added to the Gateway resource. Use this to configure cert-manager, external-dns, or other integrations.",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable Gateway CR creation",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "httpPort": {
+          "default": 80,
+          "description": "HTTP listener port",
+          "title": "httpPort",
+          "type": "integer"
+        },
+        "httpsPort": {
+          "default": 443,
+          "description": "HTTPS listener port",
+          "title": "httpsPort",
+          "type": "integer"
         },
         "infrastructure": {
           "additionalProperties": true,

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1165,6 +1165,23 @@ gateway:
 
   # @schema
   # type: object
+  # description: Gateway listener route attachment policy. Use Same to restrict routes to the Gateway namespace, or All to allow routes from any namespace.
+  # @schema
+  allowedRoutes:
+    # @schema
+    # type: object
+    # description: Namespace policy for routes that attach to Gateway listeners
+    # @schema
+    namespaces:
+      # @schema
+      # description: Gateway API allowedRoutes.namespaces.from value
+      # enum: [All, Same]
+      # default: Same
+      # @schema
+      from: Same
+
+  # @schema
+  # type: object
   # description: TLS configuration for the HTTPS listener
   # @schema
   tls:

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1176,9 +1176,9 @@ gateway:
       # @schema
       # description: Gateway API allowedRoutes.namespaces.from value
       # enum: [All, Same]
-      # default: Same
+      # default: All
       # @schema
-      from: Same
+      from: All
 
   # @schema
   # type: object


### PR DESCRIPTION
## Purpose

This PR improves the Helm Gateway configuration by making `allowedRoutes.namespaces.from` configurable instead of hardcoding it to `All`.

Hardcoding `All` allows routes from any namespace to attach to the Gateway, which can be risky in multi-tenant Kubernetes environments. This change allows operators to choose the route attachment policy based on their deployment needs.

## Approach

Updated the control-plane, data-plane, and observability-plane Gateway templates to read the value from:

`gateway.allowedRoutes.namespaces.from`

Added the same configuration to each chart’s `values.yaml` and `values.schema.json`.

Defaults:
- control-plane: `All`, to preserve existing upgrade behavior
- observability-plane: `All`, to preserve existing upgrade behavior
- data-plane: `All`, to preserve existing cross-namespace workload routing behavior

Operators who want stricter namespace isolation can explicitly set:
`gateway.allowedRoutes.namespaces.from=Same`

## Validation

Validated with:
- `helm lint`
- `helm template`
- schema validation for invalid values

Invalid values are rejected by the chart schema.
