### PR TITLE
feat(api): surface webhook validation as HTTP 422 with field paths

### DIFF
--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -12416,6 +12416,7 @@ type EvaluatesResp struct {
 	JSON200      *[]Decision
 	JSON400      *BadRequest
 	JSON401      *Unauthorized
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12495,6 +12496,7 @@ type CreateClusterRoleBindingResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12574,6 +12576,7 @@ type UpdateClusterRoleBindingResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12627,6 +12630,7 @@ type CreateClusterRoleResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12706,6 +12710,7 @@ type UpdateClusterRoleResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12759,6 +12764,7 @@ type CreateClusterComponentTypeResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12838,6 +12844,7 @@ type UpdateClusterComponentTypeResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12917,6 +12924,7 @@ type CreateClusterDataPlaneResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -12996,6 +13004,7 @@ type UpdateClusterDataPlaneResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13049,6 +13058,7 @@ type CreateClusterObservabilityPlaneResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13128,6 +13138,7 @@ type UpdateClusterObservabilityPlaneResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13181,6 +13192,7 @@ type CreateClusterTraitResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13260,6 +13272,7 @@ type UpdateClusterTraitResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13339,6 +13352,7 @@ type CreateClusterWorkflowPlaneResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13418,6 +13432,7 @@ type UpdateClusterWorkflowPlaneResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13471,6 +13486,7 @@ type CreateClusterWorkflowResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13550,6 +13566,7 @@ type UpdateClusterWorkflowResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13629,6 +13646,7 @@ type CreateNamespaceResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13707,6 +13725,7 @@ type UpdateNamespaceResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13760,6 +13779,7 @@ type CreateNamespaceRoleBindingResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13841,6 +13861,7 @@ type UpdateNamespaceRoleBindingResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13894,6 +13915,7 @@ type CreateNamespaceRoleResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -13975,6 +13997,7 @@ type UpdateNamespaceRoleResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14029,6 +14052,7 @@ type CreateComponentReleaseResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14134,6 +14158,7 @@ type CreateComponentResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14213,6 +14238,7 @@ type UpdateComponentResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14240,6 +14266,7 @@ type GenerateReleaseResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14319,6 +14346,7 @@ type CreateComponentTypeResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14398,6 +14426,7 @@ type UpdateComponentTypeResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14477,6 +14506,7 @@ type CreateDataPlaneResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14556,6 +14586,7 @@ type UpdateDataPlaneResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14609,6 +14640,7 @@ type CreateDeploymentPipelineResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14687,6 +14719,7 @@ type UpdateDeploymentPipelineResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14740,6 +14773,7 @@ type CreateEnvironmentResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14819,6 +14853,7 @@ type UpdateEnvironmentResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14872,6 +14907,7 @@ type CreateObservabilityAlertsNotificationChannelResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -14950,6 +14986,7 @@ type UpdateObservabilityAlertsNotificationChannelResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15003,6 +15040,7 @@ type CreateObservabilityPlaneResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15082,6 +15120,7 @@ type UpdateObservabilityPlaneResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15136,6 +15175,7 @@ type CreateProjectResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15215,6 +15255,7 @@ type UpdateProjectResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15269,6 +15310,7 @@ type CreateReleaseBindingResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15347,6 +15389,7 @@ type UpdateReleaseBindingResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15481,6 +15524,7 @@ type CreateSecretReferenceResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15559,6 +15603,7 @@ type UpdateSecretReferenceResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15612,6 +15657,7 @@ type CreateTraitResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15691,6 +15737,7 @@ type UpdateTraitResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15770,6 +15817,7 @@ type CreateWorkflowPlaneResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15849,6 +15897,7 @@ type UpdateWorkflowPlaneResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15902,6 +15951,7 @@ type CreateWorkflowRunResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -15980,6 +16030,7 @@ type UpdateWorkflowRunResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16110,6 +16161,7 @@ type CreateWorkflowResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16189,6 +16241,7 @@ type UpdateWorkflowResp struct {
 	JSON403      *Forbidden
 	JSON404      *NotFound
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16269,6 +16322,7 @@ type CreateWorkloadResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16347,6 +16401,7 @@ type UpdateWorkloadResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16372,6 +16427,7 @@ type HandleAutoBuildResp struct {
 	JSON200      *WebhookEventResponse
 	JSON400      *BadRequest
 	JSON401      *Unauthorized
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16424,6 +16480,7 @@ type CreateGitSecretResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -16476,6 +16533,7 @@ type CreateSecretResp struct {
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON409      *Conflict
+	JSON422      *UnprocessableContent
 	JSON500      *InternalError
 }
 
@@ -18686,6 +18744,13 @@ func ParseEvaluatesResp(rsp *http.Response) (*EvaluatesResp, error) {
 		}
 		response.JSON401 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -18854,6 +18919,13 @@ func ParseCreateClusterRoleBindingResp(rsp *http.Response) (*CreateClusterRoleBi
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -19024,6 +19096,13 @@ func ParseUpdateClusterRoleBindingResp(rsp *http.Response) (*UpdateClusterRoleBi
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -19138,6 +19217,13 @@ func ParseCreateClusterRoleResp(rsp *http.Response) (*CreateClusterRoleResp, err
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -19308,6 +19394,13 @@ func ParseUpdateClusterRoleResp(rsp *http.Response) (*UpdateClusterRoleResp, err
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -19422,6 +19515,13 @@ func ParseCreateClusterComponentTypeResp(rsp *http.Response) (*CreateClusterComp
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -19592,6 +19692,13 @@ func ParseUpdateClusterComponentTypeResp(rsp *http.Response) (*UpdateClusterComp
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -19760,6 +19867,13 @@ func ParseCreateClusterDataPlaneResp(rsp *http.Response) (*CreateClusterDataPlan
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -19930,6 +20044,13 @@ func ParseUpdateClusterDataPlaneResp(rsp *http.Response) (*UpdateClusterDataPlan
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -20044,6 +20165,13 @@ func ParseCreateClusterObservabilityPlaneResp(rsp *http.Response) (*CreateCluste
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -20214,6 +20342,13 @@ func ParseUpdateClusterObservabilityPlaneResp(rsp *http.Response) (*UpdateCluste
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -20328,6 +20463,13 @@ func ParseCreateClusterTraitResp(rsp *http.Response) (*CreateClusterTraitResp, e
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -20498,6 +20640,13 @@ func ParseUpdateClusterTraitResp(rsp *http.Response) (*UpdateClusterTraitResp, e
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -20666,6 +20815,13 @@ func ParseCreateClusterWorkflowPlaneResp(rsp *http.Response) (*CreateClusterWork
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -20836,6 +20992,13 @@ func ParseUpdateClusterWorkflowPlaneResp(rsp *http.Response) (*UpdateClusterWork
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -20950,6 +21113,13 @@ func ParseCreateClusterWorkflowResp(rsp *http.Response) (*CreateClusterWorkflowR
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -21120,6 +21290,13 @@ func ParseUpdateClusterWorkflowResp(rsp *http.Response) (*UpdateClusterWorkflowR
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -21289,6 +21466,13 @@ func ParseCreateNamespaceResp(rsp *http.Response) (*CreateNamespaceResp, error) 
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -21451,6 +21635,13 @@ func ParseUpdateNamespaceResp(rsp *http.Response) (*UpdateNamespaceResp, error) 
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -21565,6 +21756,13 @@ func ParseCreateNamespaceRoleBindingResp(rsp *http.Response) (*CreateNamespaceRo
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -21749,6 +21947,13 @@ func ParseUpdateNamespaceRoleBindingResp(rsp *http.Response) (*UpdateNamespaceRo
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -21863,6 +22068,13 @@ func ParseCreateNamespaceRoleResp(rsp *http.Response) (*CreateNamespaceRoleResp,
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -22047,6 +22259,13 @@ func ParseUpdateNamespaceRoleResp(rsp *http.Response) (*UpdateNamespaceRoleResp,
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -22168,6 +22387,13 @@ func ParseCreateComponentReleaseResp(rsp *http.Response) (*CreateComponentReleas
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -22392,6 +22618,13 @@ func ParseCreateComponentResp(rsp *http.Response) (*CreateComponentResp, error) 
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -22561,6 +22794,13 @@ func ParseUpdateComponentResp(rsp *http.Response) (*UpdateComponentResp, error) 
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -22621,6 +22861,13 @@ func ParseGenerateReleaseResp(rsp *http.Response) (*GenerateReleaseResp, error) 
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -22791,6 +23038,13 @@ func ParseCreateComponentTypeResp(rsp *http.Response) (*CreateComponentTypeResp,
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -22959,6 +23213,13 @@ func ParseUpdateComponentTypeResp(rsp *http.Response) (*UpdateComponentTypeResp,
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -23129,6 +23390,13 @@ func ParseCreateDataPlaneResp(rsp *http.Response) (*CreateDataPlaneResp, error) 
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -23298,6 +23566,13 @@ func ParseUpdateDataPlaneResp(rsp *http.Response) (*UpdateDataPlaneResp, error) 
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -23412,6 +23687,13 @@ func ParseCreateDeploymentPipelineResp(rsp *http.Response) (*CreateDeploymentPip
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -23575,6 +23857,13 @@ func ParseUpdateDeploymentPipelineResp(rsp *http.Response) (*UpdateDeploymentPip
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -23689,6 +23978,13 @@ func ParseCreateEnvironmentResp(rsp *http.Response) (*CreateEnvironmentResp, err
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -23859,6 +24155,13 @@ func ParseUpdateEnvironmentResp(rsp *http.Response) (*UpdateEnvironmentResp, err
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -23973,6 +24276,13 @@ func ParseCreateObservabilityAlertsNotificationChannelResp(rsp *http.Response) (
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -24136,6 +24446,13 @@ func ParseUpdateObservabilityAlertsNotificationChannelResp(rsp *http.Response) (
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -24250,6 +24567,13 @@ func ParseCreateObservabilityPlaneResp(rsp *http.Response) (*CreateObservability
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -24420,6 +24744,13 @@ func ParseUpdateObservabilityPlaneResp(rsp *http.Response) (*UpdateObservability
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -24541,6 +24872,13 @@ func ParseCreateProjectResp(rsp *http.Response) (*CreateProjectResp, error) {
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -24711,6 +25049,13 @@ func ParseUpdateProjectResp(rsp *http.Response) (*UpdateProjectResp, error) {
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -24832,6 +25177,13 @@ func ParseCreateReleaseBindingResp(rsp *http.Response) (*CreateReleaseBindingRes
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -24994,6 +25346,13 @@ func ParseUpdateReleaseBindingResp(rsp *http.Response) (*UpdateReleaseBindingRes
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -25293,6 +25652,13 @@ func ParseCreateSecretReferenceResp(rsp *http.Response) (*CreateSecretReferenceR
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -25455,6 +25821,13 @@ func ParseUpdateSecretReferenceResp(rsp *http.Response) (*UpdateSecretReferenceR
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -25569,6 +25942,13 @@ func ParseCreateTraitResp(rsp *http.Response) (*CreateTraitResp, error) {
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -25739,6 +26119,13 @@ func ParseUpdateTraitResp(rsp *http.Response) (*UpdateTraitResp, error) {
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -25907,6 +26294,13 @@ func ParseCreateWorkflowPlaneResp(rsp *http.Response) (*CreateWorkflowPlaneResp,
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -26077,6 +26471,13 @@ func ParseUpdateWorkflowPlaneResp(rsp *http.Response) (*UpdateWorkflowPlaneResp,
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -26191,6 +26592,13 @@ func ParseCreateWorkflowRunResp(rsp *http.Response) (*CreateWorkflowRunResp, err
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -26353,6 +26761,13 @@ func ParseUpdateWorkflowRunResp(rsp *http.Response) (*UpdateWorkflowRunResp, err
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -26624,6 +27039,13 @@ func ParseCreateWorkflowResp(rsp *http.Response) (*CreateWorkflowResp, error) {
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -26792,6 +27214,13 @@ func ParseUpdateWorkflowResp(rsp *http.Response) (*UpdateWorkflowResp, error) {
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -26969,6 +27398,13 @@ func ParseCreateWorkloadResp(rsp *http.Response) (*CreateWorkloadResp, error) {
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -27131,6 +27567,13 @@ func ParseUpdateWorkloadResp(rsp *http.Response) (*UpdateWorkloadResp, error) {
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -27177,6 +27620,13 @@ func ParseHandleAutoBuildResp(rsp *http.Response) (*HandleAutoBuildResp, error) 
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -27286,6 +27736,13 @@ func ParseCreateGitSecretResp(rsp *http.Response) (*CreateGitSecretResp, error) 
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -27393,6 +27850,13 @@ func ParseCreateSecretResp(rsp *http.Response) (*CreateSecretResp, error) {
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -205,13 +205,14 @@ const (
 
 // Defines values for ErrorResponseCode.
 const (
-	BADREQUEST         ErrorResponseCode = "BAD_REQUEST"
-	CONFLICT           ErrorResponseCode = "CONFLICT"
-	FORBIDDEN          ErrorResponseCode = "FORBIDDEN"
-	INTERNALERROR      ErrorResponseCode = "INTERNAL_ERROR"
-	NOTFOUND           ErrorResponseCode = "NOT_FOUND"
-	UNAUTHORIZED       ErrorResponseCode = "UNAUTHORIZED"
-	UNKNOWNGITPROVIDER ErrorResponseCode = "UNKNOWN_GIT_PROVIDER"
+	BADREQUEST           ErrorResponseCode = "BAD_REQUEST"
+	CONFLICT             ErrorResponseCode = "CONFLICT"
+	FORBIDDEN            ErrorResponseCode = "FORBIDDEN"
+	INTERNALERROR        ErrorResponseCode = "INTERNAL_ERROR"
+	NOTFOUND             ErrorResponseCode = "NOT_FOUND"
+	UNAUTHORIZED         ErrorResponseCode = "UNAUTHORIZED"
+	UNKNOWNGITPROVIDER   ErrorResponseCode = "UNKNOWN_GIT_PROVIDER"
+	UNPROCESSABLECONTENT ErrorResponseCode = "UNPROCESSABLE_CONTENT"
 )
 
 // Defines values for ExternalRefKind.
@@ -3782,6 +3783,9 @@ type NotFound = ErrorResponse
 
 // Unauthorized Standard error response format
 type Unauthorized = ErrorResponse
+
+// UnprocessableContent Standard error response format
+type UnprocessableContent = ErrorResponse
 
 // EvaluatesJSONBody defines parameters for Evaluates.
 type EvaluatesJSONBody = []EvaluateRequest

--- a/internal/openchoreo-api/api/gen/server.gen.go
+++ b/internal/openchoreo-api/api/gen/server.gen.go
@@ -7118,6 +7118,8 @@ type NotFoundJSONResponse ErrorResponse
 
 type UnauthorizedJSONResponse ErrorResponse
 
+type UnprocessableContentJSONResponse ErrorResponse
+
 type GetOAuthProtectedResourceMetadataRequestObject struct {
 }
 
@@ -7242,6 +7244,17 @@ type Evaluates401JSONResponse struct{ UnauthorizedJSONResponse }
 func (response Evaluates401JSONResponse) VisitEvaluatesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type Evaluates422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response Evaluates422JSONResponse) VisitEvaluatesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -7410,6 +7423,17 @@ type CreateClusterRoleBinding409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterRoleBinding409JSONResponse) VisitCreateClusterRoleBindingResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterRoleBinding422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterRoleBinding422JSONResponse) VisitCreateClusterRoleBindingResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -7591,6 +7615,17 @@ func (response UpdateClusterRoleBinding409JSONResponse) VisitUpdateClusterRoleBi
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterRoleBinding422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterRoleBinding422JSONResponse) VisitUpdateClusterRoleBindingResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterRoleBinding500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterRoleBinding500JSONResponse) VisitUpdateClusterRoleBindingResponse(w http.ResponseWriter) error {
@@ -7702,6 +7737,17 @@ type CreateClusterRole409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterRole409JSONResponse) VisitCreateClusterRoleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterRole422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterRole422JSONResponse) VisitCreateClusterRoleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -7883,6 +7929,17 @@ func (response UpdateClusterRole404JSONResponse) VisitUpdateClusterRoleResponse(
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterRole422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterRole422JSONResponse) VisitUpdateClusterRoleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterRole500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterRole500JSONResponse) VisitUpdateClusterRoleResponse(w http.ResponseWriter) error {
@@ -7994,6 +8051,17 @@ type CreateClusterComponentType409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterComponentType409JSONResponse) VisitCreateClusterComponentTypeResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterComponentType422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterComponentType422JSONResponse) VisitCreateClusterComponentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -8175,6 +8243,17 @@ func (response UpdateClusterComponentType409JSONResponse) VisitUpdateClusterComp
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterComponentType422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterComponentType422JSONResponse) VisitUpdateClusterComponentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterComponentType500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterComponentType500JSONResponse) VisitUpdateClusterComponentTypeResponse(w http.ResponseWriter) error {
@@ -8339,6 +8418,17 @@ type CreateClusterDataPlane409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterDataPlane409JSONResponse) VisitCreateClusterDataPlaneResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterDataPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterDataPlane422JSONResponse) VisitCreateClusterDataPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -8520,6 +8610,17 @@ func (response UpdateClusterDataPlane409JSONResponse) VisitUpdateClusterDataPlan
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterDataPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterDataPlane422JSONResponse) VisitUpdateClusterDataPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterDataPlane500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterDataPlane500JSONResponse) VisitUpdateClusterDataPlaneResponse(w http.ResponseWriter) error {
@@ -8631,6 +8732,17 @@ type CreateClusterObservabilityPlane409JSONResponse struct{ ConflictJSONResponse
 func (response CreateClusterObservabilityPlane409JSONResponse) VisitCreateClusterObservabilityPlaneResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterObservabilityPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterObservabilityPlane422JSONResponse) VisitCreateClusterObservabilityPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -8812,6 +8924,17 @@ func (response UpdateClusterObservabilityPlane409JSONResponse) VisitUpdateCluste
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterObservabilityPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterObservabilityPlane422JSONResponse) VisitUpdateClusterObservabilityPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterObservabilityPlane500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterObservabilityPlane500JSONResponse) VisitUpdateClusterObservabilityPlaneResponse(w http.ResponseWriter) error {
@@ -8923,6 +9046,17 @@ type CreateClusterTrait409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterTrait409JSONResponse) VisitCreateClusterTraitResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterTrait422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterTrait422JSONResponse) VisitCreateClusterTraitResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -9104,6 +9238,17 @@ func (response UpdateClusterTrait409JSONResponse) VisitUpdateClusterTraitRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterTrait422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterTrait422JSONResponse) VisitUpdateClusterTraitResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterTrait500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterTrait500JSONResponse) VisitUpdateClusterTraitResponse(w http.ResponseWriter) error {
@@ -9268,6 +9413,17 @@ type CreateClusterWorkflowPlane409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterWorkflowPlane409JSONResponse) VisitCreateClusterWorkflowPlaneResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterWorkflowPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterWorkflowPlane422JSONResponse) VisitCreateClusterWorkflowPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -9449,6 +9605,17 @@ func (response UpdateClusterWorkflowPlane409JSONResponse) VisitUpdateClusterWork
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterWorkflowPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterWorkflowPlane422JSONResponse) VisitUpdateClusterWorkflowPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterWorkflowPlane500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterWorkflowPlane500JSONResponse) VisitUpdateClusterWorkflowPlaneResponse(w http.ResponseWriter) error {
@@ -9560,6 +9727,17 @@ type CreateClusterWorkflow409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateClusterWorkflow409JSONResponse) VisitCreateClusterWorkflowResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateClusterWorkflow422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateClusterWorkflow422JSONResponse) VisitCreateClusterWorkflowResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -9741,6 +9919,17 @@ func (response UpdateClusterWorkflow409JSONResponse) VisitUpdateClusterWorkflowR
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateClusterWorkflow422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateClusterWorkflow422JSONResponse) VisitUpdateClusterWorkflowResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateClusterWorkflow500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateClusterWorkflow500JSONResponse) VisitUpdateClusterWorkflowResponse(w http.ResponseWriter) error {
@@ -9905,6 +10094,17 @@ type CreateNamespace409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateNamespace409JSONResponse) VisitCreateNamespaceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateNamespace422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateNamespace422JSONResponse) VisitCreateNamespaceResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -10077,6 +10277,17 @@ func (response UpdateNamespace404JSONResponse) VisitUpdateNamespaceResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateNamespace422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateNamespace422JSONResponse) VisitUpdateNamespaceResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateNamespace500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateNamespace500JSONResponse) VisitUpdateNamespaceResponse(w http.ResponseWriter) error {
@@ -10190,6 +10401,17 @@ type CreateNamespaceRoleBinding409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateNamespaceRoleBinding409JSONResponse) VisitCreateNamespaceRoleBindingResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateNamespaceRoleBinding422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateNamespaceRoleBinding422JSONResponse) VisitCreateNamespaceRoleBindingResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -10392,6 +10614,17 @@ func (response UpdateNamespaceRoleBinding409JSONResponse) VisitUpdateNamespaceRo
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateNamespaceRoleBinding422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateNamespaceRoleBinding422JSONResponse) VisitUpdateNamespaceRoleBindingResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateNamespaceRoleBinding500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateNamespaceRoleBinding500JSONResponse) VisitUpdateNamespaceRoleBindingResponse(w http.ResponseWriter) error {
@@ -10505,6 +10738,17 @@ type CreateNamespaceRole409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateNamespaceRole409JSONResponse) VisitCreateNamespaceRoleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateNamespaceRole422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateNamespaceRole422JSONResponse) VisitCreateNamespaceRoleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -10707,6 +10951,17 @@ func (response UpdateNamespaceRole404JSONResponse) VisitUpdateNamespaceRoleRespo
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateNamespaceRole422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateNamespaceRole422JSONResponse) VisitUpdateNamespaceRoleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateNamespaceRole500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateNamespaceRole500JSONResponse) VisitUpdateNamespaceRoleResponse(w http.ResponseWriter) error {
@@ -10829,6 +11084,17 @@ type CreateComponentRelease409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateComponentRelease409JSONResponse) VisitCreateComponentReleaseResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateComponentRelease422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateComponentRelease422JSONResponse) VisitCreateComponentReleaseResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -11066,6 +11332,17 @@ func (response CreateComponent409JSONResponse) VisitCreateComponentResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
+type CreateComponent422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateComponent422JSONResponse) VisitCreateComponentResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type CreateComponent500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response CreateComponent500JSONResponse) VisitCreateComponentResponse(w http.ResponseWriter) error {
@@ -11246,6 +11523,17 @@ func (response UpdateComponent409JSONResponse) VisitUpdateComponentResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateComponent422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateComponent422JSONResponse) VisitUpdateComponentResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateComponent500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateComponent500JSONResponse) VisitUpdateComponentResponse(w http.ResponseWriter) error {
@@ -11306,6 +11594,17 @@ type GenerateRelease404JSONResponse struct{ NotFoundJSONResponse }
 func (response GenerateRelease404JSONResponse) VisitGenerateReleaseResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GenerateRelease422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response GenerateRelease422JSONResponse) VisitGenerateReleaseResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -11477,6 +11776,17 @@ type CreateComponentType409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateComponentType409JSONResponse) VisitCreateComponentTypeResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateComponentType422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateComponentType422JSONResponse) VisitCreateComponentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -11661,6 +11971,17 @@ func (response UpdateComponentType409JSONResponse) VisitUpdateComponentTypeRespo
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateComponentType422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateComponentType422JSONResponse) VisitUpdateComponentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateComponentType500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateComponentType500JSONResponse) VisitUpdateComponentTypeResponse(w http.ResponseWriter) error {
@@ -11828,6 +12149,17 @@ type CreateDataPlane409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateDataPlane409JSONResponse) VisitCreateDataPlaneResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDataPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateDataPlane422JSONResponse) VisitCreateDataPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -12012,6 +12344,17 @@ func (response UpdateDataPlane409JSONResponse) VisitUpdateDataPlaneResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateDataPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateDataPlane422JSONResponse) VisitUpdateDataPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateDataPlane500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateDataPlane500JSONResponse) VisitUpdateDataPlaneResponse(w http.ResponseWriter) error {
@@ -12125,6 +12468,17 @@ type CreateDeploymentPipeline409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateDeploymentPipeline409JSONResponse) VisitCreateDeploymentPipelineResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDeploymentPipeline422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateDeploymentPipeline422JSONResponse) VisitCreateDeploymentPipelineResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -12300,6 +12654,17 @@ func (response UpdateDeploymentPipeline404JSONResponse) VisitUpdateDeploymentPip
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateDeploymentPipeline422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateDeploymentPipeline422JSONResponse) VisitUpdateDeploymentPipelineResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateDeploymentPipeline500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateDeploymentPipeline500JSONResponse) VisitUpdateDeploymentPipelineResponse(w http.ResponseWriter) error {
@@ -12413,6 +12778,17 @@ type CreateEnvironment409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateEnvironment409JSONResponse) VisitCreateEnvironmentResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateEnvironment422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateEnvironment422JSONResponse) VisitCreateEnvironmentResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -12597,6 +12973,17 @@ func (response UpdateEnvironment409JSONResponse) VisitUpdateEnvironmentResponse(
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateEnvironment422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateEnvironment422JSONResponse) VisitUpdateEnvironmentResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateEnvironment500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateEnvironment500JSONResponse) VisitUpdateEnvironmentResponse(w http.ResponseWriter) error {
@@ -12710,6 +13097,17 @@ type CreateObservabilityAlertsNotificationChannel409JSONResponse struct{ Conflic
 func (response CreateObservabilityAlertsNotificationChannel409JSONResponse) VisitCreateObservabilityAlertsNotificationChannelResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateObservabilityAlertsNotificationChannel422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateObservabilityAlertsNotificationChannel422JSONResponse) VisitCreateObservabilityAlertsNotificationChannelResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -12885,6 +13283,17 @@ func (response UpdateObservabilityAlertsNotificationChannel404JSONResponse) Visi
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateObservabilityAlertsNotificationChannel422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateObservabilityAlertsNotificationChannel422JSONResponse) VisitUpdateObservabilityAlertsNotificationChannelResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateObservabilityAlertsNotificationChannel500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateObservabilityAlertsNotificationChannel500JSONResponse) VisitUpdateObservabilityAlertsNotificationChannelResponse(w http.ResponseWriter) error {
@@ -12998,6 +13407,17 @@ type CreateObservabilityPlane409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateObservabilityPlane409JSONResponse) VisitCreateObservabilityPlaneResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateObservabilityPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateObservabilityPlane422JSONResponse) VisitCreateObservabilityPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -13182,6 +13602,17 @@ func (response UpdateObservabilityPlane409JSONResponse) VisitUpdateObservability
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateObservabilityPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateObservabilityPlane422JSONResponse) VisitUpdateObservabilityPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateObservabilityPlane500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateObservabilityPlane500JSONResponse) VisitUpdateObservabilityPlaneResponse(w http.ResponseWriter) error {
@@ -13304,6 +13735,17 @@ type CreateProject409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateProject409JSONResponse) VisitCreateProjectResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateProject422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateProject422JSONResponse) VisitCreateProjectResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -13488,6 +13930,17 @@ func (response UpdateProject409JSONResponse) VisitUpdateProjectResponse(w http.R
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateProject422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateProject422JSONResponse) VisitUpdateProjectResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateProject500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateProject500JSONResponse) VisitUpdateProjectResponse(w http.ResponseWriter) error {
@@ -13610,6 +14063,17 @@ type CreateReleaseBinding409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateReleaseBinding409JSONResponse) VisitCreateReleaseBindingResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateReleaseBinding422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateReleaseBinding422JSONResponse) VisitCreateReleaseBindingResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -13781,6 +14245,17 @@ type UpdateReleaseBinding404JSONResponse struct{ NotFoundJSONResponse }
 func (response UpdateReleaseBinding404JSONResponse) VisitUpdateReleaseBindingResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateReleaseBinding422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateReleaseBinding422JSONResponse) VisitUpdateReleaseBindingResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -14093,6 +14568,17 @@ func (response CreateSecretReference409JSONResponse) VisitCreateSecretReferenceR
 	return json.NewEncoder(w).Encode(response)
 }
 
+type CreateSecretReference422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateSecretReference422JSONResponse) VisitCreateSecretReferenceResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type CreateSecretReference500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response CreateSecretReference500JSONResponse) VisitCreateSecretReferenceResponse(w http.ResponseWriter) error {
@@ -14264,6 +14750,17 @@ func (response UpdateSecretReference404JSONResponse) VisitUpdateSecretReferenceR
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateSecretReference422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateSecretReference422JSONResponse) VisitUpdateSecretReferenceResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateSecretReference500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateSecretReference500JSONResponse) VisitUpdateSecretReferenceResponse(w http.ResponseWriter) error {
@@ -14377,6 +14874,17 @@ type CreateTrait409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateTrait409JSONResponse) VisitCreateTraitResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateTrait422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateTrait422JSONResponse) VisitCreateTraitResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -14561,6 +15069,17 @@ func (response UpdateTrait409JSONResponse) VisitUpdateTraitResponse(w http.Respo
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateTrait422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateTrait422JSONResponse) VisitUpdateTraitResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateTrait500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateTrait500JSONResponse) VisitUpdateTraitResponse(w http.ResponseWriter) error {
@@ -14728,6 +15247,17 @@ type CreateWorkflowPlane409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateWorkflowPlane409JSONResponse) VisitCreateWorkflowPlaneResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateWorkflowPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateWorkflowPlane422JSONResponse) VisitCreateWorkflowPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -14912,6 +15442,17 @@ func (response UpdateWorkflowPlane409JSONResponse) VisitUpdateWorkflowPlaneRespo
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateWorkflowPlane422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateWorkflowPlane422JSONResponse) VisitUpdateWorkflowPlaneResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateWorkflowPlane500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateWorkflowPlane500JSONResponse) VisitUpdateWorkflowPlaneResponse(w http.ResponseWriter) error {
@@ -15025,6 +15566,17 @@ type CreateWorkflowRun404JSONResponse struct{ NotFoundJSONResponse }
 func (response CreateWorkflowRun404JSONResponse) VisitCreateWorkflowRunResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateWorkflowRun422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateWorkflowRun422JSONResponse) VisitCreateWorkflowRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -15196,6 +15748,17 @@ type UpdateWorkflowRun404JSONResponse struct{ NotFoundJSONResponse }
 func (response UpdateWorkflowRun404JSONResponse) VisitUpdateWorkflowRunResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkflowRun422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateWorkflowRun422JSONResponse) VisitUpdateWorkflowRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -15472,6 +16035,17 @@ func (response CreateWorkflow409JSONResponse) VisitCreateWorkflowResponse(w http
 	return json.NewEncoder(w).Encode(response)
 }
 
+type CreateWorkflow422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateWorkflow422JSONResponse) VisitCreateWorkflowResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type CreateWorkflow500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response CreateWorkflow500JSONResponse) VisitCreateWorkflowResponse(w http.ResponseWriter) error {
@@ -15648,6 +16222,17 @@ type UpdateWorkflow409JSONResponse struct{ ConflictJSONResponse }
 func (response UpdateWorkflow409JSONResponse) VisitUpdateWorkflowResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkflow422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateWorkflow422JSONResponse) VisitUpdateWorkflowResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -15832,6 +16417,17 @@ func (response CreateWorkload409JSONResponse) VisitCreateWorkloadResponse(w http
 	return json.NewEncoder(w).Encode(response)
 }
 
