### PR TITLE
feat(cli): add occ secret get, list, create, delete commands

### DIFF
--- a/internal/occ/cmd/secret/cmd.go
+++ b/internal/occ/cmd/secret/cmd.go
@@ -1,0 +1,238 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/auth"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/flags"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+)
+
+// NewSecretCmd returns the root `occ secret` command.
+func NewSecretCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "secret",
+		Aliases: []string{"secrets"},
+		Short:   "Manage user workload secrets",
+		Long:    "Manage secrets that are pushed to a target plane's external secret store.",
+	}
+	cmd.AddCommand(
+		newListCmd(f),
+		newGetCmd(f),
+		newDeleteCmd(f),
+		newCreateCmd(f),
+	)
+	return cmd
+}
+
+func newListCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List secrets",
+		Long:  "List secrets in a namespace. Only secrets that target a plane are shown.",
+		Example: `  # List all secrets in a namespace
+  occ secret list --namespace acme-corp`,
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).List(ListParams{
+				Namespace: flags.GetNamespace(cmd),
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newGetCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [SECRET_NAME]",
+		Short: "Get a secret",
+		Long:  "Get a secret and display its details in YAML format.",
+		Example: `  # Get a secret
+  occ secret get my-secret --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Get(GetParams{
+				Namespace:  flags.GetNamespace(cmd),
+				SecretName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [SECRET_NAME]",
+		Short: "Delete a secret",
+		Long:  "Delete a secret from the control plane and the target plane.",
+		Example: `  # Delete a secret
+  occ secret delete my-secret --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Delete(DeleteParams{
+				Namespace:  flags.GetNamespace(cmd),
+				SecretName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newCreateCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a secret",
+		Long:  "Create a secret of the specified type on a target plane.",
+	}
+	cmd.AddCommand(
+		newCreateGenericCmd(f),
+		newCreateDockerRegistryCmd(f),
+		newCreateTLSCmd(f),
+	)
+	return cmd
+}
+
+// addCommonCreateFlags wires the flags shared by every `create` subcommand.
+func addCommonCreateFlags(cmd *cobra.Command) {
+	flags.AddNamespace(cmd)
+	cmd.Flags().String("target-plane", "", "Target plane in Kind/Name form (e.g. DataPlane/dp-prod)")
+}
+
+func readCreateInput(cmd *cobra.Command, args []string) CreateInput {
+	literals, _ := cmd.Flags().GetStringArray("from-literal")
+	files, _ := cmd.Flags().GetStringArray("from-file")
+	envFiles, _ := cmd.Flags().GetStringArray("from-env-file")
+	targetPlane, _ := cmd.Flags().GetString("target-plane")
+
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	return CreateInput{
+		Namespace:   flags.GetNamespace(cmd),
+		SecretName:  name,
+		TargetPlane: targetPlane,
+		FromLiteral: literals,
+		FromFile:    files,
+		FromEnvFile: envFiles,
+	}
+}
+
+func newCreateGenericCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generic [SECRET_NAME]",
+		Short: "Create a generic (Opaque) secret",
+		Long: `Create an Opaque secret from literals, files, or env files.
+
+Use --type to create a typed Kubernetes secret (e.g. kubernetes.io/basic-auth,
+kubernetes.io/ssh-auth) while still sourcing data the same way.`,
+		Example: `  # Create an Opaque secret from literal values
+  occ secret create generic db-creds \
+    --namespace acme-corp \
+    --target-plane DataPlane/dp-prod \
+    --from-literal=username=admin \
+    --from-literal=password=s3cret
+
+  # Create a basic-auth secret
+  occ secret create generic basic --type=kubernetes.io/basic-auth \
+    --namespace acme-corp --target-plane DataPlane/dp-prod \
+    --from-literal=username=admin --from-literal=password=s3cret`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			st, _ := cmd.Flags().GetString("type")
+			return New(cl).CreateGeneric(readCreateInput(cmd, args), st)
+		},
+	}
+	addCommonCreateFlags(cmd)
+	cmd.Flags().StringArray("from-literal", nil, "Key=value literal (repeatable)")
+	cmd.Flags().StringArray("from-file", nil, "Key=path or path (repeatable). Key defaults to the filename.")
+	cmd.Flags().StringArray("from-env-file", nil, "Path to a KEY=VALUE env file (repeatable)")
+	cmd.Flags().String("type", "", "Kubernetes secret type override (e.g. kubernetes.io/basic-auth)")
+	return cmd
+}
+
+func newCreateDockerRegistryCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "docker-registry [SECRET_NAME]",
+		Short: "Create a Docker registry credentials secret",
+		Long:  "Create a kubernetes.io/dockerconfigjson secret from registry credentials.",
+		Example: `  # Create a Docker registry secret
+  occ secret create docker-registry regcred \
+    --namespace acme-corp --target-plane DataPlane/dp-prod \
+    --docker-server=https://index.docker.io/v1/ \
+    --docker-username=jdoe --docker-password=hunter2 \
+    --docker-email=jdoe@example.com`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			server, _ := cmd.Flags().GetString("docker-server")
+			user, _ := cmd.Flags().GetString("docker-username")
+			pass, _ := cmd.Flags().GetString("docker-password")
+			email, _ := cmd.Flags().GetString("docker-email")
+			return New(cl).CreateDockerRegistry(readCreateInput(cmd, args), server, user, pass, email)
+		},
+	}
+	addCommonCreateFlags(cmd)
+	cmd.Flags().String("docker-server", "", "Docker registry server URL")
+	cmd.Flags().String("docker-username", "", "Docker registry username")
+	cmd.Flags().String("docker-password", "", "Docker registry password")
+	cmd.Flags().String("docker-email", "", "Docker registry email (optional)")
+	return cmd
+}
+
+func newCreateTLSCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tls [SECRET_NAME]",
+		Short: "Create a TLS secret",
+		Long:  "Create a kubernetes.io/tls secret from a certificate and key pair.",
+		Example: `  # Create a TLS secret
+  occ secret create tls my-tls \
+    --namespace acme-corp --target-plane DataPlane/dp-prod \
+    --cert=./tls.crt --key=./tls.key`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			cert, _ := cmd.Flags().GetString("cert")
+			key, _ := cmd.Flags().GetString("key")
+			return New(cl).CreateTLS(readCreateInput(cmd, args), cert, key)
+		},
+	}
+	addCommonCreateFlags(cmd)
+	cmd.Flags().String("cert", "", "Path to PEM-encoded certificate file")
+	cmd.Flags().String("key", "", "Path to PEM-encoded private key file")
+	return cmd
+}

