### PR TITLE
feat: expose gateway info in Resource pipeline CEL context

### DIFF
--- a/internal/controller/resourcereleasebinding/controller.go
+++ b/internal/controller/resourcereleasebinding/controller.go
@@ -211,7 +211,8 @@ func (r *Reconciler) renderAndEmit(
 	resourceType := buildResourceTypeFromRelease(release)
 	snapshotResource := buildResourceFromRelease(release)
 	metadataCtx := buildMetadataContext(binding, environment, dataPlane, resource, project)
-	dpCtx := buildDataPlaneContext(dataPlane)
+	dpCtx := resourcepipeline.BuildDataPlaneContext(dataPlane)
+	envCtx := resourcepipeline.BuildEnvironmentContext(environment, dataPlane)
 
 	input := &resourcepipeline.RenderInput{
 		ResourceType:           resourceType,
@@ -219,6 +220,7 @@ func (r *Reconciler) renderAndEmit(
 		ResourceReleaseBinding: binding,
 		Metadata:               metadataCtx,
 		DataPlane:              dpCtx,
+		Environment:            envCtx,
 	}
 
 	output, err := r.Pipeline.RenderManifests(input)
@@ -415,22 +417,6 @@ func buildMetadataContext(
 		Labels:            standardLabels,
 		Annotations:       binding.Annotations,
 	}
-}
-
-// buildDataPlaneContext exposes the dataplane fields the resource pipeline
-// surfaces to CEL templates: secretStore and observabilityPlaneRef.
-func buildDataPlaneContext(dataPlane *openchoreov1alpha1.DataPlane) resourcepipeline.DataPlaneContext {
-	dpCtx := resourcepipeline.DataPlaneContext{}
-	if dataPlane.Spec.SecretStoreRef != nil {
-		dpCtx.SecretStore = dataPlane.Spec.SecretStoreRef.Name
-	}
-	if dataPlane.Spec.ObservabilityPlaneRef != nil {
-		dpCtx.ObservabilityPlaneRef = &resourcepipeline.ObservabilityPlaneRefContext{
-			Kind: string(dataPlane.Spec.ObservabilityPlaneRef.Kind),
-			Name: dataPlane.Spec.ObservabilityPlaneRef.Name,
-		}
-	}
-	return dpCtx
 }
 
 // validateReleaseOwner enforces that the binding and the pinned

--- a/internal/controller/resourcereleasebinding/controller_status.go
+++ b/internal/controller/resourcereleasebinding/controller_status.go
@@ -283,6 +283,7 @@ func buildPipelineInput(
 		Resource:               buildResourceFromRelease(release),
 		ResourceReleaseBinding: binding,
 		Metadata:               buildMetadataContext(binding, environment, dataPlane, resource, project),
-		DataPlane:              buildDataPlaneContext(dataPlane),
+		DataPlane:              resourcepipeline.BuildDataPlaneContext(dataPlane),
+		Environment:            resourcepipeline.BuildEnvironmentContext(environment, dataPlane),
 	}
 }

