### PR TITLE
feat(cli): add occ secret update and --category on create

### DIFF
--- a/internal/occ/cmd/secret/category.go
+++ b/internal/occ/cmd/secret/category.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// secretTypeLabel marks a SecretReference's category (e.g. git
+	// credentials). The key matches the one used by the Backstage plugins
+	// (openchoreo.dev/secret-type) so the CLI and UI agree on categories.
+	secretTypeLabel = "openchoreo.dev/secret-type"
+
+	// categoryGeneric is the default category. It is represented by the
+	// absence of the secret-type label.
+	categoryGeneric = "generic"
+
+	// categoryGitCredentials marks a secret that holds git credentials.
+	// Workflows and CI build dialogs discover git secrets by this value.
+	categoryGitCredentials = "git-credentials"
+)
+
+// knownCategories lists every category accepted by the CLI.
+var knownCategories = []string{categoryGeneric, categoryGitCredentials}
+
+// labelsFor returns the label map to send on a Create or Update request for
+// the given category, plus an error if the category is unknown.
+//
+// The returned map captures the full intended label set: the caller can
+// pass it through as-is for full-replace label semantics. The secret-type
+// label is always set (including for the default "generic" category), so
+// the category is explicit on every secret managed by the CLI.
+//
+//   - "" (unspecified): defaults to the generic category.
+//   - "generic": {secretTypeLabel: "generic"}.
+//   - "git-credentials": {secretTypeLabel: "git-credentials"}.
+func labelsFor(category string) (map[string]string, error) {
+	if category == "" {
+		category = categoryGeneric
+	}
+	switch category {
+	case categoryGeneric, categoryGitCredentials:
+		return map[string]string{secretTypeLabel: category}, nil
+	default:
+		return nil, fmt.Errorf("invalid --category %q: must be one of %s", category, strings.Join(knownCategories, ", "))
+	}
+}

