### PR TITLE
feat(cli): add commands for resource abstractions

### DIFF
--- a/internal/occ/cmd/apply/registry.go
+++ b/internal/occ/cmd/apply/registry.go
@@ -59,7 +59,7 @@ func getResourceRegistry() map[string]resourceEntry {
 	return reg
 }
 
-//nolint:funlen // cluster-scoped resources registry table
+//nolint:funlen,gocyclo // cluster-scoped resources registry table — one entry per resource kind
 func addClusterScopedResources(reg map[string]resourceEntry) {
 	reg["Namespace"] = resourceEntry{
 		scope: scopeCluster,
@@ -279,6 +279,31 @@ func addClusterScopedResources(reg map[string]resourceEntry) {
 		},
 		update: func(ctx context.Context, c *gen.ClientWithResponses, _, name string, body io.Reader) (int, []byte, error) {
 			r, err := c.UpdateClusterRoleBindingWithBodyWithResponse(ctx, name, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+	}
+
+	reg["ClusterResourceType"] = resourceEntry{
+		scope: scopeCluster,
+		get: func(ctx context.Context, c *gen.ClientWithResponses, _, name string) (int, error) {
+			r, err := c.GetClusterResourceTypeWithResponse(ctx, name)
+			if err != nil {
+				return 0, err
+			}
+			return r.StatusCode(), nil
+		},
+		create: func(ctx context.Context, c *gen.ClientWithResponses, _ string, body io.Reader) (int, []byte, error) {
+			r, err := c.CreateClusterResourceTypeWithBodyWithResponse(ctx, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+		update: func(ctx context.Context, c *gen.ClientWithResponses, _, name string, body io.Reader) (int, []byte, error) {
+			r, err := c.UpdateClusterResourceTypeWithBodyWithResponse(ctx, name, contentTypeJSON, body)
 			if err != nil {
 				return 0, nil, err
 			}
@@ -708,6 +733,81 @@ func addNamespacedScopedResources(reg map[string]resourceEntry) {
 		},
 	}
 
+	reg["ResourceType"] = resourceEntry{
+		scope: scopeNamespaced,
+		get: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string) (int, error) {
+			r, err := c.GetResourceTypeWithResponse(ctx, ns, name)
+			if err != nil {
+				return 0, err
+			}
+			return r.StatusCode(), nil
+		},
+		create: func(ctx context.Context, c *gen.ClientWithResponses, ns string, body io.Reader) (int, []byte, error) {
+			r, err := c.CreateResourceTypeWithBodyWithResponse(ctx, ns, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+		update: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string, body io.Reader) (int, []byte, error) {
+			r, err := c.UpdateResourceTypeWithBodyWithResponse(ctx, ns, name, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+	}
+
+	reg["Resource"] = resourceEntry{
+		scope: scopeNamespaced,
+		get: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string) (int, error) {
+			r, err := c.GetResourceWithResponse(ctx, ns, name)
+			if err != nil {
+				return 0, err
+			}
+			return r.StatusCode(), nil
+		},
+		create: func(ctx context.Context, c *gen.ClientWithResponses, ns string, body io.Reader) (int, []byte, error) {
+			r, err := c.CreateResourceWithBodyWithResponse(ctx, ns, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+		update: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string, body io.Reader) (int, []byte, error) {
+			r, err := c.UpdateResourceWithBodyWithResponse(ctx, ns, name, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+	}
+
+	reg["ResourceReleaseBinding"] = resourceEntry{
+		scope: scopeNamespaced,
+		get: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string) (int, error) {
+			r, err := c.GetResourceReleaseBindingWithResponse(ctx, ns, name)
+			if err != nil {
+				return 0, err
+			}
+			return r.StatusCode(), nil
+		},
+		create: func(ctx context.Context, c *gen.ClientWithResponses, ns string, body io.Reader) (int, []byte, error) {
+			r, err := c.CreateResourceReleaseBindingWithBodyWithResponse(ctx, ns, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+		update: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string, body io.Reader) (int, []byte, error) {
+			r, err := c.UpdateResourceReleaseBindingWithBodyWithResponse(ctx, ns, name, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+	}
+
 	// Create-only resources
 
 	reg["WorkflowRun"] = resourceEntry{
@@ -722,6 +822,25 @@ func addNamespacedScopedResources(reg map[string]resourceEntry) {
 		},
 		create: func(ctx context.Context, c *gen.ClientWithResponses, ns string, body io.Reader) (int, []byte, error) {
 			r, err := c.CreateWorkflowRunWithBodyWithResponse(ctx, ns, contentTypeJSON, body)
+			if err != nil {
+				return 0, nil, err
+			}
+			return r.StatusCode(), r.Body, nil
+		},
+	}
+
+	reg["ResourceRelease"] = resourceEntry{
+		scope:      scopeNamespaced,
+		capability: capCreateOnly,
+		get: func(ctx context.Context, c *gen.ClientWithResponses, ns, name string) (int, error) {
+			r, err := c.GetResourceReleaseWithResponse(ctx, ns, name)
+			if err != nil {
+				return 0, err
+			}
+			return r.StatusCode(), nil
+		},
+		create: func(ctx context.Context, c *gen.ClientWithResponses, ns string, body io.Reader) (int, []byte, error) {
+			r, err := c.CreateResourceReleaseWithBodyWithResponse(ctx, ns, contentTypeJSON, body)
 			if err != nil {
 				return 0, nil, err
 			}

--- a/internal/occ/cmd/apply/registry_test.go
+++ b/internal/occ/cmd/apply/registry_test.go
@@ -15,3 +15,34 @@ func TestSupportedKinds(t *testing.T) {
 	require.NotEmpty(t, kinds)
 	assert.IsNonDecreasing(t, kinds)
 }
+
+func TestResourceFamilyKindsRegistered(t *testing.T) {
+	reg := getResourceRegistry()
+	tests := []struct {
+		kind       string
+		scope      resourceScope
+		capability applyCapability
+		hasUpdate  bool
+	}{
+		{"ClusterResourceType", scopeCluster, capCreateAndUpdate, true},
+		{"ResourceType", scopeNamespaced, capCreateAndUpdate, true},
+		{"Resource", scopeNamespaced, capCreateAndUpdate, true},
+		{"ResourceRelease", scopeNamespaced, capCreateOnly, false},
+		{"ResourceReleaseBinding", scopeNamespaced, capCreateAndUpdate, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			entry, ok := reg[tt.kind]
+			require.True(t, ok, "kind %q not registered", tt.kind)
+			assert.Equal(t, tt.scope, entry.scope)
+			assert.Equal(t, tt.capability, entry.capability)
+			assert.NotNil(t, entry.get)
+			assert.NotNil(t, entry.create)
+			if tt.hasUpdate {
+				assert.NotNil(t, entry.update)
+			} else {
+				assert.Nil(t, entry.update)
+			}
+		})
+	}
+}

--- a/internal/occ/cmd/clusterresourcetype/clusterresourcetype.go
+++ b/internal/occ/cmd/clusterresourcetype/clusterresourcetype.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ClusterResourceType implements cluster resource type operations
+type ClusterResourceType struct {
+	client client.Interface
+}
+
+// New creates a new cluster resource type implementation
+func New(c client.Interface) *ClusterResourceType {
+	return &ClusterResourceType{client: c}
+}
+
+// List lists all cluster-scoped resource types
+func (c *ClusterResourceType) List() error {
+	ctx := context.Background()
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ClusterResourceType, string, error) {
+		p := &gen.ListClusterResourceTypesParams{}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := c.client.ListClusterResourceTypes(ctx, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+	return printList(items)
+}
+
+// Get retrieves a single cluster resource type and outputs it as YAML
+func (c *ClusterResourceType) Get(params GetParams) error {
+	ctx := context.Background()
+
+	result, err := c.client.GetClusterResourceType(ctx, params.ClusterResourceTypeName)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cluster resource type to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete deletes a single cluster resource type
+func (c *ClusterResourceType) Delete(params DeleteParams) error {
+	ctx := context.Background()
+
+	if err := c.client.DeleteClusterResourceType(ctx, params.ClusterResourceTypeName); err != nil {
+		return err
+	}
+
+	fmt.Printf("ClusterResourceType '%s' deleted\n", params.ClusterResourceTypeName)
+	return nil
+}
+
+func printList(items []gen.ClusterResourceType) error {
+	if len(items) == 0 {
+		fmt.Println("No cluster resource types found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tRETAIN POLICY\tAGE")
+
+	for _, rt := range items {
+		retainPolicy := ""
+		if rt.Spec != nil && rt.Spec.RetainPolicy != nil {
+			retainPolicy = string(*rt.Spec.RetainPolicy)
+		}
+		age := ""
+		if rt.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*rt.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			rt.Metadata.Name,
+			retainPolicy,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/clusterresourcetype/clusterresourcetype_test.go
+++ b/internal/occ/cmd/clusterresourcetype/clusterresourcetype_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func TestPrint_Nil(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(nil))
+	})
+	assert.Contains(t, out, "No cluster resource types found")
+}
+
+func TestPrint_Empty(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList([]gen.ClusterResourceType{}))
+	})
+	assert.Contains(t, out, "No cluster resource types found")
+}
+
+func TestPrint_WithItems(t *testing.T) {
+	now := time.Now()
+	retain := gen.ResourceTypeSpecRetainPolicy("Retain")
+	items := []gen.ClusterResourceType{
+		{
+			Metadata: gen.ObjectMeta{
+				Name:              "mysql",
+				CreationTimestamp: &now,
+			},
+			Spec: &gen.ResourceTypeSpec{
+				RetainPolicy: &retain,
+			},
+		},
+		{
+			Metadata: gen.ObjectMeta{
+				Name: "redis",
+			},
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "RETAIN POLICY")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "mysql")
+	assert.Contains(t, out, "Retain")
+	assert.Contains(t, out, "redis")
+}
+
+func TestPrint_NilSpec(t *testing.T) {
+	now := time.Now()
+	items := []gen.ClusterResourceType{
+		{
+			Metadata: gen.ObjectMeta{
+				Name:              "no-spec-type",
+				CreationTimestamp: &now,
+			},
+			Spec: nil,
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "no-spec-type")
+}
+
+// --- List tests ---
+
+func TestList_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListClusterResourceTypes(mock.Anything, mock.Anything).Return(nil, fmt.Errorf("server error"))
+
+	crt := New(mc)
+	assert.EqualError(t, crt.List(), "server error")
+}
+
+func TestList_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListClusterResourceTypes(mock.Anything, mock.Anything).Return(&gen.ClusterResourceTypeList{
+		Items:      []gen.ClusterResourceType{{Metadata: gen.ObjectMeta{Name: "mysql"}}},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	crt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, crt.List())
+	})
+
+	assert.Contains(t, out, "mysql")
+}
+
+func TestList_MultipleItems(t *testing.T) {
+	now := time.Now()
+	retain := gen.ResourceTypeSpecRetainPolicy("Retain")
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListClusterResourceTypes(mock.Anything, mock.Anything).Return(&gen.ClusterResourceTypeList{
+		Items: []gen.ClusterResourceType{
+			{
+				Metadata: gen.ObjectMeta{Name: "mysql", CreationTimestamp: &now},
+				Spec:     &gen.ResourceTypeSpec{RetainPolicy: &retain},
+			},
+			{
+				Metadata: gen.ObjectMeta{Name: "redis", CreationTimestamp: &now},
+			},
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	crt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, crt.List())
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "RETAIN POLICY")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "mysql")
+	assert.Contains(t, out, "redis")
+}
+
+func TestList_Empty(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListClusterResourceTypes(mock.Anything, mock.Anything).Return(&gen.ClusterResourceTypeList{
+		Items:      []gen.ClusterResourceType{},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	crt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, crt.List())
+	})
+
+	assert.Contains(t, out, "No cluster resource types found")
+}
+
+// --- Get tests ---
+
+func TestGet_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetClusterResourceType(mock.Anything, "missing").Return(nil, fmt.Errorf("not found: missing"))
+
+	crt := New(mc)
+	assert.EqualError(t, crt.Get(GetParams{ClusterResourceTypeName: "missing"}), "not found: missing")
+}
+
+func TestGet_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetClusterResourceType(mock.Anything, "mysql").Return(&gen.ClusterResourceType{
+		Metadata: gen.ObjectMeta{Name: "mysql"},
+	}, nil)
+
+	crt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, crt.Get(GetParams{ClusterResourceTypeName: "mysql"}))
+	})
+
+	assert.Contains(t, out, "name: mysql")
+}
+
+// --- Delete tests ---
+
+func TestDelete_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteClusterResourceType(mock.Anything, "mysql").Return(fmt.Errorf("forbidden: mysql"))
+
+	crt := New(mc)
+	assert.EqualError(t, crt.Delete(DeleteParams{ClusterResourceTypeName: "mysql"}), "forbidden: mysql")
+}
+
+func TestDelete_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteClusterResourceType(mock.Anything, "mysql").Return(nil)
+
+	crt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, crt.Delete(DeleteParams{ClusterResourceTypeName: "mysql"}))
+	})
+
+	assert.Contains(t, out, "ClusterResourceType 'mysql' deleted")
+}

--- a/internal/occ/cmd/clusterresourcetype/cmd.go
+++ b/internal/occ/cmd/clusterresourcetype/cmd.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/auth"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+)
+
+func NewClusterResourceTypeCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "clusterresourcetype",
+		Aliases: []string{"crt", "clusterresourcetypes"},
+		Short:   "Manage cluster resource types",
+		Long:    `Manage cluster-scoped resource types for OpenChoreo.`,
+	}
+	cmd.AddCommand(
+		newListCmd(f),
+		newGetCmd(f),
+		newDeleteCmd(f),
+	)
+	return cmd
+}
+
+func newListCmd(f client.NewClientFunc) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List cluster resource types",
+		Long:  `List all cluster-scoped resource types available across the cluster.`,
+		Example: `  # List all cluster resource types
+  occ clusterresourcetype list`,
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).List()
+		},
+	}
+}
+
+func newGetCmd(f client.NewClientFunc) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get [CLUSTER_RESOURCE_TYPE_NAME]",
+		Short: "Get a cluster resource type",
+		Long:  `Get a cluster resource type and display its details in YAML format.`,
+		Example: `  # Get a cluster resource type
+  occ clusterresourcetype get mysql`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Get(GetParams{ClusterResourceTypeName: args[0]})
+		},
+	}
+}
+
+func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete [CLUSTER_RESOURCE_TYPE_NAME]",
+		Short: "Delete a cluster resource type",
+		Long:  `Delete a cluster resource type by name.`,
+		Example: `  # Delete a cluster resource type
+  occ clusterresourcetype delete mysql`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Delete(DeleteParams{ClusterResourceTypeName: args[0]})
+		},
+	}
+}

--- a/internal/occ/cmd/clusterresourcetype/cmd_test.go
+++ b/internal/occ/cmd/clusterresourcetype/cmd_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return mc, nil
+	}
+}
+
+func errFactory(msg string) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+// --- NewClusterResourceTypeCmd structure ---
+
+func TestNewClusterResourceTypeCmd_Use(t *testing.T) {
+	cmd := NewClusterResourceTypeCmd(errFactory("unused"))
+	assert.Equal(t, "clusterresourcetype", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "crt")
+	assert.Contains(t, cmd.Aliases, "clusterresourcetypes")
+}
+
+func TestNewClusterResourceTypeCmd_Subcommands(t *testing.T) {
+	cmd := NewClusterResourceTypeCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "delete"}, names)
+}
+
+// --- list ---
+
+func TestListCmd_FactoryError(t *testing.T) {
+	cmd := newListCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, nil)
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestListCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListClusterResourceTypes(mock.Anything, mock.Anything).Return(&gen.ClusterResourceTypeList{
+		Items:      []gen.ClusterResourceType{{Metadata: gen.ObjectMeta{Name: "mysql"}}},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	cmd := newListCmd(mockFactory(mc))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	})
+	assert.Contains(t, out, "mysql")
+}
+
+// --- get ---
+
+func TestGetCmd_MissingArg(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required argument")
+}
+
+func TestGetCmd_TooManyArgs(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{"a", "b"})
+	assert.EqualError(t, err, "accepts 1 arg(s), received 2")
+}
+
+func TestGetCmd_FactoryError(t *testing.T) {
+	cmd := newGetCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"mysql"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestGetCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetClusterResourceType(mock.Anything, "mysql").Return(
+		&gen.ClusterResourceType{Metadata: gen.ObjectMeta{Name: "mysql"}}, nil,
+	)
+
+	cmd := newGetCmd(mockFactory(mc))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"mysql"}))
+	})
+	assert.Contains(t, out, "mysql")
+}
+
+// --- delete ---
+
+func TestDeleteCmd_MissingArg(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CLUSTER_RESOURCE_TYPE_NAME")
+}
+
+func TestDeleteCmd_FactoryError(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"mysql"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestDeleteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteClusterResourceType(mock.Anything, "mysql").Return(nil)
+
+	cmd := newDeleteCmd(mockFactory(mc))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"mysql"}))
+	})
+	assert.Contains(t, out, "deleted")
+}

--- a/internal/occ/cmd/clusterresourcetype/params.go
+++ b/internal/occ/cmd/clusterresourcetype/params.go
@@ -1,0 +1,14 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterresourcetype
+
+// GetParams defines parameters for getting a single cluster resource type
+type GetParams struct {
+	ClusterResourceTypeName string
+}
+
+// DeleteParams defines parameters for deleting a single cluster resource type
+type DeleteParams struct {
+	ClusterResourceTypeName string
+}

