### PR TITLE
ci: set top-level read permissions on release workflows

### DIFF
--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -24,6 +24,9 @@ concurrency:
   group: prepare-next-version-${{ github.event.inputs.major }}-${{ github.event.inputs.minor }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -36,6 +36,9 @@ concurrency:
   group: release-orchestrator-${{ github.event.inputs.major }}-${{ github.event.inputs.minor }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   # ----------------------------------------------------------------
   # Validate: resolve inputs, check preconditions, poll for images.


### PR DESCRIPTION
## Purpose
Scorecard's Token-Permissions check flags `release-orchestrator.yml` and `prepare-next-version.yml` for missing a top-level `permissions:` block. This PR adds `permissions: contents: read` at the workflow level. Every existing job already declares its own permissions block (escalating where genuinely required to push refs or open PRs), so this is defense-in-depth with no behavior change.

## Related Issues
https://github.com/openchoreo/openchoreo/security/code-scanning/275
https://github.com/openchoreo/openchoreo/security/code-scanning/276

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)