### PR TITLE
feat: install tracing module in quickstart and bump metrics to 0.5.1

### DIFF
--- a/install/k3d/k3d-observability-plane.sh
+++ b/install/k3d/k3d-observability-plane.sh
@@ -15,7 +15,7 @@ OPENCHOREO_REF="${OPENCHOREO_REF:-main}"           # overridable via env; defaul
 OPENCHOREO_OP_VERSION="${OPENCHOREO_OP_VERSION:-0.0.0-latest-dev}"  # overridable via env
 LOGS_OPENSEARCH_VERSION="0.4.0"
 TRACES_OPENSEARCH_VERSION="0.4.1"
-METRICS_PROMETHEUS_VERSION="0.4.2"
+METRICS_PROMETHEUS_VERSION="0.5.1"
 
 # -- derived constants --
 RAW_BASE="https://raw.githubusercontent.com/openchoreo/openchoreo/${OPENCHOREO_REF}"

--- a/install/quick-start/.config.sh
+++ b/install/quick-start/.config.sh
@@ -30,3 +30,8 @@ KGATEWAY_VERSION="v2.2.1"
 
 # Thunder configuration
 THUNDER_VERSION="0.28.0"
+
+# Observability module versions (community-modules)
+LOGS_OPENSEARCH_VERSION="0.4.0"
+TRACES_OPENSEARCH_VERSION="0.4.1"
+METRICS_PROMETHEUS_VERSION="0.5.1"

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -1088,19 +1088,24 @@ install_observability_plane() {
     log_info "Installing observability modules..."
 
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.4.0" \
+        "--version" "$LOGS_OPENSEARCH_VERSION" \
         "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials" \
         "--set" "adapter.openSearchSecretName=opensearch-admin-credentials"
+
+    install_helm_chart "observability-traces-opensearch" "$modules_repo/observability-tracing-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
+        "--version" "$TRACES_OPENSEARCH_VERSION" \
+        "--set" "openSearch.enabled=false" \
+        "--set" "openSearchSetup.openSearchSecretName=opensearch-admin-credentials"
+
+    install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
+        "--version" "$METRICS_PROMETHEUS_VERSION"
 
     # Enable fluent-bit after opensearch is installed and ready
     log_info "Enabling fluent-bit for log collection..."
     install_helm_chart "observability-logs-opensearch" "$modules_repo/observability-logs-opensearch" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.4.0" \
+        "--version" "$LOGS_OPENSEARCH_VERSION" \
         "--reuse-values" \
         "--set" "fluent-bit.enabled=true"
-
-    install_helm_chart "observability-metrics-prometheus" "$modules_repo/observability-metrics-prometheus" "$OBSERVABILITY_NS" "true" "true" "true" "600" \
-        "--version" "0.4.2"
 }
 
 # Apply ClusterWorkflowTemplates required by the workflow plane


### PR DESCRIPTION
## Summary

- Add `observability-tracing-opensearch` 0.4.1 to the quickstart's `install_observability_plane` helper. Previously only the logs (opensearch) and metrics (prometheus) modules were installed, so the quickstart was the odd one out vs. `install/k3d/k3d-observability-plane.sh` and the on-k3d-locally guide, which both ship tracing.
- Bump `observability-metrics-prometheus` 0.4.2 → 0.5.1 in both `install/quick-start/.helpers.sh` and `install/k3d/k3d-observability-plane.sh` to match the latest published chart in `openchoreo/community-modules`.
- Reorder the helper so all three modules install before the `fluent-bit.enabled=true` upgrade, matching the order in `k3d-observability-plane.sh`.

The `openchoreo.github.io` docs already pin metrics at 0.5.1 on `main`, so no docs change is needed.

## Test plan

- [ ] Build the quickstart image locally and run `./install.sh --version <tag> --with-observability` end-to-end.
- [ ] Verify all three modules (`observability-logs-opensearch`, `observability-traces-opensearch`, `observability-metrics-prometheus`) are healthy via `helm list -n openchoreo-observability-plane`.
- [ ] Confirm Fluent Bit comes up after the second logs upgrade.
- [ ] Sanity-check that the in-cluster trace pipeline lands data in OpenSearch.