### PR TITLE
fix: use openchoreo.dev/restartedAt on pod template

### DIFF
--- a/internal/controller/annotations.go
+++ b/internal/controller/annotations.go
@@ -20,9 +20,9 @@ const (
 	// AnnotationKeyRestartedAt is set on a ReleaseBinding to trigger a rolling
 	// restart of every Deployment deployed by the binding. The ReleaseBinding
 	// controller propagates the annotation to the dataplane RenderedRelease,
-	// and the rendered release controller injects the value into
-	// kubectl.kubernetes.io/restartedAt on each Deployment's pod template at
-	// apply time. The value is opaque; any change triggers a restart.
+	// and the rendered release controller sets the same annotation on each
+	// Deployment's pod template at apply time. The value is opaque; any change
+	// triggers a restart.
 	AnnotationKeyRestartedAt = "openchoreo.dev/restartedAt"
 
 	// SchemaExtensionComponentParameterRepositoryPrefix is the common prefix for all openAPIV3Schema

--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -300,12 +300,11 @@ func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRe
 	return desiredObjects, nil
 }
 
-// injectRestartedAt sets kubectl.kubernetes.io/restartedAt on the pod template
-// of an apps/v1 Deployment so the data plane performs a rolling restart, the
-// same way `kubectl rollout restart deployment` does. It is a no-op for any
-// other kind. Returns an error if the manifest is malformed (e.g. annotations
-// is not a string map), so the caller can surface it instead of silently
-// dropping the restart trigger.
+// injectRestartedAt sets openchoreo.dev/restartedAt on the pod template of an
+// apps/v1 Deployment so a change to the value causes the data plane to perform
+// a rolling restart. It is a no-op for any other kind. Returns an error if the
+// manifest is malformed (e.g. annotations is not a string map), so the caller
+// can surface it instead of silently dropping the restart trigger.
 func injectRestartedAt(obj *unstructured.Unstructured, value string) error {
 	gvk := obj.GroupVersionKind()
 	if gvk.Group != appsAPIGroup || gvk.Kind != "Deployment" {
@@ -318,7 +317,7 @@ func injectRestartedAt(obj *unstructured.Unstructured, value string) error {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations["kubectl.kubernetes.io/restartedAt"] = value
+	annotations[controller.AnnotationKeyRestartedAt] = value
 	if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
 		return fmt.Errorf("set pod template annotations: %w", err)
 	}


### PR DESCRIPTION
## Purpose

When a `ReleaseBinding` carries `openchoreo.dev/restartedAt`, the rendered release controller was translating that into `kubectl.kubernetes.io/restartedAt` on each Deployment's pod template. This PR drops the translation and writes the OpenChoreo-owned annotation directly, so the same key flows end-to-end from `ReleaseBinding` to pod template.

## Approach

- In `injectRestartedAt`, set `openchoreo.dev/restartedAt` on the pod template instead of `kubectl.kubernetes.io/restartedAt`.
- Update the `AnnotationKeyRestartedAt` doc comment to match the new behavior.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)