### PR TITLE
refactor: update finops agent configs and add role and rolebinding

### DIFF
--- a/finops-agent/src/auth/authz_client.py
+++ b/finops-agent/src/auth/authz_client.py
@@ -43,7 +43,7 @@ class AuthzClient:
         if auth_token:
             headers["Authorization"] = f"Bearer {auth_token}"
 
-        body = [request.model_dump(by_alias=True)]
+        body = [request.model_dump()]
 
         logger.debug("Authz request", extra={"url": url})
 

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1071,6 +1071,17 @@ openchoreoApi:
                 - "clustertrait:view"
                 - "clusterworkflow:view"
 
+            # FinOps agent role for cost analysis and resource overprovisioning assessment
+            - name: finops-agent
+              system: true
+              actions:
+                - "component:view"
+                - "project:view"
+                - "namespace:view"
+                - "environment:view"
+                - "metrics:view"
+                - "alerts:view"
+
             # Root Cause Analysis (RCA) agent role for troubleshooting and debugging
             - name: rca-agent
               system: true
@@ -1462,6 +1473,19 @@ openchoreoApi:
               entitlement:
                 claim: sub
                 value: openchoreo-backstage-client
+              effect: allow
+
+            # FinOps agent mapping - grants FinOps service account cost analysis access
+            - name: finops-agent-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: finops-agent
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-finops-agent
               effect: allow
 
             # RCA agent mapping - grants RCA service account troubleshooting access

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -47,3 +47,5 @@ data:
   TRACING_ADAPTER_ENABLED: {{ .Values.observer.tracingAdapter.enabled | quote }}
   TRACING_ADAPTER_URL: {{ .Values.observer.tracingAdapter.url | default "http://tracing-adapter:9100" | quote }}
   TRACING_ADAPTER_TIMEOUT: {{ .Values.observer.tracingAdapter.timeout | default "30s" | quote }}
+  FINOPS_AGENT_ENABLED: {{ .Values.finOpsAgent.enabled | default false | quote }}
+  FINOPS_AGENT_URL: "http://finops-agent:{{ .Values.finOpsAgent.service.port | default 8080 }}"

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -996,7 +996,7 @@
           "type": "string"
         },
         "openchoreoApiUrl": {
-          "default": "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080",
+          "default": "http://api.openchoreo.localhost:8080",
           "description": "OpenChoreo API URL for authorization service",
           "title": "openchoreoApiUrl",
           "type": "string"

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1765,9 +1765,9 @@ finOpsAgent:
   # @schema
   # type: string
   # description: OpenChoreo API URL for authorization service
-  # default: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
+  # default: "http://api.openchoreo.localhost:8080"
   # @schema
-  openchoreoApiUrl: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
+  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
 
   # @schema
   # type: object

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -1,5 +1,10 @@
 # Helm values for OpenChoreo Observability Plane in k3d single-cluster setup
 
+finOpsAgent:
+  http:
+    hostnames:
+    - finops-agent.openchoreo.localhost
+
 # Observer API - REST API for querying logs and metrics
 observer:
   openSearchSecretName: opensearch-admin-credentials

--- a/internal/observer/service/alerts.go
+++ b/internal/observer/service/alerts.go
@@ -661,6 +661,9 @@ func (s *AlertService) triggerFinOpsAnalysis(alertID string, alertDetails *legac
 		return
 	}
 
+	if s.logger.Enabled(context.Background(), slog.LevelDebug) {
+		fmt.Println(string(payloadBytes))
+	}
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	resp, err := httpClient.Post(s.finOpsAgentURL+"/api/v1alpha1/analyses", "application/json", bytes.NewReader(payloadBytes))
 	if err != nil {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The FinOps agent lacked the necessary RBAC role, role binding, and configuration wiring to function within the Choreo control/observability planes. Additionally, the authz client was serializing request fields using aliases instead of their original names, which could cause authorization failures.

## Approach
- Added a finops-agent ClusterAuthzRole with read-only permissions and a corresponding ClusterAuthzRoleBinding mapping it to the openchoreo-finops-agent service account
- Wired FINOPS_AGENT_ENABLED and FINOPS_AGENT_URL into the observer ConfigMap
- Added finOpsAgent hostname config to the k3d single-cluster overlay.
- Updated the observability plane values.yaml to use the local API URL instead of the in-cluster service URL.
- Fixed authz_client.py to use model_dump() instead of model_dump(by_alias=True) (aliases).

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3374

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
