### PR TITLE
fix: return empty result when OpenObserve stream not yet created

### DIFF
--- a/internal/observer/service/tracing_adapter.go
+++ b/internal/observer/service/tracing_adapter.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -12,6 +13,28 @@ import (
 	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
 	"github.com/openchoreo/openchoreo/pkg/observability"
 )
+
+// openObserveStreamNotFoundCode is the error code OpenObserve returns when a
+// queried stream has never been written to (typical when no telemetry has been
+// ingested yet). Surfaces as HTTP 400 with body
+// {"code":20002,"message":"Search stream not found: ..."}.
+const openObserveStreamNotFoundCode = 20002
+
+type openObserveError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// isStreamNotFound reports whether the OpenObserve response body indicates
+// that the queried stream does not exist yet, which should surface as an
+// empty result set rather than an internal server error. Issue #3435.
+func isStreamNotFound(body []byte) bool {
+	var e openObserveError
+	if err := json.Unmarshal(body, &e); err != nil {
+		return false
+	}
+	return e.Code == openObserveStreamNotFoundCode
+}
 
 type TracingAdapter struct {
 	client *gen.ClientWithResponses
@@ -72,6 +95,9 @@ func (t *TracingAdapter) GetTraces(ctx context.Context, params observability.Tra
 	}
 
 	if resp.StatusCode() != http.StatusOK {
+		if isStreamNotFound(resp.Body) {
+			return &observability.TracesQueryResult{}, nil
+		}
 		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode(), string(resp.Body))
 	}
 

--- a/internal/observer/service/tracing_adapter_test.go
+++ b/internal/observer/service/tracing_adapter_test.go
@@ -182,3 +182,45 @@ func TestConvertSpansAdapterResponse_NilAttributes(t *testing.T) {
 		t.Errorf("Expected ResourceAttributes to be nil, got %v", span.ResourceAttributes)
 	}
 }
+
+func TestIsStreamNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{
+			name: "openobserve stream not found",
+			body: []byte(`{"code":20002,"message":"Search stream not found: default"}`),
+			want: true,
+		},
+		{
+			name: "openobserve other error code",
+			body: []byte(`{"code":12345,"message":"some other error"}`),
+			want: false,
+		},
+		{
+			name: "empty body",
+			body: []byte(``),
+			want: false,
+		},
+		{
+			name: "non-json body",
+			body: []byte(`Internal Server Error`),
+			want: false,
+		},
+		{
+			name: "json without code field",
+			body: []byte(`{"message":"some error"}`),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStreamNotFound(tt.body); got != tt.want {
+				t.Errorf("isStreamNotFound(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

Fixes the 500-on-empty-trace-data behavior reported in #3435. When a component has never emitted spans, OpenObserve returns HTTP 400 with body `{"code":20002,"message":"Search stream not found: default"}` because the search stream is created lazily on first write. The tracing adapter currently treats any non-200 as a hard failure and surfaces it as `ErrTracesRetrieval` → HTTP 500 with `OBS-V1-T-05`. "No data yet" is not a server error; the API should return an empty result set.

## Approach

In `internal/observer/service/tracing_adapter.go`:

- Add a small helper `isStreamNotFound(body []byte) bool` that parses the OpenObserve error envelope and returns true when `code == 20002`. The constant `openObserveStreamNotFoundCode = 20002` is named at the top of the file so the magic number doesn't sit inline.
- In `GetTraces`, when the status is non-200, ask the helper first. If the body says stream-not-found, return an empty `*observability.TracesQueryResult` and `nil` error. Otherwise fall through to the existing wrapped-error path.

Only `GetTraces` is touched. The issue body speculates the same pattern may apply to logs and metrics adapters, but flagged that as a follow-up; I kept the PR scoped to the title's path so the change stays small and reviewable. If you'd like the logs/metrics adapters in this PR, happy to fold them in.

The helper is tolerant: a malformed body, an empty body, JSON without `code`, or a JSON with a different code all return false, so existing error paths are unchanged for everything except this one specific OpenObserve response.

## Related Issues

Refs #3435

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable) -- no samples touch this code path
- [x] Backport label -- maintainer decision; I do not have permission to apply labels. Happy to add one if you'd like a release branch to receive this.

## Remarks

`TestIsStreamNotFound` is a table-test covering the 20002 case, an unrelated code, an empty body, a non-JSON body, and a JSON body without a `code` field. Local run:

    go build ./internal/observer/service/...      # clean
    go vet ./internal/observer/service/...        # clean
    go test ./internal/observer/service/ -run "TestIsStreamNotFound|TestNewTracingAdapter|TestConvertTraces|TestConvertSpans" -timeout 60s
    # 13 passed in 1 packages

AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.
