### PR TITLE
feat: add sandbox workloadType and agent ClusterComponentType

### DIFF
--- a/samples/getting-started/component-types/agent.yaml
+++ b/samples/getting-started/component-types/agent.yaml
@@ -1,0 +1,328 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  name: agent
+  annotations:
+    openchoreo.dev/description: "An AI agent workload with kernel-level sandbox isolation via kubernetes-sigs/agent-sandbox"
+spec:
+  workloadType: proxy
+
+  allowedWorkflows:
+    - kind: ClusterWorkflow
+      name: paketo-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: gcp-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: dockerfile-builder
+    - kind: ClusterWorkflow
+      name: ballerina-buildpack-builder
+
+  allowedTraits:
+    - kind: ClusterTrait
+      name: observability-alert-rule
+
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        isolationTier:
+          type: string
+          description: "Container runtime for sandbox isolation: runc (standard Linux), gvisor (syscall interception), kata (microVM)."
+          default: runc
+          enum:
+            - runc
+            - gvisor
+            - kata
+        warmPoolSize:
+          type: integer
+          description: "Number of pre-warmed sandbox instances to keep ready for fast claiming."
+          default: 0
+          minimum: 0
+        ttlSeconds:
+          type: integer
+          description: "Time-to-live in seconds for the sandbox after being claimed. 0 means no expiry."
+          default: 0
+          minimum: 0
+
+  validations:
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.external)
+          : true}
+      message: "Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane."
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "internal" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.internal)
+          : true}
+      message: "Endpoints with 'internal' visibility require gateway.ingress.internal to be configured on the Environment or DataPlane."
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        ResourceQuantity:
+          type: object
+          default: {}
+          properties:
+            cpu:
+              type: string
+              default: "100m"
+            memory:
+              type: string
+              default: "256Mi"
+        ResourceRequirements:
+          type: object
+          properties:
+            requests:
+              $ref: "#/$defs/ResourceQuantity"
+            limits:
+              $ref: "#/$defs/ResourceQuantity"
+          default: {}
+      properties:
+        replicas:
+          type: integer
+          default: 1
+          minimum: 0
+        resources:
+          $ref: "#/$defs/ResourceRequirements"
+        imagePullPolicy:
+          type: string
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+
+  resources:
+    # ── SandboxTemplate: defines the sandbox spec for the upstream controller ─
+    - id: sandbox-template
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxTemplate
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          podTemplate:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              automountServiceAccountToken: false
+              runtimeClassName: |
+                ${parameters.isolationTier == "gvisor" ? "gvisor"
+                  : parameters.isolationTier == "kata" ? "kata-qemu"
+                  : oc_omit()}
+              nodeSelector: |
+                ${parameters.isolationTier == "gvisor"
+                  ? {"gvisor-enabled": "true"}
+                  : parameters.isolationTier == "kata"
+                    ? {"kata-enabled": "true"}
+                    : oc_omit()}
+              containers:
+                - name: main
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  command: |
+                    ${has(workload.container.command) ? workload.container.command : oc_omit()}
+                  args: |
+                    ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  resources:
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  volumeMounts: ${configurations.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes()}
+
+    # ── SandboxClaim: claims one sandbox from the template ───────────────
+    - id: sandbox-claim
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxClaim
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          sandboxTemplateRef:
+            name: ${metadata.name}
+          lifecycle: |
+            ${parameters.ttlSeconds > 0
+              ? {"ttlSecondsAfterFinished": parameters.ttlSeconds}
+              : oc_omit()}
+
+    # ── SandboxWarmPool: pre-warmed sandbox instances ────────────────────
+    - id: sandbox-warmpool
+      includeWhen: ${parameters.warmPoolSize > 0}
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxWarmPool
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: ${parameters.warmPoolSize}
+          sandboxTemplateRef:
+            name: ${metadata.name}
+
+    # ── Service (optional, only if endpoints are defined) ────────────────
+    - id: service
+      includeWhen: ${size(workload.endpoints) > 0}
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.componentName}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          type: ClusterIP
+          selector: ${metadata.podSelectors}
+          ports: ${workload.toServicePorts()}
+
+    - id: httproute-external
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
+          namespace: ${metadata.namespace}
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          rules:
+          - matches:
+            - path:
+                type: PathPrefix
+                value: /${metadata.componentName}-${endpoint.key}
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
+            backendRefs:
+            - name: ${metadata.componentName}
+              port: ${endpoint.value.port}
+
+    - id: httproute-internal
+      forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
+          namespace: ${metadata.namespace}
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.internal.name}
+              namespace: ${gateway.ingress.internal.namespace}
+          hostnames: |
+            ${[gateway.ingress.internal.?http, gateway.ingress.internal.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          rules:
+          - matches:
+            - path:
+                type: PathPrefix
+                value: /${metadata.componentName}-${endpoint.key}
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
+            backendRefs:
+            - name: ${metadata.componentName}
+              port: ${endpoint.value.port}
+
+    - id: env-config
+      forEach: ${configurations.toConfigEnvsByContainer()}
+      var: envConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+
+    - id: file-config
+      forEach: ${configurations.toConfigFileList()}
+      var: config
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${config.resourceName}
+          namespace: ${metadata.namespace}
+        data:
+          ${config.name}: |
+            ${config.value}
+
+    - id: secret-env-external
+      forEach: ${configurations.toSecretEnvsByContainer()}
+      var: secretEnv
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${secretEnv.resourceName}
+            creationPolicy: Owner
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}
+
+    - id: secret-file-external
+      forEach: ${configurations.toSecretFileList()}
+      var: file
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${file.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${file.resourceName}
+            creationPolicy: Owner
+          data:
+            - secretKey: ${file.name}
+              remoteRef:
+                key: ${file.remoteRef.key}
+                property: |
+                  ${has(file.remoteRef.property) ? file.remoteRef.property : oc_omit()}

--- a/samples/getting-started/component-types/agent.yaml
+++ b/samples/getting-started/component-types/agent.yaml
@@ -40,7 +40,7 @@ spec:
           minimum: 0
         ttlSeconds:
           type: integer
-          description: "Time-to-live in seconds for the sandbox after being claimed. 0 means no expiry."
+          description: "Time-to-live in seconds after the sandbox finishes execution. 0 means no automatic cleanup."
           default: 0
           minimum: 0
 
@@ -79,10 +79,6 @@ spec:
               $ref: "#/$defs/ResourceQuantity"
           default: {}
       properties:
-        replicas:
-          type: integer
-          default: 1
-          minimum: 0
         resources:
           $ref: "#/$defs/ResourceRequirements"
         imagePullPolicy:


### PR DESCRIPTION
## Summary
- Adds `sandbox` as a new workloadType enum value for ComponentType and ClusterComponentType
- The `sandbox` type follows the same validation pattern as `proxy` — no primary workload resource kind required, and standard workload kinds (Deployment, StatefulSet, etc.) are rejected
- Adds the `agent` ClusterComponentType sample that renders SandboxTemplate, SandboxClaim, and SandboxWarmPool resources via the standard rendering pipeline
- The upstream kubernetes-sigs/agent-sandbox controller (installed via the community module on each data plane) fulfills the SandboxClaims

### Core changes

| File | Change |
|---|---|
| `api/v1alpha1/componenttype_types.go` | Add `sandbox` to workloadType enum + CEL validation |
| `api/v1alpha1/clustercomponenttype_types.go` | Same |
| `internal/validation/component/resource_template.go` | Skip primary-kind check for `sandbox` (same as `proxy`) |
| `config/crd/bases/` | Regenerated CRDs |
| `install/helm/openchoreo-control-plane/crds/` | Synced helm CRDs |

### Agent CCT parameters

| Parameter | Type | Default | Values | Description |
|---|---|---|---|---|
| `isolationTier` | string | `runc` | `runc`, `gvisor`, `kata` | Container runtime for sandbox isolation |
| `warmPoolSize` | integer | `0` | >= 0 | Pre-warmed sandbox instances (0 = no warm pool) |
| `ttlSeconds` | integer | `0` | >= 0 | Time-to-live after claiming (0 = no expiry) |

### Resources rendered by the agent CCT

| ID | Kind | Condition |
|---|---|---|
| `sandbox-template` | SandboxTemplate | Always |
| `sandbox-claim` | SandboxClaim | Always |
| `sandbox-warmpool` | SandboxWarmPool | When `warmPoolSize > 0` |
| `service` | Service | When endpoints defined |
| `httproute-*` | HTTPRoute | When external/internal endpoints |

### Related
- Community module (installs upstream controller on data planes): openchoreo/community-modules#94

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Existing component types (`service`, `worker`, `webapp`) unaffected
- [ ] `kubectl apply` the agent CCT with `workloadType: sandbox` succeeds
- [ ] CCT with `sandbox` type rejects Deployment/StatefulSet resource templates
- [ ] Create a Component with `sandbox/agent` type — SandboxTemplate + SandboxClaim rendered to data plane
- [ ] Upstream controller fulfills the SandboxClaim