### PR TITLE
feat(helm): enable secretManagement in k3d single-cluster

### DIFF
--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -27,3 +27,7 @@ gateway:
   httpsPort: 8443
   tls:
     enabled: false
+
+features:
+  secretManagement:
+    enabled: true


### PR DESCRIPTION
## Purpose

Turn on the Secret management feature flag for the k3d single-cluster setup so the Secret management API on the openchoreo-api server and the corresponding Backstage UI are available out of the box when developers spin up a local cluster.

## Approach

- Set `features.secretManagement.enabled: true` in `install/k3d/single-cluster/values-cp.yaml`.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)