--- a/internal/occ/cmd/resource/cmd.go
+++ b/internal/occ/cmd/resource/cmd.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/auth"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/flags"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+)
+
+func NewResourceCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resource",
+		Aliases: []string{"resources"},
+		Short:   "Manage resources",
+		Long:    `Manage resources for OpenChoreo.`,
+	}
+	cmd.AddCommand(
+		newListCmd(f),
+		newGetCmd(f),
+		newDeleteCmd(f),
+		newPromoteCmd(f),
+	)
+	return cmd
+}
+
+func newListCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List resources",
+		Long:  `List all resources in a namespace, optionally filtered by project.`,
+		Example: `  # List all resources in a namespace
+  occ resource list --namespace acme-corp
+
+  # List resources in a specific project
+  occ resource list --namespace acme-corp --project online-store`,
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).List(ListParams{
+				Namespace: flags.GetNamespace(cmd),
+				Project:   flags.GetProject(cmd),
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	flags.AddProject(cmd)
+	return cmd
+}
+
+func newGetCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [RESOURCE_NAME]",
+		Short: "Get a resource",
+		Long:  `Get a resource and display its details in YAML format.`,
+		Example: `  # Get a resource
+  occ resource get analytics-db --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Get(GetParams{
+				Namespace:    flags.GetNamespace(cmd),
+				ResourceName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [RESOURCE_NAME]",
+		Short: "Delete a resource",
+		Long:  `Delete a resource by name.`,
+		Example: `  # Delete a resource
+  occ resource delete analytics-db --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Delete(DeleteParams{
+				Namespace:    flags.GetNamespace(cmd),
+				ResourceName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newPromoteCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "promote [RESOURCE_NAME]",
+		Short: "Promote a resource to its latest release in a target environment",
+		Long: `Promote advances the ResourceReleaseBinding for the target environment ` +
+			`to the resource's latest release. The release name is read from ` +
+			`Resource.status.latestRelease.`,
+		Example: `  # Promote analytics-db to its latest release in dev
+  occ resource promote analytics-db --env dev --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Promote(PromoteParams{
+				Namespace:    flags.GetNamespace(cmd),
+				ResourceName: args[0],
+				Environment:  flags.GetEnvironment(cmd),
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	flags.AddEnvironment(cmd)
+	return cmd
+}

--- a/internal/occ/cmd/resource/cmd_test.go
+++ b/internal/occ/cmd/resource/cmd_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return mc, nil
+	}
+}
+
+func errFactory(msg string) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+// --- NewResourceCmd structure ---
+
+func TestNewResourceCmd_Use(t *testing.T) {
+	cmd := NewResourceCmd(errFactory("unused"))
+	assert.Equal(t, "resource", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "resources")
+}
+
+func TestNewResourceCmd_Subcommands(t *testing.T) {
+	cmd := NewResourceCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "delete", "promote"}, names)
+}
+
+// --- list ---
+
+func TestListCmd_FactoryError(t *testing.T) {
+	cmd := newListCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, nil)
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestListCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResources(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceInstanceList{
+		Items:      []gen.ResourceInstance{resourceInstance("analytics-db", "ResourceType", "mysql")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	cmd := newListCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	})
+	assert.Contains(t, out, "analytics-db")
+}
+
+// --- get ---
+
+func TestGetCmd_MissingArg(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required argument")
+}
+
+func TestGetCmd_FactoryError(t *testing.T) {
+	cmd := newGetCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestGetCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(
+		&gen.ResourceInstance{Metadata: gen.ObjectMeta{Name: "analytics-db"}}, nil,
+	)
+
+	cmd := newGetCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db"}))
+	})
+	assert.Contains(t, out, "analytics-db")
+}
+
+// --- delete ---
+
+func TestDeleteCmd_MissingArg(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RESOURCE_NAME")
+}
+
+func TestDeleteCmd_FactoryError(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestDeleteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResource(mock.Anything, "my-org", "analytics-db").Return(nil)
+
+	cmd := newDeleteCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db"}))
+	})
+	assert.Contains(t, out, "deleted")
+}
+
+// --- promote ---
+
+func TestPromoteCmd_MissingArg(t *testing.T) {
+	cmd := newPromoteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RESOURCE_NAME")
+}
+
+func TestPromoteCmd_FactoryError(t *testing.T) {
+	cmd := newPromoteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestPromoteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(
+		resourceWithLatestRelease(), nil)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseBindingList{
+		Items:      []gen.ResourceReleaseBinding{bindingForEnv("analytics-db-dev", "dev")},
+		Pagination: gen.Pagination{},
+	}, nil)
+	mc.EXPECT().UpdateResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev", mock.Anything).
+		Return(&gen.ResourceReleaseBinding{Metadata: gen.ObjectMeta{Name: "analytics-db-dev"}}, nil)
+
+	cmd := newPromoteCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	require.NoError(t, cmd.Flags().Set("env", "dev"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db"}))
+	})
+	assert.Contains(t, out, "promoted")
+	assert.Contains(t, out, "analytics-db-abc123")
+}

--- a/internal/occ/cmd/resource/params.go
+++ b/internal/occ/cmd/resource/params.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+// ListParams defines parameters for listing resources
+type ListParams struct {
+	Namespace string
+	Project   string
+}
+
+// GetParams defines parameters for getting a single resource
+type GetParams struct {
+	Namespace    string
+	ResourceName string
+}
+
+// DeleteParams defines parameters for deleting a single resource
+type DeleteParams struct {
+	Namespace    string
+	ResourceName string
+}
+
+// PromoteParams defines parameters for promoting a resource to a target environment
+type PromoteParams struct {
+	Namespace    string
+	ResourceName string
+	Environment  string
+}

--- a/internal/occ/cmd/resource/resource.go
+++ b/internal/occ/cmd/resource/resource.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// Resource implements resource operations
+type Resource struct {
+	client client.Interface
+}
+
+// New creates a new resource implementation
+func New(c client.Interface) *Resource {
+	return &Resource{client: c}
+}
+
+// List lists resources in a namespace, optionally filtered by project
+func (r *Resource) List(params ListParams) error {
+	if err := cmdutil.RequireFields("list", "resource", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ResourceInstance, string, error) {
+		p := &gen.ListResourcesParams{}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		if params.Project != "" {
+			p.Project = &params.Project
+		}
+		result, err := r.client.ListResources(ctx, params.Namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+	return printList(items, params.Project == "")
+}
+
+// Get retrieves a single resource and outputs it as YAML
+func (r *Resource) Get(params GetParams) error {
+	if err := cmdutil.RequireFields("get", "resource", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	result, err := r.client.GetResource(ctx, params.Namespace, params.ResourceName)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete deletes a single resource
+func (r *Resource) Delete(params DeleteParams) error {
+	if err := cmdutil.RequireFields("delete", "resource", map[string]string{"namespace": params.Namespace, "name": params.ResourceName}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if err := r.client.DeleteResource(ctx, params.Namespace, params.ResourceName); err != nil {
+		return err
+	}
+
+	fmt.Printf("Resource '%s' deleted\n", params.ResourceName)
+	return nil
+}
+
+// Promote advances the ResourceReleaseBinding for the given environment to the
+// resource's latest release. It is a thin client wrapper: read
+// Resource.status.latestRelease.name, find the binding for the target environment,
+// and PUT it with the new spec.resourceRelease. No dedicated server endpoint.
+func (r *Resource) Promote(params PromoteParams) error {
+	if err := cmdutil.RequireFields("promote", "resource", map[string]string{
+		"namespace": params.Namespace,
+		"name":      params.ResourceName,
+		"env":       params.Environment,
+	}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	resource, err := r.client.GetResource(ctx, params.Namespace, params.ResourceName)
+	if err != nil {
+		return err
+	}
+	if resource.Status == nil || resource.Status.LatestRelease == nil || resource.Status.LatestRelease.Name == "" {
+		return fmt.Errorf("resource %q has no released versions yet", params.ResourceName)
+	}
+	releaseName := resource.Status.LatestRelease.Name
+
+	binding, err := r.findBindingForEnv(ctx, params.Namespace, params.ResourceName, params.Environment)
+	if err != nil {
+		return err
+	}
+
+	binding.Spec.ResourceRelease = &releaseName
+	if _, err := r.client.UpdateResourceReleaseBinding(ctx, params.Namespace, binding.Metadata.Name, *binding); err != nil {
+		return err
+	}
+
+	fmt.Printf("ResourceReleaseBinding '%s' promoted to resourcerelease '%s'\n", binding.Metadata.Name, releaseName)
+	return nil
+}
+
+func (r *Resource) findBindingForEnv(ctx context.Context, namespace, resourceName, env string) (*gen.ResourceReleaseBinding, error) {
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ResourceReleaseBinding, string, error) {
+		p := &gen.ListResourceReleaseBindingsParams{Resource: &resourceName}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := r.client.ListResourceReleaseBindings(ctx, namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range items {
+		b := items[i]
+		if b.Spec != nil && b.Spec.Environment == env {
+			return &b, nil
+		}
+	}
+	return nil, fmt.Errorf("no ResourceReleaseBinding found for resource %q in environment %q", resourceName, env)
+}
+
+func printList(items []gen.ResourceInstance, showProject bool) error {
+	if len(items) == 0 {
+		fmt.Println("No resources found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	if showProject {
+		fmt.Fprintln(w, "NAME\tTYPE\tPROJECT\tAGE")
+	} else {
+		fmt.Fprintln(w, "NAME\tTYPE\tAGE")
+	}
+
+	for _, r := range items {
+		typeStr := ""
+		project := ""
+		if r.Spec != nil {
+			kind := "ResourceType"
+			if r.Spec.Type.Kind != nil && *r.Spec.Type.Kind != "" {
+				kind = string(*r.Spec.Type.Kind)
+			}
+			typeStr = fmt.Sprintf("%s/%s", kind, r.Spec.Type.Name)
+			project = r.Spec.Owner.ProjectName
+		}
+		age := ""
+		if r.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*r.Metadata.CreationTimestamp)
+		}
+		if showProject {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Metadata.Name, typeStr, project, age)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", r.Metadata.Name, typeStr, age)
+		}
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/resource/resource_test.go
+++ b/internal/occ/cmd/resource/resource_test.go
@@ -1,0 +1,375 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func resourceTypeKindPtr(k gen.ResourceTypeRefKind) *gen.ResourceTypeRefKind {
+	return &k
+}
+
+func resourceInstance(name, typeKind, typeName string) gen.ResourceInstance {
+	r := gen.ResourceInstance{
+		Metadata: gen.ObjectMeta{Name: name},
+		Spec: &gen.ResourceInstanceSpec{
+			Type: gen.ResourceTypeRef{Name: typeName},
+		},
+	}
+	r.Spec.Owner.ProjectName = "online-store"
+	if typeKind != "" {
+		r.Spec.Type.Kind = resourceTypeKindPtr(gen.ResourceTypeRefKind(typeKind))
+	}
+	return r
+}
+
+// --- printList tests ---
+
+func TestPrint_Nil(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(nil, true))
+	})
+	assert.Contains(t, out, "No resources found")
+}
+
+func TestPrint_Empty(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList([]gen.ResourceInstance{}, true))
+	})
+	assert.Contains(t, out, "No resources found")
+}
+
+func TestPrint_WithItems_ShowProject(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceInstance{
+		resourceInstance("analytics-db", "ResourceType", "mysql"),
+		resourceInstance("billing-cache", "ClusterResourceType", "redis"),
+	}
+	items[0].Metadata.CreationTimestamp = &now
+	items[1].Metadata.CreationTimestamp = &now
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items, true))
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "TYPE")
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "analytics-db")
+	assert.Contains(t, out, "ResourceType/mysql")
+	assert.Contains(t, out, "ClusterResourceType/redis")
+	assert.Contains(t, out, "online-store")
+}
+
+func TestPrint_WithItems_HideProject(t *testing.T) {
+	items := []gen.ResourceInstance{
+		resourceInstance("analytics-db", "ResourceType", "mysql"),
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items, false))
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "TYPE")
+	assert.NotContains(t, out, "PROJECT")
+	assert.Contains(t, out, "analytics-db")
+}
+
+func TestPrint_NilSpec(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceInstance{
+		{
+			Metadata: gen.ObjectMeta{Name: "no-spec", CreationTimestamp: &now},
+			Spec:     nil,
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items, true))
+	})
+
+	assert.Contains(t, out, "no-spec")
+}
+
+// --- Validation tests ---
+
+func TestList_ValidationError(t *testing.T) {
+	r := New(mocks.NewMockInterface(t))
+	assert.Error(t, r.List(ListParams{Namespace: ""}))
+}
+
+func TestGet_ValidationError(t *testing.T) {
+	r := New(mocks.NewMockInterface(t))
+	assert.Error(t, r.Get(GetParams{Namespace: ""}))
+}
+
+func TestDelete_ValidationError(t *testing.T) {
+	r := New(mocks.NewMockInterface(t))
+	assert.Error(t, r.Delete(DeleteParams{Namespace: "my-org", ResourceName: ""}))
+}
+
+func TestPromote_ValidationError_MissingNamespace(t *testing.T) {
+	r := New(mocks.NewMockInterface(t))
+	assert.Error(t, r.Promote(PromoteParams{Namespace: "", ResourceName: "db", Environment: "dev"}))
+}
+
+func TestPromote_ValidationError_MissingResource(t *testing.T) {
+	r := New(mocks.NewMockInterface(t))
+	assert.Error(t, r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "", Environment: "dev"}))
+}
+
+func TestPromote_ValidationError_MissingEnv(t *testing.T) {
+	r := New(mocks.NewMockInterface(t))
+	assert.Error(t, r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "db", Environment: ""}))
+}
+
+// --- List tests ---
+
+func TestList_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResources(mock.Anything, "my-org", mock.Anything).Return(nil, fmt.Errorf("server error"))
+
+	r := New(mc)
+	assert.EqualError(t, r.List(ListParams{Namespace: "my-org"}), "server error")
+}
+
+func TestList_Success_NoProjectFilter(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResources(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourcesParams) bool {
+		return p.Project == nil
+	})).Return(&gen.ResourceInstanceList{
+		Items: []gen.ResourceInstance{
+			resourceInstance("analytics-db", "ResourceType", "mysql"),
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	r := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, r.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "analytics-db")
+	assert.Contains(t, out, "online-store")
+}
+
+func TestList_Success_WithProjectFilter(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResources(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourcesParams) bool {
+		return p.Project != nil && *p.Project == "online-store"
+	})).Return(&gen.ResourceInstanceList{
+		Items: []gen.ResourceInstance{
+			resourceInstance("analytics-db", "ResourceType", "mysql"),
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	r := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, r.List(ListParams{Namespace: "my-org", Project: "online-store"}))
+	})
+
+	assert.NotContains(t, out, "PROJECT")
+	assert.Contains(t, out, "analytics-db")
+}
+
+func TestList_Empty(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResources(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceInstanceList{
+		Items:      []gen.ResourceInstance{},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	r := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, r.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "No resources found")
+}
+
+// --- Get tests ---
+
+func TestGet_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "missing").Return(nil, fmt.Errorf("not found: missing"))
+
+	r := New(mc)
+	assert.EqualError(t, r.Get(GetParams{Namespace: "my-org", ResourceName: "missing"}), "not found: missing")
+}
+
+func TestGet_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(&gen.ResourceInstance{
+		Metadata: gen.ObjectMeta{Name: "analytics-db"},
+	}, nil)
+
+	r := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, r.Get(GetParams{Namespace: "my-org", ResourceName: "analytics-db"}))
+	})
+
+	assert.Contains(t, out, "name: analytics-db")
+}
+
+// --- Delete tests ---
+
+func TestDelete_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResource(mock.Anything, "my-org", "analytics-db").Return(fmt.Errorf("forbidden"))
+
+	r := New(mc)
+	assert.EqualError(t, r.Delete(DeleteParams{Namespace: "my-org", ResourceName: "analytics-db"}), "forbidden")
+}
+
+func TestDelete_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResource(mock.Anything, "my-org", "analytics-db").Return(nil)
+
+	r := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, r.Delete(DeleteParams{Namespace: "my-org", ResourceName: "analytics-db"}))
+	})
+
+	assert.Contains(t, out, "Resource 'analytics-db' deleted")
+}
+
+// --- Promote tests ---
+
+func resourceWithLatestRelease() *gen.ResourceInstance {
+	r := &gen.ResourceInstance{
+		Metadata: gen.ObjectMeta{Name: "analytics-db"},
+		Status:   &gen.ResourceInstanceStatus{},
+	}
+	r.Status.LatestRelease = &struct {
+		Hash string `json:"hash"`
+		Name string `json:"name"`
+	}{Hash: "abc123", Name: "analytics-db-abc123"}
+	return r
+}
+
+func bindingForEnv(bindingName, env string) gen.ResourceReleaseBinding {
+	b := gen.ResourceReleaseBinding{
+		Metadata: gen.ObjectMeta{Name: bindingName},
+		Spec: &gen.ResourceReleaseBindingSpec{
+			Environment: env,
+		},
+	}
+	b.Spec.Owner.ResourceName = "analytics-db"
+	return b
+}
+
+func TestPromote_GetResourceError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(nil, fmt.Errorf("not found"))
+
+	r := New(mc)
+	err := r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "analytics-db", Environment: "dev"})
+	assert.EqualError(t, err, "not found")
+}
+
+func TestPromote_ResourceHasNoLatestRelease(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(&gen.ResourceInstance{
+		Metadata: gen.ObjectMeta{Name: "analytics-db"},
+		Status:   &gen.ResourceInstanceStatus{},
+	}, nil)
+
+	r := New(mc)
+	err := r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "analytics-db", Environment: "dev"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no released versions")
+}
+
+func TestPromote_ListBindingsError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(
+		resourceWithLatestRelease(), nil)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(nil, fmt.Errorf("api blew up"))
+
+	r := New(mc)
+	err := r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "analytics-db", Environment: "dev"})
+	assert.EqualError(t, err, "api blew up")
+}
+
+func TestPromote_NoBindingForEnv(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(
+		resourceWithLatestRelease(), nil)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseBindingList{
+		Items: []gen.ResourceReleaseBinding{
+			bindingForEnv("analytics-db-staging", "staging"),
+			bindingForEnv("analytics-db-prod", "prod"),
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	r := New(mc)
+	err := r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "analytics-db", Environment: "dev"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dev")
+	assert.Contains(t, err.Error(), "analytics-db")
+}
+
+func TestPromote_FiltersByResource(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(
+		resourceWithLatestRelease(), nil)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourceReleaseBindingsParams) bool {
+		return p.Resource != nil && *p.Resource == "analytics-db"
+	})).Return(&gen.ResourceReleaseBindingList{
+		Items: []gen.ResourceReleaseBinding{
+			bindingForEnv("analytics-db-dev", "dev"),
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+	mc.EXPECT().UpdateResourceReleaseBinding(
+		mock.Anything,
+		"my-org",
+		"analytics-db-dev",
+		mock.MatchedBy(func(b gen.ResourceReleaseBinding) bool {
+			return b.Spec != nil && b.Spec.ResourceRelease != nil && *b.Spec.ResourceRelease == "analytics-db-abc123"
+		}),
+	).Return(&gen.ResourceReleaseBinding{Metadata: gen.ObjectMeta{Name: "analytics-db-dev"}}, nil)
+
+	r := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "analytics-db", Environment: "dev"}))
+	})
+
+	assert.Contains(t, out, "analytics-db-dev")
+	assert.Contains(t, out, "analytics-db-abc123")
+}
+
+func TestPromote_UpdateError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResource(mock.Anything, "my-org", "analytics-db").Return(
+		resourceWithLatestRelease(), nil)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseBindingList{
+		Items: []gen.ResourceReleaseBinding{
+			bindingForEnv("analytics-db-dev", "dev"),
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+	mc.EXPECT().UpdateResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev", mock.Anything).
+		Return(nil, fmt.Errorf("conflict"))
+
+	r := New(mc)
+	err := r.Promote(PromoteParams{Namespace: "my-org", ResourceName: "analytics-db", Environment: "dev"})
+	assert.EqualError(t, err, "conflict")
+}

--- a/internal/occ/cmd/resourcerelease/cmd.go
+++ b/internal/occ/cmd/resourcerelease/cmd.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/auth"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/flags"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+)
+
+func NewResourceReleaseCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resourcerelease",
+		Aliases: []string{"resourcereleases"},
+		Short:   "Manage resource releases",
+		Long:    "Commands for managing resource releases.",
+	}
+	cmd.AddCommand(
+		newListCmd(f),
+		newGetCmd(f),
+		newDeleteCmd(f),
+	)
+	return cmd
+}
+
+func newListCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List resource releases",
+		Long:  `List all resource releases in a namespace, optionally filtered by resource.`,
+		Example: `  # List all resource releases in a namespace
+  occ resourcerelease list --namespace acme-corp
+
+  # List releases for a specific resource
+  occ resourcerelease list --namespace acme-corp --resource analytics-db`,
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).List(ListParams{
+				Namespace: flags.GetNamespace(cmd),
+				Resource:  flags.GetResource(cmd),
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	flags.AddResource(cmd)
+	return cmd
+}
+
+func newGetCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [RESOURCE_RELEASE_NAME]",
+		Short: "Get a resource release",
+		Long:  `Get a resource release and display its details in YAML format.`,
+		Example: `  # Get a resource release
+  occ resourcerelease get analytics-db-abc123 --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Get(GetParams{
+				Namespace:           flags.GetNamespace(cmd),
+				ResourceReleaseName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [RESOURCE_RELEASE_NAME]",
+		Short: "Delete a resource release",
+		Long:  `Delete a resource release by name.`,
+		Example: `  # Delete a resource release
+  occ resourcerelease delete analytics-db-abc123 --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Delete(DeleteParams{
+				Namespace:           flags.GetNamespace(cmd),
+				ResourceReleaseName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}

--- a/internal/occ/cmd/resourcerelease/cmd_test.go
+++ b/internal/occ/cmd/resourcerelease/cmd_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return mc, nil
+	}
+}
+
+func errFactory(msg string) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+// --- NewResourceReleaseCmd structure ---
+
+func TestNewResourceReleaseCmd_Use(t *testing.T) {
+	cmd := NewResourceReleaseCmd(errFactory("unused"))
+	assert.Equal(t, "resourcerelease", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "resourcereleases")
+}
+
+func TestNewResourceReleaseCmd_Subcommands(t *testing.T) {
+	cmd := NewResourceReleaseCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "delete"}, names)
+}
+
+// --- list ---
+
+func TestListCmd_FactoryError(t *testing.T) {
+	cmd := newListCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, nil)
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestListCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleases(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseList{
+		Items:      []gen.ResourceRelease{releaseFor("analytics-db-abc123")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	cmd := newListCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	})
+	assert.Contains(t, out, "analytics-db-abc123")
+}
+
+// --- get ---
+
+func TestGetCmd_MissingArg(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required argument")
+}
+
+func TestGetCmd_FactoryError(t *testing.T) {
+	cmd := newGetCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db-abc123"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestGetCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceRelease(mock.Anything, "my-org", "analytics-db-abc123").Return(
+		&gen.ResourceRelease{Metadata: gen.ObjectMeta{Name: "analytics-db-abc123"}}, nil,
+	)
+
+	cmd := newGetCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db-abc123"}))
+	})
+	assert.Contains(t, out, "analytics-db-abc123")
+}
+
+// --- delete ---
+
+func TestDeleteCmd_MissingArg(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RESOURCE_RELEASE_NAME")
+}
+
+func TestDeleteCmd_FactoryError(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db-abc123"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestDeleteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceRelease(mock.Anything, "my-org", "analytics-db-abc123").Return(nil)
+
+	cmd := newDeleteCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db-abc123"}))
+	})
+	assert.Contains(t, out, "deleted")
+}

--- a/internal/occ/cmd/resourcerelease/params.go
+++ b/internal/occ/cmd/resourcerelease/params.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+// ListParams defines parameters for listing resource releases
+type ListParams struct {
+	Namespace string
+	Resource  string
+}
+
+// GetParams defines parameters for getting a single resource release
+type GetParams struct {
+	Namespace           string
+	ResourceReleaseName string
+}
+
+// DeleteParams defines parameters for deleting a single resource release
+type DeleteParams struct {
+	Namespace           string
+	ResourceReleaseName string
+}

--- a/internal/occ/cmd/resourcerelease/resourcerelease.go
+++ b/internal/occ/cmd/resourcerelease/resourcerelease.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ResourceRelease implements resource release operations
+type ResourceRelease struct {
+	client client.Interface
+}
+
+// New creates a new resource release implementation
+func New(c client.Interface) *ResourceRelease {
+	return &ResourceRelease{client: c}
+}
+
+// List lists resource releases in a namespace, optionally filtered by resource
+func (rr *ResourceRelease) List(params ListParams) error {
+	if err := cmdutil.RequireFields("list", "resourcerelease", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ResourceRelease, string, error) {
+		p := &gen.ListResourceReleasesParams{}
+		if params.Resource != "" {
+			p.Resource = &params.Resource
+		}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := rr.client.ListResourceReleases(ctx, params.Namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return printList(items)
+}
+
+// Get retrieves a single resource release and outputs it as YAML
+func (rr *ResourceRelease) Get(params GetParams) error {
+	if err := cmdutil.RequireFields("get", "resourcerelease", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	result, err := rr.client.GetResourceRelease(ctx, params.Namespace, params.ResourceReleaseName)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource release to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete deletes a single resource release
+func (rr *ResourceRelease) Delete(params DeleteParams) error {
+	if err := cmdutil.RequireFields("delete", "resourcerelease", map[string]string{"namespace": params.Namespace, "name": params.ResourceReleaseName}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if err := rr.client.DeleteResourceRelease(ctx, params.Namespace, params.ResourceReleaseName); err != nil {
+		return err
+	}
+
+	fmt.Printf("ResourceRelease '%s' deleted\n", params.ResourceReleaseName)
+	return nil
+}
+
+func printList(items []gen.ResourceRelease) error {
+	if len(items) == 0 {
+		fmt.Println("No resource releases found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tRESOURCE\tAGE")
+
+	for _, release := range items {
+		resourceName := ""
+		if release.Spec != nil {
+			resourceName = release.Spec.Owner.ResourceName
+		}
+		age := ""
+		if release.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*release.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			release.Metadata.Name,
+			resourceName,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/resourcerelease/resourcerelease_test.go
+++ b/internal/occ/cmd/resourcerelease/resourcerelease_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcerelease
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func releaseFor(name string) gen.ResourceRelease {
+	r := gen.ResourceRelease{
+		Metadata: gen.ObjectMeta{Name: name},
+		Spec:     &gen.ResourceReleaseSpec{},
+	}
+	r.Spec.Owner.ResourceName = "analytics-db"
+	return r
+}
+
+// --- printList tests ---
+
+func TestPrint_Nil(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(nil))
+	})
+	assert.Contains(t, out, "No resource releases found")
+}
+
+func TestPrint_Empty(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList([]gen.ResourceRelease{}))
+	})
+	assert.Contains(t, out, "No resource releases found")
+}
+
+func TestPrint_WithItems(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceRelease{
+		releaseFor("analytics-db-abc123"),
+		releaseFor("analytics-db-def456"),
+	}
+	items[0].Metadata.CreationTimestamp = &now
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "RESOURCE")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "analytics-db-abc123")
+	assert.Contains(t, out, "analytics-db")
+}
+
+func TestPrint_NilSpec(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceRelease{
+		{
+			Metadata: gen.ObjectMeta{Name: "no-spec", CreationTimestamp: &now},
+			Spec:     nil,
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "no-spec")
+}
+
+// --- Validation tests ---
+
+func TestList_ValidationError(t *testing.T) {
+	rr := New(mocks.NewMockInterface(t))
+	assert.Error(t, rr.List(ListParams{Namespace: ""}))
+}
+
+func TestGet_ValidationError(t *testing.T) {
+	rr := New(mocks.NewMockInterface(t))
+	assert.Error(t, rr.Get(GetParams{Namespace: ""}))
+}
+
+func TestDelete_ValidationError(t *testing.T) {
+	rr := New(mocks.NewMockInterface(t))
+	assert.Error(t, rr.Delete(DeleteParams{Namespace: "my-org", ResourceReleaseName: ""}))
+}
+
+// --- List tests ---
+
+func TestList_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleases(mock.Anything, "my-org", mock.Anything).Return(nil, fmt.Errorf("server error"))
+
+	rr := New(mc)
+	assert.EqualError(t, rr.List(ListParams{Namespace: "my-org"}), "server error")
+}
+
+func TestList_Success_NoResourceFilter(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleases(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourceReleasesParams) bool {
+		return p.Resource == nil
+	})).Return(&gen.ResourceReleaseList{
+		Items:      []gen.ResourceRelease{releaseFor("analytics-db-abc123")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rr := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rr.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "analytics-db-abc123")
+}
+
+func TestList_Success_WithResourceFilter(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleases(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourceReleasesParams) bool {
+		return p.Resource != nil && *p.Resource == "analytics-db"
+	})).Return(&gen.ResourceReleaseList{
+		Items:      []gen.ResourceRelease{releaseFor("analytics-db-abc123")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rr := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rr.List(ListParams{Namespace: "my-org", Resource: "analytics-db"}))
+	})
+
+	assert.Contains(t, out, "analytics-db-abc123")
+}
+
+func TestList_Empty(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleases(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseList{
+		Items:      []gen.ResourceRelease{},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rr := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rr.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "No resource releases found")
+}
+
+// --- Get tests ---
+
+func TestGet_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceRelease(mock.Anything, "my-org", "missing").Return(nil, fmt.Errorf("not found"))
+
+	rr := New(mc)
+	assert.EqualError(t, rr.Get(GetParams{Namespace: "my-org", ResourceReleaseName: "missing"}), "not found")
+}
+
+func TestGet_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceRelease(mock.Anything, "my-org", "analytics-db-abc123").Return(&gen.ResourceRelease{
+		Metadata: gen.ObjectMeta{Name: "analytics-db-abc123"},
+	}, nil)
+
+	rr := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rr.Get(GetParams{Namespace: "my-org", ResourceReleaseName: "analytics-db-abc123"}))
+	})
+
+	assert.Contains(t, out, "name: analytics-db-abc123")
+}
+
+// --- Delete tests ---
+
+func TestDelete_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceRelease(mock.Anything, "my-org", "analytics-db-abc123").Return(fmt.Errorf("forbidden"))
+
+	rr := New(mc)
+	assert.EqualError(t, rr.Delete(DeleteParams{Namespace: "my-org", ResourceReleaseName: "analytics-db-abc123"}), "forbidden")
+}
+
+func TestDelete_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceRelease(mock.Anything, "my-org", "analytics-db-abc123").Return(nil)
+
+	rr := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rr.Delete(DeleteParams{Namespace: "my-org", ResourceReleaseName: "analytics-db-abc123"}))
+	})
+
+	assert.Contains(t, out, "ResourceRelease 'analytics-db-abc123' deleted")
+}

--- a/internal/occ/cmd/resourcereleasebinding/cmd.go
+++ b/internal/occ/cmd/resourcereleasebinding/cmd.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcereleasebinding
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/auth"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/flags"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+)
+
+func NewResourceReleaseBindingCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resourcereleasebinding",
+		Aliases: []string{"resourcereleasebindings", "rrb"},
+		Short:   "Manage resource release bindings",
+		Long:    "Commands for managing resource release bindings.",
+	}
+	cmd.AddCommand(
+		newListCmd(f),
+		newGetCmd(f),
+		newDeleteCmd(f),
+	)
+	return cmd
+}
+
+func newListCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List resource release bindings",
+		Long:  `List all resource release bindings in a namespace, optionally filtered by resource.`,
+		Example: `  # List all resource release bindings in a namespace
+  occ resourcereleasebinding list --namespace acme-corp
+
+  # List bindings for a specific resource
+  occ resourcereleasebinding list --namespace acme-corp --resource analytics-db`,
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).List(ListParams{
+				Namespace: flags.GetNamespace(cmd),
+				Resource:  flags.GetResource(cmd),
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	flags.AddResource(cmd)
+	return cmd
+}
+
+func newGetCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [RESOURCE_RELEASE_BINDING_NAME]",
+		Short: "Get a resource release binding",
+		Long:  `Get a resource release binding and display its details in YAML format.`,
+		Example: `  # Get a resource release binding
+  occ resourcereleasebinding get analytics-db-dev --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Get(GetParams{
+				Namespace:                  flags.GetNamespace(cmd),
+				ResourceReleaseBindingName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [RESOURCE_RELEASE_BINDING_NAME]",
+		Short: "Delete a resource release binding",
+		Long:  `Delete a resource release binding by name.`,
+		Example: `  # Delete a resource release binding
+  occ resourcereleasebinding delete analytics-db-dev --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Delete(DeleteParams{
+				Namespace:                  flags.GetNamespace(cmd),
+				ResourceReleaseBindingName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}

--- a/internal/occ/cmd/resourcereleasebinding/cmd_test.go
+++ b/internal/occ/cmd/resourcereleasebinding/cmd_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcereleasebinding
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return mc, nil
+	}
+}
+
+func errFactory(msg string) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+// --- NewResourceReleaseBindingCmd structure ---
+
+func TestNewResourceReleaseBindingCmd_Use(t *testing.T) {
+	cmd := NewResourceReleaseBindingCmd(errFactory("unused"))
+	assert.Equal(t, "resourcereleasebinding", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "resourcereleasebindings")
+	assert.Contains(t, cmd.Aliases, "rrb")
+}
+
+func TestNewResourceReleaseBindingCmd_Subcommands(t *testing.T) {
+	cmd := NewResourceReleaseBindingCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "delete"}, names)
+}
+
+// --- list ---
+
+func TestListCmd_FactoryError(t *testing.T) {
+	cmd := newListCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, nil)
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestListCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseBindingList{
+		Items:      []gen.ResourceReleaseBinding{bindingFor("analytics-db-dev", "dev")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	cmd := newListCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	})
+	assert.Contains(t, out, "analytics-db-dev")
+}
+
+// --- get ---
+
+func TestGetCmd_MissingArg(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required argument")
+}
+
+func TestGetCmd_FactoryError(t *testing.T) {
+	cmd := newGetCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db-dev"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestGetCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev").Return(
+		&gen.ResourceReleaseBinding{Metadata: gen.ObjectMeta{Name: "analytics-db-dev"}}, nil,
+	)
+
+	cmd := newGetCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db-dev"}))
+	})
+	assert.Contains(t, out, "analytics-db-dev")
+}
+
+// --- delete ---
+
+func TestDeleteCmd_MissingArg(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RESOURCE_RELEASE_BINDING_NAME")
+}
+
+func TestDeleteCmd_FactoryError(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"analytics-db-dev"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestDeleteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev").Return(nil)
+
+	cmd := newDeleteCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"analytics-db-dev"}))
+	})
+	assert.Contains(t, out, "deleted")
+}

--- a/internal/occ/cmd/resourcereleasebinding/params.go
+++ b/internal/occ/cmd/resourcereleasebinding/params.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcereleasebinding
+
+// ListParams defines parameters for listing resource release bindings
+type ListParams struct {
+	Namespace string
+	Resource  string
+}
+
+// GetParams defines parameters for getting a single resource release binding
+type GetParams struct {
+	Namespace                  string
+	ResourceReleaseBindingName string
+}
+
+// DeleteParams defines parameters for deleting a single resource release binding
+type DeleteParams struct {
+	Namespace                  string
+	ResourceReleaseBindingName string
+}

--- a/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding.go
+++ b/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding.go
@@ -107,23 +107,38 @@ func printList(items []gen.ResourceReleaseBinding) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NAME\tRESOURCE\tENVIRONMENT\tAGE")
+	fmt.Fprintln(w, "NAME\tRESOURCE\tENVIRONMENT\tRELEASE\tSTATUS\tAGE")
 
 	for _, b := range items {
 		resourceName := ""
 		env := ""
+		release := ""
 		if b.Spec != nil {
 			resourceName = b.Spec.Owner.ResourceName
 			env = b.Spec.Environment
+			if b.Spec.ResourceRelease != nil {
+				release = *b.Spec.ResourceRelease
+			}
+		}
+		status := ""
+		if b.Status != nil && b.Status.Conditions != nil {
+			for _, c := range *b.Status.Conditions {
+				if c.Type == "Ready" {
+					status = c.Reason
+					break
+				}
+			}
 		}
 		age := ""
 		if b.Metadata.CreationTimestamp != nil {
 			age = utils.FormatAge(*b.Metadata.CreationTimestamp)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			b.Metadata.Name,
 			resourceName,
 			env,
+			release,
+			status,
 			age)
 	}
 

--- a/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding.go
+++ b/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcereleasebinding
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ResourceReleaseBinding implements resource release binding operations
+type ResourceReleaseBinding struct {
+	client client.Interface
+}
+
+// New creates a new resource release binding implementation
+func New(c client.Interface) *ResourceReleaseBinding {
+	return &ResourceReleaseBinding{client: c}
+}
+
+// List lists resource release bindings in a namespace, optionally filtered by resource
+func (rrb *ResourceReleaseBinding) List(params ListParams) error {
+	if err := cmdutil.RequireFields("list", "resourcereleasebinding", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ResourceReleaseBinding, string, error) {
+		p := &gen.ListResourceReleaseBindingsParams{}
+		if params.Resource != "" {
+			p.Resource = &params.Resource
+		}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := rrb.client.ListResourceReleaseBindings(ctx, params.Namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return printList(items)
+}
+
+// Get retrieves a single resource release binding and outputs it as YAML
+func (rrb *ResourceReleaseBinding) Get(params GetParams) error {
+	if err := cmdutil.RequireFields("get", "resourcereleasebinding", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	result, err := rrb.client.GetResourceReleaseBinding(ctx, params.Namespace, params.ResourceReleaseBindingName)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource release binding to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete deletes a single resource release binding
+func (rrb *ResourceReleaseBinding) Delete(params DeleteParams) error {
+	if err := cmdutil.RequireFields("delete", "resourcereleasebinding", map[string]string{"namespace": params.Namespace, "name": params.ResourceReleaseBindingName}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if err := rrb.client.DeleteResourceReleaseBinding(ctx, params.Namespace, params.ResourceReleaseBindingName); err != nil {
+		return err
+	}
+
+	fmt.Printf("ResourceReleaseBinding '%s' deleted\n", params.ResourceReleaseBindingName)
+	return nil
+}
+
+func printList(items []gen.ResourceReleaseBinding) error {
+	if len(items) == 0 {
+		fmt.Println("No resource release bindings found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tRESOURCE\tENVIRONMENT\tAGE")
+
+	for _, b := range items {
+		resourceName := ""
+		env := ""
+		if b.Spec != nil {
+			resourceName = b.Spec.Owner.ResourceName
+			env = b.Spec.Environment
+		}
+		age := ""
+		if b.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*b.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			b.Metadata.Name,
+			resourceName,
+			env,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding_test.go
+++ b/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding_test.go
@@ -28,6 +28,19 @@ func bindingFor(name, env string) gen.ResourceReleaseBinding {
 	return b
 }
 
+func ptrString(s string) *string { return &s }
+
+func bindingWithReadyCondition(name, env, releaseName, readyReason string) gen.ResourceReleaseBinding {
+	b := bindingFor(name, env)
+	b.Spec.ResourceRelease = ptrString(releaseName)
+	b.Status = &gen.ResourceReleaseBindingStatus{
+		Conditions: &[]gen.Condition{
+			{Type: "Ready", Reason: readyReason},
+		},
+	}
+	return b
+}
+
 // --- printList tests ---
 
 func TestPrint_Nil(t *testing.T) {
@@ -59,11 +72,45 @@ func TestPrint_WithItems(t *testing.T) {
 	assert.Contains(t, out, "NAME")
 	assert.Contains(t, out, "RESOURCE")
 	assert.Contains(t, out, "ENVIRONMENT")
+	assert.Contains(t, out, "RELEASE")
+	assert.Contains(t, out, "STATUS")
 	assert.Contains(t, out, "AGE")
 	assert.Contains(t, out, "analytics-db-dev")
 	assert.Contains(t, out, "dev")
 	assert.Contains(t, out, "prod")
 	assert.Contains(t, out, "analytics-db")
+}
+
+func TestPrint_ShowsReleaseAndReadyReason(t *testing.T) {
+	items := []gen.ResourceReleaseBinding{
+		bindingWithReadyCondition("analytics-db-dev", "dev", "analytics-db-abc123", "Ready"),
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "analytics-db-abc123")
+	assert.Contains(t, out, "Ready")
+}
+
+func TestPrint_HandlesMissingReadyCondition(t *testing.T) {
+	// Binding with conditions but no Ready type — STATUS column stays empty
+	b := bindingFor("analytics-db-dev", "dev")
+	b.Spec.ResourceRelease = ptrString("analytics-db-abc123")
+	b.Status = &gen.ResourceReleaseBindingStatus{
+		Conditions: &[]gen.Condition{
+			{Type: "Synced", Reason: "ReleaseSynced"},
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList([]gen.ResourceReleaseBinding{b}))
+	})
+
+	assert.Contains(t, out, "analytics-db-abc123")
+	// "Synced" is not surfaced — only the Ready condition's Reason makes it to STATUS.
+	assert.NotContains(t, out, "ReleaseSynced")
 }
 
 func TestPrint_NilSpec(t *testing.T) {

--- a/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding_test.go
+++ b/internal/occ/cmd/resourcereleasebinding/resourcereleasebinding_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcereleasebinding
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func bindingFor(name, env string) gen.ResourceReleaseBinding {
+	b := gen.ResourceReleaseBinding{
+		Metadata: gen.ObjectMeta{Name: name},
+		Spec: &gen.ResourceReleaseBindingSpec{
+			Environment: env,
+		},
+	}
+	b.Spec.Owner.ResourceName = "analytics-db"
+	return b
+}
+
+// --- printList tests ---
+
+func TestPrint_Nil(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(nil))
+	})
+	assert.Contains(t, out, "No resource release bindings found")
+}
+
+func TestPrint_Empty(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList([]gen.ResourceReleaseBinding{}))
+	})
+	assert.Contains(t, out, "No resource release bindings found")
+}
+
+func TestPrint_WithItems(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceReleaseBinding{
+		bindingFor("analytics-db-dev", "dev"),
+		bindingFor("analytics-db-prod", "prod"),
+	}
+	items[0].Metadata.CreationTimestamp = &now
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "RESOURCE")
+	assert.Contains(t, out, "ENVIRONMENT")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "analytics-db-dev")
+	assert.Contains(t, out, "dev")
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "analytics-db")
+}
+
+func TestPrint_NilSpec(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceReleaseBinding{
+		{
+			Metadata: gen.ObjectMeta{Name: "no-spec", CreationTimestamp: &now},
+			Spec:     nil,
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "no-spec")
+}
+
+// --- Validation tests ---
+
+func TestList_ValidationError(t *testing.T) {
+	rrb := New(mocks.NewMockInterface(t))
+	assert.Error(t, rrb.List(ListParams{Namespace: ""}))
+}
+
+func TestGet_ValidationError(t *testing.T) {
+	rrb := New(mocks.NewMockInterface(t))
+	assert.Error(t, rrb.Get(GetParams{Namespace: ""}))
+}
+
+func TestDelete_ValidationError(t *testing.T) {
+	rrb := New(mocks.NewMockInterface(t))
+	assert.Error(t, rrb.Delete(DeleteParams{Namespace: "my-org", ResourceReleaseBindingName: ""}))
+}
+
+// --- List tests ---
+
+func TestList_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(nil, fmt.Errorf("server error"))
+
+	rrb := New(mc)
+	assert.EqualError(t, rrb.List(ListParams{Namespace: "my-org"}), "server error")
+}
+
+func TestList_Success_NoResourceFilter(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourceReleaseBindingsParams) bool {
+		return p.Resource == nil
+	})).Return(&gen.ResourceReleaseBindingList{
+		Items:      []gen.ResourceReleaseBinding{bindingFor("analytics-db-dev", "dev")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rrb := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rrb.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "analytics-db-dev")
+}
+
+func TestList_Success_WithResourceFilter(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.MatchedBy(func(p *gen.ListResourceReleaseBindingsParams) bool {
+		return p.Resource != nil && *p.Resource == "analytics-db"
+	})).Return(&gen.ResourceReleaseBindingList{
+		Items:      []gen.ResourceReleaseBinding{bindingFor("analytics-db-dev", "dev")},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rrb := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rrb.List(ListParams{Namespace: "my-org", Resource: "analytics-db"}))
+	})
+
+	assert.Contains(t, out, "analytics-db-dev")
+}
+
+func TestList_Empty(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceReleaseBindings(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceReleaseBindingList{
+		Items:      []gen.ResourceReleaseBinding{},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rrb := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rrb.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "No resource release bindings found")
+}
+
+// --- Get tests ---
+
+func TestGet_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceReleaseBinding(mock.Anything, "my-org", "missing").Return(nil, fmt.Errorf("not found"))
+
+	rrb := New(mc)
+	assert.EqualError(t, rrb.Get(GetParams{Namespace: "my-org", ResourceReleaseBindingName: "missing"}), "not found")
+}
+
+func TestGet_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev").Return(&gen.ResourceReleaseBinding{
+		Metadata: gen.ObjectMeta{Name: "analytics-db-dev"},
+	}, nil)
+
+	rrb := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rrb.Get(GetParams{Namespace: "my-org", ResourceReleaseBindingName: "analytics-db-dev"}))
+	})
+
+	assert.Contains(t, out, "name: analytics-db-dev")
+}
+
+// --- Delete tests ---
+
+func TestDelete_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev").Return(fmt.Errorf("forbidden"))
+
+	rrb := New(mc)
+	assert.EqualError(t, rrb.Delete(DeleteParams{Namespace: "my-org", ResourceReleaseBindingName: "analytics-db-dev"}), "forbidden")
+}
+
+func TestDelete_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceReleaseBinding(mock.Anything, "my-org", "analytics-db-dev").Return(nil)
+
+	rrb := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rrb.Delete(DeleteParams{Namespace: "my-org", ResourceReleaseBindingName: "analytics-db-dev"}))
+	})
+
+	assert.Contains(t, out, "ResourceReleaseBinding 'analytics-db-dev' deleted")
+}

--- a/internal/occ/cmd/resourcetype/cmd.go
+++ b/internal/occ/cmd/resourcetype/cmd.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openchoreo/openchoreo/internal/occ/auth"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/flags"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+)
+
+func NewResourceTypeCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resourcetype",
+		Aliases: []string{"rt", "resourcetypes"},
+		Short:   "Manage resource types",
+		Long:    `Manage resource types for OpenChoreo.`,
+	}
+	cmd.AddCommand(
+		newListCmd(f),
+		newGetCmd(f),
+		newDeleteCmd(f),
+	)
+	return cmd
+}
+
+func newListCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List resource types",
+		Long:  `List all resource types available in a namespace.`,
+		Example: `  # List all resource types in a namespace
+  occ resourcetype list --namespace acme-corp`,
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).List(ListParams{
+				Namespace: flags.GetNamespace(cmd),
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newGetCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [RESOURCE_TYPE_NAME]",
+		Short: "Get a resource type",
+		Long:  `Get a resource type and display its details in YAML format.`,
+		Example: `  # Get a resource type
+  occ resourcetype get mysql --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Get(GetParams{
+				Namespace:        flags.GetNamespace(cmd),
+				ResourceTypeName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}
+
+func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [RESOURCE_TYPE_NAME]",
+		Short: "Delete a resource type",
+		Long:  `Delete a resource type by name.`,
+		Example: `  # Delete a resource type
+  occ resourcetype delete mysql --namespace acme-corp`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Delete(DeleteParams{
+				Namespace:        flags.GetNamespace(cmd),
+				ResourceTypeName: args[0],
+			})
+		},
+	}
+	flags.AddNamespace(cmd)
+	return cmd
+}

--- a/internal/occ/cmd/resourcetype/cmd_test.go
+++ b/internal/occ/cmd/resourcetype/cmd_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return mc, nil
+	}
+}
+
+func errFactory(msg string) client.NewClientFunc {
+	return func() (client.Interface, error) {
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+// --- NewResourceTypeCmd structure ---
+
+func TestNewResourceTypeCmd_Use(t *testing.T) {
+	cmd := NewResourceTypeCmd(errFactory("unused"))
+	assert.Equal(t, "resourcetype", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "rt")
+	assert.Contains(t, cmd.Aliases, "resourcetypes")
+}
+
+func TestNewResourceTypeCmd_Subcommands(t *testing.T) {
+	cmd := NewResourceTypeCmd(errFactory("unused"))
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "delete"}, names)
+}
+
+// --- list ---
+
+func TestListCmd_FactoryError(t *testing.T) {
+	cmd := newListCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, nil)
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestListCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceTypes(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceTypeList{
+		Items:      []gen.ResourceType{{Metadata: gen.ObjectMeta{Name: "mysql"}}},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	cmd := newListCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	})
+	assert.Contains(t, out, "mysql")
+}
+
+// --- get ---
+
+func TestGetCmd_MissingArg(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required argument")
+}
+
+func TestGetCmd_TooManyArgs(t *testing.T) {
+	cmd := newGetCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{"a", "b"})
+	assert.EqualError(t, err, "accepts 1 arg(s), received 2")
+}
+
+func TestGetCmd_FactoryError(t *testing.T) {
+	cmd := newGetCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"mysql"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestGetCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceType(mock.Anything, "my-org", "mysql").Return(
+		&gen.ResourceType{Metadata: gen.ObjectMeta{Name: "mysql"}}, nil,
+	)
+
+	cmd := newGetCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"mysql"}))
+	})
+	assert.Contains(t, out, "mysql")
+}
+
+// --- delete ---
+
+func TestDeleteCmd_MissingArg(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RESOURCE_TYPE_NAME")
+}
+
+func TestDeleteCmd_FactoryError(t *testing.T) {
+	cmd := newDeleteCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"mysql"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestDeleteCmd_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceType(mock.Anything, "my-org", "mysql").Return(nil)
+
+	cmd := newDeleteCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "my-org"))
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"mysql"}))
+	})
+	assert.Contains(t, out, "deleted")
+}

