### PR TITLE
feat: allow updating CPU and memory limits through the finops agent and fix remediation actions in report

### DIFF
--- a/finops-agent/src/agent/agent.py
+++ b/finops-agent/src/agent/agent.py
@@ -179,7 +179,7 @@ def _synthesize_remediation_actions(report: FinOpsReport) -> list[RemediationAct
         RemediationAction(
             description=(
                 f"Right-size ReleaseBinding `{rec.release_binding}` "
-                "CPU and memory requests based on actual usage"
+                "CPU and memory requests and limits based on actual usage"
             ),
             rationale=rec.rationale,
             change=ResourceChange(
@@ -192,6 +192,14 @@ def _synthesize_remediation_actions(report: FinOpsReport) -> list[RemediationAct
                     FieldChange(
                         json_pointer="/spec/componentTypeEnvironmentConfigs/resources/requests/memory",
                         value=rec.memory_request,
+                    ),
+                    FieldChange(
+                        json_pointer="/spec/componentTypeEnvironmentConfigs/resources/limits/cpu",
+                        value=rec.cpu_limit,
+                    ),
+                    FieldChange(
+                        json_pointer="/spec/componentTypeEnvironmentConfigs/resources/limits/memory",
+                        value=rec.memory_limit,
                     ),
                 ],
             ),
@@ -258,8 +266,14 @@ async def run_analysis(
                 logger.debug("FinOps tool calls: %s", summary)
             logger.info("FinOps analysis completed: usage=%s", usage_callback.usage_metadata)
 
-            if settings.remediation_enabled:
-                finops_report.recommended_actions = _synthesize_remediation_actions(finops_report)
+            # Always overwrite recommended_actions — the LLM sees the field in the
+            # schema and may hallucinate paths; only the deterministic synthesiser
+            # should populate it.
+            finops_report.recommended_actions = (
+                _synthesize_remediation_actions(finops_report)
+                if settings.remediation_enabled
+                else []
+            )
 
             report_data = finops_report.model_dump()
 

--- a/finops-agent/src/models/finops_report.py
+++ b/finops-agent/src/models/finops_report.py
@@ -1,7 +1,10 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Annotated
+
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from src.models.remediation_action import RemediationAction
 
@@ -119,7 +122,6 @@ class FinOpsReport(BaseModel):
     investigation_path: list[InvestigationStep] = Field(
         ..., min_length=1, description="Steps taken during the analysis"
     )
-    recommended_actions: list[RemediationAction] = Field(
+    recommended_actions: Annotated[list[RemediationAction], SkipJsonSchema()] = Field(
         default_factory=list,
-        description="Remediation actions synthesized from the overprovisioning recommendation",
     )


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The finops-agent synthesises a recommended_actions list from the LLM's overprovisioning recommendation and stores it on the report for clients to apply. There were two issues with it
1. recommended_actions was included in the LLM's structured-output schema, causing the LLM to hallucinate its own (incorrect) values, including invalid Kubernetes-native JSON pointer paths, which then failed Pydantic validation and crashed the analysis.
 2. The remediation action only patched CPU and memory requests, silently leaving limits unchanged.

## Approach
- Hide recommended_actions from the LLM schema
- Always overwrite recommended_actions
- Include limits in the remediation action

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3356

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