--- a/internal/occ/cmd/secret/cmd.go
+++ b/internal/occ/cmd/secret/cmd.go
@@ -17,7 +17,7 @@ func NewSecretCmd(f client.NewClientFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "secret",
 		Aliases: []string{"secrets"},
-		Short:   "Manage user workload secrets",
+		Short:   "Manage secrets",
 		Long:    "Manage secrets that are pushed to a target plane's external secret store.",
 	}
 	cmd.AddCommand(
@@ -33,7 +33,7 @@ func newListCmd(f client.NewClientFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List secrets",
-		Long:  "List secrets in a namespace. Only secrets that target a plane are shown.",
+		Long:  "List secrets in a namespace.",
 		Example: `  # List all secrets in a namespace
   occ secret list --namespace acme-corp`,
 		PreRunE: auth.RequireLogin(),
@@ -79,7 +79,7 @@ func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete [SECRET_NAME]",
 		Short: "Delete a secret",
-		Long:  "Delete a secret from the control plane and the target plane.",
+		Long:  "Delete a secret from the external secret store.",
 		Example: `  # Delete a secret
   occ secret delete my-secret --namespace acme-corp`,
 		Args:    cmdutil.ExactOneArgWithUsage(),

--- a/internal/occ/cmd/secret/cmd_test.go
+++ b/internal/occ/cmd/secret/cmd_test.go
@@ -68,6 +68,12 @@ func TestListCmd_FactoryError(t *testing.T) {
 func TestListCmd_Success(t *testing.T) {
 	mc := mocks.NewMockInterface(t)
 	tp := &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: "dp-prod"}
+	mc.EXPECT().ListSecrets(mock.Anything, mock.Anything, mock.Anything).Return(&gen.ListSecretsResponse{
+		Items: []gen.Secret{
+			{Metadata: gen.ObjectMeta{Name: "my-secret"}, Type: "Opaque"},
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
 	mc.EXPECT().ListSecretReferences(mock.Anything, mock.Anything, mock.Anything).Return(&gen.SecretReferenceList{
 		Items: []gen.SecretReference{
 			{Metadata: gen.ObjectMeta{Name: "my-secret"}, Spec: &gen.SecretReferenceSpec{TargetPlane: tp}},
@@ -101,12 +107,8 @@ func TestGetCmd_FactoryError(t *testing.T) {
 
 func TestGetCmd_Success(t *testing.T) {
 	mc := mocks.NewMockInterface(t)
-	tp := &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: "dp-prod"}
-	mc.EXPECT().GetSecretReference(mock.Anything, mock.Anything, "my-secret").Return(
-		&gen.SecretReference{
-			Metadata: gen.ObjectMeta{Name: "my-secret"},
-			Spec:     &gen.SecretReferenceSpec{TargetPlane: tp},
-		}, nil,
+	mc.EXPECT().GetSecret(mock.Anything, mock.Anything, "my-secret").Return(
+		&gen.Secret{Metadata: gen.ObjectMeta{Name: "my-secret"}, Type: "Opaque"}, nil,
 	)
 
 	cmd := newGetCmd(mockFactory(mc))

--- a/internal/occ/cmd/secret/cmd_test.go
+++ b/internal/occ/cmd/secret/cmd_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return mc, nil
+	}
+}
+
+func errFactory(msg string) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+// --- root cmd structure ---
+
+func TestNewSecretCmd_Use(t *testing.T) {
+	cmd := NewSecretCmd(errFactory("unused"))
+	assert.Equal(t, "secret", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "secrets")
+}
+
+func TestNewSecretCmd_Subcommands(t *testing.T) {
+	cmd := NewSecretCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "delete", "create"}, names)
+}
+
+func TestCreateCmd_Subcommands(t *testing.T) {
+	cmd := newCreateCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"generic", "docker-registry", "tls"}, names)
+}
+
+// --- list ---
+
+func TestListCmd_FactoryError(t *testing.T) {
+	cmd := newListCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, nil)
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestListCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	tp := &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: "dp-prod"}
+	mc.EXPECT().ListSecretReferences(mock.Anything, mock.Anything, mock.Anything).Return(&gen.SecretReferenceList{
+		Items: []gen.SecretReference{
+			{Metadata: gen.ObjectMeta{Name: "my-secret"}, Spec: &gen.SecretReferenceSpec{TargetPlane: tp}},
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	cmd := newListCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	})
+	assert.Contains(t, out, "my-secret")
+	assert.Contains(t, out, "DataPlane/dp-prod")
+}
+
+// --- get ---
+
+func TestGetCmd_MissingArg(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SECRET_NAME")
+}
+
+func TestGetCmd_FactoryError(t *testing.T) {
+	cmd := newGetCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"my-secret"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestGetCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	tp := &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: "dp-prod"}
+	mc.EXPECT().GetSecretReference(mock.Anything, mock.Anything, "my-secret").Return(
+		&gen.SecretReference{
+			Metadata: gen.ObjectMeta{Name: "my-secret"},
+			Spec:     &gen.SecretReferenceSpec{TargetPlane: tp},
+		}, nil,
+	)
+
+	cmd := newGetCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"my-secret"}))
+	})
+	assert.Contains(t, out, "name: my-secret")
+}
+
+// --- delete ---
+
+func TestDeleteCmd_MissingArg(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SECRET_NAME")
+}
+
+func TestDeleteCmd_FactoryError(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"my-secret"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestDeleteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteSecret(mock.Anything, "acme-corp", "my-secret").Return(nil)
+
+	cmd := newDeleteCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"my-secret"}))
+	})
+	assert.Contains(t, out, "deleted")
+}
+
+// --- create generic ---
+
+func TestCreateGenericCmd_MissingArg(t *testing.T) {
+	cmd := newCreateGenericCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SECRET_NAME")
+}
+
+func TestCreateGenericCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "acme-corp", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		return req.SecretName == "db-creds" &&
+			req.SecretType == gen.SecretTypeOpaque &&
+			req.TargetPlane.Kind == gen.TargetPlaneRefKindDataPlane &&
+			req.TargetPlane.Name == "dp-prod" &&
+			req.Data["username"] == "admin" &&
+			req.Data["password"] == "s3cret"
+	})).Return(&gen.Secret{}, nil)
+
+	cmd := newCreateGenericCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	require.NoError(t, cmd.Flags().Set("target-plane", "DataPlane/dp-prod"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "username=admin"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "password=s3cret"))
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"db-creds"}))
+	})
+	assert.Contains(t, out, "created")
+}
+
+// --- create docker-registry ---
+
+func TestCreateDockerRegistryCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "acme-corp", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		_, ok := req.Data[".dockerconfigjson"]
+		return req.SecretType == gen.SecretTypeKubernetesIodockerconfigjson && ok
+	})).Return(&gen.Secret{}, nil)
+
+	cmd := newCreateDockerRegistryCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	require.NoError(t, cmd.Flags().Set("target-plane", "DataPlane/dp-prod"))
+	require.NoError(t, cmd.Flags().Set("docker-server", "https://index.docker.io/v1/"))
+	require.NoError(t, cmd.Flags().Set("docker-username", "jdoe"))
+	require.NoError(t, cmd.Flags().Set("docker-password", "hunter2"))
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"regcred"}))
+	})
+	assert.Contains(t, out, "created")
+}
+
+// --- create tls ---
+
+func TestCreateTLSCmd_Success(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(certPath, []byte("CERT"), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, []byte("KEY"), 0o600))
+
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "acme-corp", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		return req.SecretType == gen.SecretTypeKubernetesIotls &&
+			req.Data["tls.crt"] == "CERT" &&
+			req.Data["tls.key"] == "KEY"
+	})).Return(&gen.Secret{}, nil)
+
+	cmd := newCreateTLSCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	require.NoError(t, cmd.Flags().Set("target-plane", "DataPlane/dp-prod"))
+	require.NoError(t, cmd.Flags().Set("cert", certPath))
+	require.NoError(t, cmd.Flags().Set("key", keyPath))
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"my-tls"}))
+	})
+	assert.Contains(t, out, "created")
+}

--- a/internal/occ/cmd/secret/cmd_test.go
+++ b/internal/occ/cmd/secret/cmd_test.go
@@ -66,15 +66,16 @@ func TestListCmd_FactoryError(t *testing.T) {
 }
 
 func TestListCmd_Success(t *testing.T) {
+	const ns = "acme-corp"
 	mc := mocks.NewMockInterface(t)
 	tp := &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: "dp-prod"}
