### PR TITLE
feat: add capability to update FinOps reports

### DIFF
--- a/finops-agent/openapi.yaml
+++ b/finops-agent/openapi.yaml
@@ -186,6 +186,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - FinOps Reports
+      summary: Update remediation action statuses in a report
+      description: |
+        Marks remediation actions as applied or dismissed. Actions must be in `revised` status
+        to be updated; already-applied or already-dismissed actions are silently skipped.
+        An index cannot appear in both `appliedIndices` and `dismissedIndices`.
+        The caller (typically the UI) is responsible for applying the actual patch to the
+        ReleaseBinding via the openchoreo-api REST surface before calling this endpoint.
+      operationId: updateReport
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: report_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportUpdateRequest'
+      responses:
+        '200':
+          description: Report updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    enum: [ok]
+        '400':
+          description: Bad request - overlapping indices or invalid body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized - missing or invalid JWT token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - insufficient permissions (requires finopsreport:update)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /health:
     get:
@@ -367,6 +434,11 @@ components:
           minItems: 1
           items:
             $ref: '#/components/schemas/InvestigationStep'
+        recommended_actions:
+          type: array
+          description: Remediation actions synthesized from overprovisioning recommendations (present when remediation is enabled)
+          items:
+            $ref: '#/components/schemas/RemediationAction'
 
     CostBreakdown:
       type: object
@@ -460,6 +532,10 @@ components:
           type: string
         rationale:
           type: string
+        release_binding:
+          type: string
+          nullable: true
+          description: Name of the ReleaseBinding for the target environment (e.g. my-service-development)
 
     InvestigationStep:
       type: object
@@ -471,3 +547,62 @@ components:
           type: string
         rationale:
           type: ["string", "null"]
+
+    ReportUpdateRequest:
+      type: object
+      properties:
+        appliedIndices:
+          type: array
+          description: Zero-based indices of recommended_actions to mark as applied
+          items:
+            type: integer
+            minimum: 0
+        dismissedIndices:
+          type: array
+          description: Zero-based indices of recommended_actions to mark as dismissed
+          items:
+            type: integer
+            minimum: 0
+
+    RemediationAction:
+      type: object
+      required: [description, rationale, status]
+      properties:
+        description:
+          type: string
+        rationale:
+          type: string
+        status:
+          type: string
+          enum: [revised, applied, dismissed]
+        change:
+          oneOf:
+            - $ref: '#/components/schemas/ResourceChange'
+            - type: 'null'
+
+    ResourceChange:
+      type: object
+      required: [release_binding, fields]
+      properties:
+        release_binding:
+          type: string
+          description: Name of the ReleaseBinding CR to patch
+        fields:
+          type: array
+          description: RFC 6901 JSON Pointer field changes to apply
+          items:
+            $ref: '#/components/schemas/FieldChange'
+
+    FieldChange:
+      type: object
+      required: [json_pointer, value]
+      properties:
+        json_pointer:
+          type: string
+          description: RFC 6901 JSON Pointer path (e.g. /spec/componentTypeEnvironmentConfigs/resources/requests/cpu)
+        value:
+          description: Scalar value to set at the pointer path
+          oneOf:
+            - type: string
+            - type: number
+            - type: boolean

--- a/finops-agent/src/agent/agent.py
+++ b/finops-agent/src/agent/agent.py
@@ -24,7 +24,7 @@ from src.auth import get_oauth2_auth
 from src.clients import MCPClient, get_model, get_report_backend
 from src.config import settings
 from src.logging_config import request_id_context
-from src.models import FinOpsReport
+from src.models import FinOpsReport, FieldChange, RemediationAction, ResourceChange
 from src.template_manager import render
 
 if TYPE_CHECKING:
@@ -170,6 +170,35 @@ FINOPS_AGENT = Agent(
 )
 
 
