### PR TITLE
fix: guard embedded trait envConfigs CEL bindings against missing keys

### DIFF
--- a/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+++ b/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
@@ -263,8 +263,8 @@ spec:
         targetCPUUtilizationPercentage: 75
       # Wire environment-specific overrides (only for replica counts)
       environmentConfigs:
-        minReplicas: ${environmentConfigs.autoscaling.minReplicas}
-        maxReplicas: ${environmentConfigs.autoscaling.maxReplicas}
+        minReplicas: "${has(environmentConfigs.autoscaling) ? environmentConfigs.autoscaling.minReplicas : parameters.autoscaling.minReplicas}"
+        maxReplicas: "${has(environmentConfigs.autoscaling) ? environmentConfigs.autoscaling.maxReplicas : parameters.autoscaling.maxReplicas}"
 
   resources:
     - id: deployment


### PR DESCRIPTION
$subject