-	mc.EXPECT().ListSecrets(mock.Anything, mock.Anything, mock.Anything).Return(&gen.ListSecretsResponse{
+	mc.EXPECT().ListSecrets(mock.Anything, ns, mock.Anything).Return(&gen.ListSecretsResponse{
 		Items: []gen.Secret{
 			{Metadata: gen.ObjectMeta{Name: "my-secret"}, Type: "Opaque"},
 		},
 		Pagination: gen.Pagination{},
 	}, nil)
-	mc.EXPECT().ListSecretReferences(mock.Anything, mock.Anything, mock.Anything).Return(&gen.SecretReferenceList{
+	mc.EXPECT().ListSecretReferences(mock.Anything, ns, mock.Anything).Return(&gen.SecretReferenceList{
 		Items: []gen.SecretReference{
 			{Metadata: gen.ObjectMeta{Name: "my-secret"}, Spec: &gen.SecretReferenceSpec{TargetPlane: tp}},
 		},
@@ -82,7 +83,7 @@ func TestListCmd_Success(t *testing.T) {
 	}, nil)
 
 	cmd := newListCmd(mockFactory(mc))
-	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	require.NoError(t, cmd.Flags().Set("namespace", ns))
 	out := testutil.CaptureStdout(t, func() {
 		require.NoError(t, cmd.RunE(cmd, nil))
 	})

--- a/internal/occ/cmd/secret/fromsource.go
+++ b/internal/occ/cmd/secret/fromsource.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// parseTargetPlane parses a "Kind/Name" string into a TargetPlaneRef.
+func parseTargetPlane(raw string) (*gen.TargetPlaneRef, error) {
+	parts := strings.SplitN(raw, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid --target-plane %q: expected Kind/Name (e.g. DataPlane/dp-prod)", raw)
+	}
+	kind := parts[0]
+	switch gen.TargetPlaneRefKind(kind) {
+	case gen.TargetPlaneRefKindDataPlane,
+		gen.TargetPlaneRefKindClusterDataPlane,
+		gen.TargetPlaneRefKindWorkflowPlane,
+		gen.TargetPlaneRefKindClusterWorkflowPlane:
+	default:
+		return nil, fmt.Errorf("invalid --target-plane kind %q: must be one of DataPlane, ClusterDataPlane, WorkflowPlane, ClusterWorkflowPlane", kind)
+	}
+	return &gen.TargetPlaneRef{
+		Kind: gen.TargetPlaneRefKind(kind),
+		Name: parts[1],
+	}, nil
+}
+
+// collectData merges --from-literal, --from-file, and --from-env-file inputs
+// into a single map. Later sources override earlier ones, matching kubectl behavior.
+func collectData(literals, files, envFiles []string) (map[string]string, error) {
+	data := map[string]string{}
+
+	for _, lit := range literals {
+		k, v, err := parseLiteral(lit)
+		if err != nil {
+			return nil, err
+		}
+		data[k] = v
+	}
+
+	for _, f := range files {
+		k, v, err := readFile(f)
+		if err != nil {
+			return nil, err
+		}
+		data[k] = v
+	}
+
+	for _, ef := range envFiles {
+		entries, err := readEnvFile(ef)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range entries {
+			data[k] = v
+		}
+	}
+
+	return data, nil
+}
+
+func parseLiteral(s string) (string, string, error) {
+	idx := strings.Index(s, "=")
+	if idx <= 0 {
+		return "", "", fmt.Errorf("invalid --from-literal %q: expected key=value", s)
+	}
+	return s[:idx], s[idx+1:], nil
+}
+
+// readFile parses a --from-file value: either "key=path" or "path" (key inferred
+// from the filename).
+func readFile(s string) (string, string, error) {
+	var key, path string
+	if idx := strings.Index(s, "="); idx > 0 {
+		key = s[:idx]
+		path = s[idx+1:]
+	} else {
+		path = s
+		key = filepath.Base(s)
+	}
+	if path == "" {
+		return "", "", fmt.Errorf("invalid --from-file %q: missing path", s)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", fmt.Errorf("read --from-file %s: %w", path, err)
+	}
+	return key, string(b), nil
+}
+
+// readEnvFile parses a KEY=VALUE file. Blank lines and lines starting with '#'
+// are ignored.
+func readEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --from-env-file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	out := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.Index(line, "=")
+		if idx <= 0 {
+			return nil, fmt.Errorf("--from-env-file %s: line %d: expected KEY=VALUE", path, lineNo)
+		}
+		out[line[:idx]] = line[idx+1:]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read --from-env-file %s: %w", path, err)
+	}
+	return out, nil
+}

--- a/internal/occ/cmd/secret/params.go
+++ b/internal/occ/cmd/secret/params.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+// ListParams defines parameters for listing secrets.
+type ListParams struct {
+	Namespace string
+}
+
+func (p ListParams) GetNamespace() string { return p.Namespace }
+
+// GetParams defines parameters for getting a single secret.
+type GetParams struct {
+	Namespace  string
+	SecretName string
+}
+
+func (p GetParams) GetNamespace() string  { return p.Namespace }
+func (p GetParams) GetSecretName() string { return p.SecretName }
+
+// DeleteParams defines parameters for deleting a secret.
+type DeleteParams struct {
+	Namespace  string
+	SecretName string
+}
+
+func (p DeleteParams) GetNamespace() string  { return p.Namespace }
+func (p DeleteParams) GetSecretName() string { return p.SecretName }
+
+// CreateInput is the shared parsed input for all create subcommands.
+type CreateInput struct {
+	Namespace   string
+	SecretName  string
+	TargetPlane string // raw "Kind/Name"
+	FromLiteral []string
+	FromFile    []string
+	FromEnvFile []string
+}

--- a/internal/occ/cmd/secret/secret.go
+++ b/internal/occ/cmd/secret/secret.go
@@ -1,0 +1,286 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// Secret implements user-workload secret operations. Read paths (list, get)
+// use the SecretReference API and surface only references that target a plane.
+// Write paths (create, delete) call the secret API which provisions or removes
+// the secret on the target plane's external secret store.
+type Secret struct {
+	client client.Interface
+}
+
+// New creates a new Secret implementation.
+func New(c client.Interface) *Secret {
+	return &Secret{client: c}
+}
+
+// List lists secrets in a namespace by enumerating SecretReferences whose
+// spec.targetPlane is set.
+func (s *Secret) List(params ListParams) error {
+	if err := cmdutil.RequireFields("list", "secret", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.SecretReference, string, error) {
+		p := &gen.ListSecretReferencesParams{}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := s.client.ListSecretReferences(ctx, params.Namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+	return printList(filterTargeted(items))
+}
+
+// Get retrieves a single secret (via its SecretReference) and outputs it as YAML.
+// Only references with spec.targetPlane set are considered user-workload secrets.
+func (s *Secret) Get(params GetParams) error {
+	if err := cmdutil.RequireFields("get", "secret", map[string]string{
+		"namespace": params.Namespace,
+		"name":      params.SecretName,
+	}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	result, err := s.client.GetSecretReference(ctx, params.Namespace, params.SecretName)
+	if err != nil {
+		return err
+	}
+	if result.Spec == nil || result.Spec.TargetPlane == nil {
+		return fmt.Errorf("secret %q not found", params.SecretName)
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal secret to YAML: %w", err)
+	}
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete removes a secret from the control plane and the target plane.
+func (s *Secret) Delete(params DeleteParams) error {
+	if err := cmdutil.RequireFields("delete", "secret", map[string]string{
+		"namespace": params.Namespace,
+		"name":      params.SecretName,
+	}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	if err := s.client.DeleteSecret(ctx, params.Namespace, params.SecretName); err != nil {
+		return err
+	}
+	fmt.Printf("Secret '%s' deleted\n", params.SecretName)
+	return nil
+}
+
+// CreateGeneric creates an Opaque secret (or basic-auth / ssh-auth via the
+// optional secretType override).
+func (s *Secret) CreateGeneric(in CreateInput, secretType string) error {
+	if err := requireCreateFields(in); err != nil {
+		return err
+	}
+
+	tp, err := parseTargetPlane(in.TargetPlane)
+	if err != nil {
+		return err
+	}
+
+	data, err := collectData(in.FromLiteral, in.FromFile, in.FromEnvFile)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("at least one of --from-literal, --from-file, or --from-env-file is required")
+	}
+
+	st := gen.SecretTypeOpaque
+	if secretType != "" {
+		st = gen.SecretType(secretType)
+	}
+	return s.create(in.Namespace, in.SecretName, st, *tp, data)
+}
+
+// CreateDockerRegistry creates a kubernetes.io/dockerconfigjson secret.
+func (s *Secret) CreateDockerRegistry(in CreateInput, server, username, password, email string) error {
+	if err := requireCreateFields(in); err != nil {
+		return err
+	}
+	missing := map[string]string{
+		"docker-server":   server,
+		"docker-username": username,
+		"docker-password": password,
+	}
+	if err := cmdutil.RequireFields("create docker-registry", "secret", missing); err != nil {
+		return err
+	}
+
+	tp, err := parseTargetPlane(in.TargetPlane)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := buildDockerConfigJSON(server, username, password, email)
+	if err != nil {
+		return err
+	}
+	data := map[string]string{".dockerconfigjson": cfg}
+
+	return s.create(in.Namespace, in.SecretName, gen.SecretTypeKubernetesIodockerconfigjson, *tp, data)
+}
+
+// CreateTLS creates a kubernetes.io/tls secret from a cert/key pair.
+func (s *Secret) CreateTLS(in CreateInput, certPath, keyPath string) error {
+	if err := requireCreateFields(in); err != nil {
+		return err
+	}
+	if err := cmdutil.RequireFields("create tls", "secret", map[string]string{
+		"cert": certPath,
+		"key":  keyPath,
+	}); err != nil {
+		return err
+	}
+
+	tp, err := parseTargetPlane(in.TargetPlane)
+	if err != nil {
+		return err
+	}
+
+	cert, err := os.ReadFile(certPath)
+	if err != nil {
+		return fmt.Errorf("read --cert %s: %w", certPath, err)
+	}
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("read --key %s: %w", keyPath, err)
+	}
+	data := map[string]string{
+		"tls.crt": string(cert),
+		"tls.key": string(key),
+	}
+
+	return s.create(in.Namespace, in.SecretName, gen.SecretTypeKubernetesIotls, *tp, data)
+}
+
+func (s *Secret) create(namespace, name string, st gen.SecretType, tp gen.TargetPlaneRef, data map[string]string) error {
+	ctx := context.Background()
+	req := gen.CreateSecretRequest{
+		SecretName:  name,
+		SecretType:  st,
+		TargetPlane: tp,
+		Data:        data,
+	}
+	resp, err := s.client.CreateSecret(ctx, namespace, req)
+	if err != nil {
+		return err
+	}
+	respName := name
+	if resp != nil && resp.Metadata.Name != "" {
+		respName = resp.Metadata.Name
+	}
+	fmt.Printf("Secret '%s' created\n", respName)
+	return nil
+}
+
+func requireCreateFields(in CreateInput) error {
+	return cmdutil.RequireFields("create", "secret", map[string]string{
+		"namespace":    in.Namespace,
+		"name":         in.SecretName,
+		"target-plane": in.TargetPlane,
+	})
+}
+
+// buildDockerConfigJSON returns the JSON payload stored under ".dockerconfigjson"
+// for a kubernetes.io/dockerconfigjson secret.
+func buildDockerConfigJSON(server, username, password, email string) (string, error) {
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	entry := map[string]string{
+		"username": username,
+		"password": password,
+		"auth":     auth,
+	}
+	if email != "" {
+		entry["email"] = email
+	}
+	cfg := map[string]map[string]map[string]string{
+		"auths": {server: entry},
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("encode docker config: %w", err)
+	}
+	return string(b), nil
+}
+
+// filterTargeted keeps only SecretReferences that target a specific plane.
+func filterTargeted(items []gen.SecretReference) []gen.SecretReference {
+	out := items[:0]
+	for _, sr := range items {
+		if sr.Spec != nil && sr.Spec.TargetPlane != nil {
+			out = append(out, sr)
+		}
+	}
+	return out
+}
+
+func printList(items []gen.SecretReference) error {
+	if len(items) == 0 {
+		fmt.Println("No secrets found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tTYPE\tTARGET PLANE\tAGE")
+
+	for _, sr := range items {
+		age := "<unknown>"
+		if sr.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*sr.Metadata.CreationTimestamp)
+		}
+		secretType := ""
+		if sr.Spec != nil && sr.Spec.Template.Type != nil {
+			secretType = string(*sr.Spec.Template.Type)
+		}
+		target := ""
+		if sr.Spec != nil && sr.Spec.TargetPlane != nil {
+			target = fmt.Sprintf("%s/%s", sr.Spec.TargetPlane.Kind, sr.Spec.TargetPlane.Name)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", sr.Metadata.Name, secretType, target, age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/secret/secret.go
+++ b/internal/occ/cmd/secret/secret.go
@@ -33,8 +33,9 @@ func New(c client.Interface) *Secret {
 	return &Secret{client: c}
 }
 
-// List lists secrets in a namespace by enumerating SecretReferences whose
-// spec.targetPlane is set.
+// List lists secrets in a namespace via the Secret API. It also fetches
+// SecretReferences in the same namespace to enrich each row with the secret's
+// target plane (which is not exposed on the Secret API response shape).
 func (s *Secret) List(params ListParams) error {
 	if err := cmdutil.RequireFields("list", "secret", map[string]string{"namespace": params.Namespace}); err != nil {
 		return err
@@ -42,13 +43,13 @@ func (s *Secret) List(params ListParams) error {
 
 	ctx := context.Background()
 
-	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.SecretReference, string, error) {
-		p := &gen.ListSecretReferencesParams{}
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.Secret, string, error) {
+		p := &gen.ListSecretsParams{}
 		p.Limit = &limit
 		if cursor != "" {
 			p.Cursor = &cursor
 		}
-		result, err := s.client.ListSecretReferences(ctx, params.Namespace, p)
+		result, err := s.client.ListSecrets(ctx, params.Namespace, p)
 		if err != nil {
 			return nil, "", err
 		}
@@ -61,11 +62,16 @@ func (s *Secret) List(params ListParams) error {
 	if err != nil {
 		return err
 	}
-	return printList(filterTargeted(items))
+
+	targets, err := s.listTargetPlanes(ctx, params.Namespace)
+	if err != nil {
+		return err
+	}
+	return printList(items, targets)
 }
 
-// Get retrieves a single secret (via its SecretReference) and outputs it as YAML.
-// Only references with spec.targetPlane set are considered user-workload secrets.
+// Get retrieves a single secret via the Secret API and outputs it as YAML.
+// Values in `.data` are base64-encoded, matching kubectl's default shape.
 func (s *Secret) Get(params GetParams) error {
 	if err := cmdutil.RequireFields("get", "secret", map[string]string{
 		"namespace": params.Namespace,
@@ -75,12 +81,9 @@ func (s *Secret) Get(params GetParams) error {
 	}
 
 	ctx := context.Background()
-	result, err := s.client.GetSecretReference(ctx, params.Namespace, params.SecretName)
+	result, err := s.client.GetSecret(ctx, params.Namespace, params.SecretName)
 	if err != nil {
 		return err
-	}
-	if result.Spec == nil || result.Spec.TargetPlane == nil {
-		return fmt.Errorf("secret %q not found", params.SecretName)
 	}
 
 	data, err := yaml.Marshal(result)
@@ -89,6 +92,37 @@ func (s *Secret) Get(params GetParams) error {
 	}
 	fmt.Print(string(data))
 	return nil
+}
+
+// listTargetPlanes returns a map from secret name to "Kind/Name" target plane,
+// by enumerating SecretReferences in the namespace.
+func (s *Secret) listTargetPlanes(ctx context.Context, namespace string) (map[string]string, error) {
+	refs, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.SecretReference, string, error) {
+		p := &gen.ListSecretReferencesParams{}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := s.client.ListSecretReferences(ctx, namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(refs))
+	for _, r := range refs {
+		if r.Spec != nil && r.Spec.TargetPlane != nil {
+			out[r.Metadata.Name] = fmt.Sprintf("%s/%s", r.Spec.TargetPlane.Kind, r.Spec.TargetPlane.Name)
+		}
+	}
+	return out, nil
 }
 
 // Delete removes a secret from the control plane and the target plane.
@@ -246,18 +280,7 @@ func buildDockerConfigJSON(server, username, password, email string) (string, er
 	return string(b), nil
 }
 
-// filterTargeted keeps only SecretReferences that target a specific plane.
-func filterTargeted(items []gen.SecretReference) []gen.SecretReference {
-	out := items[:0]
-	for _, sr := range items {
-		if sr.Spec != nil && sr.Spec.TargetPlane != nil {
-			out = append(out, sr)
-		}
-	}
-	return out
-}
-
-func printList(items []gen.SecretReference) error {
+func printList(items []gen.Secret, targets map[string]string) error {
 	if len(items) == 0 {
 		fmt.Println("No secrets found")
 		return nil
@@ -266,20 +289,13 @@ func printList(items []gen.SecretReference) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NAME\tTYPE\tTARGET PLANE\tAGE")
 
-	for _, sr := range items {
+	for _, sec := range items {
 		age := "<unknown>"
-		if sr.Metadata.CreationTimestamp != nil {
-			age = utils.FormatAge(*sr.Metadata.CreationTimestamp)
+		if sec.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*sec.Metadata.CreationTimestamp)
 		}
-		secretType := ""
-		if sr.Spec != nil && sr.Spec.Template.Type != nil {
-			secretType = string(*sr.Spec.Template.Type)
-		}
-		target := ""
-		if sr.Spec != nil && sr.Spec.TargetPlane != nil {
-			target = fmt.Sprintf("%s/%s", sr.Spec.TargetPlane.Kind, sr.Spec.TargetPlane.Name)
-		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", sr.Metadata.Name, secretType, target, age)
+		target := targets[sec.Metadata.Name]
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", sec.Metadata.Name, sec.Type, target, age)
 	}
 
 	return w.Flush()

--- a/internal/occ/cmd/secret/secret_test.go
+++ b/internal/occ/cmd/secret/secret_test.go
@@ -26,44 +26,26 @@ func dataPlane(name string) *gen.TargetPlaneRef {
 	return &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: name}
 }
 
-// --- filterTargeted ---
-
-func TestFilterTargeted_KeepsOnlyTargeted(t *testing.T) {
-	in := []gen.SecretReference{
-		{Metadata: gen.ObjectMeta{Name: "a"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}},
-		{Metadata: gen.ObjectMeta{Name: "b"}, Spec: &gen.SecretReferenceSpec{}},
-		{Metadata: gen.ObjectMeta{Name: "c"}, Spec: nil},
-		{Metadata: gen.ObjectMeta{Name: "d"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp2")}},
-	}
-	out := filterTargeted(in)
-	require.Len(t, out, 2)
-	assert.Equal(t, "a", out[0].Metadata.Name)
-	assert.Equal(t, "d", out[1].Metadata.Name)
-}
-
 // --- printList ---
 
 func TestPrintList_Empty(t *testing.T) {
 	out := testutil.CaptureStdout(t, func() {
-		require.NoError(t, printList(nil))
+		require.NoError(t, printList(nil, nil))
 	})
 	assert.Contains(t, out, "No secrets found")
 }
 
 func TestPrintList_WithItems(t *testing.T) {
 	now := time.Now()
-	tlsType := gen.SecretTemplateType("kubernetes.io/tls")
-	items := []gen.SecretReference{
+	items := []gen.Secret{
 		{
 			Metadata: gen.ObjectMeta{Name: "tls-1", CreationTimestamp: &now},
-			Spec: &gen.SecretReferenceSpec{
-				TargetPlane: dataPlane("dp-prod"),
-				Template:    gen.SecretTemplate{Type: &tlsType},
-			},
+			Type:     "kubernetes.io/tls",
 		},
 	}
+	targets := map[string]string{"tls-1": "DataPlane/dp-prod"}
 	out := testutil.CaptureStdout(t, func() {
-		require.NoError(t, printList(items))
+		require.NoError(t, printList(items, targets))
 	})
 	assert.Contains(t, out, "NAME")
 	assert.Contains(t, out, "TYPE")
@@ -82,12 +64,17 @@ func TestList_ValidationError(t *testing.T) {
 	assert.ErrorContains(t, err, "Missing required parameter: --namespace")
 }
 
-func TestList_FiltersOutNonTargeted(t *testing.T) {
+func TestList_Success(t *testing.T) {
 	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListSecrets(mock.Anything, "org-a", mock.Anything).Return(&gen.ListSecretsResponse{
+		Items: []gen.Secret{
+			{Metadata: gen.ObjectMeta{Name: "api-key"}, Type: "Opaque"},
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
 	mc.EXPECT().ListSecretReferences(mock.Anything, "org-a", mock.Anything).Return(&gen.SecretReferenceList{
 		Items: []gen.SecretReference{
-			{Metadata: gen.ObjectMeta{Name: "kept"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}},
-			{Metadata: gen.ObjectMeta{Name: "dropped"}, Spec: &gen.SecretReferenceSpec{}},
+			{Metadata: gen.ObjectMeta{Name: "api-key"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}},
 		},
 		Pagination: gen.Pagination{},
 	}, nil)
@@ -95,8 +82,9 @@ func TestList_FiltersOutNonTargeted(t *testing.T) {
 	out := testutil.CaptureStdout(t, func() {
 		require.NoError(t, New(mc).List(ListParams{Namespace: "org-a"}))
 	})
-	assert.Contains(t, out, "kept")
-	assert.NotContains(t, out, "dropped")
+	assert.Contains(t, out, "api-key")
+	assert.Contains(t, out, "Opaque")
+	assert.Contains(t, out, "DataPlane/dp")
 }
 
 // --- Get ---
@@ -107,19 +95,10 @@ func TestGet_ValidationError_NoName(t *testing.T) {
 	assert.ErrorContains(t, err, "Missing required parameter: --name")
 }
 
-func TestGet_RejectsUntargeted(t *testing.T) {
-	mc := mocks.NewMockInterface(t)
-	mc.EXPECT().GetSecretReference(mock.Anything, "ns", "x").Return(
-		&gen.SecretReference{Metadata: gen.ObjectMeta{Name: "x"}, Spec: &gen.SecretReferenceSpec{}}, nil,
-	)
-	err := New(mc).Get(GetParams{Namespace: "ns", SecretName: "x"})
-	assert.ErrorContains(t, err, `secret "x" not found`)
-}
-
 func TestGet_Success(t *testing.T) {
 	mc := mocks.NewMockInterface(t)
-	mc.EXPECT().GetSecretReference(mock.Anything, "ns", "x").Return(
-		&gen.SecretReference{Metadata: gen.ObjectMeta{Name: "x"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}}, nil,
+	mc.EXPECT().GetSecret(mock.Anything, "ns", "x").Return(
+		&gen.Secret{Metadata: gen.ObjectMeta{Name: "x"}, Type: "Opaque"}, nil,
 	)
 	out := testutil.CaptureStdout(t, func() {
 		require.NoError(t, New(mc).Get(GetParams{Namespace: "ns", SecretName: "x"}))

--- a/internal/occ/cmd/secret/secret_test.go
+++ b/internal/occ/cmd/secret/secret_test.go
@@ -1,0 +1,329 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func dataPlane(name string) *gen.TargetPlaneRef {
+	return &gen.TargetPlaneRef{Kind: gen.TargetPlaneRefKindDataPlane, Name: name}
+}
+
+// --- filterTargeted ---
+
+func TestFilterTargeted_KeepsOnlyTargeted(t *testing.T) {
+	in := []gen.SecretReference{
+		{Metadata: gen.ObjectMeta{Name: "a"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}},
+		{Metadata: gen.ObjectMeta{Name: "b"}, Spec: &gen.SecretReferenceSpec{}},
+		{Metadata: gen.ObjectMeta{Name: "c"}, Spec: nil},
+		{Metadata: gen.ObjectMeta{Name: "d"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp2")}},
+	}
+	out := filterTargeted(in)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0].Metadata.Name)
+	assert.Equal(t, "d", out[1].Metadata.Name)
+}
+
+// --- printList ---
+
+func TestPrintList_Empty(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(nil))
+	})
+	assert.Contains(t, out, "No secrets found")
+}
+
+func TestPrintList_WithItems(t *testing.T) {
+	now := time.Now()
+	tlsType := gen.SecretTemplateType("kubernetes.io/tls")
+	items := []gen.SecretReference{
+		{
+			Metadata: gen.ObjectMeta{Name: "tls-1", CreationTimestamp: &now},
+			Spec: &gen.SecretReferenceSpec{
+				TargetPlane: dataPlane("dp-prod"),
+				Template:    gen.SecretTemplate{Type: &tlsType},
+			},
+		},
+	}
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "TYPE")
+	assert.Contains(t, out, "TARGET PLANE")
+	assert.Contains(t, out, "tls-1")
+	assert.Contains(t, out, "kubernetes.io/tls")
+	assert.Contains(t, out, "DataPlane/dp-prod")
+}
+
+// --- List ---
+
+func TestList_ValidationError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	s := New(mc)
+	err := s.List(ListParams{Namespace: ""})
+	assert.ErrorContains(t, err, "Missing required parameter: --namespace")
+}
+
+func TestList_FiltersOutNonTargeted(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListSecretReferences(mock.Anything, "org-a", mock.Anything).Return(&gen.SecretReferenceList{
+		Items: []gen.SecretReference{
+			{Metadata: gen.ObjectMeta{Name: "kept"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}},
+			{Metadata: gen.ObjectMeta{Name: "dropped"}, Spec: &gen.SecretReferenceSpec{}},
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, New(mc).List(ListParams{Namespace: "org-a"}))
+	})
+	assert.Contains(t, out, "kept")
+	assert.NotContains(t, out, "dropped")
+}
+
+// --- Get ---
+
+func TestGet_ValidationError_NoName(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).Get(GetParams{Namespace: "ns"})
+	assert.ErrorContains(t, err, "Missing required parameter: --name")
+}
+
+func TestGet_RejectsUntargeted(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetSecretReference(mock.Anything, "ns", "x").Return(
+		&gen.SecretReference{Metadata: gen.ObjectMeta{Name: "x"}, Spec: &gen.SecretReferenceSpec{}}, nil,
+	)
+	err := New(mc).Get(GetParams{Namespace: "ns", SecretName: "x"})
+	assert.ErrorContains(t, err, `secret "x" not found`)
+}
+
+func TestGet_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetSecretReference(mock.Anything, "ns", "x").Return(
+		&gen.SecretReference{Metadata: gen.ObjectMeta{Name: "x"}, Spec: &gen.SecretReferenceSpec{TargetPlane: dataPlane("dp")}}, nil,
+	)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, New(mc).Get(GetParams{Namespace: "ns", SecretName: "x"}))
+	})
+	assert.Contains(t, out, "name: x")
+}
+
+// --- Delete ---
+
+func TestDelete_ValidationError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).Delete(DeleteParams{Namespace: "", SecretName: "x"})
+	assert.ErrorContains(t, err, "Missing required parameter: --namespace")
+}
+
+func TestDelete_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteSecret(mock.Anything, "ns", "x").Return(fmt.Errorf("boom"))
+	err := New(mc).Delete(DeleteParams{Namespace: "ns", SecretName: "x"})
+	assert.EqualError(t, err, "boom")
+}
+
+func TestDelete_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteSecret(mock.Anything, "ns", "x").Return(nil)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, New(mc).Delete(DeleteParams{Namespace: "ns", SecretName: "x"}))
+	})
+	assert.Contains(t, out, "Secret 'x' deleted")
+}
+
+// --- CreateGeneric ---
+
+func TestCreateGeneric_RequiresData(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).CreateGeneric(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "n",
+		TargetPlane: "DataPlane/dp",
+	}, "")
+	assert.ErrorContains(t, err, "at least one of --from-literal")
+}
+
+func TestCreateGeneric_InvalidTargetPlane(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).CreateGeneric(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "n",
+		TargetPlane: "bogus",
+		FromLiteral: []string{"k=v"},
+	}, "")
+	assert.ErrorContains(t, err, "invalid --target-plane")
+}
+
+func TestCreateGeneric_OpaqueByDefault(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		return req.SecretType == gen.SecretTypeOpaque && req.Data["k"] == "v"
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateGeneric(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "n",
+		TargetPlane: "DataPlane/dp",
+		FromLiteral: []string{"k=v"},
+	}, ""))
+}
+
+func TestCreateGeneric_TypeOverride(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		return req.SecretType == gen.SecretTypeKubernetesIobasicAuth
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateGeneric(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "n",
+		TargetPlane: "DataPlane/dp",
+		FromLiteral: []string{"username=admin", "password=s3"},
+	}, "kubernetes.io/basic-auth"))
+}
+
+// --- CreateDockerRegistry ---
+
+func TestCreateDockerRegistry_BuildsConfigJSON(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	var captured gen.CreateSecretRequest
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.Anything).Run(func(_ context.Context, _ string, req gen.CreateSecretRequest) {
+		captured = req
+	}).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateDockerRegistry(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "regcred",
+		TargetPlane: "DataPlane/dp",
+	}, "https://reg.example/v1/", "jdoe", "hunter2", "jdoe@example.com"))
+
+	assert.Equal(t, gen.SecretTypeKubernetesIodockerconfigjson, captured.SecretType)
+	raw, ok := captured.Data[".dockerconfigjson"]
+	require.True(t, ok)
+
+	var parsed struct {
+		Auths map[string]struct {
+			Username, Password, Email, Auth string
+		} `json:"auths"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &parsed))
+	entry, ok := parsed.Auths["https://reg.example/v1/"]
+	require.True(t, ok)
+	assert.Equal(t, "jdoe", entry.Username)
+	assert.Equal(t, "hunter2", entry.Password)
+	assert.Equal(t, "jdoe@example.com", entry.Email)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("jdoe:hunter2")), entry.Auth)
+}
+
+func TestCreateDockerRegistry_MissingServer(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).CreateDockerRegistry(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "regcred",
+		TargetPlane: "DataPlane/dp",
+	}, "", "jdoe", "hunter2", "")
+	assert.ErrorContains(t, err, "--docker-server")
+}
+
+// --- CreateTLS ---
+
+func TestCreateTLS_Success(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "tls.crt")
+	key := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(cert, []byte("C"), 0o600))
+	require.NoError(t, os.WriteFile(key, []byte("K"), 0o600))
+
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		return req.SecretType == gen.SecretTypeKubernetesIotls &&
+			req.Data["tls.crt"] == "C" && req.Data["tls.key"] == "K"
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateTLS(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "tls",
+		TargetPlane: "DataPlane/dp",
+	}, cert, key))
+}
+
+func TestCreateTLS_MissingFile(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).CreateTLS(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "tls",
+		TargetPlane: "DataPlane/dp",
+	}, "/no/such/cert", "/no/such/key")
+	assert.ErrorContains(t, err, "read --cert")
+}
+
+// --- parseTargetPlane ---
+
+func TestParseTargetPlane(t *testing.T) {
+	tp, err := parseTargetPlane("DataPlane/dp-prod")
+	require.NoError(t, err)
+	assert.Equal(t, gen.TargetPlaneRefKindDataPlane, tp.Kind)
+	assert.Equal(t, "dp-prod", tp.Name)
+
+	_, err = parseTargetPlane("DataPlane")
+	assert.Error(t, err)
+
+	_, err = parseTargetPlane("Bogus/x")
+	assert.ErrorContains(t, err, "invalid --target-plane kind")
+}
+
+// --- collectData ---
+
+func TestCollectData_AllSources(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "license.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("file-body"), 0o600))
+
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("# comment\nFOO=bar\nBAZ=qux\n"), 0o600))
+
+	data, err := collectData(
+		[]string{"k1=v1"},
+		[]string{"named=" + filePath, filePath},
+		[]string{envPath},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", data["k1"])
+	assert.Equal(t, "file-body", data["named"])
+	assert.Equal(t, "file-body", data["license.txt"])
+	assert.Equal(t, "bar", data["FOO"])
+	assert.Equal(t, "qux", data["BAZ"])
+}
+
+func TestCollectData_InvalidLiteral(t *testing.T) {
+	_, err := collectData([]string{"nobueno"}, nil, nil)
+	assert.ErrorContains(t, err, "invalid --from-literal")
+}
+
+func TestCollectData_InvalidEnvFileLine(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("NOTKV\n"), 0o600))
+	_, err := collectData(nil, nil, []string{envPath})
+	assert.ErrorContains(t, err, "expected KEY=VALUE")
+}

--- a/internal/occ/resources/client/interface.go
+++ b/internal/occ/resources/client/interface.go
@@ -145,6 +145,12 @@ type Interface interface {
 	GetSecretReference(ctx context.Context, namespaceName, secretReferenceName string) (*gen.SecretReference, error)
 	DeleteSecretReference(ctx context.Context, namespaceName, secretReferenceName string) error
 
+	ListSecrets(ctx context.Context, namespaceName string, params *gen.ListSecretsParams) (*gen.ListSecretsResponse, error)
+	GetSecret(ctx context.Context, namespaceName, secretName string) (*gen.Secret, error)
+	CreateSecret(ctx context.Context, namespaceName string, req gen.CreateSecretRequest) (*gen.Secret, error)
+	UpdateSecret(ctx context.Context, namespaceName, secretName string, req gen.UpdateSecretRequest) (*gen.Secret, error)
+	DeleteSecret(ctx context.Context, namespaceName, secretName string) error
+
 	ListWorkloads(ctx context.Context, namespaceName string, params *gen.ListWorkloadsParams) (*gen.WorkloadList, error)
 	GetWorkload(ctx context.Context, namespaceName, workloadName string) (*gen.Workload, error)
 	DeleteWorkload(ctx context.Context, namespaceName, workloadName string) error

--- a/internal/occ/resources/client/mocks/client.go
+++ b/internal/occ/resources/client/mocks/client.go
@@ -503,6 +503,66 @@ func (_c *MockInterface_CreateResourceType_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
+// CreateSecret provides a mock function with given fields: ctx, namespaceName, req
+func (_m *MockInterface) CreateSecret(ctx context.Context, namespaceName string, req gen.CreateSecretRequest) (*gen.Secret, error) {
+	ret := _m.Called(ctx, namespaceName, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateSecret")
+	}
+
+	var r0 *gen.Secret
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.CreateSecretRequest) (*gen.Secret, error)); ok {
+		return rf(ctx, namespaceName, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.CreateSecretRequest) *gen.Secret); ok {
+		r0 = rf(ctx, namespaceName, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.Secret)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, gen.CreateSecretRequest) error); ok {
+		r1 = rf(ctx, namespaceName, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_CreateSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateSecret'
+type MockInterface_CreateSecret_Call struct {
+	*mock.Call
+}
+
+// CreateSecret is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - req gen.CreateSecretRequest
+func (_e *MockInterface_Expecter) CreateSecret(ctx interface{}, namespaceName interface{}, req interface{}) *MockInterface_CreateSecret_Call {
+	return &MockInterface_CreateSecret_Call{Call: _e.mock.On("CreateSecret", ctx, namespaceName, req)}
+}
+
+func (_c *MockInterface_CreateSecret_Call) Run(run func(ctx context.Context, namespaceName string, req gen.CreateSecretRequest)) *MockInterface_CreateSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(gen.CreateSecretRequest))
+	})
+	return _c
+}
+
+func (_c *MockInterface_CreateSecret_Call) Return(_a0 *gen.Secret, _a1 error) *MockInterface_CreateSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_CreateSecret_Call) RunAndReturn(run func(context.Context, string, gen.CreateSecretRequest) (*gen.Secret, error)) *MockInterface_CreateSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateTrait provides a mock function with given fields: ctx, namespaceName, t
 func (_m *MockInterface) CreateTrait(ctx context.Context, namespaceName string, t gen.Trait) (*gen.Trait, error) {
 	ret := _m.Called(ctx, namespaceName, t)
@@ -1857,6 +1917,54 @@ func (_c *MockInterface_DeleteResourceType_Call) Return(_a0 error) *MockInterfac
 }
 
 func (_c *MockInterface_DeleteResourceType_Call) RunAndReturn(run func(context.Context, string, string) error) *MockInterface_DeleteResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteSecret provides a mock function with given fields: ctx, namespaceName, secretName
+func (_m *MockInterface) DeleteSecret(ctx context.Context, namespaceName string, secretName string) error {
+	ret := _m.Called(ctx, namespaceName, secretName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteSecret")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespaceName, secretName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockInterface_DeleteSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteSecret'
+type MockInterface_DeleteSecret_Call struct {
+	*mock.Call
+}
+
+// DeleteSecret is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - secretName string
+func (_e *MockInterface_Expecter) DeleteSecret(ctx interface{}, namespaceName interface{}, secretName interface{}) *MockInterface_DeleteSecret_Call {
+	return &MockInterface_DeleteSecret_Call{Call: _e.mock.On("DeleteSecret", ctx, namespaceName, secretName)}
+}
+
+func (_c *MockInterface_DeleteSecret_Call) Run(run func(ctx context.Context, namespaceName string, secretName string)) *MockInterface_DeleteSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_DeleteSecret_Call) Return(_a0 error) *MockInterface_DeleteSecret_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockInterface_DeleteSecret_Call) RunAndReturn(run func(context.Context, string, string) error) *MockInterface_DeleteSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4128,6 +4236,66 @@ func (_c *MockInterface_GetResourceTypeSchema_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// GetSecret provides a mock function with given fields: ctx, namespaceName, secretName
+func (_m *MockInterface) GetSecret(ctx context.Context, namespaceName string, secretName string) (*gen.Secret, error) {
+	ret := _m.Called(ctx, namespaceName, secretName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSecret")
+	}
+
+	var r0 *gen.Secret
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*gen.Secret, error)); ok {
+		return rf(ctx, namespaceName, secretName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *gen.Secret); ok {
+		r0 = rf(ctx, namespaceName, secretName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.Secret)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespaceName, secretName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSecret'
+type MockInterface_GetSecret_Call struct {
+	*mock.Call
+}
+
+// GetSecret is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - secretName string
+func (_e *MockInterface_Expecter) GetSecret(ctx interface{}, namespaceName interface{}, secretName interface{}) *MockInterface_GetSecret_Call {
+	return &MockInterface_GetSecret_Call{Call: _e.mock.On("GetSecret", ctx, namespaceName, secretName)}
+}
+
+func (_c *MockInterface_GetSecret_Call) Run(run func(ctx context.Context, namespaceName string, secretName string)) *MockInterface_GetSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetSecret_Call) Return(_a0 *gen.Secret, _a1 error) *MockInterface_GetSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetSecret_Call) RunAndReturn(run func(context.Context, string, string) (*gen.Secret, error)) *MockInterface_GetSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSecretReference provides a mock function with given fields: ctx, namespaceName, secretReferenceName
 func (_m *MockInterface) GetSecretReference(ctx context.Context, namespaceName string, secretReferenceName string) (*gen.SecretReference, error) {
 	ret := _m.Called(ctx, namespaceName, secretReferenceName)
@@ -6340,6 +6508,66 @@ func (_c *MockInterface_ListSecretReferences_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// ListSecrets provides a mock function with given fields: ctx, namespaceName, params
+func (_m *MockInterface) ListSecrets(ctx context.Context, namespaceName string, params *gen.ListSecretsParams) (*gen.ListSecretsResponse, error) {
+	ret := _m.Called(ctx, namespaceName, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListSecrets")
+	}
+
+	var r0 *gen.ListSecretsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListSecretsParams) (*gen.ListSecretsResponse, error)); ok {
+		return rf(ctx, namespaceName, params)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListSecretsParams) *gen.ListSecretsResponse); ok {
+		r0 = rf(ctx, namespaceName, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ListSecretsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gen.ListSecretsParams) error); ok {
+		r1 = rf(ctx, namespaceName, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_ListSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSecrets'
+type MockInterface_ListSecrets_Call struct {
+	*mock.Call
+}
+
+// ListSecrets is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - params *gen.ListSecretsParams
+func (_e *MockInterface_Expecter) ListSecrets(ctx interface{}, namespaceName interface{}, params interface{}) *MockInterface_ListSecrets_Call {
+	return &MockInterface_ListSecrets_Call{Call: _e.mock.On("ListSecrets", ctx, namespaceName, params)}
+}
+
+func (_c *MockInterface_ListSecrets_Call) Run(run func(ctx context.Context, namespaceName string, params *gen.ListSecretsParams)) *MockInterface_ListSecrets_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*gen.ListSecretsParams))
+	})
+	return _c
+}
+
+func (_c *MockInterface_ListSecrets_Call) Return(_a0 *gen.ListSecretsResponse, _a1 error) *MockInterface_ListSecrets_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_ListSecrets_Call) RunAndReturn(run func(context.Context, string, *gen.ListSecretsParams) (*gen.ListSecretsResponse, error)) *MockInterface_ListSecrets_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListTraits provides a mock function with given fields: ctx, namespaceName, params
 func (_m *MockInterface) ListTraits(ctx context.Context, namespaceName string, params *gen.ListTraitsParams) (*gen.TraitList, error) {
 	ret := _m.Called(ctx, namespaceName, params)
@@ -7001,6 +7229,67 @@ func (_c *MockInterface_UpdateResourceType_Call) Return(_a0 *gen.ResourceType, _
 }
 
 func (_c *MockInterface_UpdateResourceType_Call) RunAndReturn(run func(context.Context, string, string, gen.ResourceType) (*gen.ResourceType, error)) *MockInterface_UpdateResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateSecret provides a mock function with given fields: ctx, namespaceName, secretName, req
+func (_m *MockInterface) UpdateSecret(ctx context.Context, namespaceName string, secretName string, req gen.UpdateSecretRequest) (*gen.Secret, error) {
+	ret := _m.Called(ctx, namespaceName, secretName, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSecret")
+	}
+
+	var r0 *gen.Secret
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.UpdateSecretRequest) (*gen.Secret, error)); ok {
+		return rf(ctx, namespaceName, secretName, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.UpdateSecretRequest) *gen.Secret); ok {
+		r0 = rf(ctx, namespaceName, secretName, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.Secret)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, gen.UpdateSecretRequest) error); ok {
+		r1 = rf(ctx, namespaceName, secretName, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_UpdateSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSecret'
+type MockInterface_UpdateSecret_Call struct {
+	*mock.Call
+}
+
+// UpdateSecret is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - secretName string
+//   - req gen.UpdateSecretRequest
+func (_e *MockInterface_Expecter) UpdateSecret(ctx interface{}, namespaceName interface{}, secretName interface{}, req interface{}) *MockInterface_UpdateSecret_Call {
+	return &MockInterface_UpdateSecret_Call{Call: _e.mock.On("UpdateSecret", ctx, namespaceName, secretName, req)}
+}
+
+func (_c *MockInterface_UpdateSecret_Call) Run(run func(ctx context.Context, namespaceName string, secretName string, req gen.UpdateSecretRequest)) *MockInterface_UpdateSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(gen.UpdateSecretRequest))
+	})
+	return _c
+}
+
+func (_c *MockInterface_UpdateSecret_Call) Return(_a0 *gen.Secret, _a1 error) *MockInterface_UpdateSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_UpdateSecret_Call) RunAndReturn(run func(context.Context, string, string, gen.UpdateSecretRequest) (*gen.Secret, error)) *MockInterface_UpdateSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -833,6 +833,66 @@ func (c *Client) DeleteSecretReference(ctx context.Context, namespaceName, secre
 	return nil
 }
 
+// ListSecrets lists secrets managed by the Secret API in a namespace.
+func (c *Client) ListSecrets(ctx context.Context, namespaceName string, params *gen.ListSecretsParams) (*gen.ListSecretsResponse, error) {
+	resp, err := c.client.ListSecretsWithResponse(ctx, namespaceName, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// GetSecret retrieves a single secret managed by the Secret API.
+func (c *Client) GetSecret(ctx context.Context, namespaceName, secretName string) (*gen.Secret, error) {
+	resp, err := c.client.GetSecretWithResponse(ctx, namespaceName, secretName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// CreateSecret creates a secret on the target plane via the API server.
+func (c *Client) CreateSecret(ctx context.Context, namespaceName string, req gen.CreateSecretRequest) (*gen.Secret, error) {
+	resp, err := c.client.CreateSecretWithResponse(ctx, namespaceName, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret: %w", err)
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON201, nil
+}
+
+// UpdateSecret replaces a secret's data with the supplied final state.
+func (c *Client) UpdateSecret(ctx context.Context, namespaceName, secretName string, req gen.UpdateSecretRequest) (*gen.Secret, error) {
+	resp, err := c.client.UpdateSecretWithResponse(ctx, namespaceName, secretName, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update secret: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteSecret deletes a secret from the control plane and the target plane.
+func (c *Client) DeleteSecret(ctx context.Context, namespaceName, secretName string) error {
+	resp, err := c.client.DeleteSecretWithResponse(ctx, namespaceName, secretName)
+	if err != nil {
+		return fmt.Errorf("failed to delete secret: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return apiError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
 // GetWorkflowRun retrieves a specific workflow run
 func (c *Client) GetWorkflowRun(ctx context.Context, namespaceName, runName string) (*gen.WorkflowRun, error) {
 	resp, err := c.client.GetWorkflowRunWithResponse(ctx, namespaceName, runName)

--- a/internal/occ/root/root.go
+++ b/internal/occ/root/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcerelease"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcereleasebinding"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcetype"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/secret"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/secretreference"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/trait"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/version"
@@ -93,6 +94,7 @@ func BuildRootCmd() *cobra.Command {
 		workflow.NewWorkflowCmd(f),
 		workflowrun.NewWorkflowRunCmd(f),
 		secretreference.NewSecretReferenceCmd(f),
+		secret.NewSecretCmd(f),
 		workload.NewWorkloadCmd(f),
 		deploymentpipeline.NewDeploymentPipelineCmd(f),
 		observabilityalertsnotificationchannel.NewObservabilityAlertsNotificationChannelCmd(f),

--- a/internal/occ/root/root_test.go
+++ b/internal/occ/root/root_test.go
@@ -55,6 +55,7 @@ func TestBuildRootCmd_Subcommands(t *testing.T) {
 		"workflow",
 		"workflowrun",
 		"secretreference",
+		"secret",
 		"workload",
 		"deploymentpipeline",
 		"observabilityalertsnotificationchannel",


### PR DESCRIPTION
## Purpose

Add `occ secret` commands so platform users can manage workload secrets that
are pushed to a target plane's external secret store, without writing raw
SecretReference YAML.

## Approach

- New `internal/occ/cmd/secret/` package with subcommands:
  - `occ secret list` and `occ secret get <name>` use the SecretReference API
    and surface only references that have `spec.targetPlane` set.
  - `occ secret create generic|docker-registry|tls` calls the API server's
    `CreateSecret` endpoint, which writes to the target plane's external
    secret store.
  - `occ secret delete <name>` calls `DeleteSecret`, removing the secret from
    both the control plane and the target plane.
- Common create flags: `-n/--namespace`, `--target-plane Kind/Name`,
  `--from-literal`, `--from-file` (key inferred from filename when omitted),
  and `--from-env-file`. Layout mirrors `kubectl create secret`.
- Type-specific flags:
  - `generic`: `--type` to create typed secrets (e.g. `kubernetes.io/basic-auth`).
  - `docker-registry`: `--docker-server/-username/-password/-email`, builds the
    `.dockerconfigjson` payload locally.
  - `tls`: `--cert` and `--key` (PEM file paths).
- `CreateSecret` and `DeleteSecret` added to the CLI client `Interface` and
  `openapi_client.go`; mocks regenerated via `make mockery-gen`.
- Wired into the root command and updated `root_test.go` expectations.
- End-to-end verified against a k3d cluster with OpenBao as the external
  secret store: all four secret types materialise on the data plane with the
  expected payloads, and `delete` cleans up both layers.

`update` from the original issue is not included — the API server does not
expose an `UpdateSecret` endpoint, so that needs a server-side change first.

## Related Issues

Related #3288

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)