+def _synthesize_remediation_actions(report: FinOpsReport) -> list[RemediationAction]:
+    rec = report.overprovisioning.recommendation
+    if not rec or not rec.release_binding:
+        return []
+
+    return [
+        RemediationAction(
+            description=(
+                f"Right-size ReleaseBinding `{rec.release_binding}` "
+                "CPU and memory requests based on actual usage"
+            ),
+            rationale=rec.rationale,
+            change=ResourceChange(
+                release_binding=rec.release_binding,
+                fields=[
+                    FieldChange(
+                        json_pointer="/spec/componentTypeEnvironmentConfigs/resources/requests/cpu",
+                        value=rec.cpu_request,
+                    ),
+                    FieldChange(
+                        json_pointer="/spec/componentTypeEnvironmentConfigs/resources/requests/memory",
+                        value=rec.memory_request,
+                    ),
+                ],
+            ),
+        )
+    ]
+
+
 # Module-level semaphore for limiting concurrent analyses
 _semaphore: asyncio.Semaphore | None = None
 
@@ -228,6 +257,9 @@ async def run_analysis(
             if agent_logging and (summary := agent_logging.tool_call_summary()):
                 logger.debug("FinOps tool calls: %s", summary)
             logger.info("FinOps analysis completed: usage=%s", usage_callback.usage_metadata)
+
+            if settings.remediation_enabled:
+                finops_report.recommended_actions = _synthesize_remediation_actions(finops_report)
 
             report_data = finops_report.model_dump()
 

--- a/finops-agent/src/api/report_routes.py
+++ b/finops-agent/src/api/report_routes.py
@@ -5,9 +5,9 @@ import logging
 from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 
-from src.auth import require_authn, require_reports_authz
+from src.auth import require_authn, require_reports_authz, require_reports_update_authz
 from src.auth.authz_models import SubjectContext
 from src.clients import get_report_backend
 from src.models import BaseModel
@@ -111,3 +111,78 @@ async def get_finops_report(
         status=result["status"],
         report=result.get("report"),
     )
+
+
+class ReportUpdateRequest(BaseModel):
+    applied_indices: list[int] = Field(default_factory=list, alias="appliedIndices")
+    dismissed_indices: list[int] = Field(default_factory=list, alias="dismissedIndices")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def _no_overlap(self) -> "ReportUpdateRequest":
+        overlap = set(self.applied_indices) & set(self.dismissed_indices)
+        if overlap:
+            raise ValueError(
+                f"Indices cannot appear in both appliedIndices and dismissedIndices: {sorted(overlap)}"
+            )
+        return self
+
+
+@router.put("/{report_id}")
+async def update_report(
+    report_id: str,
+    body: ReportUpdateRequest,
+    _auth: Annotated[SubjectContext, Depends(require_authn)] = None,
+    _authz: Annotated[SubjectContext, Depends(require_reports_update_authz)] = None,
+):
+    logger.info(
+        "Updating report %s: applied=%s dismissed=%s",
+        report_id,
+        body.applied_indices,
+        body.dismissed_indices,
+    )
+    await _update_action_statuses(
+        report_id,
+        applied=set(body.applied_indices),
+        dismissed=set(body.dismissed_indices),
+    )
+    return {"status": "ok"}
+
+
+async def _update_action_statuses(
+    report_id: str,
+    applied: set[int],
+    dismissed: set[int],
+) -> None:
+    report_backend = get_report_backend()
+
+    validation_error: HTTPException | None = None
+
+    def mutate(actions: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+        nonlocal validation_error
+        invalid = sorted(i for i in applied | dismissed if not (0 <= i < len(actions)))
+        if invalid:
+            if not actions:
+                detail = f"No available actions; cannot apply or dismiss indices: {invalid}"
+            else:
+                detail = f"Invalid action indices (out of range 0–{len(actions) - 1}): {invalid}"
+            validation_error = HTTPException(status_code=400, detail=detail)
+            return actions, False
+
+        changed = False
+        for i, action in enumerate(actions):
+            current = action.get("status")
+            if i in applied and current == "revised":
+                action["status"] = "applied"
+                changed = True
+            elif i in dismissed and current == "revised":
+                action["status"] = "dismissed"
+                changed = True
+        return actions, changed
+
+    stored = await report_backend.update_report_actions_atomic(report_id, mutate)
+    if stored is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    if validation_error:
+        raise validation_error

--- a/finops-agent/src/auth/__init__.py
+++ b/finops-agent/src/auth/__init__.py
@@ -10,7 +10,7 @@ from src.auth.authz_models import (
     SubjectContext,
 )
 from src.auth.bearer import BearerTokenAuth
-from src.auth.dependencies import require_authn, require_reports_authz
+from src.auth.dependencies import require_authn, require_reports_authz, require_reports_update_authz
 from src.auth.jwt import JWTValidationError, JWTValidator, get_jwt_validator
 from src.auth.oauth_client import OAuth2ClientCredentialsAuth, check_oauth2_connection, get_oauth2_auth
 
@@ -34,4 +34,5 @@ __all__ = [
     # Dependencies
     "require_authn",
     "require_reports_authz",
+    "require_reports_update_authz",
 ]

--- a/finops-agent/src/auth/dependencies.py
+++ b/finops-agent/src/auth/dependencies.py
@@ -217,3 +217,7 @@ class ReportAuthorizationChecker(AuthorizationChecker):
 require_reports_authz = ReportAuthorizationChecker(
     action="finopsreport:view", resource_type="finopsreport"
 )
+
+require_reports_update_authz = ReportAuthorizationChecker(
+    action="finopsreport:update", resource_type="finopsreport"
+)

--- a/finops-agent/src/clients/backend/report_backend.py
+++ b/finops-agent/src/clients/backend/report_backend.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
@@ -39,6 +40,17 @@ class ReportBackend(ABC):
         limit: int = 100,
         sort: str = "desc",
     ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    async def update_report_actions_atomic(
+        self,
+        report_id: str,
+        mutate_fn: Callable[[list[dict[str, Any]]], tuple[list[dict[str, Any]], bool]],
+    ) -> dict[str, Any] | None:
+        """Load the report, apply mutate_fn to recommended_actions inside a DB
+        transaction/row lock, write back if mutate_fn signals a change, and return
+        the stored document (or None if not found)."""
+        ...
 
     @abstractmethod
     async def initialize(self) -> None: ...

--- a/finops-agent/src/clients/backend/sql_backend.py
+++ b/finops-agent/src/clients/backend/sql_backend.py
@@ -9,6 +9,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from collections.abc import Callable
+
 from sqlalchemy import Column, Index, MetaData, String, Table, Text, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -144,6 +146,41 @@ class SQLReportBackend(ReportBackend):
 
         logger.info(f"Successfully upserted FinOps report {report_id} with status={status}")
         return {"result": "created", "_id": report_id}
+
+    async def update_report_actions_atomic(
+        self,
+        report_id: str,
+        mutate_fn: Callable[[list[dict[str, Any]]], tuple[list[dict[str, Any]], bool]],
+    ) -> dict[str, Any] | None:
+        async with self.engine.begin() as conn:
+            # PostgreSQL uses SELECT FOR UPDATE to row-lock; SQLite serializes
+            # writes at the transaction level so no hint is needed.
+            if self._is_sqlite:
+                stmt = select(finops_reports).where(finops_reports.c.report_id == report_id)
+            else:
+                stmt = (
+                    select(finops_reports)
+                    .where(finops_reports.c.report_id == report_id)
+                    .with_for_update()
+                )
+            row = (await conn.execute(stmt)).mappings().fetchone()
+            if row is None:
+                return None
+
+            doc = _row_to_doc(row)
+            actions: list[dict[str, Any]] = doc.get("report", {}).get("recommended_actions", [])
+            new_actions, changed = mutate_fn(actions)
+
+            if changed:
+                report_data: dict[str, Any] = doc.get("report") or {}
+                report_data["recommended_actions"] = new_actions
+                await conn.execute(
+                    finops_reports.update()
+                    .where(finops_reports.c.report_id == report_id)
+                    .values(report=json.dumps(report_data))
+                )
+
+        return doc
 
     async def get_report(
         self,

--- a/finops-agent/src/config.py
+++ b/finops-agent/src/config.py
@@ -50,6 +50,8 @@ class Settings(BaseSettings):
     max_concurrent_analyses: int = 5
     analysis_timeout_seconds: int = 600
 
+    remediation_enabled: bool = False
+
     log_level: str = "INFO"
     tls_insecure_skip_verify: bool = False
     cors_allowed_origins: str = ""

--- a/finops-agent/src/models/__init__.py
+++ b/finops-agent/src/models/__init__.py
@@ -3,9 +3,13 @@
 
 from src.models.base import BaseModel, get_current_utc
 from src.models.finops_report import FinOpsReport
+from src.models.remediation_action import FieldChange, RemediationAction, ResourceChange
 
 __all__ = [
     "BaseModel",
     "get_current_utc",
     "FinOpsReport",
+    "FieldChange",
+    "RemediationAction",
+    "ResourceChange",
 ]

--- a/finops-agent/src/models/finops_report.py
+++ b/finops-agent/src/models/finops_report.py
@@ -3,6 +3,8 @@
 
 from pydantic import BaseModel, Field
 
+from src.models.remediation_action import RemediationAction
+
 
 class ResourceMetrics(BaseModel):
     """Current resource configuration and actual usage metrics"""
@@ -68,6 +70,10 @@ class ResourceRecommendation(BaseModel):
     estimated_savings: float = Field(..., description="Estimated cost savings")
     currency: str = Field(..., description="Currency code (e.g. 'USD')")
     rationale: str = Field(..., description="Explanation of the recommendation")
+    release_binding: str | None = Field(
+        default=None,
+        description="Name of the ReleaseBinding to patch (e.g. 'my-service-development'). Required for remediation.",
+    )
 
 
 class OverprovisioningAssessment(BaseModel):
@@ -112,4 +118,8 @@ class FinOpsReport(BaseModel):
     summary: str = Field(..., description="1-2 sentence summary of the analysis")
     investigation_path: list[InvestigationStep] = Field(
         ..., min_length=1, description="Steps taken during the analysis"
+    )
+    recommended_actions: list[RemediationAction] = Field(
+        default_factory=list,
+        description="Remediation actions synthesized from the overprovisioning recommendation",
     )

--- a/finops-agent/src/models/remediation_action.py
+++ b/finops-agent/src/models/remediation_action.py
@@ -1,0 +1,23 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class FieldChange(BaseModel):
+    json_pointer: str = Field(..., description="RFC 6901 JSON Pointer starting with /spec/")
+    value: str | int | float | bool = Field(..., description="Scalar value to set at this path")
+
+
+class ResourceChange(BaseModel):
+    release_binding: str = Field(..., description="Name of the ReleaseBinding to patch")
+    fields: list[FieldChange] = Field(default_factory=list)
+
+
+class RemediationAction(BaseModel):
+    description: str = Field(..., description="Short description of the remediation action")
+    rationale: str = Field(..., description="Explanation of why this change is recommended")
+    status: Literal["revised", "applied", "dismissed"] = "revised"
+    change: ResourceChange | None = None

--- a/finops-agent/src/templates/prompts/finops_agent_prompt.j2
+++ b/finops-agent/src/templates/prompts/finops_agent_prompt.j2
@@ -51,6 +51,7 @@ Given a component that has triggered a budget alert, you must:
 - Set recommended memory request to P95 actual usage + 25% headroom
 - Set recommended memory limit to 1.5x the recommended request (or based on peak usage + headroom)
 - Calculate estimated savings based on the difference between current and recommended resource costs
+- Set `release_binding` to the name of the component's ReleaseBinding for the target environment. The ReleaseBinding name follows the convention `<component>-<environment>` (e.g. `my-service-development`). Use the component name and environment from the request to construct it.
 
 ## Output Format Requirements
 

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1268,6 +1268,7 @@ openchoreoApi:
                 - "rcareport:view"
                 - "rcareport:update"
                 - "finopsreport:view"
+                - "finopsreport:update"
 
             # Platform engineer role - engineers managing the OpenChoreo platform infrastructure
             - name: platform-engineer
@@ -1356,6 +1357,7 @@ openchoreoApi:
                 - "rcareport:view"
                 - "rcareport:update"
                 - "finopsreport:view"
+                - "finopsreport:update"
                 - "observabilityalertsnotificationchannel:view"
                 - "observabilityalertsnotificationchannel:create"
                 - "observabilityalertsnotificationchannel:update"

--- a/install/helm/openchoreo-observability-plane/templates/finops-agent/config-map.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/finops-agent/config-map.yaml
@@ -27,6 +27,7 @@ data:
   OBSERVABILITY_MCP_SERVER_URL: {{ .Values.finOpsAgent.observabilityMcpServerUrl | quote }}
   OPENCHOREO_API_URL: {{ .Values.finOpsAgent.openchoreoApiUrl | quote }}
   OPENCOST_MCP_SERVER_URL: {{ .Values.finOpsAgent.opencostMcpServerUrl | quote }}
+  REMEDIATION_ENABLED: {{ .Values.finOpsAgent.remediationEnabled | default false | quote }}
   REPORT_BACKEND: {{ .Values.finOpsAgent.reportBackend | quote }}
   TLS_INSECURE_SKIP_VERIFY: {{ .Values.finOpsAgent.tlsInsecureSkipVerify | quote }}
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1007,6 +1007,12 @@
           "title": "opencostMcpServerUrl",
           "type": "string"
         },
+        "remediationEnabled": {
+          "default": false,
+          "description": "Enable remediation capability (synthesizes a ResourceChange action from overprovisioning recommendations)",
+          "title": "remediationEnabled",
+          "type": "boolean"
+        },
         "replicas": {
           "default": 1,
           "description": "Number of FinOps agent replicas",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1745,6 +1745,13 @@ finOpsAgent:
   analysisTimeoutSeconds: 600
 
   # @schema
+  # type: boolean
+  # description: Enable remediation capability (synthesizes a ResourceChange action from overprovisioning recommendations)
+  # default: false
+  # @schema
+  remediationEnabled: false
+
+  # @schema
   # type: object
   # description: OAuth2 client credentials configuration for FinOps agent authentication
   # @schema

--- a/internal/authz/core/actions.go
+++ b/internal/authz/core/actions.go
@@ -239,7 +239,8 @@ const (
 	ActionUpdateRCAReport = "rcareport:update"
 
 	// FinOps Report actions
-	ActionViewFinOpsReport = "finopsreport:view"
+	ActionViewFinOpsReport   = "finopsreport:view"
+	ActionUpdateFinOpsReport = "finopsreport:update"
 )
 
 // Action represents a system action with metadata
@@ -471,6 +472,7 @@ var systemActions = []Action{
 
 	// FinOps Report
 	{Name: ActionViewFinOpsReport, LowestScope: ScopeProject, IsInternal: false},
+	{Name: ActionUpdateFinOpsReport, LowestScope: ScopeProject, IsInternal: false},
 }
 
 // AllActions returns all system-defined actions


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Add remediation capability to the FinOps agent. Currently, the agent analyzes CPU/memory usage, detects overprovisioning, and produces recommended resource values. But users have no way to apply those recommendations automatically. This PR includes the changes required to update the FinOps report when users apply the recommendations automatically. 

## Approach
finops-agent:
- Added RemediationAction, ResourceChange, and FieldChange models 
- Extended ResourceRecommendation with a release_binding field and updated the agent prompt to instruct the LLM to populate it
- Added _synthesize_remediation_actions() in agent.py which deterministically builds one RemediationAction with two field changes (/spec/componentTypeEnvironmentConfigs/resources/requests/cpu and .../memory) from the LLM-produced recommendation
- Extended FinOpsReport with recommended_actions: list[RemediationAction]
- Added PUT /api/v1alpha1/reports/{report_id} endpoint that flips action statuses; rejects overlapping indices with 400; guarded by new finopsreport:update authz action
- Added require_reports_update_authz dependency

openchoreo (authz + helm):
  - Registered finopsreport:update as a system action in internal/authz/core/actions.go
  - Added finopsreport:update to the SRE and platform-engineer default roles in the control-plane Helm values
  - Added remediationEnabled: false to the observability-plane Helm values and wired it into the finops-agent ConfigMap

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3356

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
The actual releaseBinding update logic will be added to the backstage-plugins repository
