### PR TITLE
chore: update release pipelines to use client_id instead of app_id

### DIFF
--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -35,7 +35,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.OC_RELEASE_APP_ID }}
+          client-id: ${{ secrets.OC_RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.OC_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -47,7 +47,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.OC_RELEASE_APP_ID }}
+          client-id: ${{ secrets.OC_RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.OC_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
$subject since app_id is deprecated.

Related to https://github.com/openchoreo/openchoreo/issues/3341