### PR TITLE
feat: update validation logic in Observer to accept budget type metric alert rules

### DIFF
--- a/internal/observer/api/handlers/validations.go
+++ b/internal/observer/api/handlers/validations.go
@@ -258,8 +258,8 @@ func validateAlertRuleRequest(req gen.AlertRuleRequest) error {
 			return fmt.Errorf("source.metric is required for metric-based alert rules")
 		}
 		metric := string(*req.Source.Metric)
-		if metric != "cpu_usage" && metric != "memory_usage" {
-			return fmt.Errorf("source.metric must be 'cpu_usage' or 'memory_usage' for metric-based alert rules")
+		if metric != "cpu_usage" && metric != "memory_usage" && metric != "budget" {
+			return fmt.Errorf("source.metric must be 'cpu_usage', 'memory_usage' or 'budget' for metric-based alert rules")
 		}
 	}
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Update the request validation logic in Observer to accept budget alerts

## Approach
Added `budget` as a valid metric type to the condition that checks for accepted metric types

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3374

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
