### PR TITLE
fix: use gateway TLS config for exec WebSocket dialer

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -237,7 +237,17 @@ func main() {
 	var topHandler http.Handler = handler
 	if cfg.ClusterGateway.Enabled && gatewayURL != "" {
 		execAuthzChecker := svcpkg.NewAuthzChecker(runtime.pdp, logger.With("component", "exec-authz"))
-		execHandler := openapihandlers.NewExecHandler(k8sClient, gwClient, gatewayURL, execAuthzChecker, logger)
+		gwTLSConf, err := gatewayClient.BuildTLSConfig(&gatewayClient.TLSConfig{
+			CAFile:             cfg.ClusterGateway.TLS.CACertPath,
+			ClientCertFile:     cfg.ClusterGateway.TLS.ClientCertPath,
+			ClientKeyFile:      cfg.ClusterGateway.TLS.ClientKeyPath,
+			InsecureSkipVerify: cfg.ClusterGateway.TLS.Insecure,
+		})
+		if err != nil {
+			logger.Error("Failed to build gateway TLS config for exec", slog.Any("error", err))
+			os.Exit(1)
+		}
+		execHandler := openapihandlers.NewExecHandler(k8sClient, gwClient, gatewayURL, gwTLSConf, execAuthzChecker, logger)
 		authedExecHandler := jwtMiddleware(execHandler)
 		topMux := http.NewServeMux()
 		topMux.Handle("/exec/", authedExecHandler)

--- a/internal/clients/gateway/client.go
+++ b/internal/clients/gateway/client.go
@@ -167,7 +167,7 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		return nil, fmt.Errorf("baseURL is required")
 	}
 
-	tlsConfig, err := buildTLSConfig(&config.TLS)
+	tlsConfig, err := BuildTLSConfig(&config.TLS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -190,7 +190,7 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	}, nil
 }
 
-func buildTLSConfig(config *TLSConfig) (*tls.Config, error) {
+func BuildTLSConfig(config *TLSConfig) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12, // Enforce minimum TLS 1.2
 	}

--- a/internal/clients/gateway/client_test.go
+++ b/internal/clients/gateway/client_test.go
@@ -758,11 +758,11 @@ func TestGetPodEventsFromPlane(t *testing.T) {
 	})
 }
 
