### PR TITLE
feat: add MCP tools for authz role + binding CRUD and evaluation

### DIFF
--- a/internal/openchoreo-api/mcphandlers/authz.go
+++ b/internal/openchoreo-api/mcphandlers/authz.go
@@ -1,0 +1,483 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+// ---------------------------------------------------------------------------
+// AuthzRole (namespace-scoped)
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListAuthzRoles(ctx context.Context, namespaceName string, opts tools.ListOpts) (any, error) {
+	result, err := h.services.AuthzService.ListNamespaceRoles(ctx, namespaceName, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList("authz_roles", result.Items, result.NextCursor, authzRoleSummary), nil
+}
+
+func (h *MCPHandler) GetAuthzRole(ctx context.Context, namespaceName, roleName string) (any, error) {
+	role, err := h.services.AuthzService.GetNamespaceRole(ctx, namespaceName, roleName)
+	if err != nil {
+		return nil, err
+	}
+	return authzRoleDetail(role), nil
+}
+
+func (h *MCPHandler) CreateAuthzRole(
+	ctx context.Context, namespaceName string, req *gen.CreateNamespaceRoleJSONRequestBody,
+) (any, error) {
+	role, err := authzRoleFromRequest(req, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+	created, err := h.services.AuthzService.CreateNamespaceRole(ctx, namespaceName, role)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateAuthzRole(
+	ctx context.Context, namespaceName string, req *gen.UpdateNamespaceRoleJSONRequestBody,
+) (any, error) {
+	role, err := authzRoleFromRequest(req, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := h.services.AuthzService.UpdateNamespaceRole(ctx, namespaceName, role)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteAuthzRole(ctx context.Context, namespaceName, roleName string) (any, error) {
+	if err := h.services.AuthzService.DeleteNamespaceRole(ctx, namespaceName, roleName); err != nil {
+		return nil, err
+	}
+	return map[string]any{"name": roleName, "namespace": namespaceName, "action": "deleted"}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ClusterAuthzRole (cluster-scoped)
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListClusterAuthzRoles(ctx context.Context, opts tools.ListOpts) (any, error) {
+	result, err := h.services.AuthzService.ListClusterRoles(ctx, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList("cluster_authz_roles", result.Items, result.NextCursor, clusterAuthzRoleSummary), nil
+}
+
+func (h *MCPHandler) GetClusterAuthzRole(ctx context.Context, roleName string) (any, error) {
+	role, err := h.services.AuthzService.GetClusterRole(ctx, roleName)
+	if err != nil {
+		return nil, err
+	}
+	return clusterAuthzRoleDetail(role), nil
+}
+
+func (h *MCPHandler) CreateClusterAuthzRole(
+	ctx context.Context, req *gen.CreateClusterRoleJSONRequestBody,
+) (any, error) {
+	role, err := clusterAuthzRoleFromRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	created, err := h.services.AuthzService.CreateClusterRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateClusterAuthzRole(
+	ctx context.Context, req *gen.UpdateClusterRoleJSONRequestBody,
+) (any, error) {
+	role, err := clusterAuthzRoleFromRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := h.services.AuthzService.UpdateClusterRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteClusterAuthzRole(ctx context.Context, roleName string) (any, error) {
+	if err := h.services.AuthzService.DeleteClusterRole(ctx, roleName); err != nil {
+		return nil, err
+	}
+	return map[string]any{"name": roleName, "action": "deleted"}, nil
+}
+
+// ---------------------------------------------------------------------------
+// AuthzRoleBinding (namespace-scoped)
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListAuthzRoleBindings(ctx context.Context, namespaceName string, opts tools.ListOpts) (any, error) {
+	result, err := h.services.AuthzService.ListNamespaceRoleBindings(ctx, namespaceName, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList(
+		"authz_role_bindings", result.Items, result.NextCursor, authzRoleBindingSummary,
+	), nil
+}
+
+func (h *MCPHandler) GetAuthzRoleBinding(ctx context.Context, namespaceName, bindingName string) (any, error) {
+	binding, err := h.services.AuthzService.GetNamespaceRoleBinding(ctx, namespaceName, bindingName)
+	if err != nil {
+		return nil, err
+	}
+	return authzRoleBindingDetail(binding), nil
+}
+
+func (h *MCPHandler) CreateAuthzRoleBinding(
+	ctx context.Context, namespaceName string, req *gen.CreateNamespaceRoleBindingJSONRequestBody,
+) (any, error) {
+	binding, err := authzRoleBindingFromRequest(req, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+	created, err := h.services.AuthzService.CreateNamespaceRoleBinding(ctx, namespaceName, binding)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateAuthzRoleBinding(
+	ctx context.Context, namespaceName string, req *gen.UpdateNamespaceRoleBindingJSONRequestBody,
+) (any, error) {
+	binding, err := authzRoleBindingFromRequest(req, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := h.services.AuthzService.UpdateNamespaceRoleBinding(ctx, namespaceName, binding)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteAuthzRoleBinding(ctx context.Context, namespaceName, bindingName string) (any, error) {
+	if err := h.services.AuthzService.DeleteNamespaceRoleBinding(ctx, namespaceName, bindingName); err != nil {
+		return nil, err
+	}
+	return map[string]any{"name": bindingName, "namespace": namespaceName, "action": "deleted"}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ClusterAuthzRoleBinding (cluster-scoped)
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListClusterAuthzRoleBindings(ctx context.Context, opts tools.ListOpts) (any, error) {
+	result, err := h.services.AuthzService.ListClusterRoleBindings(ctx, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList(
+		"cluster_authz_role_bindings", result.Items, result.NextCursor, clusterAuthzRoleBindingSummary,
+	), nil
+}
+
+func (h *MCPHandler) GetClusterAuthzRoleBinding(ctx context.Context, bindingName string) (any, error) {
+	binding, err := h.services.AuthzService.GetClusterRoleBinding(ctx, bindingName)
+	if err != nil {
+		return nil, err
+	}
+	return clusterAuthzRoleBindingDetail(binding), nil
+}
+
+func (h *MCPHandler) CreateClusterAuthzRoleBinding(
+	ctx context.Context, req *gen.CreateClusterRoleBindingJSONRequestBody,
+) (any, error) {
+	binding, err := clusterAuthzRoleBindingFromRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	created, err := h.services.AuthzService.CreateClusterRoleBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateClusterAuthzRoleBinding(
+	ctx context.Context, req *gen.UpdateClusterRoleBindingJSONRequestBody,
+) (any, error) {
+	binding, err := clusterAuthzRoleBindingFromRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := h.services.AuthzService.UpdateClusterRoleBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteClusterAuthzRoleBinding(ctx context.Context, bindingName string) (any, error) {
+	if err := h.services.AuthzService.DeleteClusterRoleBinding(ctx, bindingName); err != nil {
+		return nil, err
+	}
+	return map[string]any{"name": bindingName, "action": "deleted"}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) EvaluateAuthz(ctx context.Context, requests []gen.EvaluateRequest) (any, error) {
+	callerSubject, _ := auth.GetSubjectContextFromContext(ctx)
+
+	internal := make([]authzcore.EvaluateRequest, len(requests))
+	for i, r := range requests {
+		var authzCtx authzcore.Context
+		if r.Context != nil {
+			converted, err := convertSpec[gen.AuthzContext, authzcore.Context](*r.Context)
+			if err != nil {
+				return nil, err
+			}
+			authzCtx = converted
+		}
+		subject := resolveEvaluateSubject(r.SubjectContext, callerSubject)
+		internal[i] = authzcore.EvaluateRequest{
+			Action: r.Action,
+			Resource: authzcore.Resource{
+				Type: r.Resource.Type,
+				ID:   derefString(r.Resource.Id),
+				Hierarchy: authzcore.ResourceHierarchy{
+					Namespace: derefString(r.Resource.Hierarchy.Namespace),
+					Project:   derefString(r.Resource.Hierarchy.Project),
+					Component: derefString(r.Resource.Hierarchy.Component),
+					Resource:  derefString(r.Resource.Hierarchy.Resource),
+				},
+			},
+			SubjectContext: subject,
+			Context:        authzCtx,
+		}
+	}
+
+	decisions, err := h.services.AuthzService.Evaluate(ctx, internal)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, len(decisions))
+	for i, d := range decisions {
+		entry := map[string]any{"decision": d.Decision}
+		if d.Context != nil && d.Context.Reason != "" {
+			entry["reason"] = d.Context.Reason
+		}
+		out[i] = entry
+	}
+	return map[string]any{"decisions": out}, nil
+}
+
+func (h *MCPHandler) ListAuthzActions(ctx context.Context) (any, error) {
+	actions, err := h.services.AuthzService.ListActions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, len(actions))
+	for i, a := range actions {
+		entry := map[string]any{
+			"name":         a.Name,
+			"lowest_scope": string(a.LowestScope),
+		}
+		if len(a.Conditions) > 0 {
+			conds := make([]map[string]any, len(a.Conditions))
+			for j, c := range a.Conditions {
+				conds[j] = map[string]any{"key": c.Key, "description": c.Description}
+			}
+			entry["conditions"] = conds
+		}
+		out[i] = entry
+	}
+	return map[string]any{"actions": out}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — request → CRD
+// ---------------------------------------------------------------------------
+
+// metadataFromRequest builds a metav1.ObjectMeta from a gen.ObjectMeta request
+// payload, applying the standard cleanAnnotations pass. Shared by the four
+// authz CRD builders; other PE handlers inline this because each touches only
+// one CRD shape.
+func metadataFromRequest(meta gen.ObjectMeta, namespace string) metav1.ObjectMeta {
+	annotations := map[string]string{}
+	if meta.Annotations != nil {
+		maps.Copy(annotations, *meta.Annotations)
+	}
+	cleanAnnotations(annotations)
+	out := metav1.ObjectMeta{Name: meta.Name}
+	if namespace != "" {
+		out.Namespace = namespace
+	}
+	if len(annotations) > 0 {
+		out.Annotations = annotations
+	}
+	return out
+}
+
+func authzRoleFromRequest(req *gen.AuthzRole, namespace string) (*openchoreov1alpha1.AuthzRole, error) {
+	role := &openchoreov1alpha1.AuthzRole{ObjectMeta: metadataFromRequest(req.Metadata, namespace)}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.AuthzRoleSpec, openchoreov1alpha1.AuthzRoleSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		role.Spec = spec
+	}
+	return role, nil
+}
+
+func clusterAuthzRoleFromRequest(req *gen.ClusterAuthzRole) (*openchoreov1alpha1.ClusterAuthzRole, error) {
+	role := &openchoreov1alpha1.ClusterAuthzRole{ObjectMeta: metadataFromRequest(req.Metadata, "")}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.ClusterAuthzRoleSpec, openchoreov1alpha1.ClusterAuthzRoleSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		role.Spec = spec
+	}
+	return role, nil
+}
+
+func authzRoleBindingFromRequest(
+	req *gen.AuthzRoleBinding, namespace string,
+) (*openchoreov1alpha1.AuthzRoleBinding, error) {
+	binding := &openchoreov1alpha1.AuthzRoleBinding{ObjectMeta: metadataFromRequest(req.Metadata, namespace)}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.AuthzRoleBindingSpec, openchoreov1alpha1.AuthzRoleBindingSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		binding.Spec = spec
+	}
+	return binding, nil
+}
+
+func clusterAuthzRoleBindingFromRequest(
+	req *gen.ClusterAuthzRoleBinding,
+) (*openchoreov1alpha1.ClusterAuthzRoleBinding, error) {
+	binding := &openchoreov1alpha1.ClusterAuthzRoleBinding{ObjectMeta: metadataFromRequest(req.Metadata, "")}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.ClusterAuthzRoleBindingSpec, openchoreov1alpha1.ClusterAuthzRoleBindingSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		binding.Spec = spec
+	}
+	return binding, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — CRD → response shape
+// ---------------------------------------------------------------------------
+
+func authzRoleSummary(r openchoreov1alpha1.AuthzRole) map[string]any {
+	m := extractCommonMeta(&r)
+	m["actions"] = r.Spec.Actions
+	return m
+}
+
+func authzRoleDetail(r *openchoreov1alpha1.AuthzRole) map[string]any {
+	m := extractCommonMeta(r)
+	if spec := specToMap(r.Spec); len(spec) > 0 {
+		m["spec"] = spec
+	}
+	return m
+}
+
+func clusterAuthzRoleSummary(r openchoreov1alpha1.ClusterAuthzRole) map[string]any {
+	m := extractCommonMeta(&r)
+	m["actions"] = r.Spec.Actions
+	return m
+}
+
+func clusterAuthzRoleDetail(r *openchoreov1alpha1.ClusterAuthzRole) map[string]any {
+	m := extractCommonMeta(r)
+	if spec := specToMap(r.Spec); len(spec) > 0 {
+		m["spec"] = spec
+	}
+	return m
+}
+
+func authzRoleBindingSummary(b openchoreov1alpha1.AuthzRoleBinding) map[string]any {
+	m := extractCommonMeta(&b)
+	m["entitlement"] = map[string]any{"claim": b.Spec.Entitlement.Claim, "value": b.Spec.Entitlement.Value}
+	m["effect"] = string(b.Spec.Effect)
+	m["roleMappingCount"] = len(b.Spec.RoleMappings)
+	return m
+}
+
+func authzRoleBindingDetail(b *openchoreov1alpha1.AuthzRoleBinding) map[string]any {
+	m := extractCommonMeta(b)
+	if spec := specToMap(b.Spec); len(spec) > 0 {
+		m["spec"] = spec
+	}
+	return m
+}
+
+func clusterAuthzRoleBindingSummary(b openchoreov1alpha1.ClusterAuthzRoleBinding) map[string]any {
+	m := extractCommonMeta(&b)
+	m["entitlement"] = map[string]any{"claim": b.Spec.Entitlement.Claim, "value": b.Spec.Entitlement.Value}
+	m["effect"] = string(b.Spec.Effect)
+	m["roleMappingCount"] = len(b.Spec.RoleMappings)
+	return m
+}
+
+func clusterAuthzRoleBindingDetail(b *openchoreov1alpha1.ClusterAuthzRoleBinding) map[string]any {
+	m := extractCommonMeta(b)
+	if spec := specToMap(b.Spec); len(spec) > 0 {
+		m["spec"] = spec
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — diagnostics
+// ---------------------------------------------------------------------------
+
+// resolveEvaluateSubject returns the subject context to evaluate against.
+// Unlike the HTTP /evaluates endpoint, which requires the client to supply a
+// subject, the MCP tool defaults to the caller when the request omits one — the
+// "can I do X?" case is overwhelmingly the common one for agents.
+func resolveEvaluateSubject(genSubject gen.SubjectContext, caller *auth.SubjectContext) *authzcore.SubjectContext {
+	if genSubject.EntitlementClaim != "" {
+		return &authzcore.SubjectContext{
+			Type:              string(genSubject.Type),
+			EntitlementClaim:  genSubject.EntitlementClaim,
+			EntitlementValues: genSubject.EntitlementValues,
+		}
+	}
+	if caller == nil {
+		return &authzcore.SubjectContext{}
+	}
+	return authzcore.GetAuthzSubjectContext(caller)
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/pkg/mcp/tools/crdschema.go
+++ b/pkg/mcp/tools/crdschema.go
@@ -14,19 +14,27 @@ import (
 
 // crdSpecSchemas caches the extracted spec schemas so YAML parsing happens only once.
 var crdSpecSchemas struct {
-	once                    sync.Once
-	componentType           map[string]any
-	clusterComponentType    map[string]any
-	trait                   map[string]any
-	clusterTrait            map[string]any
-	workflow                map[string]any
-	clusterWorkflow         map[string]any
-	componentTypeErr        error
-	clusterComponentTypeErr error
-	traitErr                error
-	clusterTraitErr         error
-	workflowErr             error
-	clusterWorkflowErr      error
+	once                       sync.Once
+	componentType              map[string]any
+	clusterComponentType       map[string]any
+	trait                      map[string]any
+	clusterTrait               map[string]any
+	workflow                   map[string]any
+	clusterWorkflow            map[string]any
+	authzRole                  map[string]any
+	clusterAuthzRole           map[string]any
+	authzRoleBinding           map[string]any
+	clusterAuthzRoleBinding    map[string]any
+	componentTypeErr           error
+	clusterComponentTypeErr    error
+	traitErr                   error
+	clusterTraitErr            error
+	workflowErr                error
+	clusterWorkflowErr         error
+	authzRoleErr               error
+	clusterAuthzRoleErr        error
+	authzRoleBindingErr        error
+	clusterAuthzRoleBindingErr error
 }
 
 // ComponentTypeCreationSchema returns the JSON schema for the ComponentType spec,
@@ -68,6 +76,30 @@ func ClusterWorkflowCreationSchema() (map[string]any, error) {
 	return crdSpecSchemas.clusterWorkflow, crdSpecSchemas.clusterWorkflowErr
 }
 
+// AuthzRoleCreationSchema returns the JSON schema for the AuthzRole spec.
+func AuthzRoleCreationSchema() (map[string]any, error) {
+	crdSpecSchemas.once.Do(parseCRDSchemas)
+	return crdSpecSchemas.authzRole, crdSpecSchemas.authzRoleErr
+}
+
+// ClusterAuthzRoleCreationSchema returns the JSON schema for the ClusterAuthzRole spec.
+func ClusterAuthzRoleCreationSchema() (map[string]any, error) {
+	crdSpecSchemas.once.Do(parseCRDSchemas)
+	return crdSpecSchemas.clusterAuthzRole, crdSpecSchemas.clusterAuthzRoleErr
+}
+
+// AuthzRoleBindingCreationSchema returns the JSON schema for the AuthzRoleBinding spec.
+func AuthzRoleBindingCreationSchema() (map[string]any, error) {
+	crdSpecSchemas.once.Do(parseCRDSchemas)
+	return crdSpecSchemas.authzRoleBinding, crdSpecSchemas.authzRoleBindingErr
+}
+
+// ClusterAuthzRoleBindingCreationSchema returns the JSON schema for the ClusterAuthzRoleBinding spec.
+func ClusterAuthzRoleBindingCreationSchema() (map[string]any, error) {
+	crdSpecSchemas.once.Do(parseCRDSchemas)
+	return crdSpecSchemas.clusterAuthzRoleBinding, crdSpecSchemas.clusterAuthzRoleBindingErr
+}
+
 func parseCRDSchemas() {
 	crdSpecSchemas.componentType, crdSpecSchemas.componentTypeErr = extractSpecSchema(
 		"bases/openchoreo.dev_componenttypes.yaml",
@@ -86,6 +118,18 @@ func parseCRDSchemas() {
 	)
 	crdSpecSchemas.clusterWorkflow, crdSpecSchemas.clusterWorkflowErr = extractSpecSchema(
 		"bases/openchoreo.dev_clusterworkflows.yaml",
+	)
+	crdSpecSchemas.authzRole, crdSpecSchemas.authzRoleErr = extractSpecSchema(
+		"bases/openchoreo.dev_authzroles.yaml",
+	)
+	crdSpecSchemas.clusterAuthzRole, crdSpecSchemas.clusterAuthzRoleErr = extractSpecSchema(
+		"bases/openchoreo.dev_clusterauthzroles.yaml",
+	)
+	crdSpecSchemas.authzRoleBinding, crdSpecSchemas.authzRoleBindingErr = extractSpecSchema(
+		"bases/openchoreo.dev_authzrolebindings.yaml",
+	)
+	crdSpecSchemas.clusterAuthzRoleBinding, crdSpecSchemas.clusterAuthzRoleBindingErr = extractSpecSchema(
+		"bases/openchoreo.dev_clusterauthzrolebindings.yaml",
 	)
 }
 

--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -697,3 +697,147 @@ func (m *MockCoreToolsetHandler) GetResourceLogs(
 	m.recordCall("GetResourceLogs", namespaceName, releaseBindingName, podName, sinceSeconds)
 	return `{"logEntries":[]}`, nil
 }
+
+// Authz role methods
+
+func (m *MockCoreToolsetHandler) ListAuthzRoles(
+	ctx context.Context, namespaceName string, opts ListOpts,
+) (any, error) {
+	m.recordCall("ListAuthzRoles", namespaceName, opts)
+	return `[{"name":"role-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetAuthzRole(
+	ctx context.Context, namespaceName, roleName string,
+) (any, error) {
+	m.recordCall("GetAuthzRole", namespaceName, roleName)
+	return `{"name":"role-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateAuthzRole(
+	ctx context.Context, namespaceName string, req *gen.CreateNamespaceRoleJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateAuthzRole", namespaceName, req)
+	return `{"name":"new-role","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateAuthzRole(
+	ctx context.Context, namespaceName string, req *gen.UpdateNamespaceRoleJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateAuthzRole", namespaceName, req)
+	return `{"name":"updated-role","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteAuthzRole(
+	ctx context.Context, namespaceName, roleName string,
+) (any, error) {
+	m.recordCall("DeleteAuthzRole", namespaceName, roleName)
+	return deletedResponse, nil
+}
+
+func (m *MockCoreToolsetHandler) ListClusterAuthzRoles(ctx context.Context, opts ListOpts) (any, error) {
+	m.recordCall("ListClusterAuthzRoles", opts)
+	return `[{"name":"cluster-role-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterAuthzRole(ctx context.Context, roleName string) (any, error) {
+	m.recordCall("GetClusterAuthzRole", roleName)
+	return `{"name":"cluster-role-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateClusterAuthzRole(
+	ctx context.Context, req *gen.CreateClusterRoleJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateClusterAuthzRole", req)
+	return `{"name":"new-cluster-role","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateClusterAuthzRole(
+	ctx context.Context, req *gen.UpdateClusterRoleJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateClusterAuthzRole", req)
+	return `{"name":"updated-cluster-role","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteClusterAuthzRole(ctx context.Context, roleName string) (any, error) {
+	m.recordCall("DeleteClusterAuthzRole", roleName)
+	return deletedResponse, nil
+}
+
+// Authz role binding methods
+
+func (m *MockCoreToolsetHandler) ListAuthzRoleBindings(
+	ctx context.Context, namespaceName string, opts ListOpts,
+) (any, error) {
+	m.recordCall("ListAuthzRoleBindings", namespaceName, opts)
+	return `[{"name":"binding-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetAuthzRoleBinding(
+	ctx context.Context, namespaceName, bindingName string,
+) (any, error) {
+	m.recordCall("GetAuthzRoleBinding", namespaceName, bindingName)
+	return `{"name":"binding-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateAuthzRoleBinding(
+	ctx context.Context, namespaceName string, req *gen.CreateNamespaceRoleBindingJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateAuthzRoleBinding", namespaceName, req)
+	return `{"name":"new-binding","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateAuthzRoleBinding(
+	ctx context.Context, namespaceName string, req *gen.UpdateNamespaceRoleBindingJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateAuthzRoleBinding", namespaceName, req)
+	return `{"name":"updated-binding","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteAuthzRoleBinding(
+	ctx context.Context, namespaceName, bindingName string,
+) (any, error) {
+	m.recordCall("DeleteAuthzRoleBinding", namespaceName, bindingName)
+	return deletedResponse, nil
+}
+
+func (m *MockCoreToolsetHandler) ListClusterAuthzRoleBindings(ctx context.Context, opts ListOpts) (any, error) {
+	m.recordCall("ListClusterAuthzRoleBindings", opts)
+	return `[{"name":"cluster-binding-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterAuthzRoleBinding(ctx context.Context, bindingName string) (any, error) {
+	m.recordCall("GetClusterAuthzRoleBinding", bindingName)
+	return `{"name":"cluster-binding-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateClusterAuthzRoleBinding(
+	ctx context.Context, req *gen.CreateClusterRoleBindingJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateClusterAuthzRoleBinding", req)
+	return `{"name":"new-cluster-binding","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateClusterAuthzRoleBinding(
+	ctx context.Context, req *gen.UpdateClusterRoleBindingJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateClusterAuthzRoleBinding", req)
+	return `{"name":"updated-cluster-binding","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteClusterAuthzRoleBinding(ctx context.Context, bindingName string) (any, error) {
+	m.recordCall("DeleteClusterAuthzRoleBinding", bindingName)
+	return deletedResponse, nil
+}
+
+// Authz diagnostics methods
+
+func (m *MockCoreToolsetHandler) EvaluateAuthz(ctx context.Context, requests []gen.EvaluateRequest) (any, error) {
+	m.recordCall("EvaluateAuthz", requests)
+	return `{"decisions":[{"decision":"allow"}]}`, nil
+}
+
+func (m *MockCoreToolsetHandler) ListAuthzActions(ctx context.Context) (any, error) {
+	m.recordCall("ListAuthzActions")
+	return `{"actions":[{"name":"component:view","lowest_scope":"component"}]}`, nil
+}

--- a/pkg/mcp/tools/pe_authz_specs_test.go
+++ b/pkg/mcp/tools/pe_authz_specs_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import "testing"
+
+const (
+	testAuthzRoleName        = "developer"
+	testAuthzRoleBindingName = "developer-binding"
+)
+
+// peAuthzSpecs returns test specs for the authz tool surface (roles, role bindings,
+// and diagnostics). All CRUD tools are scope-collapsed; diagnostics are flat.
+func peAuthzSpecs() []toolTestSpec {
+	listGet := []toolTestSpec{
+		authzListSpec("list_authz_roles", []string{"list", "authz", "role"}, "ListAuthzRoles"),
+		authzGetSpec("get_authz_role", []string{"authz", "role", "spec"}, testAuthzRoleName, "GetAuthzRole"),
+		authzListSpec(
+			"list_authz_role_bindings",
+			[]string{"list", "authz", "role", "binding"}, "ListAuthzRoleBindings",
+		),
+		authzGetSpec(
+			"get_authz_role_binding",
+			[]string{"authz", "role", "binding"}, testAuthzRoleBindingName, "GetAuthzRoleBinding",
+		),
+	}
+	writes := peAuthzWriteAndSchemaSpecs()
+	diagnostics := peAuthzDiagnosticsSpecs()
+	specs := make([]toolTestSpec, 0, len(listGet)+len(writes)+len(diagnostics))
+	specs = append(specs, listGet...)
+	specs = append(specs, writes...)
+	specs = append(specs, diagnostics...)
+	return specs
+}
+
+func authzListSpec(name string, keywords []string, method string) toolTestSpec {
+	return toolTestSpec{
+		name:                name,
+		toolset:             "pe",
+		descriptionKeywords: keywords,
+		descriptionMinLen:   10,
+		optionalParams:      []string{"scope", "namespace_name", "limit", "cursor"},
+		testArgs:            map[string]any{"namespace_name": testNamespaceName},
+		expectedMethod:      method,
+		validateCall: func(t *testing.T, args []interface{}) {
+			if args[0] != testNamespaceName {
+				t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+			}
+		},
+	}
+}
+
+func authzGetSpec(name string, keywords []string, resourceName, method string) toolTestSpec {
+	return toolTestSpec{
+		name:                name,
+		toolset:             "pe",
+		descriptionKeywords: keywords,
+		descriptionMinLen:   10,
+		requiredParams:      []string{"name"},
+		optionalParams:      []string{"scope", "namespace_name"},
+		testArgs:            map[string]any{"namespace_name": testNamespaceName, "name": resourceName},
+		expectedMethod:      method,
+		validateCall: func(t *testing.T, args []interface{}) {
+			if args[0] != testNamespaceName || args[1] != resourceName {
+				t.Errorf("Expected (%s, %s), got (%v, %v)", testNamespaceName, resourceName, args[0], args[1])
+			}
+		},
+	}
+}
+
+func peAuthzWriteAndSchemaSpecs() []toolTestSpec {
+	roleSpec := map[string]any{"actions": []any{"component:view"}}
+	bindingSpec := map[string]any{
+		"entitlement": map[string]any{"claim": "groups", "value": "dev-team"},
+		"roleMappings": []any{
+			map[string]any{"roleRef": map[string]any{"kind": "AuthzRole", "name": testAuthzRoleName}},
+		},
+	}
+	return []toolTestSpec{
+		// Creation schemas (static, no handler call)
+		{
+			name:                "get_authz_role_creation_schema",
+			toolset:             "pe",
+			descriptionKeywords: []string{"schema", "AuthzRole"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope"},
+			testArgs:            map[string]any{},
+		},
+		{
+			name:                "get_authz_role_binding_creation_schema",
+			toolset:             "pe",
+			descriptionKeywords: []string{"schema", "binding"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope"},
+			testArgs:            map[string]any{},
+		},
+		// Roles — writes
+		authzWriteSpec(
+			"create_authz_role", []string{"create", "authz", "role"},
+			testAuthzRoleName, roleSpec, "CreateAuthzRole"),
+		authzWriteSpec(
+			"update_authz_role", []string{"update", "authz", "role"},
+			testAuthzRoleName, roleSpec, "UpdateAuthzRole"),
+		authzDeleteSpec("delete_authz_role", []string{"delete", "authz", "role"},
+			testAuthzRoleName, "DeleteAuthzRole"),
+		// Bindings — writes
+		authzWriteSpec(
+			"create_authz_role_binding", []string{"create", "authz", "role", "binding"},
+			testAuthzRoleBindingName, bindingSpec, "CreateAuthzRoleBinding"),
+		authzWriteSpec(
+			"update_authz_role_binding", []string{"update", "authz", "role", "binding"},
+			testAuthzRoleBindingName, bindingSpec, "UpdateAuthzRoleBinding"),
+		authzDeleteSpec("delete_authz_role_binding", []string{"delete", "authz", "role", "binding"},
+			testAuthzRoleBindingName, "DeleteAuthzRoleBinding"),
+	}
+}
+
+func authzWriteSpec(
+	name string, keywords []string, resourceName string, spec map[string]any, method string,
+) toolTestSpec {
+	return toolTestSpec{
+		name:                name,
+		toolset:             "pe",
+		descriptionKeywords: keywords,
+		descriptionMinLen:   10,
+		requiredParams:      []string{"name", "spec"},
+		optionalParams:      []string{"scope", "namespace_name", "display_name", "description"},
+		testArgs: map[string]any{
+			"namespace_name": testNamespaceName,
+			"name":           resourceName,
+			"spec":           spec,
+		},
+		expectedMethod: method,
+		validateCall: func(t *testing.T, args []interface{}) {
+			if args[0] != testNamespaceName {
+				t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+			}
+		},
+	}
+}
+
+func authzDeleteSpec(name string, keywords []string, resourceName, method string) toolTestSpec {
+	return toolTestSpec{
+		name:                name,
+		toolset:             "pe",
+		descriptionKeywords: keywords,
+		descriptionMinLen:   10,
+		optionalParams:      []string{"scope", "namespace_name"},
+		requiredParams:      []string{"name"},
+		testArgs: map[string]any{
+			"namespace_name": testNamespaceName,
+			"name":           resourceName,
+		},
+		expectedMethod: method,
+		validateCall: func(t *testing.T, args []interface{}) {
+			if args[0] != testNamespaceName || args[1] != resourceName {
+				t.Errorf("Expected (%s, %s), got (%v, %v)", testNamespaceName, resourceName, args[0], args[1])
+			}
+		},
+	}
+}
+
+func peAuthzDiagnosticsSpecs() []toolTestSpec {
+	return []toolTestSpec{
+		{
+			name:                "evaluate_authz",
+			toolset:             "pe",
+			descriptionKeywords: []string{"evaluat", "authoriz"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"requests"},
+			testArgs: map[string]any{
+				"requests": []any{
+					map[string]any{
+						"action":   "component:view",
+						"resource": map[string]any{"type": "component"},
+						"subject_context": map[string]any{
+							"type":               "user",
+							"entitlement_claim":  "groups",
+							"entitlement_values": []any{"dev-team"},
+						},
+					},
+				},
+			},
+			expectedMethod: "EvaluateAuthz",
+			validateCall:   func(t *testing.T, args []interface{}) {},
+		},
+		{
+			name:                "list_authz_actions",
+			toolset:             "pe",
+			descriptionKeywords: []string{"list", "action"},
+			descriptionMinLen:   10,
+			testArgs:            map[string]any{},
+			expectedMethod:      "ListAuthzActions",
+			validateCall:        func(t *testing.T, args []interface{}) {},
+		},
+	}
+}

--- a/pkg/mcp/tools/pe_specs_test.go
+++ b/pkg/mcp/tools/pe_specs_test.go
@@ -22,6 +22,7 @@ func peToolSpecs() []toolTestSpec {
 	specs = append(specs, peClusterPlatformStandardsSpecs()...)
 	specs = append(specs, pePlatformStandardsSpecs()...)
 	specs = append(specs, peDiagnosticsSpecs()...)
+	specs = append(specs, peAuthzSpecs()...)
 	return specs
 }
 

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -230,10 +230,28 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 		t.RegisterUpdateClusterWorkflow,
 		t.RegisterDeleteClusterWorkflow,
 
+		// Authz roles (scope-collapsed)
+		t.RegisterListAuthzRoles,
+		t.RegisterGetAuthzRole,
+		t.RegisterGetAuthzRoleCreationSchema,
+		t.RegisterCreateAuthzRole,
+		t.RegisterUpdateAuthzRole,
+		t.RegisterDeleteAuthzRole,
+
+		// Authz role bindings (scope-collapsed)
+		t.RegisterListAuthzRoleBindings,
+		t.RegisterGetAuthzRoleBinding,
+		t.RegisterGetAuthzRoleBindingCreationSchema,
+		t.RegisterCreateAuthzRoleBinding,
+		t.RegisterUpdateAuthzRoleBinding,
+		t.RegisterDeleteAuthzRoleBinding,
+
 		// Diagnostics
 		t.RegisterGetResourceTree,
 		t.RegisterGetResourceEvents,
 		t.RegisterGetResourceLogs,
+		t.RegisterEvaluateAuthz,
+		t.RegisterListAuthzActions,
 	}
 }
 

--- a/pkg/mcp/tools/scoped_authz.go
+++ b/pkg/mcp/tools/scoped_authz.go
@@ -1,0 +1,322 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ---------------------------------------------------------------------------
+// Authz CRDs — scope-collapsed canonical tools.
+//
+// Roles and role bindings each have one scope-collapsed family (5 CRUD + 1
+// creation_schema). Plus two flat diagnostic tools (evaluate_authz, list_authz_actions).
+// No deprecated cluster-prefixed aliases — these tools are net-new and ship
+// scope-collapsed from day one.
+// ---------------------------------------------------------------------------
+
+const (
+	scopedAuthzRoleNoun        = "authz role"
+	scopedAuthzRoleBindingNoun = "authz role binding"
+)
+
+// ---------------------------------------------------------------------------
+// AuthzRole / ClusterAuthzRole
+// ---------------------------------------------------------------------------
+
+func (t *Toolsets) RegisterListAuthzRoles(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedListTool(s, perms, "list_authz_roles", scopedAuthzRoleNoun,
+		"List authz roles. With scope=\"namespace\" (default) lists a namespace's AuthzRoles "+
+			"(requires namespace_name); with scope=\"cluster\" lists platform-wide ClusterAuthzRoles. "+
+			"Roles define what actions a subject is permitted to perform. Supports pagination via limit and cursor.",
+		authzcore.ActionViewAuthzRole, authzcore.ActionViewClusterAuthzRole,
+		scopedListHandlers{
+			namespace: t.PEToolset.ListAuthzRoles,
+			cluster:   t.PEToolset.ListClusterAuthzRoles,
+		})
+}
+
+func (t *Toolsets) RegisterGetAuthzRole(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "get_authz_role", scopedAuthzRoleNoun,
+		"Get the full definition of an authz role including its complete spec (actions, description). "+
+			"Use scope=\"cluster\" for a platform-wide ClusterAuthzRole. Call before update_authz_role.",
+		authzcore.ActionViewAuthzRole, authzcore.ActionViewClusterAuthzRole,
+		"name", "Authz role name. Use list_authz_roles to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.GetAuthzRole,
+			cluster:   t.PEToolset.GetClusterAuthzRole,
+		})
+}
+
+func (t *Toolsets) RegisterGetAuthzRoleCreationSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSchemaTool(s, perms, "get_authz_role_creation_schema", scopedAuthzRoleNoun,
+		"Get the JSON schema for the AuthzRole spec. Use scope=\"cluster\" for the ClusterAuthzRole "+
+			"variant. Use list_authz_actions to discover valid values for spec.actions[].",
+		authzcore.ActionViewAuthzRole, authzcore.ActionViewClusterAuthzRole,
+		scopedSchemaProviders{
+			namespace: func() (any, error) { return AuthzRoleCreationSchema() },
+			cluster:   func() (any, error) { return ClusterAuthzRoleCreationSchema() },
+		})
+}
+
+//nolint:dupl // create/update register helpers share a near-identical shape per resource
+func (t *Toolsets) RegisterCreateAuthzRole(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedWriteTool(s, perms, "create_authz_role", scopedAuthzRoleNoun,
+		"Create an authz role. With scope=\"namespace\" (default) creates an AuthzRole in namespace_name; "+
+			"with scope=\"cluster\" creates a platform-wide ClusterAuthzRole. spec.actions[] lists "+
+			"permitted actions (e.g. \"component:create\", \"component:*\", \"*\"). Use list_authz_actions "+
+			"to discover valid action names.",
+		authzcore.ActionCreateAuthzRole, authzcore.ActionCreateClusterAuthzRole,
+		"DNS-compatible identifier (lowercase, alphanumeric, hyphens only, max 63 chars)",
+		"AuthzRoleSpec — must include actions[] (min 1). Optional: description.",
+		scopedWriteHandlers{
+			namespace: func(ctx context.Context, ns, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.AuthzRoleSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.CreateAuthzRole(ctx, ns, &gen.CreateNamespaceRoleJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+			cluster: func(ctx context.Context, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ClusterAuthzRoleSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.CreateClusterAuthzRole(ctx, &gen.CreateClusterRoleJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+		})
+}
+
+//nolint:dupl // create/update register helpers share a near-identical shape per resource
+func (t *Toolsets) RegisterUpdateAuthzRole(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedWriteTool(s, perms, "update_authz_role", scopedAuthzRoleNoun,
+		"Update an existing authz role (full-spec replacement). Use scope=\"cluster\" for a platform-wide "+
+			"ClusterAuthzRole. Use get_authz_role to retrieve the current spec first.",
+		authzcore.ActionUpdateAuthzRole, authzcore.ActionUpdateClusterAuthzRole,
+		"Name of the authz role to update. Use list_authz_roles to discover valid names",
+		"Full AuthzRoleSpec to replace the existing one. Use get_authz_role to retrieve the current spec first.",
+		scopedWriteHandlers{
+			namespace: func(ctx context.Context, ns, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.AuthzRoleSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.UpdateAuthzRole(ctx, ns, &gen.UpdateNamespaceRoleJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+			cluster: func(ctx context.Context, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ClusterAuthzRoleSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.UpdateClusterAuthzRole(ctx, &gen.UpdateClusterRoleJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+		})
+}
+
+func (t *Toolsets) RegisterDeleteAuthzRole(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "delete_authz_role", scopedAuthzRoleNoun,
+		"Delete an authz role. Use scope=\"cluster\" for a platform-wide ClusterAuthzRole. "+
+			"WARNING: deleting a role in use leaves any AuthzRoleBinding referencing it dangling; "+
+			"call list_authz_role_bindings first to check.",
+		authzcore.ActionDeleteAuthzRole, authzcore.ActionDeleteClusterAuthzRole,
+		"name", "Name of the authz role to delete. Use list_authz_roles to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.DeleteAuthzRole,
+			cluster:   t.PEToolset.DeleteClusterAuthzRole,
+		})
+}
+
+// ---------------------------------------------------------------------------
+// AuthzRoleBinding / ClusterAuthzRoleBinding
+// ---------------------------------------------------------------------------
+
+func (t *Toolsets) RegisterListAuthzRoleBindings(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedListTool(s, perms, "list_authz_role_bindings", scopedAuthzRoleBindingNoun,
+		"List authz role bindings. With scope=\"namespace\" (default) lists AuthzRoleBindings in namespace_name; "+
+			"with scope=\"cluster\" lists platform-wide ClusterAuthzRoleBindings. Bindings connect a subject "+
+			"(entitlement claim) to one or more roles with optional per-mapping scope. "+
+			"Supports pagination via limit and cursor.",
+		authzcore.ActionViewAuthzRoleBinding, authzcore.ActionViewClusterAuthzRoleBinding,
+		scopedListHandlers{
+			namespace: t.PEToolset.ListAuthzRoleBindings,
+			cluster:   t.PEToolset.ListClusterAuthzRoleBindings,
+		})
+}
+
+func (t *Toolsets) RegisterGetAuthzRoleBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "get_authz_role_binding", scopedAuthzRoleBindingNoun,
+		"Get the full definition of an authz role binding including its entitlement, role mappings, and "+
+			"effect. Use scope=\"cluster\" for a platform-wide ClusterAuthzRoleBinding. Call before "+
+			"update_authz_role_binding.",
+		authzcore.ActionViewAuthzRoleBinding, authzcore.ActionViewClusterAuthzRoleBinding,
+		"name", "Authz role binding name. Use list_authz_role_bindings to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.GetAuthzRoleBinding,
+			cluster:   t.PEToolset.GetClusterAuthzRoleBinding,
+		})
+}
+
+func (t *Toolsets) RegisterGetAuthzRoleBindingCreationSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSchemaTool(s, perms, "get_authz_role_binding_creation_schema", scopedAuthzRoleBindingNoun,
+		"Get the JSON schema for the role binding spec. The schema differs between scopes: cluster "+
+			"bindings reference only ClusterAuthzRole and allow scope.namespace; namespace bindings "+
+			"can reference either AuthzRole or ClusterAuthzRole. Both expose scope.project / "+
+			"scope.component / scope.resource — scope.component and scope.resource are sibling "+
+			"sub-scopes under project and are mutually exclusive. Optional conditions[] applies "+
+			"CEL-based ABAC restrictions to specific actions.",
+		authzcore.ActionViewAuthzRoleBinding, authzcore.ActionViewClusterAuthzRoleBinding,
+		scopedSchemaProviders{
+			namespace: func() (any, error) { return AuthzRoleBindingCreationSchema() },
+			cluster:   func() (any, error) { return ClusterAuthzRoleBindingCreationSchema() },
+		})
+}
+
+//nolint:dupl // create/update register helpers share a near-identical shape per resource
+func (t *Toolsets) RegisterCreateAuthzRoleBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedWriteTool(s, perms, "create_authz_role_binding", scopedAuthzRoleBindingNoun,
+		"Create an authz role binding. With scope=\"namespace\" (default) creates an AuthzRoleBinding in "+
+			"namespace_name (can reference both AuthzRole and ClusterAuthzRole); with scope=\"cluster\" "+
+			"creates a ClusterAuthzRoleBinding (ClusterAuthzRole only, scope can include namespace). "+
+			"Use get_authz_role_binding_creation_schema for the per-scope spec shape.",
+		authzcore.ActionCreateAuthzRoleBinding, authzcore.ActionCreateClusterAuthzRoleBinding,
+		"DNS-compatible identifier (lowercase, alphanumeric, hyphens only, max 63 chars)",
+		"Binding spec — must include entitlement and roleMappings[]. Optional: effect (allow|deny, default allow).",
+		scopedWriteHandlers{
+			namespace: func(ctx context.Context, ns, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.AuthzRoleBindingSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.CreateAuthzRoleBinding(ctx, ns, &gen.CreateNamespaceRoleBindingJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+			cluster: func(ctx context.Context, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ClusterAuthzRoleBindingSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.CreateClusterAuthzRoleBinding(ctx, &gen.CreateClusterRoleBindingJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+		})
+}
+
+//nolint:dupl // create/update register helpers share a near-identical shape per resource
+func (t *Toolsets) RegisterUpdateAuthzRoleBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedWriteTool(s, perms, "update_authz_role_binding", scopedAuthzRoleBindingNoun,
+		"Update an existing authz role binding (full-spec replacement). Use scope=\"cluster\" for a "+
+			"platform-wide ClusterAuthzRoleBinding. Use get_authz_role_binding to retrieve the current spec first.",
+		authzcore.ActionUpdateAuthzRoleBinding, authzcore.ActionUpdateClusterAuthzRoleBinding,
+		"Name of the role binding to update. Use list_authz_role_bindings to discover valid names",
+		"Full binding spec to replace the existing one. Use get_authz_role_binding to retrieve the current spec first.",
+		scopedWriteHandlers{
+			namespace: func(ctx context.Context, ns, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.AuthzRoleBindingSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.UpdateAuthzRoleBinding(ctx, ns, &gen.UpdateNamespaceRoleBindingJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+			cluster: func(ctx context.Context, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ClusterAuthzRoleBindingSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.UpdateClusterAuthzRoleBinding(ctx, &gen.UpdateClusterRoleBindingJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+		})
+}
+
+func (t *Toolsets) RegisterDeleteAuthzRoleBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "delete_authz_role_binding", scopedAuthzRoleBindingNoun,
+		"Delete an authz role binding. Use scope=\"cluster\" for a platform-wide ClusterAuthzRoleBinding. "+
+			"Revokes only what this binding granted; the referenced role remains.",
+		authzcore.ActionDeleteAuthzRoleBinding, authzcore.ActionDeleteClusterAuthzRoleBinding,
+		"name", "Name of the role binding to delete. Use list_authz_role_bindings to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.DeleteAuthzRoleBinding,
+			cluster:   t.PEToolset.DeleteClusterAuthzRoleBinding,
+		})
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics — flat (not scope-collapsed)
+// ---------------------------------------------------------------------------
+
+func (t *Toolsets) RegisterEvaluateAuthz(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "evaluate_authz"
+	// Gate on authzrolebinding:view: a caller inspecting authorization decisions should be
+	// able to see the bindings that produced them. The service layer is itself ungated for
+	// the caller's own subject; this gate controls tools/list visibility only.
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewAuthzRoleBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Evaluate one or more authorization requests and return allow/deny decisions. " +
+			"Used to debug \"why am I getting 403?\" — pass the action and resource the caller tried to " +
+			"perform; the response includes the matching binding chain when a decision is denied. " +
+			"Each request must include action, resource.type, and subject_context (use the caller's own " +
+			"identity to ask \"can I do X?\").",
+		InputSchema: createSchema(map[string]any{
+			"requests": map[string]any{
+				"type": "array",
+				"description": "List of evaluation requests. Each: {action, " +
+					"resource: {type, id?, hierarchy?}, subject_context: " +
+					"{type, entitlement_claim, entitlement_values[]}, context?}.",
+				"items":    map[string]any{"type": "object"},
+				"minItems": 1,
+			},
+		}, []string{"requests"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		Requests []map[string]interface{} `json:"requests"`
+	}) (*mcp.CallToolResult, any, error) {
+		if len(args.Requests) == 0 {
+			return nil, nil, fmt.Errorf("requests must contain at least one item")
+		}
+		typed := make([]gen.EvaluateRequest, 0, len(args.Requests))
+		for i, raw := range args.Requests {
+			var r gen.EvaluateRequest
+			if err := decodeSpecStrict(raw, &r); err != nil {
+				return nil, nil, fmt.Errorf("requests[%d]: %w", i, err)
+			}
+			typed = append(typed, r)
+		}
+		return handleToolResult(t.PEToolset.EvaluateAuthz(ctx, typed))
+	})
+}
+
+func (t *Toolsets) RegisterListAuthzActions(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_authz_actions"
+	// Gate on authzrole:view: the catalog is read alongside role authoring. The service
+	// layer is ungated; this gate controls tools/list visibility only.
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewAuthzRole}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "List all authorization actions defined in the system. Each entry has a name (e.g. " +
+			"\"component:view\") and the lowest scope it applies at (cluster|namespace|project|component). " +
+			"Use this to discover valid values for AuthzRole.spec.actions[] before calling create_authz_role.",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return handleToolResult(t.PEToolset.ListAuthzActions(ctx))
+	})
+}

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -219,6 +219,50 @@ type PEToolsetHandler interface {
 		group, version, kind, name string) (any, error)
 	GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName,
 		podName string, sinceSeconds *int64) (any, error)
+
+	// Authz roles (namespace-scoped)
+	ListAuthzRoles(ctx context.Context, namespaceName string, opts ListOpts) (any, error)
+	GetAuthzRole(ctx context.Context, namespaceName, roleName string) (any, error)
+	CreateAuthzRole(
+		ctx context.Context, namespaceName string, req *gen.CreateNamespaceRoleJSONRequestBody,
+	) (any, error)
+	UpdateAuthzRole(
+		ctx context.Context, namespaceName string, req *gen.UpdateNamespaceRoleJSONRequestBody,
+	) (any, error)
+	DeleteAuthzRole(ctx context.Context, namespaceName, roleName string) (any, error)
+
+	// Authz roles (cluster-scoped)
+	ListClusterAuthzRoles(ctx context.Context, opts ListOpts) (any, error)
+	GetClusterAuthzRole(ctx context.Context, roleName string) (any, error)
+	CreateClusterAuthzRole(ctx context.Context, req *gen.CreateClusterRoleJSONRequestBody) (any, error)
+	UpdateClusterAuthzRole(ctx context.Context, req *gen.UpdateClusterRoleJSONRequestBody) (any, error)
+	DeleteClusterAuthzRole(ctx context.Context, roleName string) (any, error)
+
+	// Authz role bindings (namespace-scoped)
+	ListAuthzRoleBindings(ctx context.Context, namespaceName string, opts ListOpts) (any, error)
+	GetAuthzRoleBinding(ctx context.Context, namespaceName, bindingName string) (any, error)
+	CreateAuthzRoleBinding(
+		ctx context.Context, namespaceName string, req *gen.CreateNamespaceRoleBindingJSONRequestBody,
+	) (any, error)
+	UpdateAuthzRoleBinding(
+		ctx context.Context, namespaceName string, req *gen.UpdateNamespaceRoleBindingJSONRequestBody,
+	) (any, error)
+	DeleteAuthzRoleBinding(ctx context.Context, namespaceName, bindingName string) (any, error)
+
+	// Authz role bindings (cluster-scoped)
+	ListClusterAuthzRoleBindings(ctx context.Context, opts ListOpts) (any, error)
+	GetClusterAuthzRoleBinding(ctx context.Context, bindingName string) (any, error)
+	CreateClusterAuthzRoleBinding(
+		ctx context.Context, req *gen.CreateClusterRoleBindingJSONRequestBody,
+	) (any, error)
+	UpdateClusterAuthzRoleBinding(
+		ctx context.Context, req *gen.UpdateClusterRoleBindingJSONRequestBody,
+	) (any, error)
+	DeleteClusterAuthzRoleBinding(ctx context.Context, bindingName string) (any, error)
+
+	// Authz diagnostics
+	EvaluateAuthz(ctx context.Context, requests []gen.EvaluateRequest) (any, error)
+	ListAuthzActions(ctx context.Context) (any, error)
 }
 
 // NamespaceToolsetHandler handles namespace operations


### PR DESCRIPTION
## Purpose

Adds **14 net-new MCP tools** covering the OpenChoreo authz CRD surface (`AuthzRole`, `ClusterAuthzRole`, `AuthzRoleBinding`, `ClusterAuthzRoleBinding`) plus two high-value diagnostics. Closes the long-standing authz gap on the control-plane MCP server — this was the next priority on the MCP gap inventory after PR #3431.

Until this lands, control-plane MCP clients have to fall back to `kubectl get`/`kubectl apply -f` for authz CRDs, which is the only resource family on the server still without a write surface.

## What ships

### Scope-collapsed CRUD (12 tools)

`AuthzRole` + `ClusterAuthzRole`, and `AuthzRoleBinding` + `ClusterAuthzRoleBinding`, each family with:

- `list_authz_roles` / `list_authz_role_bindings`
- `get_authz_role` / `get_authz_role_binding`
- `get_authz_role_creation_schema` / `get_authz_role_binding_creation_schema`
- `create_authz_role` / `create_authz_role_binding`
- `update_authz_role` / `update_authz_role_binding` (full-spec replacement)
- `delete_authz_role` / `delete_authz_role_binding`

Same scope-collapsed pattern as PR #3431 — one tool per operation, `scope: "namespace" | "cluster"` selects the resource kind. **No deprecated cluster-prefixed aliases** — net-new surface, no compatibility window. `ToolPermission.ScopedActions` wires the per-scope authz action for `tools/list` filtering. Per-scope binding creation schemas differ structurally (cluster bindings allow `scope.namespace`; namespace bindings only allow `scope.{project,component}` and accept both role kinds).

### Diagnostics (2 flat tools)

- **`evaluate_authz`** — batch "would this be allowed?" evaluator. Each request carries action + resource + subject_context; missing subject defaults to the caller's identity (extracted from `auth.GetSubjectContextFromContext`). Used to debug 403s. Gated on `authzrolebinding:view` for `tools/list` filtering; the service layer is ungated for the caller's own subject.
- **`list_authz_actions`** — returns the full action catalog with name, lowest scope, and condition attribute keys. Used to discover valid values for `spec.actions[]` when authoring roles. Gated on `authzrole:view`.

## Implementation notes

- **Pure MCP plumbing.** The service layer (`internal/openchoreo-api/services/authz`) and CRDs were already complete; this PR adds 22 handler methods on `PEToolsetHandler` plus their `MCPHandler` implementations.
- **Per-CRD schema extraction.** Four new producers in `pkg/mcp/tools/crdschema.go` extract `AuthzRole` / `ClusterAuthzRole` / `AuthzRoleBinding` / `ClusterAuthzRoleBinding` spec schemas from the embedded CRD YAML, mirroring the existing ComponentType/Trait/Workflow pattern.
- **Request body decoding.** Reuses `convertSpec[gen.X, openchoreov1alpha1.X]` from `platform_standards.go` for gen→CRD spec conversion. Each handler builds the CRD object and calls the existing `AuthzService` methods, then returns either `mutationResult` (writes) or `*Detail` (reads).
- **`evaluate_authz` mirrors the HTTP `/evaluates` endpoint** but with a single concession to MCP UX: empty `subject_context.entitlement_claim` falls back to the caller's subject. The HTTP API requires the client to fill it in; for agent ergonomics, defaulting to "ask about yourself" is the obvious common case.

## Related Issues

- Closes the §"Authorization — full surface" gap from the project's MCP roadmap.
- Follows the scope-collapsed pattern established in #3431.

## Checklist

- [x] Tests added or updated (unit, integration, etc.) — extends `peToolSpecs` with a new `peAuthzSpecs` subtree exercising every new tool through `TestToolParameterWiring` and `TestToolRegistration`; permission assertions covered by the existing `TestRegisteredToolsHavePermissions` / `TestRegisteredPermissionsHaveValidActions`.
- [ ] Samples updated (if applicable) — n/a
- [ ] Added `backport/<release-branch>` label if this should be backported — n/a

## Remarks

- Follow-up (separate PR): refresh the tool catalog section in `openchoreo.github.io/docs/reference/mcp-servers.mdx`.
- `make lint` and `go test ./pkg/mcp/... ./internal/openchoreo-api/...` pass locally.