--- a/internal/occ/cmd/resourcetype/params.go
+++ b/internal/occ/cmd/resourcetype/params.go
@@ -1,0 +1,21 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+// ListParams defines parameters for listing resource types
+type ListParams struct {
+	Namespace string
+}
+
+// GetParams defines parameters for getting a single resource type
+type GetParams struct {
+	Namespace        string
+	ResourceTypeName string
+}
+
+// DeleteParams defines parameters for deleting a single resource type
+type DeleteParams struct {
+	Namespace        string
+	ResourceTypeName string
+}

--- a/internal/occ/cmd/resourcetype/resourcetype.go
+++ b/internal/occ/cmd/resourcetype/resourcetype.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/pagination"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/utils"
+	"github.com/openchoreo/openchoreo/internal/occ/cmdutil"
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ResourceType implements resource type operations
+type ResourceType struct {
+	client client.Interface
+}
+
+// New creates a new resource type implementation
+func New(c client.Interface) *ResourceType {
+	return &ResourceType{client: c}
+}
+
+// List lists all resource types in a namespace
+func (rt *ResourceType) List(params ListParams) error {
+	if err := cmdutil.RequireFields("list", "resourcetype", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	items, err := pagination.FetchAll(func(limit int, cursor string) ([]gen.ResourceType, string, error) {
+		p := &gen.ListResourceTypesParams{}
+		p.Limit = &limit
+		if cursor != "" {
+			p.Cursor = &cursor
+		}
+		result, err := rt.client.ListResourceTypes(ctx, params.Namespace, p)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if result.Pagination.NextCursor != nil {
+			next = *result.Pagination.NextCursor
+		}
+		return result.Items, next, nil
+	})
+	if err != nil {
+		return err
+	}
+	return printList(items)
+}
+
+// Get retrieves a single resource type and outputs it as YAML
+func (rt *ResourceType) Get(params GetParams) error {
+	if err := cmdutil.RequireFields("get", "resourcetype", map[string]string{"namespace": params.Namespace}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	result, err := rt.client.GetResourceType(ctx, params.Namespace, params.ResourceTypeName)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource type to YAML: %w", err)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+// Delete deletes a single resource type
+func (rt *ResourceType) Delete(params DeleteParams) error {
+	if err := cmdutil.RequireFields("delete", "resourcetype", map[string]string{"namespace": params.Namespace, "name": params.ResourceTypeName}); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if err := rt.client.DeleteResourceType(ctx, params.Namespace, params.ResourceTypeName); err != nil {
+		return err
+	}
+
+	fmt.Printf("ResourceType '%s' deleted\n", params.ResourceTypeName)
+	return nil
+}
+
+func printList(items []gen.ResourceType) error {
+	if len(items) == 0 {
+		fmt.Println("No resource types found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tRETAIN POLICY\tAGE")
+
+	for _, rt := range items {
+		retainPolicy := ""
+		if rt.Spec != nil && rt.Spec.RetainPolicy != nil {
+			retainPolicy = string(*rt.Spec.RetainPolicy)
+		}
+		age := ""
+		if rt.Metadata.CreationTimestamp != nil {
+			age = utils.FormatAge(*rt.Metadata.CreationTimestamp)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			rt.Metadata.Name,
+			retainPolicy,
+			age)
+	}
+
+	return w.Flush()
+}

--- a/internal/occ/cmd/resourcetype/resourcetype_test.go
+++ b/internal/occ/cmd/resourcetype/resourcetype_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcetype
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/occ/resources/client/mocks"
+	"github.com/openchoreo/openchoreo/internal/occ/testutil"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+func TestPrint_Nil(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(nil))
+	})
+	assert.Contains(t, out, "No resource types found")
+}
+
+func TestPrint_Empty(t *testing.T) {
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList([]gen.ResourceType{}))
+	})
+	assert.Contains(t, out, "No resource types found")
+}
+
+func TestPrint_WithItems(t *testing.T) {
+	now := time.Now()
+	retain := gen.ResourceTypeSpecRetainPolicy("Retain")
+	items := []gen.ResourceType{
+		{
+			Metadata: gen.ObjectMeta{
+				Name:              "mysql",
+				CreationTimestamp: &now,
+			},
+			Spec: &gen.ResourceTypeSpec{
+				RetainPolicy: &retain,
+			},
+		},
+		{
+			Metadata: gen.ObjectMeta{
+				Name: "redis",
+			},
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "RETAIN POLICY")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "mysql")
+	assert.Contains(t, out, "Retain")
+	assert.Contains(t, out, "redis")
+}
+
+func TestPrint_NilSpec(t *testing.T) {
+	now := time.Now()
+	items := []gen.ResourceType{
+		{
+			Metadata: gen.ObjectMeta{
+				Name:              "no-spec-type",
+				CreationTimestamp: &now,
+			},
+			Spec: nil,
+		},
+	}
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, printList(items))
+	})
+
+	assert.Contains(t, out, "no-spec-type")
+}
+
+// --- Validation tests ---
+
+func TestList_ValidationError(t *testing.T) {
+	rt := New(mocks.NewMockInterface(t))
+	assert.Error(t, rt.List(ListParams{Namespace: ""}))
+}
+
+func TestGet_ValidationError(t *testing.T) {
+	rt := New(mocks.NewMockInterface(t))
+	assert.Error(t, rt.Get(GetParams{Namespace: ""}))
+}
+
+func TestDelete_ValidationError(t *testing.T) {
+	rt := New(mocks.NewMockInterface(t))
+	assert.Error(t, rt.Delete(DeleteParams{Namespace: "my-org", ResourceTypeName: ""}))
+}
+
+// --- List tests ---
+
+func TestList_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceTypes(mock.Anything, "my-org", mock.Anything).Return(nil, fmt.Errorf("server error"))
+
+	rt := New(mc)
+	assert.EqualError(t, rt.List(ListParams{Namespace: "my-org"}), "server error")
+}
+
+func TestList_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceTypes(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceTypeList{
+		Items:      []gen.ResourceType{{Metadata: gen.ObjectMeta{Name: "mysql"}}},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rt.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "mysql")
+}
+
+func TestList_MultipleItems(t *testing.T) {
+	now := time.Now()
+	retain := gen.ResourceTypeSpecRetainPolicy("Retain")
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceTypes(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceTypeList{
+		Items: []gen.ResourceType{
+			{
+				Metadata: gen.ObjectMeta{Name: "mysql", CreationTimestamp: &now},
+				Spec:     &gen.ResourceTypeSpec{RetainPolicy: &retain},
+			},
+			{
+				Metadata: gen.ObjectMeta{Name: "redis", CreationTimestamp: &now},
+			},
+		},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rt.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "mysql")
+	assert.Contains(t, out, "redis")
+}
+
+func TestList_Empty(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().ListResourceTypes(mock.Anything, "my-org", mock.Anything).Return(&gen.ResourceTypeList{
+		Items:      []gen.ResourceType{},
+		Pagination: gen.Pagination{},
+	}, nil)
+
+	rt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rt.List(ListParams{Namespace: "my-org"}))
+	})
+
+	assert.Contains(t, out, "No resource types found")
+}
+
+// --- Get tests ---
+
+func TestGet_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceType(mock.Anything, "my-org", "missing").Return(nil, fmt.Errorf("not found: missing"))
+
+	rt := New(mc)
+	assert.EqualError(t, rt.Get(GetParams{Namespace: "my-org", ResourceTypeName: "missing"}), "not found: missing")
+}
+
+func TestGet_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetResourceType(mock.Anything, "my-org", "mysql").Return(&gen.ResourceType{
+		Metadata: gen.ObjectMeta{Name: "mysql"},
+	}, nil)
+
+	rt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rt.Get(GetParams{Namespace: "my-org", ResourceTypeName: "mysql"}))
+	})
+
+	assert.Contains(t, out, "name: mysql")
+}
+
+// --- Delete tests ---
+
+func TestDelete_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceType(mock.Anything, "my-org", "mysql").Return(fmt.Errorf("forbidden: mysql"))
+
+	rt := New(mc)
+	assert.EqualError(t, rt.Delete(DeleteParams{Namespace: "my-org", ResourceTypeName: "mysql"}), "forbidden: mysql")
+}
+
+func TestDelete_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().DeleteResourceType(mock.Anything, "my-org", "mysql").Return(nil)
+
+	rt := New(mc)
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, rt.Delete(DeleteParams{Namespace: "my-org", ResourceTypeName: "mysql"}))
+	})
+
+	assert.Contains(t, out, "ResourceType 'mysql' deleted")
+}

