### PR TITLE
feat(helm): add shared features.secretManagement flag to control plane

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -117,6 +117,8 @@ spec:
           value: {{ .Values.security.authz.enabled | quote }}
         - name: OPENCHOREO_FEATURES_AUTH_REDIRECT_FLOW_ENABLED
           value: {{ .Values.backstage.features.auth.redirectFlow.enabled | quote }}
+        - name: OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED
+          value: {{ .Values.features.secretManagement.enabled | quote }}
         # Catalog sync — periodic full sync acts as a safety net behind
         # the event-forwarder's real-time event-driven path. When the
         # event-forwarder is disabled, this becomes the sole sync

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -60,6 +60,9 @@ data:
       toolsets:
         {{- toYaml .Values.openchoreoApi.config.mcp.toolsets | nindent 8 }}
 
+    secret_management:
+      enabled: {{ .Values.features.secretManagement.enabled }}
+
     cluster_gateway:
       enabled: {{ if hasKey .Values.openchoreoApi.clusterGateway "enabled" }}{{ .Values.openchoreoApi.clusterGateway.enabled }}{{ else }}true{{ end }}
       url: {{ .Values.openchoreoApi.clusterGateway.url | quote }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2482,6 +2482,30 @@
       "title": "eventForwarder",
       "type": "object"
     },
+    "features": {
+      "additionalProperties": false,
+      "description": "Feature flags shared across the control plane (API server and Backstage).",
+      "properties": {
+        "secretManagement": {
+          "additionalProperties": false,
+          "description": "Secret management feature. Controls the Secret management API on the API server and the corresponding UI in Backstage.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable the Secret management API and Backstage UI for managing data-plane secrets.",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "secretManagement",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "features",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "openchoreo",
       "description": "Override the full name of the chart release",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -118,6 +118,23 @@ security:
 
 # @schema
 # type: object
+# description: Feature flags shared across the control plane (API server and Backstage).
+# @schema
+features:
+  # @schema
+  # type: object
+  # description: Secret management feature. Controls the Secret management API on the API server and the corresponding UI in Backstage.
+  # @schema
+  secretManagement:
+    # @schema
+    # type: boolean
+    # description: Enable the Secret management API and Backstage UI for managing data-plane secrets.
+    # default: false
+    # @schema
+    enabled: false
+
+# @schema
+# type: object
 # description: Controller Manager configuration - the main controller for OpenChoreo CRDs
 # @schema
 controllerManager:

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -115,6 +115,10 @@ backstage:
     hostnames:
     - openchoreo.localhost
 
+features:
+  secretManagement:
+    enabled: true
+
 security:
   oidc:
     issuer: "http://thunder.openchoreo.localhost:8080"


### PR DESCRIPTION
## Purpose

The Secret management feature spans two pods in the control-plane chart (openchoreo-api and Backstage). Each pod was previously toggled independently, which lets an operator flip the API server off while Backstage continues to render Secret-management UI that 501s on every request. This PR introduces one shared chart-level switch so both consumers pick up the same value.

## Approach

- Add a top-level `features.secretManagement.enabled` (default `false`) in `values.yaml`.
- Wire it into the openchoreo-api ConfigMap as `secret_management.enabled` so the API server's existing feature-flag short-circuit picks it up.
- Wire it into the Backstage Deployment as `OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED`, matching the existing `OPENCHOREO_FEATURES_*` env-var convention. Backstage's `app-config.yaml` will read `${OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED}` (change tracked in `backstage-plugins`).
- Regenerate `values.schema.json`.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

The corresponding `app-config.yaml` change in `openchoreo/backstage-plugins` adds `enabled: \${OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED}` under `openchoreo.features.secretManagement`. Without that, the env var is set but the plugin won't read it; without this chart change, the env var is missing. Land them together.