### PR TITLE
fix: handle oneOf/anyOf/allOf schemas in CEL expression validation

### DIFF
--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -118,9 +118,51 @@ func createBaseEnv() (*cel.Env, error) {
 // returning an empty object type if schema is nil or conversion fails.
 func schemaToTypeOrEmpty(schema *apiextschema.Structural, typeName string) *apiservercel.DeclType {
 	if schema != nil {
-		if dt := model.SchemaDeclType(schema, false); dt != nil {
+		normalized := normalizeForCEL(schema)
+		if dt := model.SchemaDeclType(normalized, false); dt != nil {
 			return dt.MaybeAssignTypeName(typeName)
 		}
 	}
 	return apiservercel.NewObjectType(typeName, map[string]*apiservercel.DeclField{})
+}
+
+// normalizeForCEL returns a shallow-cloned structural schema where nodes that
+// have no top-level type but carry oneOf/anyOf/allOf variants are marked as
+// x-kubernetes-int-or-string. This makes the Kubernetes SchemaDeclType
+// function treat them as CEL dyn values instead of returning nil and
+// silently dropping the enclosing field from the CEL type environment.
+func normalizeForCEL(s *apiextschema.Structural) *apiextschema.Structural {
+	if s == nil {
+		return nil
+	}
+	out := *s
+
+	if out.Type == "" && hasCompositionValidation(out.ValueValidation) {
+		out.Extensions.XIntOrString = true
+	}
+
+	if out.Items != nil {
+		out.Items = normalizeForCEL(out.Items)
+	}
+
+	if len(out.Properties) > 0 {
+		props := make(map[string]apiextschema.Structural, len(out.Properties))
+		for k, v := range out.Properties {
+			normalized := normalizeForCEL(&v)
+			props[k] = *normalized
+		}
+		out.Properties = props
+	}
+
+	if out.AdditionalProperties != nil && out.AdditionalProperties.Structural != nil {
+		ap := *out.AdditionalProperties
+		ap.Structural = normalizeForCEL(ap.Structural)
+		out.AdditionalProperties = &ap
+	}
+
+	return &out
+}
+
+func hasCompositionValidation(v *apiextschema.ValueValidation) bool {
+	return v != nil && (len(v.OneOf) > 0 || len(v.AnyOf) > 0 || len(v.AllOf) > 0)
 }

--- a/internal/validation/component/componenttype_test.go
+++ b/internal/validation/component/componenttype_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	ocschema "github.com/openchoreo/openchoreo/internal/schema"
 )
 
 func TestValidateClusterComponentTypeResourcesWithSchema(t *testing.T) {
@@ -149,6 +150,158 @@ func TestValidateClusterComponentTypeResourcesWithSchema_WithTypedSchema(t *test
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			errs := ValidateClusterComponentTypeResourcesWithSchema(tt.cct, parametersSchema, nil)
+			if tt.wantError {
+				assert.NotEmpty(t, errs, "expected validation error")
+				if tt.errMsg != "" {
+					errStr := errs.ToAggregate().Error()
+					assert.Contains(t, errStr, tt.errMsg)
+				}
+			} else {
+				assert.Empty(t, errs, "unexpected validation errors: %v", errs)
+			}
+		})
+	}
+}
+
+func TestValidateResourcesWithSchema_OneOfInEnvironmentConfigs(t *testing.T) {
+	envConfigsSchema, err := ocschema.OpenAPIV3ToStructural(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"corsAllowedOrigins": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"oneOf": []any{
+						map[string]any{"type": "string"},
+						map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"regex": map[string]any{"type": "string"},
+							},
+							"required":             []any{"regex"},
+							"additionalProperties": false,
+						},
+					},
+				},
+				"default": []any{"https://localhost:3000", "http://localhost:3000"},
+			},
+			"maxAge": map[string]any{
+				"type":    "integer",
+				"default": float64(3600),
+			},
+		},
+	})
+	require.NoError(t, err, "failed to build environmentConfigs structural schema")
+
+	tests := []struct {
+		name      string
+		ct        *v1alpha1.ComponentType
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name: "CEL referencing oneOf array field should be valid",
+			ct: &v1alpha1.ComponentType{
+				Spec: v1alpha1.ComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID: "cors-config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"origins": "${environmentConfigs.corsAllowedOrigins}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "CEL referencing typed sibling field alongside oneOf should be valid",
+			ct: &v1alpha1.ComponentType{
+				Spec: v1alpha1.ComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID: "cors-config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"origins": "${environmentConfigs.corsAllowedOrigins}", "maxAge": "${environmentConfigs.maxAge}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "CEL referencing undefined environmentConfigs field should fail",
+			ct: &v1alpha1.ComponentType{
+				Spec: v1alpha1.ComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID: "cors-config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"origins": "${environmentConfigs.nonExistent}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'nonExistent'",
+		},
+		{
+			name: "CEL referencing undefined field alongside valid oneOf field should fail",
+			ct: &v1alpha1.ComponentType{
+				Spec: v1alpha1.ComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID: "cors-config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"origins": "${environmentConfigs.corsAllowedOrigins}", "bad": "${environmentConfigs.notAField}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "undefined field 'notAField'",
+		},
+		{
+			name: "CEL indexing into oneOf array and accessing element field should be valid",
+			ct: &v1alpha1.ComponentType{
+				Spec: v1alpha1.ComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID: "cors-config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"regex": "${environmentConfigs.corsAllowedOrigins[0].regex}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "CEL accessing field directly on oneOf array should fail",
+			ct: &v1alpha1.ComponentType{
+				Spec: v1alpha1.ComponentTypeSpec{
+					Resources: []v1alpha1.ResourceTemplate{
+						{
+							ID: "cors-config",
+							Template: &runtime.RawExtension{
+								Raw: []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"bad": "${environmentConfigs.corsAllowedOrigins.something}"}}`),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "does not support field selection",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateComponentTypeResourcesWithSchema(tt.ct, nil, envConfigsSchema)
 			if tt.wantError {
 				assert.NotEmpty(t, errs, "expected validation error")
 				if tt.errMsg != "" {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Schemas using oneOf/anyOf/allOf composition without a top-level type caused the Kubernetes SchemaDeclType to return nil, silently dropping the field from the CEL type environment. This made valid expressions like `${environmentConfigs.corsAllowedOrigins}` fail with "undefined field".

```
  environmentConfigs:
    openAPIV3Schema:
      type: object
      properties:
        corsAllowedOrigins:
          type: array
          items:
            oneOf:
              - type: string
              - type: object
                properties:
                  regex:
                    type: string
                required: [regex]
                additionalProperties: false
          default: ["https://localhost:3000", "http://localhost:3000"]
```

```
Resource: "openchoreo.dev/v1alpha1, Resource=clustercomponenttypes", GroupVersionKind: "openchoreo.dev/v1alpha1, Kind=ClusterComponentType"
Name: "worker", Namespace: ""
for: "samples/getting-started/component-types/worker.yaml": error when patching "samples/getting-started/component-types/worker.yaml": admission webhook "vclustercomponenttype-v1alpha1.kb.io" denied the request: spec.resources[0].template[spec][template][metadata][s]: Invalid value: "${environmentConfigs.corsAllowedOrigins}": invalid CEL expression 'environmentConfigs.corsAllowedOrigins': type check error: ERROR: <input>:1:19: undefined field 'corsAllowedOrigins'
 | environmentConfigs.corsAllowedOrigins
 | ..................^
chathuranga@chathurangada openchoreo % 
```

## Approach
Normalize structural schemas before CEL type conversion by marking untyped composition nodes as x-kubernetes-int-or-string, which maps to CEL dyn and defers element-level type checks to runtime.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
