### PR TITLE
docs: update multi-cluster k3d README

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -677,6 +677,7 @@ helm upgrade --install observability-tracing-opensearch \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
+  --set adapter.enabled=false \
   --set-json opentelemetry-collector.extraEnvs='[]' \
   --set opentelemetryCollectorCustomizations.http.observabilityPlaneUrl="http://host.k3d.internal:11080" \
   --set opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost="opentelemetry.observability.openchoreo.localhost"
@@ -692,7 +693,7 @@ helm upgrade --install observability-metrics-prometheus \
   --kube-context k3d-openchoreo-op \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.6.0 \
+  --version 0.6.1 \
   --set global.installationMode="multiClusterReceiver" \
   --set-json 'prometheusCustomizations.http.hostnames=["prometheus.observability.openchoreo.localhost", "host.k3d.internal"]'
 ```
@@ -705,7 +706,7 @@ helm upgrade --install observability-metrics-prometheus \
   --kube-context k3d-openchoreo-dp \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.6.0 \
+  --version 0.6.1 \
   --set global.installationMode="multiClusterExporter" \
   --set prometheusCustomizations.http.observabilityPlaneUrl=http://host.k3d.internal:11080/api/v1/write \
   --set kube-prometheus-stack.prometheus.enabled=false \
@@ -798,6 +799,20 @@ kubectl --context k3d-openchoreo-dp logs -n openchoreo-data-plane -l app.kuberne
 kubectl --context k3d-openchoreo-wp logs -n openchoreo-workflow-plane -l app.kubernetes.io/component=cluster-agent --tail=5
 kubectl --context k3d-openchoreo-op logs -n openchoreo-observability-plane -l app.kubernetes.io/component=cluster-agent --tail=5
 ```
+
+## Troubleshooting
+
+### Observer returns no logs
+
+If Fluent Bit is shipping and `container-logs-*` is filling but Observer returns empty results, the index was likely created before `openSearchSetup` applied its template — so it has dynamic mappings that don't match what the adapter queries. Delete the index and let Fluent Bit recreate it:
+
+```bash
+kubectl --context k3d-openchoreo-op exec -n openchoreo-observability-plane opensearch-master-0 \
+  -- curl -ksu admin:ThisIsTheOpenSearchPassword1 \
+  -X DELETE 'https://localhost:9200/container-logs-*'
+```
+
+Only logs written after the deletion will appear (Fluent Bit's tail cursor persists at `/var/lib/fluent-bit/db/tail-container-logs.db`). Generate fresh traffic, or remove that DB and restart the DaemonSet to backfill.
 
 ## Image Preloading
 


### PR DESCRIPTION
## Summary

Three small fixes to `install/k3d/multi-cluster/README.md`, found while running the guide end-to-end against latest-dev.

- **Tracing exporter on DP was missing `--set adapter.enabled=false`.** The community-module README (`community-modules/observability-tracing-opensearch/README.md`) sets this flag because the exporter side has no local OpenSearch to talk to. Without it, `tracing-adapter-opensearch-*` ends up in CrashLoopBackOff on the data-plane cluster the whole time. Adding the flag here aligns the multi-cluster guide with the module's own README.
- **Bump `observability-metrics-prometheus` chart from `0.6.0` → `0.6.1`** to match the version pinned in the community-module README.
- **Add a Troubleshooting section** covering the case where Observer returns no logs even though Fluent Bit is shipping. Root cause: if Fluent Bit creates `container-logs-*` before `openSearchSetup` applies the index template, OpenSearch uses dynamic mappings and adapter queries miss. The fix is to delete the index so it gets recreated against the now-existing template. The note also flags Fluent Bit's persisted tail cursor so the reader knows previously-shipped lines don't come back without extra steps.

## Test plan

- [x] Verified `tracing-adapter-opensearch` CrashLoopBackOff resolves on DP after applying the `adapter.enabled=false` flag via `helm upgrade --reuse-values`.
- [x] Confirmed `otel-traces-*` index started growing in OpenSearch after the tracing-adapter fix (48 → 4k+ docs).
- [x] Reinstalled metrics module at 0.6.1 on both planes (receiver + exporter); pods rolled cleanly.
- [x] Reproduced the troubleshooting-section scenario by deleting `container-logs-*` and confirming Observer queries return results from the freshly-templated index.