### PR TITLE
feat: watch resource abstraction CRDs in event-forwarder

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml
@@ -21,12 +21,15 @@ rules:
   - workflows
   - workflowplanes
   - observabilityplanes
+  - resources
+  - resourcetypes
   - clustercomponenttypes
   - clustertraits
   - clusterworkflows
   - clusterdataplanes
   - clusterobservabilityplanes
   - clusterworkflowplanes
+  - clusterresourcetypes
   verbs:
   - get
   - list

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -96,6 +96,8 @@ func gvrList() []schema.GroupVersionResource {
 		"workflows",
 		"workflowplanes",
 		"observabilityplanes",
+		"resources",
+		"resourcetypes",
 		// Cluster-scoped
 		"clustercomponenttypes",
 		"clustertraits",
@@ -103,6 +105,7 @@ func gvrList() []schema.GroupVersionResource {
 		"clusterdataplanes",
 		"clusterobservabilityplanes",
 		"clusterworkflowplanes",
+		"clusterresourcetypes",
 	}
 
 	gvrs := make([]schema.GroupVersionResource, 0, len(resources))


### PR DESCRIPTION
## Purpose

The event-forwarder watches OpenChoreo CRDs and forwards change events to webhook consumers (typically the Backstage events plugin for catalog sync). Today it watches the component family (`ClusterComponentType`, `ComponentType`, `Component`, `Workload`) but does not watch the resource abstraction family introduced under epic #3107. Without this, Backstage's catalog only picks up resource-family entities on its periodic full-sync rather than near-real-time.

## Approach

- Add `ClusterResourceType`, `ResourceType`, and `Resource` to `gvrList()` in `internal/eventforwarder/forwarder.go`.
- Add the same three resources to the event-forwarder `ClusterRole` rules in `install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml`.
- `ResourceRelease` and `ResourceReleaseBinding` are intentionally skipped — mirrors the component-side precedent of not forwarding release/runtime CRDs (`ComponentRelease`, `ReleaseBinding`, `RenderedRelease`). Consumers reconcile from the dev-facing CRs.

## Related Issues

Closes #3525

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)