### PR TITLE
feat: add validating admission webhooks for resource type CRDs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -403,107 +403,32 @@ func main() {
 	// Setup webhooks with the controller manager
 	// -----------------------------------------------------------------------------
 
-	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err = projectwebhook.SetupProjectWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Project")
-			os.Exit(1)
+		webhookSetups := []struct {
+			name  string
+			setup func(ctrl.Manager) error
+		}{
+			{"Project", projectwebhook.SetupProjectWebhookWithManager},
+			{"ComponentType", componenttypewebhook.SetupComponentTypeWebhookWithManager},
+			{"ClusterComponentType", clustercomponenttypewebhook.SetupClusterComponentTypeWebhookWithManager},
+			{"Component", componentwebhook.SetupComponentWebhookWithManager},
+			{"Trait", traitwebhook.SetupTraitWebhookWithManager},
+			{"ClusterTrait", clustertraitwebhook.SetupClusterTraitWebhookWithManager},
+			{"ComponentRelease", componentreleasewebhook.SetupComponentReleaseWebhookWithManager},
+			{"ReleaseBinding", releasebindingwebhook.SetupReleaseBindingWebhookWithManager},
+			{"ResourceType", resourcetypewebhook.SetupResourceTypeWebhookWithManager},
+			{"ClusterResourceType", clusterresourcetypewebhook.SetupClusterResourceTypeWebhookWithManager},
+			{"ResourceRelease", resourcereleasewebhook.SetupResourceReleaseWebhookWithManager},
+			{"Workflow", workflowwebhook.SetupWorkflowWebhookWithManager},
+			{"ClusterWorkflow", clusterworkflowwebhook.SetupClusterWorkflowWebhookWithManager},
+			{"AuthzRoleBinding", authzrolebindingwebhook.SetupAuthzRoleBindingWebhookWithManager},
+			{"ClusterAuthzRoleBinding", clusterauthzrolebindingwebhook.SetupClusterAuthzRoleBindingWebhookWithManager},
 		}
-	}
-
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := componenttypewebhook.SetupComponentTypeWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ComponentType")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := clustercomponenttypewebhook.SetupClusterComponentTypeWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterComponentType")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := componentwebhook.SetupComponentWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Component")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := traitwebhook.SetupTraitWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Trait")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := clustertraitwebhook.SetupClusterTraitWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterTrait")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := componentreleasewebhook.SetupComponentReleaseWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ComponentRelease")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := releasebindingwebhook.SetupReleaseBindingWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ReleaseBinding")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := resourcetypewebhook.SetupResourceTypeWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ResourceType")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := clusterresourcetypewebhook.SetupClusterResourceTypeWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterResourceType")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := resourcereleasewebhook.SetupResourceReleaseWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ResourceRelease")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := workflowwebhook.SetupWorkflowWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Workflow")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := clusterworkflowwebhook.SetupClusterWorkflowWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterWorkflow")
-			os.Exit(1)
-		}
-	}
-	// nolint:goconst
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := authzrolebindingwebhook.SetupAuthzRoleBindingWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "AuthzRoleBinding")
-			os.Exit(1)
-		}
-		if err := clusterauthzrolebindingwebhook.SetupClusterAuthzRoleBindingWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterAuthzRoleBinding")
-			os.Exit(1)
+		for _, w := range webhookSetups {
+			if err := w.setup(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", w.name)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,6 +65,7 @@ import (
 	authzrolebindingwebhook "github.com/openchoreo/openchoreo/internal/webhook/authzrolebinding"
 	clusterauthzrolebindingwebhook "github.com/openchoreo/openchoreo/internal/webhook/clusterauthzrolebinding"
 	clustercomponenttypewebhook "github.com/openchoreo/openchoreo/internal/webhook/clustercomponenttype"
+	clusterresourcetypewebhook "github.com/openchoreo/openchoreo/internal/webhook/clusterresourcetype"
 	clustertraitwebhook "github.com/openchoreo/openchoreo/internal/webhook/clustertrait"
 	clusterworkflowwebhook "github.com/openchoreo/openchoreo/internal/webhook/clusterworkflow"
 	componentwebhook "github.com/openchoreo/openchoreo/internal/webhook/component"
@@ -72,6 +73,8 @@ import (
 	componenttypewebhook "github.com/openchoreo/openchoreo/internal/webhook/componenttype"
 	projectwebhook "github.com/openchoreo/openchoreo/internal/webhook/project"
 	releasebindingwebhook "github.com/openchoreo/openchoreo/internal/webhook/releasebinding"
+	resourcereleasewebhook "github.com/openchoreo/openchoreo/internal/webhook/resourcerelease"
+	resourcetypewebhook "github.com/openchoreo/openchoreo/internal/webhook/resourcetype"
 	traitwebhook "github.com/openchoreo/openchoreo/internal/webhook/trait"
 	workflowwebhook "github.com/openchoreo/openchoreo/internal/webhook/workflow"
 )
@@ -454,6 +457,27 @@ func main() {
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err := releasebindingwebhook.SetupReleaseBindingWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ReleaseBinding")
+			os.Exit(1)
+		}
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := resourcetypewebhook.SetupResourceTypeWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ResourceType")
+			os.Exit(1)
+		}
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := clusterresourcetypewebhook.SetupClusterResourceTypeWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterResourceType")
+			os.Exit(1)
+		}
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := resourcereleasewebhook.SetupResourceReleaseWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ResourceRelease")
 			os.Exit(1)
 		}
 	}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -196,6 +196,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-openchoreo-dev-v1alpha1-clusterresourcetype
+  failurePolicy: Fail
+  name: vclusterresourcetype-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcetypes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-openchoreo-dev-v1alpha1-clustertrait
   failurePolicy: Fail
   name: vclustertrait-v1alpha1.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -356,6 +356,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-openchoreo-dev-v1alpha1-resourcetype
+  failurePolicy: Fail
+  name: vresourcetype-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourcetypes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-openchoreo-dev-v1alpha1-trait
   failurePolicy: Fail
   name: vtrait-v1alpha1.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -376,6 +376,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-openchoreo-dev-v1alpha1-resourcerelease
+  failurePolicy: Fail
+  name: vresourcerelease-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourcereleases
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-openchoreo-dev-v1alpha1-resourcetype
   failurePolicy: Fail
   name: vresourcetype-v1alpha1.kb.io

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/validating-webhook-configuration.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/validating-webhook-configuration.yaml
@@ -153,6 +153,66 @@ webhooks:
     service:
       name: {{ .Values.controllerManager.name }}-webhook-service
       namespace: '{{ .Release.Namespace }}'
+      path: /validate-openchoreo-dev-v1alpha1-resourcerelease
+  failurePolicy: Fail
+  name: vresourcerelease-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourcereleases
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.controllerManager.name }}-webhook-service
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-openchoreo-dev-v1alpha1-resourcetype
+  failurePolicy: Fail
+  name: vresourcetype-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourcetypes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.controllerManager.name }}-webhook-service
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-openchoreo-dev-v1alpha1-clusterresourcetype
+  failurePolicy: Fail
+  name: vclusterresourcetype-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - openchoreo.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcetypes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.controllerManager.name }}-webhook-service
+      namespace: '{{ .Release.Namespace }}'
       path: /validate-openchoreo-dev-v1alpha1-trait
   failurePolicy: Fail
   name: vtrait-v1alpha1.kb.io

--- a/internal/pipeline/resource/pipeline.go
+++ b/internal/pipeline/resource/pipeline.go
@@ -315,12 +315,12 @@ func buildBaseContext(input *RenderInput) (map[string]any, error) {
 		return nil, fmt.Errorf("resolve environmentConfigs: %w", err)
 	}
 
-	return map[string]any{
-		"metadata":           metadataContextToMap(input.Metadata),
-		"parameters":         parameters,
-		"environmentConfigs": envConfigs,
-		"dataplane":          dataPlaneContextToMap(input.DataPlane),
-	}, nil
+	return structToMap(BaseContext{
+		Metadata:           input.Metadata,
+		Parameters:         parameters,
+		EnvironmentConfigs: envConfigs,
+		DataPlane:          input.DataPlane,
+	})
 }
 
 // bindingEnvironmentConfigs returns the raw environmentConfigs RawExtension
@@ -397,52 +397,19 @@ func applySchemaDefaults(target map[string]any, section *v1alpha1.SchemaSection)
 	return schema.ApplyDefaults(target, structural), nil
 }
 