--- a/internal/pipeline/resource/gateway.go
+++ b/internal/pipeline/resource/gateway.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcepipeline
+
+import "github.com/openchoreo/openchoreo/api/v1alpha1"
+
+// BuildDataPlaneContext extracts the dataplane CEL surface from a
+// v1alpha1.DataPlane CR. Pure function, no controller-runtime imports.
+// Returns a zero-valued context when dataPlane is nil so callers don't have to
+// guard.
+func BuildDataPlaneContext(dataPlane *v1alpha1.DataPlane) DataPlaneContext {
+	if dataPlane == nil {
+		return DataPlaneContext{}
+	}
+	dpCtx := DataPlaneContext{}
+	if dataPlane.Spec.SecretStoreRef != nil {
+		dpCtx.SecretStore = dataPlane.Spec.SecretStoreRef.Name
+	}
+	if dataPlane.Spec.ObservabilityPlaneRef != nil {
+		dpCtx.ObservabilityPlaneRef = &ObservabilityPlaneRefContext{
+			Kind: string(dataPlane.Spec.ObservabilityPlaneRef.Kind),
+			Name: dataPlane.Spec.ObservabilityPlaneRef.Name,
+		}
+	}
+	dpCtx.Gateway = toGatewayData(&dataPlane.Spec.Gateway)
+	return dpCtx
+}
+
+// BuildEnvironmentContext extracts the per-environment CEL surface, merging
+// environment-level gateway overrides with dataplane-level fallbacks at each
+// leaf. Mirrors the component pipeline's mergeGatewayData semantics: ingress
+// and egress merge independently; within each, external and internal endpoints
+// fall back independently. Returns a zero-valued context (no gateway) when
+// both inputs are nil.
+func BuildEnvironmentContext(env *v1alpha1.Environment, dataPlane *v1alpha1.DataPlane) EnvironmentContext {
+	var envGW, dpGW *v1alpha1.GatewaySpec
+	if env != nil {
+		envGW = &env.Spec.Gateway
+	}
+	if dataPlane != nil {
+		dpGW = &dataPlane.Spec.Gateway
+	}
+	return EnvironmentContext{
+		Gateway: mergeGatewayData(envGW, dpGW),
+	}
+}
+
+// toGatewayData converts a v1alpha1.GatewaySpec into the GatewayData shape used
+// in CEL templates. Returns nil when neither ingress nor egress is set so
+// templates can use has(...) guards.
+func toGatewayData(gw *v1alpha1.GatewaySpec) *GatewayData {
+	if gw == nil {
+		return nil
+	}
+	data := &GatewayData{}
+	if gw.Ingress != nil {
+		data.Ingress = toGatewayNetworkData(gw.Ingress)
+	}
+	if gw.Egress != nil {
+		data.Egress = toGatewayNetworkData(gw.Egress)
+	}
+	if data.Ingress == nil && data.Egress == nil {
+		return nil
+	}
+	return data
+}
+
+func toGatewayNetworkData(t *v1alpha1.GatewayNetworkSpec) *GatewayNetworkData {
+	if t == nil {
+		return nil
+	}
+	data := &GatewayNetworkData{}
+	if t.External != nil {
+		data.External = toGatewayEndpointData(t.External)
+	}
+	if t.Internal != nil {
+		data.Internal = toGatewayEndpointData(t.Internal)
+	}
+	if data.External == nil && data.Internal == nil {
+		return nil
+	}
+	return data
+}
+
+func toGatewayEndpointData(e *v1alpha1.GatewayEndpointSpec) *GatewayEndpointData {
+	if e == nil {
+		return nil
+	}
+	data := &GatewayEndpointData{
+		Name:      e.Name,
+		Namespace: e.Namespace,
+	}
+	if e.HTTP != nil {
+		data.HTTP = toGatewayListenerData(e.HTTP)
+	}
+	if e.HTTPS != nil {
+		data.HTTPS = toGatewayListenerData(e.HTTPS)
+	}
+	if e.TLS != nil {
+		data.TLS = toGatewayListenerData(e.TLS)
+	}
+	return data
+}
+
+func toGatewayListenerData(l *v1alpha1.GatewayListenerSpec) *GatewayListenerData {
+	if l == nil {
+		return nil
+	}
+	return &GatewayListenerData{
+		ListenerName: l.ListenerName,
+		Port:         l.Port,
+		Host:         l.Host,
+	}
+}
+
+// mergeGatewayData merges environment-level and dataplane-level gateway specs.
+// Ingress and egress are merged independently, so specifying only one at the
+// environment level still falls back to the dataplane value for the other.
+func mergeGatewayData(envGW, dpGW *v1alpha1.GatewaySpec) *GatewayData {
+	var envIngress, dpIngress *v1alpha1.GatewayNetworkSpec
+	var envEgress, dpEgress *v1alpha1.GatewayNetworkSpec
+
+	if envGW != nil {
+		envIngress = envGW.Ingress
+		envEgress = envGW.Egress
+	}
+	if dpGW != nil {
+		dpIngress = dpGW.Ingress
+		dpEgress = dpGW.Egress
+	}
+
+	data := &GatewayData{
+		Ingress: mergeGatewayNetworkData(envIngress, dpIngress),
+		Egress:  mergeGatewayNetworkData(envEgress, dpEgress),
+	}
+	if data.Ingress == nil && data.Egress == nil {
+		return nil
+	}
+	return data
+}
+
+// mergeGatewayNetworkData merges environment-level and dataplane-level gateway
+// network specs. External and internal endpoints are merged independently,
+// preferring environment values and falling back to dataplane values for any
+// unspecified endpoint.
+func mergeGatewayNetworkData(envNetwork, dpNetwork *v1alpha1.GatewayNetworkSpec) *GatewayNetworkData {
+	if envNetwork == nil && dpNetwork == nil {
+		return nil
+	}
+
+	var envExternal, dpExternal *v1alpha1.GatewayEndpointSpec
+	var envInternal, dpInternal *v1alpha1.GatewayEndpointSpec
+
+	if envNetwork != nil {
+		envExternal = envNetwork.External
+		envInternal = envNetwork.Internal
+	}
+	if dpNetwork != nil {
+		dpExternal = dpNetwork.External
+		dpInternal = dpNetwork.Internal
+	}
+
+	external := envExternal
+	if external == nil {
+		external = dpExternal
+	}
+	internal := envInternal
+	if internal == nil {
+		internal = dpInternal
+	}
+
+	data := &GatewayNetworkData{
+		External: toGatewayEndpointData(external),
+		Internal: toGatewayEndpointData(internal),
+	}
+	if data.External == nil && data.Internal == nil {
+		return nil
+	}
+	return data
+}