--- a/internal/occ/cmd/secret/category.go
+++ b/internal/occ/cmd/secret/category.go
@@ -14,8 +14,8 @@ const (
 	// (openchoreo.dev/secret-type) so the CLI and UI agree on categories.
 	secretTypeLabel = "openchoreo.dev/secret-type"
 
-	// categoryGeneric is the default category. It is represented by the
-	// absence of the secret-type label.
+	// categoryGeneric is the default category, emitted as the value
+	// of the secret-type label when no other category is specified.
 	categoryGeneric = "generic"
 
 	// categoryGitCredentials marks a secret that holds git credentials.
@@ -26,17 +26,7 @@ const (
 // knownCategories lists every category accepted by the CLI.
 var knownCategories = []string{categoryGeneric, categoryGitCredentials}
 
-// labelsFor returns the label map to send on a Create or Update request for
-// the given category, plus an error if the category is unknown.
-//
-// The returned map captures the full intended label set: the caller can
-// pass it through as-is for full-replace label semantics. The secret-type
-// label is always set (including for the default "generic" category), so
-// the category is explicit on every secret managed by the CLI.
-//
-//   - "" (unspecified): defaults to the generic category.
-//   - "generic": {secretTypeLabel: "generic"}.
-//   - "git-credentials": {secretTypeLabel: "git-credentials"}.
+// labelsFor returns the secret-type label for the given category (defaulting to generic), or an error if the category is unknown.
 func labelsFor(category string) (map[string]string, error) {
 	if category == "" {
 		category = categoryGeneric

--- a/internal/occ/cmd/secret/cmd.go
+++ b/internal/occ/cmd/secret/cmd.go
@@ -182,7 +182,7 @@ func newCreateCmd(f client.NewClientFunc) *cobra.Command {
 func addCommonCreateFlags(cmd *cobra.Command) {
 	flags.AddNamespace(cmd)
 	cmd.Flags().String("target-plane", "", "Target plane in Kind/Name form (e.g. DataPlane/dp-prod)")
-	cmd.Flags().String("category", "", "Secret category: 'generic' (default, no label) or 'git-credentials'")
+	cmd.Flags().String("category", "", "Secret category: 'generic' (default) or 'git-credentials'")
 }
 
 func readCreateInput(cmd *cobra.Command, args []string) CreateInput {

--- a/internal/occ/cmd/secret/cmd.go
+++ b/internal/occ/cmd/secret/cmd.go
@@ -25,6 +25,7 @@ func NewSecretCmd(f client.NewClientFunc) *cobra.Command {
 		newGetCmd(f),
 		newDeleteCmd(f),
 		newCreateCmd(f),
+		newUpdateCmd(f),
 	)
 	return cmd
 }
@@ -99,6 +100,70 @@ func newDeleteCmd(f client.NewClientFunc) *cobra.Command {
 	return cmd
 }
 
+func readUpdateInput(cmd *cobra.Command, args []string) UpdateInput {
+	literals, _ := cmd.Flags().GetStringArray("from-literal")
+	files, _ := cmd.Flags().GetStringArray("from-file")
+	envFiles, _ := cmd.Flags().GetStringArray("from-env-file")
+	replace, _ := cmd.Flags().GetBool("replace")
+
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	return UpdateInput{
+		Namespace:   flags.GetNamespace(cmd),
+		SecretName:  name,
+		FromLiteral: literals,
+		FromFile:    files,
+		FromEnvFile: envFiles,
+		Replace:     replace,
+	}
+}
+
+func newUpdateCmd(f client.NewClientFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update [SECRET_NAME]",
+		Short: "Update a secret's data",
+		Long: `Update the data of an existing secret.
+
+By default the update merges: keys passed via --from-literal, --from-file, or
+--from-env-file are set or added, and every other existing key is left
+unchanged.
+
+Use --replace to set the data to exactly what the --from-* flags specify,
+pruning any keys not listed.
+
+The secret type, target plane, and category cannot be changed; use
+'occ secret delete' and 'occ secret create' to change them.`,
+		Example: `  # Rotate one key, keep the rest
+  occ secret update db-creds --namespace acme-corp \
+    --from-literal=password=n3ws3cret
+
+  # Add a key from a file
+  occ secret update db-creds --namespace acme-corp \
+    --from-file=ca.crt=./ca.crt
+
+  # Replace the data with exactly these keys
+  occ secret update db-creds --namespace acme-corp --replace \
+    --from-literal=username=admin --from-literal=password=n3ws3cret`,
+		Args:    cmdutil.ExactOneArgWithUsage(),
+		PreRunE: auth.RequireLogin(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, err := f()
+			if err != nil {
+				return err
+			}
+			return New(cl).Update(readUpdateInput(cmd, args))
+		},
+	}
+	flags.AddNamespace(cmd)
+	cmd.Flags().StringArray("from-literal", nil, "Key=value literal to set (repeatable)")
+	cmd.Flags().StringArray("from-file", nil, "Key=path or path to set (repeatable). Key defaults to the filename.")
+	cmd.Flags().StringArray("from-env-file", nil, "Path to a KEY=VALUE env file (repeatable)")
+	cmd.Flags().Bool("replace", false, "Replace the secret data with exactly the --from-* keys, pruning all others")
+	return cmd
+}
+
 func newCreateCmd(f client.NewClientFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -117,6 +182,7 @@ func newCreateCmd(f client.NewClientFunc) *cobra.Command {
 func addCommonCreateFlags(cmd *cobra.Command) {
 	flags.AddNamespace(cmd)
 	cmd.Flags().String("target-plane", "", "Target plane in Kind/Name form (e.g. DataPlane/dp-prod)")
+	cmd.Flags().String("category", "", "Secret category: 'generic' (default, no label) or 'git-credentials'")
 }
 
 func readCreateInput(cmd *cobra.Command, args []string) CreateInput {
@@ -124,6 +190,7 @@ func readCreateInput(cmd *cobra.Command, args []string) CreateInput {
 	files, _ := cmd.Flags().GetStringArray("from-file")
 	envFiles, _ := cmd.Flags().GetStringArray("from-env-file")
 	targetPlane, _ := cmd.Flags().GetString("target-plane")
+	category, _ := cmd.Flags().GetString("category")
 
 	name := ""
 	if len(args) > 0 {
@@ -133,6 +200,7 @@ func readCreateInput(cmd *cobra.Command, args []string) CreateInput {
 		Namespace:   flags.GetNamespace(cmd),
 		SecretName:  name,
 		TargetPlane: targetPlane,
+		Category:    category,
 		FromLiteral: literals,
 		FromFile:    files,
 		FromEnvFile: envFiles,

--- a/internal/occ/cmd/secret/cmd_test.go
+++ b/internal/occ/cmd/secret/cmd_test.go
@@ -45,7 +45,7 @@ func TestNewSecretCmd_Subcommands(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		names = append(names, sub.Name())
 	}
-	assert.ElementsMatch(t, []string{"list", "get", "delete", "create"}, names)
+	assert.ElementsMatch(t, []string{"list", "get", "delete", "create", "update"}, names)
 }
 
 func TestCreateCmd_Subcommands(t *testing.T) {
@@ -145,6 +145,62 @@ func TestDeleteCmd_Success(t *testing.T) {
 		require.NoError(t, cmd.RunE(cmd, []string{"my-secret"}))
 	})
 	assert.Contains(t, out, "deleted")
+}
+
+// --- update ---
+
+func TestUpdateCmd_MissingArg(t *testing.T) {
+	cmd := newUpdateCmd(errFactory("unused"))
+	err := cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SECRET_NAME")
+}
+
+func TestUpdateCmd_FactoryError(t *testing.T) {
+	cmd := newUpdateCmd(errFactory("factory failed"))
+	err := cmd.RunE(cmd, []string{"my-secret"})
+	assert.EqualError(t, err, "factory failed")
+}
+
+func TestUpdateCmd_Merge_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	existing := map[string][]byte{"username": []byte("admin"), "password": []byte("old")}
+	mc.EXPECT().GetSecret(mock.Anything, "acme-corp", "db-creds").Return(
+		&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}, Type: "Opaque", Data: &existing}, nil,
+	)
+	mc.EXPECT().UpdateSecret(mock.Anything, "acme-corp", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
+		return req.Data["username"] == "admin" && req.Data["password"] == "new" && len(req.Data) == 2
+	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
+
+	cmd := newUpdateCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "password=new"))
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"db-creds"}))
+	})
+	assert.Contains(t, out, "updated")
+}
+
+func TestUpdateCmd_Replace_Success(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	existing := map[string][]byte{"old": []byte("v")}
+	mc.EXPECT().GetSecret(mock.Anything, "acme-corp", "db-creds").Return(
+		&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}, Type: "Opaque", Data: &existing}, nil,
+	)
+	mc.EXPECT().UpdateSecret(mock.Anything, "acme-corp", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
+		return len(req.Data) == 1 && req.Data["password"] == "new"
+	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
+
+	cmd := newUpdateCmd(mockFactory(mc))
+	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
+	require.NoError(t, cmd.Flags().Set("replace", "true"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "password=new"))
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"db-creds"}))
+	})
+	assert.Contains(t, out, "updated")
 }
 
 // --- create generic ---

