### PR TITLE
feat: ship default postgres, valkey, and nats ClusterResourceTypes

### DIFF
--- a/config/samples/openchoreo_v1alpha1_clusterresourcetype.yaml
+++ b/config/samples/openchoreo_v1alpha1_clusterresourcetype.yaml
@@ -8,26 +8,62 @@ metadata:
 spec:
   parameters:
     openAPIV3Schema:
-      version: "string | default=8.0"
+      type: object
+      properties:
+        image:
+          type: string
+          default: nginx:1.27-alpine
   environmentConfigs:
     openAPIV3Schema:
-      storageGB: "integer | default=8"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
   retainPolicy: Delete
   outputs:
-    host:
-      value: "${applied.claim.status.host}"
-    password:
-      secretKeyRef:
-        name: "${metadata.resourceName}-conn"
-        key: password
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "80"
   resources:
-    - id: claim
+    - id: service
       template:
-        apiVersion: example.org/v1alpha1
-        kind: MySQL
+        apiVersion: v1
+        kind: Service
         metadata:
-          name: ${metadata.resourceName}
+          name: ${metadata.name}
           namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
         spec:
-          version: ${parameters.version}
-          storageGB: ${environmentConfigs.storageGB}
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: http
+              port: 80
+              targetPort: 80
+    - id: deployment
+      readyWhen: "${applied.deployment.status.readyReplicas == applied.deployment.status.replicas && applied.deployment.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: ${environmentConfigs.replicas}
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: app
+                  image: ${parameters.image}
+                  ports:
+                    - containerPort: 80
+                      name: http

--- a/config/samples/openchoreo_v1alpha1_resource.yaml
+++ b/config/samples/openchoreo_v1alpha1_resource.yaml
@@ -5,11 +5,12 @@ metadata:
     app.kubernetes.io/name: openchoreo
     app.kubernetes.io/managed-by: kustomize
   name: resource-sample
+  namespace: default
 spec:
   owner:
-    projectName: analytics
+    projectName: default
   type:
-    kind: ResourceType
-    name: mysql
+    kind: ClusterResourceType
+    name: clusterresourcetype-sample
   parameters:
-    version: "8.0"
+    image: nginx:1.27-alpine

--- a/config/samples/openchoreo_v1alpha1_resourcerelease.yaml
+++ b/config/samples/openchoreo_v1alpha1_resourcerelease.yaml
@@ -1,9 +1,61 @@
+# ResourceRelease is normally cut by the Resource controller; this sample
+# illustrates the frozen-snapshot shape. spec is immutable after creation.
 apiVersion: openchoreo.dev/v1alpha1
 kind: ResourceRelease
 metadata:
   labels:
     app.kubernetes.io/name: openchoreo
     app.kubernetes.io/managed-by: kustomize
-  name: resourcerelease-sample
+  name: resource-sample-abc123
+  namespace: default
 spec:
-  # TODO(user): Add fields here
+  owner:
+    projectName: default
+    resourceName: resource-sample
+  resourceType:
+    kind: ClusterResourceType
+    name: clusterresourcetype-sample
+    spec:
+      parameters:
+        openAPIV3Schema:
+          type: object
+          properties:
+            image:
+              type: string
+              default: nginx:1.27-alpine
+      environmentConfigs:
+        openAPIV3Schema:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              default: 1
+      retainPolicy: Delete
+      outputs:
+        - name: host
+          value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+        - name: port
+          value: "80"
+      resources:
+        - id: deployment
+          template:
+            apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: ${metadata.name}
+              namespace: ${metadata.namespace}
+            spec:
+              replicas: ${environmentConfigs.replicas}
+              selector:
+                matchLabels:
+                  app: ${metadata.name}
+              template:
+                metadata:
+                  labels:
+                    app: ${metadata.name}
+                spec:
+                  containers:
+                    - name: app
+                      image: ${parameters.image}
+  parameters:
+    image: nginx:1.27-alpine

--- a/config/samples/openchoreo_v1alpha1_resourcereleasebinding.yaml
+++ b/config/samples/openchoreo_v1alpha1_resourcereleasebinding.yaml
@@ -4,14 +4,14 @@ metadata:
   labels:
     app.kubernetes.io/name: openchoreo
     app.kubernetes.io/managed-by: kustomize
-  name: analytics-shared-db-dev
+  name: resource-sample-development
+  namespace: default
 spec:
   owner:
-    projectName: analytics
-    resourceName: analytics-shared-db
-  resourceRelease: analytics-shared-db-abc123
-  environment: dev
+    projectName: default
+    resourceName: resource-sample
+  resourceRelease: resource-sample-abc123
+  environment: development
   retainPolicy: Delete
   resourceTypeEnvironmentConfigs:
-    storageGB: 100
-    tlsMode: required
+    replicas: 1

--- a/config/samples/openchoreo_v1alpha1_resourcetype.yaml
+++ b/config/samples/openchoreo_v1alpha1_resourcetype.yaml
@@ -5,29 +5,66 @@ metadata:
     app.kubernetes.io/name: openchoreo
     app.kubernetes.io/managed-by: kustomize
   name: resourcetype-sample
+  namespace: default
 spec:
   parameters:
     openAPIV3Schema:
-      version: "string | default=8.0"
+      type: object
+      properties:
+        image:
+          type: string
+          default: nginx:1.27-alpine
   environmentConfigs:
     openAPIV3Schema:
-      storageGB: "integer | default=8"
+      type: object
+      properties:
+        replicas:
+          type: integer
+          default: 1
   retainPolicy: Delete
   outputs:
-    host:
-      value: "${applied.claim.status.host}"
-    password:
-      secretKeyRef:
-        name: "${metadata.resourceName}-conn"
-        key: password
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "80"
   resources:
-    - id: claim
+    - id: service
       template:
-        apiVersion: example.org/v1alpha1
-        kind: MySQL
+        apiVersion: v1
+        kind: Service
         metadata:
-          name: ${metadata.resourceName}
+          name: ${metadata.name}
           namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
         spec:
-          version: ${parameters.version}
-          storageGB: ${environmentConfigs.storageGB}
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: http
+              port: 80
+              targetPort: 80
+    - id: deployment
+      readyWhen: "${applied.deployment.status.readyReplicas == applied.deployment.status.replicas && applied.deployment.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: ${environmentConfigs.replicas}
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: app
+                  image: ${parameters.image}
+                  ports:
+                    - containerPort: 80
+                      name: http

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -92,9 +92,10 @@ rules:
   - clustersecretstores
   - pushsecrets
   verbs: ["*"]
-# External Secrets Operator generators (Password, GithubAccessToken, etc.)
+# External Secrets Operator generators
 - apiGroups: ["generators.external-secrets.io"]
-  resources: ["*"]
+  resources:
+  - passwords
   verbs: ["*"]
 # KGateway resources (if using KGateway)
 - apiGroups: ["gateway.kgateway.dev"]

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -92,6 +92,10 @@ rules:
   - clustersecretstores
   - pushsecrets
   verbs: ["*"]
+# External Secrets Operator generators (Password, GithubAccessToken, etc.)
+- apiGroups: ["generators.external-secrets.io"]
+  resources: ["*"]
+  verbs: ["*"]
 # KGateway resources (if using KGateway)
 - apiGroups: ["gateway.kgateway.dev"]
   resources:

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -78,9 +78,12 @@ lint: golangci-lint-check license-check newline-check ## Run golangci-lint linte
 .PHONY: lint-fix
 lint-fix: golangci-lint-fix license-fix newline-fix ## Run golangci-lint linter, licenser, and newline fix to perform fixes
 
-# Detect the current git branch for use in generated file headers.
-# Falls back to "main" in detached HEAD state (e.g. during CI checkout by SHA).
-SAMPLES_BRANCH = $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's/^HEAD$$/main/')
+# Branch reference baked into generated file headers (e.g. the kubectl apply URL
+# in samples/getting-started/all.yaml). Only "main" and "release-v*" branches are
+# considered publishable; everything else (feature branches, detached HEAD) falls
+# back to "main" so contributor-local generation never burns ephemeral branch
+# names into committed files. Override with SAMPLES_BRANCH=<name> for local testing.
+SAMPLES_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -E '^(main|release-v.*)$$' || echo main)
 
 # Individual getting-started sample files that compose all.yaml (order matters)
 GETTING_STARTED_DIR := samples/getting-started

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -92,6 +92,9 @@ GETTING_STARTED_FILES := \
 	$(GETTING_STARTED_DIR)/component-types/service.yaml \
 	$(GETTING_STARTED_DIR)/component-types/webapp.yaml \
 	$(GETTING_STARTED_DIR)/component-types/scheduled-task.yaml \
+	$(GETTING_STARTED_DIR)/cluster-resource-types/postgres.yaml \
+	$(GETTING_STARTED_DIR)/cluster-resource-types/valkey.yaml \
+	$(GETTING_STARTED_DIR)/cluster-resource-types/nats.yaml \
 	$(GETTING_STARTED_DIR)/ci-workflows/paketo-buildpacks-builder.yaml \
 	$(GETTING_STARTED_DIR)/ci-workflows/gcp-buildpacks-builder.yaml \
 	$(GETTING_STARTED_DIR)/ci-workflows/ballerina-buildpack-builder.yaml \

--- a/samples/getting-started/README.md
+++ b/samples/getting-started/README.md
@@ -82,14 +82,11 @@ clustertrait.openchoreo.dev/observability-alert-rule      10s
 
 ### Cluster Resource Types
 
-Templates for in-cluster managed infrastructure that developers can consume via
-`Workload.spec.dependencies.resources[]`.
-
-| Name | Backed By | App outputs | Admin tool |
-|------|-----------|-------------|------------|
-| postgres | StatefulSet, emptyDir | `host`, `port`, `database`, `username`, `password` | Adminer (form login with the published `demo` password) |
-| valkey | StatefulSet, in-memory | `host`, `port`, `password` | Redis Commander (auto-connects, no login) |
-| nats | Deployment, in-memory | `host`, `port`, `token` | NATS built-in HTTP monitoring at `/varz` (no auth) |
+| Name | Description |
+|------|-------------|
+| postgres | PostgreSQL database backed by a StatefulSet |
+| valkey | Redis-protocol-compatible cache backed by a StatefulSet |
+| nats | NATS Core pub/sub server backed by a Deployment |
 
 ### Workflows
 

--- a/samples/getting-started/README.md
+++ b/samples/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started Resources
 
-Default resources for OpenChoreo. Apply these after installing the control plane to set up a working environment with projects, environments, component types, and build workflows.
+Default resources for OpenChoreo. Apply these after installing the control plane to set up a working environment with projects, environments, component types, build workflows, and resource types.
 
 ## Quick Start
 
@@ -19,7 +19,7 @@ kubectl apply -f samples/getting-started/all.yaml
 ## Verify Installation
 
 ```bash
-kubectl get project,environment,deploymentpipeline,componenttype,workflow,trait -n default
+kubectl get project,environment,deploymentpipeline,clustercomponenttype,clusterresourcetype,clusterworkflow,clustertrait
 ```
 
 Expected output:
@@ -36,20 +36,25 @@ environment.openchoreo.dev/staging         10s
 NAME                                           AGE
 deploymentpipeline.openchoreo.dev/default      10s
 
-NAME                                        AGE
-componenttype.openchoreo.dev/scheduled-task    10s
-componenttype.openchoreo.dev/service           10s
-componenttype.openchoreo.dev/web-application   10s
-componenttype.openchoreo.dev/worker            10s
+NAME                                                    AGE
+clustercomponenttype.openchoreo.dev/scheduled-task      10s
+clustercomponenttype.openchoreo.dev/service             10s
+clustercomponenttype.openchoreo.dev/web-application     10s
+clustercomponenttype.openchoreo.dev/worker              10s
 
-NAME                                                   AGE
-workflow.openchoreo.dev/ballerina-buildpack             10s
-workflow.openchoreo.dev/docker                          10s
-workflow.openchoreo.dev/google-cloud-buildpacks         10s
-workflow.openchoreo.dev/react                           10s
+NAME                                          AGE
+clusterresourcetype.openchoreo.dev/nats       10s
+clusterresourcetype.openchoreo.dev/postgres   10s
+clusterresourcetype.openchoreo.dev/valkey     10s
 