--- a/internal/occ/cmd/utils/utils.go
+++ b/internal/occ/cmd/utils/utils.go
@@ -11,11 +11,14 @@ import (
 // FormatAge returns a human-readable age string for a given timestamp.
 func FormatAge(t time.Time) string {
 	if t.IsZero() {
-		return "0m"
+		return "0s"
 	}
 	duration := time.Since(t)
 	if duration < 0 {
 		duration = 0
+	}
+	if duration < time.Minute {
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
 	}
 	if duration.Hours() < 1 {
 		return fmt.Sprintf("%dm", int(duration.Minutes()))

--- a/internal/occ/cmd/utils/utils_test.go
+++ b/internal/occ/cmd/utils/utils_test.go
@@ -19,7 +19,17 @@ func TestFormatAge(t *testing.T) {
 		{
 			name: "zero time",
 			t:    time.Time{},
-			want: "0m",
+			want: "0s",
+		},
+		{
+			name: "seconds ago",
+			t:    time.Now().Add(-12 * time.Second),
+			want: "12s",
+		},
+		{
+			name: "just created",
+			t:    time.Now().Add(-100 * time.Millisecond),
+			want: "0s",
 		},
 		{
 			name: "minutes ago",

--- a/internal/occ/flags/flags.go
+++ b/internal/occ/flags/flags.go
@@ -46,6 +46,17 @@ func GetComponent(cmd *cobra.Command) string {
 	return val
 }
 
+// --- Resource ---
+
+func AddResource(cmd *cobra.Command) {
+	cmd.Flags().String("resource", "", "Name of the resource (e.g., analytics-db)")
+}
+
+func GetResource(cmd *cobra.Command) string {
+	val, _ := cmd.Flags().GetString("resource")
+	return val
+}
+
 // --- Environment ---
 
 func AddEnvironment(cmd *cobra.Command) {

--- a/internal/occ/flags/flags_test.go
+++ b/internal/occ/flags/flags_test.go
@@ -70,6 +70,16 @@ func TestComponent_HasShorthand(t *testing.T) {
 	assert.Equal(t, "c", f.Shorthand)
 }
 
+func TestResource_DefaultAndSet(t *testing.T) {
+	cmd := newTestCmd()
+	AddResource(cmd)
+
+	assert.Equal(t, "", GetResource(cmd))
+
+	_ = cmd.Flags().Set("resource", "analytics-db")
+	assert.Equal(t, "analytics-db", GetResource(cmd))
+}
+
 func TestEnvironment_DefaultAndSet(t *testing.T) {
 	cmd := newTestCmd()
 	AddEnvironment(cmd)

--- a/internal/occ/resources/client/interface.go
+++ b/internal/occ/resources/client/interface.go
@@ -106,6 +106,37 @@ type Interface interface {
 	UpdateReleaseBinding(ctx context.Context, namespaceName, bindingName string, req gen.ReleaseBinding) (*gen.ReleaseBinding, error)
 	DeleteReleaseBinding(ctx context.Context, namespaceName, releaseBindingName string) error
 
+	ListResourceTypes(ctx context.Context, namespaceName string, params *gen.ListResourceTypesParams) (*gen.ResourceTypeList, error)
+	GetResourceType(ctx context.Context, namespaceName, rtName string) (*gen.ResourceType, error)
+	CreateResourceType(ctx context.Context, namespaceName string, rt gen.ResourceType) (*gen.ResourceType, error)
+	UpdateResourceType(ctx context.Context, namespaceName, rtName string, rt gen.ResourceType) (*gen.ResourceType, error)
+	DeleteResourceType(ctx context.Context, namespaceName, rtName string) error
+	GetResourceTypeSchema(ctx context.Context, namespaceName, rtName string) (*json.RawMessage, error)
+
+	ListClusterResourceTypes(ctx context.Context, params *gen.ListClusterResourceTypesParams) (*gen.ClusterResourceTypeList, error)
+	GetClusterResourceType(ctx context.Context, crtName string) (*gen.ClusterResourceType, error)
+	CreateClusterResourceType(ctx context.Context, crt gen.ClusterResourceType) (*gen.ClusterResourceType, error)
+	UpdateClusterResourceType(ctx context.Context, crtName string, crt gen.ClusterResourceType) (*gen.ClusterResourceType, error)
+	DeleteClusterResourceType(ctx context.Context, crtName string) error
+	GetClusterResourceTypeSchema(ctx context.Context, crtName string) (*json.RawMessage, error)
+
+	ListResources(ctx context.Context, namespaceName string, params *gen.ListResourcesParams) (*gen.ResourceInstanceList, error)
+	GetResource(ctx context.Context, namespaceName, resourceName string) (*gen.ResourceInstance, error)
+	CreateResource(ctx context.Context, namespaceName string, r gen.ResourceInstance) (*gen.ResourceInstance, error)
+	UpdateResource(ctx context.Context, namespaceName, resourceName string, r gen.ResourceInstance) (*gen.ResourceInstance, error)
+	DeleteResource(ctx context.Context, namespaceName, resourceName string) error
+
+	ListResourceReleases(ctx context.Context, namespaceName string, params *gen.ListResourceReleasesParams) (*gen.ResourceReleaseList, error)
+	GetResourceRelease(ctx context.Context, namespaceName, resourceReleaseName string) (*gen.ResourceRelease, error)
+	CreateResourceRelease(ctx context.Context, namespaceName string, rr gen.ResourceRelease) (*gen.ResourceRelease, error)
+	DeleteResourceRelease(ctx context.Context, namespaceName, resourceReleaseName string) error
+
+	ListResourceReleaseBindings(ctx context.Context, namespaceName string, params *gen.ListResourceReleaseBindingsParams) (*gen.ResourceReleaseBindingList, error)
+	GetResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string) (*gen.ResourceReleaseBinding, error)
+	CreateResourceReleaseBinding(ctx context.Context, namespaceName string, rrb gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error)
+	UpdateResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string, rrb gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error)
+	DeleteResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string) error
+
 	ListDeploymentPipelines(ctx context.Context, namespaceName string, params *gen.ListDeploymentPipelinesParams) (*gen.DeploymentPipelineList, error)
 	GetDeploymentPipeline(ctx context.Context, namespaceName, deploymentPipelineName string) (*gen.DeploymentPipeline, error)
 	DeleteDeploymentPipeline(ctx context.Context, namespaceName, deploymentPipelineName string) error

--- a/internal/occ/resources/client/mocks/client.go
+++ b/internal/occ/resources/client/mocks/client.go
@@ -24,6 +24,65 @@ func (_m *MockInterface) EXPECT() *MockInterface_Expecter {
 	return &MockInterface_Expecter{mock: &_m.Mock}
 }
 
+// CreateClusterResourceType provides a mock function with given fields: ctx, crt
+func (_m *MockInterface) CreateClusterResourceType(ctx context.Context, crt gen.ClusterResourceType) (*gen.ClusterResourceType, error) {
+	ret := _m.Called(ctx, crt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateClusterResourceType")
+	}
+
+	var r0 *gen.ClusterResourceType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, gen.ClusterResourceType) (*gen.ClusterResourceType, error)); ok {
+		return rf(ctx, crt)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, gen.ClusterResourceType) *gen.ClusterResourceType); ok {
+		r0 = rf(ctx, crt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ClusterResourceType)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, gen.ClusterResourceType) error); ok {
+		r1 = rf(ctx, crt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_CreateClusterResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateClusterResourceType'
+type MockInterface_CreateClusterResourceType_Call struct {
+	*mock.Call
+}
+
+// CreateClusterResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - crt gen.ClusterResourceType
+func (_e *MockInterface_Expecter) CreateClusterResourceType(ctx interface{}, crt interface{}) *MockInterface_CreateClusterResourceType_Call {
+	return &MockInterface_CreateClusterResourceType_Call{Call: _e.mock.On("CreateClusterResourceType", ctx, crt)}
+}
+
+func (_c *MockInterface_CreateClusterResourceType_Call) Run(run func(ctx context.Context, crt gen.ClusterResourceType)) *MockInterface_CreateClusterResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(gen.ClusterResourceType))
+	})
+	return _c
+}
+
+func (_c *MockInterface_CreateClusterResourceType_Call) Return(_a0 *gen.ClusterResourceType, _a1 error) *MockInterface_CreateClusterResourceType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_CreateClusterResourceType_Call) RunAndReturn(run func(context.Context, gen.ClusterResourceType) (*gen.ClusterResourceType, error)) *MockInterface_CreateClusterResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateComponentRelease provides a mock function with given fields: ctx, namespaceName, cr
 func (_m *MockInterface) CreateComponentRelease(ctx context.Context, namespaceName string, cr gen.ComponentRelease) (*gen.ComponentRelease, error) {
 	ret := _m.Called(ctx, namespaceName, cr)
@@ -200,6 +259,246 @@ func (_c *MockInterface_CreateReleaseBinding_Call) Return(_a0 *gen.ReleaseBindin
 }
 
 func (_c *MockInterface_CreateReleaseBinding_Call) RunAndReturn(run func(context.Context, string, gen.ReleaseBinding) (*gen.ReleaseBinding, error)) *MockInterface_CreateReleaseBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateResource provides a mock function with given fields: ctx, namespaceName, r
+func (_m *MockInterface) CreateResource(ctx context.Context, namespaceName string, r gen.ResourceInstance) (*gen.ResourceInstance, error) {
+	ret := _m.Called(ctx, namespaceName, r)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateResource")
+	}
+
+	var r0 *gen.ResourceInstance
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceInstance) (*gen.ResourceInstance, error)); ok {
+		return rf(ctx, namespaceName, r)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceInstance) *gen.ResourceInstance); ok {
+		r0 = rf(ctx, namespaceName, r)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceInstance)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, gen.ResourceInstance) error); ok {
+		r1 = rf(ctx, namespaceName, r)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_CreateResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateResource'
+type MockInterface_CreateResource_Call struct {
+	*mock.Call
+}
+
+// CreateResource is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - r gen.ResourceInstance
+func (_e *MockInterface_Expecter) CreateResource(ctx interface{}, namespaceName interface{}, r interface{}) *MockInterface_CreateResource_Call {
+	return &MockInterface_CreateResource_Call{Call: _e.mock.On("CreateResource", ctx, namespaceName, r)}
+}
+
+func (_c *MockInterface_CreateResource_Call) Run(run func(ctx context.Context, namespaceName string, r gen.ResourceInstance)) *MockInterface_CreateResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(gen.ResourceInstance))
+	})
+	return _c
+}
+
+func (_c *MockInterface_CreateResource_Call) Return(_a0 *gen.ResourceInstance, _a1 error) *MockInterface_CreateResource_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_CreateResource_Call) RunAndReturn(run func(context.Context, string, gen.ResourceInstance) (*gen.ResourceInstance, error)) *MockInterface_CreateResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateResourceRelease provides a mock function with given fields: ctx, namespaceName, rr
+func (_m *MockInterface) CreateResourceRelease(ctx context.Context, namespaceName string, rr gen.ResourceRelease) (*gen.ResourceRelease, error) {
+	ret := _m.Called(ctx, namespaceName, rr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateResourceRelease")
+	}
+
+	var r0 *gen.ResourceRelease
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceRelease) (*gen.ResourceRelease, error)); ok {
+		return rf(ctx, namespaceName, rr)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceRelease) *gen.ResourceRelease); ok {
+		r0 = rf(ctx, namespaceName, rr)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceRelease)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, gen.ResourceRelease) error); ok {
+		r1 = rf(ctx, namespaceName, rr)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_CreateResourceRelease_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateResourceRelease'
+type MockInterface_CreateResourceRelease_Call struct {
+	*mock.Call
+}
+
+// CreateResourceRelease is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rr gen.ResourceRelease
+func (_e *MockInterface_Expecter) CreateResourceRelease(ctx interface{}, namespaceName interface{}, rr interface{}) *MockInterface_CreateResourceRelease_Call {
+	return &MockInterface_CreateResourceRelease_Call{Call: _e.mock.On("CreateResourceRelease", ctx, namespaceName, rr)}
+}
+
+func (_c *MockInterface_CreateResourceRelease_Call) Run(run func(ctx context.Context, namespaceName string, rr gen.ResourceRelease)) *MockInterface_CreateResourceRelease_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(gen.ResourceRelease))
+	})
+	return _c
+}
+
+func (_c *MockInterface_CreateResourceRelease_Call) Return(_a0 *gen.ResourceRelease, _a1 error) *MockInterface_CreateResourceRelease_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_CreateResourceRelease_Call) RunAndReturn(run func(context.Context, string, gen.ResourceRelease) (*gen.ResourceRelease, error)) *MockInterface_CreateResourceRelease_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateResourceReleaseBinding provides a mock function with given fields: ctx, namespaceName, rrb
+func (_m *MockInterface) CreateResourceReleaseBinding(ctx context.Context, namespaceName string, rrb gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error) {
+	ret := _m.Called(ctx, namespaceName, rrb)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateResourceReleaseBinding")
+	}
+
+	var r0 *gen.ResourceReleaseBinding
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error)); ok {
+		return rf(ctx, namespaceName, rrb)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceReleaseBinding) *gen.ResourceReleaseBinding); ok {
+		r0 = rf(ctx, namespaceName, rrb)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceReleaseBinding)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, gen.ResourceReleaseBinding) error); ok {
+		r1 = rf(ctx, namespaceName, rrb)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_CreateResourceReleaseBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateResourceReleaseBinding'
+type MockInterface_CreateResourceReleaseBinding_Call struct {
+	*mock.Call
+}
+
+// CreateResourceReleaseBinding is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rrb gen.ResourceReleaseBinding
+func (_e *MockInterface_Expecter) CreateResourceReleaseBinding(ctx interface{}, namespaceName interface{}, rrb interface{}) *MockInterface_CreateResourceReleaseBinding_Call {
+	return &MockInterface_CreateResourceReleaseBinding_Call{Call: _e.mock.On("CreateResourceReleaseBinding", ctx, namespaceName, rrb)}
+}
+
+func (_c *MockInterface_CreateResourceReleaseBinding_Call) Run(run func(ctx context.Context, namespaceName string, rrb gen.ResourceReleaseBinding)) *MockInterface_CreateResourceReleaseBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(gen.ResourceReleaseBinding))
+	})
+	return _c
+}
+
+func (_c *MockInterface_CreateResourceReleaseBinding_Call) Return(_a0 *gen.ResourceReleaseBinding, _a1 error) *MockInterface_CreateResourceReleaseBinding_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_CreateResourceReleaseBinding_Call) RunAndReturn(run func(context.Context, string, gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error)) *MockInterface_CreateResourceReleaseBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateResourceType provides a mock function with given fields: ctx, namespaceName, rt
+func (_m *MockInterface) CreateResourceType(ctx context.Context, namespaceName string, rt gen.ResourceType) (*gen.ResourceType, error) {
+	ret := _m.Called(ctx, namespaceName, rt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateResourceType")
+	}
+
+	var r0 *gen.ResourceType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceType) (*gen.ResourceType, error)); ok {
+		return rf(ctx, namespaceName, rt)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ResourceType) *gen.ResourceType); ok {
+		r0 = rf(ctx, namespaceName, rt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceType)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, gen.ResourceType) error); ok {
+		r1 = rf(ctx, namespaceName, rt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_CreateResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateResourceType'
+type MockInterface_CreateResourceType_Call struct {
+	*mock.Call
+}
+
+// CreateResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rt gen.ResourceType
+func (_e *MockInterface_Expecter) CreateResourceType(ctx interface{}, namespaceName interface{}, rt interface{}) *MockInterface_CreateResourceType_Call {
+	return &MockInterface_CreateResourceType_Call{Call: _e.mock.On("CreateResourceType", ctx, namespaceName, rt)}
+}
+
+func (_c *MockInterface_CreateResourceType_Call) Run(run func(ctx context.Context, namespaceName string, rt gen.ResourceType)) *MockInterface_CreateResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(gen.ResourceType))
+	})
+	return _c
+}
+
+func (_c *MockInterface_CreateResourceType_Call) Return(_a0 *gen.ResourceType, _a1 error) *MockInterface_CreateResourceType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_CreateResourceType_Call) RunAndReturn(run func(context.Context, string, gen.ResourceType) (*gen.ResourceType, error)) *MockInterface_CreateResourceType_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -461,6 +760,53 @@ func (_c *MockInterface_DeleteClusterObservabilityPlane_Call) Return(_a0 error) 
 }
 
 func (_c *MockInterface_DeleteClusterObservabilityPlane_Call) RunAndReturn(run func(context.Context, string) error) *MockInterface_DeleteClusterObservabilityPlane_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteClusterResourceType provides a mock function with given fields: ctx, crtName