--- a/internal/pipeline/resource/gateway_test.go
+++ b/internal/pipeline/resource/gateway_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcepipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// gatewayWithHost is a small fixture builder: builds a v1alpha1.GatewaySpec
+// with a single ingress / external / HTTPS listener carrying host. Used by
+// the merge tests below.
+func gatewayWithHost(name, host string) v1alpha1.GatewaySpec {
+	return v1alpha1.GatewaySpec{
+		Ingress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      name,
+				Namespace: "openchoreo-system",
+				HTTPS: &v1alpha1.GatewayListenerSpec{
+					ListenerName: "https",
+					Port:         443,
+					Host:         host,
+				},
+			},
+		},
+	}
+}
+
+func TestBuildDataPlaneContext(t *testing.T) {
+	t.Run("returns_empty_when_dataplane_is_nil", func(t *testing.T) {
+		got := BuildDataPlaneContext(nil)
+		require.Empty(t, got.SecretStore)
+		require.Nil(t, got.Gateway)
+		require.Nil(t, got.ObservabilityPlaneRef)
+	})
+
+	t.Run("populates_secret_store_and_observability_plane_ref", func(t *testing.T) {
+		dp := &v1alpha1.DataPlane{
+			Spec: v1alpha1.DataPlaneSpec{
+				SecretStoreRef: &v1alpha1.SecretStoreRef{Name: "kind-cluster-store"},
+				ObservabilityPlaneRef: &v1alpha1.ObservabilityPlaneRef{
+					Kind: "ObservabilityPlane",
+					Name: "primary-obs",
+				},
+			},
+		}
+
+		got := BuildDataPlaneContext(dp)
+		require.Equal(t, "kind-cluster-store", got.SecretStore)
+		require.NotNil(t, got.ObservabilityPlaneRef)
+		require.Equal(t, "ObservabilityPlane", got.ObservabilityPlaneRef.Kind)
+		require.Equal(t, "primary-obs", got.ObservabilityPlaneRef.Name)
+	})
+
+	t.Run("populates_gateway_from_dataplane_spec", func(t *testing.T) {
+		dp := &v1alpha1.DataPlane{
+			Spec: v1alpha1.DataPlaneSpec{
+				Gateway: gatewayWithHost("dp-gateway", "*.dp.example.com"),
+			},
+		}
+
+		got := BuildDataPlaneContext(dp)
+		require.NotNil(t, got.Gateway)
+		require.NotNil(t, got.Gateway.Ingress)
+		require.NotNil(t, got.Gateway.Ingress.External)
+		require.NotNil(t, got.Gateway.Ingress.External.HTTPS)
+		require.Equal(t, "*.dp.example.com", got.Gateway.Ingress.External.HTTPS.Host)
+		require.EqualValues(t, 443, got.Gateway.Ingress.External.HTTPS.Port)
+		require.Equal(t, "dp-gateway", got.Gateway.Ingress.External.Name)
+	})
+
+	t.Run("gateway_nil_when_dataplane_has_no_gateway", func(t *testing.T) {
+		// A DataPlane with no ingress and no egress yields a nil Gateway so
+		// templates can guard with has(dataplane.gateway).
+		dp := &v1alpha1.DataPlane{Spec: v1alpha1.DataPlaneSpec{}}
+		got := BuildDataPlaneContext(dp)
+		require.Nil(t, got.Gateway)
+	})
+}
+
+func TestBuildEnvironmentContext(t *testing.T) {
+	t.Run("returns_empty_when_both_inputs_nil", func(t *testing.T) {
+		got := BuildEnvironmentContext(nil, nil)
+		require.Nil(t, got.Gateway)
+	})
+
+	t.Run("uses_dataplane_gateway_when_env_unset", func(t *testing.T) {
+		dp := &v1alpha1.DataPlane{
+			Spec: v1alpha1.DataPlaneSpec{
+				Gateway: gatewayWithHost("dp-gateway", "*.dp.example.com"),
+			},
+		}
+		env := &v1alpha1.Environment{}
+
+		got := BuildEnvironmentContext(env, dp)
+		require.NotNil(t, got.Gateway)
+		require.Equal(t, "*.dp.example.com", got.Gateway.Ingress.External.HTTPS.Host)
+	})
+
+	t.Run("env_gateway_overrides_dataplane_at_external_dimension", func(t *testing.T) {
+		dp := &v1alpha1.DataPlane{
+			Spec: v1alpha1.DataPlaneSpec{
+				Gateway: gatewayWithHost("dp-gateway", "*.dp.example.com"),
+			},
+		}
+		env := &v1alpha1.Environment{
+			Spec: v1alpha1.EnvironmentSpec{
+				Gateway: gatewayWithHost("env-gateway", "*.dev.example.com"),
+			},
+		}
+
+		got := BuildEnvironmentContext(env, dp)
+		require.NotNil(t, got.Gateway)
+		require.Equal(t, "*.dev.example.com", got.Gateway.Ingress.External.HTTPS.Host)
+		require.Equal(t, "env-gateway", got.Gateway.Ingress.External.Name)
+	})
+
+	t.Run("env_internal_falls_back_to_dataplane_when_env_only_sets_external", func(t *testing.T) {
+		// Locks the merge granularity: when env sets only external, dp's
+		// internal must come through. Mirrors mergeGatewayNetworkData's
+		// per-endpoint fallback.
+		dp := &v1alpha1.DataPlane{
+			Spec: v1alpha1.DataPlaneSpec{
+				Gateway: v1alpha1.GatewaySpec{
+					Ingress: &v1alpha1.GatewayNetworkSpec{
+						External: &v1alpha1.GatewayEndpointSpec{
+							Name: "dp-external",
+							HTTPS: &v1alpha1.GatewayListenerSpec{
+								Port: 443,
+								Host: "*.dp.example.com",
+							},
+						},
+						Internal: &v1alpha1.GatewayEndpointSpec{
+							Name: "dp-internal",
+							HTTP: &v1alpha1.GatewayListenerSpec{
+								Port: 80,
+								Host: "internal.dp.svc",
+							},
+						},
+					},
+				},
+			},
+		}
+		env := &v1alpha1.Environment{
+			Spec: v1alpha1.EnvironmentSpec{
+				Gateway: v1alpha1.GatewaySpec{
+					Ingress: &v1alpha1.GatewayNetworkSpec{
+						External: &v1alpha1.GatewayEndpointSpec{
+							Name: "env-external",
+							HTTPS: &v1alpha1.GatewayListenerSpec{
+								Port: 443,
+								Host: "*.dev.example.com",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		got := BuildEnvironmentContext(env, dp)
+		require.NotNil(t, got.Gateway)
+		require.NotNil(t, got.Gateway.Ingress)
+		require.NotNil(t, got.Gateway.Ingress.External)
+		require.Equal(t, "*.dev.example.com", got.Gateway.Ingress.External.HTTPS.Host)
+		require.Equal(t, "env-external", got.Gateway.Ingress.External.Name)
+		require.NotNil(t, got.Gateway.Ingress.Internal)
+		require.Equal(t, "internal.dp.svc", got.Gateway.Ingress.Internal.HTTP.Host)
+		require.Equal(t, "dp-internal", got.Gateway.Ingress.Internal.Name)
+	})
+
+	t.Run("env_egress_falls_back_to_dataplane_when_env_only_sets_ingress", func(t *testing.T) {
+		// Top-level ingress/egress merge independently: env-only ingress
+		// must not erase dp-side egress.
+		dp := &v1alpha1.DataPlane{
+			Spec: v1alpha1.DataPlaneSpec{
+				Gateway: v1alpha1.GatewaySpec{
+					Ingress: &v1alpha1.GatewayNetworkSpec{
+						External: &v1alpha1.GatewayEndpointSpec{
+							Name: "dp-ingress",
+						},
+					},
+					Egress: &v1alpha1.GatewayNetworkSpec{
+						External: &v1alpha1.GatewayEndpointSpec{
+							Name: "dp-egress",
+						},
+					},
+				},
+			},
+		}
+		env := &v1alpha1.Environment{
+			Spec: v1alpha1.EnvironmentSpec{
+				Gateway: v1alpha1.GatewaySpec{
+					Ingress: &v1alpha1.GatewayNetworkSpec{
+						External: &v1alpha1.GatewayEndpointSpec{
+							Name: "env-ingress",
+						},
+					},
+				},
+			},
+		}
+
+		got := BuildEnvironmentContext(env, dp)
+		require.NotNil(t, got.Gateway)
+		require.NotNil(t, got.Gateway.Ingress)
+		require.Equal(t, "env-ingress", got.Gateway.Ingress.External.Name)
+		require.NotNil(t, got.Gateway.Egress)
+		require.Equal(t, "dp-egress", got.Gateway.Egress.External.Name)
+	})
+}

--- a/internal/pipeline/resource/pipeline.go
+++ b/internal/pipeline/resource/pipeline.go
@@ -332,6 +332,8 @@ func buildBaseContext(input *RenderInput) (map[string]any, error) {
 		Parameters:         parameters,
 		EnvironmentConfigs: envConfigs,
 		DataPlane:          input.DataPlane,
+		Environment:        input.Environment,
+		Gateway:            input.Environment.Gateway,
 	})
 }
 

--- a/internal/pipeline/resource/pipeline_test.go
+++ b/internal/pipeline/resource/pipeline_test.go
@@ -228,6 +228,150 @@ func TestRenderManifests(t *testing.T) {
 		})
 	})
 
+	t.Run("exposes_gateway_surface", func(t *testing.T) {
+		// Three CEL paths reach the gateway: ${dataplane.gateway.*} is the raw
+		// DP gateway, ${environment.gateway.*} is the env-or-dp merged value,
+		// and top-level ${gateway.*} is shorthand for the merged value.
+
+		dpGateway := &GatewayData{
+			Ingress: &GatewayNetworkData{
+				External: &GatewayEndpointData{
+					Name:      "dp-gateway",
+					Namespace: "openchoreo-system",
+					HTTPS: &GatewayListenerData{
+						ListenerName: "https",
+						Port:         443,
+						Host:         "*.dp.example.com",
+					},
+				},
+			},
+		}
+		envGateway := &GatewayData{
+			Ingress: &GatewayNetworkData{
+				External: &GatewayEndpointData{
+					Name:      "env-gateway",
+					Namespace: "openchoreo-system",
+					HTTPS: &GatewayListenerData{
+						ListenerName: "https",
+						Port:         443,
+						Host:         "*.dev.example.com",
+					},
+				},
+			},
+		}
+
+		t.Run("dataplane_gateway_returns_raw_dp_value", func(t *testing.T) {
+			// dataplane.gateway is the raw DP value, unaffected by env overrides.
+			input := renderSingle(t,
+				rawExt(t, map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Probe",
+					"host":       "${dataplane.gateway.ingress.external.https.host}",
+				}),
+				func(in *RenderInput) {
+					in.DataPlane = DataPlaneContext{Gateway: dpGateway}
+					in.Environment = EnvironmentContext{Gateway: envGateway}
+				},
+			)
+
+			got, err := NewPipeline().RenderManifests(input)
+			require.NoError(t, err)
+			require.Equal(t, "*.dp.example.com", got.Entries[0].Object["host"])
+		})
+
+		t.Run("environment_gateway_returns_merged_value", func(t *testing.T) {
+			// environment.gateway is the merged (env-or-dp) value. With both set,
+			// env wins.
+			input := renderSingle(t,
+				rawExt(t, map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Probe",
+					"host":       "${environment.gateway.ingress.external.https.host}",
+				}),
+				func(in *RenderInput) {
+					in.DataPlane = DataPlaneContext{Gateway: dpGateway}
+					in.Environment = EnvironmentContext{Gateway: envGateway}
+				},
+			)
+
+			got, err := NewPipeline().RenderManifests(input)
+			require.NoError(t, err)
+			require.Equal(t, "*.dev.example.com", got.Entries[0].Object["host"])
+		})
+
+		t.Run("top_level_gateway_aliases_environment_gateway", func(t *testing.T) {
+			// ${gateway.*} is shorthand for ${environment.gateway.*}: same merged
+			// value. Locks the alias contract.
+			input := renderSingle(t,
+				rawExt(t, map[string]any{
+					"apiVersion":  "v1",
+					"kind":        "Probe",
+					"host":        "${gateway.ingress.external.https.host}",
+					"port":        "${gateway.ingress.external.https.port}",
+					"endpointRef": "${gateway.ingress.external.name}",
+				}),
+				func(in *RenderInput) {
+					in.DataPlane = DataPlaneContext{Gateway: dpGateway}
+					in.Environment = EnvironmentContext{Gateway: envGateway}
+				},
+			)
+
+			got, err := NewPipeline().RenderManifests(input)
+			require.NoError(t, err)
+			require.Equal(t, "*.dev.example.com", got.Entries[0].Object["host"])
+			require.EqualValues(t, 443, got.Entries[0].Object["port"])
+			require.Equal(t, "env-gateway", got.Entries[0].Object["endpointRef"])
+		})
+
+		t.Run("environment_gateway_falls_back_to_dataplane_when_unset", func(t *testing.T) {
+			// When the binding controller's BuildEnvironmentContext merges a nil
+			// env gateway with a populated DP gateway, environment.gateway and
+			// top-level gateway both surface the DP values.
+			input := renderSingle(t,
+				rawExt(t, map[string]any{
+					"apiVersion":      "v1",
+					"kind":            "Probe",
+					"envHost":         "${environment.gateway.ingress.external.https.host}",
+					"effectiveHost":   "${gateway.ingress.external.https.host}",
+					"dataPlaneHostDP": "${dataplane.gateway.ingress.external.https.host}",
+				}),
+				func(in *RenderInput) {
+					// Simulate the merged result the controller produces when
+					// env has no gateway: Environment.Gateway points at the DP
+					// gateway data directly.
+					in.DataPlane = DataPlaneContext{Gateway: dpGateway}
+					in.Environment = EnvironmentContext{Gateway: dpGateway}
+				},
+			)
+
+			got, err := NewPipeline().RenderManifests(input)
+			require.NoError(t, err)
+			require.Equal(t, "*.dp.example.com", got.Entries[0].Object["envHost"])
+			require.Equal(t, "*.dp.example.com", got.Entries[0].Object["effectiveHost"])
+			require.Equal(t, "*.dp.example.com", got.Entries[0].Object["dataPlaneHostDP"])
+		})
+
+		t.Run("gateway_absent_guarded_by_has_on_field_access", func(t *testing.T) {
+			// CEL's has() macro guards field selections, not bare identifiers,
+			// so the guard idiom is has(dataplane.gateway) /
+			// has(environment.gateway) — not has(gateway). When both env and dp
+			// lack a gateway, both guards return false. The top-level shortcut
+			// ${gateway.*} requires a populated gateway and should be wrapped
+			// in has(environment.gateway) when it might be absent.
+			input := renderSingle(t, rawExt(t, map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Probe",
+				"dpHost":     `${has(dataplane.gateway) ? dataplane.gateway.ingress.external.https.host : "no-dp-gateway"}`,
+				"envHost":    `${has(environment.gateway) ? environment.gateway.ingress.external.https.host : "no-env-gateway"}`,
+			}))
+
+			got, err := NewPipeline().RenderManifests(input)
+			require.NoError(t, err)
+			require.Equal(t, "no-dp-gateway", got.Entries[0].Object["dpHost"])
+			require.Equal(t, "no-env-gateway", got.Entries[0].Object["envHost"])
+		})
+	})
+
 	t.Run("applies_parameter_defaults_from_schema", func(t *testing.T) {
 		input := renderSingle(t, rawExt(t, map[string]any{
 			"apiVersion": "v1",

--- a/internal/pipeline/resource/types.go
+++ b/internal/pipeline/resource/types.go
@@ -45,6 +45,12 @@ type RenderInput struct {
 	// DataPlane is the controller-computed dataplane surface exposed to CEL
 	// as ${dataplane.*}.
 	DataPlane DataPlaneContext
+
+	// Environment is the controller-computed per-environment surface
+	// exposed to CEL as ${environment.*}. Gateway carries the merged
+	// effective gateway (environment-or-dataplane fallback at each leaf)
+	// for templates that emit HTTPRoute / Ingress resources.
+	Environment EnvironmentContext
 }
 
 // RenderOutput carries the rendered manifests in spec order.
@@ -118,23 +124,67 @@ type MetadataContext struct {
 }
 
 // DataPlaneContext is the dataplane surface exposed to CEL templates as
-// ${dataplane.*}. The surface is deliberately narrow — only the fields
-// managed-infra ResourceTypes commonly need; gateway and networking surface
-// is intentionally omitted. Optional fields use omitempty so templates can
-// guard with has(...) — mirrors the component pipeline's contract.
+// ${dataplane.*}. Optional fields use omitempty so templates can guard with
+// has(...) — mirrors the component pipeline's contract.
 type DataPlaneContext struct {
 	// SecretStore is the name of the ESO ClusterSecretStore configured on
 	// the DataPlane. ResourceTypes emitting ExternalSecret reference this.
 	SecretStore string `json:"secretStore,omitempty"`
+
+	// Gateway is the raw DataPlane-level gateway configuration. Templates
+	// emitting HTTPRoute / Ingress against the DP gateway reference it via
+	// ${dataplane.gateway.ingress.external.https.host} etc. Nil when the
+	// DataPlane has no gateway configured. The effective gateway used by
+	// most templates is the merged Environment-or-DataPlane value exposed
+	// at the top-level ${gateway.*} and on ${environment.gateway.*}.
+	Gateway *GatewayData `json:"gateway,omitempty"`
 
 	// ObservabilityPlaneRef is the observability plane reference for
 	// ResourceTypes that emit observability-plane-side resources (alert
 	// rules, dashboards). Optional; nil when the DataPlane has no
 	// observability plane configured. PE templates that reference
 	// ${dataplane.observabilityPlaneRef.*} must guard with
-	// has(dataplane.observabilityPlaneRef) — same convention as
-	// dataplane.gateway in the component pipeline.
+	// has(dataplane.observabilityPlaneRef).
 	ObservabilityPlaneRef *ObservabilityPlaneRefContext `json:"observabilityPlaneRef,omitempty"`
+}
+
+// EnvironmentContext is the per-environment surface exposed to CEL templates
+// as ${environment.*}. Gateway carries the merged effective gateway:
+// environment-level overrides take precedence, falling back to dataplane-level
+// values at each leaf. Mirrors the component pipeline's EnvironmentData
+// (the resource side omits DefaultNotificationChannel — that field is
+// alert-routing-specific and not relevant to the managed-infra surface).
+type EnvironmentContext struct {
+	Gateway *GatewayData `json:"gateway,omitempty"`
+}
+
+// GatewayData provides gateway configuration in templates.
+type GatewayData struct {
+	Ingress *GatewayNetworkData `json:"ingress,omitempty"`
+	Egress  *GatewayNetworkData `json:"egress,omitempty"`
+}
+
+// GatewayNetworkData provides traffic gateway data for ingress/egress in
+// templates.
+type GatewayNetworkData struct {
+	External *GatewayEndpointData `json:"external,omitempty"`
+	Internal *GatewayEndpointData `json:"internal,omitempty"`
+}
+
+// GatewayEndpointData provides endpoint data for a gateway in templates.
+type GatewayEndpointData struct {
+	Name      string               `json:"name,omitempty"`
+	Namespace string               `json:"namespace,omitempty"`
+	HTTP      *GatewayListenerData `json:"http,omitempty"`
+	HTTPS     *GatewayListenerData `json:"https,omitempty"`
+	TLS       *GatewayListenerData `json:"tls,omitempty"`
+}
+
+// GatewayListenerData provides listener data for a gateway in templates.
+type GatewayListenerData struct {
+	ListenerName string `json:"listenerName,omitempty"`
+	Port         int32  `json:"port,omitempty"`
+	Host         string `json:"host,omitempty"`
 }
 
 // ObservabilityPlaneRefContext is the {kind, name} reference exposed under
@@ -151,8 +201,18 @@ type ObservabilityPlaneRefContext struct {
 // CEL surface — validation reflects on BaseContext to declare CEL variables;
 // the pipeline JSON-marshals it via structToMap for runtime evaluation.
 type BaseContext struct {
-	Metadata           MetadataContext  `json:"metadata"`
-	Parameters         map[string]any   `json:"parameters"`
-	EnvironmentConfigs map[string]any   `json:"environmentConfigs"`
-	DataPlane          DataPlaneContext `json:"dataplane"`
+	Metadata           MetadataContext    `json:"metadata"`
+	Parameters         map[string]any     `json:"parameters"`
+	EnvironmentConfigs map[string]any     `json:"environmentConfigs"`
+	DataPlane          DataPlaneContext   `json:"dataplane"`
+	Environment        EnvironmentContext `json:"environment"`
+	// Gateway is the effective gateway (Environment.Gateway, which itself
+	// is env-or-dp merged) exposed at the top level for terseness:
+	// ${gateway.ingress.external.https.host} is identical to
+	// ${environment.gateway.ingress.external.https.host}.
+	//
+	// Templates that may evaluate against a missing gateway must guard via
+	// has(environment.gateway) — has(gateway) is invalid CEL because the
+	// top-level alias is omitted from the marshaled map when nil.
+	Gateway *GatewayData `json:"gateway,omitempty"`
 }

--- a/internal/validation/resource/cel_env_test.go
+++ b/internal/validation/resource/cel_env_test.go
@@ -135,8 +135,65 @@ func TestBuildResourceCELEnv_DataPlaneFields(t *testing.T) {
 	}
 
 	rejected := []string{
-		"dataplane.gateway",
 		"dataplane.observabilityPlaneRef.unknown",
+	}
+	for _, expr := range rejected {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			require.NotNil(t, issues)
+			assert.NotNil(t, issues.Err(), "expr %q should fail", expr)
+		})
+	}
+}
+
+// Gateway surface mirrors the component pipeline: dataplane.gateway is the raw
+// DP value, environment.gateway is the env-or-dp merged value, top-level
+// gateway is an alias for environment.gateway. All three are exposed at the
+// validation level so a ResourceType template can reference them without
+// admission rejection.
+func TestBuildResourceCELEnv_GatewayFields(t *testing.T) {
+	env, err := buildResourceCELEnv(SchemaOptions{})
+	require.NoError(t, err)
+
+	okExprs := []string{
+		// dataplane.gateway.* — raw DP gateway
+		"dataplane.gateway.ingress.external.https.host",
+		"dataplane.gateway.ingress.external.https.port",
+		"dataplane.gateway.ingress.external.https.listenerName",
+		"dataplane.gateway.ingress.external.http.host",
+		"dataplane.gateway.ingress.external.tls.host",
+		"dataplane.gateway.ingress.external.name",
+		"dataplane.gateway.ingress.external.namespace",
+		"dataplane.gateway.ingress.internal.https.host",
+		"dataplane.gateway.egress.external.https.host",
+
+		// environment.gateway.* — env-or-dp merged
+		"environment.gateway.ingress.external.https.host",
+		"environment.gateway.ingress.internal.https.host",
+		"environment.gateway.egress.external.https.host",
+
+		// top-level gateway — alias for environment.gateway
+		"gateway.ingress.external.https.host",
+		"gateway.ingress.external.https.port",
+		"gateway.ingress.internal.https.host",
+		"gateway.egress.external.https.host",
+
+		// has() guards must compile on the gateway field-access positions.
+		"has(dataplane.gateway)",
+		"has(environment.gateway)",
+		"has(gateway.ingress)",
+	}
+	for _, expr := range okExprs {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			assert.Nil(t, issues.Err(), "expr %q should compile", expr)
+		})
+	}
+
+	rejected := []string{
+		"dataplane.gateway.unknown",
+		"environment.gateway.unknown",
+		"gateway.unknown",
 	}
 	for _, expr := range rejected {
 		t.Run(expr, func(t *testing.T) {


### PR DESCRIPTION
## Purpose

The Resource pipeline's CEL context exposed only `dataplane.secretStore` and `dataplane.observabilityPlaneRef.*` — gateway info was deliberately excluded. That blocks ResourceTypes from emitting `HTTPRoute` / `Ingress` resources against the platform's gateway (e.g. admin UIs for managed infrastructure).

This PR adds the missing surface, mirroring what the Component pipeline already exposes.

## Approach

- Add a three-layer gateway CEL surface mirroring the component pipeline:
  - `${dataplane.gateway.*}` — raw data plane gateway
  - `${environment.gateway.*}` — env-or-dp merged
  - `${gateway.*}` — effective (alias for `environment.gateway`)
- Expose `BuildDataPlaneContext` and `BuildEnvironmentContext` helpers from `internal/pipeline/resource/` so the binding controller can build the context cleanly
- Validation env auto-picks up the new fields via reflection on `BaseContext` — no manual registration needed

## Related Issues

Closes #3513.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)