### PR TITLE
feat: add get_resource_tree and tighten MCP tool surface ergonomics

### DIFF
--- a/internal/openchoreo-api/mcphandlers/components.go
+++ b/internal/openchoreo-api/mcphandlers/components.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	ocLabels "github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
-	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 	clustercomponenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustercomponenttype"
 	componentsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/component"
 	componenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/componenttype"
@@ -113,9 +112,9 @@ func (h *MCPHandler) GetComponent(
 }
 
 func (h *MCPHandler) ListWorkloads(
-	ctx context.Context, namespaceName, componentName string,
+	ctx context.Context, namespaceName, componentName string, opts tools.ListOpts,
 ) (any, error) {
-	result, err := h.services.WorkloadService.ListWorkloads(ctx, namespaceName, componentName, services.ListOptions{})
+	result, err := h.services.WorkloadService.ListWorkloads(ctx, namespaceName, componentName, toServiceListOptions(opts))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/openchoreo-api/mcphandlers/pe.go
+++ b/internal/openchoreo-api/mcphandlers/pe.go
@@ -160,6 +160,14 @@ func (h *MCPHandler) GetWorkflowPlane(ctx context.Context, namespaceName, workfl
 	return workflowPlaneDetail(wp), nil
 }
 
+func (h *MCPHandler) GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (any, error) {
+	result, err := h.services.K8sResourcesService.GetResourceTree(ctx, namespaceName, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+	return resourceTreeDetail(result), nil
+}
+
 func (h *MCPHandler) GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (any, error) {
 	result, err := h.services.K8sResourcesService.GetResourceEvents(ctx, namespaceName, releaseBindingName, group, version, kind, name)
 	if err != nil {

--- a/internal/openchoreo-api/mcphandlers/transform_resources.go
+++ b/internal/openchoreo-api/mcphandlers/transform_resources.go
@@ -267,6 +267,12 @@ func releaseBindingSummary(rb openchoreov1alpha1.ReleaseBinding) map[string]any 
 	if rb.Spec.State != "" {
 		m["state"] = string(rb.Spec.State)
 	}
+	if len(rb.Status.Endpoints) > 0 {
+		m["endpoints"] = rb.Status.Endpoints
+	}
+	if len(rb.Status.PendingConnections) > 0 {
+		m["pendingConnections"] = rb.Status.PendingConnections
+	}
 	setIfNotEmpty(m, "status", readyStatus(rb.Status.Conditions))
 	return m
 }
@@ -293,7 +299,9 @@ func releaseBindingDetail(rb *openchoreov1alpha1.ReleaseBinding) map[string]any 
 	if rb.Spec.WorkloadOverrides != nil {
 		m["workloadOverrides"] = rb.Spec.WorkloadOverrides
 	}
-	m["endpoints"] = rb.Status.Endpoints
+	if len(rb.Status.Endpoints) > 0 {
+		m["endpoints"] = rb.Status.Endpoints
+	}
 	if len(rb.Status.ConnectionTargets) > 0 {
 		m["connectionTargets"] = rb.Status.ConnectionTargets
 	}
@@ -680,7 +688,7 @@ func resourceTreeDetail(result *k8sresourcessvc.K8sResourceTreeResult) map[strin
 				node["namespace"] = n.Namespace
 			}
 			if n.CreatedAt != nil {
-				node["created_at"] = n.CreatedAt
+				node["created_at"] = n.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
 			}
 			if len(n.ParentRefs) > 0 {
 				parents := make([]map[string]any, 0, len(n.ParentRefs))

--- a/internal/openchoreo-api/mcphandlers/transform_resources.go
+++ b/internal/openchoreo-api/mcphandlers/transform_resources.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	k8sresourcessvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/k8sresources"
 )
 
 // ---------------------------------------------------------------------------
@@ -649,6 +650,67 @@ func clusterWorkflowDetail(cwf *openchoreov1alpha1.ClusterWorkflow) map[string]a
 		m["spec"] = spec
 	}
 	return m
+}
+
+// ---------------------------------------------------------------------------
+// Resource tree (diagnostics)
+// ---------------------------------------------------------------------------
+
+// resourceTreeDetail drops the per-node Object blob and embedded RenderedRelease CR
+// — both bloat MCP context with no diagnostic value.
+func resourceTreeDetail(result *k8sresourcessvc.K8sResourceTreeResult) map[string]any {
+	releases := make([]map[string]any, 0, len(result.RenderedReleases))
+	for _, r := range result.RenderedReleases {
+		entry := map[string]any{
+			"name":         r.Name,
+			"target_plane": r.TargetPlane,
+		}
+		nodes := make([]map[string]any, 0, len(r.Nodes))
+		for i := range r.Nodes {
+			n := &r.Nodes[i]
+			node := map[string]any{
+				"version": n.Version,
+				"kind":    n.Kind,
+				"name":    n.Name,
+			}
+			if n.Group != "" {
+				node["group"] = n.Group
+			}
+			if n.Namespace != "" {
+				node["namespace"] = n.Namespace
+			}
+			if n.CreatedAt != nil {
+				node["created_at"] = n.CreatedAt
+			}
+			if len(n.ParentRefs) > 0 {
+				parents := make([]map[string]any, 0, len(n.ParentRefs))
+				for j := range n.ParentRefs {
+					p := &n.ParentRefs[j]
+					ref := map[string]any{
+						"kind": p.Kind,
+						"name": p.Name,
+						"uid":  p.UID,
+					}
+					if p.Namespace != "" {
+						ref["namespace"] = p.Namespace
+					}
+					parents = append(parents, ref)
+				}
+				node["parent_refs"] = parents
+			}
+			if n.Health != nil {
+				h := map[string]any{"status": n.Health.Status}
+				if n.Health.Message != "" {
+					h["message"] = n.Health.Message
+				}
+				node["health"] = h
+			}
+			nodes = append(nodes, node)
+		}
+		entry["nodes"] = nodes
+		releases = append(releases, entry)
+	}
+	return map[string]any{"rendered_releases": releases}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/mcp/tools/build_specs_test.go
+++ b/pkg/mcp/tools/build_specs_test.go
@@ -47,7 +47,7 @@ func buildWorkflowRunSpecs() []toolTestSpec {
 			optionalParams:      []string{"parameters"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":  "build-workflow",
+				"name":           "build-workflow",
 			},
 			expectedMethod: "CreateWorkflowRun",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -173,7 +173,7 @@ func buildWorkflowSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":  "build-workflow",
+				"name":           "build-workflow",
 			},
 			expectedMethod: "GetWorkflowSchema",
 			validateCall: func(t *testing.T, args []interface{}) {

--- a/pkg/mcp/tools/build_specs_test.go
+++ b/pkg/mcp/tools/build_specs_test.go
@@ -43,11 +43,11 @@ func buildWorkflowRunSpecs() []toolTestSpec {
 			toolset:             "build",
 			descriptionKeywords: []string{"create", "workflow", "run"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "workflow_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			optionalParams:      []string{"parameters"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"workflow_name":  "build-workflow",
+				"name":  "build-workflow",
 			},
 			expectedMethod: "CreateWorkflowRun",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -170,10 +170,10 @@ func buildWorkflowSpecs() []toolTestSpec {
 			toolset:             "build",
 			descriptionKeywords: []string{"workflow", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "workflow_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"workflow_name":  "build-workflow",
+				"name":  "build-workflow",
 			},
 			expectedMethod: "GetWorkflowSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -204,9 +204,9 @@ func buildClusterWorkflowSpecs() []toolTestSpec {
 			toolset:             "build",
 			descriptionKeywords: []string{"cluster", "workflow"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cwf_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"cwf_name": "build-go",
+				"name": "build-go",
 			},
 			expectedMethod: "GetClusterWorkflow",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -220,9 +220,9 @@ func buildClusterWorkflowSpecs() []toolTestSpec {
 			toolset:             "build",
 			descriptionKeywords: []string{"cluster", "workflow", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cwf_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"cwf_name": "build-go",
+				"name": "build-go",
 			},
 			expectedMethod: "GetClusterWorkflowSchema",
 			validateCall: func(t *testing.T, args []interface{}) {

--- a/pkg/mcp/tools/component.go
+++ b/pkg/mcp/tools/component.go
@@ -57,22 +57,26 @@ func (t *Toolsets) RegisterGetComponent(s *mcp.Server, perms map[string]ToolPerm
 	})
 }
 
+//nolint:dupl // paginated list handlers share similar structure
 func (t *Toolsets) RegisterListWorkloads(s *mcp.Server, perms map[string]ToolPermission) {
 	const name = "list_workloads"
 	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewWorkload}
 	mcp.AddTool(s, &mcp.Tool{
 		Name: name,
 		Description: "List workloads for a component. Shows workload names, images, and endpoint names. " +
-			"For Kubernetes users: Similar to 'kubectl get pods'.",
-		InputSchema: createSchema(map[string]any{
+			"Supports pagination via limit and cursor.",
+		InputSchema: createSchema(addPaginationProperties(map[string]any{
 			"namespace_name": defaultStringProperty(),
 			"component_name": defaultStringProperty(),
-		}, []string{"namespace_name", "component_name"}),
+		}), []string{"namespace_name", "component_name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
 		ComponentName string `json:"component_name"`
+		Limit         int    `json:"limit,omitempty"`
+		Cursor        string `json:"cursor,omitempty"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.ListWorkloads(ctx, args.NamespaceName, args.ComponentName)
+		result, err := t.ComponentToolset.ListWorkloads(
+			ctx, args.NamespaceName, args.ComponentName, ListOpts{Limit: args.Limit, Cursor: args.Cursor})
 		return handleToolResult(result, err)
 	})
 }

--- a/pkg/mcp/tools/component_specs_test.go
+++ b/pkg/mcp/tools/component_specs_test.go
@@ -260,7 +260,7 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":        "WebApplication",
+				"name":           "WebApplication",
 			},
 			expectedMethod: "GetComponentTypeSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -292,7 +292,7 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":     "autoscaling",
+				"name":           "autoscaling",
 			},
 			expectedMethod: "GetTraitSchema",
 			validateCall: func(t *testing.T, args []interface{}) {

--- a/pkg/mcp/tools/component_specs_test.go
+++ b/pkg/mcp/tools/component_specs_test.go
@@ -257,10 +257,10 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "component",
 			descriptionKeywords: []string{"component", "type", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "ct_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"ct_name":        "WebApplication",
+				"name":        "WebApplication",
 			},
 			expectedMethod: "GetComponentTypeSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -289,10 +289,10 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "component",
 			descriptionKeywords: []string{"trait", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "trait_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"trait_name":     "autoscaling",
+				"name":     "autoscaling",
 			},
 			expectedMethod: "GetTraitSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -318,8 +318,8 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "component",
 			descriptionKeywords: []string{"cluster", "component", "type"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cct_name"},
-			testArgs:            map[string]any{"cct_name": "go-service"},
+			requiredParams:      []string{"name"},
+			testArgs:            map[string]any{"name": "go-service"},
 			expectedMethod:      "GetClusterComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
 				if args[0] != "go-service" {
@@ -332,8 +332,8 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "component",
 			descriptionKeywords: []string{"cluster", "component", "type", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cct_name"},
-			testArgs:            map[string]any{"cct_name": "go-service"},
+			requiredParams:      []string{"name"},
+			testArgs:            map[string]any{"name": "go-service"},
 			expectedMethod:      "GetClusterComponentTypeSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
 				if args[0] != "go-service" {
@@ -358,8 +358,8 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "component",
 			descriptionKeywords: []string{"cluster", "trait"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"ct_name"},
-			testArgs:            map[string]any{"ct_name": "autoscaler"},
+			requiredParams:      []string{"name"},
+			testArgs:            map[string]any{"name": "autoscaler"},
 			expectedMethod:      "GetClusterTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
 				if args[0] != "autoscaler" {
@@ -372,8 +372,8 @@ func componentPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "component",
 			descriptionKeywords: []string{"cluster", "trait", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"ct_name"},
-			testArgs:            map[string]any{"ct_name": "autoscaler"},
+			requiredParams:      []string{"name"},
+			testArgs:            map[string]any{"name": "autoscaler"},
 			expectedMethod:      "GetClusterTraitSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
 				if args[0] != "autoscaler" {

--- a/pkg/mcp/tools/deployment_specs_test.go
+++ b/pkg/mcp/tools/deployment_specs_test.go
@@ -145,7 +145,7 @@ func deploymentPipelineSpecs() []toolTestSpec {
 	return makeNamespacedListGetSpecs(
 		"deployment", "list_deployment_pipelines", "get_deployment_pipeline",
 		[]string{"list", "deployment", "pipeline"}, []string{"deployment", "pipeline"},
-		"pipeline_name", "default-pipeline", "ListDeploymentPipelines", "GetDeploymentPipeline",
+		"name", "default-pipeline", "ListDeploymentPipelines", "GetDeploymentPipeline",
 	)
 }
 

--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -152,9 +152,9 @@ func (m *MockCoreToolsetHandler) GetComponent(
 }
 
 func (m *MockCoreToolsetHandler) ListWorkloads(
-	ctx context.Context, namespaceName, componentName string,
+	ctx context.Context, namespaceName, componentName string, opts ListOpts,
 ) (any, error) {
-	m.recordCall("ListWorkloads", namespaceName, componentName)
+	m.recordCall("ListWorkloads", namespaceName, componentName, opts)
 	return `[{"name":"workload1"}]`, nil
 }
 

--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -670,6 +670,13 @@ func (m *MockCoreToolsetHandler) DeleteClusterWorkflow(
 
 // Diagnostics methods
 
+func (m *MockCoreToolsetHandler) GetResourceTree(
+	ctx context.Context, namespaceName, releaseBindingName string,
+) (any, error) {
+	m.recordCall("GetResourceTree", namespaceName, releaseBindingName)
+	return `{"rendered_releases":[]}`, nil
+}
+
 func (m *MockCoreToolsetHandler) GetResourceEvents(
 	ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string,
 ) (any, error) {

--- a/pkg/mcp/tools/pe.go
+++ b/pkg/mcp/tools/pe.go
@@ -656,13 +656,13 @@ func (t *Toolsets) RegisterPEGetComponentTypeSchema(s *mcp.Server, perms map[str
 			"the parameters developers can configure when using this component type.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"ct_name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
-		}, []string{"namespace_name", "ct_name"}),
+			"name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		CtName        string `json:"ct_name"`
+		Name        string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetComponentTypeSchema(ctx, args.NamespaceName, args.CtName)
+		result, err := t.PEToolset.GetComponentTypeSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -676,13 +676,13 @@ func (t *Toolsets) RegisterPEGetComponentType(s *mcp.Server, perms map[string]To
 			"Use this before updating a component type to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"ct_name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
-		}, []string{"namespace_name", "ct_name"}),
+			"name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		CtName        string `json:"ct_name"`
+		Name        string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetComponentType(ctx, args.NamespaceName, args.CtName)
+		result, err := t.PEToolset.GetComponentType(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -717,13 +717,13 @@ func (t *Toolsets) RegisterPEGetTraitSchema(s *mcp.Server, perms map[string]Tool
 			"parameters developers can configure when using this trait.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"trait_name":     stringProperty("Trait name. Use list_traits to discover valid names"),
-		}, []string{"namespace_name", "trait_name"}),
+			"name":     stringProperty("Trait name. Use list_traits to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		TraitName     string `json:"trait_name"`
+		Name     string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetTraitSchema(ctx, args.NamespaceName, args.TraitName)
+		result, err := t.PEToolset.GetTraitSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -737,13 +737,13 @@ func (t *Toolsets) RegisterPEGetTrait(s *mcp.Server, perms map[string]ToolPermis
 			"Use this before updating a trait to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"trait_name":     stringProperty("Trait name. Use list_traits to discover valid names"),
-		}, []string{"namespace_name", "trait_name"}),
+			"name":     stringProperty("Trait name. Use list_traits to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		TraitName     string `json:"trait_name"`
+		Name     string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetTrait(ctx, args.NamespaceName, args.TraitName)
+		result, err := t.PEToolset.GetTrait(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -780,13 +780,13 @@ func (t *Toolsets) RegisterPEGetWorkflowSchema(s *mcp.Server, perms map[string]T
 			"a workflow accepts before configuring a component's workflow field or triggering a workflow run.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"workflow_name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
-		}, []string{"namespace_name", "workflow_name"}),
+			"name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		WorkflowName  string `json:"workflow_name"`
+		Name  string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetWorkflowSchema(ctx, args.NamespaceName, args.WorkflowName)
+		result, err := t.PEToolset.GetWorkflowSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -800,13 +800,13 @@ func (t *Toolsets) RegisterPEGetWorkflow(s *mcp.Server, perms map[string]ToolPer
 			"Use this before updating a workflow to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"workflow_name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
-		}, []string{"namespace_name", "workflow_name"}),
+			"name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		WorkflowName  string `json:"workflow_name"`
+		Name  string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetWorkflow(ctx, args.NamespaceName, args.WorkflowName)
+		result, err := t.PEToolset.GetWorkflow(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -815,13 +815,36 @@ func (t *Toolsets) RegisterPEGetWorkflow(s *mcp.Server, perms map[string]ToolPer
 // PE Toolset — Diagnostics
 // ---------------------------------------------------------------------------
 
+func (t *Toolsets) RegisterGetResourceTree(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_resource_tree"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewReleaseBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "List rendered Kubernetes resources (Deployment, Service, Pod, etc.) under a release binding, " +
+			"with their group/version/kind/name, parent refs, and health.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"release_binding_name": stringProperty(
+				"Name of the release binding (deployment). Use list_release_bindings to discover valid names"),
+		}, []string{"namespace_name", "release_binding_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName      string `json:"namespace_name"`
+		ReleaseBindingName string `json:"release_binding_name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.PEToolset.GetResourceTree(ctx, args.NamespaceName, args.ReleaseBindingName)
+		return handleToolResult(result, err)
+	})
+}
+
 func (t *Toolsets) RegisterGetResourceEvents(s *mcp.Server, perms map[string]ToolPermission) {
 	const name = "get_resource_events"
 	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
 		Name: name,
 		Description: "Get Kubernetes events for a specific resource in a deployment. Useful for diagnosing " +
-			"deployment issues, scheduling problems, or container startup failures.",
+			"deployment issues, scheduling problems, or container startup failures. Call get_resource_tree first " +
+			"to discover the rendered resource's exact group/version/kind/name — passing the component name " +
+			"typically fails because the rendered Deployment / Service / Pod uses a different name.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
 			"release_binding_name": stringProperty(
@@ -829,7 +852,7 @@ func (t *Toolsets) RegisterGetResourceEvents(s *mcp.Server, perms map[string]Too
 			"group":         stringProperty("API group of the resource (e.g., 'apps', '' for core resources)"),
 			"version":       stringProperty("API version of the resource (e.g., 'v1')"),
 			"kind":          stringProperty("Kind of the resource (e.g., 'Deployment', 'Pod', 'Service')"),
-			"resource_name": stringProperty("Name of the specific Kubernetes resource"),
+			"resource_name": stringProperty("Name of the rendered Kubernetes resource. Use get_resource_tree to discover this — it usually differs from the component name"),
 		}, []string{"namespace_name", "release_binding_name", "group", "version", "kind", "resource_name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName      string `json:"namespace_name"`
@@ -857,7 +880,7 @@ func (t *Toolsets) RegisterGetResourceLogs(s *mcp.Server, perms map[string]ToolP
 			"namespace_name": defaultStringProperty(),
 			"release_binding_name": stringProperty(
 				"Name of the release binding (deployment). Use list_release_bindings to discover valid names"),
-			"pod_name": stringProperty("Name of the pod. Use get_resource_events to discover pod names"),
+			"pod_name": stringProperty("Name of the pod. Use get_resource_tree to discover pod names under the binding"),
 			"since_seconds": map[string]any{
 				"type":        "integer",
 				"description": "Return logs from the last N seconds. Defaults to all available logs",
@@ -958,18 +981,18 @@ func (t *Toolsets) RegisterCreateWorkflowRun(s *mcp.Server, perms map[string]Too
 			"Workflows define automated processes like CI/CD pipelines that execute on the workflow plane.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"workflow_name":  stringProperty("Name of the Workflow CR to execute"),
+			"name":  stringProperty("Name of the Workflow CR to execute"),
 			"parameters": map[string]any{
 				"type":        "object",
 				"description": "Optional: Parameters to pass to the workflow execution",
 			},
-		}, []string{"namespace_name", "workflow_name"}),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string                 `json:"namespace_name"`
-		WorkflowName  string                 `json:"workflow_name"`
+		Name  string                 `json:"name"`
 		Parameters    map[string]interface{} `json:"parameters"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.BuildToolset.CreateWorkflowRun(ctx, args.NamespaceName, args.WorkflowName, args.Parameters)
+		result, err := t.BuildToolset.CreateWorkflowRun(ctx, args.NamespaceName, args.Name, args.Parameters)
 		return handleToolResult(result, err)
 	})
 }
@@ -1132,13 +1155,13 @@ func (t *Toolsets) RegisterGetWorkflowSchema(s *mcp.Server, perms map[string]Too
 			"a workflow accepts before configuring a component's workflow field or triggering a workflow run.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"workflow_name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
-		}, []string{"namespace_name", "workflow_name"}),
+			"name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		WorkflowName  string `json:"workflow_name"`
+		Name  string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.BuildToolset.GetWorkflowSchema(ctx, args.NamespaceName, args.WorkflowName)
+		result, err := t.BuildToolset.GetWorkflowSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1173,12 +1196,12 @@ func (t *Toolsets) RegisterGetClusterWorkflow(s *mcp.Server, perms map[string]To
 		Description: "Get the full definition of a cluster-scoped workflow including its complete spec. " +
 			"Use this before updating a cluster workflow to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
-			"cwf_name": stringProperty("Cluster workflow name. Use list_cluster_workflows to discover valid names"),
-		}, []string{"cwf_name"}),
+			"name": stringProperty("Cluster workflow name. Use list_cluster_workflows to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CwfName string `json:"cwf_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.BuildToolset.GetClusterWorkflow(ctx, args.CwfName)
+		result, err := t.BuildToolset.GetClusterWorkflow(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1191,12 +1214,12 @@ func (t *Toolsets) RegisterGetClusterWorkflowSchema(s *mcp.Server, perms map[str
 		Description: "Get the schema definition for a cluster-scoped workflow. Returns the JSON schema " +
 			"showing workflow configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
-			"cwf_name": stringProperty("Cluster workflow name. Use list_cluster_workflows to discover valid names"),
-		}, []string{"cwf_name"}),
+			"name": stringProperty("Cluster workflow name. Use list_cluster_workflows to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CwfName string `json:"cwf_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.BuildToolset.GetClusterWorkflowSchema(ctx, args.CwfName)
+		result, err := t.BuildToolset.GetClusterWorkflowSchema(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1231,12 +1254,12 @@ func (t *Toolsets) RegisterPEGetClusterComponentType(s *mcp.Server, perms map[st
 		Description: "Get the full definition of a cluster-scoped component type including its complete spec. " +
 			"Use this before updating a cluster component type to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
-			"cct_name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
-		}, []string{"cct_name"}),
+			"name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CctName string `json:"cct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetClusterComponentType(ctx, args.CctName)
+		result, err := t.PEToolset.GetClusterComponentType(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1249,12 +1272,12 @@ func (t *Toolsets) RegisterPEGetClusterComponentTypeSchema(s *mcp.Server, perms 
 		Description: "Get the schema definition for a cluster-scoped component type. Returns the JSON schema " +
 			"showing required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
-			"cct_name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
-		}, []string{"cct_name"}),
+			"name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CctName string `json:"cct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetClusterComponentTypeSchema(ctx, args.CctName)
+		result, err := t.PEToolset.GetClusterComponentTypeSchema(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1285,12 +1308,12 @@ func (t *Toolsets) RegisterPEGetClusterTrait(s *mcp.Server, perms map[string]Too
 		Description: "Get the full definition of a cluster-scoped trait including its complete spec. " +
 			"Use this before updating a cluster trait to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
-			"ct_name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
-		}, []string{"ct_name"}),
+			"name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CtName string `json:"ct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetClusterTrait(ctx, args.CtName)
+		result, err := t.PEToolset.GetClusterTrait(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1303,12 +1326,12 @@ func (t *Toolsets) RegisterPEGetClusterTraitSchema(s *mcp.Server, perms map[stri
 		Description: "Get the schema definition for a cluster-scoped trait. Returns the JSON schema " +
 			"showing trait configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
-			"ct_name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
-		}, []string{"ct_name"}),
+			"name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CtName string `json:"ct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.GetClusterTraitSchema(ctx, args.CtName)
+		result, err := t.PEToolset.GetClusterTraitSchema(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1348,13 +1371,13 @@ func (t *Toolsets) RegisterGetComponentTypeSchema(s *mcp.Server, perms map[strin
 			"required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"ct_name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
-		}, []string{"namespace_name", "ct_name"}),
+			"name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		CtName        string `json:"ct_name"`
+		Name        string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.GetComponentTypeSchema(ctx, args.NamespaceName, args.CtName)
+		result, err := t.ComponentToolset.GetComponentTypeSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1389,13 +1412,13 @@ func (t *Toolsets) RegisterGetTraitSchema(s *mcp.Server, perms map[string]ToolPe
 			"configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"trait_name":     stringProperty("Trait name. Use list_traits to discover valid names"),
-		}, []string{"namespace_name", "trait_name"}),
+			"name":     stringProperty("Trait name. Use list_traits to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		TraitName     string `json:"trait_name"`
+		Name     string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.GetTraitSchema(ctx, args.NamespaceName, args.TraitName)
+		result, err := t.ComponentToolset.GetTraitSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1426,12 +1449,12 @@ func (t *Toolsets) RegisterGetClusterComponentType(s *mcp.Server, perms map[stri
 		Description: "Get detailed information about a cluster-scoped component type including workload type, " +
 			"allowed workflows, allowed traits, and description.",
 		InputSchema: createSchema(map[string]any{
-			"cct_name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
-		}, []string{"cct_name"}),
+			"name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CctName string `json:"cct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.GetClusterComponentType(ctx, args.CctName)
+		result, err := t.ComponentToolset.GetClusterComponentType(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1444,12 +1467,12 @@ func (t *Toolsets) RegisterGetClusterComponentTypeSchema(s *mcp.Server, perms ma
 		Description: "Get the schema definition for a cluster-scoped component type. Returns the JSON schema " +
 			"showing required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
-			"cct_name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
-		}, []string{"cct_name"}),
+			"name": stringProperty("Cluster component type name. Use list_cluster_component_types to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CctName string `json:"cct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.GetClusterComponentTypeSchema(ctx, args.CctName)
+		result, err := t.ComponentToolset.GetClusterComponentTypeSchema(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1480,12 +1503,12 @@ func (t *Toolsets) RegisterGetClusterTrait(s *mcp.Server, perms map[string]ToolP
 		Description: "Get detailed information about a cluster-scoped trait including its name, " +
 			"display name, and description.",
 		InputSchema: createSchema(map[string]any{
-			"ct_name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
-		}, []string{"ct_name"}),
+			"name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CtName string `json:"ct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.GetClusterTrait(ctx, args.CtName)
+		result, err := t.ComponentToolset.GetClusterTrait(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1498,12 +1521,12 @@ func (t *Toolsets) RegisterGetClusterTraitSchema(s *mcp.Server, perms map[string
 		Description: "Get the schema definition for a cluster-scoped trait. Returns the JSON schema " +
 			"showing trait configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
-			"ct_name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
-		}, []string{"ct_name"}),
+			"name": stringProperty("Cluster trait name. Use list_cluster_traits to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CtName string `json:"ct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.ComponentToolset.GetClusterTraitSchema(ctx, args.CtName)
+		result, err := t.ComponentToolset.GetClusterTraitSchema(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1805,14 +1828,14 @@ func (t *Toolsets) RegisterDeleteComponentType(s *mcp.Server, perms map[string]T
 		Description: "Delete a component type from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"ct_name": stringProperty(
+			"name": stringProperty(
 				"Name of the component type to delete. Use list_component_types to discover valid names"),
-		}, []string{"namespace_name", "ct_name"}),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		CtName        string `json:"ct_name"`
+		Name        string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteComponentType(ctx, args.NamespaceName, args.CtName)
+		result, err := t.PEToolset.DeleteComponentType(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1909,13 +1932,13 @@ func (t *Toolsets) RegisterDeleteTrait(s *mcp.Server, perms map[string]ToolPermi
 		Description: "Delete a trait from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"trait_name":     stringProperty("Name of the trait to delete. Use list_traits to discover valid names"),
-		}, []string{"namespace_name", "trait_name"}),
+			"name":     stringProperty("Name of the trait to delete. Use list_traits to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		TraitName     string `json:"trait_name"`
+		Name     string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteTrait(ctx, args.NamespaceName, args.TraitName)
+		result, err := t.PEToolset.DeleteTrait(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -2013,13 +2036,13 @@ func (t *Toolsets) RegisterPEDeleteWorkflow(s *mcp.Server, perms map[string]Tool
 		Description: "Delete a workflow from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"workflow_name":  stringProperty("Name of the workflow to delete. Use list_workflows to discover valid names"),
-		}, []string{"namespace_name", "workflow_name"}),
+			"name":  stringProperty("Name of the workflow to delete. Use list_workflows to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		WorkflowName  string `json:"workflow_name"`
+		Name  string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteWorkflow(ctx, args.NamespaceName, args.WorkflowName)
+		result, err := t.PEToolset.DeleteWorkflow(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -2136,13 +2159,13 @@ func (t *Toolsets) RegisterDeleteClusterComponentType(s *mcp.Server, perms map[s
 		Name:        name,
 		Description: "Delete a cluster-scoped component type.",
 		InputSchema: createSchema(map[string]any{
-			"cct_name": stringProperty(
+			"name": stringProperty(
 				"Name of the cluster component type to delete. Use list_cluster_component_types to discover valid names"),
-		}, []string{"cct_name"}),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CctName string `json:"cct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteClusterComponentType(ctx, args.CctName)
+		result, err := t.PEToolset.DeleteClusterComponentType(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -2257,12 +2280,12 @@ func (t *Toolsets) RegisterDeleteClusterTrait(s *mcp.Server, perms map[string]To
 		Name:        name,
 		Description: "Delete a cluster-scoped trait.",
 		InputSchema: createSchema(map[string]any{
-			"ct_name": stringProperty("Name of the cluster trait to delete. Use list_cluster_traits to discover valid names"),
-		}, []string{"ct_name"}),
+			"name": stringProperty("Name of the cluster trait to delete. Use list_cluster_traits to discover valid names"),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CtName string `json:"ct_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteClusterTrait(ctx, args.CtName)
+		result, err := t.PEToolset.DeleteClusterTrait(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -2357,13 +2380,13 @@ func (t *Toolsets) RegisterDeleteClusterWorkflow(s *mcp.Server, perms map[string
 		Name:        name,
 		Description: "Delete a cluster-scoped workflow.",
 		InputSchema: createSchema(map[string]any{
-			"cwf_name": stringProperty(
+			"name": stringProperty(
 				"Name of the cluster workflow to delete. Use list_cluster_workflows to discover valid names"),
-		}, []string{"cwf_name"}),
+		}, []string{"name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
-		CwfName string `json:"cwf_name"`
+		Name string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteClusterWorkflow(ctx, args.CwfName)
+		result, err := t.PEToolset.DeleteClusterWorkflow(ctx, args.Name)
 		return handleToolResult(result, err)
 	})
 }

--- a/pkg/mcp/tools/pe.go
+++ b/pkg/mcp/tools/pe.go
@@ -231,13 +231,13 @@ func (t *Toolsets) RegisterDeleteEnvironment(s *mcp.Server, perms map[string]Too
 			"This will remove the deployment target and any associated resources.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"env_name":       stringProperty("Name of the environment to delete. Use list_environments to discover valid names"),
-		}, []string{"namespace_name", "env_name"}),
+			"name":           stringProperty("Name of the environment to delete. Use list_environments to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		EnvName       string `json:"env_name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteEnvironment(ctx, args.NamespaceName, args.EnvName)
+		result, err := t.PEToolset.DeleteEnvironment(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -656,11 +656,11 @@ func (t *Toolsets) RegisterPEGetComponentTypeSchema(s *mcp.Server, perms map[str
 			"the parameters developers can configure when using this component type.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
+			"name":           stringProperty("Component type name. Use list_component_types to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name        string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.GetComponentTypeSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -676,11 +676,11 @@ func (t *Toolsets) RegisterPEGetComponentType(s *mcp.Server, perms map[string]To
 			"Use this before updating a component type to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
+			"name":           stringProperty("Component type name. Use list_component_types to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name        string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.GetComponentType(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -717,11 +717,11 @@ func (t *Toolsets) RegisterPEGetTraitSchema(s *mcp.Server, perms map[string]Tool
 			"parameters developers can configure when using this trait.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":     stringProperty("Trait name. Use list_traits to discover valid names"),
+			"name":           stringProperty("Trait name. Use list_traits to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name     string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.GetTraitSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -737,11 +737,11 @@ func (t *Toolsets) RegisterPEGetTrait(s *mcp.Server, perms map[string]ToolPermis
 			"Use this before updating a trait to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":     stringProperty("Trait name. Use list_traits to discover valid names"),
+			"name":           stringProperty("Trait name. Use list_traits to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name     string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.GetTrait(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -780,11 +780,11 @@ func (t *Toolsets) RegisterPEGetWorkflowSchema(s *mcp.Server, perms map[string]T
 			"a workflow accepts before configuring a component's workflow field or triggering a workflow run.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
+			"name":           stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name  string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.GetWorkflowSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -800,11 +800,11 @@ func (t *Toolsets) RegisterPEGetWorkflow(s *mcp.Server, perms map[string]ToolPer
 			"Use this before updating a workflow to retrieve the current spec.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
+			"name":           stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name  string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.GetWorkflow(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -841,18 +841,19 @@ func (t *Toolsets) RegisterGetResourceEvents(s *mcp.Server, perms map[string]Too
 	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewReleaseBinding}
 	mcp.AddTool(s, &mcp.Tool{
 		Name: name,
-		Description: "Get Kubernetes events for a specific resource in a deployment. Useful for diagnosing " +
-			"deployment issues, scheduling problems, or container startup failures. Call get_resource_tree first " +
-			"to discover the rendered resource's exact group/version/kind/name — passing the component name " +
-			"typically fails because the rendered Deployment / Service / Pod uses a different name.",
+		Description: "Get Kubernetes events for a specific rendered resource in a deployment. " +
+			"Useful for diagnosing scheduling problems and container startup failures. " +
+			"Call get_resource_tree first to discover the exact group/version/kind/name.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
 			"release_binding_name": stringProperty(
 				"Name of the release binding (deployment). Use list_release_bindings to discover valid names"),
-			"group":         stringProperty("API group of the resource (e.g., 'apps', '' for core resources)"),
-			"version":       stringProperty("API version of the resource (e.g., 'v1')"),
-			"kind":          stringProperty("Kind of the resource (e.g., 'Deployment', 'Pod', 'Service')"),
-			"resource_name": stringProperty("Name of the rendered Kubernetes resource. Use get_resource_tree to discover this — it usually differs from the component name"),
+			"group":   stringProperty("API group of the resource (e.g., 'apps', '' for core resources)"),
+			"version": stringProperty("API version of the resource (e.g., 'v1')"),
+			"kind":    stringProperty("Kind of the resource (e.g., 'Deployment', 'Pod', 'Service')"),
+			"resource_name": stringProperty(
+				"Rendered K8s resource name (usually differs from the component name). " +
+					"Use get_resource_tree to discover it."),
 		}, []string{"namespace_name", "release_binding_name", "group", "version", "kind", "resource_name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName      string `json:"namespace_name"`
@@ -911,13 +912,13 @@ func (t *Toolsets) RegisterGetDeploymentPipeline(s *mcp.Server, perms map[string
 			"order, and associated environments.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"pipeline_name":  stringProperty("Use list_deployment_pipelines to discover valid names"),
-		}, []string{"namespace_name", "pipeline_name"}),
+			"name":           stringProperty("Use list_deployment_pipelines to discover valid names"),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		PipelineName  string `json:"pipeline_name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.DeploymentToolset.GetDeploymentPipeline(ctx, args.NamespaceName, args.PipelineName)
+		result, err := t.DeploymentToolset.GetDeploymentPipeline(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -981,7 +982,7 @@ func (t *Toolsets) RegisterCreateWorkflowRun(s *mcp.Server, perms map[string]Too
 			"Workflows define automated processes like CI/CD pipelines that execute on the workflow plane.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":  stringProperty("Name of the Workflow CR to execute"),
+			"name":           stringProperty("Name of the Workflow CR to execute"),
 			"parameters": map[string]any{
 				"type":        "object",
 				"description": "Optional: Parameters to pass to the workflow execution",
@@ -989,7 +990,7 @@ func (t *Toolsets) RegisterCreateWorkflowRun(s *mcp.Server, perms map[string]Too
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string                 `json:"namespace_name"`
-		Name  string                 `json:"name"`
+		Name          string                 `json:"name"`
 		Parameters    map[string]interface{} `json:"parameters"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.BuildToolset.CreateWorkflowRun(ctx, args.NamespaceName, args.Name, args.Parameters)
@@ -1155,11 +1156,11 @@ func (t *Toolsets) RegisterGetWorkflowSchema(s *mcp.Server, perms map[string]Too
 			"a workflow accepts before configuring a component's workflow field or triggering a workflow run.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":  stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
+			"name":           stringProperty("Name of the workflow. Use list_workflows to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name  string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.BuildToolset.GetWorkflowSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -1371,11 +1372,11 @@ func (t *Toolsets) RegisterGetComponentTypeSchema(s *mcp.Server, perms map[strin
 			"required fields, optional fields, and their types.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":        stringProperty("Component type name. Use list_component_types to discover valid names"),
+			"name":           stringProperty("Component type name. Use list_component_types to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name        string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.ComponentToolset.GetComponentTypeSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -1412,11 +1413,11 @@ func (t *Toolsets) RegisterGetTraitSchema(s *mcp.Server, perms map[string]ToolPe
 			"configuration options and parameters.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":     stringProperty("Trait name. Use list_traits to discover valid names"),
+			"name":           stringProperty("Trait name. Use list_traits to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name     string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.ComponentToolset.GetTraitSchema(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -1584,14 +1585,14 @@ func (t *Toolsets) RegisterDeleteDeploymentPipeline(s *mcp.Server, perms map[str
 		Description: "Delete a deployment pipeline from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"pipeline_name": stringProperty(
+			"name": stringProperty(
 				"Name of the deployment pipeline to delete. Use list_deployment_pipelines to discover valid names"),
-		}, []string{"namespace_name", "pipeline_name"}),
+		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		PipelineName  string `json:"pipeline_name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
-		result, err := t.PEToolset.DeleteDeploymentPipeline(ctx, args.NamespaceName, args.PipelineName)
+		result, err := t.PEToolset.DeleteDeploymentPipeline(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
 	})
 }
@@ -1833,7 +1834,7 @@ func (t *Toolsets) RegisterDeleteComponentType(s *mcp.Server, perms map[string]T
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name        string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.DeleteComponentType(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -1932,11 +1933,11 @@ func (t *Toolsets) RegisterDeleteTrait(s *mcp.Server, perms map[string]ToolPermi
 		Description: "Delete a trait from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":     stringProperty("Name of the trait to delete. Use list_traits to discover valid names"),
+			"name":           stringProperty("Name of the trait to delete. Use list_traits to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name     string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.DeleteTrait(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)
@@ -2036,11 +2037,11 @@ func (t *Toolsets) RegisterPEDeleteWorkflow(s *mcp.Server, perms map[string]Tool
 		Description: "Delete a workflow from a namespace.",
 		InputSchema: createSchema(map[string]any{
 			"namespace_name": defaultStringProperty(),
-			"name":  stringProperty("Name of the workflow to delete. Use list_workflows to discover valid names"),
+			"name":           stringProperty("Name of the workflow to delete. Use list_workflows to discover valid names"),
 		}, []string{"namespace_name", "name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`
-		Name  string `json:"name"`
+		Name          string `json:"name"`
 	}) (*mcp.CallToolResult, any, error) {
 		result, err := t.PEToolset.DeleteWorkflow(ctx, args.NamespaceName, args.Name)
 		return handleToolResult(result, err)

--- a/pkg/mcp/tools/pe_specs_test.go
+++ b/pkg/mcp/tools/pe_specs_test.go
@@ -174,10 +174,10 @@ func peEnvironmentSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "environment"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "env_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"env_name":       testEnvName,
+				"name":           testEnvName,
 			},
 			expectedMethod: "DeleteEnvironment",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -232,10 +232,10 @@ func pePipelineSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "deployment", "pipeline"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "pipeline_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"pipeline_name":  "my-pipeline",
+				"name":           "my-pipeline",
 			},
 			expectedMethod: "DeleteDeploymentPipeline",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -613,7 +613,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":        testWebAppType,
+				"name":           testWebAppType,
 			},
 			expectedMethod: "GetComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -630,7 +630,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":        testWebAppType,
+				"name":           testWebAppType,
 			},
 			expectedMethod: "GetComponentTypeSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -664,7 +664,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":     testAutoscalingTrait,
+				"name":           testAutoscalingTrait,
 			},
 			expectedMethod: "GetTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -681,7 +681,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":     testAutoscalingTrait,
+				"name":           testAutoscalingTrait,
 			},
 			expectedMethod: "GetTraitSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -715,7 +715,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":  testBuildWorkflow,
+				"name":           testBuildWorkflow,
 			},
 			expectedMethod: "GetWorkflow",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -732,7 +732,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":  testBuildWorkflow,
+				"name":           testBuildWorkflow,
 			},
 			expectedMethod: "GetWorkflowSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -831,7 +831,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":        "my-component-type",
+				"name":           "my-component-type",
 			},
 			expectedMethod: "DeleteComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -886,7 +886,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":     "my-trait",
+				"name":           "my-trait",
 			},
 			expectedMethod: "DeleteTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -941,7 +941,7 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"name":  testBuildWorkflow,
+				"name":           testBuildWorkflow,
 			},
 			expectedMethod: "DeleteWorkflow",
 			validateCall: func(t *testing.T, args []interface{}) {

--- a/pkg/mcp/tools/pe_specs_test.go
+++ b/pkg/mcp/tools/pe_specs_test.go
@@ -379,9 +379,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"cluster", "component", "type"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cct_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"cct_name": testGoServiceName,
+				"name": testGoServiceName,
 			},
 			expectedMethod: "GetClusterComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -395,9 +395,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"cluster", "component", "type", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cct_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"cct_name": testGoServiceName,
+				"name": testGoServiceName,
 			},
 			expectedMethod: "GetClusterComponentTypeSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -423,9 +423,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"cluster", "trait"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"ct_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"ct_name": testAutoscalerName,
+				"name": testAutoscalerName,
 			},
 			expectedMethod: "GetClusterTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -439,9 +439,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"cluster", "trait", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"ct_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"ct_name": testAutoscalerName,
+				"name": testAutoscalerName,
 			},
 			expectedMethod: "GetClusterTraitSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -484,9 +484,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "cluster", "component", "type"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cct_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"cct_name": testGoServiceName,
+				"name": testGoServiceName,
 			},
 			expectedMethod: "DeleteClusterComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -528,9 +528,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "cluster", "trait"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"ct_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"ct_name": testAutoscalerName,
+				"name": testAutoscalerName,
 			},
 			expectedMethod: "DeleteClusterTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -572,9 +572,9 @@ func peClusterPlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "cluster", "workflow"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"cwf_name"},
+			requiredParams:      []string{"name"},
 			testArgs: map[string]any{
-				"cwf_name": testBuildWorkflow,
+				"name": testBuildWorkflow,
 			},
 			expectedMethod: "DeleteClusterWorkflow",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -610,10 +610,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"component", "type", "spec"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "ct_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"ct_name":        testWebAppType,
+				"name":        testWebAppType,
 			},
 			expectedMethod: "GetComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -627,10 +627,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"component", "type", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "ct_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"ct_name":        testWebAppType,
+				"name":        testWebAppType,
 			},
 			expectedMethod: "GetComponentTypeSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -661,10 +661,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"trait", "spec"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "trait_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"trait_name":     testAutoscalingTrait,
+				"name":     testAutoscalingTrait,
 			},
 			expectedMethod: "GetTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -678,10 +678,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"trait", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "trait_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"trait_name":     testAutoscalingTrait,
+				"name":     testAutoscalingTrait,
 			},
 			expectedMethod: "GetTraitSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -712,10 +712,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"workflow", "spec"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "workflow_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"workflow_name":  testBuildWorkflow,
+				"name":  testBuildWorkflow,
 			},
 			expectedMethod: "GetWorkflow",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -729,10 +729,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"workflow", "schema"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "workflow_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"workflow_name":  testBuildWorkflow,
+				"name":  testBuildWorkflow,
 			},
 			expectedMethod: "GetWorkflowSchema",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -828,10 +828,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "component", "type"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "ct_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"ct_name":        "my-component-type",
+				"name":        "my-component-type",
 			},
 			expectedMethod: "DeleteComponentType",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -883,10 +883,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "trait"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "trait_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"trait_name":     "my-trait",
+				"name":     "my-trait",
 			},
 			expectedMethod: "DeleteTrait",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -938,10 +938,10 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 			toolset:             "pe",
 			descriptionKeywords: []string{"delete", "workflow"},
 			descriptionMinLen:   10,
-			requiredParams:      []string{"namespace_name", "workflow_name"},
+			requiredParams:      []string{"namespace_name", "name"},
 			testArgs: map[string]any{
 				"namespace_name": testNamespaceName,
-				"workflow_name":  testBuildWorkflow,
+				"name":  testBuildWorkflow,
 			},
 			expectedMethod: "DeleteWorkflow",
 			validateCall: func(t *testing.T, args []interface{}) {
@@ -955,6 +955,23 @@ func pePlatformStandardsSpecs() []toolTestSpec {
 
 func peDiagnosticsSpecs() []toolTestSpec {
 	return []toolTestSpec{
+		{
+			name:                "get_resource_tree",
+			toolset:             "pe",
+			descriptionKeywords: []string{"rendered", "resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "release_binding_name"},
+			testArgs: map[string]any{
+				"namespace_name":       testNamespaceName,
+				"release_binding_name": "binding-dev",
+			},
+			expectedMethod: "GetResourceTree",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
 		{
 			name:                "get_resource_events",
 			toolset:             "pe",
@@ -1023,21 +1040,21 @@ func TestComponentToolsetClosuresInPEFile(t *testing.T) {
 		{"list_component_types", map[string]any{"namespace_name": testNamespaceName}, "ListComponentTypes"},
 		{
 			"get_component_type_schema",
-			map[string]any{"namespace_name": testNamespaceName, "ct_name": testWebAppType},
+			map[string]any{"namespace_name": testNamespaceName, "name": testWebAppType},
 			"GetComponentTypeSchema",
 		},
 		{"list_traits", map[string]any{"namespace_name": testNamespaceName}, "ListTraits"},
 		{
 			"get_trait_schema",
-			map[string]any{"namespace_name": testNamespaceName, "trait_name": testAutoscalingTrait},
+			map[string]any{"namespace_name": testNamespaceName, "name": testAutoscalingTrait},
 			"GetTraitSchema",
 		},
 		{"list_cluster_component_types", map[string]any{}, "ListClusterComponentTypes"},
-		{"get_cluster_component_type", map[string]any{"cct_name": testGoServiceName}, "GetClusterComponentType"},
-		{"get_cluster_component_type_schema", map[string]any{"cct_name": testGoServiceName}, "GetClusterComponentTypeSchema"},
+		{"get_cluster_component_type", map[string]any{"name": testGoServiceName}, "GetClusterComponentType"},
+		{"get_cluster_component_type_schema", map[string]any{"name": testGoServiceName}, "GetClusterComponentTypeSchema"},
 		{"list_cluster_traits", map[string]any{}, "ListClusterTraits"},
-		{"get_cluster_trait", map[string]any{"ct_name": testAutoscalerName}, "GetClusterTrait"},
-		{"get_cluster_trait_schema", map[string]any{"ct_name": testAutoscalerName}, "GetClusterTraitSchema"},
+		{"get_cluster_trait", map[string]any{"name": testAutoscalerName}, "GetClusterTrait"},
+		{"get_cluster_trait_schema", map[string]any{"name": testAutoscalerName}, "GetClusterTraitSchema"},
 	}
 
 	for _, tt := range tests {
@@ -1080,7 +1097,7 @@ func TestBuildToolsetClosuresInPEFile(t *testing.T) {
 		{"list_workflows", map[string]any{"namespace_name": testNamespaceName}, "ListWorkflows"},
 		{
 			"get_workflow_schema",
-			map[string]any{"namespace_name": testNamespaceName, "workflow_name": testBuildWorkflow},
+			map[string]any{"namespace_name": testNamespaceName, "name": testBuildWorkflow},
 			"GetWorkflowSchema",
 		},
 	}

--- a/pkg/mcp/tools/project.go
+++ b/pkg/mcp/tools/project.go
@@ -20,7 +20,7 @@ func (t *Toolsets) RegisterListProjects(s *mcp.Server, perms map[string]ToolPerm
 		Description: "List all projects in an namespace. Projects are logical groupings of related " +
 			"components that share deployment pipelines. Supports pagination via limit and cursor.",
 		InputSchema: createSchema(addPaginationProperties(map[string]any{
-			"namespace_name": stringProperty("Use get_namespace to discover valid names"),
+			"namespace_name": stringProperty("Use list_namespaces to discover valid names"),
 		}), []string{"namespace_name"}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
 		NamespaceName string `json:"namespace_name"`

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -182,6 +182,7 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 		t.RegisterDeleteClusterWorkflow,
 
 		// Diagnostics
+		t.RegisterGetResourceTree,
 		t.RegisterGetResourceEvents,
 		t.RegisterGetResourceLogs,
 	}

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -186,6 +186,7 @@ type PEToolsetHandler interface {
 	DeleteClusterWorkflow(ctx context.Context, clusterWorkflowName string) (any, error)
 
 	// Diagnostics
+	GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (any, error)
 	GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName,
 		group, version, kind, name string) (any, error)
 	GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName,

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -226,7 +226,7 @@ type ComponentToolsetHandler interface {
 	PatchComponent(
 		ctx context.Context, namespaceName, componentName string, req *gen.PatchComponentRequest,
 	) (any, error)
-	ListWorkloads(ctx context.Context, namespaceName, componentName string) (any, error)
+	ListWorkloads(ctx context.Context, namespaceName, componentName string, opts ListOpts) (any, error)
 	GetWorkload(ctx context.Context, namespaceName, workloadName string) (any, error)
 	CreateWorkload(
 		ctx context.Context, namespaceName, componentName string, workloadSpec any,


### PR DESCRIPTION
## Summary

Follow-on improvements to the MCP server tool surface after #3389.

**`feat: add get_resource_tree and align per-resource name params`**
- New `get_resource_tree` MCP tool — wires `K8sResourcesService.GetResourceTree` through MCP so agents can discover rendered K8s resource names before calling `get_resource_events` / `get_resource_logs`. Curated transform keeps responses small.
- Per-resource `get_*` / `delete_*` / `update_*` tools (and `create_workflow_run`) now take the resource name as `name`. Replaces `cct_name` / `cwf_name` / `ct_name` / `trait_name` / `workflow_name`.

**`fix: mcp updates`**
- `list_workloads` supports `limit` / `cursor` pagination.
- `list_projects` description points at `list_namespaces` (was `get_namespace`).
- `get_deployment_pipeline` and `delete_deployment_pipeline` take `name`, matching `update_deployment_pipeline`.
- `releaseBindingSummary` exposes `endpoints`, `connectionTargets`, `resolvedConnections`, `pendingConnections` so triage doesn't need an extra `get_release_binding` per binding.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/mcp/tools/... ./internal/openchoreo-api/mcphandlers/...`
- [x] `make lint`