### PR TITLE
refactor: fine-tune finops agent prompts and fix logical vs kubernetes name mismatch

### DIFF
--- a/finops-agent/src/models/finops_report.py
+++ b/finops-agent/src/models/finops_report.py
@@ -59,7 +59,7 @@ class CostBreakdown(BaseModel):
     )
     breakdown_source: str = Field(
         ...,
-        description="How breakdown was obtained (e.g. 'opencost_allocation', 'estimated_from_usage_ratio', 'unavailable')",
+        description="How breakdown was obtained (e.g. 'cost_backend_allocation', 'estimated_from_usage_ratio', 'unavailable')",
     )
 
 

--- a/finops-agent/src/templates/api/finops_request.j2
+++ b/finops-agent/src/templates/api/finops_request.j2
@@ -18,6 +18,6 @@ Analyze the following component that has exceeded its budget:
 
 Please investigate this budget overrun by:
 1. Querying resource metrics (CPU and memory requests, limits, and actual usage) for this component over the budget period ({{ budgeted_cost.period }})
-2. Querying cost allocation data from OpenCost for this component
+2. Querying cost allocation data from the cost analytics backend for this component
 3. Analyzing whether the component is overprovisioned
 4. Providing optimization recommendations if applicable

--- a/finops-agent/src/templates/prompts/finops_agent_prompt.j2
+++ b/finops-agent/src/templates/prompts/finops_agent_prompt.j2
@@ -4,7 +4,7 @@ You are a FinOps analysis agent for OpenChoreo. Your task is to analyze componen
 
 Given a component that has triggered a budget alert, you must:
 1. Query resource metrics (CPU/memory requests, limits, and actual usage) from the Observability MCP server
-2. Query cost allocation data from the OpenCost MCP server
+2. Query cost allocation data from the cost analytics MCP server
 3. Compare actual resource usage against configured requests/limits to determine overprovisioning
 4. Compare actual cost against budgeted cost
 5. If overprovisioned, calculate recommended CPU/memory requests and limits based on actual usage (P95 + safety headroom)
@@ -24,7 +24,7 @@ Given a component that has triggered a budget alert, you must:
 - Use human-readable units: `m` for CPU millicores, `Mi`/`Gi` for memory
 
 ### Cost Analysis
-- Query cost data from OpenCost for the specific component
+- Query cost data from the cost analytics backend for the specific component
 - Break down costs by CPU and memory
 - Compare against the budgeted amount
 - **IMPORTANT**: In your final report, BOTH `budgeted_cost` and `actual_cost` must include:
@@ -33,8 +33,8 @@ Given a component that has triggered a budget alert, you must:
   - `total_cost`: The sum of cpu_cost and memory_cost
   - `currency`: The currency code (e.g., "USD")
   - `is_estimated`: A boolean set to false (estimation from usage ratios is not permitted)
-  - `breakdown_source`: A string describing how the breakdown was obtained (e.g., "opencost_allocation", "unavailable")
-- **If OpenCost tools provide separate CPU/memory cost values**: use those directly and set `is_estimated: false`, `breakdown_source: "opencost_allocation"`
+  - `breakdown_source`: A string describing how the breakdown was obtained (e.g., "cost_backend_allocation", "unavailable")
+- **If cost tools provide separate CPU/memory cost values**: use those directly and set `is_estimated: false`, `breakdown_source: "cost_backend_allocation"`
 - **If per-resource costs are unavailable**: set `cpu_cost` and `memory_cost` to null, `is_estimated: false`, and `breakdown_source: "unavailable"`
   - Do NOT attempt to derive CPU/memory cost breakdown from usage ratios, as these use incompatible units (millicores vs bytes)
   - Set total_cost to the total value provided by tools, or null if unavailable
@@ -63,7 +63,7 @@ Your final FinOpsReport MUST include properly structured cost breakdowns:
   - `total_cost` (float): sum of cpu_cost and memory_cost (or total budgeted cost if breakdown unavailable)
   - `currency` (string): e.g., "USD"
   - `is_estimated` (boolean): false (estimation from usage ratios is not permitted)
-  - `breakdown_source` (string): how breakdown was obtained (e.g., "opencost_allocation", "unavailable")
+  - `breakdown_source` (string): how breakdown was obtained (e.g., "cost_backend_allocation", "unavailable")
 
 - `actual_cost` must be a CostBreakdown with all required fields:
   - `cpu_cost` (float or null): actual CPU cost, or null if unavailable
