### PR TITLE
fix: verify cluster gateway TLS certificates by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	// +kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
@@ -111,12 +112,25 @@ func setupControlPlaneControllers(
 	mgr ctrl.Manager,
 	k8sClientMgr *kubernetesClient.KubeMultiClientManager,
 	clusterGatewayURL string,
+	gwTLS gatewayClient.TLSConfig,
 ) error {
 	// Create gateway client for plane lifecycle notifications
 	var gwClient *gatewayClient.Client
 	if clusterGatewayURL != "" {
-		gwClient = gatewayClient.NewClient(clusterGatewayURL)
-		setupLog.Info("gateway client initialized", "url", clusterGatewayURL)
+		var err error
+		gwClient, err = gatewayClient.NewClientWithConfig(&gatewayClient.Config{
+			BaseURL: clusterGatewayURL,
+			TLS:     gwTLS,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create cluster gateway client: %w", err)
+		}
+		setupLog.Info("gateway client initialized",
+			"url", clusterGatewayURL,
+			"caCert", gwTLS.CAFile != "",
+			"clientCert", gwTLS.ClientCertFile != "",
+			"insecure", gwTLS.InsecureSkipVerify,
+		)
 	}
 
 	// Create plane client provider for controllers that need to talk to remote planes.
@@ -242,6 +256,7 @@ func main() {
 	var clusterGatewayCACert string
 	var clusterGatewayClientCert string
 	var clusterGatewayClientKey string
+	var clusterGatewayInsecure bool
 	var deploymentPlane string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -258,6 +273,10 @@ func main() {
 		"Path to client certificate for mTLS authentication with the cluster gateway.")
 	flag.StringVar(&clusterGatewayClientKey, "cluster-gateway-client-key", getEnv("CLUSTER_GATEWAY_CLIENT_KEY", ""),
 		"Path to client private key for mTLS authentication with the cluster gateway.")
+	flag.BoolVar(&clusterGatewayInsecure, "cluster-gateway-insecure",
+		getEnvBool("CLUSTER_GATEWAY_INSECURE", false),
+		"Skip TLS verification when calling the cluster gateway. "+
+			"For local development only. Do not enable in production.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -352,25 +371,20 @@ func main() {
 	// -----------------------------------------------------------------------------
 	// The k8sClientMgr manages cached Kubernetes clients for accessing data planes and workflow planes.
 	// It supports both direct access mode and agent mode (via HTTP proxy through cluster gateway).
-	var k8sClientMgr *kubernetesClient.KubeMultiClientManager
-	if clusterGatewayCACert != "" || clusterGatewayClientCert != "" || clusterGatewayClientKey != "" {
-		// Create client manager with TLS configuration for HTTP proxy
-		k8sClientMgr = kubernetesClient.NewManagerWithProxyTLS(&kubernetesClient.ProxyTLSConfig{
-			CACertPath:     clusterGatewayCACert,
-			ClientCertPath: clusterGatewayClientCert,
-			ClientKeyPath:  clusterGatewayClientKey,
-		})
-		setupLog.Info("Kubernetes client manager created with proxy TLS configuration",
-			"caCert", clusterGatewayCACert != "",
-			"clientCert", clusterGatewayClientCert != "",
-			"clientKey", clusterGatewayClientKey != "")
-	} else {
-		// Create client manager without TLS configuration (insecure mode)
-		k8sClientMgr = kubernetesClient.NewManager()
-		if clusterGatewayURL != "" {
-			setupLog.Info("WARNING: Using insecure mode for cluster gateway connection. " +
-				"Please provide TLS certificates for production use.")
-		}
+	k8sClientMgr := kubernetesClient.NewManagerWithProxyTLS(&kubernetesClient.ProxyTLSConfig{
+		CACertPath:     clusterGatewayCACert,
+		ClientCertPath: clusterGatewayClientCert,
+		ClientKeyPath:  clusterGatewayClientKey,
+		Insecure:       clusterGatewayInsecure,
+	})
+	setupLog.Info("Kubernetes client manager created with proxy TLS configuration",
+		"caCert", clusterGatewayCACert != "",
+		"clientCert", clusterGatewayClientCert != "",
+		"clientKey", clusterGatewayClientKey != "",
+		"insecure", clusterGatewayInsecure)
+	if clusterGatewayURL != "" && clusterGatewayInsecure {
+		setupLog.Info("WARNING: Cluster gateway TLS verification is disabled (--cluster-gateway-insecure). " +
+			"Do not use this setting in production.")
 	}
 
 	// -----------------------------------------------------------------------------
@@ -380,7 +394,12 @@ func main() {
 	switch deploymentPlane {
 	// Control plane controllers
 	case deploymentPlaneControlPlane:
-		err = setupControlPlaneControllers(mgr, k8sClientMgr, clusterGatewayURL)
+		err = setupControlPlaneControllers(mgr, k8sClientMgr, clusterGatewayURL, gatewayClient.TLSConfig{
+			CAFile:             clusterGatewayCACert,
+			ClientCertFile:     clusterGatewayClientCert,
+			ClientKeyFile:      clusterGatewayClientKey,
+			InsecureSkipVerify: clusterGatewayInsecure,
+		})
 		if err != nil {
 			setupLog.Error(err, "unable to setup control plane controllers")
 			os.Exit(1)
@@ -454,4 +473,18 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// getEnvBool retrieves a boolean environment variable, returning a default if
+// unset or unparseable.
+func getEnvBool(key string, defaultValue bool) bool {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
 }

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -111,25 +111,20 @@ func main() {
 	}
 
 	// Initialize workflow plane client manager
-	var planeK8sClientMgr *kubernetesClient.KubeMultiClientManager
-	if cfg.ClusterGateway.TLS.CACertPath != "" ||
-		cfg.ClusterGateway.TLS.ClientCertPath != "" ||
-		cfg.ClusterGateway.TLS.ClientKeyPath != "" {
-		planeK8sClientMgr = kubernetesClient.NewManagerWithProxyTLS(&kubernetesClient.ProxyTLSConfig{
-			CACertPath:     cfg.ClusterGateway.TLS.CACertPath,
-			ClientCertPath: cfg.ClusterGateway.TLS.ClientCertPath,
-			ClientKeyPath:  cfg.ClusterGateway.TLS.ClientKeyPath,
-		})
-		logger.Info("Workflow plane client manager created with proxy TLS configuration",
-			"caCert", cfg.ClusterGateway.TLS.CACertPath != "",
-			"clientCert", cfg.ClusterGateway.TLS.ClientCertPath != "",
-			"clientKey", cfg.ClusterGateway.TLS.ClientKeyPath != "")
-	} else {
-		planeK8sClientMgr = kubernetesClient.NewManager()
-		if cfg.ClusterGateway.URL != "" {
-			logger.Warn("Using insecure mode for cluster gateway connection. " +
-				"Consider configuring TLS certificates for production deployments.")
-		}
+	planeK8sClientMgr := kubernetesClient.NewManagerWithProxyTLS(&kubernetesClient.ProxyTLSConfig{
+		CACertPath:     cfg.ClusterGateway.TLS.CACertPath,
+		ClientCertPath: cfg.ClusterGateway.TLS.ClientCertPath,
+		ClientKeyPath:  cfg.ClusterGateway.TLS.ClientKeyPath,
+		Insecure:       cfg.ClusterGateway.TLS.Insecure,
+	})
+	logger.Info("Workflow plane client manager created with proxy TLS configuration",
+		"caCert", cfg.ClusterGateway.TLS.CACertPath != "",
+		"clientCert", cfg.ClusterGateway.TLS.ClientCertPath != "",
+		"clientKey", cfg.ClusterGateway.TLS.ClientKeyPath != "",
+		"insecure", cfg.ClusterGateway.TLS.Insecure)
+	if cfg.ClusterGateway.URL != "" && cfg.ClusterGateway.TLS.Insecure {
+		logger.Warn("Cluster gateway TLS verification is disabled (cluster_gateway.tls.insecure). " +
+			"Do not use this setting in production.")
 	}
 
 	// Determine cluster gateway URL
@@ -145,9 +140,26 @@ func main() {
 			logger.Error("No cluster gateway URL provided", "clusterGateway", cfg.ClusterGateway)
 			os.Exit(1)
 		}
-		gwClient = gatewayClient.NewClient(gatewayURL)
+		var err error
+		gwClient, err = gatewayClient.NewClientWithConfig(&gatewayClient.Config{
+			BaseURL: gatewayURL,
+			TLS: gatewayClient.TLSConfig{
+				CAFile:             cfg.ClusterGateway.TLS.CACertPath,
+				ClientCertFile:     cfg.ClusterGateway.TLS.ClientCertPath,
+				ClientKeyFile:      cfg.ClusterGateway.TLS.ClientKeyPath,
+				InsecureSkipVerify: cfg.ClusterGateway.TLS.Insecure,
+			},
+		})
+		if err != nil {
+			logger.Error("Failed to create cluster gateway client", slog.Any("error", err))
+			os.Exit(1)
+		}
 	}
-	logger.Info("gateway client initialized", "url", gatewayURL)
+	logger.Info("gateway client initialized",
+		"url", gatewayURL,
+		"caCert", cfg.ClusterGateway.TLS.CACertPath != "",
+		"clientCert", cfg.ClusterGateway.TLS.ClientCertPath != "",
+		"insecure", cfg.ClusterGateway.TLS.Insecure)
 
 	// Start background processes (manager + cache sync when authz enabled)
 	if err := runtime.start(ctx); err != nil {

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -60,6 +60,13 @@ data:
       toolsets:
         {{- toYaml .Values.openchoreoApi.config.mcp.toolsets | nindent 8 }}
 
+    cluster_gateway:
+      enabled: true
+      url: {{ .Values.openchoreoApi.clusterGateway.url | quote }}
+      tls:
+        ca_cert_path: {{ .Values.openchoreoApi.clusterGateway.tls.caPath | quote }}
+        insecure: {{ .Values.openchoreoApi.clusterGateway.tls.insecure }}
+
     logging:
       {{- toYaml .Values.openchoreoApi.config.logging | nindent 6 }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         - name: config
           mountPath: /etc/openchoreo
           readOnly: true
+        - name: cluster-gateway-ca
+          mountPath: /etc/cluster-gateway
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /health
@@ -89,4 +92,7 @@ spec:
       - name: config
         configMap:
           name: {{ include "openchoreo-control-plane.openchoreoApi.name" . }}-config
+      - name: cluster-gateway-ca
+        secret:
+          secretName: {{ .Values.openchoreoApi.clusterGateway.tls.caSecret | default "cluster-gateway-ca" }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2759,6 +2759,48 @@
           "title": "autoscaling",
           "type": "object"
         },
+        "clusterGateway": {
+          "additionalProperties": false,
+          "description": "Cluster gateway connection settings for agent-based plane communication",
+          "properties": {
+            "tls": {
+              "additionalProperties": false,
+              "description": "TLS settings for the cluster gateway connection",
+              "properties": {
+                "caPath": {
+                  "default": "/etc/cluster-gateway/ca.crt",
+                  "description": "Path inside the pod where the cluster gateway CA certificate is mounted",
+                  "title": "caPath",
+                  "type": "string"
+                },
+                "caSecret": {
+                  "default": "cluster-gateway-ca",
+                  "description": "Name of the secret holding the cluster gateway CA certificate",
+                  "title": "caSecret",
+                  "type": "string"
+                },
+                "insecure": {
+                  "default": false,
+                  "description": "Skip TLS verification of the cluster gateway. For development only.",
+                  "title": "insecure",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "tls",
+              "type": "object"
+            },
+            "url": {
+              "default": "https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443",
+              "description": "Cluster gateway service URL the API server connects to",
+              "title": "url",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "clusterGateway",
+          "type": "object"
+        },
         "config": {
           "additionalProperties": false,
           "description": "OpenChoreo API specific configuration. Shared settings come from global security.* values.",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -838,6 +838,41 @@ openchoreoApi:
 
   # @schema
   # type: object
+  # description: Cluster gateway connection settings for agent-based plane communication
+  # @schema
+  clusterGateway:
+    # @schema
+    # type: string
+    # description: Cluster gateway service URL the API server connects to
+    # default: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443
+    # @schema
+    url: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443
+    # @schema
+    # type: object
+    # description: TLS settings for the cluster gateway connection
+    # @schema
+    tls:
+      # @schema
+      # type: string
+      # description: Path inside the pod where the cluster gateway CA certificate is mounted
+      # default: /etc/cluster-gateway/ca.crt
+      # @schema
+      caPath: /etc/cluster-gateway/ca.crt
+      # @schema
+      # type: string
+      # description: Name of the secret holding the cluster gateway CA certificate
+      # default: cluster-gateway-ca
+      # @schema
+      caSecret: cluster-gateway-ca
+      # @schema
+      # type: boolean
+      # description: Skip TLS verification of the cluster gateway. For development only.
+      # default: false
+      # @schema
+      insecure: false
+
+  # @schema
+  # type: object
   # description: OpenChoreo API specific configuration. Shared settings come from global security.* values.
   # Note: JWT (enabled, issuer, audience), authorization (enabled, paths), identity (clients)
   #       are read from security.* for consistency with other components.

--- a/internal/clients/gateway/client.go
+++ b/internal/clients/gateway/client.go
@@ -32,6 +32,10 @@ type TLSConfig struct {
 	CAFile             string
 	CAData             []byte
 	ServerName         string
+	// ClientCertFile and ClientKeyFile enable mTLS to the cluster gateway.
+	// Both must be set together.
+	ClientCertFile string
+	ClientKeyFile  string
 }
 
 type Client struct {
@@ -154,30 +158,10 @@ func HandleGatewayError(logger interface{ Error(error, string, ...any) }, err er
 	return false, ctrl.Result{}, nil
 }
 
-// NewClient creates a new gateway client with insecure TLS (for local development only)
-// For production use, use NewClientWithConfig with proper TLS configuration
-func NewClient(baseURL string) *Client {
-	// Skip TLS verification for local development
-	// In production, use NewClientWithConfig with proper CA certificates
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			// #nosec G402 -- InsecureSkipVerify is intentional for local development
-			// In production deployments, use NewClientWithConfig with proper CA certificates
-			InsecureSkipVerify: true,
-		},
-	}
-
-	return &Client{
-		baseURL: baseURL,
-		httpClient: &http.Client{
-			Timeout:   10 * time.Second,
-			Transport: transport,
-		},
-	}
-}
-
-// NewClientWithConfig creates a new gateway client with the provided configuration
-// This should be used for production deployments with proper TLS verification
+// NewClientWithConfig creates a new gateway client with the provided configuration.
+// The server certificate is verified against the system root CA pool by default;
+// set TLSConfig.CAFile or TLSConfig.CAData to pin a custom CA. For development
+// against self-signed gateways, callers may set TLSConfig.InsecureSkipVerify.
 func NewClientWithConfig(config *Config) (*Client, error) {
 	if config.BaseURL == "" {
 		return nil, fmt.Errorf("baseURL is required")
@@ -241,6 +225,17 @@ func buildTLSConfig(config *TLSConfig) (*tls.Config, error) {
 		}
 
 		tlsConfig.RootCAs = caCertPool
+	}
+
+	if config.ClientCertFile != "" || config.ClientKeyFile != "" {
+		if config.ClientCertFile == "" || config.ClientKeyFile == "" {
+			return nil, fmt.Errorf("both ClientCertFile and ClientKeyFile must be set for mTLS")
+		}
+		cert, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client key pair: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	return tlsConfig, nil

--- a/internal/clients/gateway/client_test.go
+++ b/internal/clients/gateway/client_test.go
@@ -5,12 +5,22 @@ package gateway
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -746,4 +756,115 @@ func TestGetPodEventsFromPlane(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, IsTransientError(err))
 	})
+}
+
+// ─── buildTLSConfig tests ─────────────────────────────────────────────────────
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Run("empty config uses default verification", func(t *testing.T) {
+		cfg, err := buildTLSConfig(&TLSConfig{})
+		require.NoError(t, err)
+		assert.False(t, cfg.InsecureSkipVerify)
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+		assert.Nil(t, cfg.RootCAs)
+		assert.Empty(t, cfg.Certificates)
+	})
+
+	t.Run("InsecureSkipVerify=true opts into skipping verification", func(t *testing.T) {
+		cfg, err := buildTLSConfig(&TLSConfig{InsecureSkipVerify: true})
+		require.NoError(t, err)
+		assert.True(t, cfg.InsecureSkipVerify)
+	})
+
+	t.Run("ServerName is propagated", func(t *testing.T) {
+		cfg, err := buildTLSConfig(&TLSConfig{ServerName: "gateway.example"})
+		require.NoError(t, err)
+		assert.Equal(t, "gateway.example", cfg.ServerName)
+	})
+
+	t.Run("valid CAFile is loaded into RootCAs", func(t *testing.T) {
+		certPEM, _ := mustGenerateKeyPairPEM(t)
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, certPEM, 0o600))
+
+		cfg, err := buildTLSConfig(&TLSConfig{CAFile: caFile})
+		require.NoError(t, err)
+		assert.NotNil(t, cfg.RootCAs)
+	})
+
+	t.Run("missing CAFile returns error", func(t *testing.T) {
+		_, err := buildTLSConfig(&TLSConfig{CAFile: "/path/does/not/exist/ca.crt"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA file")
+	})
+
+	t.Run("malformed CAData returns parse error", func(t *testing.T) {
+		_, err := buildTLSConfig(&TLSConfig{CAData: []byte("not-a-cert")})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse CA certificate")
+	})
+
+	t.Run("valid client cert and key are loaded for mTLS", func(t *testing.T) {
+		certPEM, keyPEM := mustGenerateKeyPairPEM(t)
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "client.crt")
+		keyFile := filepath.Join(dir, "client.key")
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := buildTLSConfig(&TLSConfig{
+			ClientCertFile: certFile,
+			ClientKeyFile:  keyFile,
+		})
+		require.NoError(t, err)
+		assert.Len(t, cfg.Certificates, 1)
+	})
+
+	t.Run("only ClientCertFile set returns asymmetric-config error", func(t *testing.T) {
+		_, err := buildTLSConfig(&TLSConfig{ClientCertFile: "/tmp/client.crt"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both ClientCertFile and ClientKeyFile must be set")
+	})
+
+	t.Run("only ClientKeyFile set returns asymmetric-config error", func(t *testing.T) {
+		_, err := buildTLSConfig(&TLSConfig{ClientKeyFile: "/tmp/client.key"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both ClientCertFile and ClientKeyFile must be set")
+	})
+
+	t.Run("invalid client key pair returns load error", func(t *testing.T) {
+		_, err := buildTLSConfig(&TLSConfig{
+			ClientCertFile: "/path/does/not/exist/client.crt",
+			ClientKeyFile:  "/path/does/not/exist/client.key",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client key pair")
+	})
+}
+
+// mustGenerateKeyPairPEM creates a self-signed cert + matching private key in PEM form,
+// usable for both CA and client-cert tests.
+func mustGenerateKeyPairPEM(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
 }

--- a/internal/clients/kubernetes/client.go
+++ b/internal/clients/kubernetes/client.go
@@ -21,6 +21,9 @@ type ProxyTLSConfig struct {
 	CACertPath     string
 	ClientCertPath string
 	ClientKeyPath  string
+	// Insecure disables TLS verification for proxy connections.
+	// For local development only.
+	Insecure bool
 }
 
 // KubeMultiClientManager maintains a cache of Kubernetes clients keyed by a unique identifier.

--- a/internal/clients/kubernetes/proxy_client.go
+++ b/internal/clients/kubernetes/proxy_client.go
@@ -765,14 +765,23 @@ func getGVK(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind
 // ProxyTLSConfig is defined in client.go to avoid import cycles
 // We reference it here for type safety
 
-// buildProxyTLSConfig builds a TLS config for the HTTP proxy client
+// buildProxyTLSConfig builds a TLS config for the HTTP proxy client.
+// TLS verification is enabled by default against the system root CA pool.
+// To pin a CA, set CACertPath. To skip verification (development only), set
+// Insecure=true explicitly — silent fallback to InsecureSkipVerify is not
+// supported.
 func buildProxyTLSConfig(tlsConfig *ProxyTLSConfig) (*tls.Config, error) {
 	cfg := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
 
-	// If no TLS config provided, fall back to insecure mode
+	// No config → use default verification with the system root pool.
 	if tlsConfig == nil {
+		return cfg, nil
+	}
+
+	if tlsConfig.Insecure {
+		// #nosec G402 -- Insecure mode is gated on explicit caller opt-in for development.
 		cfg.InsecureSkipVerify = true
 		return cfg, nil
 	}
@@ -789,9 +798,6 @@ func buildProxyTLSConfig(tlsConfig *ProxyTLSConfig) (*tls.Config, error) {
 			return nil, fmt.Errorf("failed to parse CA certificate")
 		}
 		cfg.RootCAs = caCertPool
-	} else {
-		// If no CA cert provided, use insecure mode
-		cfg.InsecureSkipVerify = true
 	}
 
 	// Load client certificate and key for mTLS authentication

--- a/internal/clients/kubernetes/proxy_client_test.go
+++ b/internal/clients/kubernetes/proxy_client_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -239,16 +240,36 @@ func TestGetGVK(t *testing.T) {
 }
 
 func TestBuildProxyTLSConfig(t *testing.T) {
-	t.Run("nil config falls back to insecure mode", func(t *testing.T) {
+	t.Run("nil config uses default verification", func(t *testing.T) {
 		cfg, err := buildProxyTLSConfig(nil)
+		require.NoError(t, err)
+		assert.False(t, cfg.InsecureSkipVerify)
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	})
+
+	t.Run("empty config without CA uses default verification", func(t *testing.T) {
+		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{})
+		require.NoError(t, err)
+		assert.False(t, cfg.InsecureSkipVerify)
+		assert.Nil(t, cfg.RootCAs)
+	})
+
+	t.Run("Insecure=true opts into skipping verification", func(t *testing.T) {
+		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{Insecure: true})
 		require.NoError(t, err)
 		assert.True(t, cfg.InsecureSkipVerify)
 	})
 
-	t.Run("empty config without CA uses insecure mode", func(t *testing.T) {
-		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{})
+	t.Run("Insecure=true short-circuits before reading CA", func(t *testing.T) {
+		// Confirms that a misconfigured CA path is ignored when the caller has
+		// explicitly opted into insecure mode — no surprise read errors.
+		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{
+			Insecure:   true,
+			CACertPath: "/path/does/not/exist/ca.crt",
+		})
 		require.NoError(t, err)
 		assert.True(t, cfg.InsecureSkipVerify)
+		assert.Nil(t, cfg.RootCAs)
 	})
 
 	t.Run("invalid CA path returns error", func(t *testing.T) {

--- a/internal/controller/testutils/testgateway/fake_gateway.go
+++ b/internal/controller/testutils/testgateway/fake_gateway.go
@@ -39,5 +39,10 @@ func StartFakeGateway(notifyCode int, statusResp *gw.PlaneConnectionStatus) (*gw
 		}
 		_ = json.NewEncoder(w).Encode(statusResp)
 	}))
-	return gw.NewClient(srv.URL), &n, srv.Close
+	c, err := gw.NewClientWithConfig(&gw.Config{BaseURL: srv.URL})
+	if err != nil {
+		srv.Close()
+		panic("StartFakeGateway: failed to build gateway client: " + err.Error())
+	}
+	return c, &n, srv.Close
 }

--- a/internal/openchoreo-api/config/cluster_gateway.go
+++ b/internal/openchoreo-api/config/cluster_gateway.go
@@ -26,6 +26,9 @@ type ClusterGatewayTLSConfig struct {
 	ClientCertPath string `koanf:"client_cert_path"`
 	// ClientKeyPath is the path to the client private key file for mTLS authentication.
 	ClientKeyPath string `koanf:"client_key_path"`
+	// Insecure disables TLS verification for the cluster gateway connection.
+	// For local development only.
+	Insecure bool `koanf:"insecure"`
 }
 
 // ClusterGatewayDefaults returns the default cluster gateway configuration.

--- a/internal/openchoreo-api/services/k8sresources/service_integration_test.go
+++ b/internal/openchoreo-api/services/k8sresources/service_integration_test.go
@@ -52,7 +52,9 @@ func testGatewayServer(t *testing.T, handler http.HandlerFunc) *gateway.Client {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	return gateway.NewClient(server.URL)
+	c, err := gateway.NewClientWithConfig(&gateway.Config{BaseURL: server.URL})
+	require.NoError(t, err)
+	return c
 }
 
 // testRESTMapper creates a REST mapper with standard K8s type mappings.
@@ -199,7 +201,8 @@ func jsonMarshal(t *testing.T, v any) []byte {
 
 func TestNewService(t *testing.T) {
 	fc := newFakeClient()
-	gc := gateway.NewClient("http://localhost")
+	gc, err := gateway.NewClientWithConfig(&gateway.Config{BaseURL: "http://localhost"})
+	require.NoError(t, err)
 	svc := NewService(fc, gc, testLogger())
 	require.NotNil(t, svc)
 }
@@ -963,7 +966,8 @@ func TestBuildResourceTreeNodes(t *testing.T) {
 
 func TestNewServiceWithAuthz(t *testing.T) {
 	fc := newFakeClient()
-	gc := gateway.NewClient("http://localhost")
+	gc, err := gateway.NewClientWithConfig(&gateway.Config{BaseURL: "http://localhost"})
+	require.NoError(t, err)
 	pdp := authzmocks.NewMockPDP(t)
 	svc := NewServiceWithAuthz(fc, gc, pdp, testLogger())
 	require.NotNil(t, svc)


### PR DESCRIPTION
## Purpose
Replace the silent `InsecureSkipVerify: true` in the cluster-gateway HTTP client and kubernetes proxy TLS builder with explicit, opt-in insecure mode.

## Goals
- Manager and openchoreo-api now check the cluster-gateway's TLS certificate by default. If the configured CA is missing or wrong, the call fails, where previously silently continued without verifying.
- Provide an explicit `--cluster-gateway-insecure` flag (manager) and `cluster_gateway.tls.insecure` config field (openchoreo-api) for local-dev use.
- Make the standard Helm install verified out of the box by mounting the existing `cluster-gateway-ca` secret into openchoreo-api.

## Related
Addresses:
https://github.com/openchoreo/openchoreo/security/code-scanning/71
https://github.com/openchoreo/openchoreo/security/code-scanning/72
https://github.com/openchoreo/openchoreo/security/code-scanning/73