### PR TITLE
feat(api): make username optional for basic-auth secrets

### DIFF
--- a/internal/openchoreo-api/services/secret/service_test.go
+++ b/internal/openchoreo-api/services/secret/service_test.go
@@ -83,10 +83,9 @@ func TestValidateSecretData(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "basic-auth missing username fails",
+			name:       "basic-auth with password only succeeds",
 			secretType: corev1.SecretTypeBasicAuth,
 			data:       map[string]string{"password": "p"},
-			wantErr:    true,
 		},
 		{
 			name:       "ssh-auth with key succeeds",
@@ -502,7 +501,7 @@ func TestCreateSecret_ValidationErrors(t *testing.T) {
 				SecretName:  testSecretName,
 				SecretType:  corev1.SecretTypeBasicAuth,
 				TargetPlane: openchoreov1alpha1.TargetPlaneRef{Kind: planeKindWorkflowPlane, Name: "wp1"},
-				Data:        map[string]string{"username": "u"}, // missing password
+				Data:        map[string]string{"username": "u", "other": "v"}, // missing password
 			},
 		},
 		{
@@ -1149,8 +1148,8 @@ func TestUpdateSecret_ValidationFailure(t *testing.T) {
 	svc := &secretService{k8sClient: cpClient, logger: newTestLogger()}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
-		// Missing required keys for basic-auth.
-		Data: map[string]string{"username": "u"},
+		// Missing required password key for basic-auth.
+		Data: map[string]string{"username": "u", "other": "v"},
 	})
 	if !isValidationError(err) {
 		t.Errorf("expected ValidationError, got %v", err)

--- a/internal/openchoreo-api/services/secret/validation.go
+++ b/internal/openchoreo-api/services/secret/validation.go
@@ -26,7 +26,7 @@ var supportedSecretTypes = map[corev1.SecretType]struct{}{
 // data map for each typed Secret. Opaque has no required keys but must contain
 // at least one entry (enforced separately).
 var requiredKeys = map[corev1.SecretType][]string{
-	corev1.SecretTypeBasicAuth:        {"username", "password"},
+	corev1.SecretTypeBasicAuth:        {"password"},
 	corev1.SecretTypeSSHAuth:          {"ssh-privatekey"},
 	corev1.SecretTypeDockerConfigJson: {".dockerconfigjson"},
 	corev1.SecretTypeTLS:              {"tls.crt", "tls.key"},


### PR DESCRIPTION
## Purpose

The Secret API rejected `kubernetes.io/basic-auth` payloads that omitted `username`, even though kube-apiserver itself accepts such secrets as long as `password` is set. This forced callers to supply a placeholder username for token-style flows (GitHub PATs, GitLab tokens) where the username field is effectively ignored by the git host.

## Approach

- Drop `username` from the required-keys list for `SecretTypeBasicAuth` in the validator; `password` remains required.
- Update the validator test table: the former "missing username fails" case becomes a "password only succeeds" case.
- Adjust two downstream test fixtures (`TestCreateSecret_ValidationErrors` and `TestUpdateSecret_ValidationFailure`) that previously relied on `{username}` alone being rejected, so they still exercise the missing-`password` failure path.

Verified against a live k3d cluster that kube-apiserver accepts a basic-auth Secret with only `password` set (it only enforces both keys when `data` is entirely empty).

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)