--- a/internal/occ/cmd/secret/cmd_test.go
+++ b/internal/occ/cmd/secret/cmd_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 )
 
+const (
+	testUsername    = "admin"
+	testNewPassword = "new"
+)
+
 func mockFactory(mc *mocks.MockInterface) client.NewClientFunc {
 	return func() (client.Interface, error) {
 		return mc, nil
@@ -164,17 +169,17 @@ func TestUpdateCmd_FactoryError(t *testing.T) {
 
 func TestUpdateCmd_Merge_Success(t *testing.T) {
 	mc := mocks.NewMockInterface(t)
-	existing := map[string][]byte{"username": []byte("admin"), "password": []byte("old")}
+	existing := map[string][]byte{"username": []byte(testUsername), "password": []byte("old")}
 	mc.EXPECT().GetSecret(mock.Anything, "acme-corp", "db-creds").Return(
 		&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}, Type: "Opaque", Data: &existing}, nil,
 	)
 	mc.EXPECT().UpdateSecret(mock.Anything, "acme-corp", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
-		return req.Data["username"] == "admin" && req.Data["password"] == "new" && len(req.Data) == 2
+		return req.Data["username"] == testUsername && req.Data["password"] == testNewPassword && len(req.Data) == 2
 	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
 
 	cmd := newUpdateCmd(mockFactory(mc))
 	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
-	require.NoError(t, cmd.Flags().Set("from-literal", "password=new"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "password="+testNewPassword))
 
 	out := testutil.CaptureStdout(t, func() {
 		require.NoError(t, cmd.RunE(cmd, []string{"db-creds"}))
@@ -189,13 +194,13 @@ func TestUpdateCmd_Replace_Success(t *testing.T) {
 		&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}, Type: "Opaque", Data: &existing}, nil,
 	)
 	mc.EXPECT().UpdateSecret(mock.Anything, "acme-corp", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
-		return len(req.Data) == 1 && req.Data["password"] == "new"
+		return len(req.Data) == 1 && req.Data["password"] == testNewPassword
 	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
 
 	cmd := newUpdateCmd(mockFactory(mc))
 	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
 	require.NoError(t, cmd.Flags().Set("replace", "true"))
-	require.NoError(t, cmd.Flags().Set("from-literal", "password=new"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "password="+testNewPassword))
 
 	out := testutil.CaptureStdout(t, func() {
 		require.NoError(t, cmd.RunE(cmd, []string{"db-creds"}))
@@ -219,14 +224,14 @@ func TestCreateGenericCmd_Success(t *testing.T) {
 			req.SecretType == gen.SecretTypeOpaque &&
 			req.TargetPlane.Kind == gen.TargetPlaneRefKindDataPlane &&
 			req.TargetPlane.Name == "dp-prod" &&
-			req.Data["username"] == "admin" &&
+			req.Data["username"] == testUsername &&
 			req.Data["password"] == "s3cret"
 	})).Return(&gen.Secret{}, nil)
 
 	cmd := newCreateGenericCmd(mockFactory(mc))
 	require.NoError(t, cmd.Flags().Set("namespace", "acme-corp"))
 	require.NoError(t, cmd.Flags().Set("target-plane", "DataPlane/dp-prod"))
-	require.NoError(t, cmd.Flags().Set("from-literal", "username=admin"))
+	require.NoError(t, cmd.Flags().Set("from-literal", "username="+testUsername))
 	require.NoError(t, cmd.Flags().Set("from-literal", "password=s3cret"))
 
 	out := testutil.CaptureStdout(t, func() {

--- a/internal/occ/cmd/secret/params.go
+++ b/internal/occ/cmd/secret/params.go
@@ -33,7 +33,21 @@ type CreateInput struct {
 	Namespace   string
 	SecretName  string
 	TargetPlane string // raw "Kind/Name"
+	Category    string // "" (default: generic), "generic", or "git-credentials"
 	FromLiteral []string
 	FromFile    []string
 	FromEnvFile []string
 }
+
+// UpdateInput is the parsed input for the update command.
+type UpdateInput struct {
+	Namespace   string
+	SecretName  string
+	FromLiteral []string
+	FromFile    []string
+	FromEnvFile []string
+	Replace     bool
+}
+
+func (in UpdateInput) GetNamespace() string  { return in.Namespace }
+func (in UpdateInput) GetSecretName() string { return in.SecretName }

--- a/internal/occ/cmd/secret/secret.go
+++ b/internal/occ/cmd/secret/secret.go
@@ -142,6 +142,100 @@ func (s *Secret) Delete(params DeleteParams) error {
 	return nil
 }
 
+// Update changes a secret's data. By default it merges: keys named via
+// --from-* are set or added, and every other existing key is preserved.
+// With --replace, the data is exactly what --from-* specifies and all
+// other keys are pruned. The secret's category is preserved through every
+// update (use 'occ secret delete' + 'create' to change it).
+func (s *Secret) Update(in UpdateInput) error {
+	if err := cmdutil.RequireFields("update", "secret", map[string]string{
+		"namespace": in.Namespace,
+		"name":      in.SecretName,
+	}); err != nil {
+		return err
+	}
+
+	if len(in.FromLiteral) == 0 && len(in.FromFile) == 0 && len(in.FromEnvFile) == 0 {
+		return fmt.Errorf("at least one of --from-literal, --from-file, or --from-env-file is required")
+	}
+
+	ctx := context.Background()
+
+	// We always need the existing secret so we can carry forward the
+	// category label: the API's UpdateSecret treats Labels as a full
+	// replace, so omitting it (or sending an empty map) would strip
+	// any user-set labels. Re-sending the existing category label keeps
+	// the categorization intact across data-only updates.
+	existing, err := s.client.GetSecret(ctx, in.Namespace, in.SecretName)
+	if err != nil {
+		return err
+	}
+
+	var data map[string]string
+	if in.Replace {
+		data, err = collectData(in.FromLiteral, in.FromFile, in.FromEnvFile)
+		if err != nil {
+			return err
+		}
+	} else {
+		data = bytesMapToString(existing.Data)
+		updates, err := collectData(in.FromLiteral, in.FromFile, in.FromEnvFile)
+		if err != nil {
+			return err
+		}
+		for k, v := range updates {
+			data[k] = v
+		}
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("update would leave the secret with no data keys; use 'occ secret delete' to remove a secret")
+	}
+
+	labels := preservedLabels(existing.Metadata.Labels)
+	resp, err := s.client.UpdateSecret(ctx, in.Namespace, in.SecretName, gen.UpdateSecretRequest{
+		Data:   data,
+		Labels: &labels,
+	})
+	if err != nil {
+		return err
+	}
+	respName := in.SecretName
+	if resp != nil && resp.Metadata.Name != "" {
+		respName = resp.Metadata.Name
+	}
+	fmt.Printf("Secret '%s' updated\n", respName)
+	return nil
+}
+
+// preservedLabels returns the subset of an existing secret's labels that
+// the CLI carries forward on update. We forward the category label
+// (openchoreo.dev/secret-type) so it survives the API's full-replace
+// label semantics. The managed-by label is dropped here because the API
+// re-stamps it itself; sending it back is redundant and the API would
+// reject any caller-supplied managed-by anyway.
+func preservedLabels(existing *map[string]string) map[string]string {
+	out := map[string]string{}
+	if existing == nil {
+		return out
+	}
+	if v, ok := (*existing)[secretTypeLabel]; ok {
+		out[secretTypeLabel] = v
+	}
+	return out
+}
+
+// bytesMapToString decodes a Secret response's data map into plaintext strings.
+func bytesMapToString(data *map[string][]byte) map[string]string {
+	out := map[string]string{}
+	if data == nil {
+		return out
+	}
+	for k, v := range *data {
+		out[k] = string(v)
+	}
+	return out
+}
+
 // CreateGeneric creates an Opaque secret (or basic-auth / ssh-auth via the
 // optional secretType override).
 func (s *Secret) CreateGeneric(in CreateInput, secretType string) error {
@@ -166,7 +260,7 @@ func (s *Secret) CreateGeneric(in CreateInput, secretType string) error {
 	if secretType != "" {
 		st = gen.SecretType(secretType)
 	}
-	return s.create(in.Namespace, in.SecretName, st, *tp, data)
+	return s.create(in.Namespace, in.SecretName, st, *tp, data, in.Category)
 }
 
 // CreateDockerRegistry creates a kubernetes.io/dockerconfigjson secret.
@@ -194,7 +288,7 @@ func (s *Secret) CreateDockerRegistry(in CreateInput, server, username, password
 	}
 	data := map[string]string{".dockerconfigjson": cfg}
 
-	return s.create(in.Namespace, in.SecretName, gen.SecretTypeKubernetesIodockerconfigjson, *tp, data)
+	return s.create(in.Namespace, in.SecretName, gen.SecretTypeKubernetesIodockerconfigjson, *tp, data, in.Category)
 }
 
 // CreateTLS creates a kubernetes.io/tls secret from a cert/key pair.
@@ -227,16 +321,22 @@ func (s *Secret) CreateTLS(in CreateInput, certPath, keyPath string) error {
 		"tls.key": string(key),
 	}
 
-	return s.create(in.Namespace, in.SecretName, gen.SecretTypeKubernetesIotls, *tp, data)
+	return s.create(in.Namespace, in.SecretName, gen.SecretTypeKubernetesIotls, *tp, data, in.Category)
 }
 
-func (s *Secret) create(namespace, name string, st gen.SecretType, tp gen.TargetPlaneRef, data map[string]string) error {
+func (s *Secret) create(namespace, name string, st gen.SecretType, tp gen.TargetPlaneRef, data map[string]string, category string) error {
+	labels, err := labelsFor(category)
+	if err != nil {
+		return err
+	}
+
 	ctx := context.Background()
 	req := gen.CreateSecretRequest{
 		SecretName:  name,
 		SecretType:  st,
 		TargetPlane: tp,
 		Data:        data,
+		Labels:      &labels,
 	}
 	resp, err := s.client.CreateSecret(ctx, namespace, req)
 	if err != nil {

--- a/internal/occ/cmd/secret/secret_test.go
+++ b/internal/occ/cmd/secret/secret_test.go
@@ -130,6 +130,167 @@ func TestDelete_Success(t *testing.T) {
 	assert.Contains(t, out, "Secret 'x' deleted")
 }
 
+// --- Update ---
+
+func bytesData(m map[string]string) *map[string][]byte {
+	out := make(map[string][]byte, len(m))
+	for k, v := range m {
+		out[k] = []byte(v)
+	}
+	return &out
+}
+
+func TestUpdate_ValidationError_NoNamespace(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).Update(UpdateInput{SecretName: "x", FromLiteral: []string{"k=v"}})
+	assert.ErrorContains(t, err, "Missing required parameter: --namespace")
+}
+
+func TestUpdate_ValidationError_NoName(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).Update(UpdateInput{Namespace: "ns", FromLiteral: []string{"k=v"}})
+	assert.ErrorContains(t, err, "Missing required parameter: --name")
+}
+
+func TestUpdate_RequiresMutatingFlag(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).Update(UpdateInput{Namespace: "ns", SecretName: "x"})
+	assert.ErrorContains(t, err, "at least one of --from-literal")
+}
+
+// labelsPtr is a small helper for tests that populates the Metadata.Labels
+// pointer on a fake gen.Secret response.
+func labelsPtr(in map[string]string) *map[string]string {
+	cp := make(map[string]string, len(in))
+	for k, v := range in {
+		cp[k] = v
+	}
+	return &cp
+}
+
+func TestUpdate_Replace_RequiresFrom(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	err := New(mc).Update(UpdateInput{Namespace: "ns", SecretName: "x", Replace: true})
+	assert.ErrorContains(t, err, "at least one of --from-literal")
+}
+
+func TestUpdate_Merge_KeepsUnmentionedKeys(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetSecret(mock.Anything, "ns", "db-creds").Return(&gen.Secret{
+		Metadata: gen.ObjectMeta{
+			Name:   "db-creds",
+			Labels: labelsPtr(map[string]string{"openchoreo.dev/secret-type": "generic"}),
+		},
+		Type: "Opaque",
+		Data: bytesData(map[string]string{"username": "admin", "password": "old"}),
+	}, nil)
+	mc.EXPECT().UpdateSecret(mock.Anything, "ns", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
+		if req.Data["username"] != "admin" || req.Data["password"] != "new" || len(req.Data) != 2 {
+			return false
+		}
+		// Category label must be carried forward so the API's full-replace
+		// of labels does not drop it.
+		if req.Labels == nil {
+			return false
+		}
+		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic"
+	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, New(mc).Update(UpdateInput{
+			Namespace:   "ns",
+			SecretName:  "db-creds",
+			FromLiteral: []string{"password=new"},
+		}))
+	})
+	assert.Contains(t, out, "Secret 'db-creds' updated")
+}
+
+func TestUpdate_Merge_NoCategoryLabelOnExisting(t *testing.T) {
+	// If the existing secret has no secret-type label, the request sends
+	// an empty labels map so other user labels are reset but no category
+	// is invented.
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetSecret(mock.Anything, "ns", "x").Return(&gen.Secret{
+		Metadata: gen.ObjectMeta{Name: "x"},
+		Type:     "Opaque",
+		Data:     bytesData(map[string]string{"k": "v"}),
+	}, nil)
+	mc.EXPECT().UpdateSecret(mock.Anything, "ns", "x", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
+		if req.Labels == nil {
+			return false
+		}
+		return len(*req.Labels) == 0
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).Update(UpdateInput{
+		Namespace:   "ns",
+		SecretName:  "x",
+		FromLiteral: []string{"k=v2"},
+	}))
+}
+
+func TestUpdate_Merge_GetError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetSecret(mock.Anything, "ns", "x").Return(nil, fmt.Errorf("not found"))
+	err := New(mc).Update(UpdateInput{
+		Namespace:   "ns",
+		SecretName:  "x",
+		FromLiteral: []string{"k=v"},
+	})
+	assert.EqualError(t, err, "not found")
+}
+
+func TestUpdate_Replace_PrunesAndPreservesCategory(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	// Replace mode still GETs the secret so it can carry the existing
+	// category label through the full-replace update.
+	mc.EXPECT().GetSecret(mock.Anything, "ns", "db-creds").Return(&gen.Secret{
+		Metadata: gen.ObjectMeta{
+			Name:   "db-creds",
+			Labels: labelsPtr(map[string]string{"openchoreo.dev/secret-type": "git-credentials"}),
+		},
+		Type: "Opaque",
+		Data: bytesData(map[string]string{"old-key": "should-be-pruned"}),
+	}, nil)
+	mc.EXPECT().UpdateSecret(mock.Anything, "ns", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
+		if len(req.Data) != 2 || req.Data["username"] != "admin" || req.Data["password"] != "new" {
+			return false
+		}
+		if req.Labels == nil {
+			return false
+		}
+		return (*req.Labels)["openchoreo.dev/secret-type"] == "git-credentials"
+	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
+
+	out := testutil.CaptureStdout(t, func() {
+		require.NoError(t, New(mc).Update(UpdateInput{
+			Namespace:   "ns",
+			SecretName:  "db-creds",
+			Replace:     true,
+			FromLiteral: []string{"username=admin", "password=new"},
+		}))
+	})
+	assert.Contains(t, out, "updated")
+}
+
+func TestUpdate_APIError(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().GetSecret(mock.Anything, "ns", "x").Return(&gen.Secret{
+		Metadata: gen.ObjectMeta{Name: "x"},
+		Type:     "Opaque",
+		Data:     bytesData(map[string]string{"a": "b"}),
+	}, nil)
+	mc.EXPECT().UpdateSecret(mock.Anything, "ns", "x", mock.Anything).Return(nil, fmt.Errorf("boom"))
+	err := New(mc).Update(UpdateInput{
+		Namespace:   "ns",
+		SecretName:  "x",
+		Replace:     true,
+		FromLiteral: []string{"k=v"},
+	})
+	assert.EqualError(t, err, "boom")
+}
+
 // --- CreateGeneric ---
 
 func TestCreateGeneric_RequiresData(t *testing.T) {
@@ -156,7 +317,14 @@ func TestCreateGeneric_InvalidTargetPlane(t *testing.T) {
 func TestCreateGeneric_OpaqueByDefault(t *testing.T) {
 	mc := mocks.NewMockInterface(t)
 	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
-		return req.SecretType == gen.SecretTypeOpaque && req.Data["k"] == "v"
+		if req.SecretType != gen.SecretTypeOpaque || req.Data["k"] != "v" {
+			return false
+		}
+		// Default category should always stamp the secret-type label.
+		if req.Labels == nil {
+			return false
+		}
+		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic" && len(*req.Labels) == 1
 	})).Return(&gen.Secret{}, nil)
 
 	require.NoError(t, New(mc).CreateGeneric(CreateInput{
@@ -165,6 +333,75 @@ func TestCreateGeneric_OpaqueByDefault(t *testing.T) {
 		TargetPlane: "DataPlane/dp",
 		FromLiteral: []string{"k=v"},
 	}, ""))
+}
+
+func TestCreateGeneric_CategoryGitCredentials(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		if req.Labels == nil {
+			return false
+		}
+		return (*req.Labels)["openchoreo.dev/secret-type"] == "git-credentials"
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateGeneric(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "n",
+		TargetPlane: "DataPlane/dp",
+		Category:    "git-credentials",
+		FromLiteral: []string{"username=admin", "password=s3"},
+	}, "kubernetes.io/basic-auth"))
+}
+
+func TestCreateGeneric_UnknownCategory(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	// No CreateSecret call expected: validation must fail first.
+	err := New(mc).CreateGeneric(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "n",
+		TargetPlane: "DataPlane/dp",
+		Category:    "bogus",
+		FromLiteral: []string{"k=v"},
+	}, "")
+	assert.ErrorContains(t, err, "invalid --category")
+}
+
+func TestCreateDockerRegistry_CategoryDefault(t *testing.T) {
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		if req.Labels == nil {
+			return false
+		}
+		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic"
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateDockerRegistry(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "regcred",
+		TargetPlane: "DataPlane/dp",
+	}, "https://reg.example/v1/", "jdoe", "hunter2", ""))
+}
+
+func TestCreateTLS_CategoryDefault(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "tls.crt")
+	key := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(cert, []byte("C"), 0o600))
+	require.NoError(t, os.WriteFile(key, []byte("K"), 0o600))
+
+	mc := mocks.NewMockInterface(t)
+	mc.EXPECT().CreateSecret(mock.Anything, "ns", mock.MatchedBy(func(req gen.CreateSecretRequest) bool {
+		if req.Labels == nil {
+			return false
+		}
+		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic"
+	})).Return(&gen.Secret{}, nil)
+
+	require.NoError(t, New(mc).CreateTLS(CreateInput{
+		Namespace:   "ns",
+		SecretName:  "tls",
+		TargetPlane: "DataPlane/dp",
+	}, cert, key))
 }
 
 func TestCreateGeneric_TypeOverride(t *testing.T) {

--- a/internal/occ/cmd/secret/secret_test.go
+++ b/internal/occ/cmd/secret/secret_test.go
@@ -179,13 +179,13 @@ func TestUpdate_Merge_KeepsUnmentionedKeys(t *testing.T) {
 	mc.EXPECT().GetSecret(mock.Anything, "ns", "db-creds").Return(&gen.Secret{
 		Metadata: gen.ObjectMeta{
 			Name:   "db-creds",
-			Labels: labelsPtr(map[string]string{"openchoreo.dev/secret-type": "generic"}),
+			Labels: labelsPtr(map[string]string{"openchoreo.dev/secret-type": categoryGeneric}),
 		},
 		Type: "Opaque",
-		Data: bytesData(map[string]string{"username": "admin", "password": "old"}),
+		Data: bytesData(map[string]string{"username": testUsername, "password": "old"}),
 	}, nil)
 	mc.EXPECT().UpdateSecret(mock.Anything, "ns", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
-		if req.Data["username"] != "admin" || req.Data["password"] != "new" || len(req.Data) != 2 {
+		if req.Data["username"] != testUsername || req.Data["password"] != testNewPassword || len(req.Data) != 2 {
 			return false
 		}
 		// Category label must be carried forward so the API's full-replace
@@ -193,14 +193,14 @@ func TestUpdate_Merge_KeepsUnmentionedKeys(t *testing.T) {
 		if req.Labels == nil {
 			return false
 		}
-		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic"
+		return (*req.Labels)["openchoreo.dev/secret-type"] == categoryGeneric
 	})).Return(&gen.Secret{Metadata: gen.ObjectMeta{Name: "db-creds"}}, nil)
 
 	out := testutil.CaptureStdout(t, func() {
 		require.NoError(t, New(mc).Update(UpdateInput{
 			Namespace:   "ns",
 			SecretName:  "db-creds",
-			FromLiteral: []string{"password=new"},
+			FromLiteral: []string{"password=" + testNewPassword},
 		}))
 	})
 	assert.Contains(t, out, "Secret 'db-creds' updated")
@@ -254,7 +254,7 @@ func TestUpdate_Replace_PrunesAndPreservesCategory(t *testing.T) {
 		Data: bytesData(map[string]string{"old-key": "should-be-pruned"}),
 	}, nil)
 	mc.EXPECT().UpdateSecret(mock.Anything, "ns", "db-creds", mock.MatchedBy(func(req gen.UpdateSecretRequest) bool {
-		if len(req.Data) != 2 || req.Data["username"] != "admin" || req.Data["password"] != "new" {
+		if len(req.Data) != 2 || req.Data["username"] != testUsername || req.Data["password"] != testNewPassword {
 			return false
 		}
 		if req.Labels == nil {
@@ -268,7 +268,7 @@ func TestUpdate_Replace_PrunesAndPreservesCategory(t *testing.T) {
 			Namespace:   "ns",
 			SecretName:  "db-creds",
 			Replace:     true,
-			FromLiteral: []string{"username=admin", "password=new"},
+			FromLiteral: []string{"username=" + testUsername, "password=" + testNewPassword},
 		}))
 	})
 	assert.Contains(t, out, "updated")
@@ -324,7 +324,7 @@ func TestCreateGeneric_OpaqueByDefault(t *testing.T) {
 		if req.Labels == nil {
 			return false
 		}
-		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic" && len(*req.Labels) == 1
+		return (*req.Labels)["openchoreo.dev/secret-type"] == categoryGeneric && len(*req.Labels) == 1
 	})).Return(&gen.Secret{}, nil)
 
 	require.NoError(t, New(mc).CreateGeneric(CreateInput{
@@ -349,7 +349,7 @@ func TestCreateGeneric_CategoryGitCredentials(t *testing.T) {
 		SecretName:  "n",
 		TargetPlane: "DataPlane/dp",
 		Category:    "git-credentials",
-		FromLiteral: []string{"username=admin", "password=s3"},
+		FromLiteral: []string{"username=" + testUsername, "password=s3"},
 	}, "kubernetes.io/basic-auth"))
 }
 