+func (_m *MockInterface) DeleteClusterResourceType(ctx context.Context, crtName string) error {
+	ret := _m.Called(ctx, crtName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteClusterResourceType")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, crtName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockInterface_DeleteClusterResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteClusterResourceType'
+type MockInterface_DeleteClusterResourceType_Call struct {
+	*mock.Call
+}
+
+// DeleteClusterResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - crtName string
+func (_e *MockInterface_Expecter) DeleteClusterResourceType(ctx interface{}, crtName interface{}) *MockInterface_DeleteClusterResourceType_Call {
+	return &MockInterface_DeleteClusterResourceType_Call{Call: _e.mock.On("DeleteClusterResourceType", ctx, crtName)}
+}
+
+func (_c *MockInterface_DeleteClusterResourceType_Call) Run(run func(ctx context.Context, crtName string)) *MockInterface_DeleteClusterResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_DeleteClusterResourceType_Call) Return(_a0 error) *MockInterface_DeleteClusterResourceType_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockInterface_DeleteClusterResourceType_Call) RunAndReturn(run func(context.Context, string) error) *MockInterface_DeleteClusterResourceType_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1323,6 +1669,198 @@ func (_c *MockInterface_DeleteReleaseBinding_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// DeleteResource provides a mock function with given fields: ctx, namespaceName, resourceName
+func (_m *MockInterface) DeleteResource(ctx context.Context, namespaceName string, resourceName string) error {
+	ret := _m.Called(ctx, namespaceName, resourceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteResource")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespaceName, resourceName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockInterface_DeleteResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteResource'
+type MockInterface_DeleteResource_Call struct {
+	*mock.Call
+}
+
+// DeleteResource is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - resourceName string
+func (_e *MockInterface_Expecter) DeleteResource(ctx interface{}, namespaceName interface{}, resourceName interface{}) *MockInterface_DeleteResource_Call {
+	return &MockInterface_DeleteResource_Call{Call: _e.mock.On("DeleteResource", ctx, namespaceName, resourceName)}
+}
+
+func (_c *MockInterface_DeleteResource_Call) Run(run func(ctx context.Context, namespaceName string, resourceName string)) *MockInterface_DeleteResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_DeleteResource_Call) Return(_a0 error) *MockInterface_DeleteResource_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockInterface_DeleteResource_Call) RunAndReturn(run func(context.Context, string, string) error) *MockInterface_DeleteResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteResourceRelease provides a mock function with given fields: ctx, namespaceName, resourceReleaseName
+func (_m *MockInterface) DeleteResourceRelease(ctx context.Context, namespaceName string, resourceReleaseName string) error {
+	ret := _m.Called(ctx, namespaceName, resourceReleaseName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteResourceRelease")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespaceName, resourceReleaseName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockInterface_DeleteResourceRelease_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteResourceRelease'
+type MockInterface_DeleteResourceRelease_Call struct {
+	*mock.Call
+}
+
+// DeleteResourceRelease is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - resourceReleaseName string
+func (_e *MockInterface_Expecter) DeleteResourceRelease(ctx interface{}, namespaceName interface{}, resourceReleaseName interface{}) *MockInterface_DeleteResourceRelease_Call {
+	return &MockInterface_DeleteResourceRelease_Call{Call: _e.mock.On("DeleteResourceRelease", ctx, namespaceName, resourceReleaseName)}
+}
+
+func (_c *MockInterface_DeleteResourceRelease_Call) Run(run func(ctx context.Context, namespaceName string, resourceReleaseName string)) *MockInterface_DeleteResourceRelease_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_DeleteResourceRelease_Call) Return(_a0 error) *MockInterface_DeleteResourceRelease_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockInterface_DeleteResourceRelease_Call) RunAndReturn(run func(context.Context, string, string) error) *MockInterface_DeleteResourceRelease_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteResourceReleaseBinding provides a mock function with given fields: ctx, namespaceName, bindingName
+func (_m *MockInterface) DeleteResourceReleaseBinding(ctx context.Context, namespaceName string, bindingName string) error {
+	ret := _m.Called(ctx, namespaceName, bindingName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteResourceReleaseBinding")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespaceName, bindingName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockInterface_DeleteResourceReleaseBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteResourceReleaseBinding'
+type MockInterface_DeleteResourceReleaseBinding_Call struct {
+	*mock.Call
+}
+
+// DeleteResourceReleaseBinding is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - bindingName string
+func (_e *MockInterface_Expecter) DeleteResourceReleaseBinding(ctx interface{}, namespaceName interface{}, bindingName interface{}) *MockInterface_DeleteResourceReleaseBinding_Call {
+	return &MockInterface_DeleteResourceReleaseBinding_Call{Call: _e.mock.On("DeleteResourceReleaseBinding", ctx, namespaceName, bindingName)}
+}
+
+func (_c *MockInterface_DeleteResourceReleaseBinding_Call) Run(run func(ctx context.Context, namespaceName string, bindingName string)) *MockInterface_DeleteResourceReleaseBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_DeleteResourceReleaseBinding_Call) Return(_a0 error) *MockInterface_DeleteResourceReleaseBinding_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockInterface_DeleteResourceReleaseBinding_Call) RunAndReturn(run func(context.Context, string, string) error) *MockInterface_DeleteResourceReleaseBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteResourceType provides a mock function with given fields: ctx, namespaceName, rtName
+func (_m *MockInterface) DeleteResourceType(ctx context.Context, namespaceName string, rtName string) error {
+	ret := _m.Called(ctx, namespaceName, rtName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteResourceType")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespaceName, rtName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockInterface_DeleteResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteResourceType'
+type MockInterface_DeleteResourceType_Call struct {
+	*mock.Call
+}
+
+// DeleteResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rtName string
+func (_e *MockInterface_Expecter) DeleteResourceType(ctx interface{}, namespaceName interface{}, rtName interface{}) *MockInterface_DeleteResourceType_Call {
+	return &MockInterface_DeleteResourceType_Call{Call: _e.mock.On("DeleteResourceType", ctx, namespaceName, rtName)}
+}
+
+func (_c *MockInterface_DeleteResourceType_Call) Run(run func(ctx context.Context, namespaceName string, rtName string)) *MockInterface_DeleteResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_DeleteResourceType_Call) Return(_a0 error) *MockInterface_DeleteResourceType_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockInterface_DeleteResourceType_Call) RunAndReturn(run func(context.Context, string, string) error) *MockInterface_DeleteResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteSecretReference provides a mock function with given fields: ctx, namespaceName, secretReferenceName
 func (_m *MockInterface) DeleteSecretReference(ctx context.Context, namespaceName string, secretReferenceName string) error {
 	ret := _m.Called(ctx, namespaceName, secretReferenceName)
@@ -1856,6 +2394,124 @@ func (_c *MockInterface_GetClusterObservabilityPlane_Call) Return(_a0 *gen.Clust
 }
 
 func (_c *MockInterface_GetClusterObservabilityPlane_Call) RunAndReturn(run func(context.Context, string) (*gen.ClusterObservabilityPlane, error)) *MockInterface_GetClusterObservabilityPlane_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetClusterResourceType provides a mock function with given fields: ctx, crtName
+func (_m *MockInterface) GetClusterResourceType(ctx context.Context, crtName string) (*gen.ClusterResourceType, error) {
+	ret := _m.Called(ctx, crtName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetClusterResourceType")
+	}
+
+	var r0 *gen.ClusterResourceType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*gen.ClusterResourceType, error)); ok {
+		return rf(ctx, crtName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *gen.ClusterResourceType); ok {
+		r0 = rf(ctx, crtName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ClusterResourceType)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, crtName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetClusterResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetClusterResourceType'
+type MockInterface_GetClusterResourceType_Call struct {
+	*mock.Call
+}
+
+// GetClusterResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - crtName string
+func (_e *MockInterface_Expecter) GetClusterResourceType(ctx interface{}, crtName interface{}) *MockInterface_GetClusterResourceType_Call {
+	return &MockInterface_GetClusterResourceType_Call{Call: _e.mock.On("GetClusterResourceType", ctx, crtName)}
+}
+
+func (_c *MockInterface_GetClusterResourceType_Call) Run(run func(ctx context.Context, crtName string)) *MockInterface_GetClusterResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetClusterResourceType_Call) Return(_a0 *gen.ClusterResourceType, _a1 error) *MockInterface_GetClusterResourceType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetClusterResourceType_Call) RunAndReturn(run func(context.Context, string) (*gen.ClusterResourceType, error)) *MockInterface_GetClusterResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetClusterResourceTypeSchema provides a mock function with given fields: ctx, crtName
+func (_m *MockInterface) GetClusterResourceTypeSchema(ctx context.Context, crtName string) (*json.RawMessage, error) {
+	ret := _m.Called(ctx, crtName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetClusterResourceTypeSchema")
+	}
+
+	var r0 *json.RawMessage
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*json.RawMessage, error)); ok {
+		return rf(ctx, crtName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *json.RawMessage); ok {
+		r0 = rf(ctx, crtName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*json.RawMessage)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, crtName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetClusterResourceTypeSchema_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetClusterResourceTypeSchema'
+type MockInterface_GetClusterResourceTypeSchema_Call struct {
+	*mock.Call
+}
+
+// GetClusterResourceTypeSchema is a helper method to define mock.On call
+//   - ctx context.Context
+//   - crtName string
+func (_e *MockInterface_Expecter) GetClusterResourceTypeSchema(ctx interface{}, crtName interface{}) *MockInterface_GetClusterResourceTypeSchema_Call {
+	return &MockInterface_GetClusterResourceTypeSchema_Call{Call: _e.mock.On("GetClusterResourceTypeSchema", ctx, crtName)}
+}
+
+func (_c *MockInterface_GetClusterResourceTypeSchema_Call) Run(run func(ctx context.Context, crtName string)) *MockInterface_GetClusterResourceTypeSchema_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetClusterResourceTypeSchema_Call) Return(_a0 *json.RawMessage, _a1 error) *MockInterface_GetClusterResourceTypeSchema_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetClusterResourceTypeSchema_Call) RunAndReturn(run func(context.Context, string) (*json.RawMessage, error)) *MockInterface_GetClusterResourceTypeSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3172,6 +3828,306 @@ func (_c *MockInterface_GetReleaseBinding_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// GetResource provides a mock function with given fields: ctx, namespaceName, resourceName
+func (_m *MockInterface) GetResource(ctx context.Context, namespaceName string, resourceName string) (*gen.ResourceInstance, error) {
+	ret := _m.Called(ctx, namespaceName, resourceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResource")
+	}
+
+	var r0 *gen.ResourceInstance
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*gen.ResourceInstance, error)); ok {
+		return rf(ctx, namespaceName, resourceName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *gen.ResourceInstance); ok {
+		r0 = rf(ctx, namespaceName, resourceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceInstance)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespaceName, resourceName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResource'
+type MockInterface_GetResource_Call struct {
+	*mock.Call
+}
+
+// GetResource is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - resourceName string
+func (_e *MockInterface_Expecter) GetResource(ctx interface{}, namespaceName interface{}, resourceName interface{}) *MockInterface_GetResource_Call {
+	return &MockInterface_GetResource_Call{Call: _e.mock.On("GetResource", ctx, namespaceName, resourceName)}
+}
+
+func (_c *MockInterface_GetResource_Call) Run(run func(ctx context.Context, namespaceName string, resourceName string)) *MockInterface_GetResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetResource_Call) Return(_a0 *gen.ResourceInstance, _a1 error) *MockInterface_GetResource_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetResource_Call) RunAndReturn(run func(context.Context, string, string) (*gen.ResourceInstance, error)) *MockInterface_GetResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceRelease provides a mock function with given fields: ctx, namespaceName, resourceReleaseName
+func (_m *MockInterface) GetResourceRelease(ctx context.Context, namespaceName string, resourceReleaseName string) (*gen.ResourceRelease, error) {
+	ret := _m.Called(ctx, namespaceName, resourceReleaseName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceRelease")
+	}
+
+	var r0 *gen.ResourceRelease
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*gen.ResourceRelease, error)); ok {
+		return rf(ctx, namespaceName, resourceReleaseName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *gen.ResourceRelease); ok {
+		r0 = rf(ctx, namespaceName, resourceReleaseName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceRelease)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespaceName, resourceReleaseName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetResourceRelease_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceRelease'
+type MockInterface_GetResourceRelease_Call struct {
+	*mock.Call
+}
+
+// GetResourceRelease is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - resourceReleaseName string
+func (_e *MockInterface_Expecter) GetResourceRelease(ctx interface{}, namespaceName interface{}, resourceReleaseName interface{}) *MockInterface_GetResourceRelease_Call {
+	return &MockInterface_GetResourceRelease_Call{Call: _e.mock.On("GetResourceRelease", ctx, namespaceName, resourceReleaseName)}
+}
+
+func (_c *MockInterface_GetResourceRelease_Call) Run(run func(ctx context.Context, namespaceName string, resourceReleaseName string)) *MockInterface_GetResourceRelease_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetResourceRelease_Call) Return(_a0 *gen.ResourceRelease, _a1 error) *MockInterface_GetResourceRelease_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetResourceRelease_Call) RunAndReturn(run func(context.Context, string, string) (*gen.ResourceRelease, error)) *MockInterface_GetResourceRelease_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceReleaseBinding provides a mock function with given fields: ctx, namespaceName, bindingName
+func (_m *MockInterface) GetResourceReleaseBinding(ctx context.Context, namespaceName string, bindingName string) (*gen.ResourceReleaseBinding, error) {
+	ret := _m.Called(ctx, namespaceName, bindingName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceReleaseBinding")
+	}
+
+	var r0 *gen.ResourceReleaseBinding
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*gen.ResourceReleaseBinding, error)); ok {
+		return rf(ctx, namespaceName, bindingName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *gen.ResourceReleaseBinding); ok {
+		r0 = rf(ctx, namespaceName, bindingName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceReleaseBinding)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespaceName, bindingName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetResourceReleaseBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceReleaseBinding'
+type MockInterface_GetResourceReleaseBinding_Call struct {
+	*mock.Call
+}
+
+// GetResourceReleaseBinding is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - bindingName string
+func (_e *MockInterface_Expecter) GetResourceReleaseBinding(ctx interface{}, namespaceName interface{}, bindingName interface{}) *MockInterface_GetResourceReleaseBinding_Call {
+	return &MockInterface_GetResourceReleaseBinding_Call{Call: _e.mock.On("GetResourceReleaseBinding", ctx, namespaceName, bindingName)}
+}
+
+func (_c *MockInterface_GetResourceReleaseBinding_Call) Run(run func(ctx context.Context, namespaceName string, bindingName string)) *MockInterface_GetResourceReleaseBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetResourceReleaseBinding_Call) Return(_a0 *gen.ResourceReleaseBinding, _a1 error) *MockInterface_GetResourceReleaseBinding_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetResourceReleaseBinding_Call) RunAndReturn(run func(context.Context, string, string) (*gen.ResourceReleaseBinding, error)) *MockInterface_GetResourceReleaseBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceType provides a mock function with given fields: ctx, namespaceName, rtName
+func (_m *MockInterface) GetResourceType(ctx context.Context, namespaceName string, rtName string) (*gen.ResourceType, error) {
+	ret := _m.Called(ctx, namespaceName, rtName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceType")
+	}
+
+	var r0 *gen.ResourceType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*gen.ResourceType, error)); ok {
+		return rf(ctx, namespaceName, rtName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *gen.ResourceType); ok {
+		r0 = rf(ctx, namespaceName, rtName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceType)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespaceName, rtName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceType'
+type MockInterface_GetResourceType_Call struct {
+	*mock.Call
+}
+
+// GetResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rtName string
+func (_e *MockInterface_Expecter) GetResourceType(ctx interface{}, namespaceName interface{}, rtName interface{}) *MockInterface_GetResourceType_Call {
+	return &MockInterface_GetResourceType_Call{Call: _e.mock.On("GetResourceType", ctx, namespaceName, rtName)}
+}
+
+func (_c *MockInterface_GetResourceType_Call) Run(run func(ctx context.Context, namespaceName string, rtName string)) *MockInterface_GetResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetResourceType_Call) Return(_a0 *gen.ResourceType, _a1 error) *MockInterface_GetResourceType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetResourceType_Call) RunAndReturn(run func(context.Context, string, string) (*gen.ResourceType, error)) *MockInterface_GetResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceTypeSchema provides a mock function with given fields: ctx, namespaceName, rtName
+func (_m *MockInterface) GetResourceTypeSchema(ctx context.Context, namespaceName string, rtName string) (*json.RawMessage, error) {
+	ret := _m.Called(ctx, namespaceName, rtName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceTypeSchema")
+	}
+
+	var r0 *json.RawMessage
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*json.RawMessage, error)); ok {
+		return rf(ctx, namespaceName, rtName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *json.RawMessage); ok {
+		r0 = rf(ctx, namespaceName, rtName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*json.RawMessage)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespaceName, rtName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetResourceTypeSchema_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceTypeSchema'
+type MockInterface_GetResourceTypeSchema_Call struct {
+	*mock.Call
+}
+
+// GetResourceTypeSchema is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rtName string
+func (_e *MockInterface_Expecter) GetResourceTypeSchema(ctx interface{}, namespaceName interface{}, rtName interface{}) *MockInterface_GetResourceTypeSchema_Call {
+	return &MockInterface_GetResourceTypeSchema_Call{Call: _e.mock.On("GetResourceTypeSchema", ctx, namespaceName, rtName)}
+}
+
+func (_c *MockInterface_GetResourceTypeSchema_Call) Run(run func(ctx context.Context, namespaceName string, rtName string)) *MockInterface_GetResourceTypeSchema_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetResourceTypeSchema_Call) Return(_a0 *json.RawMessage, _a1 error) *MockInterface_GetResourceTypeSchema_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetResourceTypeSchema_Call) RunAndReturn(run func(context.Context, string, string) (*json.RawMessage, error)) *MockInterface_GetResourceTypeSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSecretReference provides a mock function with given fields: ctx, namespaceName, secretReferenceName
 func (_m *MockInterface) GetSecretReference(ctx context.Context, namespaceName string, secretReferenceName string) (*gen.SecretReference, error) {
 	ret := _m.Called(ctx, namespaceName, secretReferenceName)
@@ -3946,6 +4902,65 @@ func (_c *MockInterface_ListClusterObservabilityPlanes_Call) Return(_a0 *gen.Clu
 }
 
 func (_c *MockInterface_ListClusterObservabilityPlanes_Call) RunAndReturn(run func(context.Context, *gen.ListClusterObservabilityPlanesParams) (*gen.ClusterObservabilityPlaneList, error)) *MockInterface_ListClusterObservabilityPlanes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListClusterResourceTypes provides a mock function with given fields: ctx, params
+func (_m *MockInterface) ListClusterResourceTypes(ctx context.Context, params *gen.ListClusterResourceTypesParams) (*gen.ClusterResourceTypeList, error) {
+	ret := _m.Called(ctx, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListClusterResourceTypes")
+	}
+
+	var r0 *gen.ClusterResourceTypeList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *gen.ListClusterResourceTypesParams) (*gen.ClusterResourceTypeList, error)); ok {
+		return rf(ctx, params)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *gen.ListClusterResourceTypesParams) *gen.ClusterResourceTypeList); ok {
+		r0 = rf(ctx, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ClusterResourceTypeList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *gen.ListClusterResourceTypesParams) error); ok {
+		r1 = rf(ctx, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_ListClusterResourceTypes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListClusterResourceTypes'
+type MockInterface_ListClusterResourceTypes_Call struct {
+	*mock.Call
+}
+
+// ListClusterResourceTypes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *gen.ListClusterResourceTypesParams
+func (_e *MockInterface_Expecter) ListClusterResourceTypes(ctx interface{}, params interface{}) *MockInterface_ListClusterResourceTypes_Call {
+	return &MockInterface_ListClusterResourceTypes_Call{Call: _e.mock.On("ListClusterResourceTypes", ctx, params)}
+}
+
+func (_c *MockInterface_ListClusterResourceTypes_Call) Run(run func(ctx context.Context, params *gen.ListClusterResourceTypesParams)) *MockInterface_ListClusterResourceTypes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*gen.ListClusterResourceTypesParams))
+	})
+	return _c
+}
+
+func (_c *MockInterface_ListClusterResourceTypes_Call) Return(_a0 *gen.ClusterResourceTypeList, _a1 error) *MockInterface_ListClusterResourceTypes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_ListClusterResourceTypes_Call) RunAndReturn(run func(context.Context, *gen.ListClusterResourceTypesParams) (*gen.ClusterResourceTypeList, error)) *MockInterface_ListClusterResourceTypes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5025,6 +6040,246 @@ func (_c *MockInterface_ListReleaseBindings_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// ListResourceReleaseBindings provides a mock function with given fields: ctx, namespaceName, params
+func (_m *MockInterface) ListResourceReleaseBindings(ctx context.Context, namespaceName string, params *gen.ListResourceReleaseBindingsParams) (*gen.ResourceReleaseBindingList, error) {
+	ret := _m.Called(ctx, namespaceName, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListResourceReleaseBindings")
+	}
+
+	var r0 *gen.ResourceReleaseBindingList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourceReleaseBindingsParams) (*gen.ResourceReleaseBindingList, error)); ok {
+		return rf(ctx, namespaceName, params)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourceReleaseBindingsParams) *gen.ResourceReleaseBindingList); ok {
+		r0 = rf(ctx, namespaceName, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceReleaseBindingList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gen.ListResourceReleaseBindingsParams) error); ok {
+		r1 = rf(ctx, namespaceName, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_ListResourceReleaseBindings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListResourceReleaseBindings'
+type MockInterface_ListResourceReleaseBindings_Call struct {
+	*mock.Call
+}
+
+// ListResourceReleaseBindings is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - params *gen.ListResourceReleaseBindingsParams
+func (_e *MockInterface_Expecter) ListResourceReleaseBindings(ctx interface{}, namespaceName interface{}, params interface{}) *MockInterface_ListResourceReleaseBindings_Call {
+	return &MockInterface_ListResourceReleaseBindings_Call{Call: _e.mock.On("ListResourceReleaseBindings", ctx, namespaceName, params)}
+}
+
+func (_c *MockInterface_ListResourceReleaseBindings_Call) Run(run func(ctx context.Context, namespaceName string, params *gen.ListResourceReleaseBindingsParams)) *MockInterface_ListResourceReleaseBindings_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*gen.ListResourceReleaseBindingsParams))
+	})
+	return _c
+}
+
+func (_c *MockInterface_ListResourceReleaseBindings_Call) Return(_a0 *gen.ResourceReleaseBindingList, _a1 error) *MockInterface_ListResourceReleaseBindings_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_ListResourceReleaseBindings_Call) RunAndReturn(run func(context.Context, string, *gen.ListResourceReleaseBindingsParams) (*gen.ResourceReleaseBindingList, error)) *MockInterface_ListResourceReleaseBindings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListResourceReleases provides a mock function with given fields: ctx, namespaceName, params
+func (_m *MockInterface) ListResourceReleases(ctx context.Context, namespaceName string, params *gen.ListResourceReleasesParams) (*gen.ResourceReleaseList, error) {
+	ret := _m.Called(ctx, namespaceName, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListResourceReleases")
+	}
+
+	var r0 *gen.ResourceReleaseList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourceReleasesParams) (*gen.ResourceReleaseList, error)); ok {
+		return rf(ctx, namespaceName, params)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourceReleasesParams) *gen.ResourceReleaseList); ok {
+		r0 = rf(ctx, namespaceName, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceReleaseList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gen.ListResourceReleasesParams) error); ok {
+		r1 = rf(ctx, namespaceName, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_ListResourceReleases_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListResourceReleases'
+type MockInterface_ListResourceReleases_Call struct {
+	*mock.Call
+}
+
+// ListResourceReleases is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - params *gen.ListResourceReleasesParams
+func (_e *MockInterface_Expecter) ListResourceReleases(ctx interface{}, namespaceName interface{}, params interface{}) *MockInterface_ListResourceReleases_Call {
+	return &MockInterface_ListResourceReleases_Call{Call: _e.mock.On("ListResourceReleases", ctx, namespaceName, params)}
+}
+
+func (_c *MockInterface_ListResourceReleases_Call) Run(run func(ctx context.Context, namespaceName string, params *gen.ListResourceReleasesParams)) *MockInterface_ListResourceReleases_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*gen.ListResourceReleasesParams))
+	})
+	return _c
+}
+
+func (_c *MockInterface_ListResourceReleases_Call) Return(_a0 *gen.ResourceReleaseList, _a1 error) *MockInterface_ListResourceReleases_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_ListResourceReleases_Call) RunAndReturn(run func(context.Context, string, *gen.ListResourceReleasesParams) (*gen.ResourceReleaseList, error)) *MockInterface_ListResourceReleases_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListResourceTypes provides a mock function with given fields: ctx, namespaceName, params
+func (_m *MockInterface) ListResourceTypes(ctx context.Context, namespaceName string, params *gen.ListResourceTypesParams) (*gen.ResourceTypeList, error) {
+	ret := _m.Called(ctx, namespaceName, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListResourceTypes")
+	}
+
+	var r0 *gen.ResourceTypeList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourceTypesParams) (*gen.ResourceTypeList, error)); ok {
+		return rf(ctx, namespaceName, params)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourceTypesParams) *gen.ResourceTypeList); ok {
+		r0 = rf(ctx, namespaceName, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceTypeList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gen.ListResourceTypesParams) error); ok {
+		r1 = rf(ctx, namespaceName, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_ListResourceTypes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListResourceTypes'
+type MockInterface_ListResourceTypes_Call struct {
+	*mock.Call
+}
+
+// ListResourceTypes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - params *gen.ListResourceTypesParams
+func (_e *MockInterface_Expecter) ListResourceTypes(ctx interface{}, namespaceName interface{}, params interface{}) *MockInterface_ListResourceTypes_Call {
+	return &MockInterface_ListResourceTypes_Call{Call: _e.mock.On("ListResourceTypes", ctx, namespaceName, params)}
+}
+
+func (_c *MockInterface_ListResourceTypes_Call) Run(run func(ctx context.Context, namespaceName string, params *gen.ListResourceTypesParams)) *MockInterface_ListResourceTypes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*gen.ListResourceTypesParams))
+	})
+	return _c
+}
+
+func (_c *MockInterface_ListResourceTypes_Call) Return(_a0 *gen.ResourceTypeList, _a1 error) *MockInterface_ListResourceTypes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_ListResourceTypes_Call) RunAndReturn(run func(context.Context, string, *gen.ListResourceTypesParams) (*gen.ResourceTypeList, error)) *MockInterface_ListResourceTypes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListResources provides a mock function with given fields: ctx, namespaceName, params
+func (_m *MockInterface) ListResources(ctx context.Context, namespaceName string, params *gen.ListResourcesParams) (*gen.ResourceInstanceList, error) {
+	ret := _m.Called(ctx, namespaceName, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListResources")
+	}
+
+	var r0 *gen.ResourceInstanceList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourcesParams) (*gen.ResourceInstanceList, error)); ok {
+		return rf(ctx, namespaceName, params)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gen.ListResourcesParams) *gen.ResourceInstanceList); ok {
+		r0 = rf(ctx, namespaceName, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceInstanceList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gen.ListResourcesParams) error); ok {
+		r1 = rf(ctx, namespaceName, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_ListResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListResources'
+type MockInterface_ListResources_Call struct {
+	*mock.Call
+}
+
+// ListResources is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - params *gen.ListResourcesParams
+func (_e *MockInterface_Expecter) ListResources(ctx interface{}, namespaceName interface{}, params interface{}) *MockInterface_ListResources_Call {
+	return &MockInterface_ListResources_Call{Call: _e.mock.On("ListResources", ctx, namespaceName, params)}
+}
+
+func (_c *MockInterface_ListResources_Call) Run(run func(ctx context.Context, namespaceName string, params *gen.ListResourcesParams)) *MockInterface_ListResources_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*gen.ListResourcesParams))
+	})
+	return _c
+}
+
+func (_c *MockInterface_ListResources_Call) Return(_a0 *gen.ResourceInstanceList, _a1 error) *MockInterface_ListResources_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_ListResources_Call) RunAndReturn(run func(context.Context, string, *gen.ListResourcesParams) (*gen.ResourceInstanceList, error)) *MockInterface_ListResources_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListSecretReferences provides a mock function with given fields: ctx, namespaceName, params
 func (_m *MockInterface) ListSecretReferences(ctx context.Context, namespaceName string, params *gen.ListSecretReferencesParams) (*gen.SecretReferenceList, error) {
 	ret := _m.Called(ctx, namespaceName, params)
@@ -5385,6 +6640,66 @@ func (_c *MockInterface_ListWorkloads_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
+// UpdateClusterResourceType provides a mock function with given fields: ctx, crtName, crt
+func (_m *MockInterface) UpdateClusterResourceType(ctx context.Context, crtName string, crt gen.ClusterResourceType) (*gen.ClusterResourceType, error) {
+	ret := _m.Called(ctx, crtName, crt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateClusterResourceType")
+	}
+
+	var r0 *gen.ClusterResourceType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ClusterResourceType) (*gen.ClusterResourceType, error)); ok {
+		return rf(ctx, crtName, crt)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, gen.ClusterResourceType) *gen.ClusterResourceType); ok {
+		r0 = rf(ctx, crtName, crt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ClusterResourceType)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, gen.ClusterResourceType) error); ok {
+		r1 = rf(ctx, crtName, crt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_UpdateClusterResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateClusterResourceType'
+type MockInterface_UpdateClusterResourceType_Call struct {
+	*mock.Call
+}
+
+// UpdateClusterResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - crtName string
+//   - crt gen.ClusterResourceType
+func (_e *MockInterface_Expecter) UpdateClusterResourceType(ctx interface{}, crtName interface{}, crt interface{}) *MockInterface_UpdateClusterResourceType_Call {
+	return &MockInterface_UpdateClusterResourceType_Call{Call: _e.mock.On("UpdateClusterResourceType", ctx, crtName, crt)}
+}
+
+func (_c *MockInterface_UpdateClusterResourceType_Call) Run(run func(ctx context.Context, crtName string, crt gen.ClusterResourceType)) *MockInterface_UpdateClusterResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(gen.ClusterResourceType))
+	})
+	return _c
+}
+
+func (_c *MockInterface_UpdateClusterResourceType_Call) Return(_a0 *gen.ClusterResourceType, _a1 error) *MockInterface_UpdateClusterResourceType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_UpdateClusterResourceType_Call) RunAndReturn(run func(context.Context, string, gen.ClusterResourceType) (*gen.ClusterResourceType, error)) *MockInterface_UpdateClusterResourceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateComponentType provides a mock function with given fields: ctx, namespaceName, ctName, ct
 func (_m *MockInterface) UpdateComponentType(ctx context.Context, namespaceName string, ctName string, ct gen.ComponentType) (*gen.ComponentType, error) {
 	ret := _m.Called(ctx, namespaceName, ctName, ct)
@@ -5503,6 +6818,189 @@ func (_c *MockInterface_UpdateReleaseBinding_Call) Return(_a0 *gen.ReleaseBindin
 }
 
 func (_c *MockInterface_UpdateReleaseBinding_Call) RunAndReturn(run func(context.Context, string, string, gen.ReleaseBinding) (*gen.ReleaseBinding, error)) *MockInterface_UpdateReleaseBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateResource provides a mock function with given fields: ctx, namespaceName, resourceName, r
+func (_m *MockInterface) UpdateResource(ctx context.Context, namespaceName string, resourceName string, r gen.ResourceInstance) (*gen.ResourceInstance, error) {
+	ret := _m.Called(ctx, namespaceName, resourceName, r)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateResource")
+	}
+
+	var r0 *gen.ResourceInstance
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.ResourceInstance) (*gen.ResourceInstance, error)); ok {
+		return rf(ctx, namespaceName, resourceName, r)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.ResourceInstance) *gen.ResourceInstance); ok {
+		r0 = rf(ctx, namespaceName, resourceName, r)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceInstance)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, gen.ResourceInstance) error); ok {
+		r1 = rf(ctx, namespaceName, resourceName, r)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_UpdateResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateResource'
+type MockInterface_UpdateResource_Call struct {
+	*mock.Call
+}
+
+// UpdateResource is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - resourceName string
+//   - r gen.ResourceInstance
+func (_e *MockInterface_Expecter) UpdateResource(ctx interface{}, namespaceName interface{}, resourceName interface{}, r interface{}) *MockInterface_UpdateResource_Call {
+	return &MockInterface_UpdateResource_Call{Call: _e.mock.On("UpdateResource", ctx, namespaceName, resourceName, r)}
+}
+
+func (_c *MockInterface_UpdateResource_Call) Run(run func(ctx context.Context, namespaceName string, resourceName string, r gen.ResourceInstance)) *MockInterface_UpdateResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(gen.ResourceInstance))
+	})
+	return _c
+}
+
+func (_c *MockInterface_UpdateResource_Call) Return(_a0 *gen.ResourceInstance, _a1 error) *MockInterface_UpdateResource_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_UpdateResource_Call) RunAndReturn(run func(context.Context, string, string, gen.ResourceInstance) (*gen.ResourceInstance, error)) *MockInterface_UpdateResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateResourceReleaseBinding provides a mock function with given fields: ctx, namespaceName, bindingName, rrb
+func (_m *MockInterface) UpdateResourceReleaseBinding(ctx context.Context, namespaceName string, bindingName string, rrb gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error) {
+	ret := _m.Called(ctx, namespaceName, bindingName, rrb)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateResourceReleaseBinding")
+	}
+
+	var r0 *gen.ResourceReleaseBinding
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error)); ok {
+		return rf(ctx, namespaceName, bindingName, rrb)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.ResourceReleaseBinding) *gen.ResourceReleaseBinding); ok {
+		r0 = rf(ctx, namespaceName, bindingName, rrb)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceReleaseBinding)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, gen.ResourceReleaseBinding) error); ok {
+		r1 = rf(ctx, namespaceName, bindingName, rrb)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_UpdateResourceReleaseBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateResourceReleaseBinding'
+type MockInterface_UpdateResourceReleaseBinding_Call struct {
+	*mock.Call
+}
+
+// UpdateResourceReleaseBinding is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - bindingName string
+//   - rrb gen.ResourceReleaseBinding
+func (_e *MockInterface_Expecter) UpdateResourceReleaseBinding(ctx interface{}, namespaceName interface{}, bindingName interface{}, rrb interface{}) *MockInterface_UpdateResourceReleaseBinding_Call {
+	return &MockInterface_UpdateResourceReleaseBinding_Call{Call: _e.mock.On("UpdateResourceReleaseBinding", ctx, namespaceName, bindingName, rrb)}
+}
+
+func (_c *MockInterface_UpdateResourceReleaseBinding_Call) Run(run func(ctx context.Context, namespaceName string, bindingName string, rrb gen.ResourceReleaseBinding)) *MockInterface_UpdateResourceReleaseBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(gen.ResourceReleaseBinding))
+	})
+	return _c
+}
+
+func (_c *MockInterface_UpdateResourceReleaseBinding_Call) Return(_a0 *gen.ResourceReleaseBinding, _a1 error) *MockInterface_UpdateResourceReleaseBinding_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_UpdateResourceReleaseBinding_Call) RunAndReturn(run func(context.Context, string, string, gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error)) *MockInterface_UpdateResourceReleaseBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateResourceType provides a mock function with given fields: ctx, namespaceName, rtName, rt
+func (_m *MockInterface) UpdateResourceType(ctx context.Context, namespaceName string, rtName string, rt gen.ResourceType) (*gen.ResourceType, error) {
+	ret := _m.Called(ctx, namespaceName, rtName, rt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateResourceType")
+	}
+
+	var r0 *gen.ResourceType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.ResourceType) (*gen.ResourceType, error)); ok {
+		return rf(ctx, namespaceName, rtName, rt)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, gen.ResourceType) *gen.ResourceType); ok {
+		r0 = rf(ctx, namespaceName, rtName, rt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gen.ResourceType)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, gen.ResourceType) error); ok {
+		r1 = rf(ctx, namespaceName, rtName, rt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_UpdateResourceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateResourceType'
+type MockInterface_UpdateResourceType_Call struct {
+	*mock.Call
+}
+
+// UpdateResourceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespaceName string
+//   - rtName string
+//   - rt gen.ResourceType
+func (_e *MockInterface_Expecter) UpdateResourceType(ctx interface{}, namespaceName interface{}, rtName interface{}, rt interface{}) *MockInterface_UpdateResourceType_Call {
+	return &MockInterface_UpdateResourceType_Call{Call: _e.mock.On("UpdateResourceType", ctx, namespaceName, rtName, rt)}
+}
+
+func (_c *MockInterface_UpdateResourceType_Call) Run(run func(ctx context.Context, namespaceName string, rtName string, rt gen.ResourceType)) *MockInterface_UpdateResourceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(gen.ResourceType))
+	})
+	return _c
+}
+
+func (_c *MockInterface_UpdateResourceType_Call) Return(_a0 *gen.ResourceType, _a1 error) *MockInterface_UpdateResourceType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_UpdateResourceType_Call) RunAndReturn(run func(context.Context, string, string, gen.ResourceType) (*gen.ResourceType, error)) *MockInterface_UpdateResourceType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/occ/resources/client/openapi_client.go
+++ b/internal/occ/resources/client/openapi_client.go
@@ -1376,6 +1376,339 @@ func (c *Client) GetClusterWorkflowSchema(ctx context.Context, clusterWorkflowNa
 	return schemaResponseToRaw(resp.JSON200)
 }
 
