### PR TITLE
feat(cli): parse resource dependencies in workload descriptor

### DIFF
--- a/internal/occ/resources/kinds/workload_test.go
+++ b/internal/occ/resources/kinds/workload_test.go
@@ -155,6 +155,57 @@ endpoints:
 	require.Len(t, ep.Visibility, 1)
 	assert.Equal(t, openchoreov1alpha1.EndpointVisibilityProject, ep.Visibility[0])
 }
+func TestGenerateWorkloadCR_WithResourceDependencies(t *testing.T) {
+	wr, err := NewWorkloadResource(resources.WorkloadV1Config, "my-ns")
+	require.NoError(t, err)
+	descriptorYAML := `apiVersion: openchoreo.dev/v1alpha1
+metadata:
+  name: test-workload
+dependencies:
+  resources:
+    - ref: orders-db
+      envBindings:
+        host: DB_HOST
+        password: DB_PASSWORD
+      fileBindings:
+        caCert: /etc/ssl/db-ca.crt
+    - ref: cache
+      envBindings:
+        host: REDIS_HOST
+`
+	tmpDir := t.TempDir()
+	descriptorPath := filepath.Join(tmpDir, "workload.yaml")
+	require.NoError(t, os.WriteFile(descriptorPath, []byte(descriptorYAML), 0600))
+	params := synth.CreateWorkloadParams{
+		NamespaceName: "my-ns",
+		ProjectName:   "my-project",
+		ComponentName: "my-comp",
+		ImageURL:      "nginx:latest",
+		FilePath:      descriptorPath,
+	}
+	workloadCR, err := wr.GenerateWorkloadCR(params)
+	require.NoError(t, err)
+	require.NotNil(t, workloadCR)
+	require.NotNil(t, workloadCR.Spec.Dependencies)
+	require.Len(t, workloadCR.Spec.Dependencies.Resources, 2)
+
+	first := workloadCR.Spec.Dependencies.Resources[0]
+	assert.Equal(t, "orders-db", first.Ref)
+	assert.Equal(t, map[string]string{
+		"host":     "DB_HOST",
+		"password": "DB_PASSWORD",
+	}, first.EnvBindings)
+	assert.Equal(t, map[string]string{
+		"caCert": "/etc/ssl/db-ca.crt",
+	}, first.FileBindings)
+
+	second := workloadCR.Spec.Dependencies.Resources[1]
+	assert.Equal(t, "cache", second.Ref)
+	assert.Equal(t, map[string]string{"host": "REDIS_HOST"}, second.EnvBindings)
+	assert.Empty(t, second.FileBindings)
+
+	assert.Empty(t, workloadCR.Spec.Dependencies.Endpoints)
+}
 func TestCreateWorkload_OutputToFile(t *testing.T) {
 	wr, err := NewWorkloadResource(resources.WorkloadV1Config, "my-ns")
 	require.NoError(t, err)
@@ -240,6 +291,44 @@ endpoints:
 	yamlStr := string(data)
 	assert.Contains(t, yamlStr, "grpc-ep")
 	assert.Contains(t, yamlStr, "image: myimg:v1")
+}
+func TestCreateWorkload_WithResourceDependencies(t *testing.T) {
+	wr, err := NewWorkloadResource(resources.WorkloadV1Config, "my-ns")
+	require.NoError(t, err)
+	descriptorYAML := `apiVersion: openchoreo.dev/v1alpha1
+metadata:
+  name: test-workload
+dependencies:
+  resources:
+    - ref: orders-db
+      envBindings:
+        host: DB_HOST
+        password: DB_PASSWORD
+      fileBindings:
+        caCert: /etc/ssl/db-ca.crt
+`
+	tmpDir := t.TempDir()
+	descriptorPath := filepath.Join(tmpDir, "workload.yaml")
+	require.NoError(t, os.WriteFile(descriptorPath, []byte(descriptorYAML), 0600))
+	outPath := filepath.Join(tmpDir, "out.yaml")
+	params := synth.CreateWorkloadParams{
+		NamespaceName: "my-ns",
+		ProjectName:   "my-project",
+		ComponentName: "my-comp",
+		ImageURL:      "myimg:v1",
+		FilePath:      descriptorPath,
+		OutputPath:    outPath,
+	}
+	err = wr.CreateWorkload(params)
+	require.NoError(t, err)
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	yamlStr := string(data)
+	assert.Contains(t, yamlStr, "resources:")
+	assert.Contains(t, yamlStr, "ref: orders-db")
+	assert.Contains(t, yamlStr, "host: DB_HOST")
+	assert.Contains(t, yamlStr, "password: DB_PASSWORD")
+	assert.Contains(t, yamlStr, "caCert: /etc/ssl/db-ca.crt")
 }
 func TestCreateWorkload_Validation(t *testing.T) {
 	wr, err := NewWorkloadResource(resources.WorkloadV1Config, "my-ns")

--- a/internal/occ/resources/workload/converter.go
+++ b/internal/occ/resources/workload/converter.go
@@ -45,6 +45,21 @@ type WorkloadDescriptorEndpoint struct {
 type WorkloadDescriptorDependencies struct {
 	// Endpoints define how this workload consumes endpoints from other components.
 	Endpoints []WorkloadDescriptorConnection `yaml:"endpoints,omitempty"`
+	// Resources define how this workload consumes outputs from project-bound Resources.
+	Resources []WorkloadDescriptorResourceDependency `yaml:"resources,omitempty"`
+}
+
+// WorkloadDescriptorResourceDependency represents a dependency on a project-bound Resource.
+// Output names declared on the referenced ResourceType are wired into the consuming container
+// as env vars (envBindings) and file mounts (fileBindings).
+type WorkloadDescriptorResourceDependency struct {
+	// Ref is the name of the Resource to consume.
+	Ref string `yaml:"ref"`
+	// EnvBindings maps a ResourceType output name to a container environment variable name.
+	EnvBindings map[string]string `yaml:"envBindings,omitempty"`
+	// FileBindings maps a ResourceType output name to a container mount path. The referenced
+	// output's source kind must be secretKeyRef or configMapKeyRef.
+	FileBindings map[string]string `yaml:"fileBindings,omitempty"`
 }
 
 type WorkloadDescriptorConnection struct {
@@ -299,27 +314,53 @@ var validDependencyVisibilities = map[openchoreov1alpha1.EndpointVisibility]bool
 
 // addDependenciesFromDescriptor adds dependencies from the descriptor to the workload
 func addDependenciesFromDescriptor(workload *openchoreov1alpha1.Workload, descriptor *WorkloadDescriptor) error {
-	if descriptor.Dependencies == nil || len(descriptor.Dependencies.Endpoints) == 0 {
+	if descriptor.Dependencies == nil ||
+		(len(descriptor.Dependencies.Endpoints) == 0 && len(descriptor.Dependencies.Resources) == 0) {
 		return nil
 	}
 
-	connections := make([]openchoreov1alpha1.WorkloadConnection, 0, len(descriptor.Dependencies.Endpoints))
-	for i, dc := range descriptor.Dependencies.Endpoints {
+	connections, err := buildEndpointConnections(descriptor.Dependencies.Endpoints)
+	if err != nil {
+		return err
+	}
+	resources, err := buildResourceDependencies(descriptor.Dependencies.Resources)
+	if err != nil {
+		return err
+	}
+
+	if len(connections) == 0 && len(resources) == 0 {
+		return nil
+	}
+
+	if workload.Spec.Dependencies == nil {
+		workload.Spec.Dependencies = &openchoreov1alpha1.WorkloadDependencies{}
+	}
+	workload.Spec.Dependencies.Endpoints = connections
+	workload.Spec.Dependencies.Resources = resources
+	return nil
+}
+
+func buildEndpointConnections(entries []WorkloadDescriptorConnection) ([]openchoreov1alpha1.WorkloadConnection, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	connections := make([]openchoreov1alpha1.WorkloadConnection, 0, len(entries))
+	for i, dc := range entries {
 		if dc.Component == "" {
-			return fmt.Errorf("dependency endpoint[%d]: component is required", i)
+			return nil, fmt.Errorf("dependency endpoint[%d]: component is required", i)
 		}
 		if dc.Name == "" {
-			return fmt.Errorf("dependency endpoint[%d] (component %q): name is required", i, dc.Component)
+			return nil, fmt.Errorf("dependency endpoint[%d] (component %q): name is required", i, dc.Component)
 		}
 		if dc.Visibility == "" {
-			return fmt.Errorf("dependency endpoint[%d] (component %q): visibility is required", i, dc.Component)
+			return nil, fmt.Errorf("dependency endpoint[%d] (component %q): visibility is required", i, dc.Component)
 		}
 		visibility := openchoreov1alpha1.EndpointVisibility(dc.Visibility)
 		if !validDependencyVisibilities[visibility] {
-			return fmt.Errorf("invalid dependency endpoint visibility %q for component %q endpoint %q: must be one of [project, namespace]",
+			return nil, fmt.Errorf("invalid dependency endpoint visibility %q for component %q endpoint %q: must be one of [project, namespace]",
 				dc.Visibility, dc.Component, dc.Name)
 		}
-		connection := openchoreov1alpha1.WorkloadConnection{
+		connections = append(connections, openchoreov1alpha1.WorkloadConnection{
 			Project:    dc.Project,
 			Component:  dc.Component,
 			Name:       dc.Name,
@@ -330,14 +371,37 @@ func addDependenciesFromDescriptor(workload *openchoreov1alpha1.Workload, descri
 				Port:     dc.EnvBindings.Port,
 				BasePath: dc.EnvBindings.BasePath,
 			},
+		})
+	}
+	return connections, nil
+}
+
+func buildResourceDependencies(entries []WorkloadDescriptorResourceDependency) ([]openchoreov1alpha1.WorkloadResourceDependency, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	resources := make([]openchoreov1alpha1.WorkloadResourceDependency, 0, len(entries))
+	for i, dr := range entries {
+		if dr.Ref == "" {
+			return nil, fmt.Errorf("dependency resource[%d]: ref is required", i)
 		}
-		connections = append(connections, connection)
+		for k, v := range dr.EnvBindings {
+			if k == "" || v == "" {
+				return nil, fmt.Errorf("dependency resource[%d] (ref %q): envBindings keys (output names) and values (env var names) cannot be empty", i, dr.Ref)
+			}
+		}
+		for k, v := range dr.FileBindings {
+			if k == "" || v == "" {
+				return nil, fmt.Errorf("dependency resource[%d] (ref %q): fileBindings keys (output names) and values (mount paths) cannot be empty", i, dr.Ref)
+			}
+		}
+		resources = append(resources, openchoreov1alpha1.WorkloadResourceDependency{
+			Ref:          dr.Ref,
+			EnvBindings:  dr.EnvBindings,
+			FileBindings: dr.FileBindings,
+		})
 	}
-	if workload.Spec.Dependencies == nil {
-		workload.Spec.Dependencies = &openchoreov1alpha1.WorkloadDependencies{}
-	}
-	workload.Spec.Dependencies.Endpoints = connections
-	return nil
+	return resources, nil
 }
 
 // addConfigurationsFromDescriptor adds configurations (env vars and files) from the descriptor to the workload

--- a/internal/occ/resources/workload/converter_test.go
+++ b/internal/occ/resources/workload/converter_test.go
@@ -295,6 +295,188 @@ func TestAddDependenciesFromDescriptor(t *testing.T) {
 		})
 	}
 }
+func TestAddDependenciesFromDescriptor_Resources(t *testing.T) {
+	baseWorkload := func() *openchoreov1alpha1.Workload {
+		return &openchoreov1alpha1.Workload{
+			Spec: openchoreov1alpha1.WorkloadSpec{
+				WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{},
+			},
+		}
+	}
+	tests := []struct {
+		name          string
+		descriptor    *WorkloadDescriptor
+		wantNilDeps   bool
+		wantResources int
+		wantEndpoints int
+		wantRef       string
+		wantEnv       map[string]string
+		wantFile      map[string]string
+		wantErr       string
+	}{
+		{
+			name: "valid resources only",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{
+						{
+							Ref: "orders-db",
+							EnvBindings: map[string]string{
+								"host":     "DB_HOST",
+								"port":     "DB_PORT",
+								"password": "DB_PASSWORD",
+							},
+							FileBindings: map[string]string{
+								"caCert": "/etc/ssl/db-ca.crt",
+							},
+						},
+					},
+				},
+			},
+			wantResources: 1,
+			wantRef:       "orders-db",
+			wantEnv: map[string]string{
+				"host":     "DB_HOST",
+				"port":     "DB_PORT",
+				"password": "DB_PASSWORD",
+			},
+			wantFile: map[string]string{
+				"caCert": "/etc/ssl/db-ca.crt",
+			},
+		},
+		{
+			name: "endpoints and resources together",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Endpoints: []WorkloadDescriptorConnection{
+						{
+							Component:  "svc-b",
+							Name:       "http-ep",
+							Visibility: "project",
+							EnvBindings: WorkloadDescriptorConnectionEnvBindings{
+								Address: "SVC_B_URL",
+							},
+						},
+					},
+					Resources: []WorkloadDescriptorResourceDependency{
+						{
+							Ref:         "cache",
+							EnvBindings: map[string]string{"host": "REDIS_HOST"},
+						},
+					},
+				},
+			},
+			wantEndpoints: 1,
+			wantResources: 1,
+			wantRef:       "cache",
+			wantEnv:       map[string]string{"host": "REDIS_HOST"},
+		},
+		{
+			name: "resource without env or file bindings",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{
+						{Ref: "queue"},
+					},
+				},
+			},
+			wantResources: 1,
+			wantRef:       "queue",
+		},
+		{
+			name: "missing ref returns error",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{
+						{EnvBindings: map[string]string{"host": "DB_HOST"}},
+					},
+				},
+			},
+			wantErr: "ref is required",
+		},
+		{
+			name: "empty env binding key returns error",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{
+						{
+							Ref:         "db",
+							EnvBindings: map[string]string{"": "DB_HOST"},
+						},
+					},
+				},
+			},
+			wantErr: "envBindings",
+		},
+		{
+			name: "empty env binding value returns error",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{
+						{
+							Ref:         "db",
+							EnvBindings: map[string]string{"host": ""},
+						},
+					},
+				},
+			},
+			wantErr: "envBindings",
+		},
+		{
+			name: "empty file binding value returns error",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{
+						{
+							Ref:          "db",
+							FileBindings: map[string]string{"caCert": ""},
+						},
+					},
+				},
+			},
+			wantErr: "fileBindings",
+		},
+		{
+			name: "empty resources slice and no endpoints",
+			descriptor: &WorkloadDescriptor{
+				Dependencies: &WorkloadDescriptorDependencies{
+					Resources: []WorkloadDescriptorResourceDependency{},
+				},
+			},
+			wantNilDeps: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := baseWorkload()
+			err := addDependenciesFromDescriptor(w, tt.descriptor)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNilDeps {
+				assert.Nil(t, w.Spec.Dependencies)
+				return
+			}
+			require.NotNil(t, w.Spec.Dependencies)
+			assert.Len(t, w.Spec.Dependencies.Endpoints, tt.wantEndpoints)
+			require.Len(t, w.Spec.Dependencies.Resources, tt.wantResources)
+			assert.Equal(t, tt.wantRef, w.Spec.Dependencies.Resources[0].Ref)
+			if tt.wantEnv != nil {
+				assert.Equal(t, tt.wantEnv, w.Spec.Dependencies.Resources[0].EnvBindings)
+			} else {
+				assert.Empty(t, w.Spec.Dependencies.Resources[0].EnvBindings)
+			}
+			if tt.wantFile != nil {
+				assert.Equal(t, tt.wantFile, w.Spec.Dependencies.Resources[0].FileBindings)
+			} else {
+				assert.Empty(t, w.Spec.Dependencies.Resources[0].FileBindings)
+			}
+		})
+	}
+}
 func TestReadWorkloadDescriptorDependencies(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -302,6 +484,10 @@ func TestReadWorkloadDescriptorDependencies(t *testing.T) {
 		wantNilDeps   bool
 		wantEndpoints int
 		wantComponent string
+		wantResources int
+		wantRef       string
+		wantEnv       map[string]string
+		wantFile      map[string]string
 	}{
 		{
 			name: "parses dependencies with endpoints",
@@ -324,6 +510,30 @@ dependencies:
 `,
 			wantEndpoints: 2,
 			wantComponent: "postgres",
+		},
+		{
+			name: "parses dependencies with resources",
+			yaml: `apiVersion: openchoreo.dev/v1alpha1
+metadata:
+  name: my-service
+dependencies:
+  resources:
+    - ref: orders-db
+      envBindings:
+        host: DB_HOST
+        password: DB_PASSWORD
+      fileBindings:
+        caCert: /etc/ssl/db-ca.crt
+`,
+			wantResources: 1,
+			wantRef:       "orders-db",
+			wantEnv: map[string]string{
+				"host":     "DB_HOST",
+				"password": "DB_PASSWORD",
+			},
+			wantFile: map[string]string{
+				"caCert": "/etc/ssl/db-ca.crt",
+			},
 		},
 		{
 			name: "no dependencies section",
@@ -354,12 +564,21 @@ connections:
 			descriptor, err := readWorkloadDescriptorFromReader(reader)
 			require.NoError(t, err)
 			if tt.wantNilDeps {
-				assert.True(t, descriptor.Dependencies == nil || len(descriptor.Dependencies.Endpoints) == 0)
+				assert.True(t, descriptor.Dependencies == nil ||
+					(len(descriptor.Dependencies.Endpoints) == 0 && len(descriptor.Dependencies.Resources) == 0))
 				return
 			}
 			require.NotNil(t, descriptor.Dependencies)
 			assert.Len(t, descriptor.Dependencies.Endpoints, tt.wantEndpoints)
-			assert.Equal(t, tt.wantComponent, descriptor.Dependencies.Endpoints[0].Component)
+			if tt.wantEndpoints > 0 {
+				assert.Equal(t, tt.wantComponent, descriptor.Dependencies.Endpoints[0].Component)
+			}
+			assert.Len(t, descriptor.Dependencies.Resources, tt.wantResources)
+			if tt.wantResources > 0 {
+				assert.Equal(t, tt.wantRef, descriptor.Dependencies.Resources[0].Ref)
+				assert.Equal(t, tt.wantEnv, descriptor.Dependencies.Resources[0].EnvBindings)
+				assert.Equal(t, tt.wantFile, descriptor.Dependencies.Resources[0].FileBindings)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Purpose

Add support for `dependencies.resources[]` in `workload.yaml`. The CRD field (added in #3334) was already accepted server-side, but the descriptor parser silently dropped it.

## Approach

- Add `WorkloadDescriptorResourceDependency { ref, envBindings, fileBindings }` and `Resources` field on `WorkloadDescriptorDependencies` in the descriptor parser.
- Extend `addDependenciesFromDescriptor` to populate `Workload.spec.dependencies.resources`, with per-entry validation (`ref` required, empty binding keys/values rejected) mirroring the CRD's CEL rule.
- Relax the early-return guard so resources-only descriptors (no endpoint deps) aren't dropped.
- Both `--mode api-server` and `--mode file-system` share the converter, so both pick up the change.

Smoke-tested on a local k3d cluster: emitted YAML applies cleanly and `dependencies.resources` round-trips intact.

## Related Issues

Related #3337, #3334

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)