+type CreateWorkload422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateWorkload422JSONResponse) VisitCreateWorkloadResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type CreateWorkload500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response CreateWorkload500JSONResponse) VisitCreateWorkloadResponse(w http.ResponseWriter) error {
@@ -16003,6 +16599,17 @@ func (response UpdateWorkload404JSONResponse) VisitUpdateWorkloadResponse(w http
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UpdateWorkload422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response UpdateWorkload422JSONResponse) VisitUpdateWorkloadResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateWorkload500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response UpdateWorkload500JSONResponse) VisitUpdateWorkloadResponse(w http.ResponseWriter) error {
@@ -16044,6 +16651,17 @@ type HandleAutoBuild401JSONResponse struct{ UnauthorizedJSONResponse }
 func (response HandleAutoBuild401JSONResponse) VisitHandleAutoBuildResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type HandleAutoBuild422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response HandleAutoBuild422JSONResponse) VisitHandleAutoBuildResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -16151,6 +16769,17 @@ type CreateGitSecret409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateGitSecret409JSONResponse) VisitCreateGitSecretResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateGitSecret422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateGitSecret422JSONResponse) VisitCreateGitSecretResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -16267,6 +16896,17 @@ type CreateSecret409JSONResponse struct{ ConflictJSONResponse }
 func (response CreateSecret409JSONResponse) VisitCreateSecretResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateSecret422JSONResponse struct {
+	UnprocessableContentJSONResponse
+}
+
+func (response CreateSecret422JSONResponse) VisitCreateSecretResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -21631,473 +22271,476 @@ func (sh *strictHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+z9jXbbtrYoCr8Ktr41Rp29Jdn5aXe391jju67ttF5NYi/bae45dW4KkbCEhiJYAJSj",
-	"lZP7Ouc9zpPdgT8SJEESpCRbiTXGOXulFghMAHNOzP/5eRCQeUJiFHM2OPw8SCCFc8QRlf91HKWMI3ps",
-	"hlwvE/QGztGFGCUGhIgFFCcck3hw6BwOYjhHg+EAiwEJ5LPBcCD/dDgIAv5G/UjRXymmKBwccpqi4YAF",
-	"MzSHYgH0Cc6TSIyekhFDdIED8QFfJuJvjFMcTwdfvgzN2ieQw4sIxh5gZkObQAyTDiCyGaQoHIWQw0RM",
-	"3ATo+UTsBk5whPnSE+LqN02gN63TbUPEnqNpU9cUYt6+DzmsHfRsNk9oYcoJC2CEaBOM7wj9eBuRu3Yw",
-	"zch2SO05PYENSfAR0dEkxVHoBtdQUROgZkwTiPY8vieZ4GZiM3P+M0V0WQPcSxxxRAFFjKQ0QAxMliBw",
-	"AvyXmMUB8WBF6C5RhCBDXgdI1Vifg7Sm7X6eo8XT8cH4oBnwNj7ry2DXyV9TygitAeg8gX+lCCRwimMo",
-	"/gYCORzcUjIHECQULTBJmUCGhMQMjW/iC8gY4DME/ojRJ66m/wMsYJQi9Zk12xxxKLgq4ATcIh7M5Ifi",
-	"OzFKzFaHSnLaAh5Vt+bzZvg8Fp3eihDdwjTiLY/FCUoispyjmF/gBEW4GcZsMEj06CZonVN3hN6s4wT+",
-	"NF5gSuJ5Mw+zRjVAi+JFJ/AWbRB15VyoBswSwlnDBt1g+xnzKxRQ1HRWP2MOmBzUcFRTeyLPA5svR1PM",
-	"R2puJ3iv4ARFVyhCAa9lA0cgEqMA08MkuZbPMmU4noJf0wmiMeKIlb9hy5jDT+Ob+CpNEkI5A+ivFArJ",
-	"YzSBDIVA70ccMTsEN4OPaPl3yTZuBmDPjH0yVL/8W/4TjrMf7dkZ4vUTAxyDvQWMng4XMHr2REyjOBSO",
-	"xYdmFRATXjcyJtyMLmzqE2YcxQECwQwFH82C4jt1IHIAkyv8W+GHkCAmZ5UjxKSv04jjJEKFHQBIkXhv",
-	"53DEkBDrOQoBjENw9OYEhYCTKeIzROt5Z2TfeO1TnPz9lpKYozgcFkhEHQjjgolPh3/BJ0OOEf23v09g",
-	"8FEM/rcQJRQFAio3vuE55jV49hp+wvN0DuJ0PkEUkFuAOZozgW4U8ZTGIEFUvgx1WxOTF7akGdrg8NnB",
-	"cDBX8w8Onx6I/8Kx/q8MThxzNEVUAvoaJgmOp2dhDbCXJEJgrgaBsxM3zc7NJH70+vTZ8+HgltA55Aqa",
-	"H14MnMAJFsASGDQ9G9mYBp4S2/P485TsM+cVF1STowhRzt4Qjm9xIF/94xmMYxQ1QF6YAEA5g8Q8MwUI",
-	"1BwNOyPeQPhvG80hjkZ67fatt8kendQ+soq+Z571doXvgpI/UdD0VukRDaAm+Rz+Z6s/agKq69OeOCAt",
-	"MYx81R5gaX3hJxyHOJ42HJkeCCZqZMPR0cqUPTSROklEcKwmKAVDawBNf+0LUDjHsROMVmnoqk0SYj3E",
-	"oAYRSK13iW4RFQ93O2TUDG2FsTDpWoBtM8W02WD4eo0vHlYXD3PLXQ87C+RQiHejOZ5SydIb4WvjxRmQ",
-	"SQsfvitP2JEFm+/rdUMDige7M5MBmsaS5d25zrrE88yYeqZnjagH7zKNfc6TpnETU1GT9GByNI1HT589",
-	"f1ELY0Rg2AKgGNJy1WaWHhCazx0QfhGzKYuJtMf/BMNL9FeKGBf/FUi5W/4TJkmkJZb9P5kA3FpNjAzF",
-	"vD8dnXy4PP3n29Or68FwECIOccQGh79/HtxiFIVazhsMB3PEmJCeDweYgWw/X94PB4hSQgeHg7N4ASOs",
-	"dCbE+KE8HlAYbe/8bxTdDg4H/7/93Nuwr35l+6diyku9TbXp4hWU1gKWj0IazeLbCAf9TuT4/M3LV2fH",
-	"4jjMzozc8l3+qn8HYEQRDJdaKVvj3i61IOJY4SWhExyGKO61s5fnlz+dnZycvrG29j9ICkIidccZXCCh",
-	"Jc0xY0JQ5kT8l1ApAJ9hBkiCNLdc5z2y9PYWB1haqLK1WXFxVFz7LOaIxjA6VXvocRJnb65PL98cvfpw",
-	"enl5fjmwcVhNDQQlIgrU39e535r53xD+kqRx2Gs7b86vP7w8f/vmpA1nxTXfymU2gK6Fyd/GMOUzQvG/",
-	"UL89vX1z9Pb6l/PLs/95am/rKOUzFHOjzG2AtdSsAKTt6iOKAVa8R74Welax6FEglUOYGB2paqM3v2HE",
-	"wC2hAAKWoEAolgAGWg5JqMB1MUSeVRSRO3WC7lNn4G6GKNLfC25rPhkOpAWk7TxygM2U4iz1qwMphcuB",
-	"PKIYdwNDf7FGKPI/kIlUrL4M9aGfxbfEYXqMgcFBdZUauDvMZwBzBlhAEmm2ExzGqH9ghhGFNJgtx5Xb",
-	"CEgcYjEHc6z209ExgJxTPEk5YgAuII7gJELypo9PX4Hsa4A+JRRpRicYreCuCrgxOJ0nfAnmCMYMxCT/",
-	"SBnvmLIVonDsfbJmgiMDm+t+BcowfiUOxKEXzBBQAxynBCK0QBGAHNzNsPTCZJsRaIAWMEqhABicxwiQ",
-	"W6D9o0OQWYKGRt0eCiLL9qDMkChO54PD341bVYtYxoKU69i5h1CIJJlUZTsOS6KUEdZc2zUbCAUnuMWI",
-	"gj00no7BTT7hYUAR5Ohm8ETchWNFPcApZeYC4e9GwLKv4L0L1aco5sckjpGE7YpDnjrwUP3dOmgAxYcC",
-	"kfSXzIXX4jcXgb+bSZMwgPGyNCFmIEgpRTGPliCfIYN8QkiEoHyws1/lHhxAv8mstoU1WlbIrJrDQQSZ",
-	"ORsUXmPXtb6boRjAWEMvPgAsDQLE2G0alRbI7Kgh5GjE8Ry50EfMcYJZ4LGu4DBySbV6aH3VablfEKR8",
-	"giBvWEs8tZREWh2Vq1IUILxAoTT+p7F525QrVh+JNxyZJlBhgaHiNDACOFZzSbY7ISmvYCFgCoFd1FHF",
-	"/ZTPXqNgBmPM5kK6x1OXC1z8PaV6b+J9VS+A9ZrPzSQVGhCDeCT9JK0iRD5Uw5LB/LlZmMiWB2K44ilD",
-	"cDP4847fDMQ/iID3mfo3TPAH6eV5UuAvf97xVpYifx0W9vS+5lj/pSNb6ng/pFNk8X31ZorD1ZQ6kn8J",
-	"jYGSgb2MP+9r7pyf4RMH6zH8uT2SxTPcw34h2j0b1qSBG9/NG9NmzvY2/tbcg3moHVgkKcactHEc5fIE",
-	"5BwGM+nBAxBQ27uEY4ZDBKC5nzE4k1TIOIVYih/RUnIn9eIxEGHGUWikopuB/vvNAOiLW0qPYe5xjKWQ",
-	"Q6hgavKf4juBeTSHglCz/n8L+RQQ9aboJfVaZjBFc4hjkMbw9lZySDBZKrEi27ESDUqiclAjmb3CjIun",
-	"xSxXnApIdQQJjXMMLFcsDDiYQx7MspdfG9j1RvLnX57HHY7CANKQ1Q3/dyEoKInG4Mnv7imlvaj4raDe",
-	"TNqrMmQcn6kfn1Ylu1zWdFDY6StLFgV8BjmYp4xnUptAKE5TRfA5log/T7StgEvZ7lTt6TBjFGPb84tj",
-	"8PvNIEQLxdi0B/hm8L54HoNuHw/kzl+heMpn9tZreCLMhB/rSN43UCNHn3jjIxeoMeqpsTWNCm6ajdUr",
-	"UCMjRmcKhOSxucqgbsQ1uR1fUse/88ieQtSKwdXq6Yr/SCgJy69PnYOodIq1XM5+OyOIncE/2QgQiCEj",
-	"FTSRQEzlobBUTpkJ54H7WAL39P94d62mrbLtKSVpwlxPgISgGVQ1ZFh2Y43kpK0PtgLWLFSLlZckanrT",
-	"zAtRVHvle7BnRdccX54IVnSCbnEsNFXAUIlBQg4CGAsah4zhaayeFn3wDCywfmWyR1/o1DgGMFfqnCw6",
-	"wb8h6uZFRxdnYKF+FLDYKnnhVEmC4mBGKCLjEC32F09hlMzgU8k0YXgeR0tjZK/c4kccOzScX3EcNq6Y",
-	"n7zHGiYssU2GPJdH+RpxKE1XCQravsjAuBKDywiUrduIO9o57IFC9vW6kEfMxIywIcWOMlmqdxvGAJUJ",
-	"+nFgiznr7UAaDc3quCOkqXoZK27Co6rhIZNpvExZlaN1GLLyCOG22S7ykeUDUdAUJvM5mit9ISWDjDbx",
-	"Wmpp8zFVH3gpBxdC0pRheFC2XV+QCAdLoD4Ae3KQFM1RvHxiGdPyr+Nl0V5mfqngaAf92P3QizMmEdKx",
-	"cQ1yuhilzkW9+Vov0IK74UlTCmPOfK2g2VXp5VvE5hI+2Hsv7aIRLzrSSvXZXhvFbA2pmPOvKtMQ0+xB",
-	"yaNkpLEexoAkWuiWZ9XJMn+B6EjiVEVx1qIORQLNA172xmRijUS8klotX4BMqT6FwcyS1qVWrdRXVqNd",
-	"Y856a9dVtRpAcXZ3MxKZzAdv9MjtDg4cEZu+FBN44pkYK91i2pjU+pEyO5WxyizbiEoarrI+ZTBHCCUx",
-	"yEaLw9KmLlugK6JR85uvBOnGGW0may9TWbnAdB1wefoqhNyWiSPqS584Ovus5Z71/I3nvcLzVuVsK5pv",
-	"5FUo+wMrmlQc7pf8TwuM7pptKVXHpwVLGbRf0jmMR0K8k6Rp/Vh7JydCzRf7BlD6HgyLaQ6Ldtkxau+q",
-	"kyW3KoqDvYrZVo29J+Pt5s2tubP52BhCXU6ponWM5VZTyW/V7Sl8n+IFytzLgn9nh5xAPhuDLBnDng5S",
-	"BM4vvwurbmZrVCtU/20gwUyJROJ1uZXuOhKjzJDHjCWvbH90GNz+/vfM9iOVl7ohma2ot3Wy+XIuW41m",
-	"SjqwQpZM/JpDPLDv2S8SwUYOKS7xmSOaMo2i4nUXUDP3hcBgnjtEEricO33SzhPRr8M09zd5+L4KjlSd",
-	"zVTw/jkMZliscNR2Qr/BKEUvKZk3g1tvrzoueo7u3Vr17RgbHILDAxobytB0NzaUZ6i1V5VQyNdaZYii",
-	"j9Xq28WarbBU1QC1Nhxq1sWDenxaVQevO+0H1sibzttLyG84ssduwSqwmXWYr8qXdR9WrPKanQho/aas",
-	"ylO3ZfSzHsNWU2TNzuh1/0YvGEXntzIdpoP563ONVcnwrlWNQVWp+30nm1sh4quL6c0p4PV5LO7RHqRV",
-	"rtwaZP4gbUH5f4YoQhw9rHFIKpOZ4hbOcYyFBqqD14Wav5J1yFWLzbNiW2YFuIlLorcl4hY++ebE5eKx",
-	"bYOsXIBICcrDAcviwv14l3MuNceX9+Vd9hHECzO7hQj9GqNQPhUOcSK3RIpV1iRKFC90O8SJ6pU6Sjox",
-	"mY8kLlra/iGowVBnKpFM8mZOm5qUB5jO4yjU5Tu+ZCA0lmsmrS0q5lQo0dmyTJERZvKWtHyAYk6XMi8p",
-	"Bmq7SvS5keR4MxAy/h1cssKCKqbyRprPbgaZ1CTf/MLAMTi7BUimzBAKiApHHIKYAGjH6WkAdZCdzGNX",
-	"BtgshBHsSfEFzScoDFFoxoTS6iRlF0GYY+tTfZ5PCpk4XdxJci5LItyToZcTVDwJS+ex/24hURcfUeFW",
-	"LW7XJZCyzWFUJiN9UCatu+lJVyNBudhidkZMB6LKAF6bJRTefHPw5aKNVqEzu9KiENjaPpAjExh8NN+8",
-	"73vpM2Sl3pt9jcFrffc3ZRhuBuMqCmQAroQF1vneCyJYHgRlr27l1Ffyf69UxohiyXYt2k6fZvVdHK4x",
-	"NE8i5SURqtEUxYgK5moZEvPqMOEyhnMcwCha1lP+LaGC+7WGXAt01ssJ5jbPq3aZ5XS5RPEwyleEc0TF",
-	"RP/Pzc3fbm4+/35zw25urt7/x83Nl5sb9u9/c1k+sAMh38b4rxTZGW4ZaVHbvaKVvgq5VReJgygN0bsZ",
-	"ao80D8UVzpUnDd+WVmUzkkahIAYls4e9982ly1OW2yjanuwKi04vqcqdupWGJxM5bZGh/X2hMJL6o4sq",
-	"ucYx+RRnb9OFhTVKjCyxjSoGAjOTekdL/sCBgw4XkDp4LiEJWECKpXYiSzXczVCsa/EZ/G1jAVim45mt",
-	"uZhAY3ICrxFGLigaBdqlZR5jgGPGoXwEslfamCkq2FlDlm4O5H8d6t20PaFkgSjFYcFaXDkDA/kbJ2c2",
-	"lKgHqbvIiFHuvY0x27qNwfGCtDBslEGU7FOQDcxTXLVHbYNEUn4Iut5g9rWVthaQOKCIIxXJz4DO2rZo",
-	"68nAlefgSOUt3LfPyygLCkBe6/HX/tt8GKBphKzsahCmVOVOxSGiygTvpQv9lk15mbqNqqYWjdtacEHx",
-	"HFJVPUjWxMnZ1DJBTeKaYaU2f5U6zW0aMVnBKqAk/pNMBsOB+r8JJZ9Kxv7C182sqrAPWxzwVsdqMq5V",
-	"LT4vjaxunayUsEdlessUc4kEbqrKnmWVWdZGzp+x7H7yE/vmLDT5KW6DdSaDZkXLTD7POq0y2aw9LTI5",
-	"eq3JGpNf3nZYYorX18EKY2NhOcAmD+TxdXdNC0nmU8jRHVy2ffyzGmYQr1r/0yOkt7a/hA7xlXd/duIS",
-	"LKdCO9K8p6JfIJDMlkyO0OdhVyuucLvjS2Vukm0n5OdMCA969VJC7SBlozvE+CihJBzlFUMqxK+KJF5x",
-	"Qn2O4qo4uinqqUysXR6LesSBxdIfrU4eZ6UQVYej1mF4rCptaLgsb2FRTrOB7FZ/xkXXRJ/Gz1oFdj07",
-	"+W8GlDnRJS1kYRAzhwtCn3rIdVdZxfwuTVjcr3SJic5JjDmRghuMQxCR6VT5WW8pZJymAU/pt+dIcRzs",
-	"NrzXVbBWfLgdE67zBa9O3ylCo/AorPUld9zvdjzp53XvYFMKCain8b3ykcbR8knHnBLHNRTVcce6xvNQ",
-	"VcQdR//elwL76+4N7K9UO0DZJmQ1faPc//C8rOtbtr7f4ehfB6P/er/3+0j/69/Nn578//+2cmpLM+V3",
-	"kPmcB7pu4e8Wx+cJk398e/mqCt5PkCHw9vKVuZ2XcjyQHwDxKmhTrgvlclkpv64Z58nh/v4tjknCRlIG",
-	"GRe+Hclvx2wRHP548OOBC4f040y9ANayEV0BWLNeZ0A3Ks46CKSbXJsLCk1SLQ2gP3ZcHh+tjBo0gL3w",
-	"opPU1UOS9iDHLRKpndBup2ztBHUVIVtZjpubAnrFHqlogG9NVDbG+4eXjiUkKwrEao51ysByxp4WLO17",
-	"WovIq+5pO6Tc/KY6CDAG0Uoyi/S/uup1oju3c5wT7bRVzsTcgyUjgGSltfD+veb366veuaHv3Q3d6IHe",
-	"rjCUBPJg5qKp1yTMoqYlIcmy/8qpZ9DaRKbokogIlB1MayAsihKk6EqiuoTXKdqbkvyOvfzj6vzNhSye",
-	"mI+S2nSSNEXNkMTVR9RIKCXHIQxVZ7QkUlnzFM3Jwo307tRdASS4IEJMkW0JxXnKphfiP+biNpYdasHJ",
-	"rFiZd4o42JNR72G4r8GzjuFJBXlJMtAgdo+fkGyiPdefk+weiyeuqtM5BSP5k0NI8RRxLgt+YAuA6oH2",
-	"E88q88gK9O1FLrP+kyrOtfB21cBYujBT0s8Aro/AyXvWwPoLZLgC698k/1V4WGAKX3fcQ5vO0kMrNTJW",
-	"3bxZUGdr83EvjSgbbSfIZxGn8gWxIrdhQAmTzSPySiDfXqK8Fdj78CqVAWZFrSqbZp2KlZm0p251l8V6",
-	"r0W9yq5tOzSsQmO4Vmrt4A88Pts/PgEywvxbdwIWz3CbyHEdrr/iXJsgzO4Ov7tCm8I1U+Y2ufkKMHXw",
-	"8JVRsosbr3i4lVSewtRP6vM56l12ZeB6eOtMYmkJ1hZX3Vo8bFXa6mCbar6X1f1qX194VPFp6eZKCvCD",
-	"BEa5OGIX4bkZCbbIm1MGdDsdOWUoV/HhFOTYHnTtqH+nmiReolvHPZzqX8HxpZ0YKNhYJHYIYyE8/ak6",
-	"h+BYG3Z0AzbZryEVuqL4K6YA+3dSO83Bcr90m0hNs9pNVCyv0mShNF+5a2ldAzAi8VQ2fSnmGqax906z",
-	"Pr0NHQFpGl+v35bs2lBmAynvpWpe4NHRrQ67j5CbUq7xHI04GUV4ocwrVlNiK8UIinlk1oKaCOyFprqe",
-	"4pYgwh8ReHoQPp09P5g/GTstUg5JpL8cKfHu/bBJlqnjQ9Uz/I5pPSO32IzBiXr1JV45pxHvfCj7hciB",
-	"NwNlLNJ51+NqMRELSTzEgxXehU7FcXIUHDG+jGxuvgaO7WSVPpVSbbNObplRdlhNKAEJkSqWkzd0CQq1",
-	"H7OCrrqwyTekOVqtHB9SXTR/6q0jZhOsRzE003nbajKQVtUBswt5aMXPTHqp+mY1EJkeYdPa2Xyecmn+",
-	"ZjFM2IwUT0kzHVkyS33L8Rx9g2RlDm87qEtDUyWylotVA8Fe3jlUlgcZApxds37bKZIY9aR+wzVZnn7k",
-	"qAHqTJUGzdZGneZet4xI/dWFKoLWlCG/oOQWuyoOXzkJO5fY5ZOq4lQCHRJQXqRvwvFxIfHVWtMpwNbk",
-	"w1uTFFPh/cUVEyfgjlRyySxBuU6Y/6ZfUvIvFBejE2QBnTIbdR0CuYuRw1N5ZkwlrFSQQtydFnZMdI5a",
-	"YIKkKgQ4qUcZd0r+BaRKslqxiH3j7EnPevY27dnrDEu7et8BwfSFKewSF8UcN5VhWhMitPp8TSZyL4zK",
-	"0pj9kKkcaSExq4zZFkiNfKs7w6pKCCknP8kCQrWNtjkBYtQcclVjBnCKp1NElbom+8VLJSBJWaHU/C2M",
-	"GHI13xaznUhtoRCBoMd7AqHUDfF3PUGhCIZUAvMAuAymAkYU+oE3ViCsqrQFPpK3XWkueOYoiVEa75aU",
-	"iqUKwJ7X6gWjfmkZJ7T+1TJKL0heMAzLgK055Ifgs13d4Mv+58IJC27wZeAum7A/JRYfs1Jv9vIx/8sq",
-	"y/C/dFGG/yX+vyzI8GR/xSydWudBzUNwLv7MZjgpdBk35vOglvgaebLtKCk8Jjk2FJ6Tlbm1a8MryxjX",
-	"BRHDVDLZU1JAVsxOxw5asSAVVPZ+OK5LpXnsVtTl61iLpJJb1bxnMjYi4/LxehWan4IuhqpahFzJ29D9",
-	"XBtcDNKaXK89n1W6+QsQ1EcV8dw8BI7aL5UTaHda1i3iVGXny1Fe6xFOgqfPnjvzpNQcv0DmiAoVf21b",
-	"XCqy9sJsBp99/8Nh3ZIu6Xq9Xh3rhPu5copUV0PmxT7z9dfaXO/qrKHQlV7CxLnbNysEEhbAyO24rD72",
-	"PoWvMgfEntqgAKbcvGxYLFHVXBDLLFoujJXvpBQF2Pb4q0Uz/0hVD2k8lTVVyWJrK3xVxLOzOEl525si",
-	"kS0rNtsf7Zxl1lwVDit63mPGvAzOh8E8LcJsAP/ctc/rip6b7lOZ/pn7YFOmRCrxn4L3AhRPcYwQlW60",
-	"KVkgGhekyBlcYEK/QQPyFhRGX0tF9A2UQu9VA329Rc+3qtp5vzLn66xvrhhNrs3fQ6Fz55JDY1GR7MJR",
-	"/XwMXhIKNLkdgs9mvkNwo7jlzWCYDRZ/nC9HXP39i1is8IG9suM787yY77+W8urdXl6t9no8nj2iLN14",
-	"VZ+35GsMWb2qepYQkgP3tVdYL9W6tWbtUn0d7DUcjS1jWfOvpxD73YoV2Hel1x8yifyrr6q+y1TfFUz/",
-	"Zgumr0lRd0ttTzYpPDQlOe/qnu/qnm+y7nnvguetlc5rvDFVR7iRiYJKT3PL+DcGkkyFoiTJX6gMOr5r",
-	"7OMJ9hQYLR9ZRVa7X7HxsgkSTX9r4xYnRgUeJZQssHg5rGAp42p1HI4fp3jvgx81xuEG9MhpzcT2fZOY",
-	"8K7u+i32YGtfa8SLtwzRkVHa8zzCjn4C9/Ub92SHaP3K9UaQ8WsKYyZ/vsau43sFGZfhQloCN+1refZd",
-	"MYhl8Ozg2fejg6ejgx+unx4cHhwcHnz/P20/Wwg5GhXjj2xbJ2Nwilrbg5px9sIXOg5BivEwXDYU2PR2",
-	"IxrWnZfnyk/gDjKgXqBWH6K0hjLXYq9hMMMxynemBlrxGfnl5Vu9REIMwZFbLakL/lUPVJbfas+cyWap",
-	"ONOXMJJxo2/jjzG5i8t+kdR5ddz58KsgoFvr2PbQeDoegktxRU9Ku3LeWrl4inox9SaHLiTOjruRdI44",
-	"p3iScgfURzE4+unoGEAzBMAFxJG8oFst8eU7smQ/QGIAY91st/qyrtgBNwNnXDi3U0tfgIyRAEtZT6pv",
-	"rdWI0NIR3phGEQiJtEQmkM8q66tLBDeZeDS2dJabwZMifK5B7anSaFl6XGouU2elnsaLn4yK5KCyxEp5",
-	"DLKPAAxDcXVWkocsJWYdaEGFrXoV9ASOvMt4Ib61tS0ZKsVJQKIRTMQ0FOtoFQOOOovxTfySUPDL9fXF",
-	"vvg/V/vvxP+7OgRSHEeH+/szwvhhQijfFyL/BeQz9c308uJ4//r4Yv/tycUhyEZJ51nl7s2nHsD/mTIV",
-	"xSK+kTjhmlCs12UyMb5WFiO001xiPIjT+cTlYHXHcMQc4hjRc61iu/ybeog21RtlvIoGKF54u5ZO48Vv",
-	"kLp0qFscIX8X1UscIedEzt1KK5YVmvNXilyXpX+wKlNCEKO7hjCCzQfMriFGtjYodM8/JLT4WOko0GJA",
-	"aAWLGxl+DpT9d3uR1xDH4PL06lpWnc7XsQrCPz149sK1MGZJBJdui1D5pVFjq3KxWPTKteiz73/oEY8r",
-	"iTar9ZEqs5Q27+pYzycNWQObqoI/fNhklXJIaCF+Zw0xoUoxdHCbXGBLKAqkjdut3Z5eXJ4eH12fnhyC",
-	"t8yCR8p2AnAEwzF4haYwWJbDwWWFyHEPyukdtqr3661JSS73M+aqOkcrY5yQUOXYK6VZttieYg5UKZAK",
-	"d1R/bg+iLkxRCOSbYj7KfqmpQOJmekcpn6GY6yKpZYvaBDIcjGAqn3LGZuqfBVG/MKS6NJv96pIer65+",
-	"AQnFC/F4fERLsGfuQR6bWelJ/ZRnoXtSMdnZiZzl6N0VOCaheNDmsiNnor3rrUtw8tHlGyqflRhVgjw/",
-	"DefEKUPUzQHf6l/yWcTrZy+Xwf+ktS7Cr/79sqsFi0p2FVPOpL2sUms9pQKMb/w9uWsoqmSRWIEeXAfn",
-	"ArSeK6zAEmrYgYnjcr8xn1sECKHHiBNUkwt6UGVYI4hVqRblkxiDS4O3ckiIEiTQIwb56RRY8udBAhm7",
-	"IzQUaz/XkOcIPYARLpQ1yQ/Kl7+5eZsvX2uvqpSFaRVdsk0fXudDTTkmP7Sy1xgO6qPYJA5Z9VI6C912",
-	"BZe1Zdh6GCUtxBC7Ezrfh5RGg8NBQhifUsT+ig739yMSwEjqmN+/eP5sf74MJzIgY6qsZx+ySsWDxbPx",
-	"0/GBE4EMBB14hiz2jYKUl/iFBnWUQeDl7MkWL8iBrgttaDvb3m/W8rSbynLffKPZLekwu3Jr2TX3lO3c",
-	"THZ93WO3pm1s936x30ij2Hsugdi3Nez9t4Tt1Qt2u5vAbnH315Xbvp6gANe8RymfEYr/pcAIzThHOqeQ",
-	"WRtr+JmPTS3CyiR1brXLohfNAiJHcSEIgRlkAIZzHANKIuRnOQ49t04RSyMO9sQDAf5e6EPZbM4ssdRs",
-	"PScjzeSGC5ygCDulk8oYV7JOQsmcSMATyGcMTBC/Qyi2LbGsFDiQCy3fUPF7x4k+rPhSgae3HFOdaT0C",
-	"TWVeb8kmr8uX6E9XFnGq1/fQso77Ar2EHhcuVuo0KLK9EFTrCr1rJ2vf9+nCXsvP8VSLc37ve/v+mx7o",
-	"VyojPXfea5Gt8Eo7cFCBsKHilqdxmBAccy1Nvr185c6/Us5qLZoCMUxF9YmrUzNUzmLGedLuflQfv718",
-	"JX22nCes4zc86vZF0yk4u69emUYOoezBKiMZMGdNtRjdvudftIcZEArOLoy7v87JNArRYqTNjmM9YhyQ",
-	"+cC7SZaAVnvH8xX2YYL3F0/9vdwXBV92NtGLF8+LwtrzZ85YIxUl4AZO/Qb2xLUPgbz8IeBBMgRpmAzB",
-	"HRP/X/wpYk8qPWxZq0FF3sL75uuuo/8M5XNUBwzH08gU0s1sJbX4b0phG5rywVCbDGUs/RqmWJCPyInY",
-	"2R6TdBLhQGJ3FvxstjUEIaJYjJIpNUpQiUMkyOGX6+uLS1I2fcnLOdzf74nLbreF2Z2OGC6kHwqY3tnF",
-	"xSrguJVGCZo+mS4Mx+nfygBUhafE0QxlBMwQ/ExhMvvnqyF4hyaMBB8RH4Lr44sheHtyYUeYim8Gw4H4",
-	"aDAc6K8Gw0H22WA4uD4WQ96eXBRdIvrTnhlnpzHHPEJzZ41j60fF+4II4rmM3lbt9KoWEIjnjpZ97671",
-	"pxXXvmnK5tuvzwbJwGDxUKFBjWrmLB2JgtUs1HI2dVHvx5VoZvSJUxhI7wuyYJWr6dw06dRjvod3nB2c",
-	"ztPiJmYsDgtL6IDGG3WmTOUJy4oT7GbwpHrqbLBivEYhpMwcZ77IzzWL1NyDvbL7NmS4kisUqxIkVw0g",
-	"dzmIfzMhdR/Rcr+CmSdH10c/HV2dfhC036WhpJ60ip3GaVF1WUiHhXuFl5TM/SK5fsuGu2IY64/0N3sZ",
-	"V3dMHa5uZ2C7ggt+RUtn2x5ldGv43Hk5V5lv0f+l0N+4Q/m+uILcXUeShXs1oppluDi1DRPUOFtseV55",
-	"6lhe5T2rGfPtmCtOC4FyD2insADpa6Cwp1iLZcKa0NckUdKLVzFF2FfzwDaI8uV4GB9iUEStaiSDZ8uw",
-	"gincSvnJ/2aJwNmK45v47BbERBXYxbcYhcXiH5b139FpQwup0sdhU31evp4I8Bhy+lubaTH3x4G9xo3Z",
-	"oqZtcS+PK0qW9sgeWbEWdBttVtbPaYbZBSVhGrj9F1mAsEAGzFRfDj26LiS4ppRvyyvTwQrVTAirOIiK",
-	"826Zi6gIXC8n0SmlhF4ilpDYVSjzisM4hDQESIwT2CoH6jK9jpN2BelXMqjUZHJwTn0/HZ18uDz959vT",
-	"q2uhzL05env9y/nl2f88PRkMBy/PL386Ozk5fTMYDt6cX394ef72jfj78fmbl6/OjsUXZ2+uTy/fHL36",
-	"cHp5eX4pp/j1zfm7Nx9+Prv+cHF5/tvZyellkYztmRxxXRziqLmDldqIHmnUDCu5W/4uzTR1tT0wctXO",
-	"fqm6tqs+x7Iem8ACOVuBUdSlZtQm6cnrNrl5OVNXYBRCv3QMOOQgQpBx8BQEMyj0N9/sjUrFFgl9m+aE",
-	"bACdyYPf5fWJv5OPzy1J47CVV5rDk1jnfH91Cn5tDNiVsnTBggdRJ+4rZ6L6sCK01nDSo0AHsmbZ/6Wc",
-	"LOjMHbS8so3u8pTP/nWsx1ola9q+s1uksVSezgfPJa/U8GzRcu+s/KnTR1JdwXkxVpu6ls6nMUBWM727",
-	"GdG1bQHu108PTPECxbqn3oqqSJZtnelHvWvw/DeYoIDMdeMIG/JCLty4MSXjWSUl471Owhjl6Rh/G/RU",
-	"g5y7NazeRO0atbdfbRHHImCPpUlCKGeVkh9jv0o21rUOW+Urk9/l4N+ReLTTzoYX+aHT6KKqA4yXcB45",
-	"Ob5YzJ0q+FrCIbNEsYrTkBlzZQdIsq+W6GDRkdBK1Iv5xs009h5dl6GlWGNydutQelCOMMaiX6y+0Mtt",
-	"p+cWWqwQ4Iw47eW+q/m2nQjKG6pTSKRy5Z5K/tRlPg/nonM/7ho7OXQNt1qYqPZWIz2q7TKdjsjfMOUp",
-	"jGTKa2a7NTO6jsH81h4XncFFYu9D9vE7tnoav9Sf6BvE7wj96D7QrCWteiv1fxhHt6EZVuvd80SPAq1a",
-	"nr1enzfstRlrqu0mAY6nMulcOhLUP2N1XqqXUHXjU5Nj7gG3ffRy170/du5ZVxzUtf19UhqyIoUwtrrK",
-	"mU5EWRPBzNepW9GVWwo6Yv/kDG4COU+yNsBqHZV8ClNORgagEGBlYDJVe4rOmsXT8cH4wE8dyfIHBSup",
-	"V3hNjdE826/BxOjzqZfJwEpu1IC5jZGo3oAhfq1k11shB+L3K/wvF6eSHwnIJawgQVTO5pyGEw6jY/EQ",
-	"O/JkxW8ahmw6N1eq2kffN91Z/X39nB22zU27NuXom9vZ5WWtXyOfZWOphbKo++AB8gWrCzcZNysY8AuC",
-	"EZ+dxbfEYTmQv5n+mCoaJa8gpYxLRUSoNYtkvGjmLGIkFIkIqjqksiqGvXKX+j5FkPfUfy6H4ARNKQxR",
-	"OAQXlMjXAMfTIdDVfYYA8WD8pD3NUq3qoqRff2RGsb+mCNXTk/nF6AmqFqGpBEiRrqcMoyiPeDH9PQG5",
-	"092YYN6yUFV8cTwN6uNL0xvUGYhjrSq4UnlFsJeVYRVP9T6hoFqL9YkvE84ezPycnOGCRZtGaRuuw3+t",
-	"sKjByooFbWTYZqys/vib3ZrLcHZuGqKb7u8oBCwNAsTYbaoqDzfjlZnUtbc3Phyw0Ac85pSYVJmM8zEw",
-	"I1FolSqWzei1yY8NrUr1QymU2Y7l8U18PUOsMBuklr0kaxAWwQmKwB8lD3CgQBpJkP7OaYr+cDmcerpl",
-	"O/pXs0Nbj3c1m87Xt5qf4Yqe1RwxHtivWj5Rr6jmN9aTXArmnjk7iuXIrgbkxq6jgOOF+MO1rGUt08+L",
-	"bohshMeD+IYIlFZFCU7nEEcd4q/EcCFNZxOAYAbjGEXVu751Br1cSW6nJ3JG6kaIcvZ/tQQzsnm7McXe",
-	"59Xr64s8E9Auo+07gzwpU5ldibH18jtFAU6wkKkLG0WFrf4+4AjOCzu16/tX7XP1RbBLaC2PXkKoT6ql",
-	"vHb9PqtqvdxPW/XwIiZMSLism0mWVcimU3XDq/NZiC7Q4xD87bPEk7HgNV9MO1gUAsiznxiHlLMj/sVp",
-	"JNdegzqw9M9A5gl0AO/3bHW0QBTz5Zf3YFSC9tpA2y6NaSCH6gjbrk4g+VHqst+KX8rlSJoNXHmtiA5E",
-	"JlUTywRbrJfSe5rSqWRzDnMofY6mjs3Jw5H8u83qB/XhduE68kJqy+bZa1uF8qw6SnOetGYpOO189tRy",
-	"hDXt9z/+p/Tr4Ll4YH74/vvn30v+ov77qVNrb7fYlrd+/eqqpr2oPAwN+HBgag9FzOse82mr5oNXV44a",
-	"yOIjV2M8FKQUXX3EyW+I4luPynZiLJBriHkkTAgIOs9ew72YyCgLMp+Lh07VFMqjWywFrDGEpUoOdfGf",
-	"ReeliaIKZBklGQxplaSoKVfj9CL9ipZ2Uw6H1SGjvV6eNxdYRawfBRRJ8RtGrLtgU2YijqQhWWOETISK",
-	"mtXyqQm9L8fgdmNl+rtWmN+hyYyQj/7i2J36wFMgmyEYNhaS8d+XhvQXOaM85GoZo8wg8sv19QXQi4sj",
-	"1+1bTPCe2UQe++DoAb2URRtrpZJsrX9cnb8Benj7u10t70UjR7iaBjDz88lstRmSDbmEsArucBSBiaCS",
-	"UqdMk7IjvmdjFsHgo2Di+zpHhu2boZYjJqW4VTAQcL73wyb7jlzGpNA0lDSxQrHYSVbiHsdSBCIULDDM",
-	"zaR10eY1Xt4zNcvMWm4lZ2+buFA5mHPxDF9QwmXIhrHPvLb08RJCifHg2fhAVvNVcR6ZDcuoy6V0qcuX",
-	"x+C//vPZj06xIQv3+aCe5KbeZIXoIP2Cy7SzgvKQpYOlfDYu2iOa9YiyJj1BkCL6YY74jITsgw5/QK76",
-	"fOYnoL7RFfT0lyXw5F13gyTfxYcgwjI220HqKD6WY2SgTiwjZPbM2YP/87+fPRkDdX1qjqJAIG2PN3EW",
-	"4yMlHPOTjr47fnX2ZAze6h6mGhJZthazgCxUXA+mN7H66QNWAUFZHUGVFqQMQF6GjnxPx3LGlrORggvm",
-	"yw8ohpPIdVFeh3QWh1KCYYKZyYDcooZwE8tY7VtCAxQqvzNmGh/H4N0MxUBJSYZ1qxQM2QpdJmEBSNFN",
-	"DIMAJRyFpeIzdTV+7SCzamarlh6qRFmXKVmijP15kLjbn6tpPsTeuVl+oFg38fr4Qhbaram1I5HGj/oU",
-	"eqsvBv4EVhNM90ErHXZwnZNjNbAKB/yu98kybNbHCVuioe4ZmjHcPYNgH3Ec7ueBVk/GN/FryIOZjmdj",
-	"JrVc3JL4evF0nK+dhWbImFUmhAIiWyphKP98dHHmzByKY8LzxkwrVneUP6vSjVnKp3KMME7kbzD9hCMM",
-	"6VIG+7vkItPS5RrPEeNwnjiERj1EdvdQY5r7eBz49/EIUYTE3D9TGKALRDEJr1BA4pA1eYiZGgIm6Jbo",
-	"GlX6mmWE5ZzIAMtbjigwC6hfJI8pegIPvNpymGkajin7yTQBsdyPd9BaXTwDE6Qga+iJ8qzrWUq/wmbx",
-	"itApjPG/bHecs4a1T9ikiZUs1vfOLP9Pyv5pHW3d0QFucQLbwe3v+U79+lHuWQu9PTspQv/99wfoxxcH",
-	"ByP07L8moxdPwxcj+J9Pfxi9ePHDD99//+LFwcHBQf8U8UKlOGncZLZwe6yUuTqPQ9t3rgpQ0GiIitkg",
-	"6VxVmkxBkWRjoANDZJNiacaOQ6fOqZxlGev/dtIuPW/nQTMy/WDsm6zpOftaPI1+a/m6IQtufKOp+1lK",
-	"urkpPZHkgX2YHdDEK23UmzRIjDSeJY737HPm5JQsZvC+phMUshyV778M2ybTXKp2uruCqe29QNxSNGbR",
-	"MdrJS5g7GlFTwrv9ouasrdCXSGpcLpwFExSReCq00lJk1MKZEsJO48WJsW17N3DR+Zmqfpbq2OIExsjT",
-	"ztZPlm7X3D3MNbXlBFf4Mcyv1t63+bEagla2qXY0cdY4MBw7XYHoumSpetNdMzA1Ja6rY2pqXc9JjI2e",
-	"EocgItOpbLEd31KYa1/fckkGx3FujxywUiVsx0zrf9871cYuvuVrKZLtuL5teqE9qy6UGUK5SIETSbtU",
-	"QXCcPNjruKRdIMEJUD2w71sprofv0bWnjMuB1yZtWWVhg5M3V6OnT589V6F/45pA5E31repYrqGGCXSX",
-	"6DZVhP0Wx+cJk3901s77CTIELEvvSzkeyA9kfzTtNXTdYV7JvGgKPtzfv8UxSdhI1gsfF75VMZtjtggO",
-	"fzz48aChnyz1Alg/2nQFYM16nQHdTHV5B7V3KzMvR4UjMnH6XGkA/dHh8vhoZVygAeyFCF/86K23MLe9",
-	"Je6dYG5ZIRMnjL3qmVS8cTXeYZd70RTvLTngyq5G29PoYLLaq1iz8DOz8tlJjQg8CiLc72nUM1ugFjPI",
-	"3fNqT1QduOrn3D8qQ+kx04sV3cZiEzKLPqHkFkeZ6r+u0Fjt68rPOIPe9ZxeFMS/CtEwQkcTyGQDZTMw",
-	"c1ZJDzKzvFkjMWCh0mJwnFo96NhNLKOrb29xgHUmnpmOzyhJpzMQQaryOoQWzpC7Fn+MPnEFl8snDP9K",
-	"ZeIlI4rx3yIezExCkvhU5uyNwQVkTN2QCgyB0gRwE/+hvv0D/JUiusy7SRk+LKfQnpIxOJrIQn3GnyJd",
-	"wRSBmIA5oUhl9pVfCrT8x7OzPwmevPvt4H9cfU/Pf3mdwnc/LsI/T/Gr438sQ3z2w+t//fPgzfODv7vd",
-	"uHOVcFSTXniUJJR8wnPB5kpJhiD7Vjuf5AHIA7mJr02lqhggxtX3WYjMZGm7LIU2PIdLmXI6QQB9ggEf",
-	"38RvVcUj8PYMzLBQoGV2ys3g//3+wDqPm8EYvIZLKX6q45PRCrc44jK8WRw8RuVje/GsJ6e7gDyYdWoX",
-	"nIgvAMzTdsfgKIqMI1Xcr2lyOAanMJipX8AtiSJyJ46TcgyjUZqEkKObmKE5jDkO2CGAeqiMQsIMkDmW",
-	"rcmt6sgKigjBhXbzBoSqRCfpwshguonzHuZpHMxgPEXhGBzlV6aWEheaJBFGoYrkEXueyOCWiNw5DRWl",
-	"LsjlNtKUREz2PB7Z5Sl7tzvu2Uhex2aYzQ4BRUkkU5qkje4TZrKArv3FTXw6T/jSeA8xA1y2qJMHczOI",
-	"CVCneDMAe+Jicu+5aQ37ZOxuP963RbHvJuxPNreLlXsHX6+vdbDqG6w80YXOwS1HFnMseLBaRllW9u5m",
-	"JEIj+W89GEB1LCzCAQKyI/oT/SII5ifPV76sgJObOIgQVJmcatoOMU+e/YvX0CG4yvaUz7MoVJdZntXV",
-	"z+rdr2IkSRqFhsGbmlCOQnamo3OjxKWq1xb6PxeNBxVkzArjN86bRavqgiHd12lwzNekYPbfk4kPaNyS",
-	"HqQugdzFrOdidf2kTvQLwMDdbKlpK7v5uktv9/tbSYA6BsKG1WpzoOFyCqIkfEWmpzGnjqfnyHRQiIis",
-	"i06X6tWEICFVvIzI1GkgyHKH82pMuWB2xcXLLWQj8WAGhdBUEsv8ElBnleA+YTemzE22AxVQ+/z58//K",
-	"K0UWYm1ejA6ejp4eXD99dvj8xeH3P4z/88f/8o23KTsFrdgocTzOG6jDUFNU0PKTmKRjIEvBWw1NHA4R",
-	"HTpqbLrQ1anm23GaXGQ08ICeEg1EX/eI+XwtPhE9ma8jRPOQVZ0f5hoe2ONhX4RPo6wce0plqisNpDzr",
-	"VVdb5sm3JdShUiWfNruJBbHaBGpKbWjLj0XpWMdL6xtrrj+tvfHurnQ15akdDa0cXeAdM/Yrldi2Xlef",
-	"SK94uS8NSNQhNb8Oj1axkeZzbplhNAesn42g0A2upfFcXd+5UjadRBqr/oYftWblFvP4mKz6cLGtpR+x",
-	"FUtfu6kMOZpSWNRlT9GPrOoWKEX0rJ+UTIf74jW49E8lX1cahGZH7ovy1471WpMUnLhSB7trl7qszk+6",
-	"iJADzezfbSlO/Emof5aBTJUMKmbaFrsZfCNyWunUHlRcK8LSV2orzbIW4a04p68MV6prtaosV7qqBxbp",
-	"HJflI9lV8K3GlnK9TGxmoOIKOhrlrO9HGRUXLXVkgSjFoTs/ojGos8otq23ZaoI0yV2MXH4b8efcZ8+K",
-	"Rj+pPuaGEcxKR1kMFK051fbSfAWLhaur5qDeqNM+e24Z8UsaKaGmvc6wtCsXjjbWFC2IHfkx62+8aocq",
-	"5oSK0kZWoanGbaDS1jRByFAHzSYCbcM2XtO8HF6lPNTbWEnpfrWhtMl5I+QkZy5QQaDndtyHafl5nlFd",
-	"C5t6V/mgjBKKloq06sGuOugQrRxrxYbFxfm/Y1nF3HV1Lc5Nj01tWlWb07xbK4LBrKFTq2fHrHKbWAdw",
-	"EWTSMPBWugqvsYtWq+ZDyFQnKe3pybWgSWbQFeQWFWtfN2bm+Shjr3PVy1RCljKd1+r1iYtJ2VHBnKZ4",
-	"82Ozd8LPMFRxjTiuxkzaDa4ZXCAwEcqhXTmyM4SXlcX9GnK7SnM2FwwtdifOH4CulYHzL6v6IQldcTNH",
-	"UVQsQ8tMiIWAq8tJiRnekBC5r7FQeLSLKF38UEjRpa4OaRSB0jBwfAn2skzu/1Bk+h+6kK10vGY6aU1y",
-	"gpatlNOpcrjmNczquQ4M7dqlXB1qujtCyIbEXJT7BZkTjvJGJI56+zg2vex0/RQcF/rM6L8yTqhnj48L",
-	"3YlD+cLd01iVmigJ98WxTCBD+011m/TSro6h5mVX/vL+paEWdcrwb0VFWO+GExWmZM/favKoa8l6WcX4",
-	"Mv0XUbZUdRZi7XO8xarqvK4lbIX/zGGMb2UtDCWKKT+91a1PB6ayb8lWUDzVBzYWFIDpby0oTrMmc0EV",
-	"Nj/luHzApVzFXMh16zQOpTSznJYLYnulE8ZcsFVXrSwZH2Z+1+UsdCuIUuHtvFCzDIYF38+H4PkBKyXf",
-	"zzeqKRepfacqVyuv5bXkz7pcOqcwZlLxUEbVlrt/Wr73pwesqUwPa6wVkReb1wXg1OubJNHS+BJyhlzf",
-	"WNGvdoTJoGhqxEOyWrPdQscixAuVErONSQcl1sb3qo+s0pJM//beo8diRQIzBgxbrmqQy1QbfeMr7CSX",
-	"WXzHGtuM0A5FvxaZ3UzdU9tvZsFrUPcLC2xE32+gnsuMIE1EbIVQVK1nWfksV2yz/hU1NCQDYNzCjIqN",
-	"qQoWFepRrTKuvPphOOQUjX66EcZAejQNTxuY9iDLwXBwlbJEFm0dDAemm4bTq+diDJnmaLGGOdTx9UJw",
-	"GTtq7vQUvXo1OjTgxVX+t1JPmm4zW3KYNyeUyqT7fvPocNeyOeUv+knVnVvUug0PFYOFoxhtFLJsdWl4",
-	"e3v5qmiAyGMRd6GmX02oqS4o62kNlaiKGVbvoqu/oPlNRWYDyMHdDAez4jWogmWZWc1wwFxGtKNSs4Z5",
-	"w7z13vu1hrVaOxrWVq69rC37mHFWSQ01nZOrxY4xopAGs6WvleyX7IM2Dl9Ku2uR7N01T3JDoy5vYzVp",
-	"zQ+xJWpVfZrvtOlcTxdO9nBki5doIdUkxkiApctJvviwvita4M6yymv9ycBapWypyWeQARJI0aZQPO+5",
-	"y/x9iynjDUX7Xorf5Rr2Egr7A0LVS+5bfq9xJdu+v5b1atsw1af1ZNx2UQnOtu3pkDE8jVFoko72hXZI",
-	"pDwXkxCNng46RMRfzQjlYF5uvq+G52V/qhAFMxSmEXJaAOsIPXPBK66bN3B0r6H3N2J6LepPfabiUDYx",
-	"2Hsjri0ChIJ3kAqltaiPqp99SVIf57Cx7VWBMlm3dmoSaNOwLnO61tKpGt6oM1szloSgTr4GxWbagro0",
-	"PE2n8ovNv2t4Z8b5VIZxF7Eox7VKdEYLP/eSjSuTthWqTNqyC1wzNhl9ag9WeoPqU0jK4nyhcV/1hFVs",
-	"whH3KTzrELD9mOX6lMg2NLZ6Rd6jUrYuFWxdpiepcLnMTmRSxDe7QwOtDSDNfGNMZRBTO9aVdeUwzqDR",
-	"3LZR6z/JuIZR96TqmO/Sv3zs2YnPwa9N5bQZp5l0WCgEpABttPKZ3as8so6vTUSmlbemJrPsNOYUuwxM",
-	"r3RiF0YsV9rVJH6BCVYCXNvzYsHRdBY+/XRK2OrHFdfBr74F3vNVkU8LptR590v44uKaxqIapqpcYt7n",
-	"mKZtPuBavKi98ubbbD4fa+1ha6mxK0mZNifxf2Fkmx41QdaqtphAJRVjNtR55UMhmJtjKzQaKRuc815o",
-	"2m/x48GPBy7lkiKZyMoKg5/65cTUnMVVnXlP75TpVGLVjogkKD66OPvtuf41y3Itbqg0rNs566nVgsw0",
-	"WDhXU4LfnoN9YF9FBoJH2pVqu3MCObyq0efUCGWZNZ1zYJK4WznrIJp2KaAYbSPUSdNjy93ETPbq0Gzb",
-	"os6ratSKiZAZ1YevlJNTsqWH1hbe156WagTmyUo23sqtx6uxnjb2dbPUo1nDqZUGuCre04IAWoqX0tGJ",
-	"soD9Mg5kyKuprJHVwvtGInXKh/mgkTolYPpG6pSnWUukTmlS38yecnu0VVN7yvf1wLk9rhvziV+qol0p",
-	"fdvZgu21eiusc5VNTaoUXDzvDgdrPV7NNeTEad1SxGb1MTC/kDtAbjmKBYAUBSQOcIT29Xd1gZJPZ06j",
-	"ZTEEw48OrvOPpIpcick9K8ZFKX8aJ+BuRlhNFKkF9k2sasHdQQaSlM10a1NpBy/dr65DlMYM8aFjijlc",
-	"gggvkAqDXdYsTREMZtLabCrgyRp0Fi/HsXKsy2J7OnzYs7G3gjjv5l0245ofhgNfFtElmKSNHlYOJinT",
-	"xRpjSCLIBOQCqd05Ge9M/6QKEAJ1ZIJGQkmAGGton/S0a/sktdiVwBxWK4lKxGJaGtbBj/kddGAccp0G",
-	"ttwkyNQZXq7McZk61L+pzk2yZiJaIAoo4imNUTgEJI6WUiyUUtfYJQa6TkE1jzOPleSmusoVKMiGpt+Y",
-	"VZbTEomz9tudWjt2kC0LNu41S5z+Fnn1ybX2H3kwEzGyyry7sOx6tDEI114N/tQw0yst3Z4niEKel2e3",
-	"JuyRy1KdpGO8jJOAWlWhxgQJpyxskzzQpoyyIGwOwVMRKkxZ8ccslDOyacoabK3M27XPmTuBRW66/uWq",
-	"b6Z8ZTdP1LpEGsnqXy4Fungb89qWukeZ1SLv52jcjbmvt0axXU/vxaN8FolYYRbmWGYz+Wmt3JjvlZzA",
-	"c716a5MdiqtK+VbjcC23ttPUYXowmM8/ZoPGmOyHJPiIqMrT/VP5r50DbqeVXyaQ4WCk+/gXf2Js5v6B",
-	"y8ZbE0I44xQm49Kv5COKS+0fDNjebOba6f2vHE0WhNN8Pn022Xqm4hS8djkcXKVye8ck5uiTK5Yn794r",
-	"CEmNVtX8PnFH0gjHPEJzFPMPQQSxo0X+aT4EyCFVrqdcHc7IwXx61YOyeX49piB0wHCO45FZIkQL/e9O",
-	"goc7AkSfZfnmhWwzEG+/dP9/gIGKcCpckB7jFQhSPWTnyTi5tIJQoHDevKoSGlmuPJ9du5gPpEx1Ji/2",
-	"dZaJMIVAOmfH8tcomMEYszlrakVcmnqefZSrh6x41l5y9pENQN49pHy5XaoLS0OweXBKMOW3Kz8Cb5k7",
-	"nCihmFBnaObxDAUfAaGhTgkp3EOIuDb970XkDlHwdzDD0xmiwEz4xJ3faPkr2vG40NFU9Re4kdh6MxD/",
-	"KiH1zaAY4dQFre1jtw5lWMYbF147q0D5ZKzRWn15i0p7+ZR/YRxOlROkZ+Gukt7QXjlN23pkFj5hnJV1",
-	"vXHHplBWLHSxe5J1fqYOc6nHU/nPJ5DD0pD8TwW+a4/s4bqohddRuHC1HkyyoHVdHW+He0KyPyZ5VEAJ",
-	"Y6Mg5VwVtI8DRLO6DjCWfQHy/Jycb347Lgp1eA/qmJAg9HVHqI/X4oSQU/m6HnT1+NX8DerwH9jLkB+/",
-	"j2/B4IsrLtHVhh7duWI0pHqmPjINS2T3AFl5P8uJq09zuyX0FAaO8pjHp68A+pTYNWJNfZh4CuamxVYO",
-	"hy7cLa7VnXkdRGmI3s1Q3LqYkDroXIVw4Vtj8NSeeDaTZWImWX0pD0fEfeaCVmGx7BX+ARBNWcEqvaF4",
-	"aM76VAtIXQFtJAELSHEuXErMUdZlgxCtApXZlU9qLnJW6mo0TRbiUiqNLDp+yoOZi6Zek9DqBC/9c7o7",
-	"R47WuYFHl0Iq1NtbD2FRlCBFV7p1Dw+c7jWS6PpMjr384+r8jeyKA/JRWfJ4PZgkcfVbMmWgSkomDMOB",
-	"ij+C2gc/Jws30ifOmrsyZEeWlUHUiHi6eQ4Bc3EbS2dInVA2HUll0inHCWCIgz2pRYbhvmkHkh/Dk2ru",
-	"dTLQILqwt9GfqjhLrfyc0yrJ7vG+YiwLqVk2ABuKURwO7maIolYU5wSoPlA65a/wdtXAWLowY0opxUHW",
-	"FwdejfUXyHAF1r9J/qvwsMAUfFixbA1bx0SOT1/ptnD5MEDTSKbZyIzFPBpUlcZQ6qCXjPZbNuVlGnn6",
-	"Hm2h1MtDbaSqykxvGaLHMFFXhlFDILkYWUrX1C39sojPqthmzdxkcW+0HMkHK4NxWTXIv4aSO0Dd0YeA",
-	"wrKugq/m0lx5LtfYYJ49DbhDFOW3XevoPujq6JZmmranu2godqJECY38cbgZhcvOoJosx1NKCc0azrAZ",
-	"uYuzRoHFVSR3u4WRxJa2vj51O7HZ6B2FSaLMon/7PB6Pvyjtep4yni0qH1UqrfBW6+abm7/d3Hz+/eaG",
-	"3dxcvf+Pm5svNzfs39t7NkuwmnMB5Rv8kpK5ryuUUIBj2YNBveqVEvtWvKmf/7oQm1ovLZxZq4I90+xP",
-	"3FA0gcHHJ37uGW2YaIqGkK2FzCOKY0UdLlv1JMVR6I5F+Un8BOzuPq1UWE0+w/wSLbD7of8Zy2oAc8zB",
-	"1S9HxTTCSfD02fMXzinJEXXJtPoBhTSYYY6kC7Y45Tz8oWbC86va6fTLFk8BWzKO5oUpIxynn9xT1hqP",
-	"fibZvUgHAydA3kHRMUSejp+9GD/zN9YdWZ2lKjZTq7ctTHCvuoJ6aMFnfzB+Oj7wdajnUpONE0MLAfVN",
-	"ZDdsH6OL7N+hyYyQjzJp1iMlS/Ul1dFTOpVEzZClR5dMgLe3KOAozJQtV0CZNiBZrWvMZ1nJab1KyTtX",
-	"yJO9Q5MRTDr65mrfByWrmAeicGf6zPIgskI5WWckj/rdGarGZ0g5hMxByvjGuqlbO3ZyiqdTRFEoOQ9r",
-	"Ko0gsYaB7At7+mfONJRC5oHeU36G1cWdGGe1U/wWzMXZfh7UYmyg6Gs0zr5fi93YzOZrOrbzqlaxHmd3",
-	"8cAG5KKLqUr19s+2P8bq+Xl8tn98okhUyB4UsiwmqtrB79txvpSdc1tAUhKUVelKTbJW4pJTdqUwZRtZ",
-	"F52pW9omYvPJqC6SXx6XWsa9Lv7o4vl2dUK/byKBHp7mIjSb9TVXycTHadZ81jrt7WiqK6c05gpYY/Mw",
-	"nYJdz8aMZh7h+kigs/j32YmzpgAOoCkN56jJmsyWTI7IM/leG5dbEQ+PL5l0sLMZNGkv4kb10qV++4MA",
-	"j/SMLbkI3tp3NtqpLrv4mJcdr/miob41qyxho2WtODxv3bFK28QyhFvWPLEMXq8WimaS+hp3Jhi77CCG",
-	"MchtoM7iAirqz64oUA3m6VLI2PYRW0nDZoHxqk5p3V9VeaZlp22jg9krW3XJnSvekzN47FddudGJm11+",
-	"Gn9rStelLF+xBULiZRqvKiKKKdYqIF6mcV3crhmie2KZAF4T4Kg82DlrNIXrF1g2dFOQ64DpMZC3JUZI",
-	"F5h4vfB8nqqa+8pgFOhKXGOPwMmSgFQbPJkFY4YW7zE0tZdBXhXvnjiks6pg1iHi8rIJEtPLpepXt8Mg",
-	"/DnICVqgSAwZqftAIcinsornVUBqZSStEt5lGks7oSqBVF/ArVLPU0cUNRadWWs5St0pRRbAxrF4+WlN",
-	"fJFf2clUPASqeIlf8cn6BXl9iU95uN18BX4eO3fgtl6uHH7uW2fSArNLzUkLmTrrrjSN16W5iodjS/RW",
-	"cRKmrlg9UUW6etnSi5oiMnUXQHPZs684SsDTQ3AcmV4ZCWGYE7ocj8cdcfhVBuba8bhaYq3tWDtro5eO",
-	"o+Q8OhKPmO6G4RSUrvEcjTgZyZoCmRRr35B5CLNJwF5oXl21QRDhjwg8PQifzp4fzJ84D/7Osp17YrlR",
-	"iUund1d95txH2EPVc52i3rgJYPDjW01aXf7IjBhfRrZit/5OFV3LQ9YXS6FpXEg67jyhfsu6HCOH7GN3",
-	"DnkN2Ue/2J4KujQ41bMeCkUGBpQCJ8hAiDZMcKQQcYijKsOfQfYKL1DBWFPvWZMkGZEp29f1hYV8mteu",
-	"yApBVg14bZ42VkcaC0RhFBX3l3UpMZKnbnM5GA4u0zhW/5JVtJEq4v0SYlW8WgaqFC2E+ReO7hYoccB0",
-	"YQ5VN7HIz7YTToiXoq5fatk9aDasIBq6r62J+3Tm3tUEU12JwF0UNqtTcHxp1+fK2l8IjQbHfyo/dFaR",
-	"S+jnOqEVSLFQ96PB0kzg13w2B8stg/QOkG5or2PlvrubUylrh8rMlH2qoGxFhkNUpA9t3+kmbRkd3s0R",
-	"r9dvS3FtyPkwj13hdr3efIsNAhwLbUE2M1rnu28bsnv4n9xVmSq5el7+keppfsesUO0xOFEavcQt5wSq",
-	"hfONUf1vBir+jswx5ygcO4LYckRp5Bs9RJZOBZA2K3p8adxaxn+bnlaBfyFe4DCF1jMkGHFln7c4xmzm",
-	"jivN6yiJl8OMbBLnn3ZSS2tqnIjFKtFXQURiNNJbqBpTZpDVTaV+6/HwXn3ESVL3BNtfuFpMUe5zprlh",
-	"YhMakj5EdQBNFCNFvXrVU8iP+xLeLPIgQyr0CQVpbUeozhK/ZQXyLy9cc/vG75OBqFAhz8ZlH1svr++p",
-	"1512RGDotsbKNvaO1FyJK+pxC0iIhqYqOqLDrN0Sk49ciGTvuDiQBc6lUybjPN9WgIg8xQc3+wsoVrH5",
-	"y+/XZvAXszX1dzuyurepQl1E6kcZcN8xYHXM8m5jcl1qSGZYd2tbt8VPWDJin7dSw31qfdRe/0C3IpNO",
-	"id5t4Wq7opT3/R3LOraJFcfg7BagecKXQ9MGiWWVl6RfXw+GpkdwzNI5ok7xr29DNszsS9dLsEKntpbm",
-	"bK1t2OyjNEHKdrM1+55bUFdxNXf7PWXMN/WoayrG0Clr+hrSaTqXEchdAoQDMp9DF6fKJ5b2TnOa/jOj",
-	"eOEqSJSX7TCpZd5S5Wm8+A1S11q3OHIphS+xkl5zF6D3WuLTmsXw3OnIOT8+A/InqZylQhPCU8RkJgmH",
-	"pW5XFE0x43Q51n8aB2S+b9eg24cJPlw8HR94RM8rgJrQ77S+yyTiQtjJ+UkzEk4gQxfOlNmfhOyRQD4z",
-	"z5t4Y9GnhMgMJwzLZFmt6da30lDTpHmzgoK5iFCewabTpa1Z5vATngum8cP33z//XvJQ9d/OskEs6xpQ",
-	"lTHyLtLaqexSxLh+eGr9Wj5NUlUyqXO3OSVHmHEkfSDiXMCezbnFX5503rzb9XZBCScBifY5CmYxich0",
-	"We5kajHmX66vLwbDwfTy4ngwHPxMYTL756uBzN1gJPgok0evj8WQtycX7vTVhgfEMgxlOJ6NF6LkBC1J",
-	"HAI8TyIcYJ69XAU+n/GMdbT6bDEtanejRN0mou7iXxTj1+FblKLpFjgWBRznC0QpDt1177JnZpR1eTDn",
-	"AEj2oYsas2e6RWhTAw0Q9YaNTI72tfVq8b8nZFWJQ6bn5rqTCw5LsxIaUVFyZt/lmpijyKH5xXEJmtxy",
-	"IU1ymvL0XaytJTXAy7pUALFPwnPlFa0kPL+Rtj73G+pMeFZN9asyhPizVdDbPHF39WihoX3TGjRN7mJV",
-	"8spqIezbklFzO+9Fcu7o3U7RZgT2csPSHt97VXQtKaDexlJ9yNUVGApSivlS+iS0LIQgRfQoVdKQ+q+X",
-	"xqDyj3fXldCuf7y7Bj/JYUAWXy2VdhzfxDfx+URQLYB6hPTfLUlKdRwpX+o4NW3514GhAJsC4zfxUaEi",
-	"wAzBENFD8Efhz4cGjpv04OB5INeS/0R/CCCuZfE6lR+sctOlD+Ujik1t93+8+/Uqdy4aERuFADOWmoYu",
-	"kn6kV1Eulp/rjPNk8OWLDGy9JRl7U3qoUnsH5wmKj6XpRfe0Vp+xw/39KeazdCJF5txAY/2zSp+Xp1fX",
-	"UiAVBJXPDM70ew2ysDNwEUF+S+hc3UY+VB87s8K/RuKRWiAAJ4xTqBmcqsikZ1OWq0RPCVA8xTFClA1v",
-	"YiFvyBKlKs1UFqoaqTh7Oz1ZRc0GhRbt0hqWdeMHDCWQGgwaDAcRDpD2TuuzPEpgMEPgmdQlimd5d3c3",
-	"hvLnMaHTff0t2391dnz65up0JL6RITE8Kt6KOE4rZfdwoHQVVf0nhgkeHA6ejw/Gz3UFG0ky++M7FEWj",
-	"jzG5i/eJQH/BE7j0QY6oFbztLF1zKcvzM3AucFnsBmQf5y6yrPI1ZEr8VpUILl8eg//6z2c/jm/it1rq",
-	"f318AYIII2NglO7PV2fiiQoxC4SUUCqvoWnCypW/icWXapaSpllCoFwOEZJhrGoqYRSFDOwZ4MD/+d/P",
-	"nhzexCPwR47NHzSMfxzqjTtXk3gnBXPzB12g9PjV2ZNxeUrDzT6gWOhT4R+HwAQUlMrNYgaQ2G6AQmVl",
-	"wkwfg0K2zCV2Fsqofy5hvDD3Yjyjr419TzpxZfSERIhnBwclLQjmSer7f+rYxVzFajRzNq8s+U3pFZDn",
-	"2YBEBdY/OPz9/XDA0vkc0qXaLGifQehmU6aKXucFcMS8QsXfXzzdFyce7+tytiPZla+VBEpc166Fy7I2",
-	"/k0FiceVuxPqhFUSma16VX7dPio1mKsiXbXee5ZQ7z4AMceLg6d1a2e72n8bmzNBUqv5Xm2x+SPzZiiv",
-	"mUSQDCUkZEVY8vsvvMBVFPjXvn5CWi8fRlHG2ooMSs/gvtyjwIijm79XtZZp8+x7oeYA+t7fi4Pn7R+9",
-	"JHSCwxDF67txmJ2s911n1XdUS02XJn+aFeghKk5hTigqXbiQmhHjTLUv1A7NAEZRFQWy6QZK2EaM/0TC",
-	"5frv3ix0qRZxI0Au7kt30H3g5AkKVEERD4wsCtGh/pJlXXykyiNLkWsHB46TlOfXsWc++R2/BwGhaneh",
-	"jkSSg37H758opPVAwZ9gaB3nwzA3c6+VyvbeSK/Lk3m9bu7CZkYhhq5ODGOXPKJfmAu9dDH+7Pf6vkYs",
-	"IKpspvjzXymiS+MCOiyY/HIkrOi0DrOofBiaps5V5A4TZ9VnGqe2Nf/6yd9vUEKrrW3noEBTd9/gzD1S",
-	"ygM8I0KWZKUdexGWzpKW9EVJhCaW17lViNAfjyTWhEB8D8wEbhlCR7pdkghlfs8KSbmOIR+yL9v1XKEI",
-	"BZzQC/H3gUDptq/wHHPv0ccpZdnkm0Rpk54vzt86FWmbbxJd1WfFI//GcVzu3b3xelQf1ghHx6r+OIAg",
-	"RndNiFzFY/VpFZNXkIt6YIifGPT0fsAona3jjkwR82LBrq1G2BcH/9X+hdA6I6yMxitjuMIsJ46vxs33",
-	"P4s3/Isigwi5esqdyL8LgnAtX6UCNd5JBY0SkhM5dGiMlDpkueqCqDQo47ktf1g+CNmMyjqvVsnkhYMv",
-	"uMBTZ+bC3XtCxBftX7wh/CVJ4/WI6upyuyLisFli0Ek1ylmSWTP9sO1nxL9uVDvYGkZscpu+ZfwV4nBn",
-	"5E1SB/K+TZT3CsZ50wQ/lFVffnVYu2UCzPbQTSrv8+sSYDrS3f1LPIpI1ijx9FJcSzZRMU2r+rrTWwvU",
-	"1EVhfXSK6toV1CrCeqip96SfPrRi2srQd5poL020Jz/urXp6qJydRKm1iFCGDqUotRYd82vTLe8fFx3K",
-	"6CaV0Dbl82tAuoOH466PUb1cv1r5HTNBATp3NfvYQ9HcUgzdFtHjAYnjEeiQm1AJO4ke2YJ+kXAwy3Mp",
-	"ydh5yq6cqFEhLPTK3GmGlSPx1Q5LZ/6Y9MTy1nOUd+NYT82xuEyL1lhuAbtBHl5c6mFUSAcMbl5ePMSd",
-	"QtldoSyeoAeyt/H5/c+BSvjppmm6yQJMlqpKQbMKWiaPbkzfNYnYQC2LrtckC3M8em9lZ9xaRWX05au5",
-	"DnnPWHOwLVzysSiGcBVEdCqLl6rTt1NbrGFge4LqtbrxpEVl3DxCbpPUsDX0sPMnbt6fuEExYz9HktZY",
-	"9IxcTGsIVX5szW/JVVYh5Gt5URTETVHcNbSjp38sNkb37vtgc9bb38cwklRKgZQQNU8ibjaPnEAOL7LG",
-	"eo/eNJIdh69ZxDrnx2QSsbddQXYLp3qaQvLpW8wg2VKbNYHkyzyM+aO0vpMRZ2N2Ro/uRo8c4VrQuYlv",
-	"738OwqS/ocOq++Bn5LCRv5dgkU3Q07iRo9xjN2x44886DBpN3DEXQO8JOw4eltc9Np92B0TrbbCwGFEX",
-	"Y8XmEG5b3vUHxvWdWWLzZokVBIFC4+b1aXKFaX1Uumov6J1u5z4XXyXPdQWPSdtz7r9CHi6866n/ORZs",
-	"UQSri29WI3Ss9zCqYR0gzrekOninLHZXFh3Y6UsNXq/G/uegbo7u2qULWk/90klTvSQ790Z6aJwOBH7s",
-	"qucK2LgOZdSLVeda6YPh1MGDMl4nFT4+t/tKuNpZn3UeeheN9j6RdesklYNtk1R26u/m1d+1ijacQsxX",
-	"CPNW3zfqutdqiZ16q4/CV6PVV/OIdFhuMKWEzBqDeiqqctYW1VSusFltVC3xMAqotbZb9JFnZPTMnWrZ",
-	"qFpyjSt1SFrHZDOVUY7s74NUd+WnHhq87iUQZXD2UALlt49e72tDlXUodzXsLVfnNowDBw/ErB6fZtaO",
-	"Tb3diepIu+hd68eqbXh5HwqZtd60U5XWqyqt8aneYMCyHwdfLT75Pvm4f1yyQv5HFo5c2HQX3DRt0b39",
-	"1jU6e9Ze3cNRbZq473zUGSkVjsRXmS+d+WPS6stbr6B8Ccd6qvnFZVr0/cKSm9X7i0s9jP7vgMHJkAvj",
-	"dm7n7raBIhJ6oHobl88kkcKX/Y0HRQA9rQhlamnt4WH6UdYei6NeTt0+G2vorFJArIjsj91U0Rlz12G7",
-	"aOPZuQj8NaPgwUOx8zK1Pz6TSQ+s7m1DKR12F2PKV4bd2yQrHWyHrLRzfG/emrNG4WoN2rOf3rxTme3T",
-	"6KotP0o9uUFDXlk59lSL70cjfmBl2Etw2rnEu6i9zZjbwI4rau4aNNxuum1fw7oNcA8/ufl8p396odA6",
-	"lU4fdXOjWHHwoJzt8SqDre/ryhpgH91v3ai2Jc/3wyL5zq++UU1sze/9Bn3sXZj+ap72e2b9/s72jCge",
-	"mb+9vG9fnM3ajPdLET9PUHw8IxQRIC6akkgbBvN5JSKnDFEwgwxAKfgBTsY38XkcLe2Bd5jP5OgITlAE",
-	"/iAJigM5+ThEi329wEgu8HfBiP8AkCJAJXwoHN/E1zPMwC2OBKoCknLAloyjub3IHhpPx0OQzz0qzDsE",
-	"H9MJGqnvngAYhzexVYaCpjHHc3t745vYaSJ5kx/sozaOZOfQZhaxMPER2ENiGz0MqVo442sCaSdASRbW",
-	"fwPMAEw5mUOOAxhFS0Vu4vkQ9OdBdS6UV1BlG9iQbSWf/56tKqWFq74KdbS7YAJvq0psoYoT/52PlOoU",
-	"Jv/dxXjipow244mNzd04+BsbyC4GkxyVHquppBUvellHcm7oEo03fdEH982HHovZwwNZOtg5ariEl51j",
-	"Ayj04M/nvaPtrvWVt5FiPc/nftaDUzdU9muNnE1iDA92T+Yal3EGnNVXm62FWIaPS6EqNyf31quKt/So",
-	"lKzS1lfttNyI/+M23aixz//2PBb9evE/3fD6dU9HoQ3/Tg3rrob16Kvf5V3p1OLZDVSrmrZuwhp+9kO3",
-	"tbRHDdECRWJ7I+sO+gR+1wBZr0/uZKs6FdSXJlZTSVuQ3NZPHyGGH2zDg1LQp3f04lTB/YnFu9u1L4mU",
-	"VPDHQSXbIvFtBYHuItM3Fw+xaRGxp80B2qtK0HwsDzuTwyqE2c3W8AhtDBuwLVTx3MvC8FWYFh7MpuDx",
-	"tOyMCD2NCGt8GVawGnhZC+5FPFyvWLgms8AjMAfcPzk47QebtRu02wu+VRw/eJBXYWcJ8LQEbMIC8B0D",
-	"MBCjxaAQWJ972QS+IUp4cJnsYahvFyDQU2tfWSbLwKAoQpD17SiWNak208igUxzb4tsQEDmXjE1Vwdwo",
-	"BJNl/nVNUrr5+dKAeD+qfrbuP1NEl4/TQlA++9Yc+Aoi7MjYlTVfPSYrsaOC79558+VpHVRYm0RfWnWb",
-	"7QwVWO87F9+5fulmKnexMzz4p+aXD6+FPHq+dfufg9JknYLPyxfclrO/CQrr8IxZW+yU61/Z56PN9u+I",
-	"lf3y/cuLuJM+vwJcOnhgfvtoOndvllmuqBF00gQSSv5EQZsecF8KwIWCZif+x9xb7t/J+43yvlPO7yPg",
-	"9xDsvwqJ/sFE+eY3ZSe7d5fd61C96/tjSem9xHNfsfy+Zaj+gvijF8DruegqEnezpL1V6HFw3wzw0QnT",
-	"DQ91h8xTc3x+NbW2BdUe/H2/d/TexZlusO7WpgWC/SmKBTWhkVGADz/XiNM/65GSTvF8nnI4iVBmMmAx",
-	"TNiMcHBLyVzVKE8plQJghiqMi03tZTu4XiZoCFTnoyF4R+jHiMDwiesxUWs/kMlm80Re2mBGE1+RcX6n",
-	"vZafRHWlfkamtRBzhzJ6AZlPcIzCunp61vtbIFfwH5penzSLfD1r6X0dgp9H7b2c5z2SonvlDa8Hx/ky",
-	"WTmuQs4B4ALiSL5YOJYU0GD9KZhMryUIuxSJ/q+JOEH/6Ad15Y+h/n9pyw6KUbjX3cQpJuxj5xTrfRW2",
-	"TgnoQ0lH+eJ1TF+e/87w2SNogSsMrKWEPu/H/uegn/lTXqOvDXRttNNB3hFr9reFyu3tIhLaUG7FWAQx",
-	"fbOsvJWYc/BgfPPxBR+0Y2Afw6k8zG7W023BxK2QHB6OAnYm1XswqW5W1FhrS4OOb8nD2F7u8UXpYn+R",
-	"BPXojDD2rldG8RByqHu497HE5L0C8oC2uM38cgI5vDB943eml44Ekp1em9nFupvHYHKxt5uThYVrvqYW",
-	"q/+FF0qrr7OFttnGkgN5z/aV0sIl9dz8uDOr+JtVciytw/auD8D+5zDpYEqxyKTFjLJe0mhnxdl6Xc0n",
-	"OSI+VstJO1b1spjk0zol3O1EkIP75n6PxTjig2T+RhGLD3kZRLYG2R78eb93BN/ZPjZn+1ibPICSiCzn",
-	"KOYJTlCEe2uG2Twgm8jLbSk1xOzjiwyInarYnSwrx9iqMzpu7VEoj659W3TkwEdvdbI6dQf3fXXlrdYv",
-	"q9Det6JZA0FZi6neyU739Nc9q8fXSiy9X5/9z2Flwi5qquOq2/TVzdCch6jo3GgnDdax20ery/bA0n7a",
-	"bXUht5r7leDVwRZw40ejC/dC0g7aseNs/dTk7UXW7ZFbtoFSdkUC/XXkjcktKF5gSuJ578Ig9gT+ntRT",
-	"e9mdgtyZ6qzza9OMCzf8CDRiVEQtQyQFjPNVga25urhUrbW2Wem1wbxnbbeydPEWrJ936q2/eosKeFeD",
-	"+d3fhf3PKF74a65xgWxaVNZ1k0o7j7ZW7Kqk2mj5WJVTLxzrpY1aMzu10O1FlYOH4IuPRdH0RDh/zdLm",
-	"Tl4a5VYh3haIAQ+C7jsX7OZcsGuUG8iEIbqAExxhvoQRopzFhAv+LvEjmME4RlE/VbMwN1CTA3t2YKb3",
-	"9tee21MeyRnfWBMeG3B3Kmpn2vY72jbt1f/OH4Nu2+E0cjr2xXFfpdgbiA7eYj8Yt1mZ9tzBPevZXaAq",
-	"3vm59y3vFHRvBd2bdHqR71pf6P3PxGvhLnYBf87RYjW4R3bR/qKee59TF1uDP/09VkvEZomplwnDGySn",
-	"geNbw+qDr+oZeyz2lE2Tjb8hxv858DLTfAPks91i6ddFz7vwAm/7z9aJpSskdhf3Usrw7mQO2mV6r4W8",
-	"vVK+Xbf2+Aw6lSRwFz72M9MU08I7GmS2Pj3cAe1DGlpqM8qqo3bWk77Wk3LKmJtWej8+JftHlgjZz9bh",
-	"lW6+IZrrKKz2SkB3IPbOLOGPpWswNtQnqX8taHXwkMxYU+jjNAL4Imlf1b5DkvsWI+v2iC0HDy+27MIx",
-	"NheOsTk5R/fj7KdZm4/9o/wvzHI7HbozZeqza1OcsxvdWbaq2nWS45+hngwlfdVoPUeX8H+9xjYrzAbE",
-	"e9aSC8sWT13/tNOH/fXhJMMzB3Z3exD2P+t/dUhQN5TRotWukxq8ezx31V8N9j1WpbURlXppp7Wtv39G",
-	"fPtQ4uA+WdxjUTJbkMpfmzScxkuD3ArkeuAX+17ReacKbk4VXMMTr/v7TXAc4njaT/UzXRXNJA5H0hAQ",
-	"OROMoiW4xRFHFIVCNmhoxyyEdN3V8ScD3j0XiP9niujycWqYxZNvUzTLKLBTOB0KZ+WQcrot47mv/lma",
-	"soMLt7jiNmujJUjvWSl1rV5mjcU72Omo3jpqCX0bCaLXe7b/mRYm6qDAlkmrRZHdAD21vwaXlc11UWvL",
-	"iPtY1dsuWNhL2y0t4NR6tx1/Dh6Qoz4WlbgbIvpryGVW5qUpbyFCbods8ZCUsAtb9laOH0a22P/4I6OI",
-	"kZSKGdDCq3Lar+kE0VjKHeqLcjs1M6NpBF7a23csH8EpQh4PzK8/skv9yeniHuus1RL4sHw4RxdnYEpJ",
-	"mojHVG1ab3EPzRO+BIxTGUxCAZljLqhCnFpAaD6UPRkMB1jM9pfQ5AfDgbjSweFATjwYWnQqW+sdDtSk",
-	"AqNc8CwQZZjEDojG0zFYPK1bTn83KDOXTgD8iuOwvHLNeh9xHK62mLgZz8Xk/3RZbLPChY3UTf32zEhN",
-	"cjsuWpVHfv3RYiwFzrQNzDUiHvZKMajMTRMSboSRviLT7WOjNiEnJKyh4YSEb7qScXWpdD5BVCzGUEDi",
-	"kAGG4wCBuxkOZoATwGbkTt5IDRRy+JX6tsCcbwmdQz44HOCY//BiMBzMcYzn6XxweDA0cOGYoymi98Rf",
-	"LkgorruJwVyQUG12x1mqzj99NlvETgS9e7g/ZhhRSIMZDmAEFhjdSV0/ikCEF8iW5LKZdX1e5e+wmA4D",
-	"5C42f8WsfAhDgOMgSpVJcYaj0JpxT6h5OIBXiLMhuCAhG4J/kAl70o1hXYstf8OWhtJWm4i18NRJVNhR",
-	"bbM8IA5pY+TLUEARp+gWURQHPZM91SQgn8U70/NKfnmZL78LUe3e8bp4hm0exMplPYYEz+qmc9Kp4KCv",
-	"T7A8aQenYGnNbfYKlkG9Z7egc/nirVyV72HnGPR2DJZxuJku+r0p+59ZcaoOzsEKjbV4BzdBWO28/qq6",
-	"vy7+wQoCP1YHYTds7OUiLC/hFOS3H4sOHpTBPhY/YVd89PcUVvial6twK/FyS0SOh6WInb/Q21+4CZGD",
-	"U4h75lOqTwFcQBzBSZS5/lo012u14k5f7Uxe8uTatFR9oY9ANeUGkQwRaMzy1ULl9x1UTzn9NiucCsB7",
-	"VjOtRYuHLX/YaZT+GiXX+FVB5y6cfP+z/N8OiqIigxbtcH24385Pr80GumiCCtseq/pXizq9ND05m1O9",
-	"2y40OLgvJvZYtLYGNPJX0BQ/8dLKHhydHvQNvjf03SU4bi7Bce2P9n5+5Y2sW0bLGPQG6qNyGFELI79S",
-	"K3177FxtrMmZrghDz/Yo2LrZbG9UvSP0421E7laobWymaChrDK6XCQ5kEi6JEUgQbbMnvNOT7sod9yWX",
-	"wgm22RdKd/gYDA3lLeckVMI9X8tDccIOJojCettsiigCes8mCcfixdsoDNiZKPxNFEXEbSKEPm/K/uc7",
-	"e5oONowSQbUYM9ZPRe3M/F15Z12MG0V8faxGDn/k62X1KE7vlJq3G3EO7p+BPrKqw10w0N9gUmJeXpaT",
-	"rcPErRAhDh5KhNhZWDZnYdmUzEHT2EeLNbrrFMWI2s+E+N7T5W0gvRRL3i+xPuL6UNapeyu1Eikek0pL",
-	"FUqWaapJl72meDpF1CizLsJo018v0/hr0F4FmA+ku2ZL1wheNI2N4rqLlmrWValENheGd38w9j/TNO6j",
-	"mIr78lRL10Uc/o/EpdpTH5VUbuzRa6T1KLaaKupkpZYiun2ocvAgnPDRKaBNCNdD8xRn2Env3ArE24KH",
-	"/2HQfRcz3V173IwUsLb6SV1Y/r2WQ3LTX6WyxktZMdlsbrIEHLKPQBfecVXSEL8PNlmDB3M0Zx2oTp7q",
-	"acypJCUNDaQULlvpccX6PF/f22N2vAGC6l0zpwDfLSVzaZkpWfXBK/ElpAjcIh7MZGzCAtUN/28QEyBL",
-	"aSyQrgYCZe0uAUVWzWueKOlXbKSNdO+xAE83wpWbWwfZDt13phaI0R2igM9grGoyQC5OP0zVeQEcm7o8",
-	"211+pytreUWm/RjLSsV5vkK2oisvrZ2pMA55yrxi6sgCURhFQH0CYByCBNER4ygxf+uvrF0pOB6ByqZ2",
-	"2hSCV0B0fUFfK94yc6+rY+4qPonuyXg5nLu4ud7o7utdeFSeha5ehWKEXMWp0D1G7mtwMDyUd6GRH+/i",
-	"4Tr7GNbD+fP4tz4eBk/vwj0LH739Co/dp7AJf0KjeLpNiHFwvxzvsbkP1uk66OQ2eGAce+iH/J7ReheV",
-	"tvmotI28/OvMAfTi/feaCXjPL0B7MmBGMI8kH/CutN9VUTgiMOyfECi/XmNDzncZRLtWnPdpCRFn7mMJ",
-	"UXez81a7TScGc22KVH/rklwovuhoMhGfbLvJRML4ACaTfN3qwyGPemcy6WQy0bjmwvGOr44SnMQ/O5pM",
-	"5LV5mEzWRhZ+cpHZSVeTidzOYzaZNKBUb5OJmKBWbN42xDi4X473mEwmjbjVzWQiz87bZLIFOPbQD/k9",
-	"o/UusrKTBcTrIYdRMoNP92HKySTFUShWdwuyF5SIU0cM4Dggc0k0aDIj5GMWNUnJHMB4CViaJISKq5pi",
-	"DhJKFjhEFHACuEpPAmK9OeQ4AHJVNr6Jr2eoOByzfJjUM0PEUSAbNZqIME0CYIZgiCg7vIlH4GfMf0kn",
-	"h+CP/3v0SzoZXeFpDHlK0ejZ9z/8oQe8gmrAz5hHcDK6Jh9RLH/7CfNJGnxEXP4sow5Hv6LlHzdxhRP8",
-	"AuMwQkcpJz/Jg6uwguLxKbCyI2MGLA07SBkKxQmpTcrQlgWMsLxN/a065rEJv1If5vFXjv12CwZTB5OB",
-	"yMWpeIInvmsFzz7tbpBl11JEudFHtKwBMP+iFazsltsjXvsxXBiGWBlLLqjAIY4FA1X98So3kOO/2WoC",
-	"l4aUFUxk8icK7r2O3TsFjjytRoOdAVvzi4fj132ZKQpSivlycPj7e5u1KoIv8ih9RxabzRmCg802aE1T",
-	"zFUJcQ9jXRRJKPR44NOS6mes2z+w9dkRNoRoGagC7iZMM4Yr6yy+uogcG/Yciazb8g7KySaSTgbdZS0g",
-	"IRKv6AzFXN9GnZ0pW3ObDU0lUDMOcb9mJ2v9euz8Ob+QnQXK2wIFLUSuI4h+bHX/89RM0sEcZZFVi0Fq",
-	"vfTTrhT+bO+mi0nKQszHapRaN5ZZL7d/i70xECqPuQnIodB4pGTBMIlR1mSaQzpFXCW93MRQTGJlrOme",
-	"LUmUih8uUjbTf+EzyAFbxgEDmEvdaybeg/gWT1OKwpsYfVLnZEBgnFA0Bkeg1K9EgGU4mAZJcFFKIgMT",
-	"I+IvLJ0jykAAY6uDDM+3OFmCj2g5dqhSdvfA7X99HvTpaX93rnZvTuc3p8IJVmIDpjNg94aA+onJDRwF",
-	"QpNat80NmtsF3msfrZ7NAesfoJ1Jr/JmtWDpDMGIz1q1x/NfAb7VfJkulJ1Nfbocg7dMZ05GeIFixOSD",
-	"NEHu1Mlf1IKtqiBHn/h+EkFc4nPoE5wnERocDs5/za0bmcXFwdlK8Dar63IMCGYosPXzc7MLc2wkQTFM",
-	"8Njw4dagrvMExUcXZ+D5+CBzSakUSXFwshe7+BnH4B9X52+Ayn50HqCe6SpBwWBFhboIbj2IIQnSuZjR",
-	"aU1yz1KYofHMf0YcuL9quACKoHqjG0/+UoyqYq78WEg3MAhQwo1FmFmoLIbgNlyW068Dlc1EHbBZHUDT",
-	"uV5mW2hF5wWiDHtgsh4HcKwQVPwbTkjK5QHLC5QAOk/rN73IBq1AeokmSee36hZasVNjziLbgPsgi7N8",
-	"HkwQpIgepYK//v5ePHFqIpel/xUJYARCtEARSTStpTQaHA5mnCeH+/uRGDAj/x9pV7PbRgiEX2WVc6zm",
-	"GPWWOlXVSxtFufaA19MNEoYVsK18yLtXDP8wxJVztWe+YWc/ZoBhwdjP93f3d5gwQytaKB/DbjOFb/3K",
-	"e3hwkMdVcf+tf1jOLh6jX0ZPCX46MckWCI0LqulfSvVJKxcmCsW4hSmPhzJUkKaA0o48AmqNagkoSVNQ",
-	"X+UfrpU80WBUuwoNCvCRWebPDC3gXAj5myvrq1Bn/N0PxArwpE1B10eSNvD775/2j74S5sismbF6m+2m",
-	"IaM3B2r2Fn4eHCXZgQtuz6SZk5LcKhePkEVCLYuLTZk7HQL5AsVmLOidmdUKx4nyWfH+vPC7rmkAR57q",
-	"QC96pAF+10Ed+lXOSHR9Oa8wWTitAqf9R/jNpd8g635x4WoCuXAJLoS0piuU/7Dq70vJ1uLJF8rgx8az",
-	"Vsbs5s3iRodZyRm07K2+xLsphz32yoe69DQfbP643bWX0sbq2hL2utglYr1ZLnjWhhlyjrL3rf0sNhnq",
-	"ezGl/6wE7A7MDVsYzobS7C80DectPlNTxH0oJW7I8m5fXHzFopYOB7Y0VfkKO1S1etzu1mCqcd0duHSI",
-	"xCBb1i6QZNwntMqLcafyOL9oEMDMoJNHqWcvRL6PoH/gEglC4QSZL16EzCk5Y6x8BcEHYSfLPQWxi0F+",
-	"YgK0NZNUNg/w51cmJQjSRqX9gMo/Ct29VzUD7oQ1iiapjAtN2W6xrjqkTwHLsMvnfuToj+uj6YqXilTm",
-	"5u3X278AAAD//xCbb97W1wMA",
+	"H4sIAAAAAAAC/+z9jXbbuJIoCr8KRt9eq50ZSXZ+uqe3Z+31Xcd2ut2d2N6207ln2rlpmIQldCiCDYBy",
+	"tDO5r3Pe4zzZXfgjQRIkQUqWlVhrnTM7bYFAoVBVqD9UfR4EZJaQGMWcDfY/DxJI4QxxROV/HUYp44ge",
+	"miFXiwSdwhk6F6PEgBCxgOKEYxIP9p3DQQxnaDAcYDEggXw6GA7kn/YHQcBP1Y8U/ZViisLBPqcpGg5Y",
+	"MEUzKBZAn+AsicToCRkxROc4EB/wRSL+xjjF8WTw5cvQrH0EOTyPYOwBZja0CcQw6QAim0KKwlEIOUzE",
+	"xE2Ant2I3cAbHGG+8IS4+k0T6E3rdNsQsedo2tQVhZi370MOawc9m80TWphywgIYIdoE4ztCP95G5K4d",
+	"TDOyHVJ7Tk9gQxJ8RHR0k+IodINruKgJUDOmCUR7Hl9MJriZ2cyc/0wRXdQA9wpHHFFAESMpDRADNwsQ",
+	"OAH+S8zigHiwJHQXKEKQIS8EUjXWB5HWtN3xOZo/He+N95oBb5OzvgJ2lfI1pYzQGoDOEvhXikACJziG",
+	"4m8gkMPBLSUzAEFC0RyTlAliSEjM0Pg6PoeMAT5F4I8YfeJq+j/AHEYpUp9Zs80Qh0KqAk7ALeLBVH4o",
+	"vhOjxGx1pCSnLdBRdWs+d4bPZdHprgjRLUwj3nJZHKEkIosZivk5TlCEm2HMBoNEj26C1jl1R+jNOk7g",
+	"j+M5piSeNcswa1QDtCiedwJv3gZRV8mFasAsEZw1bNANtp8wv0QBRU24+glzwOSgBlRN7Ik8ETZbjCaY",
+	"j9TcTvBewxsUXaIIBbxWDByASIwCTA+T7FrGZcpwPAG/pjeIxogjVv6GLWIOP42v48s0SQjlDKC/Uig0",
+	"j9ENZCgEej8CxWwfXA8+osU/pNi4HoAdM/bJUP3yb/lPOM5+tGdniNdPDHAMduYwejqcw+jZEzGNklA4",
+	"Fh+aVUBMeN3ImHAzurCpT5hxFAcIBFMUfDQLiu8UQuQAJlf4t8IPIUFMzipHiEnfpBHHSYQKOwCQInHf",
+	"zuCIIaHWcxQCGIfg4PQIhYCTCeJTROtlZ2SfeO1VnPzjlpKYozgcFlhEIYRxIcQnw7/gkyHHiP7bP25g",
+	"8FEM/rcQJRQFAio3veEZ5jV09gZ+wrN0BuJ0doMoILcAczRjgtwo4imNQYKovBnqtiYmL2xJC7TB/rO9",
+	"4WCm5h/sP90T/4Vj/V8ZnDjmaIKoBPQNTBIcT07CGmAvSITATA0CJ0dunp2ZSfz49emz58PBLaEzyBU0",
+	"P7wYOIETIoAlMGi6NrIxDTIltufxlynZZ84jLpgmBxGinJ0Sjm9xIG/9wymMYxQ1QF6YAEA5g6Q8MwUI",
+	"1BwNOyPeQPhvG80gjkZ67fatt+kencw+soy9Z671doPvnJI/UdB0V+kRDaAm+Rz+uNUfNQHV9WpPHJCW",
+	"BEa+ag+wtL3wEschjicNKNMDwY0a2YA6WpmyhyVSp4kIidUEpRBoDaDpr30BCmc4doLRqg1dtmlCrIca",
+	"1KACqfUu0C2i4uJuh4yaoa0wFiZdCbBtrpg2HwxfrfPFw+vi4W656+FngRwK9W40wxMqRXojfG2yOAMy",
+	"aZHDd+UJO4pg8329bWhA8RB3ZjJA01iKvDsXrksyz4ypF3rWiHrwLtLYB580jZuEipqkh5CjaTx6+uz5",
+	"i1oYIwLDFgDFkJajNrP0gNB87oDwi5hNeUykP/4lDC/QXyliXPxXIPVu+U+YJJHWWHb/ZAJwazUxMhTz",
+	"vjw4+nBx/M+3x5dXg+EgRBziiA32f/88uMUoCrWeNxgOZogxoT3vDzAD2X6+vB8OEKWEDvYHJ/EcRljZ",
+	"TIjxfYkeUBht7/xvFN0O9gf/v9082rCrfmW7x2LKC71NteniEZTWAlaMQjrN4tsIB/0wcnh2+ur1yaFA",
+	"h9mZ0Vu+y2/17wCMKILhQhtlK9zbhVZEHCu8IvQGhyGKe+3s1dnFy5Ojo+NTa2v/i6QgJNJ2nMI5ElbS",
+	"DDMmFGVOxH8JkwLwKWaAJEhLy1WeI0tvb3GApYcqW5sVF0fFtU9ijmgMo2O1hx6YODm9Or44PXj94fji",
+	"4uxiYNOwmhoITkQUqL+vcr81858S/oqkcdhrO6dnVx9enb09PWqjWXHMt3KZeyDXwuRvY5jyKaH4X6jf",
+	"nt6eHry9+vns4uS/j+1tHaR8imJujLl7EC01KwDpu/qIYoCV7FG7TCgJhGS8idBhvsUeuz2/ODs8vrw8",
+	"ePn6+MPh2enV8WmdQGYJCsYk5UnK2e9778fSp1SQ0GkcoiCCVDqwjL7JCfhOAoPC7wpy2znfPvCYZIU0",
+	"pMT4DQkX4sa4Q1E0EsyPQnCTcnALcYRCIPGuxUC2uLwFDwJpmcPEGKjVAIn5DSMGbgkFEIiNC6sewEAr",
+	"gQkVgkYMkUcXReROka+b5Bm4myKK9PcCcPPJcCDdT22IyQE2Uwqk6isfUgoXA4mrGHcDQ3+xQijyP5Ab",
+	"adV+GWqkn8S3xOH3jYERAIqPNHB3mE8B5gywgCTSZyrEu7G9wRQjCmkwXYwrpxGQOMRiDuZY7eXBIYCc",
+	"U3yTcsQAnEMcCZ6UJ314/BpkXwP0KaFI3zLilhNXmwJuDI5nCV+AGYIxAzHJP1KeU6YctSgce2PWTHBg",
+	"YHOdryAZxi8FQhxG2RQBNcCBJRChOYoA5OBuimUILNuMIAMkWBkKgMFZjAC5BTo4PQSZG25ofB1DIeGy",
+	"PSgfMIrT2WD/dxPT1vqtcd/lDo48PCvkSqbS2lHbkh5rNGXXds0GQiGGbzGiYAeNJ2NwnU+4H1AEOboe",
+	"PBFn4VhRD3Cq+Lk2/rvRbu0jeO8i9QmK+SGJYyRhu+SQpw46VH+3EA2g+FAQkv6Sueha/OZi8HdT6Y8H",
+	"MF6UJsQMBCmlKObRAuQzZJDfEBIhKLWl7Fe5BwfQp5nLvLBGywqZS3k4iCAzuEHhFXYd67spigGMNfTi",
+	"A8DSQNyct2lUWiBzYoeQoxHHM+QiHzHHEWaBx7pCwsgl1eqh9VWn5X5GkPIbBHnDWuLmpyTSvgC5KkUB",
+	"wnMUyshLGhvFQsXBNUq84cgu+YoIDJWkgRHAsZpLit0bkvIKFQKmCNjFHVXaT/n0DQqmMMZsJkwrPHHl",
+	"H4i/p1TvTdyv6gawVKmZmaTCA2IQj2SQqlWXyIdqWDKYPzdrctnyQAxXMmUIrgd/3vHrgfgHEfA+U/+G",
+	"Cf4gQ2xPCvLlzzveKlLkr8PCnt7XoPVfOq2oTvZDOkGW3Fd3pkCu5tSR/EtovMMM7GTyeVdL5xyHTxyi",
+	"x8jn9jQiz1wb+4ZoDytZkwZuejd3TFsswdvzXnMO5qJ2UJHkGINpE7XL9QnIOQymMnwKIKB2aA/HDIcI",
+	"QHM+Y3AiuZBxCrFUP6KFlE7qxmMgwoyj0GhF1wP99+sB0Ae3kOHaPNwbSyWHUCHU5D/Fd4LyaA4FoWb9",
+	"/xL6KSDqTtFL6rXMYIpmEMcgjeHtrZSQ4Gah1Ipsx0o1KKnKQY1m9hozLq4Ws1xxKqBsCWHuj4EVB4cB",
+	"BzPIg2l28+voht5Ifv1LfNzhKAwgDVnd8H8XioLSaAyd/O6eUjrrit8K7s20vapAxvGJ+vFpVbPLdU0H",
+	"hx2/tnRRwKeQg1nKeKa1CYLiNFUMn1OJ+PONdtRwqdsdqz3tZ4JibIfdcQx+vx6EaK4Emw6/Xw/eF/Ex",
+	"6PbxQO78NYonfGpvvUYmwkz5sVDyvoEbOfrEGy+5QI1RV41taVRo02ys3oAaGTU6MyCkjM1NBnUirsnt",
+	"5J46+Z2nVRVShgytVrEr/iOhJCzfPnXRuRIWa6WcfXdGEDszr7IRIBBDRipjJYGYSqSwVE6ZKeeBGy2B",
+	"e/pf3l2paatie0JJmjDXFaD8G42gGhdIKYY4kpO2XtgKWLNQLVVekKjpTjM3RNHslffBjpXadHhxJETR",
+	"EbrFsbBUAUMlAQk5CGAseBwyhiexulo04hmYY33LZJe+sKlxDGBu1DlFdIJ/Q9Qtiw7OT8Bc/ShgsU3y",
+	"AlZJguJgSigi4xDNd+dPYZRM4VMpNGF4FkcLE+GonOJHHDssnF9xHDaumGPeYw2TE9qmQ55JVL5BHEof",
+	"VoKCti8yMC7F4DIBZes20o6OzHuQkH28LuIRMzGjbEi1o8yW6t6GMUBlhn4c1GJwvRlEo6FZnnaENlWv",
+	"Y8VNdFR1PGQ6jZcrq4JahyMrT89um+08H1lGiIKmMJkPai71gZQcMtrFa5mlzWiqXvBSDy7kAyrH8KDs",
+	"xD4nEQ4WQH0AduQgqZqjePHEcqblX8eLor/M/FKh0Q72sfuiFzgmEdKJiQ16uhil8KLufG0XaMXdyKQJ",
+	"hTFnvl7Q7Kj08i1qc4ke7L2XdtFIFx15pXptr4xjNoZVDP6rxjTENLtQ8miPdNbDGJBEK90SV5088+eI",
+	"jiRNVQxnrepQJMg84OVoTKbWSMIrmdXyBsiM6mMYTC1tXVrVynxlNdY15qy3dV01qwEUuLubksg8O/Em",
+	"j9zv4KARsekLMYEnnYmxMiymnUmtHym3U5mqzLKNpKThKttTVpwQxiAbLZClXV22Qlcko+Y7XynSjTPa",
+	"QtZeprJyQeg64PKMVQi9LVNH1Jc+SYw2ruWe9fyN+F7ieqtKtiXdN/IolP+BFV0qjvBL/qc5RnfNvpRq",
+	"4NOCpQzaz+kMxiOh3knWtH6sPZMjYeaLfQMoYw9GxDTnpLv8GLVn1cmTW1XFwU7FbavGrsl5e//u1jzY",
+	"fGgcoa6gVNE7xnKvqZS36vQUvU/wHGXhZSG/MyQnkE/HIHsJY08HKQJnF9+F1TCzNaoVqv8ykGCmVCJx",
+	"u9zKcB2JUebIY8aTV/Y/Ohxu//hH5vuRxkvdkMxX1Ns72Xw4F61OM6UdWPliJlfFoR7Y5+yXiWATh1SX",
+	"+NSRyppGUfG4C6SZx0JgMMsDIglczJwxaSdG9O0wyeNNHrGvQiBVPyUrRP8cDjMsVjhow9BvMErRK0pm",
+	"zeDW+6sOi5GjtXurvh1ng0NxeEBnQxma7s6G8gy1/qoSCfl6qwxT9PFafbtUsxGeqhqgVkZDzbZ4UE9P",
+	"y9rgddh+YIu8Cd9eSn4Dyh67B6sgZlbhviof1jq8WOU1OzHQ6l1Zlatuw/hnNY6tpsyardNr/U4vGEVn",
+	"tzL1vYP763ONV8nIrmWdQVWt+30nn1sh46uL682p4PW5LNboD9ImV+4NMn+QvqD8P0MUIY4e1jkkjcnM",
+	"cAtnOMbCAtXJ68LMX8o75CqE51kuL/MCXMcl1dtScQuffHPqchFtm6ArFyBSivJwwLK8cD/Z5ZxLzfHl",
+	"fXmXfRTxwsxuJULfxiiUV4VDncg9kWKVFakSxQPdDHWieqSOelpMPgYTBy19/xDUUKjzKZF8Yc+cPjWp",
+	"DzD9jqNQFPHwgoHQeK6Z9LaonFNhRGfLMsVGmMlT0voBijmVD6qErqNsban6XEt2vB4IHf8OLlhhQZVT",
+	"eS3dZ9eDTGuSd35h4Bic3AIkn8wQCohKRxyCmABo5+lpAHWSnSwioBywWQoj2JHqC5rdoDBEoRkTSq+T",
+	"1F3kGzXrU43PJ4WXOF3CSXIuSyPckamXN6iICcvmsf9uEVGXGFHhVC1p1yWRsi1gVGYjjSjzpr7pSlcj",
+	"QbnSZYYjphNRZQKvLRIKd75BfLliplVlzi5zKRS2tg/kyAQGH8037/se+hRZdQ/MvsbgjT776zIM14Nx",
+	"lQQyAJeiAgu/ayEEK4Kg/NWtkvpS/u+lejGiRLJdCLjTp1lxHUdoDM2SSEVJhGk0QTGiQrhajsS8NE+4",
+	"iOEMBzCKFvWcf0uokH6tKdeCnPVyQrjN8pJpZjldq1JcjPIW4RxRMdH/c339t+vrz79fX7Pr68v3/3F9",
+	"/eX6mv3731yeD+wgyLcx/itF9gu3jLWoHV7RRl+F3aqLxEGUhujdFLVnmofiCGcqkoZvS6uyKUmjUDCD",
+	"0tnD3vvmMuQpa50UfU92eUtnlFS9nbqVjieTOW2xof19oSqV+qOLK7mmMXkVZ3fTuUU1So0siY0qBQIz",
+	"k7pHS/HAgYMP55A6ZC4hCZhDiqV1Iutk3E1RrAshGvptEwFYPsczW3MJgcbHCbxGGTmnaBTokJa5jAGO",
+	"GYfyEshuaeOmqFBnDVu6JZD/cah7046EkjmiFIcFb3EFBwbyU6dkNpyoB6mzyJhR7r1NMNu2jaHxgrYw",
+	"bNRBlO5T0A3MVVz1R22CRlK+CLqeYPa19WwtIHFAEUcqk58B/Wrb4q0nA9c7B8dT3sJ5+9yMeVUBd8Rf",
+	"x2/zYYCmEbJeV4MwpertVBwiqlzwXrbQb9mUF6nbqWoKAbm9BecUzyBVpZtkQaJcTC0S1KSuGVFqy1dp",
+	"09ymEZPlwwJK4j/JzWA4UP83oeRTydlf+LpZVBX2YasD3uZYzYtrVQjRyyKrWyer4+zRFsByxVwgQZuq",
+	"rGrZZJaFqfNrLDufHGPfnIcmx+ImeGcyaJb0zOTzrNIrk83a0yOTk9eKvDH54W2GJ6Z4fB28MDYVlhNs",
+	"8kQe33DXpPDIfAI5uoOLto9/UsMM4VWLr3qk9NY299ApvvLsT45ciuVEWEda9lTsCwSS6YLJERofdqno",
+	"irQ7vFDuJtnzQ37OhPKgVy89qB2kbHSHGB8llISjvGJIhflVhcpLTqgPKi6Lo5uynsrM2uWyqCccWCz9",
+	"0RrkcVYKUXU4agOGh6rShobLihYW9TQbyG71Z1x8TTQ2ftImsOvayX8zoMyILmkhC4OYOVwQ+hSjrjvK",
+	"KuV36YDjvqVLQnRGYsyJVNxgHIKITCYqznpLIeM0DXhKv71AigOxm3BfV8Fa8uJ2TLjKG7w6facMjcKl",
+	"sNKb3HG+m3Gln9Xdg01PSEA9j++UURpHiycd35Q4jqFojjvWNZGHqiHuQP17Xw7sb7s3iL9S7QDlm5Ct",
+	"DIxx/8Pzsq1v+fp+h6N/7Y3+/n7n95H+17+bPz35//9t6actzZzfQedzInTVyt8tjs8SJv/49uJ1FbyX",
+	"kCHw9uK1OZ1XcjyQHwBxK2hXrovkcl0pP64p58n+7u4tjknCRlIHGRe+Hclvx2we7P+49+Oei4b05Uy9",
+	"ANa6EV0CWLNeZ0DvVZ11MEg3vTZXFJq0WhpAf+q4ODxYmjRoAHvRRSetq4cm7cGOG6RSO6HdTN3aCeoy",
+	"SrbyHDd3ZPTKPVLZAN+aqmyc9w+vHUtIllSI1Ryr1IHljD09WDr2tBKVV53TZmi5+Ul1UGAMoZV0Fhl/",
+	"ddXrRHfu4DgnOmirgol5BEtmAKmqzeuPmq83Vr0NQ689DN0Ygd6sNJQE8mDq4qk3JMyypiUjyZ4LKqhn",
+	"yNpkpuiSiAiUA0wrYCyKEqT4SpK6hNep2pt+CI69/HJ5dnouiyfmo6Q1nSRNWTMkcTVxNRpKKXAIQ9WW",
+	"LonUq3mKZmTuJnr3010BJDgnQk2RPSEFPmWBe/EfM3Eaiw614OSrWPnuFHGwI7Pew3BXg2eh4UmFeEky",
+	"0CB2z5+QYqL9rT8n2TkWMa6q0zkVI/mTQ0nxVHEuCnFgC4AqQvupZ5V5ZAX69iKXWfNPledauLtqYCwd",
+	"mCnpZwDXKHDKnhWI/gIbLiH671P+KjosCIWvO++hzWbpYZUaHatu3iyps7Xzu5dFlI22H8hnGafyBrEy",
+	"t2FACZPNI/JKIN/eQ3krsffhTSoDzJJWVTbNKg0rM2lP2+ouy/VeiXmVHdtmWFiFrnyt3NohHnh4snt4",
+	"BGSG+bceBCzicJPYcRWhv+Jc98GY3QN+d4UekSvmzE0K8xVg6hDhK5NklzBeEbmVpzyFqZ/Uv+eoD9mV",
+	"gesRrTMPS0uwtoTqVhJhq/JWB99U87ksH1f7+tKjildLt1BSgB8kMcolEbsoz81EsEHRnDKgmxnIKUO5",
+	"TAynoMf24GtH/TvVofIC3TrO4Vj/Cg4v7IeBQoxFYocwFsrTn6pzCI61Y0c3YJP9GlJhK4q/Ygqwfye1",
+	"4xws9013H0/TrHYTFc+rdFkoy1fuWnrXAIxIPJFNX4pvDdPYe6dZk+SGjoA0ja9W70t2bSjzgZT3UnUv",
+	"8OjgVqfdR8jNKVd4hkacjCI8V+4VqyO09cQIinnkqwU1EdgJTXU9JS1BhD8i8HQvfDp9vjd7MnZ6pBya",
+	"SH89UtLd+2GTLlMnh6o4/I5pOyP32IzBkbr1JV05pxH3fCj7hciB1wPlLNLvrsfVYiIWkXioB0vcC52K",
+	"4+QkOGJ8EdnSfAUS2ykqfSql2m6d3DOj/LCaUQISIlUsJ2/oEhRqP2YFXXVhk2/IcrRaOT6kuWj+1NtG",
+	"zCZYjWFopvP21WQgLWsDZgfy0IafmfRC9c1qYDI9wua1k9ks5dL9zWKYsCkpYkkLHVkyS33L8Qx9g2xl",
+	"kLcZ3KWhqTJZy8GqgWAn7xwqy4MMAc6OWd/tFEmKelK/4ZpXnn7sqAHqzJWGzFbGneZcN4xJ/c2FKoHW",
+	"lCE/p+QWuyoOXzoZO9fY5ZWq8lQCnRJQXqTvg+PDwsNXa02nAlvzHt6apPgU3l9dMXkC7kwll84SlOuE",
+	"+W/6FSX/QnExO0EW0CmLURcSyF2MHJHKE+MqYaWCFOLstLJjsnPUAjdImkKAk3qScT/JP4dUaVZLFrFv",
+	"nD3pWc/e5j17nWFpV+87EJg+MEVd4qCY46QySmsihNaYr3mJ3IuismfMfsRUzrSQlFWmbAukRrnVXWBV",
+	"NYSUk5eygFBto21OgBg1g1zVmAGc4skEUWWuyX7x0ghIUlYoNX8LI4ZczbfFbEfSWihkIOjxnkAoc0P8",
+	"XU9QKIIhjcA8AS6DqUARhX7gjRUIqyZtQY7kbVeaC545SmKUxrs1pWKpArDjtXrBqV9axgmtf7WM0g2S",
+	"FwzDMmFrBvk++GxXN/iy+7mAYSENvgzcZRN2J8SSY9bTm518zP9YZRn+Rxdl+B/x/2VBhie7S77SqQ0e",
+	"1FwEZ+LPbIqTQpdx4z4PapmvUSbbgZLCZZJTQ+E6WVpauza8tI5xVVAxTCWTHaUFZMXsdO6glQtSIWXv",
+	"i+OqVJrHbkVdPo6VaCq5V817JuMjMiEfr1uh+Sro4qiqJcilog3d8doQYpDe5Hrr+aTSzV+AoD6qqOfm",
+	"InDUfqlgoD1oWbeI05SdLUZ5rUd4Ezx99tz5TkrN8TNkjqxQ8de2xaUhay/MpvDZ9z/s1y3p0q5XG9Wx",
+	"MNwvlFPkuho2L/aZrz/W5npXJw2FrvQSJs/dPlmhkLAARu7AZfWy9yl8lQUgdtQGBTDl5mXDYomq5oJY",
+	"ZtFyYax8J6UswLbLXy2axUeqdkgjVlZUJYutrPBVkc5O4iTlbXeKJLas2Gx/snOWWXNVOKzYeY+Z8jI4",
+	"H4bytApzD/Tnrn1eV/TcdJ/K7M88BpsypVKJ/xSyF6B4gmOEqAyjTcgc0bigRU7hHBP6DTqQN6Aw+koq",
+	"ot9DKfReNdBXW/R8o6qd9ytzvsr65krQ5Nb8GgqdO5ccGo+KFBeO6udj8IpQoNltH3w28+2DayUtrwfD",
+	"bLD442wx4urvX8RihQ/slR3fmevFfP+1lFfvdvNqs9fj8uyRZemmq/p3S77OkOWrqmcPQnLgvvYK66Va",
+	"t9asXaqvg50G1Ng6ljX/agqx3y1ZgX1bev0hH5F/9VXVty/VtwXTv9mC6Ssy1N1a25P7VB6aHjlv655v",
+	"657fZ93z3gXPWyud10RjqoFwoxMFlZ7mlvNvDCSbCkNJsr8wGXR+19gnEuypMFoxsoqutl618aIJEs1/",
+	"K5MWR8YEHiWUzLG4OaxkKRNqdSDHT1K896GPGudwA3nkvGZy+75JSnhXd/yWeLCtrxXSxVuG6MgY7fk7",
+	"wo5xAvfxm/Bkh2z9yvFGkPErCmMmf77CLvS9hozLdCGtgZv2tTz7rpjEMni29+z70d7T0d4PV0/39vf2",
+	"9ve+/287zhZCjkbF/CPb18kYnKDW9qBmnL3wuc5DkGo8DBcNBTa9w4hGdOfluXIM3EEG1A3UGkOU3lDm",
+	"WuwNDKY4RvnO1EArPyM/vHyrF0ioIThymyV1yb/qgsret9ozZ7pZKnD6CkYyb/Rt/DEmd3E5LpI6j447",
+	"L36VBHRroW0HjSfjIbgQR/SktCvnqZWLp6gbU29y6CLiDN2NrHPAOcU3KXdAfRCDg5cHhwCaIQDOIY7k",
+	"Ad1qjS/fkaX7ARIDGOtmu9WbdckOuBk44wLeji17ATJGAix1PWm+tVYjQgtHemMaRSAk0hOZQD6trK8O",
+	"EVxn6tHYslmuB0+K8LkGtT+VRovS5VJzmPpV6nE8f2lMJAeXJdaTxyD7CMAwFEdnPfKQpcQshBZM2GpU",
+	"QU/geHcZz8W3trUlU6U4CUg0gomYhmKdrWLAUbgYX8evCAU/X12d74r/c7n7Tvy/y30g1XG0v7s7JYzv",
+	"J4TyXaHyn0M+Vd9MLs4Pd68Oz3ffHp3vg2yUDJ5Vzt586gH8nylTWSziG0kTrgnFel0mE+NrdTFCO80l",
+	"xoM4nd24AqzuHI6YQxwjeqZNbFd8Uw/RrnpjjFfJAMVz79DScTz/DVKXDXWLI+QfonqFI+ScyLlb6cWy",
+	"UnP+SpHrsPQPVmVKCGJ015BGcP8JsyvIka1NCt3xTwktXlY6C7SYEFqh4kaBnwNl/91e5A3EMbg4vryS",
+	"VafzdayC8E/3nr1wLYxZEsGF2yNUvmnU2KpeLBa9dC367PsfeuTjSqbNan2kyi2l3bs61/NJw6uB+6qC",
+	"P3zYxyrllNBC/s4KckKVYeiQNrnCllAUSB+327o9Pr84Pjy4Oj7aB2+ZBY/U7QTgCIZj8BpNYLAop4PL",
+	"CpHjHpzTO21V79fbkpJS7ifMVXWOVsF4Q0L1xl4ZzbLF9gRzoEqBVKSj+nN7EnVhikIi3wTzUfZLTQUS",
+	"t9A7SPkUxVwXSS171G4gw8EIpvIqZ2yq/llQ9QtDqkuz6a8u7fHy8meQUDwXl8dHtAA75hwk2sxKT+qn",
+	"PAndk4rJTo7kLAfvLsEhCcWFNpMdORMdXW9dgpOPrthQGVdiVAnyHBvOiVOGqFsCvtW/5LOI289eLoP/",
+	"SWtdhF/9+2VXCxaV/CqmnEl7WaXWekoFGE/9I7krKKpksViBH1yIcwFaLxWWEAk14sDkcbnvmM8tCoSw",
+	"YwQG1eSCH1QZ1ghiVapFxSTG4MLQrRwSogQJ8ohBjp2CSP48SCBjd4SGYu3nGvKcoAcwwoWyJjmifOWb",
+	"W7b5yrX2qkpZmlYxJNv04VU+1JRj8iMre43hoD6LTdKQVS+ls9JtV3BZ2QtbD6ekRRhid8Lm+5DSaLA/",
+	"SAjjE4rYX9H+7m5EAhhJG/P7F8+f7c4W4Y1MyJgo79mHrFLxYP5s/HS85yQgA0EHmSGLfaMg5SV5oUEd",
+	"ZRB4BXuyxQt6oOtAG9rOtvebtSLtprLcN99odkM6zC7dWnbFPWU7N5NdXffYjWkb271f7DfSKHbNJRD7",
+	"toZdf0vYXr1gN7sJ7AZ3f1267esRCnDNfZTyKaH4XwqM0IxzPOcUOmtjDT/zsalFWJmkLqx2UYyiWUDk",
+	"JC4UITCFDMBwhmNASYT8PMeh59YpYmnEwY64IMA/Cn0om92ZJZGarecUpJnecI4TFGGndlIZ43qsk1Ay",
+	"IxLwBPIpAzeI3yEU255YVkocyJWWb6j4vQOjD6u+VODprcdUZ1qNQlOZ11uzyevyJfrTpVWc6vE9tK7j",
+	"PkAvpcdFi5U6DYptzwXXulLv2tna9346t9fyCzzV0pzf/d6+/6YL+rV6kZ4H77XKVrilHTSoQLin4pbH",
+	"cZgQHHOtTb69eO1+f6WC1Vo1BWKYyuoTR6dmqOBiynnSHn5UH7+9eC1jtpwnrOM3POr2RRMWnN1XL00j",
+	"h1D2YJWZDJizplqM7tjzzzrCDAgFJ+cm3F8XZBqFaD7SbsexHjEOyGzg3SRLQKuj4/kKuzDBu/On/lHu",
+	"80IsO5voxYvnRWXt+TNnrpHKEnADp34DO+LYh0Ae/hDwIBmCNEyG4I6J/y/+FLEnlR62rNWhIk/hffNx",
+	"1/F/RvI5qQOG40lkCulmvpJa+jelsA1P+VCozYYyl34FU8zJR+Qk7GyPSXoT4UBSd5b8bLY1BCGiWIyS",
+	"T2qUohKHSLDDz1dX5xek7PqSh7O/u9uTlt1hC7M7nTFceH4oYHpnFxergOM2GiVoGjNdBI4zvpUBqApP",
+	"CdQMZQbMEPxEYTL95+sheIduGAk+Ij4EV4fnQ/D26NzOMBXfDIYD8dFgONBfDYaD7LPBcHB1KIa8PTov",
+	"hkT0pz1fnB3HHPMIzZw1jq0flewLIohnMntbtdOrekAgnjla9r270p9WQvumKZtvvz4bJAODJUOFBTWq",
+	"mbOEEgWrWagFN3VZ74eVbGb0iVMYyOgLsmCVq+m3aTKox3yRd5ghTr/T4iZnLA4LS+iExmuFU6beCcuK",
+	"E+x68KSKdTZYMl+jkFJm0Jkv8lPNIjXnYK/sPg2ZruRKxaokyVUTyF0B4t9MSt1HtNitUObRwdXBy4PL",
+	"4w+C97s0lNSTVqnTBC2qIQsZsHCv8IqSmV8m12/ZcFcOYz1Kf7OXcXXH1Onq9gtsV3LBr2jhbNujnG4N",
+	"nzsP5zKLLfrfFPobdyrfF1eSuwslWbpXI6lZjotj2zFBTbDF1udVpI7lVd6zmjHfjrviuJAo94B+CguQ",
+	"vg4Ke4qVeCasCX1dEiW7eBlXhH00D+yDKB+Oh/MhBkXSqmYyeLYMK7jCrSc/+d8sFThbcXwdn9yCmKgC",
+	"u/gWo7BY/MPy/js6bWglVcY4bK7Py9cTAR5DznhrMy/m8Tiw07gxW9W0Pe7lcUXN0h7Z41WsBd29Nivr",
+	"FzTD7JySMA3c8YssQVgQA2aqL4ceXZcSXFPKt+WW6eCFamaEZQJExXk3LERUBK5XkOiYUkIvEEtI7CqU",
+	"eclhHEIaAiTGCWqVA3WZXgemXUn6lRdUajI5OOe+lwdHHy6O//n2+PJKGHOnB2+vfj67OPnv46PBcPDq",
+	"7OLlydHR8elgODg9u/rw6uztqfj74dnpq9cnh+qL84uzw+PLy4OXr48/HJ6dXh2fir+fnF4dX5wevP5w",
+	"fHFxdiEH/np69u70w08nVx/OL85+Ozk6viiyt72CI9+LQxw1d7ZSG9QjjflhPfqWv0v3TV3ND4xcNbVf",
+	"qW7uqv+xrNMmqEPOVhAgdU82ah/vSTIwb/ZyYa/AKKSE6dxwyEGEIOPgKQimUNh1vq86KpVcJPRtFhWy",
+	"AXQ+Kvwur1v8nbyUbkkah60y1CBPUqPzXtZP82tzwy6VBwwWIov6Qb8KMqoPK8psjYQ9CHSCa1YVoPRW",
+	"CzrfFFrR2sYwesqn/zrUY61SNm3f2a3TWCqx88FzyUs1PFu03FMrvwI1SqorOA/Gal/X0hE1Bshqsnc3",
+	"JbrmLcD9+uyBCZ6jWPfaW9JEyV5hZ3ZT79o8/wVuUEBmuqGEDXnhjdy48anGs8pTjff6ccYof6bxt0FP",
+	"88i5W3MFmGxeYw73qzniWATssDRJCOWsUgpk7FfhxjrWYaveZd59OeR3JC7ztLNDRn7odMaoqgHjBZxF",
+	"TokvFnM/IXwj4ZCvR7HK35Av6cqBkWRXLdHB0yOhlaQX83t339h7dB2G1m6NK9ptW+lBOcEYT3+xKkOv",
+	"cJ6eW1i3QrEzarZXWK/m23YmKG+ozlCRRpd7KvlTl/k8go7O/bhr7+TQNZxqYaLaU430qLbDdAYof8OU",
+	"pzCST2Ezn66Z0YUG81t7vnQGF4m9kewTj2yNQH6px+gp4neEfnQjNGtVq+5K/R8mAG54htVG/TzJo8Cr",
+	"VsSv1+cNe22mmmobSoDjiXyMLgMM6p+xwpfqMVTd+MS8PfeA20a93HXvj5171pUIdc1/n6cOWfFCGFvd",
+	"5kyHoqy5YBYD1S3qyq0GHTmBcgY3g5wlWXtgtY56lApTTkYGoBBg5Xgy1XyKQZz50/HeeM/PHMneFQpR",
+	"Um8Im9qj+SvABtejz6dergTr0aMGzO2kRPWODfFr5dW9lYogfr/E/3JJKvmRgFzCChJE5WzOaTjhMDoU",
+	"F7Hj/az4TcOQTeeWSlW/6fumM6s/r58yZNvStGuzjr5vPrvcrPVr5LPc25NDWex98ADvCKsLNzk9KxTw",
+	"M4IRn57Et8ThOZC/mb6ZKkslryylnE5FQqh1i2SyaOosbiQMiQiq+qSyWoa9cpe6P0WQd9R/LobgCE0o",
+	"DFE4BOeUyNsAx5Mh0FV/hgDxYPyk/fmlWtXFSb/+yIxhf0URqucn84uxE1SNQlMhkCJdZxlGUZ4JY/p+",
+	"AnKnuzTBvJWhqgTjuBrUxxemZ6gzQcdaVUil8opgJyvPKq7qXUJBtUbrE18hnF2YOZ6caYRFn0ZpGy7k",
+	"v1FU1OB9xYI3Mmoz3ld/+s1OzeU4OzON0k1XeBQClgYBYuw2VRWJm+nKTOra26mPBCz0B485JeYJTSb5",
+	"GJiSKLRKGMsm9drlx4ZWBfuhVMrsgPP4Or6aIlaYDVLLX5I1DovgDYrAH6XIcKBAGkmQ/sFpiv5wBaJ6",
+	"hms7xl0zpK0m6ppN5xtzzXG4ZMQ1J4wHjreWMeqV7XxqXcmlJO+ps9NYTuxqQO7sOgg4nos/XMka1/JZ",
+	"ejEMkY3wuBBPiSBpVazgeAZx1CEvSwwX2nQ2AQimMI5RVD3rW2cyzKWUdnoiZwZvhChn/1dLkiObtTtT",
+	"7H1evrk6z18I2uW1fWeQmDIV25UaW6+/UxTgBAudurBRVNjq7wOO4KywU7vuf9U/V18cu0TWEvUSQo2p",
+	"lrLb9fusmvVyP21VxYuUcEPCRd1MstxCNp2qJ16dzyJ0QR774G+fJZ2Mhaz5YtrEohBAnv3EOKScHfAv",
+	"Tie5jhrUgaV/BvL9QAfwfs9WR3NEMV98eQ9GJWivDLTt2pgGcqhQ2HZ0gsgPUpf/VvxSLlPS7ODKa0h0",
+	"YDJpmlgu2GIdld7TlLCSzTnMofRBTZ2Yk8iR8rvN6wc1crtIHXkgteX07LWtAnpWfaUZT1pfLzj9fPbU",
+	"coQ17fc//qeM6+CZuGB++P77599L+aL++6nTam/32Ja3fvX6sqbtqESGBnw4MDWJIuZ1jvm0VffB60tH",
+	"bWTxkathHgpSii4/4uQ3RPGtR8U7MRbINcQ8EiYEBJ9nt+FOTGT2BZnNxEWnag3lWS+WAdaY2lJlh7q8",
+	"0GLw0mRXBbK8kkyStEpV1JSxcUaRfkULu1mHw+uQ8V6vyJsLrCLVjwKKpPoNI9ZdsSkLEcdjIll7hNwI",
+	"EzWr8VOTkl/Oze0myvR3rTC/QzdTQj76q2N36gNPhWyKYNhYYMZ/XxrSn+WMEsnV8kaZQ+Tnq6tzoBcX",
+	"KNdtXUxSn9lEnvvg6A29kMUca7WSbK1fLs9OgR7efm9Xy37RyJHGpgHM4nzyFdsUyUZdQlkFdziKwI3g",
+	"klIHTfOUR3zPxiyCwUchxHf12xm2a4ZagZiU4lbFQMD53o+a7DNyOZNC02jS5ArFYidZ6XscSxWIUDDH",
+	"MHeT1mWh10R5T9QsU2u5pYK9bepCBTFn4ho+p4TLlA3jn3lj2eMlghLjwbPxnqzyq/I8Mh+WMZdLz6gu",
+	"Xh2Cv//nsx+dakOW7vNBXclNPcsK2UH6BpfP0QrGQ/ZMLOXTcdEf0WxHlC3pGwQpoh9miE9JyD7o9Afk",
+	"qttnfgLqG11ZT39ZAk+edTdI8l18CCIsc7YdrI7iQzlGJurEMkNmx+Ae/J///ezJGKjjU3MUFQLpe7yO",
+	"sxwfqeGYn3T23eHrkydj8Fb3NtWQyHK2mAVkrvJ6ML2O1U8fsEoIyuoLqudCygHk5ejI93QoZ2zBjVRc",
+	"MF98QDG8iVwH5YWkkziUGgwTwkwm6hYthOtY5nDfEhqgUMWdMdP0OAbvpigGSksyols9zZAt0uXjLAAp",
+	"uo5hEKCEo7BUlKau9q+dZFZ98aq1hypT1r2gLHHG7ixI3G3R1TQfYu83W36gWCfx5vBcFuCtqcEjicaP",
+	"+xR5qy8G/gxWk0z3QRsddnKdU2I1iAoH/K77yXJs1ucPW6qh7iWaCdwdQ2AfcRzu5olWT8bX8RvIg6nO",
+	"Z2Pmybk4JfH1/Ok4XztLzZA5q0woBUS2WsJQ/vng/MT5oiiOCc8bNi1Z9VH+rEo6Zk9BVWCEcSJ/g+kn",
+	"HGFIF/IRgEsvMq1ervAMMQ5niUNp1ENk1w81prm/x55/f48QRUjM/ROFATpHFJPwEgUkDllThJipIeAG",
+	"3RJdu0ofs8ywnBGZYHnLEQVmAfWLlDHFSOCeV7sOM00DmrKfTHMQK/x4B63VxTVwgxRkDb1SnnXFpYwr",
+	"3C9dETqBMf6XHY5z1rb2SZs0uZLFut+Z5/9JOT6ts607BsAtSWAHuP0j36lfn8oda6G3J0dF6L//fg/9",
+	"+GJvb4Se/f1m9OJp+GIE//PpD6MXL3744fvvX7zY29vb6/90vFBBTjo3ma3cHipjri7i0PadqzIUNBai",
+	"EjZIBleVJVMwJNkY6MQQ2bxYurHj0GlzqmBZJvq/neeYnqfzoC81/WDs+4jTc/aVRBr91vINQxbC+MZS",
+	"9/OUdAtTehLJA8cwO5CJ13NSb9YgMdJ0ljjus89ZkFOKmMH7mg5RyApUvv8ybJtMS6na6e4Krrb3gnBL",
+	"2ZjFwGinKGEeaERND+HtGzUXbYV+RdLictEsuEERiSfCKi1lRs2dT0LYcTw/Mr5t78Yu+t2mqqulOrk4",
+	"gTH6tLMllGXbNXcVc01tBcEVfQzzo7X3bX6spqCVfaodXZw1AQzHTpdgui6vV735rhmYmtLX1TE1NbBn",
+	"JMbGTolDEJHJRLbejm8pzK2vb7lUgwOdm6MHLFUh2zHT6u/3TjWzi3f5SopnO45vk25oz2oMZYFQLl7g",
+	"JNIu1REcmAc7HZe0Cyc4AaoH9n0rx/WIPbr2lEk58MY8W1avsMHR6eXo6dNnz1Xq37gmEfm++ll1LONQ",
+	"IwS6a3T3VZz9FsdnCZN/dNbUewkZApan95UcD+QHsm+ajhq6zjCvcF50Be/v7t7imCRsJOuIjwvfqpzN",
+	"MZsH+z/u/bjX0GeWegGsL226BLBmvc6A3k/VeQe3dys/L0eFI3LjjLnSAPqTw8XhwdK0QAPYixC++PFb",
+	"b2Vuc0vfO8HcsAInThh71TmpRONqosOu8KIp6lsKwJVDjXak0SFkdVSxZuFnZuWToxoVeBREuN/VqGe2",
+	"QC2+IHfPqyNRdeCqn/P4qEylx0wvVgwbi03IV/QJJbc4ykz/VaXG6lhXjuMMetd1el5Q/ypMwwgd3UAm",
+	"GyubgVmwSkaQmRXNGokBc/UsBsep1ZuOXccyu/r2FgdYv8Qz0/EpJelkCiJI1bsOYYUz5K7RH6NPXMHl",
+	"ignDv1L58JIRJfhvEQ+m5kGS+FS+2RuDc8iYOiGVGAKlC+A6/kN9+wf4K0V0kXeZMnJYTqEjJWNwcCML",
+	"+Jl4igwFUwRiAmaEIvWyr3xToMUvz07+JPjm3W97/+vye3r285sUvvtxHv55jF8f/rII8ckPb/71z73T",
+	"53v/cIdxZ+rBUc3zwoMkoeQTngkxV3pkCLJvdfBJIkAi5Dq+MhWsYoAYV99nKTI3CztkKazhGVzIJ6c3",
+	"CKBPMODj6/itqoQE3p6AKRYGtHydcj34f7/fs/BxPRiDN3Ah1U+FPpmtcIsjLtObBeIxKqPtxbOeku4c",
+	"8mDaqY1wIr4AMH+2OwYHUWQCqeJ8TfPDMTiGwVT9Am5JFJE7gU7KMYxGaRJCjq5jhmYw5jhg+wDqoTIL",
+	"CTNAZli2LLeqJisoIgTnOswbEKoeOskQRgbTdZz3Nk/jYArjCQrH4CA/MrWUONAkiTAKVSaP2PONTG6J",
+	"yJ3TUVHqjlxuL01JxGQv5JFdtrJ3G+SeDeZ1bobZ7BBQlETySZP00X3CTBbWtb+4jo9nCV+Y6CFmgMvW",
+	"dRIx14OYAIXF6wHYEQeTR89Ny9gnY3db8r6ti303YX9yf7tYuqfw1epaCqt+wioSXego3IKymGMhg9Uy",
+	"yrOyczclERrJf+vBACq0sAgHCMhO6U/0jSCEn8SvvFkBJ9dxECGoXnKqaTvkPHn2NV5B5+Cq2FMxz6JS",
+	"XRZ5Vrc/q6e/ypEkaRQaAW9qQjkK3JlOz40al6pqW+gLXXQeVIgxK5jfOG+WraoLhnRfpyEwX/MEs/+e",
+	"TH5A45b0IHUI5C5mPRer6zN1pG8ABu6mC81b2cnXHXp73N96BKhzIGxYrfYHGi6nIkrC12RyHHPquHoO",
+	"TGeFiMh66XShbk0IElKly4hMnA6C7O1wXo0pV8wuubi5hW4kLsygkJpKYvm+BNR5JbhP2o0pc5PtQCXU",
+	"Pn/+/O95BclCrs2L0d7T0dO9q6fP9p+/2P/+h/F//vh333ybclDQyo0S6HGeQB2FmqKCVpzEPDoGskS8",
+	"1ejEERDRqaPGpwtdHWy+naDJecYDDxgp0UD0DY+Yz1cSE9GT+QZCtAxZNvhhjuGBIx72Qfg00Mqpp1S+",
+	"utJYyrOOdbWVnrxbQp0qVYpps+tYMKvNoKbUhvb8WJyOdb60PrHmutQ6Gu/uVldTttrR6MrRHd4xY79S",
+	"iW3rdY2J9MqX+9JARB2e5tfR0TI+0nzODXOM5oD18xEUusS1NKSr60dXek0nicaqv+HHrVm5xTw/Jqs+",
+	"XGx36cdsxZLYbi5DjmYVFnfZU/Rjq7oFShk9q2cl0/m+eAwu+1Pp15XGoRnKfUn+yrFe6yMFJ63Uwe7a",
+	"pS6r81IXEXKQmf27rcWJPwnzz3KQqZJBxZe2xS4H34ieVsLag6prRVj6am2lWVaivBXn9NXhSnWtltXl",
+	"Skf1wCqd47B8NLsKvdX4Uq4WiS0MVF5BR6ec9f0o4+Kip47MEaU4dL+PaEzqrErLaru2miRNchcjV9xG",
+	"/DmP2bOi00+aj7ljBLMSKouJojVYbS/NV/BYuLptDuqdOu2z554Rv0cjJdK01xmWduWi0caaogW1I0ez",
+	"/sardqgSTqiobWQVmmrCBurZmmYImeqgxUSgfdgmapqXw6uUh3obKy3drzaUdjnfCzvJmQtcEOi5Hedh",
+	"WoGeZVzXIqbeVT4ok4TipSKveoirDjZEq8RaspFxcf7vWFYxd1XdjHPXY1P7VtX+NO/iimAwbejg6tlJ",
+	"q9w+1gFcBJl0DLyVocIr7OLVqvsQMtVhSkd6civoJnPoCnaLirWvG1/m+Rhjb3LTy1RCljqd1+r1DxeT",
+	"cqCCOV3x5sfm6ISfY6gSGnEcjZm0G1xTOEfgRhiHduXIzhBeVBb3a9TtKs3ZXDC02LU4vwC6VgbOv6za",
+	"hyR05c0cRFGxDC0zKRYCri6YEjOckhC5j7FQeLSLKl38UGjRpa4OaRSB0jBweAF2spfc/6HY9D90IVsZ",
+	"eM1s0prHCVq3UkGnCnLNbZjVcx0Y3rVLuTrMdHeGkA2JOSj3DTIjHOWNSBz19nFsetzp+ik4LvSZ0X9l",
+	"nFDPHh/nuhOHioW7p7EqNVES7gq03ECGdpvqNumlXZ1Ezc2u4uX9S0PN64zh34qGsN4NJypNyZ6/1eVR",
+	"16r1okrxZf4vkmyp6izEOuZ4i1XVeV1L2Er/mcEY38paGEoVU3F6q4ufTkxl35KvoIjVB3YWFIDp7y0o",
+	"TrMid0EVNj/juIzg0lvFXMl12zQOozTznJYLYns9J4y5EKuuWlkyP8z8rstZ6FYQpcLbeaFmmQwLvp8N",
+	"wfM9Vnp8P7tXS7nI7VtTuVp5La8lf9Ll0DmFMZOGh3Kqtpz90/K5P91jTWV6WGOtiLzYvC4Ap27fJIkW",
+	"JpaQC+T6xop+tSPMC4qmRjwkqzXbLXUsQrxQKTHbmAxQYu18r8bIKi3J9G/vPXosVjQw48Cw9aoGvUy1",
+	"1zexwk56mSV3rLHNBO0w9GuJ2S3UPa39ZhG8AnO/sMC92PsN3HORMaTJiK0wiqr1LCuf5YZt1r+ihodk",
+	"AoxbmVG5MVXFosI9qlXGpVc/DIeeoslPN8IYyIimkWkD0x5kMRgOLlOWyKKtg+HAdNNwRvVcgiGzHC3R",
+	"MIM6v14oLmNHzZ2eqlevRocGvLgq/5bqSdNtZksP85aE0ph0n2+eHe5aNuf8eT+tunOLWrfjoeKwcBSj",
+	"jUKWrS4db28vXhcdEHku4jbV9KtJNdUFZT29oZJUMcPqXnT1FzS/qcxsADm4m+JgWjwGVbAsc6sZCZjr",
+	"iHZWatYwb5i33nu/0rRWa0fD2sq1F7VlHzPJKrmhpnNytdgxRhTSYLrw9ZL9nH3QJuFLz+5aNHt3zZPc",
+	"0ajL21hNWnMktmStqk/znTbh9XjuFA8HtnqJ5tJMYowEWIac5I0P67uiBe5XVnmtP5lYq4wtNfkUMkAC",
+	"qdoUiuc9d7m/bzFlvKFo3yvxu1zDXkJRf0Cousl9y+81rmT791eyXm0bpvpnPZm0nVeSs21/OmQMT2IU",
+	"mkdHu8I6JFKfi0mIRk8HHTLiL6eEcjArN+VXw/OyP1WIgikK0wg5PYB1jJ6F4JXUzRs4utfQ+xsxvRb1",
+	"5z5TcSibGOycimOLAKHgHaTCaC3ao+pnX5bU6Bw2tr0qcCbr1k5NAm0a1mVB11o+VcMbbWZrxpIS1CnW",
+	"oMRMW1KXhqcJKz/b8rtGdmaST70w7qIW5bRWyc5okedeunFl0rZClUnb6wLXjE1On1rEymhQ/ROSsjpf",
+	"aNxXxbDKTTjgPoVnHQq2n7BcnRHZRsZWr8g1GmWrMsFW5XqSBpfL7URuivRmd2igtQmkWWyMqRfE1M51",
+	"ZV0ljDNpNPdt1MZPMqlhzD1pOua79C8fe3Lkg/iVmZy24DSTDguFgBSgjV4+s3v1jqzjbRORSeWuqXlZ",
+	"dhxzil0Optf6YRdGLDfa1SR+iQnWA7i268WCowkXPv10StTqJxVXIa++BdnzVbFPC6XURfdL9OKSmsaj",
+	"GqaqXGLe55imbTHgWrqoPfLm02zGj7X2sLXU2KXkTFuS+N8wsk2PmiBrVVt8QCUNYzbU78qHQjE3aCs0",
+	"Gik7nPNeaDpu8ePej3su45Ii+ZCVFQY/9XsTU4OLyzr3nt4p00+JVTsikqD44Pzkt+f61+yVa3FDpWHd",
+	"8KynVgsy02DhTE0JfnsOdoF9FBkIHs+uVNudI8jhZY09p0Yoz6zpnAOTxN3KWSfRtGsBxWwbYU6aHlvu",
+	"JmayV4cW2xZ3XlazVkyGzKg+faX8OCVbemht4X0ttlQjME9Rcu+t3HrcGqtpY183Sz2ZNWCtNMBV8Z4W",
+	"FNBSvpTOTpQF7BdxIFNeTWWNrBbeN5KpU0bmg2bqlIDpm6lTnmYlmTqlSX1f9pTboy37tKd8Xg/8tsd1",
+	"Yj75S1WyKz3fdrZge6PuCguvsqlJlYOL+O6AWOvyaq4hJ7B1SxGb1ufA/EzuALnlKBYAUhSQOMAR2tXf",
+	"1SVKPp06nZbFFAw/PrjKP5ImciUn96SYF6XiaZyAuylhNVmkFtjXsaoFdwcZSFI21a1NpR+8dL66DlEa",
+	"M8SHjilmcAEiPEcqDXZRszRFMJhKb7OpgCdr0FmyHMcqsC6L7en0Yc/G3grivJt32Y1rfhgOfEVEl2SS",
+	"Nn5YOpmkzBcrzCGJIBOQC6J2v8l4Z/onVYAQpCMfaCSUBIixhvZJT7u2T1KLXQrKYbWaqCQsprVhnfyY",
+	"n0EHwSHXaRDLTYpMnePl0qDL1KH+TXVukjUT0RxRQBFPaYzCISBxtJBqodS6xi410IUF1TzOXFZSmuoq",
+	"V6CgG5p+Y1ZZTkslztpvd2rt2EG3LPi4V6xx+nvk1SdXOn7kIUzEyKrw7iKy68nGEFx7NfhjI0wvtXZ7",
+	"liAKeV6e3Zqwx1uW6iQd82WcDNRqCjU+kHDqwjbLA+3KKCvCBgmehlBhyko8Zq6CkU1T1lBrZd6ufc7c",
+	"D1jkputvrvpmypd280RtS6SRrP7lMqCLpzGrbal7kHkt8n6OJtyYx3prDNvV9F48yGeRhBVmaY5lMZNj",
+	"a+nGfK/lBJ7r1Xub7FRcVcq3modrhbWdrg7Tg8F8/jEbNMZkNyTBR0TVO90/VfzaOeB2UvnlBjIcjHQf",
+	"/+JPjE3dP3DZeOuGEM44hcm49Cv5iOJS+wcDtreYuXJG/yuoyZJwmvHTZ5OtOBVY8NrlcHCZyu0dkpij",
+	"T65cnrx7r2AkNVpV8/vEHY9GOOYRmqGYfwgiiB0t8o/zIUAOqUo9FepwZg7m06selM3z6zEFpQOGMxyP",
+	"zBIhmut/d1I83BkgGpflkxe6zUDc/TL8/wEGKsOpcEB6jFciSBXJTsw4pbSCUJBw3ryqkhpZrjyfHbuY",
+	"D6RMdSYv9nWWD2EKiXTOjuVvUDCFMWYz1tSKuDT1LPsoNw9ZEddeevaBDUDePaR8uF2qC0tHsLlwSjDl",
+	"pys/Am+ZO50ooZhQZ2rm4RQFHwGhoX4SUjiHEHHt+t+JyB2i4B9giidTRIGZ8In7faMVr2in40JHU9Vf",
+	"4FpS6/VA/KtE1NeDYoZTF7K20W4hZVimGxddO6tA+bxYo7X28gaV9vIp/8I4nKggSM/CXSW7ob1ymvb1",
+	"yFf4hHFWtvXGHZtCWbnQxe5JFv5MHeZSj6fyn48gh6Uh+Z8Kctce2SN0UQuvo3Dhcj2YZEHrujrejvCE",
+	"FH9MyqiAEsZGQcq5KmgfB4hmdR1gLPsC5O9zcrn57YQoFPIeNDAhQegbjlAfryQIIafyDT3o6vHLxRsU",
+	"8h84ypCj3ye2YOjFlZfoakOP7lw5GtI8Ux+ZhiWye4CsvJ+9iat/5nZL6DEMHOUxD49fA/QpsWvEmvow",
+	"8QTMTIutHA5duFscq/vldRClIXo3RXHrYkLroDOVwoVvjcNTR+LZVJaJucnqS3kEItb5FrQKi+Wv8E+A",
+	"aHoVrJ43FJHmrE81h9SV0EYSMIcU58qlpBzlXTYE0apQmV35PM1Fzkpdja7JQl5KpZFFx095MHXx1BsS",
+	"Wp3gZXxOd+fIyTp38OhSSIV6e6thLIoSpPhKt+7hgTO8RhJdn8mxl18uz05lVxyQj8oej9eDSRJXvyVT",
+	"BqpkZMIwHKj8I6hj8DMydxN94qy5K1N2ZFkZRI2Kp5vnEDATp7FwptQJY9PxqEwG5TgBDHGwI63IMNw1",
+	"7UByNDypvr1OBhpEF/U2xlOVZKnVn3NeJdk5rivHsvA0ywbgnnIUh4O7KaKolcQ5AaoPlH7yV7i7amAs",
+	"HZhxpZTyIOuLAy8n+gtsuITov0/5q+iwIBR8RLFsDVsnRA6PX+u2cPkwQNNIPrORLxbzbFBVGkOZg146",
+	"2m/ZlBdp5Bl7tJVSrwi10aoqM71liB7CRB0ZRg2J5GJk6bmmbumXZXxW1TZr5iaPe6PnSF5YGYyLqkP+",
+	"DZTSAeqOPgQUlnUVfDWH5nrncoUN5dnTgDtEUX7atYHuva6Bbummabu6i45iJ0mUyMifhptJuBwMqnnl",
+	"eEwpoVnDGTYld3HWKLC4ipRutzCS1NLW16duJ7YYvaMwSZRb9G+fx+PxF2Vdz1LGs0XlpUqlF95q3Xx9",
+	"/bfr68+/X1+z6+vL9/9xff3l+pr9e3vPZglW81tAeQe/omTmGwolFOBY9mBQt3qlxL6Vb+oXvy7kptZr",
+	"CyfWqmDHNPsTJxTdwODjE7/wjHZMNGVDyNZC5hLFseIOl6/6JsVR6M5FeSl+AnZ3n1YurD4+w/wCzbH7",
+	"ov8Jy2oAM8zB5c8HxWeEN8HTZ89fOKckB9Sl0+oLFNJgijmSIdjilLPwh5oJzy5rp9M3WzwBbME4mhWm",
+	"jHCcfnJPWes8+olk5yIDDJwAeQbFwBB5On72YvzM31l3YHWWqvhMrd62MMG96grqoYWY/d746XjPN6Ce",
+	"a002TQwtAtQnkZ2wjUYX279DN1NCPspHsx5PslRfUp09pZ+SqBmy59ElF+DtLQo4CjNjy5VQph1IVusa",
+	"81lWclqvUorOFd7J3qGbEUw6xuZq7welq5gLonBmGmd5ElmhnKwzk0f97kxV41OkAkIGkTK/sW7q1o6d",
+	"nOLJBFEUSsnDmkojSKphIPvCnv6Z8xlK4eWB3lOOw+riToqz2il+C+7ibD8P6jE2UPR1Gmffr8RvbGbz",
+	"dR3b76qW8R5nZ/HADuRiiKnK9fbPdjzG6vl5eLJ7eKRYVOgeFLIsJ6rawe/bCb6Ug3MbwFISlGX5Sk2y",
+	"UuaSU3blMOUbWRWfqVPaJGbzeVFdZL88L7VMe13i0UX8dg1Cv29igR6R5iI09xtrrrKJT9CsGdf62dvB",
+	"RFdOaXwrYI3N03QKfj2bMpplhOsjQc7i3ydHzpoCOICmNJyjJmsyXTA5In/J98aE3Ip0eHjBZICdTaF5",
+	"9iJOVC9d6rc/CPBIz9jyFsHb+s5GO81llxzz8uM1HzTUp2aVJWz0rBWH5607lmmbWIZww5onlsHr1ULR",
+	"TFJf484kY5cDxDAGuQ/UWVxAZf3ZFQWqyTxdChnbMWLr0bBZYLxsUFr3V1WRadlp29hg9spWXXLnimsK",
+	"Bo/9qis3BnGzw0/jb83oupDlKzZASbxI42VVRDHFShXEizSuy9s1Q3RPLJPAaxIcVQQ7F42mcP0cy4Zu",
+	"CnKdMD0G8rTECBkCE7cXns1SVXNfOYwCXYlr7JE4WVKQapMns2TM0JI9hqd2Msir6t0Th3ZWVcw6ZFxe",
+	"NEFierlU4+p2GoS/BDlCcxSJISN1HigE+VRW8bwKSK2CpFXDu0hj6SdUJZDqC7hV6nnqjKLGojMrLUep",
+	"O6XIAtg4Fjc/rckv8is7mYqLQBUv8Ss+Wb8gry/xKZHbLVbgF7FzJ27r5crp5751Ji0wu9SctIips+1K",
+	"03hVlqu4ODbEbhWYMHXF6pkq0tXLFl7cFJGJuwCay599yVECnu6Dw8j0ykgIw5zQxXg87kjDrzMwV07H",
+	"1RJrbWjtbI1eOFDJeXQgLjHdDcOpKF3hGRpxMpI1BTIt1j4hcxFmk4Cd0Ny6aoMgwh8ReLoXPp0+35s9",
+	"cSL+zvKde1K5MYlL2LurXnNuFPYw9VxY1Bs3CQx+cqvJqssvmRHji8g27FbfqaJrecj6Yik0jQuPjjtP",
+	"qO+yLmjkkH3sLiGvIPvol9tTIZeGoHrWQ6EowIAy4AQbCNWGCYkUIg5xVBX4U8he4zkqOGvqI2uSJSMy",
+	"Ybu6vrDQT/PaFVkhyKoDry3SxupYY44ojKLi/rIuJUbz1G0uB8PBRRrH6l+yijZSRbxfQayKV8tElaKH",
+	"MP/C0d0CJQ6Yzg1SdROLHLedaELcFHX9UsvhQbNhBdHQfWxN0qez9K4+MNWVCNxFYbM6BYcXdn2urP2F",
+	"sGhw/KeKQ2cVuYR9rh+0AqkW6n40WLoJ/JrP5mC5dZDeCdIN7XWst+/u5lTK26FeZso+VVC2IsMhKvKH",
+	"9u9007aMDe+WiFer96W4NuS8mMeudLted74lBgGOhbUgmxmt8t63Hdk94k/uqkyVt3pe8ZEqNr9jVqr2",
+	"GBwpi17SlnMC1cL52pj+1wOVf0dmmHMUjh1JbDmhNMqNHipLpwJI96t6fGncWiZ/m65WQX8hnuMwhdY1",
+	"JARxZZ+3OMZs6s4rzesoiZvDjGxS5592MktrapyIxSrZV0FEYjTSW6g6U6aQ1U2lfutx8V5+xElSdwXb",
+	"X7haTFHug9PcMXEfFpJGokJAE8dIVa/e9BT6466EN8s8yIgKfUJBWtsRqrPGb3mB/MsL15y+iftkICpS",
+	"yF/jso+th9cX63XYjggM3d5Y2cbe8TRX0oq63AISoqGpio7oMGu3xOQlFyLZOy4OZIFzGZTJJM+3lSAi",
+	"sfjgbn8BxTI+f/n9yhz+Yram/m4HVvc2VaiLSPsoA+47BqyOWd5tTK5KDcmM6G5t6zZ/iaUg9rkrNdzH",
+	"1kft9Q90KzIZlOjdFq62K0p539+xrGObWHEMTm4BmiV8MTRtkFhWeUnG9fVgaHoExyydIepU//o2ZMPM",
+	"PnS9BCt0amtpztbahs1GpUlStput2efcQrpKqrnb7ylnvqlHXVMxhk5Y09eQTtKZzEDukiAckNkMuiRV",
+	"PrH0dxps+s+M4rmrIFFetsM8LfPWKo/j+W+Quta6xZHLKHyFlfaahwC91xKf1iyGZ85AztnhCZA/SeMs",
+	"FZYQniAmX5JwWOp2RdEEM04XY/2ncUBmu3YNul2Y4P350/GeR/a8AqiJ/I7ru0wiLpSdXJ40E+ENZOjc",
+	"+WT2pdA9Esin5noTdyz6lBD5wgnDMltWa7r1rTTUNGnerKDgLiKUZ7Dp59LWLDP4Cc+E0Pjh+++ffy9l",
+	"qPpvZ9kglnUNqOoYeRdpHVR2GWJcXzy1cS2fJqnqMalztzknR5hxJGMgAi9gx5bc4i9POm/eHXo7p4ST",
+	"gES7HAXTmERksih3MrUE889XV+eD4WBycX44GA5+ojCZ/vP1QL7dYCT4KB+PXh2KIW+Pzt3PVxsuEMsx",
+	"lNF4Nl6okjdoQeIQ4FkS4QDz7OYqyPlMZqyi1WeLa1GHGyXpNjF1l/iiGL+K2KJUTTcgsCjgOJsjSnHo",
+	"rnuXXTOjrMuDwQMg2Ycubsyu6RalTQ00QNQ7NjI92tfXq9X/npBVNQ75PDe3nVxwWJaVsIiKmjP7LrfE",
+	"HEUOzS+OQ9DslitpUtKUp+/ibS2ZAV7epQKIfR48V27RyoPnU+nrc9+hzgfPqql+VYcQf7YKepsr7q6e",
+	"LDS0p61J0+QuViWvrBbCvi0ZtbTzXiSXjt7tFG1BYC83LO3xvVdF15IB6u0s1UiursBQkFLMFzImoXUh",
+	"BCmiB6nShtR/vTIOlV/eXVVSu355dwVeymFAFl8tlXYcX8fX8dmN4FoA9QgZv1uQlOo8Ur7QeWra868T",
+	"QwE2Bcav44NCRYApgiGi++CPwp/3DRzX6d7e80CuJf+J/hBAXMnidep9sHqbLmMoH1Fsarv/8u7Xyzy4",
+	"aFRsFALMWGoaukj+kVFFuViO1ynnyeDLF5nYeksy8absUGX2Ds4SFB9K14vuaa0+Y/u7uxPMp+mNVJlz",
+	"B431zyp/XhxfXkmFVDBUPjM40fc1yNLOwHkE+S2hM3Ua+VCNdmalf43EJTVHAN4wTqEWcKoik55Nea4S",
+	"PSVA8QTHCFE2vI6FviFLlKpnprJQ1Ujl2dvPk1XWbFBo0S69YVk3fsBQAqmhoMFwEOEA6ei0xuVBAoMp",
+	"As+kLVHE5d3d3RjKn8eETnb1t2z39cnh8enl8Uh8I1NieFQ8FYFO68nu/kDZKqr6TwwTPNgfPB/vjZ/r",
+	"CjaSZXbHdyiKRh9jchfvEkH+QiZwGYMcUSt521m65kKW52fgTNCy2A3IPs5DZFnla8iU+q0qEVy8OgR/",
+	"/89nP46v47da639zeA6CCCPjYJThz9cn4ooKMQuEllAqr6F5wnorfx2LL9UsJUuzREC5HiI0w1jVVMIo",
+	"ChnYMcCB//O/nz3Zv45H4I+cmj9oGP/Y1xt3ribpTirm5g+6QOnh65Mn4/KURpp9QLGwp8I/9oFJKCiV",
+	"m8UMILHdAIXKy4SZRoMitiwkdhLKrH8uYTw352Iio2+Mf08GcWX2hCSIZ3t7JSsI5o/Ud//UuYu5idXo",
+	"5mxeWcqb0i0g8dlARAXRP9j//f1wwNLZDNKF2ixon0HYZhOmil7nBXDEvMLE350/3RUYj3d1OduR7MrX",
+	"ygIlqWvXwmVZG/+mgsTjytkJc8IqicyWPSq/bh+VGsxVla5a7z17UO9GgJjjxd7TurWzXe2+jQ1OkLRq",
+	"vldbbP7I3BkqaiYJJCMJCVkRlvz8CzdwlQT+tauvkNbDh1GUibaigNIzuA/3IDDq6P2fq1rLtHn2PVCD",
+	"gL7n92LveftHrwi9wWGI4tWdOMww633WWfUd1VLTZckfZwV6iMpTmBGKSgcutGbEOFPtC3VAM4BRVCWB",
+	"bLqBUrYR4y9JuFj92ZuFLtQibgLI1X0ZDloHTR6hQBUU8aDIohId6i9Z1sVHmjyyFLkOcOA4SXl+HDvm",
+	"k9/xexAQqnYX6kwkOeh3/P6JIloPEnwJQwud/Zjj2TOfj3RpDqEWHGr0r4JPDFFUyuJ7c4yubeZ1Nbqr",
+	"ohlrGrraOIxdyoy+ns710sXktd/rmyKxgKiam+LPf6WILkz8aL/gL8wpuGIQO3yq8lZpmjq3rztMnJWu",
+	"aZzadhvUT/7+HtW72sJ4DvY1RfsNzayTzdZ/BwlFlJV27MVY+om15C9KInRjhaxbNRD98UhSTQjE98BM",
+	"4FZAdJrcBYlQFjStsJQLDfmQXdnr5xJFKOCEnou/DwRJt32FZ5h7jz5MKcsmv0+SNm/7Bf4trEjHfpPe",
+	"qz4rovwbp3G5d/fG60l9WKNZHari5QCCGN01EXKVjtWnVUpeQqnqQSF+OtTT9YBRwq3jjEwF9GK1r40m",
+	"2Bd7f2//QpisEVYe54dVrxRZOhlkuatg97NQAL4oHoqQq5vdkfy74CbX8lUWUuOdLNSoXjkpSyflSJVF",
+	"Fsou6FmDMpPYyosV/ZBtsCx8tao1LxxCxQWewpmL8NdExS/avzgl/BVJ49V4QNThdiXEYbO6oZ/zqDBN",
+	"5kf1o7afEP+6SW1vY6S4eVX1LdOv0KU7E2+SOoj3baLiZjDO2zX4kaz68quj2g3TfjaHb1J5nl+X9tOR",
+	"774ydUlx2ArVpV4mc8mVK6ZpNZy3FnOBFbuYyo/ORF65aVwlWA8DeU2W8UObxK23wdYGXr8N3FOY9zZ6",
+	"PYzdTkrcSpQ3w8RSiVuJdfu1WbWdCfk+zOD7NH/bzN6vgej2Hk40P0bDdvUG7XfMJELo97rZxx4m7oZS",
+	"6KboLQ/IHI/Bet00Y7ST3pIt6Jc6CLOHQSXtPn/jLCdqNEULzUW3NmkFJb52aQnnj8lCLW89J3k3jfW0",
+	"WYvLtNir5Z6593gBFJd6GOPVAYP7IigicWvKrtmULaLfg1PaLondz4F6XtXNxnXzFLhZqJoQzcZvmbe6",
+	"3RiuScQGauV7vQ1bmOPRR2g709YyxqqvUM6t1zVTzd6miNjHYpLCZQjRaaZeqL7qTju1RoDtCK7Xhs6T",
+	"FmP1/glyk1SOjeGHbQx1w2Oo96ij7OYU1pr5n/Ga6eKhKsWt+CK6zIq5fC3XkYK4KWe+hvH09I/FNere",
+	"fR9qDiGHuhthu0smqVRtKRFq/t672TFzBDk8z3ogPnqnTIYOX4eMhefH5Iyxt10hdoumejph8ulbHDDZ",
+	"UvfrfMmXeRjHS2l9pyDOxmzdLWt2t+TU2sILTUJ/93MQJv1dLFZ9Dz/3is05vbSSbIKebpWcXh+7S8Wb",
+	"flbhSmkSrbn2uibq2HtYQfnY4vgdCK23q8QSRF3cJPdHcJuiFDwwrW8dIhvuEFlCiyh0916dDVmY1seY",
+	"rDYM31qVbrz4mpeuI3hMdqZz/xX2cNFdT8vTsWCLCVpd/H5tUcd6D2OU1gHivIiqg7dm6prNVAdp+7KS",
+	"15Wz+zmom6O7XeuC1tOydTJkL53SvZEetq6D+h+70bsENa7CDPaS87k9/GA0tfegUtvJhY8v1WApWu1s",
+	"STuR3sWWXiexbpyas7dpas7W8N5ww3ulehGnEPMlkurV941W9pVaYmtYa1T42tL6aB6R9cwNpZSIWVNQ",
+	"TxNZztpiFMsV7tcOVks8jOlrre3WmySOjIW7NWrvz6jlmtDqKLxOQmfGqhzZP+6qDtrPMDVM0UsVy+Ds",
+	"YX7Kbx+9xdlGKqswK2tkY25I3jMN7D2QpHt8NmE7NfUOoSqUdrH4Vk9Vm3BtPxQxa4tta6RtkJG2wnv+",
+	"HtPD/cT/ctng67wE/LPAFec8suTvwqa70OYdoR9vI3LnHauv8RaYeXyC8+/02G1cPmOlAkp83QglnD8m",
+	"f0J56xWSL9FYTwdDcZkWT0Nhyfv1OBSXehjPgwMGp0AujNuG2tfslShSsAeftF0RmRpT+LK/26IIoKf/",
+	"osxqrc1tTJfXWrQ4KjLV7bOxStMyJeqKnPLYnSSdKXcVXpM2gZ/rz18zCe491F1Q5vbH56zpQdW9vTcl",
+	"ZHdx43xl1L1JitbeZiha22D/hvuRVqiZrcBu97PYt8a6jY2udvqjtNAbbPOlzXJPg3w9tvgDm+FeWtc2",
+	"DWBtBncz2TfI8oqBvQLbuptV3TceYAPcIzfAfL61fL1IaJXmro+he69UsfegYvHxmqGtl/PStmcfq3PV",
+	"pLYhd//DEvk2l2BzbcAVKwv3mFfQ5cZYLrtgzfeGf4JBxlGPLMegvG9fmhWaJ0vEhdGrFMBZguLDKaGI",
+	"AHHQlETan5nPKwk5ZYiCKWQASq0RcDK+js/iaGEPvMN8KkdH8AZF4A+SoDiQk49DNN/VC4zkAv8QUvwP",
+	"ACkCVMKHwvF1fDXFDNziSJAqICkHbME4mtmL7KDxZDwE+dyjwrxD8DG9QSP13RMA4/A6tmqV0DTmeGZv",
+	"b3wdO50zpzliH7VbJsNDm0PGosRH4ImJbfIwrGrRjK/zpZ0BJVtY/w0wAzDlZAY5DmAULRS7ietD8J8H",
+	"17lIXkGVbeCevDr5/Gv255QWroZYFGq3CRTr8efEFp05mcd5w6n+e/LfXdw2brZqc9vYrNBN/J/aQHZx",
+	"1eR0+FidNK100csvk4tSl1593we9t24h9lgcLh7E0sHDUiMlvDws90BCD373rp1stw3l1uMeWc3du5u1",
+	"xdUN0v1anWeTGJeH3WO9JkyeAWc12Wcr4bTh4zLlsuaOGoneFl3xlB6VeVfa+rKd0xvpf9xmlVlnt8k3",
+	"TZnO1m3sudevu3fsE9gagOs2AAvo9+tv2uVS6tSy3Q1Uq4G4aq4cfvaj1ZW0Ow7RHEVieyPrDPqk2dcA",
+	"WW/JfjNa3cqNX1+eWM4YbiFy2zJ+hBS+twm3UcGS3/KL0/j3Zxbv7vW+LFIy/h8Hl2yKurgRDLp9B7Ch",
+	"OSD3rV/29HZAe1UJmo/PY+vsWIaru3k5HqF34x68GlU69/JtfBVOjQfzZnjcS1v3xUO4L1Z4rSzhr/Dy",
+	"U6xFMV2tQroih8QjcER05qX78Vzcr8ei3VPxrdL43oNcKVsfhKcP4j58D98xAAMxWgwKgfW5lzfiG+KE",
+	"B1foHob7tkkRD+EvWFqhy8CgKEKQ9e3TlzWdN9PIFF8c27rfEBA5l8wEVqnzKAQ3i/zrmuID5ucLA+J6",
+	"nAzZuv9MEV08Tt9EGfettQ4qhLC9jl3VEaposp7RVOjduz5CeVoHF9YWSyituskejgqs66654Fy/dDKV",
+	"s9i6PNZUgqGM+Rbe6nlR7n4OSpN1SvUvU0dbbYb7YM8Od6C1xU41HSr7fLRVHTpSZb+6DuVF3O9zvwJa",
+	"2ntgYf1oOvHfr7Bc0pzoZEYklPyJgjYjYl3Ww7mCZms7xNzbaNgaC43GgtNI6GMd9LAKvgpz4MHsgOY7",
+	"Zav4r1nxr+OTrpeXpeL30u19dfp1K2D9tfhHr73Xi+Bl1PVmNX2jyGNv3dLz0WniDbd8h0fCBn1+hdc2",
+	"hdQeXDlYO3lvE3M3tTjbfWsTuxMUC1ZEI2N673+uUeR/0iMlk+PZLOVi05mzgsUwYVPCwS0lM1V/P6VU",
+	"qp4ZnTEuNrWT7eBqkaAhUC3BhuAdoR8jAsMnrptIrf1AzqL7lxClDWYM9RXFFLaB9hXyv6EHP9/YSiRB",
+	"h0KNAZnd4BiFdRUbrZu/wOvgPzSzP2lWNntWa/w6VE6P6o65wHwkZR3LG14NjfNFsnQuiZwDwDnEkbzu",
+	"cCw5oMFpVfD0XkkQtg9S+l9FAoP+GR/qyB9Db4vSlh0co2ivu2dWTNjHPSvW+ypctBLQh1Kt8sXrhL7E",
+	"/9Zfu+5EDa7It5aN+lw+u5+Dfl5bSQO+rtuVMV4HZUms2d+FK7e3zcJoI7kl8y/E9M2K9kZSzt6DCd3H",
+	"l3DRToF9/L0Smd2cvptCiRuhdjwcB2w9wZvuCb5fPWWl7To6XkQP4/VZ43XUxfMjufHRuX/sXS9N4iHk",
+	"UDWK7+UDyvtg5BmAcZvj5whyqLukbp0+nRkkw16bw8c6m8fg7LG3m7OFRWu+Th6rt4sXSauvs4U22buT",
+	"A7lmz05p4ZJtb37cOnTW5NDJSbyOVbreHrufw6SDE8fisRYHzmr5ql2OZ+t1ddzkVPxYfTbtVNXLV5NP",
+	"61SPN5NA9tYtOh+LW8aHyPzdMZYc8nLFbAyxPbhusHYC33pdNtTrsjJlAiURWcxQzBOcoAj3tkmzeUA2",
+	"kVeoVtqm2cfnGRBbI7U7T1fQ2GqtOk7tUZitrn1bfOSgR29Dtjp1h5SF6sobbdlWoV23iVsDQdkEqp7J",
+	"1updk9VbxX0rp/W+unY/h5UJuxjIDjpps5Tvh2E9lFTnRjvZzo7dPlorugeV9rOrqwu5DeyvhK72NkCU",
+	"PxorvBeRdrDLHbj1M9A3l1g3R+nZBE7ZlqFck3V+b0oPiueYknjWu3qMPYF/9PjYXnZrmndmWQt/bTZ5",
+	"4YQfgS2OiqRlmKRAcb7GtzVXlzCytdYmm9s2mGu2sytLF0/B+nlrWK/JsEYFoq1hm+6Xyu5nFM/9bea4",
+	"wHMtxvKq+axdwFsrdjWPbZp+rGaxF431soOtmZ327+aSyt5DCNXHYuJ6Epy/TWtLJy9bdqMIbwN0iAch",
+	"923YeUPDzitUOsgNQ3QOb3CE+QJGiHIWEy4uB0lcwRTGMYr6GbmFuYGaHNizAzO9d4z6zJ7yQM54ak14",
+	"aMDdGsedBYMfatvsZv8zfwxWdQds5HzsS+O+5rg3EB0i5H4wbrIZ77mDNVv4XaAqnvmZ9ylvXQPrcQ14",
+	"810v3l/p9b77mXgt3MUj4S92WvwVa5Q17dfxmTeeung5/Jn3sfpA7peZejlPvEFyula+Nare+6ruwMfi",
+	"yblvtvF3AflfB14Oom+AfTZbp/26+HmbUrEez9PG6bRLPOAv7qX0kr+TI2r7on8lssHrab/r1B6fK6ny",
+	"2N9Fj/0cRMXn/x1dQRtfBsAB7UO6eGof/1VHbf02D+K3Kb/uczNa75ur5HnJHrz287J4lRW4J4btqCb3",
+	"KjTg4IqtQ8SfSlfg5qgvRvC1kNXeQ0pyzaGP0/3gS6R9nQodihlsMLFujs6z9/A6zzYFZUNTUO5PSdIt",
+	"cvvZ9OZj/zcV52a5rfXema017tpM9uxEt51zq3Z9ktOf4Z6MJH0NeD1Hl8cWeo1NNtUNiGu2zwvLFrGu",
+	"f9pa4muyxJOMSB2s0e022f2s/9WhEIFhqxZ7epWs5N2zvavlbEj3sZrLjaTUyy6ubeX/E+KbRxJ765SP",
+	"j8W8bSEqfzvWSBov23UjiOuBr/u1kvPWCN1QI3QF+oHumnmD4xDHk35Gp2l0aiZxBM+GgMiZYBQtwC2O",
+	"OKIoFIpFQ3t1YR7oRqsvDXhrbn7wzxTRxeO0bYuYbzNxyySwNXUdpm4FSTnflunc1/ItTdkhbF1ccZPt",
+	"4BKkazaHXauXRWPxDLbW8Xqs4xLtN3JTr8tw9zMtTNTBdC7zZYsJfQ/M2H6VXFQ218WgLlP9YzWsu1Bh",
+	"Lzu7tIDT3t50+tl7QHH8WIzxboTob5uXRZmXjb6BBLkZislDcsI2SXw9ZvnDKCa7H39kFDGSUjEDmnvV",
+	"5vs1vUE0lkqL+qLcpNDMaBr7l/b2HctHcIqQx+3064/sQn9yPF9jJb9a6TAsI+fg/ARMKEkTcROrTest",
+	"7qBZwheAcSqzbyggM8wFSwmsBYTmQ9mTwXCAxWx/pYguBsOBONLB/kBOPBhaTC4bVu4P1KSColzwzBFl",
+	"mMQOiMaTMZg/rVtOfzcoS6ZOAPyK47C8cs16H3EcLreYOBnPxeT/dFnsfjUTm6ibuliakZrltr6SqjLz",
+	"64+WYClIpk0QrhHx8JSKQWVpmpDwXgTpazLZPDFqM3JCwhoeTkh42pWNq0ulsxtExWIMBSQOGWA4DhC4",
+	"m+JgCjgBbEru5InUQCGHX6pvC8L5ltAZ5IP9AY75Dy8Gw8EMx3iWzgb7e0MDF445miC6JvlyTkJx3E0C",
+	"5pyEarNbyVKNWWrcbJA4EfzuEXiZYkQhDaY4gBGYY3QnHQVRBCI8R7Yml82sK0CrSIsldBggd7H5K2Zl",
+	"JAwBjoMoVc7MKY5Ca8YdYSPiAF4izobgnIRsCH4hN+xJN4F1Jbb8DbspSlttYtbCVSdJYcu1zfqAQNK9",
+	"sS9DAUWcoltEURz0fFqrJgH5LN7vai/llxf58tu03O595Is4bItdVg7rMTynrW46Z50KDfpGI8uTdghH",
+	"ltbc5HhkGdQ1BySdyxdP5bJ8DtuQ5HpCkmUGaGaqfhfS7mdWnKpDWLLCoC1xyfvgyvaL4rK6vy6RyQr1",
+	"P9bQZDdq7BWcLC/htAI2n4r2HlQ6P5YIZVd69I9RVuSaV5ByI+lyQ/SVh+WIbaRyPZHK+9BXOIW45+tV",
+	"9SmAc4gjsWPjK2+xma/UiltLuTNvSsy12cf6QB+BUcwNIRkm0JTla//K7zsYvXL6TTZ1FYBrNnCtRYvI",
+	"lj9sbdk12bJcE2eFF7pcA7uf5f92MFEVD7XYpatjnHZhfGU20MUGVaT6WA3PWtLpZWPK2ZyG5WaRwd66",
+	"JOBjsRcbyMjfNFTyxMsefHByetALfG3ku31OuqHPSVd+4+/m9NIo92WGkOENoD4qp0613AKXaqVv7y5Q",
+	"G2tKIFBcpWd7FHeC2WxvUr0j9ONtRO6WqJ5tpmgonA2uFgkO5JNnEiOQINrmyXinJ90W1O7LLgUMtnk2",
+	"Smf4GFwc5S3nLFSiPV+fR3HCDs6Pwnqb7AQpArpmZ4hj8eJpFAZsnSNrco4Uqb6Ji/pcSLuf7+xpOnhP",
+	"StzY4kZZPQu23wTvyjvr4lYpEvtjda/4E18vf0txeqfKvdmEs7d+6fvI6lp3oUB/V01JeHn5bDaOEjdC",
+	"/9h7KP1j69vZUN/OfSksNI197GdjNU9QjKh9x4jvPcP8BtILseR6Of0R1wGzsO5tTkuieEzGNFUkWeap",
+	"Jiv6iuLJBFFjRrsYo81yvkjjr8FuFmA+kNWcLV2jtdE0NibzNr3sHq1kKinVxR7db5vdzzSN+5jE4rA9",
+	"DeJVcZb/DXOh9tTHGJYbe/S2cD2JLWcEO+WwZQJvHqnsPYgYfXSmbxPB9bB5BQ47WbwbQXgboDU8DLlv",
+	"M9TXbLfejwqxsjpZXe6LtZa9cjNvpYLKK1mT22zuZgE4ZB+BLrDkqpgifh/cZ60lzNGMdWBZidXjmFPJ",
+	"hxoaSClctDLzknWYvr6Ly+z4Hhiqd22kAny3lMykT6gUjACvxZeQInCLeDCV+RhzVDf8v0BMgCyZMke6",
+	"6guUNdoEFFnVtlmiVGexkTbWXWOhpW6MKze3CrYdus9MLRCjO0QBn8JY1d6AXGA/TBW+AI5N/aXNLrPU",
+	"VbS8JpN+gmWpIkxfoVjRFbZWLlQYhzxlXnmEZI4ojCKgPgEwDkGC6IhxlJi/9bf0LhUcj8DeUzttSjss",
+	"ELo+oK+Vbpk51+Upd5loSPenjzmc21zB3uTuG9d4VDGNrvGMYlZgJZzRPS/wawhtPFRco1Eeb3MA1xvd",
+	"WM21kef89YlteMY11qy59I5oPPZoxn1EMhp1200ijL31isvHFrhYZdCiU8DigWnsobWANZP1NhNvwzPx",
+	"7kVtWOWLS6+LY63vLtd8fbQ/vcy47ZG8vrwr7XdZEo4IDPs/v5Rfr7DZ7LsMom2b2XX6YATOfXww6my2",
+	"1dHdThtDuTZHqr91ecopvujorBGfbLqzRsL4AM6afN3qxSFRvXXWrM9ZownVxSAdryyldYl/dnTWyDP3",
+	"cNasjKf8lCqzk67OGrmdx+ysaSCp3s4aMUGtzr1phLG3XnH5mJw1jbTVzVkjceftrNkAGntoLWDNZL3N",
+	"Jl2f78VLC4BRMoVPd2HKyU2Ko1Cs7lahzxXAiAEcB2QmOQ7dTAn5mGWKUjIDMF4AliYJoeKcJ5iDhJI5",
+	"DhEFnACuHoMBsd4MchwAuSobX8dXU1Qcjlk+TFq4IeIokE1ITRac5h8wRTBElO1fxyPwE+Y/pzf74I//",
+	"e/RzejO6xJMY8pSi0bPvf/hDD3gN1YCfMI/gzeiKfESx/O0l5jdp8BFx+bPMtBz9ihZ/XMcVMfIzjMMI",
+	"HaScvJSIq8iRIvoUWBnKmAFLww5ShkKBIbVJmc4zhxGWp6m/VWgem5Qz9WGec+bYb7cEOIWYDEQusOIJ",
+	"nviuFTwb290gy46lSHKjj2hRA2D+RStY2Sm3Z/n2k9YwDLFy05xTQUMcC+mrej9WTiCnf7PVBC4MKyuY",
+	"yM2fKFh7scN3ChyJrUZXoQFby4sHFPYPIYlRkFLMF4P939/bcllJi6KA0wdsyehcmjhkdIO9NsFcVbj3",
+	"8DFGkYRCjwc+vdp+wrq1CVud++OeqDQDVcDdRKbG32bh4qtLYbJhz4nIOi3vLKZsIhkb0e0HAxIicQVP",
+	"Ucz1adS5x7I1N9k/VgI1Ey/r9ZZZ69dT50/5gWwdZ+txnEGLC+q4qZ9M3v08MZN08KJZPNniR1st87Xb",
+	"sj/Zu+niSbOo+rH60lZNZda179+4cgyEsWVOAnIobC2pljBMYpS1bueQThBXT4yuYygmsd4H6mZGSZSK",
+	"H85TNtV/4VPIAVvEAQOYS6tvKi6T+BZPUorC6xh9UngyIDBOKBqDA1DqxSPAMuJPgyREMCWRgYkR8ReW",
+	"zhBlIICx1VqJ51u8WYCPaDF2GHF2T87Nv7oe9N5qv7QutxfWei+sihhZSoaYfpvd22zq+yn3yxS4VDoL",
+	"bFHS3IRzrd3perbcrL+9tvH6yoXXQqVTBCM+bbVbz34F+FYLdTpX7kH16WIM3jL9yDXCcxQjJm+zG+R+",
+	"5fqzWrDVCOXoE99NIohLQhJ9grMkQoP9wdmvuVMmcxQ5xGIJ3mZHgRwDgikKbM/AmdmFQRtJUAwTPDZC",
+	"vDUL7ixB8cH5CXg+3svCcOo1q0Acn2IGxM84Br9cnp0C9VDViUA902WCgsGSpnwR3HoQQxKks/+Ptivq",
+	"bdsF4l/FynOr9LHKW/7pX9Wkaauiqi9TH7BzS5AIWIAzRVO/+8SBAZuz3XXb25Td/Q6OH3eYo+AQyU0w",
+	"GmWAMOvzR7AVrTUzABqYT/Cznt87qZK5qOyWRqxpoLX9RrbJqOxE+BKXEf5vULkH+g02ewfM+XUfu7BI",
+	"5wtow9/B5CBXcekJ6v7NatVZdDAOIDaQ9NZLMPIP95+Cibll0kvZhUV2BuZcYgdoRw5Rfq5qYBr0tnPx",
+	"9durS3EeiCpQfFYNE9UBLiBUG+Zap8VqszpZ227Wa+EETsrYzf3d/R0mzNCKMZSPYTeJwje+YBA6DvLQ",
+	"Ku6vZQi78Fk3yt3/mOCrM5PsCKFxQTX+L6X6pJULE5lif+YrrYcSVJCmgOIRRgKq7dUiUJSmoP6XF66V",
+	"PNNgVLsyDQrwgVnmb6XN4FwI+ZFOE7RCXfF3vxDLwKM2BT289HYEv/u03j34Ap4js2bG6q6xnYaEPrp1",
+	"tbTwtXaUZDUX3F5JM2cluVUuHiGLhDoeXWxK3CkQyAEUnbGgb02jWjhUlM+y8fPCs64ZAU55qgBd9MgI",
+	"eNZBBfqHnBHp+nxtobJwbgXuGRzgO5f+RLH7xYWrCuSRS3AhZGx6gPIOq/45n2Stv6RE4QdT1WhlzG3T",
+	"WTzc0SjZgJal1ef+0dbJGfvBTi315g+bP93uoZfiSfShJZx1/ZToy+TyiNeimEnOUfYex3/BHA2Vs5jS",
+	"3ysBtzVzyxaGX0Px6y80Db9bfKamiLvNJVZkVbqsiZ6wnKbD3TqjwwQD7FBPK3GLt7ipxhWPQ9MhEoNs",
+	"XjVBknGf0AZe7I92T+cXDQKYmZjkvdTeC5HjEfRrLpEgFE6Q+c+LkDklZYyWtyD4RNhJck9BbDHIV0yA",
+	"tqaSyqYFfnNiUoIgbQy0t6j8JdPdeVUzwZ2wRzFKKtMlrmQ325SdpE8Gy3DKp3nk6I+bq/EFogGpzOrt",
+	"9e1XAAAA//9O+HA8PecDAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/openchoreo-api/api/handlers/authz.go
+++ b/internal/openchoreo-api/api/handlers/authz.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
@@ -290,8 +291,7 @@ func (h *Handler) ListClusterRoles(
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			return gen.ListClusterRoles403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
 			return gen.ListClusterRoles400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster roles", "error", err)
@@ -332,8 +332,10 @@ func (h *Handler) CreateClusterRole(
 		if errors.Is(err, authzsvc.ErrRoleAlreadyExists) {
 			return gen.CreateClusterRole409JSONResponse{ConflictJSONResponse: conflict("Cluster role already exists")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterRole422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterRole400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster role", "error", err)
@@ -405,8 +407,10 @@ func (h *Handler) UpdateClusterRole(
 		if errors.Is(err, authzsvc.ErrRoleNotFound) {
 			return gen.UpdateClusterRole404JSONResponse{NotFoundJSONResponse: notFound("Cluster role")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterRole422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterRole400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster role", "error", err)
@@ -464,8 +468,7 @@ func (h *Handler) ListClusterRoleBindings(
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			return gen.ListClusterRoleBindings403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
 			return gen.ListClusterRoleBindings400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster role bindings", "error", err)
@@ -509,8 +512,10 @@ func (h *Handler) CreateClusterRoleBinding(
 		if errors.Is(err, authzsvc.ErrRoleNotFound) {
 			return gen.CreateClusterRoleBinding400JSONResponse{BadRequestJSONResponse: badRequest("Referenced role not found")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterRoleBinding422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterRoleBinding400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster role binding", "error", err)
@@ -582,8 +587,10 @@ func (h *Handler) UpdateClusterRoleBinding(
 		if errors.Is(err, authzsvc.ErrRoleBindingNotFound) {
 			return gen.UpdateClusterRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Cluster role binding")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterRoleBinding422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterRoleBinding400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster role binding", "error", err)
@@ -638,8 +645,7 @@ func (h *Handler) ListNamespaceRoles(
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			return gen.ListNamespaceRoles403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
 			return gen.ListNamespaceRoles400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list namespace roles", "error", err)
@@ -680,8 +686,10 @@ func (h *Handler) CreateNamespaceRole(
 		if errors.Is(err, authzsvc.ErrRoleAlreadyExists) {
 			return gen.CreateNamespaceRole409JSONResponse{ConflictJSONResponse: conflict("Namespace role already exists")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateNamespaceRole422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateNamespaceRole400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create namespace role", "error", err)
@@ -753,8 +761,10 @@ func (h *Handler) UpdateNamespaceRole(
 		if errors.Is(err, authzsvc.ErrRoleNotFound) {
 			return gen.UpdateNamespaceRole404JSONResponse{NotFoundJSONResponse: notFound("Namespace role")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateNamespaceRole422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateNamespaceRole400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update namespace role", "error", err)
@@ -812,8 +822,7 @@ func (h *Handler) ListNamespaceRoleBindings(
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			return gen.ListNamespaceRoleBindings403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
 			return gen.ListNamespaceRoleBindings400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list namespace role bindings", "error", err)
@@ -854,8 +863,10 @@ func (h *Handler) CreateNamespaceRoleBinding(
 		if errors.Is(err, authzsvc.ErrRoleBindingAlreadyExists) {
 			return gen.CreateNamespaceRoleBinding409JSONResponse{ConflictJSONResponse: conflict("Namespace role binding already exists")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateNamespaceRoleBinding422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateNamespaceRoleBinding400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create namespace role binding", "error", err)
@@ -927,8 +938,10 @@ func (h *Handler) UpdateNamespaceRoleBinding(
 		if errors.Is(err, authzsvc.ErrRoleBindingNotFound) {
 			return gen.UpdateNamespaceRoleBinding404JSONResponse{NotFoundJSONResponse: notFound("Namespace role binding")}, nil
 		}
-		var validationErr *svcpkg.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcpkg.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateNamespaceRoleBinding422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateNamespaceRoleBinding400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update namespace role binding", "error", err)

--- a/internal/openchoreo-api/api/handlers/cluster_scoped_handlers_test.go
+++ b/internal/openchoreo-api/api/handlers/cluster_scoped_handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -623,6 +624,7 @@ func TestUpdateClusterComponentTypeHandler_MapsErrors(t *testing.T) {
 		{"forbidden -> 403", svcpkg.ErrForbidden, gen.UpdateClusterComponentType403JSONResponse{}},
 		{"not found -> 404", clustercomponenttypesvc.ErrClusterComponentTypeNotFound, gen.UpdateClusterComponentType404JSONResponse{}},
 		{"validation error -> 400", &svcpkg.ValidationError{Msg: "invalid spec"}, gen.UpdateClusterComponentType400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "invalid spec", StatusCode: http.StatusUnprocessableEntity}, gen.UpdateClusterComponentType422JSONResponse{}},
 	}
 
 	for _, tt := range tests {
@@ -720,6 +722,8 @@ func TestCreateClusterWorkflowHandler_MapsErrors(t *testing.T) {
 		wantTyp any
 	}{
 		{"already exists -> 409", clusterworkflowsvc.ErrClusterWorkflowAlreadyExists, gen.CreateClusterWorkflow409JSONResponse{}},
+		{"validation error -> 400", &svcpkg.ValidationError{Msg: "invalid spec"}, gen.CreateClusterWorkflow400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "invalid spec", StatusCode: http.StatusUnprocessableEntity}, gen.CreateClusterWorkflow422JSONResponse{}},
 		{"internal -> 500", errors.New("internal server error"), gen.CreateClusterWorkflow500JSONResponse{}},
 	}
 	for _, tt := range tests {
@@ -781,6 +785,8 @@ func TestUpdateClusterWorkflowHandler(t *testing.T) {
 	}{
 		{"forbidden -> 403", svcpkg.ErrForbidden, gen.UpdateClusterWorkflow403JSONResponse{}},
 		{"not found -> 404", clusterworkflowsvc.ErrClusterWorkflowNotFound, gen.UpdateClusterWorkflow404JSONResponse{}},
+		{"validation error -> 400", &svcpkg.ValidationError{Msg: "invalid spec"}, gen.UpdateClusterWorkflow400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "invalid spec", StatusCode: http.StatusUnprocessableEntity}, gen.UpdateClusterWorkflow422JSONResponse{}},
 		{"internal -> 500", errors.New("internal server error"), gen.UpdateClusterWorkflow500JSONResponse{}},
 	}
 	for _, tt := range tests {

--- a/internal/openchoreo-api/api/handlers/clustercomponenttypes.go
+++ b/internal/openchoreo-api/api/handlers/clustercomponenttypes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -27,8 +28,7 @@ func (h *Handler) ListClusterComponentTypes(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListClusterComponentTypes403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListClusterComponentTypes400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster component types", "error", err)
@@ -71,8 +71,10 @@ func (h *Handler) CreateClusterComponentType(
 		if errors.Is(err, clustercomponenttypesvc.ErrClusterComponentTypeAlreadyExists) {
 			return gen.CreateClusterComponentType409JSONResponse{ConflictJSONResponse: conflict("Cluster component type already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterComponentType422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterComponentType400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster component type", "error", err)
@@ -116,8 +118,10 @@ func (h *Handler) UpdateClusterComponentType(
 		if errors.Is(err, clustercomponenttypesvc.ErrClusterComponentTypeNotFound) {
 			return gen.UpdateClusterComponentType404JSONResponse{NotFoundJSONResponse: notFound("ClusterComponentType")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterComponentType422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterComponentType400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster component type", "error", err)

--- a/internal/openchoreo-api/api/handlers/clusterdataplanes.go
+++ b/internal/openchoreo-api/api/handlers/clusterdataplanes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -27,8 +28,7 @@ func (h *Handler) ListClusterDataPlanes(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListClusterDataPlanes403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListClusterDataPlanes400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster data planes", "error", err)
@@ -71,8 +71,10 @@ func (h *Handler) CreateClusterDataPlane(
 		if errors.Is(err, clusterdataplanesvc.ErrClusterDataPlaneAlreadyExists) {
 			return gen.CreateClusterDataPlane409JSONResponse{ConflictJSONResponse: conflict("ClusterDataPlane already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterDataPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterDataPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster data plane", "error", err)
@@ -144,8 +146,10 @@ func (h *Handler) UpdateClusterDataPlane(
 		if errors.Is(err, clusterdataplanesvc.ErrClusterDataPlaneNotFound) {
 			return gen.UpdateClusterDataPlane404JSONResponse{NotFoundJSONResponse: notFound("ClusterDataPlane")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterDataPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterDataPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster data plane", "error", err)

--- a/internal/openchoreo-api/api/handlers/clusterobservabilityplanes.go
+++ b/internal/openchoreo-api/api/handlers/clusterobservabilityplanes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListClusterObservabilityPlanes(
 
 	result, err := h.services.ClusterObservabilityPlaneService.ListClusterObservabilityPlanes(ctx, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListClusterObservabilityPlanes400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster observability planes", "error", err)
@@ -96,8 +96,10 @@ func (h *Handler) CreateClusterObservabilityPlane(
 		if errors.Is(err, clusterobservabilityplanesvc.ErrClusterObservabilityPlaneAlreadyExists) {
 			return gen.CreateClusterObservabilityPlane409JSONResponse{ConflictJSONResponse: conflict("ClusterObservabilityPlane already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterObservabilityPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster observability plane", "error", err)
@@ -141,8 +143,10 @@ func (h *Handler) UpdateClusterObservabilityPlane(
 		if errors.Is(err, clusterobservabilityplanesvc.ErrClusterObservabilityPlaneNotFound) {
 			return gen.UpdateClusterObservabilityPlane404JSONResponse{NotFoundJSONResponse: notFound("ClusterObservabilityPlane")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterObservabilityPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster observability plane", "error", err)

--- a/internal/openchoreo-api/api/handlers/clustertraits.go
+++ b/internal/openchoreo-api/api/handlers/clustertraits.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -27,8 +28,7 @@ func (h *Handler) ListClusterTraits(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListClusterTraits403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListClusterTraits400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster traits", "error", err)
@@ -71,8 +71,10 @@ func (h *Handler) CreateClusterTrait(
 		if errors.Is(err, clustertraitsvc.ErrClusterTraitAlreadyExists) {
 			return gen.CreateClusterTrait409JSONResponse{ConflictJSONResponse: conflict("Cluster trait already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterTrait422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterTrait400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster trait", "error", err)
@@ -116,8 +118,10 @@ func (h *Handler) UpdateClusterTrait(
 		if errors.Is(err, clustertraitsvc.ErrClusterTraitNotFound) {
 			return gen.UpdateClusterTrait404JSONResponse{NotFoundJSONResponse: notFound("ClusterTrait")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterTrait422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterTrait400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster trait", "error", err)

--- a/internal/openchoreo-api/api/handlers/clusterworkflowplanes.go
+++ b/internal/openchoreo-api/api/handlers/clusterworkflowplanes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -92,8 +93,10 @@ func (h *Handler) CreateClusterWorkflowPlane(
 		if errors.Is(err, clusterworkflowplanesvc.ErrClusterWorkflowPlaneAlreadyExists) {
 			return gen.CreateClusterWorkflowPlane409JSONResponse{ConflictJSONResponse: conflict("ClusterWorkflowPlane already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterWorkflowPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateClusterWorkflowPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create cluster workflow plane", "error", err)
@@ -137,8 +140,10 @@ func (h *Handler) UpdateClusterWorkflowPlane(
 		if errors.Is(err, clusterworkflowplanesvc.ErrClusterWorkflowPlaneNotFound) {
 			return gen.UpdateClusterWorkflowPlane404JSONResponse{NotFoundJSONResponse: notFound("ClusterWorkflowPlane")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterWorkflowPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateClusterWorkflowPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster workflow plane", "error", err)

--- a/internal/openchoreo-api/api/handlers/clusterworkflows.go
+++ b/internal/openchoreo-api/api/handlers/clusterworkflows.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListClusterWorkflows(
 
 	result, err := h.services.ClusterWorkflowService.ListClusterWorkflows(ctx, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListClusterWorkflows400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list cluster workflows", "error", err)
@@ -68,6 +68,12 @@ func (h *Handler) CreateClusterWorkflow(
 		if errors.Is(err, clusterworkflowsvc.ErrClusterWorkflowAlreadyExists) {
 			return gen.CreateClusterWorkflow409JSONResponse{ConflictJSONResponse: conflict("Cluster workflow already exists")}, nil
 		}
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateClusterWorkflow422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
+			return gen.CreateClusterWorkflow400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
+		}
 		h.logger.Error("Failed to create cluster workflow", "error", err)
 		return gen.CreateClusterWorkflow500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
 	}
@@ -108,6 +114,12 @@ func (h *Handler) UpdateClusterWorkflow(
 		}
 		if errors.Is(err, clusterworkflowsvc.ErrClusterWorkflowNotFound) {
 			return gen.UpdateClusterWorkflow404JSONResponse{NotFoundJSONResponse: notFound("ClusterWorkflow")}, nil
+		}
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateClusterWorkflow422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
+			return gen.UpdateClusterWorkflow400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update cluster workflow", "error", err)
 		return gen.UpdateClusterWorkflow500JSONResponse{InternalErrorJSONResponse: internalError()}, nil

--- a/internal/openchoreo-api/api/handlers/component_releases.go
+++ b/internal/openchoreo-api/api/handlers/component_releases.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -29,8 +30,7 @@ func (h *Handler) ListComponentReleases(
 
 	result, err := h.services.ComponentReleaseService.ListComponentReleases(ctx, request.NamespaceName, componentName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListComponentReleases400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list component releases", "error", err)
@@ -104,8 +104,10 @@ func (h *Handler) CreateComponentRelease(
 		if errors.Is(err, componentreleasesvc.ErrComponentReleaseAlreadyExists) {
 			return gen.CreateComponentRelease409JSONResponse{ConflictJSONResponse: conflict("ComponentRelease already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateComponentRelease422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateComponentRelease400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create component release", "error", err)

--- a/internal/openchoreo-api/api/handlers/components.go
+++ b/internal/openchoreo-api/api/handlers/components.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -38,8 +39,7 @@ func (h *Handler) ListComponents(
 		if errors.Is(err, projectsvc.ErrProjectNotFound) {
 			return gen.ListComponents404JSONResponse{NotFoundJSONResponse: notFound("Project")}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
 			return gen.ListComponents400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list components", "error", err)
@@ -88,8 +88,10 @@ func (h *Handler) CreateComponent(
 		if errors.Is(err, componentsvc.ErrComponentAlreadyExists) {
 			return gen.CreateComponent409JSONResponse{ConflictJSONResponse: conflict("Component already exists")}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateComponent422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateComponent400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create component", "error", err)
@@ -239,8 +241,10 @@ func (h *Handler) UpdateComponent(
 		if errors.Is(err, componentsvc.ErrComponentNotFound) {
 			return gen.UpdateComponent404JSONResponse{NotFoundJSONResponse: notFound("Component")}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateComponent422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateComponent400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update component", "error", err)
@@ -349,6 +353,12 @@ func (h *Handler) GenerateRelease(
 		}
 		if errors.Is(err, componentsvc.ErrTraitNotFound) {
 			return gen.GenerateRelease404JSONResponse{NotFoundJSONResponse: notFound("Trait")}, nil
+		}
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.GenerateRelease422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
+			return gen.GenerateRelease400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to generate release", "error", err)
 		return gen.GenerateRelease500JSONResponse{InternalErrorJSONResponse: internalError()}, nil

--- a/internal/openchoreo-api/api/handlers/components_test.go
+++ b/internal/openchoreo-api/api/handlers/components_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -764,6 +765,8 @@ func TestGenerateReleaseHandler(t *testing.T) {
 		{"workload not found -> 404", componentsvc.ErrWorkloadNotFound, gen.GenerateRelease404JSONResponse{}},
 		{"component type not found -> 404", componentsvc.ErrComponentTypeNotFound, gen.GenerateRelease404JSONResponse{}},
 		{"trait not found -> 404", componentsvc.ErrTraitNotFound, gen.GenerateRelease404JSONResponse{}},
+		{"validation error -> 400", &svcpkg.ValidationError{Msg: "invalid spec"}, gen.GenerateRelease400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "invalid spec", StatusCode: http.StatusUnprocessableEntity}, gen.GenerateRelease422JSONResponse{}},
 		{"internal -> 500", errors.New("internal server error"), gen.GenerateRelease500JSONResponse{}},
 	}
 	for _, tt := range tests {

--- a/internal/openchoreo-api/api/handlers/componenttypes.go
+++ b/internal/openchoreo-api/api/handlers/componenttypes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListComponentTypes(
 
 	result, err := h.services.ComponentTypeService.ListComponentTypes(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListComponentTypes400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list component types", "error", err)
@@ -69,8 +69,10 @@ func (h *Handler) CreateComponentType(
 		if errors.Is(err, componenttypesvc.ErrComponentTypeAlreadyExists) {
 			return gen.CreateComponentType409JSONResponse{ConflictJSONResponse: conflict("Component type already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateComponentType422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateComponentType400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create component type", "error", err)
@@ -143,8 +145,10 @@ func (h *Handler) UpdateComponentType(
 		if errors.Is(err, componenttypesvc.ErrComponentTypeNotFound) {
 			return gen.UpdateComponentType404JSONResponse{NotFoundJSONResponse: notFound("Component type")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateComponentType422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateComponentType400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update component type", "error", err)

--- a/internal/openchoreo-api/api/handlers/dataplanes.go
+++ b/internal/openchoreo-api/api/handlers/dataplanes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -28,8 +29,7 @@ func (h *Handler) ListDataPlanes(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListDataPlanes403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListDataPlanes400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list data planes", "error", err)
@@ -76,8 +76,10 @@ func (h *Handler) CreateDataPlane(
 		if errors.Is(err, dataplanesvc.ErrDataPlaneAlreadyExists) {
 			return gen.CreateDataPlane409JSONResponse{ConflictJSONResponse: conflict("DataPlane already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateDataPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateDataPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create data plane", "error", err)
@@ -149,8 +151,10 @@ func (h *Handler) UpdateDataPlane(
 		if errors.Is(err, dataplanesvc.ErrDataPlaneNotFound) {
 			return gen.UpdateDataPlane404JSONResponse{NotFoundJSONResponse: notFound("DataPlane")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateDataPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateDataPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update data plane", "error", err)

--- a/internal/openchoreo-api/api/handlers/deployment_pipelines.go
+++ b/internal/openchoreo-api/api/handlers/deployment_pipelines.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -27,8 +28,7 @@ func (h *Handler) ListDeploymentPipelines(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListDeploymentPipelines403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListDeploymentPipelines400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list deployment pipelines", "error", err)
@@ -71,8 +71,10 @@ func (h *Handler) CreateDeploymentPipeline(
 		if errors.Is(err, deploymentpipelinesvc.ErrDeploymentPipelineAlreadyExists) {
 			return gen.CreateDeploymentPipeline409JSONResponse{ConflictJSONResponse: conflict("Deployment pipeline already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateDeploymentPipeline422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateDeploymentPipeline400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create deployment pipeline", "error", err)
@@ -144,8 +146,10 @@ func (h *Handler) UpdateDeploymentPipeline(
 		if errors.Is(err, deploymentpipelinesvc.ErrDeploymentPipelineNotFound) {
 			return gen.UpdateDeploymentPipeline404JSONResponse{NotFoundJSONResponse: notFound("DeploymentPipeline")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateDeploymentPipeline422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateDeploymentPipeline400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update deployment pipeline", "error", err)

--- a/internal/openchoreo-api/api/handlers/environments.go
+++ b/internal/openchoreo-api/api/handlers/environments.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -25,8 +26,7 @@ func (h *Handler) ListEnvironments(
 
 	result, err := h.services.EnvironmentService.ListEnvironments(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListEnvironments400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list environments", "error", err)
@@ -76,8 +76,10 @@ func (h *Handler) CreateEnvironment(
 		if errors.Is(err, environmentsvc.ErrDataPlaneNotFound) {
 			return gen.CreateEnvironment400JSONResponse{BadRequestJSONResponse: badRequest("DataPlane not found")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateEnvironment422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateEnvironment400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create environment", "error", err)
@@ -149,8 +151,10 @@ func (h *Handler) UpdateEnvironment(
 		if errors.Is(err, environmentsvc.ErrEnvironmentNotFound) {
 			return gen.UpdateEnvironment404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateEnvironment422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateEnvironment400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update environment", "error", err)

--- a/internal/openchoreo-api/api/handlers/git_secrets.go
+++ b/internal/openchoreo-api/api/handlers/git_secrets.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
@@ -123,6 +124,9 @@ func mapCreateGitSecretError(h *Handler, err error) (gen.CreateGitSecretResponse
 	case errors.Is(err, gitsecretsvc.ErrInvalidSecretType):
 		return gen.CreateGitSecret400JSONResponse{BadRequestJSONResponse: badRequest(err.Error())}, nil
 	case errors.As(err, &validationErr):
+		if validationErr.StatusCode == http.StatusUnprocessableEntity {
+			return gen.CreateGitSecret422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+		}
 		return gen.CreateGitSecret400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 	case errors.Is(err, gitsecretsvc.ErrWorkflowPlaneNotFound):
 		return gen.CreateGitSecret400JSONResponse{BadRequestJSONResponse: badRequest("workflow plane not found")}, nil

--- a/internal/openchoreo-api/api/handlers/namespaces.go
+++ b/internal/openchoreo-api/api/handlers/namespaces.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -28,8 +29,7 @@ func (h *Handler) ListNamespaces(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListNamespaces403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListNamespaces400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list namespaces", "error", err)
@@ -101,8 +101,10 @@ func (h *Handler) CreateNamespace(
 		if errors.Is(err, namespacesvc.ErrNamespaceAlreadyExists) {
 			return gen.CreateNamespace409JSONResponse{ConflictJSONResponse: conflict("Namespace already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateNamespace422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateNamespace400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create namespace", "error", err)
@@ -147,8 +149,10 @@ func (h *Handler) UpdateNamespace(
 		if errors.Is(err, namespacesvc.ErrNamespaceNotFound) {
 			return gen.UpdateNamespace404JSONResponse{NotFoundJSONResponse: notFound("Namespace")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateNamespace422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateNamespace400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update namespace", "error", err)

--- a/internal/openchoreo-api/api/handlers/observability_alerts_notification_channels.go
+++ b/internal/openchoreo-api/api/handlers/observability_alerts_notification_channels.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListObservabilityAlertsNotificationChannels(
 
 	result, err := h.services.ObservabilityAlertsNotificationChannelService.ListObservabilityAlertsNotificationChannels(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListObservabilityAlertsNotificationChannels400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list observability alerts notification channels", "error", err)
@@ -68,8 +68,10 @@ func (h *Handler) CreateObservabilityAlertsNotificationChannel(
 		if errors.Is(err, observabilityalertsnotificationchannelsvc.ErrObservabilityAlertsNotificationChannelAlreadyExists) {
 			return gen.CreateObservabilityAlertsNotificationChannel409JSONResponse{ConflictJSONResponse: conflict("Observability alerts notification channel already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateObservabilityAlertsNotificationChannel422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateObservabilityAlertsNotificationChannel400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create observability alerts notification channel", "error", err)
@@ -141,8 +143,10 @@ func (h *Handler) UpdateObservabilityAlertsNotificationChannel(
 		if errors.Is(err, observabilityalertsnotificationchannelsvc.ErrObservabilityAlertsNotificationChannelNotFound) {
 			return gen.UpdateObservabilityAlertsNotificationChannel404JSONResponse{NotFoundJSONResponse: notFound("ObservabilityAlertsNotificationChannel")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateObservabilityAlertsNotificationChannel422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateObservabilityAlertsNotificationChannel400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update observability alerts notification channel", "error", err)

--- a/internal/openchoreo-api/api/handlers/observabilityplanes.go
+++ b/internal/openchoreo-api/api/handlers/observabilityplanes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -27,8 +28,7 @@ func (h *Handler) ListObservabilityPlanes(
 		if errors.Is(err, services.ErrForbidden) {
 			return gen.ListObservabilityPlanes403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListObservabilityPlanes400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list observability planes", "error", err)
@@ -99,8 +99,10 @@ func (h *Handler) CreateObservabilityPlane(
 		if errors.Is(err, observabilityplanesvc.ErrObservabilityPlaneAlreadyExists) {
 			return gen.CreateObservabilityPlane409JSONResponse{ConflictJSONResponse: conflict("ObservabilityPlane already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateObservabilityPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create observability plane", "error", err)
@@ -144,8 +146,10 @@ func (h *Handler) UpdateObservabilityPlane(
 		if errors.Is(err, observabilityplanesvc.ErrObservabilityPlaneNotFound) {
 			return gen.UpdateObservabilityPlane404JSONResponse{NotFoundJSONResponse: notFound("ObservabilityPlane")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateObservabilityPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateObservabilityPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update observability plane", "error", err)

--- a/internal/openchoreo-api/api/handlers/projects.go
+++ b/internal/openchoreo-api/api/handlers/projects.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListProjects(
 
 	result, err := h.services.ProjectService.ListProjects(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListProjects400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list projects", "error", err)
@@ -69,8 +69,10 @@ func (h *Handler) CreateProject(
 		if errors.Is(err, projectsvc.ErrProjectAlreadyExists) {
 			return gen.CreateProject409JSONResponse{ConflictJSONResponse: conflict("Project already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateProject422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateProject400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create project", "error", err)
@@ -143,8 +145,10 @@ func (h *Handler) UpdateProject(
 		if errors.Is(err, projectsvc.ErrProjectNotFound) {
 			return gen.UpdateProject404JSONResponse{NotFoundJSONResponse: notFound("Project")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateProject422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateProject400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update project", "error", err)

--- a/internal/openchoreo-api/api/handlers/release_bindings.go
+++ b/internal/openchoreo-api/api/handlers/release_bindings.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -35,8 +36,7 @@ func (h *Handler) ListReleaseBindings(
 		if errors.Is(err, releasebindingsvc.ErrComponentNotFound) {
 			return gen.ListReleaseBindings404JSONResponse{NotFoundJSONResponse: notFound("Component")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListReleaseBindings400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list release bindings", "error", err)
@@ -89,8 +89,10 @@ func (h *Handler) CreateReleaseBinding(
 		if errors.Is(err, releasebindingsvc.ErrComponentNotFound) {
 			return gen.CreateReleaseBinding400JSONResponse{BadRequestJSONResponse: badRequest("Referenced component not found")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateReleaseBinding422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateReleaseBinding400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create release binding", "error", err)
@@ -167,8 +169,10 @@ func (h *Handler) UpdateReleaseBinding(
 		if errors.Is(err, releasebindingsvc.ErrReleaseBindingNotFound) {
 			return gen.UpdateReleaseBinding404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateReleaseBinding422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateReleaseBinding400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update release binding", "error", err)

--- a/internal/openchoreo-api/api/handlers/response.go
+++ b/internal/openchoreo-api/api/handlers/response.go
@@ -35,6 +35,13 @@ func conflict(message string) gen.ConflictJSONResponse {
 	}
 }
 
+func unprocessableContent(message string) gen.UnprocessableContentJSONResponse {
+	return gen.UnprocessableContentJSONResponse{
+		Code:  gen.UNPROCESSABLECONTENT,
+		Error: message,
+	}
+}
+
 func internalError() gen.InternalErrorJSONResponse {
 	return gen.InternalErrorJSONResponse{
 		Code:  gen.INTERNALERROR,

--- a/internal/openchoreo-api/api/handlers/secret_references.go
+++ b/internal/openchoreo-api/api/handlers/secret_references.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListSecretReferences(
 
 	result, err := h.services.SecretReferenceService.ListSecretReferences(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListSecretReferences400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list secret references", "error", err)
@@ -69,8 +69,10 @@ func (h *Handler) CreateSecretReference(
 		if errors.Is(err, secretreferencesvc.ErrSecretReferenceAlreadyExists) {
 			return gen.CreateSecretReference409JSONResponse{ConflictJSONResponse: conflict("Secret reference already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateSecretReference422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateSecretReference400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create secret reference", "error", err)
@@ -143,8 +145,10 @@ func (h *Handler) UpdateSecretReference(
 		if errors.Is(err, secretreferencesvc.ErrSecretReferenceNotFound) {
 			return gen.UpdateSecretReference404JSONResponse{NotFoundJSONResponse: notFound("SecretReference")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateSecretReference422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateSecretReference400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update secret reference", "error", err)

--- a/internal/openchoreo-api/api/handlers/secrets.go
+++ b/internal/openchoreo-api/api/handlers/secrets.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -88,6 +89,9 @@ func mapCreateSecretError(h *Handler, err error) (gen.CreateSecretResponseObject
 	case errors.Is(err, secretsvc.ErrSecretStoreNotConfigured):
 		return gen.CreateSecret400JSONResponse{BadRequestJSONResponse: badRequest("secret store is not configured on the target plane")}, nil
 	case errors.As(err, &validationErr):
+		if validationErr.StatusCode == http.StatusUnprocessableEntity {
+			return gen.CreateSecret422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+		}
 		return gen.CreateSecret400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 	default:
 		h.logger.Error("Failed to create secret", "error", err)

--- a/internal/openchoreo-api/api/handlers/traits.go
+++ b/internal/openchoreo-api/api/handlers/traits.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -24,8 +25,7 @@ func (h *Handler) ListTraits(
 
 	result, err := h.services.TraitService.ListTraits(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListTraits400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list traits", "error", err)
@@ -69,8 +69,10 @@ func (h *Handler) CreateTrait(
 		if errors.Is(err, traitsvc.ErrTraitAlreadyExists) {
 			return gen.CreateTrait409JSONResponse{ConflictJSONResponse: conflict("Trait already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateTrait422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateTrait400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create trait", "error", err)
@@ -143,8 +145,10 @@ func (h *Handler) UpdateTrait(
 		if errors.Is(err, traitsvc.ErrTraitNotFound) {
 			return gen.UpdateTrait404JSONResponse{NotFoundJSONResponse: notFound("Trait")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateTrait422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateTrait400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update trait", "error", err)

--- a/internal/openchoreo-api/api/handlers/workflowplanes.go
+++ b/internal/openchoreo-api/api/handlers/workflowplanes.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -92,8 +93,10 @@ func (h *Handler) CreateWorkflowPlane(
 		if errors.Is(err, workflowplanesvc.ErrWorkflowPlaneAlreadyExists) {
 			return gen.CreateWorkflowPlane409JSONResponse{ConflictJSONResponse: conflict("WorkflowPlane already exists")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateWorkflowPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateWorkflowPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create workflow plane", "error", err)
@@ -137,8 +140,10 @@ func (h *Handler) UpdateWorkflowPlane(
 		if errors.Is(err, workflowplanesvc.ErrWorkflowPlaneNotFound) {
 			return gen.UpdateWorkflowPlane404JSONResponse{NotFoundJSONResponse: notFound("WorkflowPlane")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateWorkflowPlane422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateWorkflowPlane400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update workflow plane", "error", err)

--- a/internal/openchoreo-api/api/handlers/workflows.go
+++ b/internal/openchoreo-api/api/handlers/workflows.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -26,8 +27,7 @@ func (h *Handler) ListWorkflows(
 
 	result, err := h.services.WorkflowService.ListWorkflows(ctx, request.NamespaceName, opts)
 	if err != nil {
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
 			return gen.ListWorkflows400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list workflows", "error", err)
@@ -70,8 +70,10 @@ func (h *Handler) CreateWorkflow(
 		if errors.Is(err, workflowsvc.ErrWorkflowAlreadyExists) {
 			return gen.CreateWorkflow409JSONResponse{ConflictJSONResponse: conflict("Workflow already exists")}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateWorkflow422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateWorkflow400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create workflow", "error", err)
@@ -143,8 +145,10 @@ func (h *Handler) UpdateWorkflow(
 		if errors.Is(err, workflowsvc.ErrWorkflowNotFound) {
 			return gen.UpdateWorkflow404JSONResponse{NotFoundJSONResponse: notFound("Workflow")}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateWorkflow422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateWorkflow400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update workflow", "error", err)
@@ -225,8 +229,7 @@ func (h *Handler) ListWorkflowRuns(
 		if errors.Is(err, svcerrors.ErrForbidden) {
 			return gen.ListWorkflowRuns403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
 			return gen.ListWorkflowRuns400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list workflow runs", "error", err)
@@ -269,8 +272,10 @@ func (h *Handler) CreateWorkflowRun(
 		if errors.Is(err, svcerrors.ErrForbidden) {
 			return gen.CreateWorkflowRun403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
 		}
-		var validationErr *svcerrors.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateWorkflowRun422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateWorkflowRun400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create workflow run", "error", err)
@@ -348,9 +353,11 @@ func (h *Handler) UpdateWorkflowRun(
 		if errors.Is(err, workflowrunsvc.ErrWorkflowRunNotFound) {
 			return gen.UpdateWorkflowRun404JSONResponse{NotFoundJSONResponse: notFound("WorkflowRun")}, nil
 		}
-		var valErr *svcerrors.ValidationError
-		if errors.As(err, &valErr) {
-			return gen.UpdateWorkflowRun400JSONResponse{BadRequestJSONResponse: badRequest(valErr.Error())}, nil
+		if validationErr, ok := errors.AsType[*svcerrors.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateWorkflowRun422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
+			return gen.UpdateWorkflowRun400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update workflow run", "error", err)
 		return gen.UpdateWorkflowRun500JSONResponse{InternalErrorJSONResponse: internalError()}, nil

--- a/internal/openchoreo-api/api/handlers/workflows_test.go
+++ b/internal/openchoreo-api/api/handlers/workflows_test.go
@@ -444,6 +444,18 @@ func TestCreateWorkflowHandler(t *testing.T) {
 		assert.IsType(t, gen.CreateWorkflow400JSONResponse{}, resp)
 	})
 
+	t.Run("validation 422 returns 422", func(t *testing.T) {
+		svc := workflowmocks.NewMockService(t)
+		svc.EXPECT().CreateWorkflow(mock.Anything, ns, mock.Anything).Return(nil, &svcpkg.ValidationError{Msg: "invalid spec", StatusCode: http.StatusUnprocessableEntity})
+		h := &Handler{
+			services: &handlerservices.Services{WorkflowService: svc},
+			logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		resp, err := h.CreateWorkflow(ctx, gen.CreateWorkflowRequestObject{NamespaceName: ns, Body: validBody})
+		require.NoError(t, err)
+		assert.IsType(t, gen.CreateWorkflow422JSONResponse{}, resp)
+	})
+
 	t.Run("internal error returns 500", func(t *testing.T) {
 		svc := workflowmocks.NewMockService(t)
 		svc.EXPECT().CreateWorkflow(mock.Anything, ns, mock.Anything).Return(nil, errors.New("internal server error"))
@@ -480,6 +492,7 @@ func TestUpdateWorkflowHandler_MapsErrors(t *testing.T) {
 		{"forbidden -> 403", svcpkg.ErrForbidden, gen.UpdateWorkflow403JSONResponse{}},
 		{"not found -> 404", workflowsvc.ErrWorkflowNotFound, gen.UpdateWorkflow404JSONResponse{}},
 		{"validation -> 400", &svcpkg.ValidationError{Msg: "invalid request"}, gen.UpdateWorkflow400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "invalid request", StatusCode: http.StatusUnprocessableEntity}, gen.UpdateWorkflow422JSONResponse{}},
 		{"internal -> 500", errors.New("internal server error"), gen.UpdateWorkflow500JSONResponse{}},
 	}
 	for _, tt := range tests {
@@ -654,6 +667,7 @@ func TestCreateWorkflowRunHandler(t *testing.T) {
 		{"workflow not found -> 404", workflowrunsvc.ErrWorkflowNotFound, gen.CreateWorkflowRun404JSONResponse{}},
 		{"forbidden -> 403", svcpkg.ErrForbidden, gen.CreateWorkflowRun403JSONResponse{}},
 		{"validation -> 400", &svcpkg.ValidationError{Msg: "bad request"}, gen.CreateWorkflowRun400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "bad request", StatusCode: http.StatusUnprocessableEntity}, gen.CreateWorkflowRun422JSONResponse{}},
 		{"internal -> 500", errors.New("internal server error"), gen.CreateWorkflowRun500JSONResponse{}},
 	}
 	for _, tt := range tests {

--- a/internal/openchoreo-api/api/handlers/workflows_test.go
+++ b/internal/openchoreo-api/api/handlers/workflows_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"testing"
 	"time"
 
@@ -740,6 +741,7 @@ func TestUpdateWorkflowRunHandler_MapsErrors(t *testing.T) {
 		{"forbidden -> 403", svcpkg.ErrForbidden, gen.UpdateWorkflowRun403JSONResponse{}},
 		{"not found -> 404", workflowrunsvc.ErrWorkflowRunNotFound, gen.UpdateWorkflowRun404JSONResponse{}},
 		{"validation -> 400", &svcpkg.ValidationError{Msg: "bad request"}, gen.UpdateWorkflowRun400JSONResponse{}},
+		{"validation 422 -> 422", &svcpkg.ValidationError{Msg: "bad request", StatusCode: http.StatusUnprocessableEntity}, gen.UpdateWorkflowRun422JSONResponse{}},
 		{"internal -> 500", errors.New("internal server error"), gen.UpdateWorkflowRun500JSONResponse{}},
 	}
 	for _, tt := range tests {

--- a/internal/openchoreo-api/api/handlers/workloads.go
+++ b/internal/openchoreo-api/api/handlers/workloads.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
@@ -29,8 +30,7 @@ func (h *Handler) ListWorkloads(
 
 	result, err := h.services.WorkloadService.ListWorkloads(ctx, request.NamespaceName, componentName, opts)
 	if err != nil {
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
 			return gen.ListWorkloads400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to list workloads", "error", err)
@@ -77,8 +77,10 @@ func (h *Handler) CreateWorkload(
 		if errors.Is(err, workloadsvc.ErrComponentNotFound) {
 			return gen.CreateWorkload400JSONResponse{BadRequestJSONResponse: badRequest("Referenced component not found")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.CreateWorkload422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.CreateWorkload400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to create workload", "error", err)
@@ -151,8 +153,10 @@ func (h *Handler) UpdateWorkload(
 		if errors.Is(err, workloadsvc.ErrWorkloadNotFound) {
 			return gen.UpdateWorkload404JSONResponse{NotFoundJSONResponse: notFound("Workload")}, nil
 		}
-		var validationErr *services.ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			if validationErr.StatusCode == http.StatusUnprocessableEntity {
+				return gen.UpdateWorkload422JSONResponse{UnprocessableContentJSONResponse: unprocessableContent(validationErr.Msg)}, nil
+			}
 			return gen.UpdateWorkload400JSONResponse{BadRequestJSONResponse: badRequest(validationErr.Msg)}, nil
 		}
 		h.logger.Error("Failed to update workload", "error", err)

--- a/internal/openchoreo-api/services/authz/service.go
+++ b/internal/openchoreo-api/services/authz/service.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -63,8 +62,8 @@ func (s *authzService) CreateClusterRole(ctx context.Context, role *openchoreov1
 	s.logger.Debug("Creating cluster role", "name", role.Name)
 	created, err := s.pap.CreateClusterRole(ctx, role)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -104,8 +103,8 @@ func (s *authzService) UpdateClusterRole(ctx context.Context, role *openchoreov1
 	s.logger.Debug("Updating cluster role", "name", role.Name)
 	updated, err := s.pap.UpdateClusterRole(ctx, role)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -128,8 +127,8 @@ func (s *authzService) CreateNamespaceRole(ctx context.Context, namespace string
 	s.logger.Debug("Creating namespace role", "namespace", namespace, "name", role.Name)
 	created, err := s.pap.CreateNamespacedRole(ctx, role)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -170,8 +169,8 @@ func (s *authzService) UpdateNamespaceRole(ctx context.Context, namespace string
 	s.logger.Debug("Updating namespace role", "namespace", namespace, "name", role.Name)
 	updated, err := s.pap.UpdateNamespacedRole(ctx, role)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -193,8 +192,8 @@ func (s *authzService) CreateClusterRoleBinding(ctx context.Context, binding *op
 	s.logger.Debug("Creating cluster role binding", "name", binding.Name)
 	created, err := s.pap.CreateClusterRoleBinding(ctx, binding)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -234,8 +233,8 @@ func (s *authzService) UpdateClusterRoleBinding(ctx context.Context, binding *op
 	s.logger.Debug("Updating cluster role binding", "name", binding.Name)
 	updated, err := s.pap.UpdateClusterRoleBinding(ctx, binding)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -258,8 +257,8 @@ func (s *authzService) CreateNamespaceRoleBinding(ctx context.Context, namespace
 	s.logger.Debug("Creating namespace role binding", "namespace", namespace, "name", binding.Name)
 	created, err := s.pap.CreateNamespacedRoleBinding(ctx, binding)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}
@@ -300,8 +299,8 @@ func (s *authzService) UpdateNamespaceRoleBinding(ctx context.Context, namespace
 	s.logger.Debug("Updating namespace role binding", "namespace", namespace, "name", binding.Name)
 	updated, err := s.pap.UpdateNamespacedRoleBinding(ctx, binding)
 	if err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		return nil, err
 	}

--- a/internal/openchoreo-api/services/clustercomponenttype/service.go
+++ b/internal/openchoreo-api/services/clustercomponenttype/service.go
@@ -53,8 +53,8 @@ func (s *clusterComponentTypeService) CreateClusterComponentType(ctx context.Con
 			s.logger.Warn("Cluster component type already exists", "clusterComponentType", cct.Name)
 			return nil, ErrClusterComponentTypeAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create cluster component type CR", "error", err)
 		return nil, fmt.Errorf("failed to create cluster component type: %w", err)
@@ -89,8 +89,8 @@ func (s *clusterComponentTypeService) UpdateClusterComponentType(ctx context.Con
 	existing.Annotations = cct.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update cluster component type CR", "error", err)
 		return nil, fmt.Errorf("failed to update cluster component type: %w", err)

--- a/internal/openchoreo-api/services/clusterdataplane/service.go
+++ b/internal/openchoreo-api/services/clusterdataplane/service.go
@@ -113,8 +113,8 @@ func (s *clusterDataPlaneService) CreateClusterDataPlane(ctx context.Context, cd
 			s.logger.Warn("Cluster data plane already exists", "clusterDataPlane", cdp.Name)
 			return nil, ErrClusterDataPlaneAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create cluster data plane CR", "error", err)
 		return nil, fmt.Errorf("failed to create cluster data plane: %w", err)
@@ -148,8 +148,8 @@ func (s *clusterDataPlaneService) UpdateClusterDataPlane(ctx context.Context, cd
 	existing.Annotations = cdp.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update cluster data plane CR", "error", err)
 		return nil, fmt.Errorf("failed to update cluster data plane: %w", err)

--- a/internal/openchoreo-api/services/clusterobservabilityplane/service.go
+++ b/internal/openchoreo-api/services/clusterobservabilityplane/service.go
@@ -102,8 +102,8 @@ func (s *clusterObservabilityPlaneService) CreateClusterObservabilityPlane(ctx c
 		if apierrors.IsAlreadyExists(err) {
 			return nil, ErrClusterObservabilityPlaneAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create cluster observability plane CR", "error", err)
 		return nil, fmt.Errorf("failed to create cluster observability plane: %w", err)
@@ -137,8 +137,8 @@ func (s *clusterObservabilityPlaneService) UpdateClusterObservabilityPlane(ctx c
 	existing.Annotations = cop.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update cluster observability plane CR", "error", err)
 		return nil, fmt.Errorf("failed to update cluster observability plane: %w", err)

--- a/internal/openchoreo-api/services/clustertrait/service.go
+++ b/internal/openchoreo-api/services/clustertrait/service.go
@@ -53,8 +53,8 @@ func (s *clusterTraitService) CreateClusterTrait(ctx context.Context, ct *opench
 			s.logger.Warn("Cluster trait already exists", "clusterTrait", ct.Name)
 			return nil, ErrClusterTraitAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create cluster trait CR", "error", err)
 		return nil, fmt.Errorf("failed to create cluster trait: %w", err)
@@ -89,8 +89,8 @@ func (s *clusterTraitService) UpdateClusterTrait(ctx context.Context, ct *opench
 	existing.Annotations = ct.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update cluster trait CR", "error", err)
 		return nil, fmt.Errorf("failed to update cluster trait: %w", err)

--- a/internal/openchoreo-api/services/clusterworkflow/service.go
+++ b/internal/openchoreo-api/services/clusterworkflow/service.go
@@ -53,6 +53,10 @@ func (s *clusterWorkflowService) CreateClusterWorkflow(ctx context.Context, cwf 
 			s.logger.Warn("Cluster workflow already exists", "clusterWorkflow", cwf.Name)
 			return nil, ErrClusterWorkflowAlreadyExists
 		}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			s.logger.Error("Cluster workflow create rejected by validation", "error", err)
+			return nil, vErr
+		}
 		s.logger.Error("Failed to create cluster workflow CR", "error", err)
 		return nil, fmt.Errorf("failed to create cluster workflow: %w", err)
 	}
@@ -86,9 +90,9 @@ func (s *clusterWorkflowService) UpdateClusterWorkflow(ctx context.Context, cwf 
 	existing.Annotations = cwf.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Cluster workflow update rejected by validation", "error", err)
-			return nil, fmt.Errorf("cluster workflow validation failed: %s", services.ExtractValidationMessage(err))
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update cluster workflow CR", "error", err)
 		return nil, fmt.Errorf("failed to update cluster workflow: %w", err)

--- a/internal/openchoreo-api/services/clusterworkflow/service_test.go
+++ b/internal/openchoreo-api/services/clusterworkflow/service_test.go
@@ -5,12 +5,19 @@ package clusterworkflow
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
@@ -51,6 +58,29 @@ func TestCreateClusterWorkflow(t *testing.T) {
 
 		_, err := svc.CreateClusterWorkflow(ctx, dup)
 		require.ErrorIs(t, err, ErrClusterWorkflowAlreadyExists)
+	})
+
+	t.Run("invalid wraps as ValidationError with 422 status", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		require.NoError(t, openchoreov1alpha1.AddToScheme(scheme))
+		invalidErr := apierrors.NewInvalid(
+			schema.GroupKind{Group: "openchoreo.dev", Kind: "ClusterWorkflow"},
+			"bad-cwf",
+			field.ErrorList{field.Invalid(field.NewPath("spec", "runTemplate"), "x", "undeclared id")},
+		)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return invalidErr
+			},
+		}).Build()
+		svc := NewService(fakeClient, testutil.TestLogger())
+
+		_, err := svc.CreateClusterWorkflow(ctx, testutil.NewClusterWorkflow("bad-cwf"))
+		require.Error(t, err)
+		var vErr *services.ValidationError
+		require.True(t, errors.As(err, &vErr), "expected *services.ValidationError, got %T", err)
+		assert.Equal(t, http.StatusUnprocessableEntity, vErr.StatusCode)
+		assert.Contains(t, vErr.Msg, "undeclared id")
 	})
 }
 

--- a/internal/openchoreo-api/services/clusterworkflowplane/service.go
+++ b/internal/openchoreo-api/services/clusterworkflowplane/service.go
@@ -105,8 +105,8 @@ func (s *clusterWorkflowPlaneService) CreateClusterWorkflowPlane(ctx context.Con
 		if apierrors.IsAlreadyExists(err) {
 			return nil, ErrClusterWorkflowPlaneAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create cluster workflow plane CR", "error", err)
 		return nil, fmt.Errorf("failed to create cluster workflow plane: %w", err)
@@ -141,8 +141,8 @@ func (s *clusterWorkflowPlaneService) UpdateClusterWorkflowPlane(ctx context.Con
 	existing.Annotations = cwp.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update cluster workflow plane CR", "error", err)
 		return nil, fmt.Errorf("failed to update cluster workflow plane: %w", err)

--- a/internal/openchoreo-api/services/component/service.go
+++ b/internal/openchoreo-api/services/component/service.go
@@ -89,8 +89,8 @@ func (s *componentService) CreateComponent(ctx context.Context, namespaceName st
 			s.logger.Warn("Component already exists", "namespace", namespaceName, "component", component.Name)
 			return nil, ErrComponentAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create component CR", "error", err)
 		return nil, fmt.Errorf("failed to create component: %w", err)
@@ -139,9 +139,9 @@ func (s *componentService) UpdateComponent(ctx context.Context, namespaceName st
 	existing.Labels[labels.LabelKeyProjectName] = existing.Spec.Owner.ProjectName
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Component update rejected by validation", "error", err)
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update component CR", "error", err)
 		return nil, fmt.Errorf("failed to update component: %w", err)
@@ -322,6 +322,10 @@ func (s *componentService) GenerateRelease(ctx context.Context, namespaceName, c
 	}
 
 	if err := s.k8sClient.Create(ctx, componentRelease); err != nil {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			s.logger.Error("ComponentRelease create rejected by validation", "error", err)
+			return nil, vErr
+		}
 		s.logger.Error("Failed to create ComponentRelease CR", "error", err)
 		return nil, fmt.Errorf("failed to create component release: %w", err)
 	}

--- a/internal/openchoreo-api/services/component/service_test.go
+++ b/internal/openchoreo-api/services/component/service_test.go
@@ -9,14 +9,19 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/labels"
@@ -532,6 +537,35 @@ func TestGenerateRelease(t *testing.T) {
 
 		_, err := svc.GenerateRelease(ctx, testNamespace, testComponentName, &GenerateReleaseRequest{ReleaseName: "v1"})
 		require.ErrorIs(t, err, ErrWorkloadNotFound)
+	})
+
+	t.Run("componentrelease webhook denial wraps as ValidationError with 422 status", func(t *testing.T) {
+		scheme := newScheme(t)
+		invalidErr := apierrors.NewInvalid(
+			schema.GroupKind{Group: "openchoreo.dev", Kind: "ComponentRelease"},
+			"bad-release",
+			field.ErrorList{field.Invalid(field.NewPath("spec", "workload", "container", "image"), "", "workload container must have an image")},
+		)
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(tier3SeedObjects()...).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if _, ok := obj.(*openchoreov1alpha1.ComponentRelease); ok {
+						return invalidErr
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		svc := NewService(k8sClient, testLogger())
+
+		_, err := svc.GenerateRelease(ctx, testNamespace, testComponentName, &GenerateReleaseRequest{ReleaseName: "v1"})
+		require.Error(t, err)
+		var vErr *services.ValidationError
+		require.True(t, errors.As(err, &vErr), "expected *services.ValidationError, got %T", err)
+		assert.Equal(t, http.StatusUnprocessableEntity, vErr.StatusCode)
+		assert.Contains(t, vErr.Msg, "workload container must have an image")
 	})
 
 	t.Run("ClusterComponentType", func(t *testing.T) {

--- a/internal/openchoreo-api/services/component/service_test.go
+++ b/internal/openchoreo-api/services/component/service_test.go
@@ -565,6 +565,7 @@ func TestGenerateRelease(t *testing.T) {
 		var vErr *services.ValidationError
 		require.True(t, errors.As(err, &vErr), "expected *services.ValidationError, got %T", err)
 		assert.Equal(t, http.StatusUnprocessableEntity, vErr.StatusCode)
+		assert.Contains(t, vErr.Msg, "spec.workload.container.image")
 		assert.Contains(t, vErr.Msg, "workload container must have an image")
 	})
 

--- a/internal/openchoreo-api/services/componentrelease/service.go
+++ b/internal/openchoreo-api/services/componentrelease/service.go
@@ -132,8 +132,8 @@ func (s *componentReleaseService) CreateComponentRelease(ctx context.Context, na
 			s.logger.Warn("Component release already exists", "namespace", namespaceName, "componentRelease", cr.Name)
 			return nil, ErrComponentReleaseAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create component release CR", "error", err)
 		return nil, fmt.Errorf("failed to create component release: %w", err)

--- a/internal/openchoreo-api/services/componenttype/service.go
+++ b/internal/openchoreo-api/services/componenttype/service.go
@@ -64,8 +64,8 @@ func (s *componentTypeService) CreateComponentType(ctx context.Context, namespac
 			s.logger.Warn("Component type already exists", "namespace", namespaceName, "componentType", ct.Name)
 			return nil, ErrComponentTypeAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create component type CR", "error", err)
 		return nil, fmt.Errorf("failed to create component type: %w", err)
@@ -102,8 +102,8 @@ func (s *componentTypeService) UpdateComponentType(ctx context.Context, namespac
 	existing.Annotations = ct.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update component type CR", "error", err)
 		return nil, fmt.Errorf("failed to update component type: %w", err)

--- a/internal/openchoreo-api/services/dataplane/service.go
+++ b/internal/openchoreo-api/services/dataplane/service.go
@@ -117,8 +117,8 @@ func (s *dataPlaneService) CreateDataPlane(ctx context.Context, namespaceName st
 			s.logger.Warn("Data plane already exists", "namespace", namespaceName, "dataPlane", dp.Name)
 			return nil, ErrDataPlaneAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create data plane CR", "error", err)
 		return nil, fmt.Errorf("failed to create data plane: %w", err)
@@ -154,8 +154,8 @@ func (s *dataPlaneService) UpdateDataPlane(ctx context.Context, namespaceName st
 	existing.Annotations = dp.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update data plane CR", "error", err)
 		return nil, fmt.Errorf("failed to update data plane: %w", err)

--- a/internal/openchoreo-api/services/deploymentpipeline/service.go
+++ b/internal/openchoreo-api/services/deploymentpipeline/service.go
@@ -63,8 +63,8 @@ func (s *deploymentPipelineService) CreateDeploymentPipeline(ctx context.Context
 			s.logger.Warn("Deployment pipeline already exists", "namespace", namespaceName, "deploymentPipeline", dp.Name)
 			return nil, ErrDeploymentPipelineAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create deployment pipeline CR", "error", err)
 		return nil, fmt.Errorf("failed to create deployment pipeline: %w", err)
@@ -101,8 +101,8 @@ func (s *deploymentPipelineService) UpdateDeploymentPipeline(ctx context.Context
 	existing.Annotations = dp.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update deployment pipeline CR", "error", err)
 		return nil, fmt.Errorf("failed to update deployment pipeline: %w", err)

--- a/internal/openchoreo-api/services/environment/service.go
+++ b/internal/openchoreo-api/services/environment/service.go
@@ -133,8 +133,8 @@ func (s *environmentService) CreateEnvironment(ctx context.Context, namespaceNam
 	env.Namespace = namespaceName
 
 	if err := s.k8sClient.Create(ctx, env); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create environment CR", "error", err)
 		return nil, fmt.Errorf("failed to create environment: %w", err)
@@ -171,9 +171,9 @@ func (s *environmentService) UpdateEnvironment(ctx context.Context, namespaceNam
 	existing.Annotations = env.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Environment update rejected by validation", "error", err)
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update environment CR", "error", err)
 		return nil, fmt.Errorf("failed to update environment: %w", err)

--- a/internal/openchoreo-api/services/errors.go
+++ b/internal/openchoreo-api/services/errors.go
@@ -8,8 +8,12 @@ import "errors"
 var ErrForbidden = errors.New("insufficient permissions to perform this action")
 
 // ValidationError represents a request validation failure.
+// StatusCode carries the originating HTTP status when the error came from kube-apiserver
+// (typically 422 for a webhook or CRD CEL denial). It is unset for openchoreo-api's own
+// pre-kube input checks, which the handler maps to HTTP 400.
 type ValidationError struct {
-	Msg string
+	Msg        string
+	StatusCode int
 }
 
 func (e *ValidationError) Error() string { return e.Msg }

--- a/internal/openchoreo-api/services/namespace/service.go
+++ b/internal/openchoreo-api/services/namespace/service.go
@@ -66,8 +66,8 @@ func (s *namespaceService) CreateNamespace(ctx context.Context, ns *corev1.Names
 			s.logger.Warn("Namespace already exists", "namespace", ns.Name)
 			return nil, ErrNamespaceAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create namespace", "error", err)
 		return nil, fmt.Errorf("failed to create namespace: %w", err)
@@ -116,8 +116,8 @@ func (s *namespaceService) UpdateNamespace(ctx context.Context, ns *corev1.Names
 	}
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update namespace", "error", err)
 		return nil, fmt.Errorf("failed to update namespace: %w", err)

--- a/internal/openchoreo-api/services/observabilityalertsnotificationchannel/service.go
+++ b/internal/openchoreo-api/services/observabilityalertsnotificationchannel/service.go
@@ -63,8 +63,8 @@ func (s *observabilityAlertsNotificationChannelService) CreateObservabilityAlert
 			s.logger.Warn("Observability alerts notification channel already exists", "namespace", namespaceName, "channel", nc.Name)
 			return nil, ErrObservabilityAlertsNotificationChannelAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create observability alerts notification channel CR", "error", err)
 		return nil, fmt.Errorf("failed to create observability alerts notification channel: %w", err)
@@ -105,8 +105,8 @@ func (s *observabilityAlertsNotificationChannelService) UpdateObservabilityAlert
 	existing.Annotations = nc.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update observability alerts notification channel CR", "error", err)
 		return nil, fmt.Errorf("failed to update observability alerts notification channel: %w", err)

--- a/internal/openchoreo-api/services/observabilityplane/service.go
+++ b/internal/openchoreo-api/services/observabilityplane/service.go
@@ -105,8 +105,8 @@ func (s *observabilityPlaneService) CreateObservabilityPlane(ctx context.Context
 		if apierrors.IsAlreadyExists(err) {
 			return nil, ErrObservabilityPlaneAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create observability plane CR", "error", err)
 		return nil, fmt.Errorf("failed to create observability plane: %w", err)
@@ -142,8 +142,8 @@ func (s *observabilityPlaneService) UpdateObservabilityPlane(ctx context.Context
 	existing.Annotations = op.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update observability plane CR", "error", err)
 		return nil, fmt.Errorf("failed to update observability plane: %w", err)

--- a/internal/openchoreo-api/services/project/service.go
+++ b/internal/openchoreo-api/services/project/service.go
@@ -73,8 +73,8 @@ func (s *projectService) CreateProject(ctx context.Context, namespaceName string
 			s.logger.Warn("Project already exists", "namespace", namespaceName, "project", project.Name)
 			return nil, ErrProjectAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create project CR", "error", err)
 		return nil, fmt.Errorf("failed to create project: %w", err)
@@ -111,8 +111,8 @@ func (s *projectService) UpdateProject(ctx context.Context, namespaceName string
 	existing.Annotations = project.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update project CR", "error", err)
 		return nil, fmt.Errorf("failed to update project: %w", err)

--- a/internal/openchoreo-api/services/releasebinding/service.go
+++ b/internal/openchoreo-api/services/releasebinding/service.go
@@ -75,8 +75,8 @@ func (s *releaseBindingService) CreateReleaseBinding(ctx context.Context, namesp
 			s.logger.Warn("Release binding already exists", "namespace", namespaceName, "releaseBinding", rb.Name)
 			return nil, ErrReleaseBindingAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create release binding CR", "error", err)
 		return nil, fmt.Errorf("failed to create release binding: %w", err)
@@ -120,9 +120,9 @@ func (s *releaseBindingService) UpdateReleaseBinding(ctx context.Context, namesp
 	existing.Labels[labels.LabelKeyComponentName] = existing.Spec.Owner.ComponentName
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Release binding update rejected by validation", "error", err)
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update release binding CR", "error", err)
 		return nil, fmt.Errorf("failed to update release binding: %w", err)

--- a/internal/openchoreo-api/services/secretreference/service.go
+++ b/internal/openchoreo-api/services/secretreference/service.go
@@ -63,8 +63,8 @@ func (s *secretReferenceService) CreateSecretReference(ctx context.Context, name
 			s.logger.Warn("Secret reference already exists", "namespace", namespaceName, "secretReference", sr.Name)
 			return nil, ErrSecretReferenceAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create secret reference CR", "error", err)
 		return nil, fmt.Errorf("failed to create secret reference: %w", err)
@@ -101,8 +101,8 @@ func (s *secretReferenceService) UpdateSecretReference(ctx context.Context, name
 	existing.Annotations = sr.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update secret reference CR", "error", err)
 		return nil, fmt.Errorf("failed to update secret reference: %w", err)

--- a/internal/openchoreo-api/services/trait/service.go
+++ b/internal/openchoreo-api/services/trait/service.go
@@ -64,8 +64,8 @@ func (s *traitService) CreateTrait(ctx context.Context, namespaceName string, t 
 			s.logger.Warn("Trait already exists", "namespace", namespaceName, "trait", t.Name)
 			return nil, ErrTraitAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create trait CR", "error", err)
 		return nil, fmt.Errorf("failed to create trait: %w", err)
@@ -102,8 +102,8 @@ func (s *traitService) UpdateTrait(ctx context.Context, namespaceName string, t 
 	existing.Annotations = t.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update trait CR", "error", err)
 		return nil, fmt.Errorf("failed to update trait: %w", err)

--- a/internal/openchoreo-api/services/utils.go
+++ b/internal/openchoreo-api/services/utils.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,11 +23,15 @@ func FormatDualScopedResourceName(namespace, name string, isClusterScoped bool) 
 
 // ExtractValidationMessage extracts cause messages from a K8s StatusError, falling back to a generic message to avoid leaking internal details.
 func ExtractValidationMessage(err error) string {
-	var statusErr *apierrors.StatusError
-	if errors.As(err, &statusErr) && statusErr.ErrStatus.Reason == metav1.StatusReasonInvalid && statusErr.ErrStatus.Details != nil {
+	if statusErr, ok := errors.AsType[*apierrors.StatusError](err); ok && statusErr.ErrStatus.Reason == metav1.StatusReasonInvalid && statusErr.ErrStatus.Details != nil {
 		var msgs []string
 		for _, cause := range statusErr.ErrStatus.Details.Causes {
-			if cause.Message != "" {
+			if cause.Message == "" {
+				continue
+			}
+			if cause.Field != "" {
+				msgs = append(msgs, fmt.Sprintf("%s: %s", cause.Field, cause.Message))
+			} else {
 				msgs = append(msgs, cause.Message)
 			}
 		}
@@ -35,4 +40,21 @@ func ExtractValidationMessage(err error) string {
 		}
 	}
 	return "validation failed"
+}
+
+// ExtractValidationError wraps a Kubernetes Invalid StatusError as a *ValidationError,
+// carrying through the originating HTTP status (typically 422). Returns nil for any
+// error that is not a Kubernetes Invalid status, including nil input.
+func ExtractValidationError(err error) *ValidationError {
+	if err == nil {
+		return nil
+	}
+	statusErr, ok := errors.AsType[*apierrors.StatusError](err)
+	if !ok || statusErr.ErrStatus.Reason != metav1.StatusReasonInvalid {
+		return nil
+	}
+	return &ValidationError{
+		Msg:        ExtractValidationMessage(err),
+		StatusCode: int(statusErr.ErrStatus.Code),
+	}
 }

--- a/internal/openchoreo-api/services/utils_test.go
+++ b/internal/openchoreo-api/services/utils_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestExtractValidationError_FromNewInvalid(t *testing.T) {
+	errs := field.ErrorList{
+		field.Invalid(field.NewPath("spec", "resources").Index(0).Child("template"), "${applied.x}", "undeclared id"),
+	}
+	err := apierrors.NewInvalid(schema.GroupKind{Group: "openchoreo.dev", Kind: "ResourceType"}, "rt-1", errs)
+
+	got := ExtractValidationError(err)
+
+	require.NotNil(t, got)
+	require.Equal(t, http.StatusUnprocessableEntity, got.StatusCode)
+	require.Contains(t, got.Msg, "undeclared id")
+}
+
+func TestExtractValidationError_ReturnsNilForNotFound(t *testing.T) {
+	err := apierrors.NewNotFound(schema.GroupResource{Group: "openchoreo.dev", Resource: "resourcetypes"}, "missing")
+	require.Nil(t, ExtractValidationError(err))
+}
+
+func TestExtractValidationError_ReturnsNilForGenericError(t *testing.T) {
+	require.Nil(t, ExtractValidationError(errors.New("some other error")))
+}
+
+func TestExtractValidationError_ReturnsNilForNil(t *testing.T) {
+	require.Nil(t, ExtractValidationError(nil))
+}
+
+func TestExtractValidationMessage_PrefixesFieldPath(t *testing.T) {
+	errs := field.ErrorList{
+		field.Invalid(field.NewPath("spec", "outputs").Index(0).Child("value"), "${applied.x}", "undeclared id"),
+	}
+	err := apierrors.NewInvalid(schema.GroupKind{Group: "openchoreo.dev", Kind: "ResourceType"}, "rt-1", errs)
+
+	msg := ExtractValidationMessage(err)
+
+	require.Contains(t, msg, "spec.outputs[0].value: ")
+	require.Contains(t, msg, "undeclared id")
+}
+
+func TestExtractValidationMessage_JoinsMultipleFieldErrors(t *testing.T) {
+	errs := field.ErrorList{
+		field.Invalid(field.NewPath("spec", "foo"), "x", "bad x"),
+		field.Invalid(field.NewPath("spec", "bar"), "y", "bad y"),
+	}
+	err := apierrors.NewInvalid(schema.GroupKind{Group: "openchoreo.dev", Kind: "ResourceType"}, "rt-1", errs)
+
+	msg := ExtractValidationMessage(err)
+
+	require.Contains(t, msg, "spec.foo: ")
+	require.Contains(t, msg, "spec.bar: ")
+	require.Contains(t, msg, "; ")
+}

--- a/internal/openchoreo-api/services/workflow/service.go
+++ b/internal/openchoreo-api/services/workflow/service.go
@@ -133,8 +133,8 @@ func (s *workflowService) CreateWorkflow(ctx context.Context, namespaceName stri
 	wf.Status = openchoreov1alpha1.WorkflowStatus{}
 
 	if err := s.k8sClient.Create(ctx, wf); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create workflow CR", "error", err)
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
@@ -169,8 +169,8 @@ func (s *workflowService) UpdateWorkflow(ctx context.Context, namespaceName stri
 	existing.Annotations = wf.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update workflow CR", "error", err)
 		return nil, fmt.Errorf("failed to update workflow: %w", err)

--- a/internal/openchoreo-api/services/workflowplane/service.go
+++ b/internal/openchoreo-api/services/workflowplane/service.go
@@ -114,8 +114,8 @@ func (s *workflowPlaneService) CreateWorkflowPlane(ctx context.Context, namespac
 		if apierrors.IsAlreadyExists(err) {
 			return nil, ErrWorkflowPlaneAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create workflow plane CR", "error", err)
 		return nil, fmt.Errorf("failed to create workflow plane: %w", err)
@@ -152,8 +152,8 @@ func (s *workflowPlaneService) UpdateWorkflowPlane(ctx context.Context, namespac
 	existing.Annotations = wp.Annotations
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update workflow plane CR", "error", err)
 		return nil, fmt.Errorf("failed to update workflow plane: %w", err)

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -105,8 +105,8 @@ func (s *workflowRunService) CreateWorkflowRun(ctx context.Context, namespaceNam
 			s.logger.Warn("Workflow run already exists", "namespace", namespaceName, "name", wfRun.Name)
 			return nil, ErrWorkflowRunAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create workflow run", "error", err)
 		return nil, fmt.Errorf("failed to create workflow run: %w", err)
@@ -151,9 +151,9 @@ func (s *workflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceNam
 			s.logger.Warn("Workflow run not found", "namespace", namespaceName, "name", wfRun.Name)
 			return nil, ErrWorkflowRunNotFound
 		}
-		if apierrors.IsInvalid(err) {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Workflow run update rejected by validation", "error", err)
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update workflow run", "error", err)
 		return nil, fmt.Errorf("failed to update workflow run: %w", err)

--- a/internal/openchoreo-api/services/workload/service.go
+++ b/internal/openchoreo-api/services/workload/service.go
@@ -76,8 +76,8 @@ func (s *workloadService) CreateWorkload(ctx context.Context, namespaceName stri
 			s.logger.Warn("Workload already exists", "namespace", namespaceName, "workload", w.Name)
 			return nil, ErrWorkloadAlreadyExists
 		}
-		if apierrors.IsInvalid(err) {
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+		if vErr := services.ExtractValidationError(err); vErr != nil {
+			return nil, vErr
 		}
 		s.logger.Error("Failed to create workload CR", "error", err)
 		return nil, fmt.Errorf("failed to create workload: %w", err)
@@ -121,9 +121,9 @@ func (s *workloadService) UpdateWorkload(ctx context.Context, namespaceName stri
 	existing.Labels[labels.LabelKeyComponentName] = existing.Spec.Owner.ComponentName
 
 	if err := s.k8sClient.Update(ctx, existing); err != nil {
-		if apierrors.IsInvalid(err) {
+		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Workload update rejected by validation", "error", err)
-			return nil, &services.ValidationError{Msg: services.ExtractValidationMessage(err)}
+			return nil, vErr
 		}
 		s.logger.Error("Failed to update workload CR", "error", err)
 		return nil, fmt.Errorf("failed to update workload: %w", err)

--- a/internal/webhook/authzrolebinding/webhook.go
+++ b/internal/webhook/authzrolebinding/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,7 +47,7 @@ func (v *AuthzRoleBindingValidator) ValidateCreate(_ context.Context, obj runtim
 	}
 	log.Info("Validation for AuthzRoleBinding upon creation", "name", rb.GetName())
 	if errs := validateRoleMappings(rb.Spec.RoleMappings); len(errs) > 0 {
-		return nil, errs.ToAggregate()
+		return nil, apierrors.NewInvalid(rb.GroupVersionKind().GroupKind(), rb.GetName(), errs)
 	}
 	return nil, nil
 }
@@ -58,7 +59,7 @@ func (v *AuthzRoleBindingValidator) ValidateUpdate(_ context.Context, _, newObj 
 	}
 	log.Info("Validation for AuthzRoleBinding upon update", "name", rb.GetName())
 	if errs := validateRoleMappings(rb.Spec.RoleMappings); len(errs) > 0 {
-		return nil, errs.ToAggregate()
+		return nil, apierrors.NewInvalid(rb.GroupVersionKind().GroupKind(), rb.GetName(), errs)
 	}
 	return nil, nil
 }

--- a/internal/webhook/clusterauthzrolebinding/webhook.go
+++ b/internal/webhook/clusterauthzrolebinding/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,7 +49,7 @@ func (v *ClusterAuthzRoleBindingValidator) ValidateCreate(_ context.Context, obj
 	}
 	log.Info("Validation for ClusterAuthzRoleBinding upon creation", "name", rb.GetName())
 	if errs := validateClusterRoleMappings(rb.Spec.RoleMappings); len(errs) > 0 {
-		return nil, errs.ToAggregate()
+		return nil, apierrors.NewInvalid(rb.GroupVersionKind().GroupKind(), rb.GetName(), errs)
 	}
 	return nil, nil
 }
@@ -60,7 +61,7 @@ func (v *ClusterAuthzRoleBindingValidator) ValidateUpdate(_ context.Context, _, 
 	}
 	log.Info("Validation for ClusterAuthzRoleBinding upon update", "name", rb.GetName())
 	if errs := validateClusterRoleMappings(rb.Spec.RoleMappings); len(errs) > 0 {
-		return nil, errs.ToAggregate()
+		return nil, apierrors.NewInvalid(rb.GroupVersionKind().GroupKind(), rb.GetName(), errs)
 	}
 	return nil, nil
 }

--- a/internal/webhook/clustercomponenttype/webhook.go
+++ b/internal/webhook/clustercomponenttype/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,7 +50,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	allErrs := validateClusterComponentType(clustercomponenttype)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(clustercomponenttype.GroupVersionKind().GroupKind(), clustercomponenttype.GetName(), allErrs)
 	}
 
 	return nil, nil
@@ -73,7 +74,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	allErrs := validateClusterComponentType(newClusterComponentType)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(newClusterComponentType.GroupVersionKind().GroupKind(), newClusterComponentType.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/internal/webhook/clustertrait/webhook.go
+++ b/internal/webhook/clustertrait/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -62,7 +63,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	)...)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(ct.GroupVersionKind().GroupKind(), ct.GetName(), allErrs)
 	}
 
 	return nil, nil
@@ -92,7 +93,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	)...)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(newClusterTrait.GroupVersionKind().GroupKind(), newClusterTrait.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/internal/webhook/clusterworkflow/webhook.go
+++ b/internal/webhook/clusterworkflow/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,7 +50,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	allErrs := validateClusterWorkflow(cwf)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(cwf.GroupVersionKind().GroupKind(), cwf.GetName(), allErrs)
 	}
 
 	return nil, nil
@@ -66,7 +67,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	allErrs := validateClusterWorkflow(newCwf)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(newCwf.GroupVersionKind().GroupKind(), newCwf.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/internal/webhook/component/webhook.go
+++ b/internal/webhook/component/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -85,7 +86,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	allErrs = append(allErrs, validateUniqueTraitInstanceNames(component)...)
 
 	if len(allErrs) > 0 {
-		return warnings, allErrs.ToAggregate()
+		return warnings, apierrors.NewInvalid(component.GroupVersionKind().GroupKind(), component.GetName(), allErrs)
 	}
 
 	return warnings, nil
@@ -115,7 +116,7 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	allErrs = append(allErrs, validateUniqueTraitInstanceNames(newComponent)...)
 
 	if len(allErrs) > 0 {
-		return warnings, allErrs.ToAggregate()
+		return warnings, apierrors.NewInvalid(newComponent.GroupVersionKind().GroupKind(), newComponent.GetName(), allErrs)
 	}
 
 	return warnings, nil

--- a/internal/webhook/componentrelease/webhook.go
+++ b/internal/webhook/componentrelease/webhook.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -129,7 +130,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	}
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(componentrelease.GroupVersionKind().GroupKind(), componentrelease.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/internal/webhook/componenttype/webhook.go
+++ b/internal/webhook/componenttype/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,7 +50,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	allErrs := validateComponentType(componenttype)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(componenttype.GroupVersionKind().GroupKind(), componenttype.GetName(), allErrs)
 	}
 
 	return nil, nil
@@ -73,7 +74,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	allErrs := validateComponentType(newComponentType)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(newComponentType.GroupVersionKind().GroupKind(), newComponentType.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/internal/webhook/componenttype/webhook_test.go
+++ b/internal/webhook/componenttype/webhook_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -142,6 +143,7 @@ var _ = Describe("ComponentType Webhook", func() {
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse parameters schema"))
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected NewInvalid wrap so kube returns 422")
 		})
 
 		It("should reject invalid JSON in spec.parameters.openAPIV3Schema", func() {

--- a/internal/webhook/trait/webhook.go
+++ b/internal/webhook/trait/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -62,7 +63,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	)...)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(trait.GroupVersionKind().GroupKind(), trait.GetName(), allErrs)
 	}
 
 	return nil, nil
@@ -92,7 +93,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	)...)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(newTrait.GroupVersionKind().GroupKind(), newTrait.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/internal/webhook/workflow/webhook.go
+++ b/internal/webhook/workflow/webhook.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,7 +52,7 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 	allErrs := ValidateWorkflowSpec(wf.Spec.RunTemplate, wf.Spec.Resources, wf.Spec.ExternalRefs, wf.Spec.Parameters)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(wf.GroupVersionKind().GroupKind(), wf.GetName(), allErrs)
 	}
 
 	return nil, nil
@@ -68,7 +69,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	allErrs := ValidateWorkflowSpec(newWf.Spec.RunTemplate, newWf.Spec.Resources, newWf.Spec.ExternalRefs, newWf.Spec.Parameters)
 
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return nil, apierrors.NewInvalid(newWf.GroupVersionKind().GroupKind(), newWf.GetName(), allErrs)
 	}
 
 	return nil, nil

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -228,6 +228,8 @@ paths:
                 $ref: '#/components/schemas/Namespace'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -283,6 +285,8 @@ paths:
                 $ref: '#/components/schemas/Namespace'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -366,6 +370,8 @@ paths:
                 $ref: '#/components/schemas/Project'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -423,6 +429,8 @@ paths:
                 $ref: '#/components/schemas/Project'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -510,6 +518,8 @@ paths:
                 $ref: '#/components/schemas/Component'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -572,6 +582,8 @@ paths:
                 $ref: '#/components/schemas/Environment'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -629,6 +641,8 @@ paths:
                 $ref: '#/components/schemas/Environment'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -713,6 +727,8 @@ paths:
                 $ref: '#/components/schemas/DataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -770,6 +786,8 @@ paths:
                 $ref: '#/components/schemas/DataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -854,6 +872,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -911,6 +931,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -995,6 +1017,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1052,6 +1076,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1133,6 +1159,8 @@ paths:
                 $ref: '#/components/schemas/ClusterDataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1188,6 +1216,8 @@ paths:
                 $ref: '#/components/schemas/ClusterDataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1268,6 +1298,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1333,6 +1365,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1418,6 +1452,8 @@ paths:
                 $ref: '#/components/schemas/ClusterObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1473,6 +1509,8 @@ paths:
                 $ref: '#/components/schemas/ClusterObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1553,6 +1591,8 @@ paths:
                 $ref: '#/components/schemas/ClusterComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1608,6 +1648,8 @@ paths:
                 $ref: '#/components/schemas/ClusterComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1712,6 +1754,8 @@ paths:
                 $ref: '#/components/schemas/ClusterTrait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1767,6 +1811,8 @@ paths:
                 $ref: '#/components/schemas/ClusterTrait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1874,6 +1920,8 @@ paths:
                 $ref: '#/components/schemas/ComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1931,6 +1979,8 @@ paths:
                 $ref: '#/components/schemas/ComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2040,6 +2090,8 @@ paths:
                 $ref: '#/components/schemas/Trait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2097,6 +2149,8 @@ paths:
                 $ref: '#/components/schemas/Trait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2203,6 +2257,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2258,6 +2314,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2365,6 +2423,8 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2422,6 +2482,8 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2532,6 +2594,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowRun'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2589,6 +2653,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowRun'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2763,6 +2829,8 @@ paths:
                 $ref: '#/components/schemas/Component'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2843,6 +2911,8 @@ paths:
                 $ref: '#/components/schemas/ComponentRelease'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2902,6 +2972,8 @@ paths:
                   $ref: '#/components/schemas/Decision'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -2994,6 +3066,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3061,6 +3135,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3143,6 +3219,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3210,6 +3288,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3295,6 +3375,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3366,6 +3448,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3454,6 +3538,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3525,6 +3611,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3640,6 +3728,8 @@ paths:
                 $ref: '#/components/schemas/WebhookEventResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -3698,6 +3788,8 @@ paths:
                 $ref: '#/components/schemas/SecretReference'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3755,6 +3847,8 @@ paths:
                 $ref: '#/components/schemas/SecretReference'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3840,6 +3934,8 @@ paths:
                 $ref: '#/components/schemas/Workload'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3897,6 +3993,8 @@ paths:
                 $ref: '#/components/schemas/Workload'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3981,6 +4079,8 @@ paths:
                 $ref: '#/components/schemas/ComponentRelease'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4090,6 +4190,8 @@ paths:
                 $ref: '#/components/schemas/ReleaseBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4147,6 +4249,8 @@ paths:
                 $ref: '#/components/schemas/ReleaseBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4348,6 +4452,8 @@ paths:
                 $ref: '#/components/schemas/DeploymentPipeline'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4405,6 +4511,8 @@ paths:
                 $ref: '#/components/schemas/DeploymentPipeline'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4487,6 +4595,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityAlertsNotificationChannel'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4544,6 +4654,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityAlertsNotificationChannel'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4620,6 +4732,8 @@ paths:
                 $ref: '#/components/schemas/GitSecretResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4680,6 +4794,8 @@ paths:
                 $ref: '#/components/schemas/SecretResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -5096,6 +5212,19 @@ components:
             error: "Project 'my-project' already exists"
             code: CONFLICT
 
+    UnprocessableContent:
+      description: Request body is well-formed but failed validation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "spec.outputs[0].value: undeclared reference to 'applied'"
+            code: UNPROCESSABLE_CONTENT
+            details:
+              - field: spec.outputs[0].value
+                message: undeclared reference to 'applied'
+
     InternalError:
       description: Internal server error
       content:
@@ -5133,6 +5262,7 @@ components:
             - FORBIDDEN
             - NOT_FOUND
             - CONFLICT
+            - UNPROCESSABLE_CONTENT
             - INTERNAL_ERROR
             - UNKNOWN_GIT_PROVIDER
           example: NOT_FOUND


### PR DESCRIPTION
## Purpose

Webhook validation failures surface to clients as generic HTTP 500 with no useful message. Webhooks return `allErrs.ToAggregate()` (a plain Go error), so kube-apiserver responds with HTTP 403 + empty `Reason`. The openchoreo-api server's `apierrors.IsInvalid(err)` check does not match this shape, and the error falls through to the generic 500 branch.

## Approach

- Wrap `field.ErrorList` with `apierrors.NewInvalid(...)` in 10 webhooks so kube-apiserver responds with HTTP 422 + `Reason=Invalid` and structured `details.causes[]` (with `field`, `message`).
- Add `UnprocessableContent` response component to the OpenAPI spec; codegen produces 58 new `Create...422JSONResponse` / `Update...422JSONResponse` types.
- Add `unprocessableContent(msg)` handler helper alongside `badRequest(msg)`.
- Add `StatusCode int` to `services.ValidationError`; new `ExtractValidationError(err) *ValidationError` helper captures kube's status code (422 for `NewInvalid`).
- Prefix `cause.Field` into each cause message in `ExtractValidationMessage` so clients see `spec.outputs[0].value: invalid CEL expression ...` instead of a bare message.
- Modernize `errors.As(err, &v)` to `errors.AsType[*T](err)` (Go 1.26 generic form).
- Refactor 28 service call sites to the new helper; split 52 Create/Update handlers on `StatusCode == 422` to emit 422 or 400.
- Catch previously-missed kube validation paths: clusterworkflow Create service, clusterworkflow Create+Update handlers, `UpdateWorkflowRun` handler, `component.GenerateRelease` service + handler.

Before / after wire shape for an invalid `POST /componenttypes`:

```
HTTP 500 → HTTP 422
{"code":"INTERNAL_ERROR","error":"Internal server error"}
  →
{"code":"UNPROCESSABLE_CONTENT","error":"spec.resources[0].template[spec][replicas]: Invalid value: \"${parameters.replicas}\": invalid CEL expression ..."}
```

Live-verified on k3d-openchoreo across single-CEL, multi-CEL (joined with `"; "`), duplicate-trait, trait-webhook, and Update-flow probes.

## Related Issues

Closes #3419

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)