### PR TITLE
fix: align cluster gateway TLS configuration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -268,7 +268,8 @@ func main() {
 			"Required for agent mode. Example: https://localhost:8443")
 	flag.StringVar(&clusterGatewayCACert, "cluster-gateway-ca-cert", getEnv("CLUSTER_GATEWAY_CA_CERT", ""),
 		"Path to CA certificate for verifying the cluster gateway's TLS certificate. "+
-			"If not specified, InsecureSkipVerify will be used (not recommended for production).")
+			"If --cluster-gateway-ca-cert is omitted, system root CAs are used and self-signed certificates will fail; "+
+			"use --cluster-gateway-insecure to allow insecure verification for self-signed setups.")
 	flag.StringVar(&clusterGatewayClientCert, "cluster-gateway-client-cert", getEnv("CLUSTER_GATEWAY_CLIENT_CERT", ""),
 		"Path to client certificate for mTLS authentication with the cluster gateway.")
 	flag.StringVar(&clusterGatewayClientKey, "cluster-gateway-client-key", getEnv("CLUSTER_GATEWAY_CLIENT_KEY", ""),

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -154,12 +154,12 @@ func main() {
 			logger.Error("Failed to create cluster gateway client", slog.Any("error", err))
 			os.Exit(1)
 		}
+		logger.Info("gateway client initialized",
+			"url", gatewayURL,
+			"caCert", cfg.ClusterGateway.TLS.CACertPath != "",
+			"clientCert", cfg.ClusterGateway.TLS.ClientCertPath != "",
+			"insecure", cfg.ClusterGateway.TLS.Insecure)
 	}
-	logger.Info("gateway client initialized",
-		"url", gatewayURL,
-		"caCert", cfg.ClusterGateway.TLS.CACertPath != "",
-		"clientCert", cfg.ClusterGateway.TLS.ClientCertPath != "",
-		"insecure", cfg.ClusterGateway.TLS.Insecure)
 
 	// Start background processes (manager + cache sync when authz enabled)
 	if err := runtime.start(ctx); err != nil {

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -52,6 +52,9 @@ spec:
         args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         - --cluster-gateway-url={{ .Values.controllerManager.clusterGateway.url }}
         - --cluster-gateway-ca-cert={{ .Values.controllerManager.clusterGateway.tls.caPath }}
+        {{- if .Values.controllerManager.clusterGateway.tls.insecure }}
+        - --cluster-gateway-insecure
+        {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
           value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}
@@ -94,9 +97,11 @@ spec:
           name: cert
           readOnly: true
         {{- end }}
+        {{- if .Values.clusterGateway.tls.enabled }}
         - mountPath: /etc/cluster-gateway
           name: cluster-gateway-ca
           readOnly: true
+        {{- end }}
       volumes:
       {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
       - name: cert
@@ -104,6 +109,8 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.controllerManager.name }}-webhook-server-cert
       {{- end }}
+      {{- if .Values.clusterGateway.tls.enabled }}
       - name: cluster-gateway-ca
         secret:
-          secretName: {{ .Values.controllerManager.clusterGateway.tls.caSecret | default "cluster-gateway-ca" }}
+          secretName: {{ .Values.controllerManager.clusterGateway.tls.caSecret }}
+      {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -61,7 +61,7 @@ data:
         {{- toYaml .Values.openchoreoApi.config.mcp.toolsets | nindent 8 }}
 
     cluster_gateway:
-      enabled: true
+      enabled: {{ if hasKey .Values.openchoreoApi.clusterGateway "enabled" }}{{ .Values.openchoreoApi.clusterGateway.enabled }}{{ else }}true{{ end }}
       url: {{ .Values.openchoreoApi.clusterGateway.url | quote }}
       tls:
         ca_cert_path: {{ .Values.openchoreoApi.clusterGateway.tls.caPath | quote }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -65,9 +65,11 @@ spec:
         - name: config
           mountPath: /etc/openchoreo
           readOnly: true
+        {{- if .Values.clusterGateway.tls.enabled }}
         - name: cluster-gateway-ca
           mountPath: /etc/cluster-gateway
           readOnly: true
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health
@@ -92,7 +94,9 @@ spec:
       - name: config
         configMap:
           name: {{ include "openchoreo-control-plane.openchoreoApi.name" . }}-config
+      {{- if .Values.clusterGateway.tls.enabled }}
       - name: cluster-gateway-ca
         secret:
-          secretName: {{ .Values.openchoreoApi.clusterGateway.tls.caSecret | default "cluster-gateway-ca" }}
+          secretName: {{ .Values.openchoreoApi.clusterGateway.tls.caSecret }}
+      {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1620,6 +1620,12 @@
                   "description": "Name of the secret containing the CA certificate",
                   "title": "caSecret",
                   "type": "string"
+                },
+                "insecure": {
+                  "default": false,
+                  "description": "Skip TLS verification of the cluster gateway. For development only.",
+                  "title": "insecure",
+                  "type": "boolean"
                 }
               },
               "required": [],
@@ -2763,6 +2769,12 @@
           "additionalProperties": false,
           "description": "Cluster gateway connection settings for agent-based plane communication",
           "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable cluster gateway client integration",
+              "title": "enabled",
+              "type": "boolean"
+            },
             "tls": {
               "additionalProperties": false,
               "description": "TLS settings for the cluster gateway connection",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -704,6 +704,12 @@ controllerManager:
       # default: cluster-gateway-ca
       # @schema
       caSecret: cluster-gateway-ca
+      # @schema
+      # type: boolean
+      # description: Skip TLS verification of the cluster gateway. For development only.
+      # default: false
+      # @schema
+      insecure: false
 
 # @schema
 # type: string
@@ -841,6 +847,12 @@ openchoreoApi:
   # description: Cluster gateway connection settings for agent-based plane communication
   # @schema
   clusterGateway:
+    # @schema
+    # type: boolean
+    # description: Enable cluster gateway client integration
+    # default: true
+    # @schema
+    enabled: true
     # @schema
     # type: string
     # description: Cluster gateway service URL the API server connects to

--- a/internal/clients/gateway/client.go
+++ b/internal/clients/gateway/client.go
@@ -202,10 +202,7 @@ func buildTLSConfig(config *TLSConfig) (*tls.Config, error) {
 	if config.InsecureSkipVerify {
 		// #nosec G402 -- InsecureSkipVerify is configurable and should only be used in development
 		tlsConfig.InsecureSkipVerify = true
-		return tlsConfig, nil
-	}
-
-	if config.CAFile != "" || len(config.CAData) > 0 {
+	} else if config.CAFile != "" || len(config.CAData) > 0 {
 		caCertPool := x509.NewCertPool()
 
 		var caData []byte

--- a/internal/clients/gateway/client_test.go
+++ b/internal/clients/gateway/client_test.go
@@ -776,6 +776,24 @@ func TestBuildTLSConfig(t *testing.T) {
 		assert.True(t, cfg.InsecureSkipVerify)
 	})
 
+	t.Run("InsecureSkipVerify=true still loads client cert for mTLS", func(t *testing.T) {
+		certPEM, keyPEM := mustGenerateKeyPairPEM(t)
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "client.crt")
+		keyFile := filepath.Join(dir, "client.key")
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := buildTLSConfig(&TLSConfig{
+			InsecureSkipVerify: true,
+			ClientCertFile:     certFile,
+			ClientKeyFile:      keyFile,
+		})
+		require.NoError(t, err)
+		assert.True(t, cfg.InsecureSkipVerify)
+		assert.Len(t, cfg.Certificates, 1)
+	})
+
 	t.Run("ServerName is propagated", func(t *testing.T) {
 		cfg, err := buildTLSConfig(&TLSConfig{ServerName: "gateway.example"})
 		require.NoError(t, err)

--- a/internal/clients/kubernetes/proxy_client.go
+++ b/internal/clients/kubernetes/proxy_client.go
@@ -783,11 +783,8 @@ func buildProxyTLSConfig(tlsConfig *ProxyTLSConfig) (*tls.Config, error) {
 	if tlsConfig.Insecure {
 		// #nosec G402 -- Insecure mode is gated on explicit caller opt-in for development.
 		cfg.InsecureSkipVerify = true
-		return cfg, nil
-	}
-
-	// Load CA certificate for server verification
-	if tlsConfig.CACertPath != "" {
+	} else if tlsConfig.CACertPath != "" {
+		// Load CA certificate for server verification.
 		caCert, err := os.ReadFile(tlsConfig.CACertPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
@@ -801,7 +798,10 @@ func buildProxyTLSConfig(tlsConfig *ProxyTLSConfig) (*tls.Config, error) {
 	}
 
 	// Load client certificate and key for mTLS authentication
-	if tlsConfig.ClientCertPath != "" && tlsConfig.ClientKeyPath != "" {
+	if tlsConfig.ClientCertPath != "" || tlsConfig.ClientKeyPath != "" {
+		if tlsConfig.ClientCertPath == "" || tlsConfig.ClientKeyPath == "" {
+			return nil, fmt.Errorf("both ClientCertPath and ClientKeyPath must be set for mTLS")
+		}
 		clientCert, err := tls.LoadX509KeyPair(tlsConfig.ClientCertPath, tlsConfig.ClientKeyPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load client certificate and key: %w", err)

--- a/internal/clients/kubernetes/proxy_client_test.go
+++ b/internal/clients/kubernetes/proxy_client_test.go
@@ -272,6 +272,36 @@ func TestBuildProxyTLSConfig(t *testing.T) {
 		assert.Nil(t, cfg.RootCAs)
 	})
 
+	t.Run("Insecure=true still loads client cert for mTLS", func(t *testing.T) {
+		certPEM, keyPEM := mustCreateSelfSignedCertAndKeyPEM(t)
+		dir := t.TempDir()
+		certFile := dir + "/client.crt"
+		keyFile := dir + "/client.key"
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{
+			Insecure:       true,
+			ClientCertPath: certFile,
+			ClientKeyPath:  keyFile,
+		})
+		require.NoError(t, err)
+		assert.True(t, cfg.InsecureSkipVerify)
+		assert.Len(t, cfg.Certificates, 1)
+	})
+
+	t.Run("only ClientCertPath set returns asymmetric-config error", func(t *testing.T) {
+		_, err := buildProxyTLSConfig(&ProxyTLSConfig{ClientCertPath: "/tmp/client.crt"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both ClientCertPath and ClientKeyPath must be set")
+	})
+
+	t.Run("only ClientKeyPath set returns asymmetric-config error", func(t *testing.T) {
+		_, err := buildProxyTLSConfig(&ProxyTLSConfig{ClientKeyPath: "/tmp/client.key"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both ClientCertPath and ClientKeyPath must be set")
+	})
+
 	t.Run("invalid CA path returns error", func(t *testing.T) {
 		_, err := buildProxyTLSConfig(&ProxyTLSConfig{CACertPath: "/path/does/not/exist/ca.crt"})
 		require.Error(t, err)
@@ -305,6 +335,11 @@ func TestBuildProxyTLSConfig(t *testing.T) {
 }
 
 func mustCreateSelfSignedCertPEM(t *testing.T) []byte {
+	certPEM, _ := mustCreateSelfSignedCertAndKeyPEM(t)
+	return certPEM
+}
+
+func mustCreateSelfSignedCertAndKeyPEM(t *testing.T) ([]byte, []byte) {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -323,7 +358,9 @@ func mustCreateSelfSignedCertPEM(t *testing.T) []byte {
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
 	require.NoError(t, err)
 
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
 }
 
 func TestGetGVKForList(t *testing.T) {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
- When cluster-gateway TLS is disabled in Helm, `openchoreo-api` and `controller-manager` no longer mount the `cluster-gateway-ca` secret. Before this, the pods could fail to start because they tried to mount a secret that was not created.
- `controller-manager` now has the same “insecure TLS” option that `openchoreo-api` already had. The chart can now set `controllerManager.clusterGateway.tls.insecure=true`,  which adds --cluster-gateway-insecure to the controller-manager args.
- `openchoreo-api` cluster-gateway integration can now be toggled from Helm with `openchoreoApi.clusterGateway.enabled`. Before, the generated API config hard-coded `cluster_gateway.enabled:true`.
- The Go TLS client setup now supports mTLS correctly even when server certificate verification is intentionally skipped for local/self-signed setups. Previously, enabling insecure TLS could skip loading the client certificate/key, which broke mTLS scenarios.
- The Kubernetes proxy TLS setup now returns a clear error if only a client cert or only a client key is configured. Before, that misconfiguration could fail later in a less obvious way.
- The controller-manager flag help for `--cluster-gateway-ca-cert` now reflects the actual behavior: if no CA cert is provided, system root CAs are used; self-signed certs need `--cluster-gateway-insecure`.
- The API server no longer logs “gateway client initialized” when cluster-gateway support is disabled and no gateway client was created.

## Related
This changes are related to the coderabbit comments on: https://github.com/openchoreo/openchoreo/pull/3458

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)