@@ -372,7 +372,7 @@ func TestCreateDockerRegistry_CategoryDefault(t *testing.T) {
 		if req.Labels == nil {
 			return false
 		}
-		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic"
+		return (*req.Labels)["openchoreo.dev/secret-type"] == categoryGeneric
 	})).Return(&gen.Secret{}, nil)
 
 	require.NoError(t, New(mc).CreateDockerRegistry(CreateInput{
@@ -394,7 +394,7 @@ func TestCreateTLS_CategoryDefault(t *testing.T) {
 		if req.Labels == nil {
 			return false
 		}
-		return (*req.Labels)["openchoreo.dev/secret-type"] == "generic"
+		return (*req.Labels)["openchoreo.dev/secret-type"] == categoryGeneric
 	})).Return(&gen.Secret{}, nil)
 
 	require.NoError(t, New(mc).CreateTLS(CreateInput{
@@ -414,7 +414,7 @@ func TestCreateGeneric_TypeOverride(t *testing.T) {
 		Namespace:   "ns",
 		SecretName:  "n",
 		TargetPlane: "DataPlane/dp",
-		FromLiteral: []string{"username=admin", "password=s3"},
+		FromLiteral: []string{"username=" + testUsername, "password=s3"},
 	}, "kubernetes.io/basic-auth"))
 }
 


### PR DESCRIPTION
## Purpose
related to https://github.com/openchoreo/openchoreo/issues/3288

Round out the `occ secret` CLI to match the API features added in #3467: surface secret categories on create and provide an ergonomic `update` subcommand. Backstage already uses `openchoreo.dev/secret-type` to mark git-credential secrets; this lets the CLI agree on the same categorization, and gives users a way to rotate or replace secret data without going through delete + recreate.

## Approach

`occ secret update SECRET_NAME`
- Merge mode (default): GET the secret, apply `--from-literal` / `--from-file` / `--from-env-file` over the existing data, PUT back. Unmentioned keys are preserved.
- `--replace`: data becomes exactly what the `--from-*` flags specify; everything else is pruned.
- Either mode always GETs the secret first to read the existing `openchoreo.dev/secret-type` label and re-send it on the PUT, so the category survives the API's full-replace label semantics. Without this, a data-only update strips the category label.
- Type, target plane, and category are immutable on update; use delete + create to change them.

`--category` on `occ secret create generic|docker-registry|tls`
- Accepts `generic` (default) or `git-credentials`.
- Always stamps `openchoreo.dev/secret-type: <category>` on every create so the category is explicit on every CLI-managed secret. Unknown values are rejected client-side.
- The label key matches the constant used in `backstage-plugins` so the CLI and the Backstage UI agree on what categorizes a secret.

Tests
- Unit tests cover both `update` modes, label-preservation, validation errors, and category handling on all three create flows.
- End-to-end verified against a local k3d cluster for create (all four flows), merge updates, `--replace`, label preservation across both update modes, and the negative cases.

## Related Issues

Related #3467

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)

## Remarks

The label-preservation logic on update is a client-side workaround for the API's full-replace label semantics — sending `Labels: nil` (or an empty map) on `UpdateSecret` wipes user-set labels server-side. Filing the API fix separately so callers other than the CLI also stop losing labels.