-// ─── buildTLSConfig tests ─────────────────────────────────────────────────────
+// ─── BuildTLSConfig tests ─────────────────────────────────────────────────────
 
 func TestBuildTLSConfig(t *testing.T) {
 	t.Run("empty config uses default verification", func(t *testing.T) {
-		cfg, err := buildTLSConfig(&TLSConfig{})
+		cfg, err := BuildTLSConfig(&TLSConfig{})
 		require.NoError(t, err)
 		assert.False(t, cfg.InsecureSkipVerify)
 		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
@@ -771,7 +771,7 @@ func TestBuildTLSConfig(t *testing.T) {
 	})
 
 	t.Run("InsecureSkipVerify=true opts into skipping verification", func(t *testing.T) {
-		cfg, err := buildTLSConfig(&TLSConfig{InsecureSkipVerify: true})
+		cfg, err := BuildTLSConfig(&TLSConfig{InsecureSkipVerify: true})
 		require.NoError(t, err)
 		assert.True(t, cfg.InsecureSkipVerify)
 	})
@@ -784,7 +784,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
 		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
 
-		cfg, err := buildTLSConfig(&TLSConfig{
+		cfg, err := BuildTLSConfig(&TLSConfig{
 			InsecureSkipVerify: true,
 			ClientCertFile:     certFile,
 			ClientKeyFile:      keyFile,
@@ -795,7 +795,7 @@ func TestBuildTLSConfig(t *testing.T) {
 	})
 
 	t.Run("ServerName is propagated", func(t *testing.T) {
-		cfg, err := buildTLSConfig(&TLSConfig{ServerName: "gateway.example"})
+		cfg, err := BuildTLSConfig(&TLSConfig{ServerName: "gateway.example"})
 		require.NoError(t, err)
 		assert.Equal(t, "gateway.example", cfg.ServerName)
 	})
@@ -805,19 +805,19 @@ func TestBuildTLSConfig(t *testing.T) {
 		caFile := filepath.Join(t.TempDir(), "ca.crt")
 		require.NoError(t, os.WriteFile(caFile, certPEM, 0o600))
 
-		cfg, err := buildTLSConfig(&TLSConfig{CAFile: caFile})
+		cfg, err := BuildTLSConfig(&TLSConfig{CAFile: caFile})
 		require.NoError(t, err)
 		assert.NotNil(t, cfg.RootCAs)
 	})
 
 	t.Run("missing CAFile returns error", func(t *testing.T) {
-		_, err := buildTLSConfig(&TLSConfig{CAFile: "/path/does/not/exist/ca.crt"})
+		_, err := BuildTLSConfig(&TLSConfig{CAFile: "/path/does/not/exist/ca.crt"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read CA file")
 	})
 
 	t.Run("malformed CAData returns parse error", func(t *testing.T) {
-		_, err := buildTLSConfig(&TLSConfig{CAData: []byte("not-a-cert")})
+		_, err := BuildTLSConfig(&TLSConfig{CAData: []byte("not-a-cert")})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse CA certificate")
 	})
@@ -830,7 +830,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
 		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
 
-		cfg, err := buildTLSConfig(&TLSConfig{
+		cfg, err := BuildTLSConfig(&TLSConfig{
 			ClientCertFile: certFile,
 			ClientKeyFile:  keyFile,
 		})
@@ -839,19 +839,19 @@ func TestBuildTLSConfig(t *testing.T) {
 	})
 
 	t.Run("only ClientCertFile set returns asymmetric-config error", func(t *testing.T) {
-		_, err := buildTLSConfig(&TLSConfig{ClientCertFile: "/tmp/client.crt"})
+		_, err := BuildTLSConfig(&TLSConfig{ClientCertFile: "/tmp/client.crt"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "both ClientCertFile and ClientKeyFile must be set")
 	})
 
 	t.Run("only ClientKeyFile set returns asymmetric-config error", func(t *testing.T) {
-		_, err := buildTLSConfig(&TLSConfig{ClientKeyFile: "/tmp/client.key"})
+		_, err := BuildTLSConfig(&TLSConfig{ClientKeyFile: "/tmp/client.key"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "both ClientCertFile and ClientKeyFile must be set")
 	})
 
 	t.Run("invalid client key pair returns load error", func(t *testing.T) {
-		_, err := buildTLSConfig(&TLSConfig{
+		_, err := BuildTLSConfig(&TLSConfig{
 			ClientCertFile: "/path/does/not/exist/client.crt",
 			ClientKeyFile:  "/path/does/not/exist/client.key",
 		})

--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -27,21 +27,23 @@ import (
 
 // ExecHandler handles WebSocket exec requests for component pods.
 type ExecHandler struct {
-	k8sClient     client.Client
-	gatewayClient *gatewayClient.Client
-	gatewayURL    string
-	authzChecker  *svcpkg.AuthzChecker
-	logger        *slog.Logger
+	k8sClient      client.Client
+	gatewayClient  *gatewayClient.Client
+	gatewayURL     string
+	gatewayTLSConf *tls.Config
+	authzChecker   *svcpkg.AuthzChecker
+	logger         *slog.Logger
 }
 
 // NewExecHandler creates a new exec handler.
-func NewExecHandler(k8sClient client.Client, gwClient *gatewayClient.Client, gatewayURL string, authzChecker *svcpkg.AuthzChecker, logger *slog.Logger) *ExecHandler {
+func NewExecHandler(k8sClient client.Client, gwClient *gatewayClient.Client, gatewayURL string, gwTLSConf *tls.Config, authzChecker *svcpkg.AuthzChecker, logger *slog.Logger) *ExecHandler {
 	return &ExecHandler{
-		k8sClient:     k8sClient,
-		gatewayClient: gwClient,
-		gatewayURL:    gatewayURL,
-		authzChecker:  authzChecker,
-		logger:        logger.With("component", "exec-handler"),
+		k8sClient:      k8sClient,
+		gatewayClient:  gwClient,
+		gatewayURL:     gatewayURL,
+		gatewayTLSConf: gwTLSConf,
+		authzChecker:   authzChecker,
+		logger:         logger.With("component", "exec-handler"),
 	}
 }
 
@@ -126,11 +128,9 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Connect to gateway exec WebSocket
+	// Connect to gateway exec WebSocket using the same TLS config as the gateway client.
 	gwDialer := websocket.Dialer{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // Gateway is internal, matches existing gateway client config
-		},
+		TLSClientConfig: h.gatewayTLSConf,
 	}
 	gwConn, _, err := gwDialer.DialContext(ctx, gwExecURL, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `InsecureSkipVerify: true` in the exec WebSocket dialer with the gateway TLS config from `cluster_gateway.tls`
- Exports `BuildTLSConfig` from the gateway client package so the exec handler can reuse the same TLS setup
- Clears the HTTP server's write/read deadline on the hijacked WebSocket connection so the 15s `WriteTimeout` doesn't kill idle exec sessions

### What changed
- `internal/clients/gateway/client.go` — export `BuildTLSConfig`
- `internal/clients/gateway/client_test.go` — update test references
- `internal/openchoreo-api/api/handlers/exec.go` — accept `*tls.Config`, use it for WebSocket dialer, clear deadline after upgrade
- `cmd/openchoreo-api/main.go` — build TLS config from `cfg.ClusterGateway.TLS` and pass to exec handler

## Test plan
- [ ] `go build ./...` passes
- [ ] Unit tests pass
- [ ] Exec works on clusters with `cluster_gateway.tls.insecure: true`
- [ ] Exec works on clusters with proper mTLS certs configured
- [ ] Idle exec sessions survive past the server's WriteTimeout (15s)