### PR TITLE
fix: harden quick-start scripts against common misconfigurations

### DIFF
--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -3,11 +3,27 @@
 # Helper functions for OpenChoreo installation
 # These functions provide idempotent operations for setting up OpenChoreo
 
-set -eo pipefail
+set -euo pipefail
 
 # Source shared configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/.config.sh"
+
+# Guard: abort early if running as root
+if [[ "$(id -u)" -eq 0 ]]; then
+    echo -e "\033[0;31m[ERROR]\033[0m This script should not be run as root." >&2
+    echo "" >&2
+    echo "  You appear to be running as root (uid=0). This usually happens when" >&2
+    echo "  entering the container via 'docker exec' without specifying the user." >&2
+    echo "" >&2
+    echo "  Please switch to the openchoreo user:" >&2
+    echo "    su - openchoreo" >&2
+    echo "" >&2
+    echo "  Or re-enter the container correctly:" >&2
+    echo "    docker exec -it -u openchoreo <container> bash -l" >&2
+    echo "" >&2
+    exit 1
+fi
 
 # Color codes for output
 RED='\033[0;31m'
@@ -113,11 +129,11 @@ create_k3d_cluster() {
 
     log_info "Creating k3d cluster '$CLUSTER_NAME'..."
 
-    # Use the k3d config file from user's home directory
-    local k3d_config="$HOME/.k3d-config.yaml"
+    local k3d_config="${SCRIPT_DIR}/.k3d-config.yaml"
 
     if [[ ! -f "$k3d_config" ]]; then
         log_error "k3d config file not found at $k3d_config"
+        log_error "Expected alongside install.sh in: $SCRIPT_DIR"
         return 1
     fi
 
@@ -910,7 +926,7 @@ install_control_plane() {
     # Disable --wait for control plane to avoid deadlock with webhook cert hooks
     # But keep monitoring enabled to track pod status
     install_helm_chart "openchoreo-control-plane" "openchoreo-control-plane" "$CONTROL_PLANE_NS" "true" "false" "true" "1800" \
-        "--values" "$HOME/.values-cp.yaml" \
+        "--values" "$SCRIPT_DIR/.values-cp.yaml" \
         "--set" "controllerManager.image.tag=$OPENCHOREO_VERSION" \
         "--set" "openchoreoApi.image.tag=$OPENCHOREO_VERSION" \
         "--set" "backstage.image.tag=$BACKSTAGE_VERSION"
@@ -970,7 +986,7 @@ extract_cluster_gateway_ca() {
 install_data_plane() {
     log_info "Installing OpenChoreo Data Plane..."
     install_helm_chart "openchoreo-data-plane" "openchoreo-data-plane" "$DATA_PLANE_NS" "true" "true" "true" "1800" \
-        "--values" "$HOME/.values-dp.yaml"
+        "--values" "$SCRIPT_DIR/.values-dp.yaml"
 }
 
 # Configure the dataplane and workflowplane with observabilityplane reference
@@ -994,14 +1010,14 @@ install_registry() {
     helm repo update twuni
 
     install_helm_chart "registry" "twuni/docker-registry" "$WORKFLOW_PLANE_NS" "true" "true" "true" "300" \
-        "--values" "$HOME/.values-registry.yaml"
+        "--values" "$SCRIPT_DIR/.values-registry.yaml"
 }
 
 # Install OpenChoreo Cluster Workflow Plane (optional)
 install_workflow_plane() {
     log_info "Installing OpenChoreo Cluster Workflow Plane..."
     install_helm_chart "openchoreo-workflow-plane" "openchoreo-workflow-plane" "$WORKFLOW_PLANE_NS" "true" "true" "true" "1800" \
-        "--values" "$HOME/.values-wp.yaml"
+        "--values" "$SCRIPT_DIR/.values-wp.yaml"
 }
 
 # Copy cluster-gateway CA (public cert only) from control plane to observability plane namespace
@@ -1062,7 +1078,7 @@ install_observability_plane() {
     docker exec "k3d-${CLUSTER_NAME}-server-0" sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
 
     install_helm_chart "openchoreo-observability-plane" "openchoreo-observability-plane" "$OBSERVABILITY_NS" "true" "true" "true" "1800" \
-        "--values" "$HOME/.values-op.yaml" \
+        "--values" "$SCRIPT_DIR/.values-op.yaml" \
         "--set" "observer.image.tag=$OPENCHOREO_VERSION"
 
     # Install logs and metrics observability modules
@@ -1229,9 +1245,8 @@ check_system_resources() {
             ;;
     esac
 
-    # Get disk space for home directory (where k3d cluster will be created)
     local disk_available_kb
-    disk_available_kb=$(df "$HOME" 2>/dev/null | tail -1 | awk '{print $4}' || echo "0")
+    disk_available_kb=$(df "$SCRIPT_DIR" 2>/dev/null | tail -1 | awk '{print $4}' || echo "0")
     disk_gb=$((disk_available_kb / 1024 / 1024))
 
     # Calculate required resources based on actual measured usage:
@@ -1354,6 +1369,12 @@ verify_prerequisites() {
 
     if [[ ${#missing_tools[@]} -gt 0 ]]; then
         log_error "Missing required tools: ${missing_tools[*]}"
+        return 1
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        log_error "Docker daemon is not reachable"
+        log_error "Make sure Docker is running and /var/run/docker.sock is mounted into this container"
         return 1
     fi
 

--- a/install/quick-start/occ-login.sh
+++ b/install/quick-start/occ-login.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 # Get the absolute path of the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,6 +22,8 @@ API_URL=$(kubectl get httproute -n openchoreo-control-plane openchoreo-api -o js
 
 if [ -z "$API_URL" ]; then
   log_error "Failed to discover API server URL from HTTPRoute"
+  log_error "The 'openchoreo-api' HTTPRoute in namespace 'openchoreo-control-plane' is not available yet."
+  log_error "The control plane may still be starting. Wait a minute and retry: bash occ-login.sh"
   exit 1
 fi
 
@@ -32,13 +34,15 @@ THUNDER_URL=$(kubectl get httproute -n thunder thunder-httproute -o jsonpath='{.
 
 if [ -z "$THUNDER_URL" ]; then
   log_error "Failed to discover Thunder URL from HTTPRoute"
+  log_error "The 'thunder-httproute' HTTPRoute in namespace 'thunder' is not available yet."
+  log_error "Thunder may still be starting. Wait a minute and retry: bash occ-login.sh"
   exit 1
 fi
 
 THUNDER_ENDPOINT="http://${THUNDER_URL}:8080"
 
 # Step 1: Get token using system app with scope=system
-TOKEN_RESPONSE=$(curl -s -X POST "${THUNDER_ENDPOINT}/oauth2/token" \
+TOKEN_RESPONSE=$(curl -s --max-time 10 -X POST "${THUNDER_ENDPOINT}/oauth2/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=client_credentials" \
   -d "client_id=${SYSTEM_APP_CLIENT_ID}" \
@@ -57,7 +61,7 @@ log_success "System token obtained"
 
 # Step 2: Check if CLI application already exists
 log_info "Checking if CLI application exists..."
-EXISTING_APPS=$(curl -s -X GET "${THUNDER_ENDPOINT}/applications" \
+EXISTING_APPS=$(curl -s --max-time 10 -X GET "${THUNDER_ENDPOINT}/applications" \
   -H "Authorization: Bearer ${SYSTEM_TOKEN}")
 
 APP_ID=$(echo "${EXISTING_APPS}" | jq -r --arg cid "${CLI_CLIENT_ID}" '.applications[] | select(.client_id == $cid) | .id // empty')
@@ -91,7 +95,7 @@ EOF
 if [ -n "$APP_ID" ] && [ "$APP_ID" != "null" ]; then
   # Application exists, update it
   log_info "CLI application already exists (id: ${APP_ID}), updating..."
-  APP_RESPONSE=$(curl -s -X PUT "${THUNDER_ENDPOINT}/applications/${APP_ID}" \
+  APP_RESPONSE=$(curl -s --max-time 10 -X PUT "${THUNDER_ENDPOINT}/applications/${APP_ID}" \
     -H "Authorization: Bearer ${SYSTEM_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "${APP_PAYLOAD}")
@@ -100,7 +104,7 @@ if [ -n "$APP_ID" ] && [ "$APP_ID" != "null" ]; then
 else
   # Application doesn't exist, create it
   log_info "Creating CLI application..."
-  APP_RESPONSE=$(curl -s -X POST "${THUNDER_ENDPOINT}/applications" \
+  APP_RESPONSE=$(curl -s --max-time 10 -X POST "${THUNDER_ENDPOINT}/applications" \
     -H "Authorization: Bearer ${SYSTEM_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "${APP_PAYLOAD}")

--- a/install/quick-start/uninstall.sh
+++ b/install/quick-start/uninstall.sh
@@ -54,7 +54,7 @@ if [[ "$FORCE_UNINSTALL" != "true" ]]; then
     echo "  - All OpenChoreo components"
     echo ""
     read -p "Are you sure you want to continue? (y/N): " -r
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    if [[ ! ${REPLY:-} =~ ^[Yy]$ ]]; then
         log_info "Uninstall cancelled"
         exit 0
     fi


### PR DESCRIPTION
fixes quick-start scripts failing with cryptic errors when the container is entered as root or when Docker/Thunder aren't ready. reported in #3405

the root cause for the original report: `docker exec` without `-u openchoreo` lands you as root, so `$HOME` is `/root` and all config file lookups silently point to the wrong path. but there were a few other footguns in the same area.

changes:
- add root user guard in .helpers.sh (covers install, uninstall, and deploy scripts since they all source it)
- replace `$HOME` with `$SCRIPT_DIR` for config/values file paths so they resolve correctly regardless of shell environment
- add Docker daemon connectivity check in verify_prerequisites (catches "socket not mounted" before k3d tries to use it)
- add 10s timeout to all curl calls in occ-login.sh (prevents indefinite hangs when Thunder isn't ready)
- improve error messages in occ-login.sh when HTTPRoutes aren't found (explain that services may still be starting)

tested on docker desktop (mac) with both normal entrypoint flow and `docker exec -it <id> sh` as root. the guard fires correctly and the SCRIPT_DIR paths resolve fine in both cases.

## Test plan
- [ ] run quick-start normally via entrypoint, verify install completes
- [ ] `docker exec -it -u root <container> bash` then run `./install.sh`, verify clear error message
- [ ] stop Docker daemon, run install, verify "Docker daemon is not reachable" error
- [ ] run `occ-login.sh` before Thunder is ready, verify timeout + helpful message