+// ListResourceTypes retrieves all resource types for a namespace
+func (c *Client) ListResourceTypes(ctx context.Context, namespaceName string, params *gen.ListResourceTypesParams) (*gen.ResourceTypeList, error) {
+	if params == nil {
+		params = &gen.ListResourceTypesParams{}
+	}
+	resp, err := c.client.ListResourceTypesWithResponse(ctx, namespaceName, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resource types: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// GetResourceType retrieves a specific resource type
+func (c *Client) GetResourceType(ctx context.Context, namespaceName, rtName string) (*gen.ResourceType, error) {
+	resp, err := c.client.GetResourceTypeWithResponse(ctx, namespaceName, rtName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource type: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// CreateResourceType creates a new resource type
+func (c *Client) CreateResourceType(ctx context.Context, namespaceName string, rt gen.ResourceType) (*gen.ResourceType, error) {
+	resp, err := c.client.CreateResourceTypeWithResponse(ctx, namespaceName, rt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource type: %w", err)
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON201, nil
+}
+
+// UpdateResourceType updates an existing resource type
+func (c *Client) UpdateResourceType(ctx context.Context, namespaceName, rtName string, rt gen.ResourceType) (*gen.ResourceType, error) {
+	resp, err := c.client.UpdateResourceTypeWithResponse(ctx, namespaceName, rtName, rt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update resource type: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteResourceType deletes a resource type
+func (c *Client) DeleteResourceType(ctx context.Context, namespaceName, rtName string) error {
+	resp, err := c.client.DeleteResourceTypeWithResponse(ctx, namespaceName, rtName)
+	if err != nil {
+		return fmt.Errorf("failed to delete resource type: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return apiError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
+// GetResourceTypeSchema retrieves the parameter schema for a resource type
+func (c *Client) GetResourceTypeSchema(ctx context.Context, namespaceName, rtName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetResourceTypeSchemaWithResponse(ctx, namespaceName, rtName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource type schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("resource type %q not found", rtName)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+// ListClusterResourceTypes retrieves all cluster-scoped resource types
+func (c *Client) ListClusterResourceTypes(ctx context.Context, params *gen.ListClusterResourceTypesParams) (*gen.ClusterResourceTypeList, error) {
+	if params == nil {
+		params = &gen.ListClusterResourceTypesParams{}
+	}
+	resp, err := c.client.ListClusterResourceTypesWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster resource types: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// GetClusterResourceType retrieves a specific cluster resource type
+func (c *Client) GetClusterResourceType(ctx context.Context, crtName string) (*gen.ClusterResourceType, error) {
+	resp, err := c.client.GetClusterResourceTypeWithResponse(ctx, crtName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster resource type: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// CreateClusterResourceType creates a new cluster resource type
+func (c *Client) CreateClusterResourceType(ctx context.Context, crt gen.ClusterResourceType) (*gen.ClusterResourceType, error) {
+	resp, err := c.client.CreateClusterResourceTypeWithResponse(ctx, crt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cluster resource type: %w", err)
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON201, nil
+}
+
+// UpdateClusterResourceType updates an existing cluster resource type
+func (c *Client) UpdateClusterResourceType(ctx context.Context, crtName string, crt gen.ClusterResourceType) (*gen.ClusterResourceType, error) {
+	resp, err := c.client.UpdateClusterResourceTypeWithResponse(ctx, crtName, crt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update cluster resource type: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteClusterResourceType deletes a cluster resource type
+func (c *Client) DeleteClusterResourceType(ctx context.Context, crtName string) error {
+	resp, err := c.client.DeleteClusterResourceTypeWithResponse(ctx, crtName)
+	if err != nil {
+		return fmt.Errorf("failed to delete cluster resource type: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return apiError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
+// GetClusterResourceTypeSchema retrieves the parameter schema for a cluster-scoped resource type
+func (c *Client) GetClusterResourceTypeSchema(ctx context.Context, crtName string) (*json.RawMessage, error) {
+	resp, err := c.client.GetClusterResourceTypeSchemaWithResponse(ctx, crtName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster resource type schema: %w", err)
+	}
+	if resp.JSON404 != nil {
+		return nil, fmt.Errorf("cluster resource type %q not found", crtName)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return schemaResponseToRaw(resp.JSON200)
+}
+
+// ListResources retrieves all resources for a namespace
+func (c *Client) ListResources(ctx context.Context, namespaceName string, params *gen.ListResourcesParams) (*gen.ResourceInstanceList, error) {
+	if params == nil {
+		params = &gen.ListResourcesParams{}
+	}
+	resp, err := c.client.ListResourcesWithResponse(ctx, namespaceName, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resources: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// GetResource retrieves a specific resource
+func (c *Client) GetResource(ctx context.Context, namespaceName, resourceName string) (*gen.ResourceInstance, error) {
+	resp, err := c.client.GetResourceWithResponse(ctx, namespaceName, resourceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// CreateResource creates a new resource
+func (c *Client) CreateResource(ctx context.Context, namespaceName string, r gen.ResourceInstance) (*gen.ResourceInstance, error) {
+	resp, err := c.client.CreateResourceWithResponse(ctx, namespaceName, r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON201, nil
+}
+
+// UpdateResource updates an existing resource
+func (c *Client) UpdateResource(ctx context.Context, namespaceName, resourceName string, r gen.ResourceInstance) (*gen.ResourceInstance, error) {
+	resp, err := c.client.UpdateResourceWithResponse(ctx, namespaceName, resourceName, r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update resource: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteResource deletes a resource
+func (c *Client) DeleteResource(ctx context.Context, namespaceName, resourceName string) error {
+	resp, err := c.client.DeleteResourceWithResponse(ctx, namespaceName, resourceName)
+	if err != nil {
+		return fmt.Errorf("failed to delete resource: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return apiError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
+// ListResourceReleases retrieves all resource releases for a namespace
+func (c *Client) ListResourceReleases(ctx context.Context, namespaceName string, params *gen.ListResourceReleasesParams) (*gen.ResourceReleaseList, error) {
+	if params == nil {
+		params = &gen.ListResourceReleasesParams{}
+	}
+	resp, err := c.client.ListResourceReleasesWithResponse(ctx, namespaceName, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resource releases: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// GetResourceRelease retrieves a specific resource release
+func (c *Client) GetResourceRelease(ctx context.Context, namespaceName, resourceReleaseName string) (*gen.ResourceRelease, error) {
+	resp, err := c.client.GetResourceReleaseWithResponse(ctx, namespaceName, resourceReleaseName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource release: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// CreateResourceRelease creates a new resource release
+func (c *Client) CreateResourceRelease(ctx context.Context, namespaceName string, rr gen.ResourceRelease) (*gen.ResourceRelease, error) {
+	resp, err := c.client.CreateResourceReleaseWithResponse(ctx, namespaceName, rr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource release: %w", err)
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON201, nil
+}
+
+// DeleteResourceRelease deletes a resource release
+func (c *Client) DeleteResourceRelease(ctx context.Context, namespaceName, resourceReleaseName string) error {
+	resp, err := c.client.DeleteResourceReleaseWithResponse(ctx, namespaceName, resourceReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to delete resource release: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return apiError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
+// ListResourceReleaseBindings retrieves all resource release bindings for a namespace
+func (c *Client) ListResourceReleaseBindings(ctx context.Context, namespaceName string, params *gen.ListResourceReleaseBindingsParams) (*gen.ResourceReleaseBindingList, error) {
+	if params == nil {
+		params = &gen.ListResourceReleaseBindingsParams{}
+	}
+	resp, err := c.client.ListResourceReleaseBindingsWithResponse(ctx, namespaceName, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resource release bindings: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// GetResourceReleaseBinding retrieves a specific resource release binding
+func (c *Client) GetResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string) (*gen.ResourceReleaseBinding, error) {
+	resp, err := c.client.GetResourceReleaseBindingWithResponse(ctx, namespaceName, bindingName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource release binding: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// CreateResourceReleaseBinding creates a new resource release binding
+func (c *Client) CreateResourceReleaseBinding(ctx context.Context, namespaceName string, rrb gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error) {
+	resp, err := c.client.CreateResourceReleaseBindingWithResponse(ctx, namespaceName, rrb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource release binding: %w", err)
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON201, nil
+}
+
+// UpdateResourceReleaseBinding updates an existing resource release binding
+func (c *Client) UpdateResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string, rrb gen.ResourceReleaseBinding) (*gen.ResourceReleaseBinding, error) {
+	resp, err := c.client.UpdateResourceReleaseBindingWithResponse(ctx, namespaceName, bindingName, rrb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update resource release binding: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteResourceReleaseBinding deletes a resource release binding
+func (c *Client) DeleteResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string) error {
+	resp, err := c.client.DeleteResourceReleaseBindingWithResponse(ctx, namespaceName, bindingName)
+	if err != nil {
+		return fmt.Errorf("failed to delete resource release binding: %w", err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return apiError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
 func schemaResponseToRaw(schema *gen.SchemaResponse) (*json.RawMessage, error) {
 	data, err := json.Marshal(schema)
 	if err != nil {

--- a/internal/occ/root/root.go
+++ b/internal/occ/root/root.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/releasebinding"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resource"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcerelease"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcereleasebinding"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcetype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/secretreference"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/trait"
@@ -65,6 +66,7 @@ func BuildRootCmd() *cobra.Command {
 		version.NewVersionCmd(),
 		componentrelease.NewComponentReleaseCmd(f),
 		resourcerelease.NewResourceReleaseCmd(f),
+		resourcereleasebinding.NewResourceReleaseBindingCmd(f),
 		releasebinding.NewReleaseBindingCmd(f),
 		namespace.NewNamespaceCmd(f),
 		project.NewProjectCmd(f),

--- a/internal/occ/root/root.go
+++ b/internal/occ/root/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/observabilityplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/project"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/releasebinding"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcetype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/secretreference"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/trait"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/version"
@@ -70,6 +71,7 @@ func BuildRootCmd() *cobra.Command {
 		workflowplane.NewWorkflowPlaneCmd(f),
 		observabilityplane.NewObservabilityPlaneCmd(f),
 		componenttype.NewComponentTypeCmd(f),
+		resourcetype.NewResourceTypeCmd(f),
 		clustercomponenttype.NewClusterComponentTypeCmd(f),
 		clusterresourcetype.NewClusterResourceTypeCmd(f),
 		clusterdataplane.NewClusterDataPlaneCmd(f),

--- a/internal/occ/root/root.go
+++ b/internal/occ/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clustercomponenttype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterdataplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterobservabilityplane"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterresourcetype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clustertrait"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterworkflow"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/clusterworkflowplane"
@@ -70,6 +71,7 @@ func BuildRootCmd() *cobra.Command {
 		observabilityplane.NewObservabilityPlaneCmd(f),
 		componenttype.NewComponentTypeCmd(f),
 		clustercomponenttype.NewClusterComponentTypeCmd(f),
+		clusterresourcetype.NewClusterResourceTypeCmd(f),
 		clusterdataplane.NewClusterDataPlaneCmd(f),
 		clusterobservabilityplane.NewClusterObservabilityPlaneCmd(f),
 		clusterworkflowplane.NewClusterWorkflowPlaneCmd(f),

--- a/internal/occ/root/root.go
+++ b/internal/occ/root/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/observabilityplane"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/project"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/releasebinding"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/resource"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcetype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/secretreference"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/trait"
@@ -66,6 +67,7 @@ func BuildRootCmd() *cobra.Command {
 		namespace.NewNamespaceCmd(f),
 		project.NewProjectCmd(f),
 		component.NewComponentCmd(f),
+		resource.NewResourceCmd(f),
 		environment.NewEnvironmentCmd(f),
 		dataplane.NewDataPlaneCmd(f),
 		workflowplane.NewWorkflowPlaneCmd(f),

--- a/internal/occ/root/root.go
+++ b/internal/occ/root/root.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/project"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/releasebinding"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resource"
+	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcerelease"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/resourcetype"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/secretreference"
 	"github.com/openchoreo/openchoreo/internal/occ/cmd/trait"
@@ -63,6 +64,7 @@ func BuildRootCmd() *cobra.Command {
 		config.NewConfigCmd(),
 		version.NewVersionCmd(),
 		componentrelease.NewComponentReleaseCmd(f),
+		resourcerelease.NewResourceReleaseCmd(f),
 		releasebinding.NewReleaseBindingCmd(f),
 		namespace.NewNamespaceCmd(f),
 		project.NewProjectCmd(f),

--- a/internal/occ/root/root_test.go
+++ b/internal/occ/root/root_test.go
@@ -28,6 +28,7 @@ func TestBuildRootCmd_Subcommands(t *testing.T) {
 		"version",
 		"componentrelease",
 		"resourcerelease",
+		"resourcereleasebinding",
 		"releasebinding",
 		"namespace",
 		"project",

--- a/internal/occ/root/root_test.go
+++ b/internal/occ/root/root_test.go
@@ -37,6 +37,7 @@ func TestBuildRootCmd_Subcommands(t *testing.T) {
 		"observabilityplane",
 		"componenttype",
 		"clustercomponenttype",
+		"clusterresourcetype",
 		"clusterdataplane",
 		"clusterobservabilityplane",
 		"clusterworkflowplane",

--- a/internal/occ/root/root_test.go
+++ b/internal/occ/root/root_test.go
@@ -31,6 +31,7 @@ func TestBuildRootCmd_Subcommands(t *testing.T) {
 		"namespace",
 		"project",
 		"component",
+		"resource",
 		"environment",
 		"dataplane",
 		"workflowplane",

--- a/internal/occ/root/root_test.go
+++ b/internal/occ/root/root_test.go
@@ -36,6 +36,7 @@ func TestBuildRootCmd_Subcommands(t *testing.T) {
 		"workflowplane",
 		"observabilityplane",
 		"componenttype",
+		"resourcetype",
 		"clustercomponenttype",
 		"clusterresourcetype",
 		"clusterdataplane",

--- a/internal/occ/root/root_test.go
+++ b/internal/occ/root/root_test.go
@@ -27,6 +27,7 @@ func TestBuildRootCmd_Subcommands(t *testing.T) {
 		"config",
 		"version",
 		"componentrelease",
+		"resourcerelease",
 		"releasebinding",
 		"namespace",
 		"project",


### PR DESCRIPTION
## Purpose

Add `occ` CLI commands for the resource abstraction CRDs.

## Approach

- New command groups: `occ clusterresourcetype`, `occ resourcetype`, `occ resource`, `occ resourcerelease`, `occ resourcereleasebinding`
- `list` / `get` / `delete` on all five; plus `promote` on `resource` for the dev flow (resolves `Resource.status.latestRelease.name` and updates the binding's `spec.resourceRelease` for the chosen environment)
- `resourcereleasebinding list` surfaces `RELEASE` and `STATUS` columns to make promote outcomes visible at a glance

## Related Issues

Closes #3337
Related #3107

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)