@@ -71,9 +71,9 @@ Your final FinOpsReport MUST include properly structured cost breakdowns:
   - `total_cost` (float): sum of cpu_cost and memory_cost (or total actual cost if breakdown unavailable)
   - `currency` (string): e.g., "USD"
   - `is_estimated` (boolean): false (estimation from usage ratios is not permitted)
-  - `breakdown_source` (string): how breakdown was obtained (e.g., "opencost_allocation", "unavailable")
+  - `breakdown_source` (string): how breakdown was obtained (e.g., "cost_backend_allocation", "unavailable")
 
-Example (with per-resource costs from OpenCost):
+Example (with per-resource costs from the cost analytics backend):
 ```json
 {
   "budgeted_cost": {
@@ -82,7 +82,7 @@ Example (with per-resource costs from OpenCost):
     "total_cost": 100.0,
     "currency": "USD",
     "is_estimated": false,
-    "breakdown_source": "opencost_allocation"
+    "breakdown_source": "cost_backend_allocation"
   },
   "actual_cost": {
     "cpu_cost": 90.0,
@@ -90,7 +90,7 @@ Example (with per-resource costs from OpenCost):
     "total_cost": 150.0,
     "currency": "USD",
     "is_estimated": false,
-    "breakdown_source": "opencost_allocation"
+    "breakdown_source": "cost_backend_allocation"
   }
 }
 ```
@@ -126,9 +126,9 @@ Example (when per-resource costs unavailable):
 - **Avoid redundant calls**: Do NOT call the same tool with the same or very similar parameters multiple times. If you have already received data from a tool, use that data rather than re-querying.
 - **Parallel tool calls**: When you need data from multiple independent tools, call them ALL in parallel in a single response rather than sequentially. In your FIRST response, call all the tools you need at once (e.g., query_resource_metrics, get_allocation_costs, and get_efficiency together). This minimizes the number of model iterations.
 
-### OpenCost Filter Syntax
+### Cost Backend Filter Syntax
 
-The OpenCost tools (`get_allocation_costs`, `get_efficiency`, `get_asset_costs`, `get_cloud_costs`) use a specific filter syntax. You **must** follow these rules exactly:
+The cost analytics tools (`get_allocation_costs`, `get_efficiency`, `get_asset_costs`, `get_cloud_costs`) use a specific filter syntax. You **must** follow these rules exactly:
 
 - **Format**: `field:"value"` — field name, colon, then value in **double quotes**
 - **AND** (all conditions must match): use `+` between conditions