-NAME                                               AGE
-trait.openchoreo.dev/observability-alert-rule         10s
+NAME                                                       AGE
+clusterworkflow.openchoreo.dev/ballerina-buildpack          10s
+clusterworkflow.openchoreo.dev/docker                       10s
+clusterworkflow.openchoreo.dev/google-cloud-buildpacks      10s
+clusterworkflow.openchoreo.dev/react                        10s
+
+NAME                                                      AGE
+clustertrait.openchoreo.dev/observability-alert-rule      10s
 ```
 
 ## What Gets Created
@@ -74,6 +79,17 @@ trait.openchoreo.dev/observability-alert-rule         10s
 | service | Deployment | docker, google-cloud-buildpacks, ballerina-buildpack | At least 1 endpoint |
 | web-application | Deployment | react, docker | HTTP endpoint required |
 | scheduled-task | CronJob | docker, google-cloud-buildpacks | - |
+
+### Cluster Resource Types
+
+Templates for in-cluster managed infrastructure that developers can consume via
+`Workload.spec.dependencies.resources[]`.
+
+| Name | Backed By | App outputs | Admin tool |
+|------|-----------|-------------|------------|
+| postgres | StatefulSet, emptyDir | `host`, `port`, `database`, `username`, `password` | Adminer (form login with the published `demo` password) |
+| valkey | StatefulSet, in-memory | `host`, `port`, `password` | Redis Commander (auto-connects, no login) |
+| nats | Deployment, in-memory | `host`, `port`, `token` | NATS built-in HTTP monitoring at `/varz` (no auth) |
 
 ### Workflows
 
@@ -105,6 +121,10 @@ getting-started/
 │   ├── service.yaml
 │   ├── webapp.yaml
 │   └── scheduled-task.yaml
+├── cluster-resource-types/
+│   ├── postgres.yaml
+│   ├── valkey.yaml
+│   └── nats.yaml
 ├── ci-workflows/
 │   ├── dockerfile-builder.yaml
 │   ├── paketo-buildpacks-builder.yaml

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -7,7 +7,7 @@
 # environments, pipeline, component types, workflows, and traits.
 #
 # Usage:
-#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/issue-3339-pipeline-gateway/samples/getting-started/all.yaml
+#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/getting-started/all.yaml
 #
 # Or if you have cloned the repository:
 #   kubectl apply -f samples/getting-started/all.yaml
@@ -973,18 +973,26 @@ metadata:
   annotations:
     openchoreo.dev/description: >-
       In-cluster PostgreSQL database backed by a single-replica StatefulSet.
-      Ephemeral storage (emptyDir); for demonstration purposes only. Set
-      environmentConfigs.adminEnabled=true on a binding to expose Adminer via
-      the data plane's gateway.
+      Ephemeral storage (emptyDir); for demonstration purposes only.
 spec:
   parameters:
     openAPIV3Schema:
-      database: "string | default=appdb"
+      type: object
+      properties:
+        database:
+          type: string
+          default: appdb
 
   environmentConfigs:
     openAPIV3Schema:
-      memory: "string | default=256Mi"
-      adminEnabled: "boolean | default=false"
+      type: object
+      properties:
+        memory:
+          type: string
+          default: 256Mi
+        adminEnabled:
+          type: boolean
+          default: false
 
   retainPolicy: Delete
 
@@ -997,6 +1005,8 @@ spec:
       configMapKeyRef:
         name: "${metadata.name}-config"
         key: database
+    # The application user (limited grants), created at initdb by the bootstrap
+    # script. Applications consume this output via Workload envBindings.
     - name: username
       configMapKeyRef:
         name: "${metadata.name}-config"
@@ -1005,15 +1015,24 @@ spec:
       secretKeyRef:
         name: "${metadata.name}-creds"
         key: password
+    # Adminer URL with driver=pgsql, server, username=demo (deliberately weak
+    # superuser created for the demo UI), db pre-filled via query params.
+    # Paste the value of adminPassword on the Adminer login form.
     - name: adminURL
       value: >-
         ${environmentConfigs.adminEnabled
           ? (has(gateway.ingress.external.https)
-              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/"
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/?pgsql=" + metadata.name + "&username=demo&db=" + parameters.database
               : has(gateway.ingress.external.http)
-                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/"
-                  : "")
-          : ""}
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/?pgsql=" + metadata.name + "&username=demo&db=" + parameters.database
+                  : "no-gateway-configured")
+          : "disabled"}
+    # DEMO ONLY: literal "demo" password for the demo superuser. Used to log
+    # into the admin UI. The postgres built-in superuser and the application
+    # user have ESO-generated random passwords that never appear in any output.
+    - name: adminPassword
+      value: >-
+        ${environmentConfigs.adminEnabled ? "demo" : "disabled"}
 
   resources:
     - id: config
@@ -1026,19 +1045,112 @@ spec:
           labels: ${metadata.labels}
         data:
           database: ${parameters.database}
-          username: appuser
+          username: ${metadata.resourceName}-user
 
-    - id: creds
+    # Bootstrap scripts: 01 creates the application user, 02 creates a
+    # demo superuser used by the Adminer login. Both run once on initdb
+    # (when the data directory is empty) in alphabetical order. The
+    # superuser created by the image (postgres) is reserved for internal
+    # use; its password is ESO-generated and never surfaced.
+    - id: init-scripts
       template:
         apiVersion: v1
-        kind: Secret
+        kind: ConfigMap
+        metadata:
+          name: ${metadata.name}-init
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        data:
+          01-create-app-user.sh: |
+            #!/bin/bash
+            set -e
+            psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<EOSQL
+              CREATE USER "$APPUSER" WITH PASSWORD '$APPUSER_PASSWORD';
+              GRANT ALL ON DATABASE "$POSTGRES_DB" TO "$APPUSER";
+              GRANT ALL ON SCHEMA public TO "$APPUSER";
+            EOSQL
+          02-create-demo-user.sh: |
+            #!/bin/bash
+            set -e
+            psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<EOSQL
+              CREATE USER demo WITH SUPERUSER PASSWORD 'demo';
+            EOSQL
+
+    # Postgres superuser password: generated on the data plane by ESO and
+    # never written to the control plane. Used by initdb and by the init
+    # scripts above; not surfaced to consumers.
+    - id: password-gen-postgres
+      template:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        metadata:
+          name: ${metadata.name}-creds-postgres
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds-postgres
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds-postgres
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds-postgres
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds-postgres
+
+    # Application user password: generated on the data plane by ESO and
+    # never written to the control plane. Surfaced via the `password` output
+    # as a secretKeyRef.
+    - id: password-gen-app
+      template:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
         metadata:
           name: ${metadata.name}-creds
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
-        type: Opaque
-        stringData:
-          password: ${metadata.name}-password
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds
 
     - id: service
       template:
@@ -1083,17 +1195,24 @@ spec:
                     limits:
                       memory: ${environmentConfigs.memory}
                   env:
+                    - name: POSTGRES_USER
+                      value: postgres
                     - name: POSTGRES_DB
                       valueFrom:
                         configMapKeyRef:
                           name: ${metadata.name}-config
                           key: database
-                    - name: POSTGRES_USER
+                    - name: POSTGRES_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds-postgres
+                          key: password
+                    - name: APPUSER
                       valueFrom:
                         configMapKeyRef:
                           name: ${metadata.name}-config
                           key: username
-                    - name: POSTGRES_PASSWORD
+                    - name: APPUSER_PASSWORD
                       valueFrom:
                         secretKeyRef:
                           name: ${metadata.name}-creds
@@ -1106,12 +1225,18 @@ spec:
                   volumeMounts:
                     - name: data
                       mountPath: /var/lib/postgresql/data
+                    - name: init-scripts
+                      mountPath: /docker-entrypoint-initdb.d
               volumes:
                 - name: data
                   emptyDir: {}
+                - name: init-scripts
+                  configMap:
+                    name: ${metadata.name}-init
+                    defaultMode: 0755
 
     - id: admin-deployment
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -1140,7 +1265,7 @@ spec:
                       name: http
 
     - id: admin-service
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: v1
         kind: Service
@@ -1157,7 +1282,7 @@ spec:
               targetPort: 8080
 
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
@@ -1185,19 +1310,20 @@ metadata:
   name: valkey
   annotations:
     openchoreo.dev/description: >-
-      In-cluster Valkey cache (Redis protocol-compatible) backed by a
-      single-replica StatefulSet. Data is in-memory only and is lost on pod
-      restart. Set environmentConfigs.adminEnabled=true on a binding to expose
-      Redis Commander via the data plane's gateway.
+      In-cluster Valkey cache (Redis-protocol-compatible) backed by a
+      single-replica StatefulSet. In-memory only; data is lost on pod restart.
+      For demonstration purposes only.
 spec:
-  parameters:
-    openAPIV3Schema:
-      image: "string | default=valkey/valkey:8-alpine"
-
   environmentConfigs:
     openAPIV3Schema:
-      memory: "string | default=128Mi"
-      adminEnabled: "boolean | default=false"
+      type: object
+      properties:
+        memory:
+          type: string
+          default: 128Mi
+        adminEnabled:
+          type: boolean
+          default: false
 
   retainPolicy: Delete
 
@@ -1210,19 +1336,58 @@ spec:
       secretKeyRef:
         name: "${metadata.name}-creds"
         key: password
+    # Admin URL points at a Redis Commander instance that auto-connects to
+    # Valkey using the same ESO-generated password (wired via env vars on the
+    # admin pod). The dev opens the URL and lands directly in the data
+    # browser — no login form, no password to paste.
+    - name: adminURL
+      value: >-
+        ${environmentConfigs.adminEnabled
+          ? (has(gateway.ingress.external.https)
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/"
+              : has(gateway.ingress.external.http)
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/"
+                  : "no-gateway-configured")
+          : "disabled"}
 
   resources:
-    - id: creds
+    # Valkey requirepass: generated on the data plane by ESO and never written
+    # to the control plane. Surfaced via the `password` output as a
+    # secretKeyRef.
+    - id: password-generator
       template:
-        apiVersion: v1
-        kind: Secret
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
         metadata:
           name: ${metadata.name}-creds
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
-        type: Opaque
-        stringData:
-          password: ${metadata.name}-password
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds
 
     - id: service
       template:
@@ -1262,25 +1427,25 @@ spec:
             spec:
               containers:
                 - name: valkey
-                  image: ${parameters.image}
+                  image: valkey/valkey:8-alpine
                   resources:
                     limits:
                       memory: ${environmentConfigs.memory}
-                  args:
-                    - --requirepass
-                    - $(VALKEY_PASSWORD)
                   env:
                     - name: VALKEY_PASSWORD
                       valueFrom:
                         secretKeyRef:
                           name: ${metadata.name}-creds
                           key: password
+                  args:
+                    - --requirepass
+                    - $(VALKEY_PASSWORD)
                   ports:
                     - containerPort: 6379
                       name: valkey
 
     - id: admin-deployment
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -1299,24 +1464,28 @@ spec:
                 app: ${metadata.name}-admin
             spec:
               containers:
+                # Redis Commander upstream does not publish semver tags; only
+                # :latest and branch-style tags. Production CRTs should pin a
+                # digest. Acceptable for getting-started demo.
                 - name: redis-commander
                   image: rediscommander/redis-commander:latest
                   env:
-                    - name: REDIS_HOST
-                      value: ${metadata.name}
-                    - name: REDIS_PORT
-                      value: "6379"
+                    # REDIS_PASSWORD must be defined before REDIS_HOSTS so
+                    # K8s's $(VAR) substitution can fold it into the
+                    # connection string at container start.
                     - name: REDIS_PASSWORD
                       valueFrom:
                         secretKeyRef:
                           name: ${metadata.name}-creds
                           key: password
+                    - name: REDIS_HOSTS
+                      value: "${metadata.resourceName}:${metadata.name}:6379:0:$(REDIS_PASSWORD)"
                   ports:
                     - containerPort: 8081
                       name: http
 
     - id: admin-service
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: v1
         kind: Service
@@ -1333,7 +1502,7 @@ spec:
               targetPort: 8081
 
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
@@ -1348,19 +1517,9 @@ spec:
           hostnames: |
             ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+              .map(h, metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
           rules:
-            - matches:
-                - path:
-                    type: PathPrefix
-                    value: /${metadata.resourceName}-admin
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: /
-              backendRefs:
+            - backendRefs:
                 - name: ${metadata.name}-admin
                   port: 8081
 
@@ -1371,19 +1530,21 @@ metadata:
   name: nats
   annotations:
     openchoreo.dev/description: >-
-      In-cluster NATS Core pub/sub server (no JetStream). Stateless, in-memory,
-      backed by a single-replica Deployment. Token-based auth. Set
-      environmentConfigs.adminEnabled=true on a binding to expose NATS's built-in
-      :8222 monitoring endpoint via the data plane's gateway.
+      In-cluster NATS Core pub/sub server (no JetStream) backed by a
+      single-replica Deployment. Stateless and in-memory; for demonstration
+      purposes only. Token-based auth on the client port; the monitoring
+      port serves read-only diagnostics.
 spec:
-  parameters:
-    openAPIV3Schema:
-      image: "string | default=nats:2.10-alpine"
-
   environmentConfigs:
     openAPIV3Schema:
-      memory: "string | default=64Mi"
-      adminEnabled: "boolean | default=false"
+      type: object
+      properties:
+        memory:
+          type: string
+          default: 64Mi
+        adminEnabled:
+          type: boolean
+          default: false
 
   retainPolicy: Delete
 
@@ -1395,20 +1556,59 @@ spec:
     - name: token
       secretKeyRef:
         name: "${metadata.name}-creds"
-        key: token
+        key: password
+    # Admin URL points at NATS's built-in HTTP monitoring endpoint (port
+    # 8222), which serves JSON diagnostics like /varz, /connz, /subsz. The
+    # endpoint is unauthenticated and read-only; the dev opens the URL and
+    # navigates the JSON pages directly.
+    - name: adminURL
+      value: >-
+        ${environmentConfigs.adminEnabled
+          ? (has(gateway.ingress.external.https)
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/"
+              : has(gateway.ingress.external.http)
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/"
+                  : "no-gateway-configured")
+          : "disabled"}
 
   resources:
-    - id: creds
+    # NATS auth token: generated on the data plane by ESO and never written
+    # to the control plane. Surfaced via the `token` output as a
+    # secretKeyRef.
+    - id: password-generator
       template:
-        apiVersion: v1
-        kind: Secret
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
         metadata:
           name: ${metadata.name}-creds
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
-        type: Opaque
-        stringData:
-          token: ${metadata.name}-token
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds
 
     - id: service
       template:
@@ -1450,7 +1650,7 @@ spec:
             spec:
               containers:
                 - name: nats
-                  image: ${parameters.image}
+                  image: nats:2.10-alpine
                   resources:
                     limits:
                       memory: ${environmentConfigs.memory}
@@ -1464,15 +1664,18 @@ spec:
                       valueFrom:
                         secretKeyRef:
                           name: ${metadata.name}-creds
-                          key: token
+                          key: password
                   ports:
                     - containerPort: 4222
                       name: client
                     - containerPort: 8222
                       name: monitor
 
+    # NATS's monitoring port (8222) is exposed on the same Service that
+    # serves the client port. The HTTPRoute below just routes the gateway
+    # to that monitoring port — no separate admin pod is needed.
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
@@ -1487,19 +1690,9 @@ spec:
           hostnames: |
             ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+              .map(h, metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
           rules:
-            - matches:
-                - path:
-                    type: PathPrefix
-                    value: /${metadata.resourceName}-admin
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: /
-              backendRefs:
+            - backendRefs:
                 - name: ${metadata.name}
                   port: 8222
 

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -1236,7 +1236,7 @@ spec:
                     defaultMode: 0755
 
     - id: admin-deployment
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -1265,7 +1265,7 @@ spec:
                       name: http
 
     - id: admin-service
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: v1
         kind: Service
@@ -1282,7 +1282,7 @@ spec:
               targetPort: 8080
 
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
@@ -1445,7 +1445,7 @@ spec:
                       name: valkey
 
     - id: admin-deployment
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -1485,7 +1485,7 @@ spec:
                       name: http
 
     - id: admin-service
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: v1
         kind: Service
@@ -1502,7 +1502,7 @@ spec:
               targetPort: 8081
 
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
@@ -1675,7 +1675,7 @@ spec:
     # serves the client port. The HTTPRoute below just routes the gateway
     # to that monitoring port — no separate admin pod is needed.
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -7,7 +7,7 @@
 # environments, pipeline, component types, workflows, and traits.
 #
 # Usage:
-#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/getting-started/all.yaml
+#   kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/issue-3339-pipeline-gateway/samples/getting-started/all.yaml
 #
 # Or if you have cloned the repository:
 #   kubectl apply -f samples/getting-started/all.yaml
@@ -964,6 +964,544 @@ spec:
                 key: ${file.remoteRef.key}
                 property: |
                   ${has(file.remoteRef.property) ? file.remoteRef.property : oc_omit()}
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: postgres
+  annotations:
+    openchoreo.dev/description: >-
+      In-cluster PostgreSQL database backed by a single-replica StatefulSet.
+      Ephemeral storage (emptyDir); for demonstration purposes only. Set
+      environmentConfigs.adminEnabled=true on a binding to expose Adminer via
+      the data plane's gateway.
+spec:
+  parameters:
+    openAPIV3Schema:
+      database: "string | default=appdb"
+
+  environmentConfigs:
+    openAPIV3Schema:
+      memory: "string | default=256Mi"
+      adminEnabled: "boolean | default=false"
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "5432"
+    - name: database
+      configMapKeyRef:
+        name: "${metadata.name}-config"
+        key: database
+    - name: username
+      configMapKeyRef:
+        name: "${metadata.name}-config"
+        key: username
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+    - name: adminURL
+      value: >-
+        ${environmentConfigs.adminEnabled
+          ? (has(gateway.ingress.external.https)
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/"
+              : has(gateway.ingress.external.http)
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/"
+                  : "")
+          : ""}
+
+  resources:
+    - id: config
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${metadata.name}-config
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        data:
+          database: ${parameters.database}
+          username: appuser
+
+    - id: creds
+      template:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        type: Opaque
+        stringData:
+          password: ${metadata.name}-password
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: postgres
+              port: 5432
+              targetPort: 5432
+
+    - id: statefulset
+      readyWhen: "${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          serviceName: ${metadata.name}
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: postgres
+                  image: postgres:16-alpine
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  env:
+                    - name: POSTGRES_DB
+                      valueFrom:
+                        configMapKeyRef:
+                          name: ${metadata.name}-config
+                          key: database
+                    - name: POSTGRES_USER
+                      valueFrom:
+                        configMapKeyRef:
+                          name: ${metadata.name}-config
+                          key: username
+                    - name: POSTGRES_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                    - name: PGDATA
+                      value: /var/lib/postgresql/data/pgdata
+                  ports:
+                    - containerPort: 5432
+                      name: postgres
+                  volumeMounts:
+                    - name: data
+                      mountPath: /var/lib/postgresql/data
+              volumes:
+                - name: data
+                  emptyDir: {}
+
+    - id: admin-deployment
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}-admin
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}-admin
+            spec:
+              containers:
+                - name: adminer
+                  image: adminer:4.8.1-standalone
+                  env:
+                    - name: ADMINER_DEFAULT_SERVER
+                      value: ${metadata.name}
+                  ports:
+                    - containerPort: 8080
+                      name: http
+
+    - id: admin-service
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}-admin
+          ports:
+            - name: http
+              port: 8080
+              targetPort: 8080
+
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+          rules:
+            - backendRefs:
+                - name: ${metadata.name}-admin
+                  port: 8080
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: valkey
+  annotations:
+    openchoreo.dev/description: >-
+      In-cluster Valkey cache (Redis protocol-compatible) backed by a
+      single-replica StatefulSet. Data is in-memory only and is lost on pod
+      restart. Set environmentConfigs.adminEnabled=true on a binding to expose
+      Redis Commander via the data plane's gateway.
+spec:
+  parameters:
+    openAPIV3Schema:
+      image: "string | default=valkey/valkey:8-alpine"
+
+  environmentConfigs:
+    openAPIV3Schema:
+      memory: "string | default=128Mi"
+      adminEnabled: "boolean | default=false"
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "6379"
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+
+  resources:
+    - id: creds
+      template:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        type: Opaque
+        stringData:
+          password: ${metadata.name}-password
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: valkey
+              port: 6379
+              targetPort: 6379
+
+    - id: statefulset
+      readyWhen: "${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          serviceName: ${metadata.name}
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: valkey
+                  image: ${parameters.image}
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  args:
+                    - --requirepass
+                    - $(VALKEY_PASSWORD)
+                  env:
+                    - name: VALKEY_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                  ports:
+                    - containerPort: 6379
+                      name: valkey
+
+    - id: admin-deployment
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}-admin
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}-admin
+            spec:
+              containers:
+                - name: redis-commander
+                  image: rediscommander/redis-commander:latest
+                  env:
+                    - name: REDIS_HOST
+                      value: ${metadata.name}
+                    - name: REDIS_PORT
+                      value: "6379"
+                    - name: REDIS_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                  ports:
+                    - containerPort: 8081
+                      name: http
+
+    - id: admin-service
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}-admin
+          ports:
+            - name: http
+              port: 8081
+              targetPort: 8081
+
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+          rules:
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /${metadata.resourceName}-admin
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /
+              backendRefs:
+                - name: ${metadata.name}-admin
+                  port: 8081
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: nats
+  annotations:
+    openchoreo.dev/description: >-
+      In-cluster NATS Core pub/sub server (no JetStream). Stateless, in-memory,
+      backed by a single-replica Deployment. Token-based auth. Set
+      environmentConfigs.adminEnabled=true on a binding to expose NATS's built-in
+      :8222 monitoring endpoint via the data plane's gateway.
+spec:
+  parameters:
+    openAPIV3Schema:
+      image: "string | default=nats:2.10-alpine"
+
+  environmentConfigs:
+    openAPIV3Schema:
+      memory: "string | default=64Mi"
+      adminEnabled: "boolean | default=false"
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "4222"
+    - name: token
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: token
+
+  resources:
+    - id: creds
+      template:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        type: Opaque
+        stringData:
+          token: ${metadata.name}-token
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: client
+              port: 4222
+              targetPort: 4222
+            - name: monitor
+              port: 8222
+              targetPort: 8222
+
+    - id: deployment
+      readyWhen: "${applied.deployment.status.readyReplicas == applied.deployment.status.replicas && applied.deployment.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: nats
+                  image: ${parameters.image}
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  args:
+                    - --http_port
+                    - "8222"
+                    - --auth
+                    - $(NATS_TOKEN)
+                  env:
+                    - name: NATS_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: token
+                  ports:
+                    - containerPort: 4222
+                      name: client
+                    - containerPort: 8222
+                      name: monitor
+
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled}"
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+          rules:
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /${metadata.resourceName}-admin
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /
+              backendRefs:
+                - name: ${metadata.name}
+                  port: 8222
 
 ---
 apiVersion: openchoreo.dev/v1alpha1

--- a/samples/getting-started/cluster-resource-types/nats.yaml
+++ b/samples/getting-started/cluster-resource-types/nats.yaml
@@ -1,0 +1,171 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: nats
+  annotations:
+    openchoreo.dev/description: >-
+      In-cluster NATS Core pub/sub server (no JetStream) backed by a
+      single-replica Deployment. Stateless and in-memory; for demonstration
+      purposes only. Token-based auth on the client port; the monitoring
+      port serves read-only diagnostics.
+spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        memory:
+          type: string
+          default: 64Mi
+        adminEnabled:
+          type: boolean
+          default: false
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "4222"
+    - name: token
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+    # Admin URL points at NATS's built-in HTTP monitoring endpoint (port
+    # 8222), which serves JSON diagnostics like /varz, /connz, /subsz. The
+    # endpoint is unauthenticated and read-only; the dev opens the URL and
+    # navigates the JSON pages directly.
+    - name: adminURL
+      value: >-
+        ${environmentConfigs.adminEnabled
+          ? (has(gateway.ingress.external.https)
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/"
+              : has(gateway.ingress.external.http)
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/"
+                  : "no-gateway-configured")
+          : "disabled"}
+
+  resources:
+    # NATS auth token: generated on the data plane by ESO and never written
+    # to the control plane. Surfaced via the `token` output as a
+    # secretKeyRef.
+    - id: password-generator
+      template:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: client
+              port: 4222
+              targetPort: 4222
+            - name: monitor
+              port: 8222
+              targetPort: 8222
+
+    - id: deployment
+      readyWhen: "${applied.deployment.status.readyReplicas == applied.deployment.status.replicas && applied.deployment.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: nats
+                  image: nats:2.10-alpine
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  args:
+                    - --http_port
+                    - "8222"
+                    - --auth
+                    - $(NATS_TOKEN)
+                  env:
+                    - name: NATS_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                  ports:
+                    - containerPort: 4222
+                      name: client
+                    - containerPort: 8222
+                      name: monitor
+
+    # NATS's monitoring port (8222) is exposed on the same Service that
+    # serves the client port. The HTTPRoute below just routes the gateway
+    # to that monitoring port — no separate admin pod is needed.
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+          rules:
+            - backendRefs:
+                - name: ${metadata.name}
+                  port: 8222

--- a/samples/getting-started/cluster-resource-types/nats.yaml
+++ b/samples/getting-started/cluster-resource-types/nats.yaml
@@ -149,7 +149,7 @@ spec:
     # serves the client port. The HTTPRoute below just routes the gateway
     # to that monitoring port — no separate admin pod is needed.
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute

--- a/samples/getting-started/cluster-resource-types/postgres.yaml
+++ b/samples/getting-started/cluster-resource-types/postgres.yaml
@@ -1,0 +1,336 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: postgres
+  annotations:
+    openchoreo.dev/description: >-
+      In-cluster PostgreSQL database backed by a single-replica StatefulSet.
+      Ephemeral storage (emptyDir); for demonstration purposes only.
+spec:
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        database:
+          type: string
+          default: appdb
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        memory:
+          type: string
+          default: 256Mi
+        adminEnabled:
+          type: boolean
+          default: false
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "5432"
+    - name: database
+      configMapKeyRef:
+        name: "${metadata.name}-config"
+        key: database
+    # The application user (limited grants), created at initdb by the bootstrap
+    # script. Applications consume this output via Workload envBindings.
+    - name: username
+      configMapKeyRef:
+        name: "${metadata.name}-config"
+        key: username
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+    # Adminer URL with driver=pgsql, server, username=demo (deliberately weak
+    # superuser created for the demo UI), db pre-filled via query params.
+    # Paste the value of adminPassword on the Adminer login form.
+    - name: adminURL
+      value: >-
+        ${environmentConfigs.adminEnabled
+          ? (has(gateway.ingress.external.https)
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/?pgsql=" + metadata.name + "&username=demo&db=" + parameters.database
+              : has(gateway.ingress.external.http)
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/?pgsql=" + metadata.name + "&username=demo&db=" + parameters.database
+                  : "no-gateway-configured")
+          : "disabled"}
+    # DEMO ONLY: literal "demo" password for the demo superuser. Used to log
+    # into the admin UI. The postgres built-in superuser and the application
+    # user have ESO-generated random passwords that never appear in any output.
+    - name: adminPassword
+      value: >-
+        ${environmentConfigs.adminEnabled ? "demo" : "disabled"}
+
+  resources:
+    - id: config
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${metadata.name}-config
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        data:
+          database: ${parameters.database}
+          username: ${metadata.resourceName}-user
+
+    # Bootstrap scripts: 01 creates the application user, 02 creates a
+    # demo superuser used by the Adminer login. Both run once on initdb
+    # (when the data directory is empty) in alphabetical order. The
+    # superuser created by the image (postgres) is reserved for internal
+    # use; its password is ESO-generated and never surfaced.
+    - id: init-scripts
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${metadata.name}-init
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        data:
+          01-create-app-user.sh: |
+            #!/bin/bash
+            set -e
+            psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<EOSQL
+              CREATE USER "$APPUSER" WITH PASSWORD '$APPUSER_PASSWORD';
+              GRANT ALL ON DATABASE "$POSTGRES_DB" TO "$APPUSER";
+              GRANT ALL ON SCHEMA public TO "$APPUSER";
+            EOSQL
+          02-create-demo-user.sh: |
+            #!/bin/bash
+            set -e
+            psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<EOSQL
+              CREATE USER demo WITH SUPERUSER PASSWORD 'demo';
+            EOSQL
+
+    # Postgres superuser password: generated on the data plane by ESO and
+    # never written to the control plane. Used by initdb and by the init
+    # scripts above; not surfaced to consumers.
+    - id: password-gen-postgres
+      template:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        metadata:
+          name: ${metadata.name}-creds-postgres
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds-postgres
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds-postgres
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds-postgres
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds-postgres
+
+    # Application user password: generated on the data plane by ESO and
+    # never written to the control plane. Surfaced via the `password` output
+    # as a secretKeyRef.
+    - id: password-gen-app
+      template:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: postgres
+              port: 5432
+              targetPort: 5432
+
+    - id: statefulset
+      readyWhen: "${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          serviceName: ${metadata.name}
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: postgres
+                  image: postgres:16-alpine
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  env:
+                    - name: POSTGRES_USER
+                      value: postgres
+                    - name: POSTGRES_DB
+                      valueFrom:
+                        configMapKeyRef:
+                          name: ${metadata.name}-config
+                          key: database
+                    - name: POSTGRES_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds-postgres
+                          key: password
+                    - name: APPUSER
+                      valueFrom:
+                        configMapKeyRef:
+                          name: ${metadata.name}-config
+                          key: username
+                    - name: APPUSER_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                    - name: PGDATA
+                      value: /var/lib/postgresql/data/pgdata
+                  ports:
+                    - containerPort: 5432
+                      name: postgres
+                  volumeMounts:
+                    - name: data
+                      mountPath: /var/lib/postgresql/data
+                    - name: init-scripts
+                      mountPath: /docker-entrypoint-initdb.d
+              volumes:
+                - name: data
+                  emptyDir: {}
+                - name: init-scripts
+                  configMap:
+                    name: ${metadata.name}-init
+                    defaultMode: 0755
+
+    - id: admin-deployment
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}-admin
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}-admin
+            spec:
+              containers:
+                - name: adminer
+                  image: adminer:4.8.1-standalone
+                  env:
+                    - name: ADMINER_DEFAULT_SERVER
+                      value: ${metadata.name}
+                  ports:
+                    - containerPort: 8080
+                      name: http
+
+    - id: admin-service
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}-admin
+          ports:
+            - name: http
+              port: 8080
+              targetPort: 8080
+
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+          rules:
+            - backendRefs:
+                - name: ${metadata.name}-admin
+                  port: 8080

--- a/samples/getting-started/cluster-resource-types/postgres.yaml
+++ b/samples/getting-started/cluster-resource-types/postgres.yaml
@@ -268,7 +268,7 @@ spec:
                     defaultMode: 0755
 
     - id: admin-deployment
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -297,7 +297,7 @@ spec:
                       name: http
 
     - id: admin-service
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: v1
         kind: Service
@@ -314,7 +314,7 @@ spec:
               targetPort: 8080
 
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute

--- a/samples/getting-started/cluster-resource-types/valkey.yaml
+++ b/samples/getting-started/cluster-resource-types/valkey.yaml
@@ -139,7 +139,7 @@ spec:
                       name: valkey
 
     - id: admin-deployment
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -179,7 +179,7 @@ spec:
                       name: http
 
     - id: admin-service
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: v1
         kind: Service
@@ -196,7 +196,7 @@ spec:
               targetPort: 8081
 
     - id: admin-route
-      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
       template:
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute

--- a/samples/getting-started/cluster-resource-types/valkey.yaml
+++ b/samples/getting-started/cluster-resource-types/valkey.yaml
@@ -1,0 +1,218 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: valkey
+  annotations:
+    openchoreo.dev/description: >-
+      In-cluster Valkey cache (Redis-protocol-compatible) backed by a
+      single-replica StatefulSet. In-memory only; data is lost on pod restart.
+      For demonstration purposes only.
+spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        memory:
+          type: string
+          default: 128Mi
+        adminEnabled:
+          type: boolean
+          default: false
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "6379"
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+    # Admin URL points at a Redis Commander instance that auto-connects to
+    # Valkey using the same ESO-generated password (wired via env vars on the
+    # admin pod). The dev opens the URL and lands directly in the data
+    # browser — no login form, no password to paste.
+    - name: adminURL
+      value: >-
+        ${environmentConfigs.adminEnabled
+          ? (has(gateway.ingress.external.https)
+              ? "https://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.https.host + ":" + string(gateway.ingress.external.https.port) + "/"
+              : has(gateway.ingress.external.http)
+                  ? "http://" + metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + gateway.ingress.external.http.host + ":" + string(gateway.ingress.external.http.port) + "/"
+                  : "no-gateway-configured")
+          : "disabled"}
+
+  resources:
+    # Valkey requirepass: generated on the data plane by ESO and never written
+    # to the control plane. Surfaced via the `password` output as a
+    # secretKeyRef.
+    - id: password-generator
+      template:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          length: 32
+          digits: 8
+          symbols: 0
+          noUpper: false
+          allowRepeat: true
+
+    - id: creds
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          refreshInterval: "0"
+          target:
+            name: ${metadata.name}-creds
+            creationPolicy: Owner
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: ${metadata.name}-creds
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: valkey
+              port: 6379
+              targetPort: 6379
+
+    - id: statefulset
+      readyWhen: "${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          serviceName: ${metadata.name}
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: valkey
+                  image: valkey/valkey:8-alpine
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  env:
+                    - name: VALKEY_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                  args:
+                    - --requirepass
+                    - $(VALKEY_PASSWORD)
+                  ports:
+                    - containerPort: 6379
+                      name: valkey
+
+    - id: admin-deployment
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}-admin
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}-admin
+            spec:
+              containers:
+                # Redis Commander upstream does not publish semver tags; only
+                # :latest and branch-style tags. Production CRTs should pin a
+                # digest. Acceptable for getting-started demo.
+                - name: redis-commander
+                  image: rediscommander/redis-commander:latest
+                  env:
+                    # REDIS_PASSWORD must be defined before REDIS_HOSTS so
+                    # K8s's $(VAR) substitution can fold it into the
+                    # connection string at container start.
+                    - name: REDIS_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                    - name: REDIS_HOSTS
+                      value: "${metadata.resourceName}:${metadata.name}:6379:0:$(REDIS_PASSWORD)"
+                  ports:
+                    - containerPort: 8081
+                      name: http
+
+    - id: admin-service
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}-admin
+          ports:
+            - name: http
+              port: 8081
+              targetPort: 8081
+
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled && has(environment.gateway.ingress.external)}"
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${metadata.name}-admin
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.resourceName + "-admin-" + metadata.environmentName + "-" + metadata.resourceNamespace + "." + h)}
+          rules:
+            - backendRefs:
+                - name: ${metadata.name}-admin
+                  port: 8081


### PR DESCRIPTION
## Purpose

Add three default `ClusterResourceType`s — `postgres`, `valkey`, `nats` — so developers can consume managed infra from `Workload.spec.dependencies.resources[]` out of the box.

## Approach

- New CRTs under `samples/getting-started/cluster-resource-types/`:
  - `postgres` — StatefulSet (emptyDir); bootstrap creates a named DB and a dedicated app user; outputs `host` / `port` / `database` / `username` / `password`.
  - `valkey` — StatefulSet (in-memory); outputs `host` / `port` / `password`.
  - `nats` — Deployment (in-memory); outputs `host` / `port` / `token`.
- App-side credentials generated on the data plane via ESO `Password` generators.
- Optional bundled admin UI per CRT (Adminer / Redis Commander / NATS `/varz`), opt-in via `environmentConfigs.adminEnabled` and surfaced through an `adminURL` output. Routed via subdomain `HTTPRoute` when the env has an external ingress.
- Extend `cluster-agent` ClusterRole so ESO `Password` generators can be reconciled on the data plane.
- Regenerate `samples/getting-started/all.yaml` and extend the README with a CRT table.
- Align the 5 `config/samples/openchoreo_v1alpha1_*.yaml` skeletons with the current resource-family API shape.

## Related Issues

Closes #3339

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added \`backport/<release-branch>\` label if this should be backported (e.g., \`backport/release-v1.0\`)