-// dataPlaneContextToMap exposes DataPlaneContext fields under their CEL-facing
-// keys. ObservabilityPlaneRef is exposed as an empty {kind, name} map when
-// nil so PE templates referencing ${dataplane.observabilityPlaneRef.name}
-// against a DataPlane without one get an empty string rather than a CEL
-// evaluation error.
-func dataPlaneContextToMap(d DataPlaneContext) map[string]any {
-	obsRef := map[string]any{
-		"kind": "",
-		"name": "",
+// structToMap converts typed Go structs to map[string]any for CEL evaluation
+// via JSON round-trip. CEL expressions access maps and primitives, not
+// arbitrary Go structs, so this round-trip is the conversion mechanism.
+// Field names come from the json tags on the source type. Mirrors
+// internal/pipeline/component/context.structToMap.
+func structToMap(v any) (map[string]any, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
 	}
-	if d.ObservabilityPlaneRef != nil {
-		obsRef["kind"] = d.ObservabilityPlaneRef.Kind
-		obsRef["name"] = d.ObservabilityPlaneRef.Name
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
 	}
-	return map[string]any{
-		"secretStore":           d.SecretStore,
-		"observabilityPlaneRef": obsRef,
-	}
-}
-
-// metadataContextToMap exposes MetadataContext fields under their CEL-facing
-// keys. componentName / componentUID are deliberately absent (reserved for
-// component-bound resources, not currently supported); a CEL reference to
-// ${metadata.componentName} surfaces as an evaluation error.
-func metadataContextToMap(m MetadataContext) map[string]any {
-	labels := m.Labels
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	annotations := m.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	return map[string]any{
-		"name":              m.Name,
-		"namespace":         m.Namespace,
-		"resourceNamespace": m.ResourceNamespace,
-		"resourceName":      m.ResourceName,
-		"resourceUID":       m.ResourceUID,
-		"projectName":       m.ProjectName,
-		"projectUID":        m.ProjectUID,
-		"environmentName":   m.EnvironmentName,
-		"environmentUID":    m.EnvironmentUID,
-		"dataPlaneName":     m.DataPlaneName,
-		"dataPlaneUID":      m.DataPlaneUID,
-		"labels":            labels,
-		"annotations":       annotations,
-	}
+	return result, nil
 }

--- a/internal/pipeline/resource/pipeline.go
+++ b/internal/pipeline/resource/pipeline.go
@@ -316,8 +316,19 @@ func buildBaseContext(input *RenderInput) (map[string]any, error) {
 		return nil, fmt.Errorf("resolve environmentConfigs: %w", err)
 	}
 
+	// Coerce nil Labels/Annotations to empty maps so the JSON round-trip
+	// in structToMap emits {} instead of null, keeping CEL map indexing
+	// (${metadata.labels["k"]}) safe even when callers leave them unset.
+	md := input.Metadata
+	if md.Labels == nil {
+		md.Labels = map[string]string{}
+	}
+	if md.Annotations == nil {
+		md.Annotations = map[string]string{}
+	}
+
 	return structToMap(BaseContext{
-		Metadata:           input.Metadata,
+		Metadata:           md,
 		Parameters:         parameters,
 		EnvironmentConfigs: envConfigs,
 		DataPlane:          input.DataPlane,

--- a/internal/pipeline/resource/pipeline.go
+++ b/internal/pipeline/resource/pipeline.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -367,10 +368,8 @@ func unmarshalRaw(raw *runtime.RawExtension) (map[string]any, error) {
 // evaluation share this layering: every entry in observed shows up under
 // applied[id].status.* for CEL.
 func withApplied(base map[string]any, observed map[string]map[string]any) map[string]any {
-	ctx := make(map[string]any, len(base)+1)
-	for k, v := range base {
-		ctx[k] = v
-	}
+	ctx := make(map[string]any, len(base))
+	maps.Copy(ctx, base)
 	applied := make(map[string]any, len(observed))
 	for id, status := range observed {
 		applied[id] = map[string]any{"status": status}

--- a/internal/pipeline/resource/pipeline_test.go
+++ b/internal/pipeline/resource/pipeline_test.go
@@ -211,11 +211,15 @@ func TestRenderManifests(t *testing.T) {
 			require.Equal(t, "primary-obs", got.Entries[0].Object["nameRef"])
 		})
 
-		t.Run("absent_yields_empty_string", func(t *testing.T) {
+		t.Run("absent_guarded_by_has", func(t *testing.T) {
+			// observabilityPlaneRef is omitempty: when nil it's omitted from the
+			// CEL surface entirely. Templates must guard with has(...) — mirrors
+			// the component pipeline's contract for dataplane.gateway and
+			// dataplane.secretStore.
 			input := renderSingle(t, rawExt(t, map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Probe",
-				"value":      "${dataplane.observabilityPlaneRef.name}",
+				"value":      `${has(dataplane.observabilityPlaneRef) ? dataplane.observabilityPlaneRef.name : ""}`,
 			}))
 
 			got, err := NewPipeline().RenderManifests(input)

--- a/internal/pipeline/resource/pipeline_test.go
+++ b/internal/pipeline/resource/pipeline_test.go
@@ -535,6 +535,30 @@ func TestRenderManifests(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("nil_labels_and_annotations_coerce_to_empty_maps", func(t *testing.T) {
+		// Templates index metadata.labels[] and metadata.annotations[] directly.
+		// A nil map would marshal to JSON null and break CEL indexing, so the
+		// pipeline must coerce nil to {} before structToMap. Locks the
+		// contract against future refactors.
+		input := renderSingle(t,
+			rawExt(t, map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Probe",
+				"labelsKey":  `${has(metadata.labels) ? "yes" : "no"}`,
+				"annotKey":   `${has(metadata.annotations) ? "yes" : "no"}`,
+			}),
+			func(in *RenderInput) {
+				in.Metadata.Labels = nil
+				in.Metadata.Annotations = nil
+			},
+		)
+
+		got, err := NewPipeline().RenderManifests(input)
+		require.NoError(t, err)
+		require.Equal(t, "yes", got.Entries[0].Object["labelsKey"])
+		require.Equal(t, "yes", got.Entries[0].Object["annotKey"])
+	})
 }
 
 func TestResolveOutputs(t *testing.T) {

--- a/internal/pipeline/resource/types.go
+++ b/internal/pipeline/resource/types.go
@@ -81,59 +81,78 @@ type ResolvedOutput struct {
 
 // MetadataContext is the platform-injected metadata surface exposed to CEL
 // templates as ${metadata.*}. The controller computes every field before
-// calling the pipeline.
+// calling the pipeline. JSON tags determine the CEL-facing field names when
+// the context is marshaled via structToMap, and are also reflected on by the
+// validation package to declare the CEL env surface.
 type MetadataContext struct {
 	// Name is the platform-computed base name for rendered resources,
 	// shaped {resource}-{env}-{hash} (mirrors component pipeline's
 	// {component}-{env}-{hash} convention).
-	Name string
+	Name string `json:"name"`
 
 	// Namespace is the DP-side project-env mapped namespace. Exposed via
 	// CEL only; the pipeline does NOT force-set metadata.namespace on
 	// rendered manifests.
-	Namespace string
+	Namespace string `json:"namespace"`
 
 	// ResourceNamespace is the CP namespace where the Resource CR lives.
-	ResourceNamespace string
+	ResourceNamespace string `json:"resourceNamespace"`
 
-	ResourceName    string
-	ResourceUID     string
-	ProjectName     string
-	ProjectUID      string
-	EnvironmentName string
-	EnvironmentUID  string
-	DataPlaneName   string
-	DataPlaneUID    string
+	ResourceName    string `json:"resourceName"`
+	ResourceUID     string `json:"resourceUID"`
+	ProjectName     string `json:"projectName"`
+	ProjectUID      string `json:"projectUID"`
+	EnvironmentName string `json:"environmentName"`
+	EnvironmentUID  string `json:"environmentUID"`
+	DataPlaneName   string `json:"dataPlaneName"`
+	DataPlaneUID    string `json:"dataPlaneUID"`
 
 	// Labels are platform-injected standard labels (openchoreo.dev/resource,
 	// openchoreo.dev/project, openchoreo.dev/environment, plus matching
 	// *-uid keys). PE templates that propagate ${metadata.labels} get
 	// consistent labeling across every rendered DP-side object.
-	Labels map[string]string
+	Labels map[string]string `json:"labels"`
 
 	// Annotations are propagated from the Resource CR.
-	Annotations map[string]string
+	Annotations map[string]string `json:"annotations"`
 }
 
 // DataPlaneContext is the dataplane surface exposed to CEL templates as
 // ${dataplane.*}. The surface is deliberately narrow — only the fields
 // managed-infra ResourceTypes commonly need; gateway and networking surface
-// is intentionally omitted.
+// is intentionally omitted. Optional fields use omitempty so templates can
+// guard with has(...) — mirrors the component pipeline's contract.
 type DataPlaneContext struct {
 	// SecretStore is the name of the ESO ClusterSecretStore configured on
 	// the DataPlane. ResourceTypes emitting ExternalSecret reference this.
-	SecretStore string
+	SecretStore string `json:"secretStore,omitempty"`
 
 	// ObservabilityPlaneRef is the observability plane reference for
 	// ResourceTypes that emit observability-plane-side resources (alert
 	// rules, dashboards). Optional; nil when the DataPlane has no
-	// observability plane configured.
-	ObservabilityPlaneRef *ObservabilityPlaneRefContext
+	// observability plane configured. PE templates that reference
+	// ${dataplane.observabilityPlaneRef.*} must guard with
+	// has(dataplane.observabilityPlaneRef) — same convention as
+	// dataplane.gateway in the component pipeline.
+	ObservabilityPlaneRef *ObservabilityPlaneRefContext `json:"observabilityPlaneRef,omitempty"`
 }
 
 // ObservabilityPlaneRefContext is the {kind, name} reference exposed under
 // ${dataplane.observabilityPlaneRef.*}.
 type ObservabilityPlaneRefContext struct {
-	Kind string
-	Name string
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+// BaseContext is the top-level CEL surface produced by buildBaseContext and
+// fed into the template engine. withApplied layers applied.<id>.status.* on
+// top of it for output and readyWhen evaluation. The struct exists so the
+// pipeline and the validation package share a single source of truth for the
+// CEL surface — validation reflects on BaseContext to declare CEL variables;
+// the pipeline JSON-marshals it via structToMap for runtime evaluation.
+type BaseContext struct {
+	Metadata           MetadataContext  `json:"metadata"`
+	Parameters         map[string]any   `json:"parameters"`
+	EnvironmentConfigs map[string]any   `json:"environmentConfigs"`
+	DataPlane          DataPlaneContext `json:"dataplane"`
 }

--- a/internal/validation/resource/cel_env.go
+++ b/internal/validation/resource/cel_env.go
@@ -12,55 +12,27 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 
+	resourcepipeline "github.com/openchoreo/openchoreo/internal/pipeline/resource"
 	"github.com/openchoreo/openchoreo/internal/template"
 	"github.com/openchoreo/openchoreo/internal/validation/component/decltype"
 )
 
 // schemaBasedFields are populated from user-provided schemas, not reflection.
-// validationContext does not declare these fields; the skip set keeps
-// ExtractFields behavior parallel with internal/validation/component.
+// They are skipped during ExtractFields and declared separately based on the
+// parameters / environmentConfigs schemas on the ResourceType being validated.
 var schemaBasedFields = map[string]bool{
 	"parameters":         true,
 	"environmentConfigs": true,
 }
 
-// validationContext mirrors the runtime CEL surface exposed by the resource
-// pipeline (internal/pipeline/resource/pipeline.go::buildBaseContext).
-// metadata.* and dataplane.* keys here must stay in sync with
-// metadataContextToMap and dataPlaneContextToMap in the pipeline. This struct
-// is reflection-only and is never instantiated.
-type validationContext struct {
-	Metadata  metadataView  `json:"metadata"`
-	DataPlane dataplaneView `json:"dataplane"`
-}
-
-type metadataView struct {
-	Name              string            `json:"name"`
-	Namespace         string            `json:"namespace"`
-	ResourceNamespace string            `json:"resourceNamespace"`
-	ResourceName      string            `json:"resourceName"`
-	ResourceUID       string            `json:"resourceUID"`
-	ProjectName       string            `json:"projectName"`
-	ProjectUID        string            `json:"projectUID"`
-	EnvironmentName   string            `json:"environmentName"`
-	EnvironmentUID    string            `json:"environmentUID"`
-	DataPlaneName     string            `json:"dataPlaneName"`
-	DataPlaneUID      string            `json:"dataPlaneUID"`
-	Labels            map[string]string `json:"labels"`
-	Annotations       map[string]string `json:"annotations"`
-}
-
-type dataplaneView struct {
-	SecretStore           string                    `json:"secretStore"`
-	ObservabilityPlaneRef observabilityPlaneRefView `json:"observabilityPlaneRef"`
-}
-
-type observabilityPlaneRefView struct {
-	Kind string `json:"kind"`
-	Name string `json:"name"`
-}
-
-var resourceContextFields = decltype.ExtractFields(reflect.TypeFor[validationContext](), schemaBasedFields)
+// resourceContextFields are the CEL variables declared from the pipeline's
+// BaseContext via reflection. Mirrors internal/validation/component.cel_env's
+// componentContextFields — single source of truth for the CEL surface lives
+// on the pipeline's BaseContext type.
+var resourceContextFields = decltype.ExtractFields(
+	reflect.TypeFor[resourcepipeline.BaseContext](),
+	schemaBasedFields,
+)
 
 // SchemaOptions provides schema configuration for resource CEL environment building.
 // Mirrors internal/validation/component.SchemaOptions; defined here to keep the

--- a/internal/validation/resource/cel_env.go
+++ b/internal/validation/resource/cel_env.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+
+	"github.com/openchoreo/openchoreo/internal/template"
+	"github.com/openchoreo/openchoreo/internal/validation/component/decltype"
+)
+
+// schemaBasedFields are populated from user-provided schemas, not reflection.
+// validationContext does not declare these fields; the skip set keeps
+// ExtractFields behavior parallel with internal/validation/component.
+var schemaBasedFields = map[string]bool{
+	"parameters":         true,
+	"environmentConfigs": true,
+}
+
+// validationContext mirrors the runtime CEL surface exposed by the resource
+// pipeline (internal/pipeline/resource/pipeline.go::buildBaseContext).
+// metadata.* and dataplane.* keys here must stay in sync with
+// metadataContextToMap and dataPlaneContextToMap in the pipeline. This struct
+// is reflection-only and is never instantiated.
+type validationContext struct {
+	Metadata  metadataView  `json:"metadata"`
+	DataPlane dataplaneView `json:"dataplane"`
+}
+
+type metadataView struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	ResourceNamespace string            `json:"resourceNamespace"`
+	ResourceName      string            `json:"resourceName"`
+	ResourceUID       string            `json:"resourceUID"`
+	ProjectName       string            `json:"projectName"`
+	ProjectUID        string            `json:"projectUID"`
+	EnvironmentName   string            `json:"environmentName"`
+	EnvironmentUID    string            `json:"environmentUID"`
+	DataPlaneName     string            `json:"dataPlaneName"`
+	DataPlaneUID      string            `json:"dataPlaneUID"`
+	Labels            map[string]string `json:"labels"`
+	Annotations       map[string]string `json:"annotations"`
+}
+
+type dataplaneView struct {
+	SecretStore           string                    `json:"secretStore"`
+	ObservabilityPlaneRef observabilityPlaneRefView `json:"observabilityPlaneRef"`
+}
+
+type observabilityPlaneRefView struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+var resourceContextFields = decltype.ExtractFields(reflect.TypeFor[validationContext](), schemaBasedFields)
+
+// SchemaOptions provides schema configuration for resource CEL environment building.
+// Mirrors internal/validation/component.SchemaOptions; defined here to keep the
+// resource validation package self-contained.
+type SchemaOptions struct {
+	ParametersSchema         *apiextschema.Structural
+	EnvironmentConfigsSchema *apiextschema.Structural
+}
+
+// buildResourceCELEnv creates a schema-aware CEL environment for ResourceType
+// and ClusterResourceType validation. The base env exposes metadata,
+// parameters, environmentConfigs, and dataplane as top-level variables.
+// applied.<id> is intentionally not in scope; extendEnvWithApplied layers it
+// on for outputs and readyWhen validation.
+func buildResourceCELEnv(opts SchemaOptions) (*cel.Env, error) {
+	baseEnv, err := createBaseEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	numFields := len(resourceContextFields) + len(schemaBasedFields)
+	declTypes := make([]*apiservercel.DeclType, 0, numFields)
+	varOpts := make([]cel.EnvOption, 0, numFields)
+
+	paramType := schemaToTypeOrEmpty(opts.ParametersSchema, "Parameters")
+	declTypes = append(declTypes, paramType)
+	varOpts = append(varOpts, cel.Variable("parameters", paramType.CelType()))
+
+	envConfigsType := schemaToTypeOrEmpty(opts.EnvironmentConfigsSchema, "EnvironmentConfigs")
+	declTypes = append(declTypes, envConfigsType)
+	varOpts = append(varOpts, cel.Variable("environmentConfigs", envConfigsType.CelType()))
+
+	for _, f := range resourceContextFields {
+		declTypes = append(declTypes, f.DeclType)
+		varOpts = append(varOpts, cel.Variable(f.Name, f.DeclType.CelType()))
+	}
+
+	provider := apiservercel.NewDeclTypeProvider(declTypes...)
+	providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
+	if err != nil {
+		return nil, err
+	}
+	varOpts = append(varOpts, providerOpts...)
+
+	return baseEnv.Extend(varOpts...)
+}
+
+// extendEnvWithApplied returns a new env with applied in scope as
+// map<string, AppliedEntry>. AppliedEntry has a single Dyn-typed status field;
+// the schema beneath status is not type-checked because operators populate it
+// freely. Verifying that an applied.<id> reference matches a declared
+// resources[].id is a separate AST-walk concern (see Stage 1).
+func extendEnvWithApplied(env *cel.Env) (*cel.Env, error) {
+	appliedEntryType := apiservercel.NewObjectType("AppliedEntry", map[string]*apiservercel.DeclField{
+		"status": apiservercel.NewDeclField("status", apiservercel.DynType, true, nil, nil),
+	})
+
+	// Only the named Object value type goes through the DeclTypeProvider.
+	// The map wrapper is constructed inline at the cel.Type level — registering
+	// a fresh apiservercel.MapType against an env that already carries
+	// map<string, string> (from metadata.labels / metadata.annotations) would
+	// trigger "type map definition differs between CEL environment and type
+	// provider" because the provider tries to redefine the unnamed map type.
+	provider := apiservercel.NewDeclTypeProvider(appliedEntryType)
+	providerOpts, err := provider.EnvOptions(env.CELTypeProvider())
+	if err != nil {
+		return nil, fmt.Errorf("create applied type provider: %w", err)
+	}
+
+	opts := make([]cel.EnvOption, 0, 1+len(providerOpts))
+	opts = append(opts, cel.Variable("applied", cel.MapType(cel.StringType, appliedEntryType.CelType())))
+	opts = append(opts, providerOpts...)
+
+	return env.Extend(opts...)
+}
+
+// createBaseEnv creates the base CEL environment with the standard
+// template extensions (oc_omit and friends). Component-specific helpers
+// (configurations.*, dependencies.*, connections.*) are deliberately absent —
+// those are component-render-time concerns and have no meaning for resource
+// templates.
+func createBaseEnv() (*cel.Env, error) {
+	return cel.NewEnv(template.BaseCELExtensions()...)
+}
+
+// schemaToTypeOrEmpty converts a structural schema to a DeclType, returning
+// an empty object type if the schema is nil or unconvertible.
+func schemaToTypeOrEmpty(schema *apiextschema.Structural, typeName string) *apiservercel.DeclType {
+	if schema != nil {
+		if dt := model.SchemaDeclType(schema, false); dt != nil {
+			return dt.MaybeAssignTypeName(typeName)
+		}
+	}
+	return apiservercel.NewObjectType(typeName, map[string]*apiservercel.DeclField{})
+}

--- a/internal/validation/resource/cel_env.go
+++ b/internal/validation/resource/cel_env.go
@@ -112,7 +112,7 @@ func buildResourceCELEnv(opts SchemaOptions) (*cel.Env, error) {
 // map<string, AppliedEntry>. AppliedEntry has a single Dyn-typed status field;
 // the schema beneath status is not type-checked because operators populate it
 // freely. Verifying that an applied.<id> reference matches a declared
-// resources[].id is a separate AST-walk concern (see Stage 1).
+// resources[].id is a separate AST-walk concern handled by the caller.
 func extendEnvWithApplied(env *cel.Env) (*cel.Env, error) {
 	appliedEntryType := apiservercel.NewObjectType("AppliedEntry", map[string]*apiservercel.DeclField{
 		"status": apiservercel.NewDeclField("status", apiservercel.DynType, true, nil, nil),

--- a/internal/validation/resource/cel_env_test.go
+++ b/internal/validation/resource/cel_env_test.go
@@ -96,9 +96,10 @@ func TestBuildResourceCELEnv_MetadataFields(t *testing.T) {
 	}
 }
 
-// Locks the v1.2 forward-compat boundary: component-bound resources will add
-// componentName/componentUID, but the v1.1 surface must reject them so a PE
-// template authored against v1.1 cannot quietly depend on a v1.2 field.
+// componentName/componentUID/podSelectors are reserved for component-bound
+// resources, which are not currently supported. The base surface must reject
+// them so a PE template cannot quietly depend on a field the runtime won't
+// provide.
 func TestBuildResourceCELEnv_RejectsForwardCompatFields(t *testing.T) {
 	env, err := buildResourceCELEnv(SchemaOptions{})
 	require.NoError(t, err)
@@ -147,8 +148,8 @@ func TestBuildResourceCELEnv_DataPlaneFields(t *testing.T) {
 }
 
 // applied.<id> is only valid during outputs / readyWhen evaluation, never
-// during template or includeWhen rendering. The base env (used by Stage 1
-// to validate templates) must reject any applied reference.
+// during template or includeWhen rendering. The base env must reject any
+// applied reference.
 func TestBuildResourceCELEnv_RejectsAppliedAtBase(t *testing.T) {
 	env, err := buildResourceCELEnv(SchemaOptions{})
 	require.NoError(t, err)

--- a/internal/validation/resource/cel_env_test.go
+++ b/internal/validation/resource/cel_env_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+func TestBuildResourceCELEnv_WithParametersSchema(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"version":   {Generic: apiextschema.Generic{Type: "string"}},
+			"storageGB": {Generic: apiextschema.Generic{Type: "integer"}},
+		},
+	}
+
+	env, err := buildResourceCELEnv(SchemaOptions{ParametersSchema: structural})
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	_, issues := env.Compile("parameters.version")
+	assert.Nil(t, issues.Err())
+	_, issues = env.Compile("parameters.storageGB")
+	assert.Nil(t, issues.Err())
+
+	_, issues = env.Compile("parameters.invalidField")
+	require.NotNil(t, issues)
+	assert.NotNil(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "undefined field")
+}
+
+func TestBuildResourceCELEnv_WithEnvironmentConfigsSchema(t *testing.T) {
+	structural := &apiextschema.Structural{
+		Generic: apiextschema.Generic{Type: "object"},
+		Properties: map[string]apiextschema.Structural{
+			"tlsMode":   {Generic: apiextschema.Generic{Type: "string"}},
+			"storageGB": {Generic: apiextschema.Generic{Type: "integer"}},
+		},
+	}
+
+	env, err := buildResourceCELEnv(SchemaOptions{EnvironmentConfigsSchema: structural})
+	require.NoError(t, err)
+
+	_, issues := env.Compile("environmentConfigs.tlsMode")
+	assert.Nil(t, issues.Err())
+
+	_, issues = env.Compile("environmentConfigs.unknown")
+	require.NotNil(t, issues)
+	assert.NotNil(t, issues.Err())
+}
+
+func TestBuildResourceCELEnv_WithoutSchema(t *testing.T) {
+	env, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	_, issues := env.Compile("parameters.anyField")
+	require.NotNil(t, issues)
+	assert.NotNil(t, issues.Err(), "unknown parameters field should error against empty schema")
+
+	_, issues = env.Compile("environmentConfigs.anyField")
+	require.NotNil(t, issues)
+	assert.NotNil(t, issues.Err(), "unknown environmentConfigs field should error against empty schema")
+}
+
+func TestBuildResourceCELEnv_MetadataFields(t *testing.T) {
+	env, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	okExprs := []string{
+		"metadata.name",
+		"metadata.namespace",
+		"metadata.resourceNamespace",
+		"metadata.resourceName",
+		"metadata.resourceUID",
+		"metadata.projectName",
+		"metadata.projectUID",
+		"metadata.environmentName",
+		"metadata.environmentUID",
+		"metadata.dataPlaneName",
+		"metadata.dataPlaneUID",
+		"metadata.labels",
+		"metadata.annotations",
+		`metadata.labels["app.kubernetes.io/name"]`,
+	}
+	for _, expr := range okExprs {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			assert.Nil(t, issues.Err(), "expr %q should compile", expr)
+		})
+	}
+}
+
+// Locks the v1.2 forward-compat boundary: component-bound resources will add
+// componentName/componentUID, but the v1.1 surface must reject them so a PE
+// template authored against v1.1 cannot quietly depend on a v1.2 field.
+func TestBuildResourceCELEnv_RejectsForwardCompatFields(t *testing.T) {
+	env, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	rejected := []string{
+		"metadata.componentName",
+		"metadata.componentUID",
+		"metadata.podSelectors",
+	}
+	for _, expr := range rejected {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			require.NotNil(t, issues)
+			assert.NotNil(t, issues.Err(), "expr %q should fail", expr)
+		})
+	}
+}
+
+func TestBuildResourceCELEnv_DataPlaneFields(t *testing.T) {
+	env, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	okExprs := []string{
+		"dataplane.secretStore",
+		"dataplane.observabilityPlaneRef.kind",
+		"dataplane.observabilityPlaneRef.name",
+	}
+	for _, expr := range okExprs {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			assert.Nil(t, issues.Err(), "expr %q should compile", expr)
+		})
+	}
+
+	rejected := []string{
+		"dataplane.gateway",
+		"dataplane.observabilityPlaneRef.unknown",
+	}
+	for _, expr := range rejected {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			require.NotNil(t, issues)
+			assert.NotNil(t, issues.Err(), "expr %q should fail", expr)
+		})
+	}
+}
+
+// applied.<id> is only valid during outputs / readyWhen evaluation, never
+// during template or includeWhen rendering. The base env (used by Stage 1
+// to validate templates) must reject any applied reference.
+func TestBuildResourceCELEnv_RejectsAppliedAtBase(t *testing.T) {
+	env, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	_, issues := env.Compile("applied.foo")
+	require.NotNil(t, issues)
+	assert.NotNil(t, issues.Err(), "applied.* must not be in scope at base")
+}
+
+func TestExtendEnvWithApplied_AccessCompiles(t *testing.T) {
+	base, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	extended, err := extendEnvWithApplied(base)
+	require.NoError(t, err)
+	require.NotNil(t, extended)
+
+	okExprs := []string{
+		"applied.claim",
+		"applied.claim.status",
+		"applied.claim.status.host",
+		`applied["tls-cert"]`,
+		`applied["tls-cert"].status.ready`,
+	}
+	for _, expr := range okExprs {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := extended.Compile(expr)
+			assert.Nil(t, issues.Err(), "expr %q should compile", expr)
+		})
+	}
+}
+
+// Locks the contract that extendEnvWithApplied returns a new env without
+// mutating the base. The base env is reused across many template / includeWhen
+// validations, so accidental mutation would leak applied.* into rendering
+// scope where the runtime can't satisfy it.
+func TestExtendEnvWithApplied_BaseEnvUnchanged(t *testing.T) {
+	base, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	_, err = extendEnvWithApplied(base)
+	require.NoError(t, err)
+
+	_, issues := base.Compile("applied.claim")
+	require.NotNil(t, issues)
+	assert.NotNil(t, issues.Err(), "extending should not mutate base env")
+}

