### PR TITLE
fix: windows build and bump spdystream for CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
 github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/occ/cmd/component/exec.go
+++ b/internal/occ/cmd/component/exec.go
@@ -249,8 +249,6 @@ func sendResize(ws *wsWriter, width, height uint16) {
 	_ = ws.write(websocket.BinaryMessage, msg)
 }
 
-// watchResize is defined in exec_resize_unix.go and exec_resize_windows.go
-
 func safeUint16(v int) uint16 {
 	if v < 0 {
 		return 0

--- a/internal/occ/cmd/component/exec.go
+++ b/internal/occ/cmd/component/exec.go
@@ -249,22 +249,7 @@ func sendResize(ws *wsWriter, width, height uint16) {
 	_ = ws.write(websocket.BinaryMessage, msg)
 }
 
-func watchResize(ctx context.Context, ws *wsWriter, fd int) {
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGWINCH)
-	defer signal.Stop(ch)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ch:
-			if w, h, err := term.GetSize(fd); err == nil {
-				sendResize(ws, safeUint16(w), safeUint16(h))
-			}
-		}
-	}
-}
+// watchResize is defined in exec_resize_unix.go and exec_resize_windows.go
 
 func safeUint16(v int) uint16 {
 	if v < 0 {

--- a/internal/occ/cmd/component/exec_resize_unix.go
+++ b/internal/occ/cmd/component/exec_resize_unix.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package component
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+func watchResize(ctx context.Context, ws *wsWriter, fd int) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	defer signal.Stop(ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			if w, h, err := term.GetSize(fd); err == nil {
+				sendResize(ws, safeUint16(w), safeUint16(h))
+			}
+		}
+	}
+}

--- a/internal/occ/cmd/component/exec_resize_windows.go
+++ b/internal/occ/cmd/component/exec_resize_windows.go
@@ -1,0 +1,13 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package component
+
+import (
+	"context"
+)
+
+// watchResize is a no-op on Windows — SIGWINCH is not available.
+func watchResize(_ context.Context, _ *wsWriter, _ int) {}


### PR DESCRIPTION
## Summary
- Moves `watchResize` (which uses `syscall.SIGWINCH`) to platform-specific files to fix the Windows cross-compilation build failure
- Bumps `github.com/moby/spdystream` from v0.5.0 to v0.5.1 (fixes Dependabot alert #66: DOS on CRI)

### Changes
- `exec_resize_unix.go` — full SIGWINCH implementation
- `exec_resize_windows.go` — no-op (SIGWINCH unavailable on Windows)
- `go.mod` / `go.sum` — spdystream v0.5.0 → v0.5.1

### Related
- Windows build failure: https://github.com/openchoreo/openchoreo/actions/runs/25902020255/job/76128713724
- Dependabot alert: https://github.com/openchoreo/openchoreo/security/dependabot/66

## Test plan
- [x] `GOOS=windows go build ./internal/occ/...` passes
- [x] `GOOS=linux go build ./internal/occ/...` passes
- [x] `GOOS=darwin go build ./internal/occ/...` passes
- [x] Exec terminal resize still works on Unix