### PR TITLE
fix(cli): default componentrelease generate to file-system mode

### DIFF
--- a/internal/occ/cmd/componentrelease/componentrelease.go
+++ b/internal/occ/cmd/componentrelease/componentrelease.go
@@ -75,10 +75,10 @@ func (cr *ComponentRelease) List(params ListParams) error {
 
 // Generate implements the component-release generate command
 func (cr *ComponentRelease) Generate(params GenerateParams) error {
-	// 1. Determine mode from params (default to api-server)
+	// 1. Determine mode from params. file-system is the only supported mode.
 	mode := params.Mode
 	if mode == "" {
-		mode = flags.ModeAPIServer
+		mode = flags.ModeFileSystem
 	}
 
 	if mode != flags.ModeFileSystem {

--- a/internal/occ/cmd/componentrelease/generate_test.go
+++ b/internal/occ/cmd/componentrelease/generate_test.go
@@ -20,14 +20,15 @@ import (
 
 // --- Generate: mode validation (no filesystem needed) ---
 
-func TestGenerate_DefaultModeRejectsAPIServer(t *testing.T) {
+func TestGenerate_DefaultModeIsFileSystem(t *testing.T) {
+	testutil.SetupTestHome(t)
 	mc := mocks.NewMockInterface(t)
 	cr := New(mc)
-	// Empty Mode defaults to "api-server" → rejected
+	// Empty Mode defaults to "file-system" → proceeds past mode validation,
+	// then errors at config loading (no current context set).
 	err := cr.Generate(GenerateParams{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "componentrelease generate only supports file-system mode")
-	assert.Contains(t, err.Error(), `"api-server"`)
+	assert.Contains(t, err.Error(), "no current context set")
 }
 
 func TestGenerate_ExplicitAPIServerModeRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

\`occ componentrelease generate\` only supports file-system mode, but defaulted to api-server and rejected the user. Switch the default to file-system.

## Test plan
- [x] \`go test ./internal/occ/cmd/componentrelease/...\` passes
- [x] Existing rejection tests for explicit \`api-server\` / invalid modes still hold