@@ -139,30 +139,45 @@ The OpenCost tools (`get_allocation_costs`, `get_efficiency`, `get_asset_costs`,
 
 **Valid allocation filter field names**: `cluster`, `node`, `namespace`, `controllerName`, `controllerKind`, `container`, `pod`, `services`, `label`, `annotation`, `provider`, `account`, `department`, `environment`, `owner`, `product`, `team`
 
-> **Note**: Use `controllerName` (not `controller`) to filter by deployment/statefulset/etc. name.
+> **Note**: Use `controllerName` (not `controller`) to filter by deployment/statefulset/etc. name. Label and annotation filters use `label[key]:"value"` / `annotation[key]:"value"` syntax.
 
-**Examples**:
+#### Identifying OpenChoreo workloads in the cost backend
+
+**Critical**: The `namespace` and `component` values you receive in the request are OpenChoreo **logical** identifiers. They are NOT the in-cluster Kubernetes namespace or controller name.
+
+- The actual Kubernetes namespace is a generated dataplane namespace like `dp-<namespace>-<project>-<environment>-<hash>` (e.g. `dp-default-gcp-microserv-development-4b8b4fdc`).
+- The actual controller name is suffixed and hashed, like `<component>-<environment>-<hash>` (e.g. `redis-development-a9ac0a37`).
+
+You cannot derive these in-cluster names from the logical identifiers — the hashes are not deterministic. **Do not** filter the cost backend by `namespace:"<logical-namespace>"` or `controllerName:"<component>"`; those filters will return empty results.
+
+Instead, filter by the OpenChoreo labels that the platform stamps onto every pod. The cost backend normalizes label keys (`.` and `-` become `_`), so use these keys:
+
+| Request field | Pod label key                  |
+|---------------|--------------------------------|
+| `namespace`   | `openchoreo_dev_namespace`     |
+| `project`     | `openchoreo_dev_project`       |
+| `environment` | `openchoreo_dev_environment`   |
+| `component`   | `openchoreo_dev_component`     |
+
+**Examples** (use these patterns for `get_allocation_costs` and `get_efficiency`):
 ```
-# Filter by namespace
-namespace:"default"
+# Identify a specific OpenChoreo component (preferred)
+label[openchoreo_dev_namespace]:"default"+label[openchoreo_dev_project]:"gcp-microservice-demo"+label[openchoreo_dev_environment]:"development"+label[openchoreo_dev_component]:"redis"
 
-# Filter by namespace AND controller name
-namespace:"default"+controllerName:"my-service"
-
-# Filter by namespace with multiple values
-namespace:"default","production"
-
-# Filter by namespace AND controller kind AND controller name
-namespace:"default"+controllerKind:"deployment"+controllerName:"my-service"
+# All components in a project/environment
+label[openchoreo_dev_project]:"gcp-microservice-demo"+label[openchoreo_dev_environment]:"development"
 ```
+
+When aggregating allocation results, aggregate by `label:openchoreo_dev_component` (or `controller`) to get one row per component.
 
 **Common mistakes to avoid**:
 - ✗ `namespace:default` — value must be in double quotes
 - ✗ `namespace="default"` — use `:` not `=`
 - ✗ `namespace:"default",controllerName:"svc"` — use `+` not `,` to combine different fields
 - ✗ `controller:"my-service"` — use `controllerName` not `controller`
+- ✗ `namespace:"<logical-namespace>"+controllerName:"<component>"` — these are OpenChoreo logical names, not Kubernetes names; use `label[openchoreo_dev_*]` filters instead
 
-**OpenCost parameter rules**:
+**Cost backend parameter rules**:
 - When setting `include_proportional_asset_resource_costs` to `true`, you **MUST** also set `include_idle` to `true` — otherwise the API will reject the request
 
 ## Handling Missing or Unavailable Data
@@ -175,7 +190,7 @@ namespace:"default"+controllerKind:"deployment"+controllerName:"my-service"
 ## Critical Constraints
 
 - **Use only data from tools** — never fabricate metrics, costs, or recommendations; do NOT estimate cpu_cost/memory_cost breakdown from usage ratios (incompatible units); when per-resource costs are unavailable, set them to null with `is_estimated: false` and `breakdown_source: "unavailable"`
-- **Scope enforcement** — only query data for the specified namespace/project/component
+- **Scope enforcement** — only query data for the specified namespace/project/component. For cost backend queries, the request's `namespace`/`project`/`environment`/`component` are OpenChoreo logical identifiers and must be applied via `label[openchoreo_dev_*]` filters (see "Identifying OpenChoreo workloads in the cost backend"), not via raw `namespace:`/`controllerName:` filters.
 - **Human-readable units** — use Mi, Gi for memory; m for CPU millicores; percentages for utilization
 - **ISO 8601 timestamps** — use ISO 8601 format for all timestamps
 - **Complete cost breakdowns** — ALWAYS provide CostBreakdown objects with cpu_cost, memory_cost, total_cost, currency, is_estimated, and breakdown_source fields


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The FinOps agent's cost-overrun reports kept emitting "Estimated savings could not be quantified because OpenCost did not return per-resource component cost data." Root cause: the agent's prompt told it to filter OpenCost by
  namespace:"<logical-ns>"+controllerName:"<component>", but OpenChoreo deploys workloads into generated dataplane namespaces (dp-ns-project-env-hash) under hashed controller names (component-env-hash), so those filters always matched zero allocations. The prompt also baked the backend name "OpenCost" into instructions and report fields, making it difficult to use a different finops module

## Approach
- Added an "Identifying OpenChoreo workloads in the cost backend" section to finops_agent_prompt.j2 that explains the logical-vs-Kubernetes naming mismatch and directs the model to filter by the openchoreo.dev/* pod labels (key-normalized:
  openchoreo_dev_namespace, openchoreo_dev_project, openchoreo_dev_environment, openchoreo_dev_component) via label[...]:"value" syntax, with worked examples.
- Replaced the misleading controllerName:"<component>" example and added the failing pattern to the "Common mistakes" list; updated the scope-enforcement constraint to match.
- Genericized backend-specific wording across the prompt, the API request template, and the report model. 

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3356

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