--- a/internal/validation/resource/resourcetype.go
+++ b/internal/validation/resource/resourcetype.go
@@ -29,7 +29,7 @@ var celWrapPattern = regexp.MustCompile(`^\$\{([\s\S]+)\}\s*$`)
 
 // ValidateResourceTypeSpec performs CEL-aware validation on a ResourceTypeSpec.
 // Returned errors carry full field paths under basePath; callers compose the
-// list across multiple specs (Stage 3 ResourceRelease validation).
+// list across multiple specs (e.g. when re-validating a ResourceRelease snapshot).
 //
 // What this validates:
 //   - Parameters / EnvironmentConfigs schemas parse as well-formed OpenAPI v3.

--- a/internal/validation/resource/resourcetype.go
+++ b/internal/validation/resource/resourcetype.go
@@ -1,0 +1,437 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/template"
+	"github.com/openchoreo/openchoreo/internal/validation/schemautil"
+)
+
+// celWrapPattern matches a single ${...}-wrapped CEL expression. The CRD
+// schema enforces this pattern on IncludeWhen and ReadyWhen, so the inner
+// extraction here is defensive — a non-matching value indicates the CRD layer
+// failed and we should surface a clean error instead of crashing.
+var celWrapPattern = regexp.MustCompile(`^\$\{([\s\S]+)\}\s*$`)
+
+// ValidateResourceTypeSpec performs CEL-aware validation on a ResourceTypeSpec.
+// Returned errors carry full field paths under basePath; callers compose the
+// list across multiple specs (Stage 3 ResourceRelease validation).
+//
+// What this validates:
+//   - Parameters / EnvironmentConfigs schemas parse as well-formed OpenAPI v3.
+//   - Each resources[].template CEL expression compiles against the base env
+//     (no applied.* in scope).
+//   - Each resources[].includeWhen returns bool against the base env.
+//   - Each resources[].readyWhen returns bool against the env-with-applied,
+//     and any applied.<id> reference matches a declared resources[].id.
+//   - Each outputs[] CEL expression (value / secretKeyRef.{name,key} /
+//     configMapKeyRef.{name,key}) compiles against env-with-applied with the
+//     same applied.<id> declaration check.
+func ValidateResourceTypeSpec(spec *v1alpha1.ResourceTypeSpec, basePath *field.Path) field.ErrorList {
+	if spec == nil {
+		return nil
+	}
+	return validateResourceTypeSpecCommon(
+		spec.Parameters,
+		spec.EnvironmentConfigs,
+		spec.Resources,
+		spec.Outputs,
+		basePath,
+	)
+}
+
+// ValidateClusterResourceTypeSpec is the cluster-scoped sibling. The spec
+// shape is currently identical to ResourceTypeSpec; this delegates through
+// the shared inner function so future divergence (e.g. cluster-only fields)
+// has a single place to extend.
+func ValidateClusterResourceTypeSpec(spec *v1alpha1.ClusterResourceTypeSpec, basePath *field.Path) field.ErrorList {
+	if spec == nil {
+		return nil
+	}
+	return validateResourceTypeSpecCommon(
+		spec.Parameters,
+		spec.EnvironmentConfigs,
+		spec.Resources,
+		spec.Outputs,
+		basePath,
+	)
+}
+
+func validateResourceTypeSpecCommon(
+	parameters *v1alpha1.SchemaSection,
+	environmentConfigs *v1alpha1.SchemaSection,
+	resources []v1alpha1.ResourceTypeManifest,
+	outputs []v1alpha1.ResourceTypeOutput,
+	basePath *field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+
+	parametersSchema, envConfigsSchema, schemaErrs := schemautil.ExtractAndValidateSchemas(
+		parameters, environmentConfigs, basePath,
+	)
+	allErrs = append(allErrs, schemaErrs...)
+
+	baseEnv, err := buildResourceCELEnv(SchemaOptions{
+		ParametersSchema:         parametersSchema,
+		EnvironmentConfigsSchema: envConfigsSchema,
+	})
+	if err != nil {
+		return append(allErrs, field.InternalError(basePath, fmt.Errorf("build CEL env: %w", err)))
+	}
+
+	appliedEnv, err := extendEnvWithApplied(baseEnv)
+	if err != nil {
+		return append(allErrs, field.InternalError(basePath, fmt.Errorf("extend CEL env with applied: %w", err)))
+	}
+
+	declaredIDs := make(map[string]bool, len(resources))
+	for _, r := range resources {
+		if r.ID != "" {
+			declaredIDs[r.ID] = true
+		}
+	}
+
+	resourcesPath := basePath.Child("resources")
+	for i := range resources {
+		allErrs = append(allErrs, validateResourceManifest(
+			&resources[i], baseEnv, appliedEnv, declaredIDs, resourcesPath.Index(i),
+		)...)
+	}
+
+	outputsPath := basePath.Child("outputs")
+	for i := range outputs {
+		allErrs = append(allErrs, validateResourceOutput(
+			&outputs[i], appliedEnv, declaredIDs, outputsPath.Index(i),
+		)...)
+	}
+
+	return allErrs
+}
+
+// validateResourceManifest validates a single resources[] entry: its template,
+// includeWhen, and readyWhen.
+func validateResourceManifest(
+	manifest *v1alpha1.ResourceTypeManifest,
+	baseEnv, appliedEnv *cel.Env,
+	declaredIDs map[string]bool,
+	path *field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if manifest.IncludeWhen != "" {
+		allErrs = append(allErrs, validateBoolCELField(
+			manifest.IncludeWhen, baseEnv, declaredIDs, path.Child("includeWhen"),
+			false, // applied.* not allowed during render-phase
+		)...)
+	}
+
+	if manifest.ReadyWhen != "" {
+		allErrs = append(allErrs, validateBoolCELField(
+			manifest.ReadyWhen, appliedEnv, declaredIDs, path.Child("readyWhen"),
+			true, // applied.<id> allowed; must match declared ids
+		)...)
+	}
+
+	if manifest.Template != nil {
+		allErrs = append(allErrs, validateTemplateBody(
+			manifest.Template, baseEnv, declaredIDs, path.Child("template"),
+		)...)
+	}
+
+	return allErrs
+}
+
+// validateResourceOutput validates a single outputs[] entry: each CEL field
+// in the value / secretKeyRef / configMapKeyRef branch against the
+// env-with-applied. The XOR among the three branches is enforced by a CRD
+// XValidation marker (resourcetype_types.go:51); this function trusts that.
+func validateResourceOutput(
+	out *v1alpha1.ResourceTypeOutput,
+	appliedEnv *cel.Env,
+	declaredIDs map[string]bool,
+	path *field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if out.Value != "" {
+		allErrs = append(allErrs, validateCELString(
+			out.Value, appliedEnv, declaredIDs, path.Child("value"),
+		)...)
+	}
+
+	if out.SecretKeyRef != nil {
+		ref := out.SecretKeyRef
+		refPath := path.Child("secretKeyRef")
+		if ref.Name != "" {
+			allErrs = append(allErrs, validateCELString(ref.Name, appliedEnv, declaredIDs, refPath.Child("name"))...)
+		}
+		if ref.Key != "" {
+			allErrs = append(allErrs, validateCELString(ref.Key, appliedEnv, declaredIDs, refPath.Child("key"))...)
+		}
+	}
+
+	if out.ConfigMapKeyRef != nil {
+		ref := out.ConfigMapKeyRef
+		refPath := path.Child("configMapKeyRef")
+		if ref.Name != "" {
+			allErrs = append(allErrs, validateCELString(ref.Name, appliedEnv, declaredIDs, refPath.Child("name"))...)
+		}
+		if ref.Key != "" {
+			allErrs = append(allErrs, validateCELString(ref.Key, appliedEnv, declaredIDs, refPath.Child("key"))...)
+		}
+	}
+
+	return allErrs
+}
+
+// validateBoolCELField validates a single ${...}-wrapped CEL expression that
+// must return bool. Used for IncludeWhen and ReadyWhen.
+//
+// allowApplied controls whether applied.<id> references are permitted; when
+// true, the env passed in already has applied in scope and undeclared-id
+// references are flagged via AST walk.
+func validateBoolCELField(
+	wrapped string,
+	env *cel.Env,
+	declaredIDs map[string]bool,
+	path *field.Path,
+	allowApplied bool,
+) field.ErrorList {
+	inner, ok := unwrapCEL(wrapped)
+	if !ok {
+		return field.ErrorList{field.Invalid(path, wrapped,
+			"expression must be wrapped as ${...}")}
+	}
+
+	parsed, issues := env.Parse(inner)
+	if issues != nil && issues.Err() != nil {
+		return field.ErrorList{field.Invalid(path, wrapped,
+			fmt.Sprintf("CEL parse error: %s", issues.Err()))}
+	}
+
+	checked, issues := env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return field.ErrorList{field.Invalid(path, wrapped,
+			fmt.Sprintf("CEL type check error: %s", issues.Err()))}
+	}
+
+	output := checked.OutputType()
+	if !output.IsExactType(cel.BoolType) && output != cel.DynType {
+		return field.ErrorList{field.Invalid(path, wrapped,
+			fmt.Sprintf("expression must return bool, got %s", output))}
+	}
+
+	if allowApplied {
+		if errs := validateAppliedReferences(checked.NativeRep().Expr(), declaredIDs, path, wrapped); len(errs) > 0 {
+			return errs
+		}
+	}
+
+	return nil
+}
+
+// validateCELString validates every ${...} expression in a string against the
+// supplied env. The string may contain zero or more expressions
+// (e.g. interpolated names like "${metadata.resourceName}-conn").
+//
+// declaredIDs governs whether applied.<id> references match a declared
+// resources[].id. The env is expected to be the env-with-applied — callers
+// pass baseEnv when applied.* should be rejected outright.
+func validateCELString(
+	value string,
+	env *cel.Env,
+	declaredIDs map[string]bool,
+	path *field.Path,
+) field.ErrorList {
+	matches, err := template.FindCELExpressions(value)
+	if err != nil {
+		return field.ErrorList{field.Invalid(path, value,
+			fmt.Sprintf("failed to parse CEL expressions: %v", err))}
+	}
+
+	var allErrs field.ErrorList
+	for _, m := range matches {
+		parsed, issues := env.Parse(m.InnerExpr)
+		if issues != nil && issues.Err() != nil {
+			allErrs = append(allErrs, field.Invalid(path, value,
+				fmt.Sprintf("invalid CEL expression %q: parse: %s", m.InnerExpr, issues.Err())))
+			continue
+		}
+		checked, issues := env.Check(parsed)
+		if issues != nil && issues.Err() != nil {
+			allErrs = append(allErrs, field.Invalid(path, value,
+				fmt.Sprintf("invalid CEL expression %q: type check: %s", m.InnerExpr, issues.Err())))
+			continue
+		}
+		allErrs = append(allErrs, validateAppliedReferences(
+			checked.NativeRep().Expr(), declaredIDs, path, m.InnerExpr,
+		)...)
+	}
+	return allErrs
+}
+
+// validateTemplateBody walks a JSON-serialized template body and validates
+// every CEL expression found against baseEnv (applied.* rejected outright by
+// the env's lack of registration).
+func validateTemplateBody(
+	body *runtime.RawExtension,
+	baseEnv *cel.Env,
+	declaredIDs map[string]bool,
+	path *field.Path,
+) field.ErrorList {
+	if body == nil || len(body.Raw) == 0 {
+		return nil
+	}
+
+	var data any
+	if err := json.Unmarshal(body.Raw, &data); err != nil {
+		return field.ErrorList{field.Invalid(path, string(body.Raw),
+			fmt.Sprintf("invalid JSON: %v", err))}
+	}
+
+	return walkAndValidateCEL(data, baseEnv, declaredIDs, path)
+}
+
+// walkAndValidateCEL recursively traverses a JSON-decoded structure, finds
+// CEL expressions in string nodes, and validates each against env. Mirrors
+// internal/validation/component.walkAndValidateCEL but operates against the
+// resource-side env and applies the applied.<id> check uniformly.
+func walkAndValidateCEL(
+	data any,
+	env *cel.Env,
+	declaredIDs map[string]bool,
+	path *field.Path,
+) field.ErrorList {
+	var errs field.ErrorList
+	switch v := data.(type) {
+	case string:
+		errs = append(errs, validateCELString(v, env, declaredIDs, path)...)
+	case map[string]any:
+		// Sort keys so error ordering is stable across runs (map iteration is
+		// unordered in Go and bare iteration produces flaky test output).
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if strings.Contains(k, "${") {
+				errs = append(errs, validateCELString(k, env, declaredIDs, path.Key(k))...)
+			}
+			errs = append(errs, walkAndValidateCEL(v[k], env, declaredIDs, path.Key(k))...)
+		}
+	case []any:
+		for i, item := range v {
+			errs = append(errs, walkAndValidateCEL(item, env, declaredIDs, path.Index(i))...)
+		}
+	}
+	return errs
+}
+
+// validateAppliedReferences walks a checked CEL AST and reports any
+// applied.<id> reference whose <id> is not in declaredIDs. Both
+// applied.<ident> (SelectKind) and applied["<lit>"] (CallKind with the index
+// operator) are recognized.
+//
+// fieldValue and pathValue are used only for error wrapping — they describe
+// the source field to the caller.
+func validateAppliedReferences(
+	expr celast.Expr,
+	declaredIDs map[string]bool,
+	path *field.Path,
+	fieldValue string,
+) field.ErrorList {
+	if expr == nil {
+		return nil
+	}
+
+	var undeclared []string
+	seen := make(map[string]bool)
+
+	visitor := celast.NewExprVisitor(func(e celast.Expr) {
+		var id string
+
+		switch e.Kind() {
+		case celast.SelectKind:
+			sel := e.AsSelect()
+			operand := sel.Operand()
+			if operand.Kind() == celast.IdentKind && operand.AsIdent() == "applied" {
+				id = sel.FieldName()
+			}
+		case celast.CallKind:
+			call := e.AsCall()
+			if call.FunctionName() != operators.Index {
+				return
+			}
+			args := call.Args()
+			if len(args) != 2 {
+				return
+			}
+			target := args[0]
+			key := args[1]
+			if target.Kind() != celast.IdentKind || target.AsIdent() != "applied" {
+				return
+			}
+			if key.Kind() != celast.LiteralKind {
+				// applied[someVar] — can't validate at compile time; skip.
+				return
+			}
+			lit, ok := key.AsLiteral().Value().(string)
+			if !ok {
+				return
+			}
+			id = lit
+		default:
+			return
+		}
+
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		if !declaredIDs[id] {
+			undeclared = append(undeclared, id)
+		}
+	})
+	celast.PostOrderVisit(expr, visitor)
+
+	if len(undeclared) == 0 {
+		return nil
+	}
+
+	sort.Strings(undeclared)
+	return field.ErrorList{field.Invalid(path, fieldValue,
+		fmt.Sprintf("applied.<id> references unknown ids %v; declared ids: %v",
+			undeclared, sortedKeys(declaredIDs)))}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func unwrapCEL(s string) (string, bool) {
+	m := celWrapPattern.FindStringSubmatch(s)
+	if m == nil {
+		return "", false
+	}
+	return strings.TrimSpace(m[1]), true
+}

--- a/internal/validation/resource/resourcetype_test.go
+++ b/internal/validation/resource/resourcetype_test.go
@@ -1,0 +1,388 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// rawTemplate marshals a Go map into a runtime.RawExtension for use as a
+// ResourceTypeManifest template. Test fixtures use map literals for
+// readability; this helper handles the marshal-or-fail boilerplate.
+func rawTemplate(t *testing.T, body map[string]any) *runtime.RawExtension {
+	t.Helper()
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	return &runtime.RawExtension{Raw: data}
+}
+
+// schemaSection wraps a JSON-Schema fragment into a SchemaSection ready to
+// drop on a ResourceTypeSpec. Tests build the smallest schema they need.
+func schemaSection(t *testing.T, body map[string]any) *v1alpha1.SchemaSection {
+	t.Helper()
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	return &v1alpha1.SchemaSection{
+		OpenAPIV3Schema: &runtime.RawExtension{Raw: data},
+	}
+}
+
+func TestValidateResourceTypeSpec_NilSpec(t *testing.T) {
+	errs := ValidateResourceTypeSpec(nil, field.NewPath("spec"))
+	assert.Empty(t, errs)
+}
+
+func TestValidateResourceTypeSpec_MinimalValid(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID: "claim",
+				Template: rawTemplate(t, map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": "smoke"},
+				}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "minimal valid spec should have no errors: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_MalformedParametersSchema(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Parameters: &v1alpha1.SchemaSection{
+			OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte("{not json")},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs)
+	assert.True(t, hasErrorAtPath(errs, "spec.parameters"), "expected error at spec.parameters: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_MalformedEnvironmentConfigsSchema(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		EnvironmentConfigs: &v1alpha1.SchemaSection{
+			OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte("{not json")},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs)
+	assert.True(t, hasErrorAtPath(errs, "spec.environmentConfigs"), "expected error at spec.environmentConfigs: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_TemplateValidCEL(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Parameters: schemaSection(t, map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"version": map[string]any{"type": "string"},
+			},
+		}),
+		EnvironmentConfigs: schemaSection(t, map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"replicas": map[string]any{"type": "integer"},
+			},
+		}),
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID: "claim",
+				Template: rawTemplate(t, map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata":   map[string]any{"name": "${metadata.resourceName}"},
+					"spec": map[string]any{
+						"version":  "${parameters.version}",
+						"replicas": "${environmentConfigs.replicas}",
+						"secret":   "${dataplane.secretStore}",
+					},
+				}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "valid template should pass: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_TemplateRejectsApplied(t *testing.T) {
+	// applied.* is only available during outputs / readyWhen, never during
+	// template rendering. The validator must reject any applied reference
+	// in resources[].template.
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID: "claim",
+				Template: rawTemplate(t, map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"data": map[string]any{
+						"host": "${applied.claim.status.host}",
+					},
+				}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "applied.* in template should error")
+	assert.True(t, hasErrorContaining(errs, "applied"), "expected error mentioning applied: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_IncludeWhenBool(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		EnvironmentConfigs: schemaSection(t, map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"tlsEnabled": map[string]any{"type": "boolean"},
+			},
+		}),
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:          "claim",
+				IncludeWhen: "${environmentConfigs.tlsEnabled}",
+				Template:    rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "bool includeWhen should pass: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_IncludeWhenNonBool(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Parameters: schemaSection(t, map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"size": map[string]any{"type": "integer"},
+			},
+		}),
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:          "claim",
+				IncludeWhen: "${parameters.size}",
+				Template:    rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "non-bool includeWhen should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.resources[0].includeWhen"), "expected error at includeWhen path: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_IncludeWhenRejectsApplied(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:          "claim",
+				IncludeWhen: "${applied.claim.status.ready}",
+				Template:    rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "applied.* in includeWhen should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.resources[0].includeWhen"), "expected error at includeWhen path: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_ReadyWhenDeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:        "claim",
+				ReadyWhen: "${applied.claim.status.ready}",
+				Template:  rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "applied.<declaredID> in readyWhen should pass: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_ReadyWhenUndeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:        "claim",
+				ReadyWhen: "${applied.unknown.status.ready}",
+				Template:  rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "applied.<undeclaredID> in readyWhen should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.resources[0].readyWhen"), "expected error at readyWhen path: %v", errs)
+	assert.True(t, hasErrorContaining(errs, "unknown"), "expected error to name the undeclared id: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_ReadyWhenNonBool(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:        "claim",
+				ReadyWhen: `${"not a bool"}`,
+				Template:  rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "non-bool readyWhen should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.resources[0].readyWhen"), "expected error at readyWhen path: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_OutputValueDeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Outputs: []v1alpha1.ResourceTypeOutput{
+			{Name: "host", Value: "${applied.claim.status.host}"},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "output value referencing declared id should pass: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_OutputValueUndeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Outputs: []v1alpha1.ResourceTypeOutput{
+			{Name: "host", Value: "${applied.bogus.status.host}"},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "output value referencing undeclared id should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.outputs[0].value"), "expected error at outputs[0].value: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_OutputSecretKeyRef(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Outputs: []v1alpha1.ResourceTypeOutput{
+			{
+				Name: "password",
+				SecretKeyRef: &v1alpha1.SecretKeyRef{
+					Name: "${metadata.resourceName}-conn",
+					Key:  "password",
+				},
+			},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "output secretKeyRef with valid CEL should pass: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_OutputConfigMapKeyRef(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Outputs: []v1alpha1.ResourceTypeOutput{
+			{
+				Name: "caCert",
+				ConfigMapKeyRef: &v1alpha1.ConfigMapKeyRef{
+					Name: "${metadata.resourceName}-tls",
+					Key:  "ca.crt",
+				},
+			},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, "output configMapKeyRef with valid CEL should pass: %v", errs)
+}
+
+func TestValidateResourceTypeSpec_OutputSecretKeyRefUndeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Outputs: []v1alpha1.ResourceTypeOutput{
+			{
+				Name: "password",
+				SecretKeyRef: &v1alpha1.SecretKeyRef{
+					Name: "${applied.bogus.status.secretName}",
+					Key:  "password",
+				},
+			},
+		},
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{ID: "claim", Template: rawTemplate(t, map[string]any{"kind": "X"})},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "secretKeyRef.name referencing undeclared id should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.outputs[0].secretKeyRef.name"), "expected error at secretKeyRef.name: %v", errs)
+}
+
+func TestValidateClusterResourceTypeSpec_DelegatesToResourceTypeSpec(t *testing.T) {
+	// Spec validation logic is identical for cluster-scoped sibling. Locks
+	// that delegation so a future divergence on the ClusterResourceTypeSpec
+	// shape doesn't silently bypass validation.
+	spec := &v1alpha1.ClusterResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:        "claim",
+				ReadyWhen: "${applied.unknown.status.ready}",
+				Template:  rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateClusterResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, "cluster spec with undeclared id should error")
+	assert.True(t, hasErrorAtPath(errs, "spec.resources[0].readyWhen"), "expected error at readyWhen: %v", errs)
+}
+
+// hasErrorAtPath reports whether any field error in errs has the exact field
+// path.
+func hasErrorAtPath(errs field.ErrorList, path string) bool {
+	for _, e := range errs {
+		if e.Field == path {
+			return true
+		}
+	}
+	return false
+}
+
+// hasErrorContaining reports whether any field error in errs has a Detail
+// that contains the substring.
+func hasErrorContaining(errs field.ErrorList, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Detail, substr) || strings.Contains(e.Error(), substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validation/resource/resourcetype_test.go
+++ b/internal/validation/resource/resourcetype_test.go
@@ -241,7 +241,7 @@ func TestValidateResourceTypeSpec_ReadyWhenUndeclaredID(t *testing.T) {
 }
 
 // Bracket-form applied["<id>"] takes a different AST path (CallKind on the index
-// operator) than the dot form (SelectKind). The validator recognises both — these
+// operator) than the dot form (SelectKind). The validator recognizes both — these
 // two tests lock the bracket-form path.
 
 func TestValidateResourceTypeSpec_ReadyWhenBracketDeclaredID(t *testing.T) {

--- a/internal/validation/resource/resourcetype_test.go
+++ b/internal/validation/resource/resourcetype_test.go
@@ -240,6 +240,42 @@ func TestValidateResourceTypeSpec_ReadyWhenUndeclaredID(t *testing.T) {
 	assert.True(t, hasErrorContaining(errs, "unknown"), "expected error to name the undeclared id: %v", errs)
 }
 
+// Bracket-form applied["<id>"] takes a different AST path (CallKind on the index
+// operator) than the dot form (SelectKind). The validator recognises both — these
+// two tests lock the bracket-form path.
+
+func TestValidateResourceTypeSpec_ReadyWhenBracketDeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:        "claim",
+				ReadyWhen: `${applied["claim"].status.ready}`,
+				Template:  rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	assert.Empty(t, errs, `applied["<declaredID>"] in readyWhen should pass: %v`, errs)
+}
+
+func TestValidateResourceTypeSpec_ReadyWhenBracketUndeclaredID(t *testing.T) {
+	spec := &v1alpha1.ResourceTypeSpec{
+		Resources: []v1alpha1.ResourceTypeManifest{
+			{
+				ID:        "claim",
+				ReadyWhen: `${applied["unknown"].status.ready}`,
+				Template:  rawTemplate(t, map[string]any{"kind": "X"}),
+			},
+		},
+	}
+
+	errs := ValidateResourceTypeSpec(spec, field.NewPath("spec"))
+	require.NotEmpty(t, errs, `applied["<undeclaredID>"] in readyWhen should error`)
+	assert.True(t, hasErrorAtPath(errs, "spec.resources[0].readyWhen"), "expected error at readyWhen path: %v", errs)
+	assert.True(t, hasErrorContaining(errs, "unknown"), "expected error to name the undeclared id: %v", errs)
+}
+
 func TestValidateResourceTypeSpec_ReadyWhenNonBool(t *testing.T) {
 	spec := &v1alpha1.ResourceTypeSpec{
 		Resources: []v1alpha1.ResourceTypeManifest{

--- a/internal/webhook/clusterresourcetype/suite_test.go
+++ b/internal/webhook/clusterresourcetype/suite_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClusterResourceType Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	// Skip envtest setup when binaries are not available and no envtest asset
+	// environment variables are set; unit tests calling webhook functions
+	// directly will still run.
+	binaryAssetsDir := getFirstFoundEnvTestBinaryDir()
+	if binaryAssetsDir == "" &&
+		os.Getenv("KUBEBUILDER_ASSETS") == "" &&
+		os.Getenv("TEST_ASSET_KUBE_APISERVER") == "" &&
+		os.Getenv("TEST_ASSET_ETCD") == "" &&
+		os.Getenv("TEST_ASSET_KUBECTL") == "" {
+		return
+	}
+
+	var err error
+	err = openchoreodevv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	if binaryAssetsDir != "" {
+		testEnv.BinaryAssetsDirectory = binaryAssetsDir
+	}
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupClusterResourceTypeWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		//nolint:gosec // G402: Using self-signed cert in test environment
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	if testEnv == nil {
+		return
+	}
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/internal/webhook/clusterresourcetype/webhook.go
+++ b/internal/webhook/clusterresourcetype/webhook.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	resourcevalidation "github.com/openchoreo/openchoreo/internal/validation/resource"
+)
+
+//nolint:unused // exported via webhook bootstrap; keeps parity with sibling webhooks
+var clusterresourcetypelog = logf.Log.WithName("clusterresourcetype-resource")
+
+// SetupClusterResourceTypeWebhookWithManager registers the validating webhook
+// for ClusterResourceType in the manager.
+func SetupClusterResourceTypeWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&openchoreodevv1alpha1.ClusterResourceType{}).
+		WithValidator(&Validator{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-openchoreo-dev-v1alpha1-clusterresourcetype,mutating=false,failurePolicy=fail,sideEffects=None,groups=openchoreo.dev,resources=clusterresourcetypes,verbs=create;update,versions=v1alpha1,name=vclusterresourcetype-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// Validator validates ClusterResourceType resources.
+// +kubebuilder:object:generate=false
+type Validator struct{}
+
+var _ webhook.CustomValidator = &Validator{}
+
+// ValidateCreate runs the cluster-scoped resource-type spec validator.
+func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	crt, ok := obj.(*openchoreodevv1alpha1.ClusterResourceType)
+	if !ok {
+		return nil, fmt.Errorf("expected a ClusterResourceType object but got %T", obj)
+	}
+	clusterresourcetypelog.Info("Validation for ClusterResourceType upon creation", "name", crt.GetName())
+
+	if errs := resourcevalidation.ValidateClusterResourceTypeSpec(&crt.Spec, field.NewPath("spec")); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}
+
+// ValidateUpdate re-runs the validator on the new object. Spec immutability
+// for individual fields is enforced by CRD CEL markers; the rest of the spec
+// is re-validated to catch CEL drift introduced by an update.
+func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if _, ok := oldObj.(*openchoreodevv1alpha1.ClusterResourceType); !ok {
+		return nil, fmt.Errorf("expected a ClusterResourceType object for the oldObj but got %T", oldObj)
+	}
+	crt, ok := newObj.(*openchoreodevv1alpha1.ClusterResourceType)
+	if !ok {
+		return nil, fmt.Errorf("expected a ClusterResourceType object for the newObj but got %T", newObj)
+	}
+	clusterresourcetypelog.Info("Validation for ClusterResourceType upon update", "name", crt.GetName())
+
+	if errs := resourcevalidation.ValidateClusterResourceTypeSpec(&crt.Spec, field.NewPath("spec")); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}
+
+// ValidateDelete is a no-op. ClusterResourceType deletion is gated by RBAC
+// and the runtime impact is bounded by the existing finalizer logic on
+// consumers.
+func (v *Validator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	crt, ok := obj.(*openchoreodevv1alpha1.ClusterResourceType)
+	if !ok {
+		return nil, fmt.Errorf("expected a ClusterResourceType object but got %T", obj)
+	}
+	clusterresourcetypelog.Info("Validation for ClusterResourceType upon deletion", "name", crt.GetName())
+	return nil, nil
+}

--- a/internal/webhook/clusterresourcetype/webhook_test.go
+++ b/internal/webhook/clusterresourcetype/webhook_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// validTemplate returns a minimal RawExtension for a ConfigMap manifest.
+// The validator's contract is exhaustively covered in
+// internal/validation/resource/resourcetype_test.go; the webhook tests
+// only verify dispatch through ValidateCreate/Update/Delete.
+func validTemplate() *runtime.RawExtension {
+	return &runtime.RawExtension{
+		Raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"smoke"}}`),
+	}
+}
+
+var _ = Describe("ClusterResourceType Webhook", func() {
+	var (
+		ctx       context.Context
+		obj       *openchoreodevv1alpha1.ClusterResourceType
+		oldObj    *openchoreodevv1alpha1.ClusterResourceType
+		validator Validator
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		obj = &openchoreodevv1alpha1.ClusterResourceType{}
+		oldObj = &openchoreodevv1alpha1.ClusterResourceType{}
+		validator = Validator{}
+	})
+
+	Context("ValidateCreate", func() {
+		It("admits a minimal valid spec", func() {
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects readyWhen referencing an undeclared id", func() {
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID:        "claim",
+					ReadyWhen: "${applied.bogus.status.ready}",
+					Template:  validTemplate(),
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("readyWhen"))
+		})
+
+		It("rejects template referencing applied.*", func() {
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID: "claim",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"kind":"X","data":{"host":"${applied.claim.status.host}"}}`),
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("applied"))
+		})
+
+		It("returns an error for non-ClusterResourceType objects", func() {
+			_, err := validator.ValidateCreate(ctx, &openchoreodevv1alpha1.ResourceType{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a ClusterResourceType"))
+		})
+	})
+
+	Context("ValidateUpdate", func() {
+		It("admits a valid update", func() {
+			oldObj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects an update that introduces an undeclared applied id in readyWhen", func() {
+			oldObj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID:        "claim",
+					ReadyWhen: "${applied.bogus.status.ready}",
+					Template:  validTemplate(),
+				},
+			}
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error for a non-ClusterResourceType new object", func() {
+			_, err := validator.ValidateUpdate(ctx, oldObj, &openchoreodevv1alpha1.ResourceType{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ValidateDelete", func() {
+		It("is a no-op", func() {
+			_, err := validator.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error for non-ClusterResourceType objects", func() {
+			_, err := validator.ValidateDelete(ctx, &openchoreodevv1alpha1.ResourceType{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/resourcerelease/suite_test.go
+++ b/internal/webhook/resourcerelease/suite_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ResourceRelease Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	binaryAssetsDir := getFirstFoundEnvTestBinaryDir()
+	if binaryAssetsDir == "" &&
+		os.Getenv("KUBEBUILDER_ASSETS") == "" &&
+		os.Getenv("TEST_ASSET_KUBE_APISERVER") == "" &&
+		os.Getenv("TEST_ASSET_ETCD") == "" &&
+		os.Getenv("TEST_ASSET_KUBECTL") == "" {
+		return
+	}
+
+	var err error
+	err = openchoreodevv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	if binaryAssetsDir != "" {
+		testEnv.BinaryAssetsDirectory = binaryAssetsDir
+	}
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupResourceReleaseWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		//nolint:gosec // G402: Using self-signed cert in test environment
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	if testEnv == nil {
+		return
+	}
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/internal/webhook/resourcerelease/webhook.go
+++ b/internal/webhook/resourcerelease/webhook.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/schema"
+	resourcevalidation "github.com/openchoreo/openchoreo/internal/validation/resource"
+)
+
+//nolint:unused // exported via webhook bootstrap; keeps parity with sibling webhooks
+var resourcereleaselog = logf.Log.WithName("resourcerelease-resource")
+
+// omitValue suppresses raw values in field.Invalid errors when the value
+// itself isn't useful to the operator reading the error.
+var omitValue = field.OmitValueType{}
+
+// SetupResourceReleaseWebhookWithManager registers the validating webhook for
+// ResourceRelease in the manager.
+func SetupResourceReleaseWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&openchoreodevv1alpha1.ResourceRelease{}).
+		WithValidator(&Validator{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-openchoreo-dev-v1alpha1-resourcerelease,mutating=false,failurePolicy=fail,sideEffects=None,groups=openchoreo.dev,resources=resourcereleases,verbs=create;update,versions=v1alpha1,name=vresourcerelease-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// Validator validates ResourceRelease resources.
+// +kubebuilder:object:generate=false
+type Validator struct{}
+
+var _ webhook.CustomValidator = &Validator{}
+
+// ValidateCreate runs the on-snapshot checks: parameters against the embedded
+// (Cluster)ResourceType.Spec.Parameters schema, and a re-validation of the
+// embedded ResourceType.Spec for schema drift since the release was cut.
+func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rr, ok := obj.(*openchoreodevv1alpha1.ResourceRelease)
+	if !ok {
+		return nil, fmt.Errorf("expected a ResourceRelease object but got %T", obj)
+	}
+	resourcereleaselog.Info("Validation for ResourceRelease upon creation", "name", rr.GetName())
+
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validateParametersAgainstSnapshot(rr)...)
+	allErrs = append(allErrs, validateEmbeddedResourceType(rr)...)
+
+	if len(allErrs) > 0 {
+		return nil, allErrs.ToAggregate()
+	}
+	return nil, nil
+}
+
+// ValidateUpdate is a no-op. ResourceRelease.spec is immutable via a
+// spec-level CEL XValidation marker (api/v1alpha1/resourcerelease_types.go:16);
+// any update either matches the existing spec or is rejected at the CRD layer
+// before reaching this webhook.
+func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if _, ok := oldObj.(*openchoreodevv1alpha1.ResourceRelease); !ok {
+		return nil, fmt.Errorf("expected a ResourceRelease object for the oldObj but got %T", oldObj)
+	}
+	if _, ok := newObj.(*openchoreodevv1alpha1.ResourceRelease); !ok {
+		return nil, fmt.Errorf("expected a ResourceRelease object for the newObj but got %T", newObj)
+	}
+	return nil, nil
+}
+
+// ValidateDelete is a no-op. ResourceRelease deletion is driven by the
+// owning Resource's finalizer.
+func (v *Validator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rr, ok := obj.(*openchoreodevv1alpha1.ResourceRelease)
+	if !ok {
+		return nil, fmt.Errorf("expected a ResourceRelease object but got %T", obj)
+	}
+	resourcereleaselog.Info("Validation for ResourceRelease upon deletion", "name", rr.GetName())
+	return nil, nil
+}
+
+// validateParametersAgainstSnapshot validates spec.parameters against the
+// embedded snapshot's parameters.openAPIV3Schema. Mirrors
+// internal/webhook/componentrelease/webhook.go::validateParamsAgainstSchema —
+// the snapshot lives on the same object, so no cross-CRD lookup is needed.
+func validateParametersAgainstSnapshot(rr *openchoreodevv1alpha1.ResourceRelease) field.ErrorList {
+	section := rr.Spec.ResourceType.Spec.Parameters
+	if section == nil {
+		return nil
+	}
+
+	rawSchema := section.GetRaw()
+	if rawSchema == nil || len(rawSchema.Raw) == 0 {
+		return nil
+	}
+
+	fieldPath := field.NewPath("spec", "parameters")
+
+	jsonSchema, err := schema.SectionToJSONSchema(section)
+	if err != nil {
+		return field.ErrorList{field.Invalid(fieldPath, omitValue,
+			fmt.Sprintf("ResourceType snapshot has invalid parameters schema: %v", err))}
+	}
+
+	var params map[string]any
+	if rr.Spec.Parameters != nil && len(rr.Spec.Parameters.Raw) > 0 {
+		if err := json.Unmarshal(rr.Spec.Parameters.Raw, &params); err != nil {
+			return field.ErrorList{field.Invalid(fieldPath, omitValue,
+				fmt.Sprintf("failed to parse parameters: %v", err))}
+		}
+	} else {
+		params = map[string]any{}
+	}
+
+	if err := schema.ValidateWithJSONSchema(params, jsonSchema); err != nil {
+		return field.ErrorList{field.Invalid(fieldPath, omitValue,
+			fmt.Sprintf("parameters do not match ResourceType schema: %v", err))}
+	}
+	return nil
+}
+
+// validateEmbeddedResourceType re-runs the resource-type spec validator
+// against the embedded snapshot. Defends against schema drift between when
+// the release was cut and admission today: a webhook upgrade can tighten CEL
+// rules that previously admitted a permissive ResourceType, and we want
+// those releases to be rejected at admission rather than silently rendering
+// failed at runtime. Mirrors componentrelease.validateEmbeddedResourceTemplates.
+func validateEmbeddedResourceType(rr *openchoreodevv1alpha1.ResourceRelease) field.ErrorList {
+	specPath := field.NewPath("spec", "resourceType", "spec")
+	return resourcevalidation.ValidateResourceTypeSpec(&rr.Spec.ResourceType.Spec, specPath)
+}

--- a/internal/webhook/resourcerelease/webhook_test.go
+++ b/internal/webhook/resourcerelease/webhook_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+func mustRaw(v any) *runtime.RawExtension {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return &runtime.RawExtension{Raw: data}
+}
+
+func validTemplate() *runtime.RawExtension {
+	return mustRaw(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "smoke"},
+	})
+}
+
+// validReleaseFixture builds a minimal ResourceRelease with a single-resource
+// snapshot. Tests mutate the returned object before calling the validator.
+func validReleaseFixture() *openchoreodevv1alpha1.ResourceRelease {
+	return &openchoreodevv1alpha1.ResourceRelease{
+		Spec: openchoreodevv1alpha1.ResourceReleaseSpec{
+			Owner: openchoreodevv1alpha1.ResourceReleaseOwner{
+				ProjectName:  "demo",
+				ResourceName: "mysql",
+			},
+			ResourceType: openchoreodevv1alpha1.ResourceReleaseResourceType{
+				Kind: openchoreodevv1alpha1.ResourceTypeRefKindResourceType,
+				Name: "mysql",
+				Spec: openchoreodevv1alpha1.ResourceTypeSpec{
+					Resources: []openchoreodevv1alpha1.ResourceTypeManifest{
+						{ID: "claim", Template: validTemplate()},
+					},
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("ResourceRelease Webhook", func() {
+	var (
+		ctx       context.Context
+		validator Validator
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		validator = Validator{}
+	})
+
+	Context("ValidateCreate", func() {
+		It("admits a release with no parameter schema and no parameters", func() {
+			rr := validReleaseFixture()
+			_, err := validator.ValidateCreate(ctx, rr)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("admits a release whose parameters satisfy the snapshot schema", func() {
+			rr := validReleaseFixture()
+			rr.Spec.ResourceType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
+				OpenAPIV3Schema: mustRaw(map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"version": map[string]any{"type": "string"},
+					},
+					"required": []string{"version"},
+				}),
+			}
+			rr.Spec.Parameters = mustRaw(map[string]any{"version": "8.0"})
+
+			_, err := validator.ValidateCreate(ctx, rr)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects a release whose parameters violate the snapshot schema", func() {
+			rr := validReleaseFixture()
+			rr.Spec.ResourceType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
+				OpenAPIV3Schema: mustRaw(map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"version": map[string]any{"type": "string"},
+					},
+					"required": []string{"version"},
+				}),
+			}
+			rr.Spec.Parameters = mustRaw(map[string]any{}) // missing required field
+
+			_, err := validator.ValidateCreate(ctx, rr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parameters"))
+		})
+
+		It("rejects a release with a malformed snapshot parameter schema", func() {
+			rr := validReleaseFixture()
+			rr.Spec.ResourceType.Spec.Parameters = &openchoreodevv1alpha1.SchemaSection{
+				OpenAPIV3Schema: &runtime.RawExtension{Raw: []byte(`{not json`)},
+			}
+
+			_, err := validator.ValidateCreate(ctx, rr)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("rejects a release whose embedded ResourceType template references applied.*", func() {
+			// Schema-drift defense: the snapshot was cut against a previous
+			// ResourceType, but the live ResourceType has since broken its CEL
+			// surface. Re-validating the embedded snapshot at admission time
+			// catches the regression instead of letting it surface only at
+			// runtime via Synced=False, Reason=RenderingFailed.
+			rr := validReleaseFixture()
+			rr.Spec.ResourceType.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID: "claim",
+					Template: mustRaw(map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"data":       map[string]any{"host": "${applied.claim.status.host}"},
+					}),
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, rr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("applied"))
+		})
+
+		It("rejects a release whose embedded ResourceType has an undeclared applied id in readyWhen", func() {
+			rr := validReleaseFixture()
+			rr.Spec.ResourceType.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID:        "claim",
+					ReadyWhen: "${applied.bogus.status.ready}",
+					Template:  validTemplate(),
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, rr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("readyWhen"))
+		})
+
+		It("returns an error for non-ResourceRelease objects", func() {
+			_, err := validator.ValidateCreate(ctx, &openchoreodevv1alpha1.ResourceType{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a ResourceRelease"))
+		})
+	})
+
+	Context("ValidateUpdate", func() {
+		It("is a no-op since spec immutability is CRD-enforced", func() {
+			old := validReleaseFixture()
+			rr := validReleaseFixture()
+			_, err := validator.ValidateUpdate(ctx, old, rr)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error when the new object is not a ResourceRelease", func() {
+			old := validReleaseFixture()
+			_, err := validator.ValidateUpdate(ctx, old, &openchoreodevv1alpha1.ResourceType{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error when the old object is not a ResourceRelease", func() {
+			rr := validReleaseFixture()
+			_, err := validator.ValidateUpdate(ctx, &openchoreodevv1alpha1.ResourceType{}, rr)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ValidateDelete", func() {
+		It("is a no-op", func() {
+			rr := validReleaseFixture()
+			_, err := validator.ValidateDelete(ctx, rr)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error for non-ResourceRelease objects", func() {
+			_, err := validator.ValidateDelete(ctx, &openchoreodevv1alpha1.ResourceType{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/resourcetype/suite_test.go
+++ b/internal/webhook/resourcetype/suite_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ResourceType Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	// Skip envtest setup when binaries are not available and no envtest asset
+	// environment variables are set; unit tests calling webhook functions
+	// directly will still run.
+	binaryAssetsDir := getFirstFoundEnvTestBinaryDir()
+	if binaryAssetsDir == "" &&
+		os.Getenv("KUBEBUILDER_ASSETS") == "" &&
+		os.Getenv("TEST_ASSET_KUBE_APISERVER") == "" &&
+		os.Getenv("TEST_ASSET_ETCD") == "" &&
+		os.Getenv("TEST_ASSET_KUBECTL") == "" {
+		return
+	}
+
+	var err error
+	err = openchoreodevv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	if binaryAssetsDir != "" {
+		testEnv.BinaryAssetsDirectory = binaryAssetsDir
+	}
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupResourceTypeWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		//nolint:gosec // G402: Using self-signed cert in test environment
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	if testEnv == nil {
+		return
+	}
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/internal/webhook/resourcetype/webhook.go
+++ b/internal/webhook/resourcetype/webhook.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	resourcevalidation "github.com/openchoreo/openchoreo/internal/validation/resource"
+)
+
+// log is for logging in this package.
+//
+//nolint:unused // exported via webhook bootstrap; keeps parity with sibling webhooks
+var resourcetypelog = logf.Log.WithName("resourcetype-resource")
+
+// SetupResourceTypeWebhookWithManager registers the validating webhook for
+// ResourceType in the manager.
+func SetupResourceTypeWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&openchoreodevv1alpha1.ResourceType{}).
+		WithValidator(&Validator{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-openchoreo-dev-v1alpha1-resourcetype,mutating=false,failurePolicy=fail,sideEffects=None,groups=openchoreo.dev,resources=resourcetypes,verbs=create;update,versions=v1alpha1,name=vresourcetype-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// Validator validates ResourceType resources.
+// +kubebuilder:object:generate=false
+type Validator struct{}
+
+var _ webhook.CustomValidator = &Validator{}
+
+// ValidateCreate runs the resource-type spec validator on creation.
+func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rt, ok := obj.(*openchoreodevv1alpha1.ResourceType)
+	if !ok {
+		return nil, fmt.Errorf("expected a ResourceType object but got %T", obj)
+	}
+	resourcetypelog.Info("Validation for ResourceType upon creation", "name", rt.GetName())
+
+	if errs := resourcevalidation.ValidateResourceTypeSpec(&rt.Spec, field.NewPath("spec")); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}
+
+// ValidateUpdate re-runs the validator on the new object. Spec immutability
+// for individual fields is enforced by CRD CEL markers; the rest of the spec
+// is re-validated to catch CEL drift introduced by an update.
+func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if _, ok := oldObj.(*openchoreodevv1alpha1.ResourceType); !ok {
+		return nil, fmt.Errorf("expected a ResourceType object for the oldObj but got %T", oldObj)
+	}
+	rt, ok := newObj.(*openchoreodevv1alpha1.ResourceType)
+	if !ok {
+		return nil, fmt.Errorf("expected a ResourceType object for the newObj but got %T", newObj)
+	}
+	resourcetypelog.Info("Validation for ResourceType upon update", "name", rt.GetName())
+
+	if errs := resourcevalidation.ValidateResourceTypeSpec(&rt.Spec, field.NewPath("spec")); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}
+
+// ValidateDelete is a no-op. ResourceType deletion is gated by RBAC and the
+// runtime impact is bounded by the existing finalizer logic on consumers.
+func (v *Validator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rt, ok := obj.(*openchoreodevv1alpha1.ResourceType)
+	if !ok {
+		return nil, fmt.Errorf("expected a ResourceType object but got %T", obj)
+	}
+	resourcetypelog.Info("Validation for ResourceType upon deletion", "name", rt.GetName())
+	return nil, nil
+}

--- a/internal/webhook/resourcetype/webhook_test.go
+++ b/internal/webhook/resourcetype/webhook_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// validTemplate returns a minimal RawExtension for a ConfigMap manifest.
+// The resourcetype validator's contract is exhaustively covered in
+// internal/validation/resource/resourcetype_test.go; the webhook tests
+// only verify dispatch through ValidateCreate/Update/Delete.
+func validTemplate() *runtime.RawExtension {
+	return &runtime.RawExtension{
+		Raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"smoke"}}`),
+	}
+}
+
+var _ = Describe("ResourceType Webhook", func() {
+	var (
+		ctx       context.Context
+		obj       *openchoreodevv1alpha1.ResourceType
+		oldObj    *openchoreodevv1alpha1.ResourceType
+		validator Validator
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		obj = &openchoreodevv1alpha1.ResourceType{}
+		oldObj = &openchoreodevv1alpha1.ResourceType{}
+		validator = Validator{}
+	})
+
+	Context("ValidateCreate", func() {
+		It("admits a minimal valid spec", func() {
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects readyWhen referencing an undeclared id", func() {
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID:        "claim",
+					ReadyWhen: "${applied.bogus.status.ready}",
+					Template:  validTemplate(),
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("readyWhen"))
+		})
+
+		It("rejects template referencing applied.*", func() {
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID: "claim",
+					Template: &runtime.RawExtension{
+						Raw: []byte(`{"kind":"X","data":{"host":"${applied.claim.status.host}"}}`),
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("applied"))
+		})
+
+		It("returns an error for non-ResourceType objects", func() {
+			_, err := validator.ValidateCreate(ctx, &openchoreodevv1alpha1.ClusterResourceType{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a ResourceType"))
+		})
+	})
+
+	Context("ValidateUpdate", func() {
+		It("admits a valid update", func() {
+			oldObj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects an update that introduces an undeclared applied id in readyWhen", func() {
+			oldObj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{ID: "claim", Template: validTemplate()},
+			}
+			obj.Spec.Resources = []openchoreodevv1alpha1.ResourceTypeManifest{
+				{
+					ID:        "claim",
+					ReadyWhen: "${applied.bogus.status.ready}",
+					Template:  validTemplate(),
+				},
+			}
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error for a non-ResourceType new object", func() {
+			_, err := validator.ValidateUpdate(ctx, oldObj, &openchoreodevv1alpha1.ClusterResourceType{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ValidateDelete", func() {
+		It("is a no-op", func() {
+			_, err := validator.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error for non-ResourceType objects", func() {
+			_, err := validator.ValidateDelete(ctx, &openchoreodevv1alpha1.ClusterResourceType{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Purpose

Add the validating admission webhook layer for the resource abstraction CRDs introduced in #3392. Catches schema-aware CEL violations and parameter-against-snapshot mismatches at admission time, before they surface as controller status failures.

## Approach

**Validator**
- Schema-aware CEL env over the runtime template surface (`metadata`, `parameters`, `environmentConfigs`, `dataplane`). `applied` is registered as `map<string, AppliedEntry>` via a base-extension helper so output and `readyWhen` paths see `applied.<id>.status.x` without polluting the template path.
- Shared `ValidateResourceTypeSpec` walks templates / `includeWhen` / `readyWhen` / outputs with an AST visitor that recognises both `applied.<id>` (SelectKind) and `applied["<id>"]` (CallKind on index). Undeclared ids surface a clean validation error with a sorted list of unknown vs declared ids.

**Webhooks**
- `ResourceType` and `ClusterResourceType` — thin wrappers calling the shared validator (mirrors the componenttype family).
- `ResourceRelease` — validates `spec.parameters` against the snapshot schema, and re-runs the type-spec validator on the embedded snapshot for drift defense. Snapshot lives on the same object, so no cross-CRD admission lookup.

**Wiring**
- Webhook registrations collapsed into a single `ENABLE_WEBHOOKS` guard plus a `{name, setup}` slice loop.
- Webhook manifests regenerated for both the core config and the helm-shipped template.

## Related Issues

Closes #3427
Related #3107

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)