### PR TITLE
fix(controller): surface real reason when observability release is skipped

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -818,6 +818,9 @@ type observabilityReleaseResult struct {
 	resourceCount     int
 	managed           bool
 	ownershipConflict bool
+	// skipReason explains why the observability Release was skipped when managed == false.
+	// Empty when managed == true.
+	skipReason string
 }
 
 // reconcileObservabilityRelease handles the creation, update, or cleanup of the observability plane Release.
@@ -832,13 +835,20 @@ func (r *Reconciler) reconcileObservabilityRelease(
 	logger := log.FromContext(ctx)
 
 	// Determine if we should create/manage an observability Release:
-	// 1. ObservabilityPlane must exist (with default fallback)
-	// 2. There must be observability plane resources to deploy
+	// 1. There must be observability plane resources to deploy
+	// 2. ObservabilityPlane must resolve (with default fallback)
 	shouldManage := false
-	if len(observabilityPlaneReleaseResources) > 0 {
+	var skipReason string
+	if len(observabilityPlaneReleaseResources) == 0 {
+		skipReason = "no observability resources to deploy"
+	} else {
 		// Try to resolve the ObservabilityPlane - this will use "default" if not explicitly specified
-		_, err := dataPlaneResult.GetObservabilityPlane(ctx, r.Client)
-		shouldManage = (err == nil)
+		if _, err := dataPlaneResult.GetObservabilityPlane(ctx, r.Client); err != nil {
+			skipReason = fmt.Sprintf("failed to resolve ObservabilityPlane: %v", err)
+			logger.Info("Skipping observability Release reconciliation", "reason", skipReason)
+		} else {
+			shouldManage = true
+		}
 	}
 
 	releaseName := makeObservabilityReleaseName(componentRelease, releaseBinding)
@@ -847,6 +857,7 @@ func (r *Reconciler) reconcileObservabilityRelease(
 		releaseName:   releaseName,
 		resourceCount: len(observabilityPlaneReleaseResources),
 		managed:       shouldManage,
+		skipReason:    skipReason,
 	}
 
 	if shouldManage {
@@ -954,8 +965,8 @@ func (r *Reconciler) setReleaseSyncedCondition(
 				dpReleaseName, dpOp, dpResourceCount,
 				obsResult.releaseName, obsResult.operation, obsResult.resourceCount)
 		} else {
-			msg = fmt.Sprintf("Dataplane Release %q %s with %d resources (observability release skipped: no ObservabilityPlaneRef or no resources)",
-				dpReleaseName, dpOp, dpResourceCount)
+			msg = fmt.Sprintf("Dataplane Release %q %s with %d resources (observability release skipped: %s)",
+				dpReleaseName, dpOp, dpResourceCount, obsResult.skipReason)
 		}
 		controller.MarkTrueCondition(releaseBinding, ConditionReleaseSynced, ReasonReleaseCreated, msg)
 
@@ -965,8 +976,8 @@ func (r *Reconciler) setReleaseSyncedCondition(
 			msg = fmt.Sprintf("Dataplane Release %q is up to date; observability Release %q is %s",
 				dpReleaseName, obsResult.releaseName, obsResult.operation)
 		} else {
-			msg = fmt.Sprintf("Dataplane Release %q is up to date (observability release skipped: no ObservabilityPlaneRef or no resources)",
-				dpReleaseName)
+			msg = fmt.Sprintf("Dataplane Release %q is up to date (observability release skipped: %s)",
+				dpReleaseName, obsResult.skipReason)
 		}
 		controller.MarkTrueCondition(releaseBinding, ConditionReleaseSynced, ReasonReleaseSynced, msg)
 	}

--- a/internal/controller/releasebinding/controller_unit_test.go
+++ b/internal/controller/releasebinding/controller_unit_test.go
@@ -6,6 +6,7 @@ package releasebinding
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1056,7 +1057,7 @@ func TestSetReleaseSyncedCondition_Created(t *testing.T) {
 	rb := makeReleaseBindingForConditions()
 
 	r.setReleaseSyncedCondition(rb, "my-release", controllerutil.OperationResultCreated, 3,
-		observabilityReleaseResult{managed: false})
+		observabilityReleaseResult{managed: false, skipReason: "no observability resources to deploy"})
 
 	cond := findCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
 	if cond == nil {
@@ -1068,6 +1069,9 @@ func TestSetReleaseSyncedCondition_Created(t *testing.T) {
 	if cond.Reason != string(ReasonReleaseCreated) {
 		t.Errorf("Reason = %q, want %q", cond.Reason, ReasonReleaseCreated)
 	}
+	if !strings.Contains(cond.Message, "no observability resources to deploy") {
+		t.Errorf("Message = %q, want to contain skip reason", cond.Message)
+	}
 }
 
 func TestSetReleaseSyncedCondition_Updated(t *testing.T) {
@@ -1075,7 +1079,7 @@ func TestSetReleaseSyncedCondition_Updated(t *testing.T) {
 	rb := makeReleaseBindingForConditions()
 
 	r.setReleaseSyncedCondition(rb, "my-release", controllerutil.OperationResultUpdated, 5,
-		observabilityReleaseResult{managed: false})
+		observabilityReleaseResult{managed: false, skipReason: "no observability resources to deploy"})
 
 	cond := findCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
 	if cond == nil {
@@ -1094,7 +1098,7 @@ func TestSetReleaseSyncedCondition_None(t *testing.T) {
 	rb := makeReleaseBindingForConditions()
 
 	r.setReleaseSyncedCondition(rb, "my-release", controllerutil.OperationResultNone, 3,
-		observabilityReleaseResult{managed: false})
+		observabilityReleaseResult{managed: false, skipReason: "no observability resources to deploy"})
 
 	cond := findCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
 	if cond == nil {
@@ -1105,6 +1109,40 @@ func TestSetReleaseSyncedCondition_None(t *testing.T) {
 	}
 	if cond.Reason != string(ReasonReleaseSynced) {
 		t.Errorf("Reason = %q, want %q", cond.Reason, ReasonReleaseSynced)
+	}
+}
+
+func TestSetReleaseSyncedCondition_SkippedDueToPlaneLookupFailure(t *testing.T) {
+	r := newTestReconciler()
+
+	cases := []struct {
+		name string
+		op   controllerutil.OperationResult
+	}{
+		{name: "created", op: controllerutil.OperationResultCreated},
+		{name: "none", op: controllerutil.OperationResultNone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rb := makeReleaseBindingForConditions()
+			skipReason := `failed to resolve ObservabilityPlane: observabilityplanes.openchoreo.dev "default" not found`
+
+			r.setReleaseSyncedCondition(rb, "my-release", tc.op, 3,
+				observabilityReleaseResult{managed: false, skipReason: skipReason})
+
+			cond := findCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
+			if cond == nil {
+				t.Fatal("ReleaseSynced condition should be set")
+			}
+			if !strings.Contains(cond.Message, skipReason) {
+				t.Errorf("Message = %q, want to contain underlying skip reason %q", cond.Message, skipReason)
+			}
+			// Sanity check: the old generic boilerplate should no longer leak through.
+			if strings.Contains(cond.Message, "no ObservabilityPlaneRef or no resources") {
+				t.Errorf("Message = %q, must not contain the misleading boilerplate", cond.Message)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Previously the ReleaseSynced condition reported a hardcoded "observability release skipped: no ObservabilityPlaneRef or no resources" regardless of which condition triggered the skip, hiding lookup errors from `GetObservabilityPlane()` and making debugging harder.

Distinguish the two skip paths and surface the actual lookup error in the condition message:
- "no observability resources to deploy" when nothing was rendered
- "failed to resolve ObservabilityPlane: <err>" when the lookup fails

## Approach
> Summarize the solution and implementation details.

## Related Issues
Fixes #2766

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
