### PR TITLE
fix(helm): align control plane pdb selectors

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/controller-manager/pdb.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/pdb.yaml
@@ -16,6 +16,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: controller-manager
-      app.kubernetes.io/name: {{ include "openchoreo-control-plane.fullname" . }}
+      {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 6 }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/pdb.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/pdb.yaml
@@ -17,5 +17,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: api-server
-      app.kubernetes.io/name: {{ include "openchoreo-control-plane.fullname" . }}
+      {{- include "openchoreo-control-plane.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
## Purpose
This fixes the Helm chart PodDisruptionBudget selectors for `controller-manager` and `openchoreo-api` so they match the labels on the pods created by the corresponding Deployments. Without that, the PDBs can fail to match any pods and report zero allowed disruptions.

## Approach
- update `controller-manager` PDB to reuse `componentSelectorLabels`
- update `openchoreo-api` PDB to reuse `selectorLabels`
- keep the change scoped to the two broken PDB templates

## Related Issues
- Fixes #2975

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
Validated by rendering the affected controller-manager and openchoreo-api Deployment and PodDisruptionBudget templates with explicit non-placeholder chart values and confirming the rendered `matchLabels` blocks now match.
