### PR TITLE
feat: add doclet from-image sample with composite Resource URL outputs

### DIFF
--- a/samples/from-image/doclet/README.md
+++ b/samples/from-image/doclet/README.md
@@ -1,0 +1,168 @@
+# Doclet on OpenChoreo (From Image)
+
+A sample application that demonstrates how an OpenChoreo Workload consumes managed infrastructure via the resource abstraction model. Doclet is a small collaborative document editor: a React frontend, two Go services, and dependencies on Postgres and NATS.
+
+## What this sample shows
+
+- A **Project** with three Components (frontend, two services) and two **Resources** (Postgres + NATS) provisioned from the shipped `ClusterResourceType`s.
+- The document service consumes Postgres outputs via `dependencies.resources[].envBindings` — five individual env vars (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`) wired to the container.
+- Both Go services consume NATS via a single envBinding to the composite `url` output. The full `nats://<token>@<host>:<port>` URL is composed on the data plane; the token never reaches the control plane.
+- The frontend wires `dependencies.endpoints[]` to the two backend services, and nginx reverse-proxies `/api/document-svc` and `/ws/collab-svc` to them.
+- `ResourceReleaseBinding`s ship as YAML under `bindings/development/`, demonstrating per-environment overrides via `resourceTypeEnvironmentConfigs`. The dev bindings enable the bundled admin UIs (Adminer for Postgres, NATS `/varz`).
+
+## Architecture
+
+```
+                  external HTTP
+                       │
+                       ▼
+              ┌────────────────┐
+              │ doclet-frontend│ (nginx + React, port 80)
+              └───────┬────────┘
+                      │ reverse proxy
+        ┌─────────────┴────────────────┐
+        ▼                              ▼
+┌────────────────┐            ┌────────────────┐
+│ doclet-document│            │ doclet-collab  │
+│  (HTTP :8080)  │            │  (WS :8090)    │
+└───────┬────────┘            └────────┬───────┘
+        │                              │
+        │   ┌──────────────────────────┤
+        ▼   ▼                          ▼
+ ┌────────────────┐            ┌────────────────┐
+ │ doclet-postgres│            │  doclet-nats   │
+ │  (ResourceType)│            │ (ResourceType) │
+ └────────────────┘            └────────────────┘
+```
+
+## Prerequisites
+
+- An OpenChoreo cluster with the control plane installed
+- `kubectl` access to the cluster
+
+## Step 1: Enable WebSockets at the data-plane gateway
+
+The doclet frontend reverse-proxies a WebSocket sub-path (`/ws/collab-svc`) to the collab service. kgateway disables WebSocket upgrades by default; enable them on the data-plane Gateway with a one-time `HTTPListenerPolicy`:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: default-httplistenerpolicy
+  namespace: openchoreo-data-plane
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-default
+  upgradeConfig:
+    enabledUpgrades:
+      - websocket
+EOF
+```
+
+## Step 2: Deploy
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/project.yaml
+
+kubectl apply \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/resources/postgres.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/resources/nats.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/components/service-document.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/components/service-collab.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/components/frontend.yaml
+
+kubectl apply \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/bindings/development/postgres.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/bindings/development/nats.yaml
+```
+
+Components have `autoDeploy: true` and create their `ReleaseBinding`s automatically. The `ResourceReleaseBinding`s under `bindings/development/` are applied with `spec.resourceRelease` intentionally unset — they will stay pending until promoted in the next step.
+
+## Step 3: Promote each resource to the development environment
+
+Pin each Resource's binding to its latest release:
+
+```bash
+for r in doclet-postgres doclet-nats; do
+  release=$(kubectl get resource $r -n default -o jsonpath='{.status.latestRelease.name}')
+  kubectl patch resourcereleasebinding $r-development -n default \
+    --type=merge -p "{\"spec\":{\"resourceRelease\":\"$release\"}}"
+done
+```
+
+Wait for everything to reach `Ready=True`:
+
+```bash
+kubectl get resourcereleasebinding,releasebinding -n default | grep doclet
+```
+
+## Access the frontend
+
+Find the gateway URL from the frontend's `ReleaseBinding`:
+
+```bash
+kubectl get releasebinding doclet-frontend-development -n default -o jsonpath='{.status.endpoints[0].url}'
+```
+
+Open the URL in a browser. The React app loads, lists documents (empty on first launch), and lets you create and edit documents with real-time collaboration.
+
+You can also smoke-test the document service directly through the frontend's reverse proxy:
+
+```bash
+GATEWAY=$(kubectl get releasebinding doclet-frontend-development -n default -o jsonpath='{.status.endpoints[0].url}')
+curl -sS "$GATEWAY/api/document-svc/documents"
+curl -sS -X POST -H 'Content-Type: application/json' -d '{"title":"smoke test"}' "$GATEWAY/api/document-svc/documents"
+```
+
+## Access the admin UIs (dev only)
+
+The dev bindings enable `adminEnabled: true`, which spins up an admin UI for each resource. The URLs surface on the `ResourceReleaseBinding.status.outputs[*].adminURL`:
+
+```bash
+kubectl get resourcereleasebinding doclet-postgres-development -n default -o jsonpath='{.status.outputs[?(@.name=="adminURL")].value}'
+kubectl get resourcereleasebinding doclet-nats-development     -n default -o jsonpath='{.status.outputs[?(@.name=="adminURL")].value}'
+```
+
+- **Postgres → Adminer**. Server, database, and username (`demo`) are pre-filled via the query string. Password is `demo` (printed in `status.outputs[*].adminPassword`). The `demo` superuser is created by the CRT's bootstrap script and exists only when `adminEnabled: true`; the application user has an ESO-generated random password that never appears in any output.
+- **NATS → built-in monitoring**. Unauthenticated read-only `/varz`, `/connz`, `/subsz` JSON pages. Useful for verifying that the document and collab services have connected (`/connz` shows two client connections).
+
+## How the resource wiring works
+
+The document service's `Workload` (in `components/service-document.yaml`):
+
+```yaml
+dependencies:
+  resources:
+    - ref: doclet-postgres
+      envBindings:
+        host: DB_HOST
+        port: DB_PORT
+        username: DB_USER
+        password: DB_PASSWORD
+        database: DB_NAME
+    - ref: doclet-nats
+      envBindings:
+        url: DOCLET_NATS_URL
+```
+
+At runtime the container sees:
+
+- `DB_HOST=r-doclet-postgres-development-<hash>.<dp-namespace>.svc.cluster.local`
+- `DB_PORT=5432`
+- `DB_USER=doclet-postgres-user`
+- `DB_PASSWORD=<32-char random, resolved from a DP-side Secret>`
+- `DB_NAME=doclet`
+- `DOCLET_NATS_URL=nats://<token>@r-doclet-nats-development-<hash>.<dp-namespace>.svc.cluster.local:4222`
+
+The Postgres outputs are atomic (one env var per output). The NATS `url` is a composite output: ESO templates the full URL on the data plane using the generated token, then the consumer reads a single env var. The token bytes never reach the control plane.
+
+## Cleanup
+
+```bash
+kubectl delete -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/project.yaml
+```
+
+Deleting the Project cascades through Components, Resources, and bindings. Postgres and NATS use `retainPolicy: Delete` (the CRT default), so DP-side state is removed along with the bindings.

--- a/samples/from-image/doclet/bindings/development/nats.yaml
+++ b/samples/from-image/doclet/bindings/development/nats.yaml
@@ -1,0 +1,20 @@
+# ResourceReleaseBinding for the NATS resource in the `development` env.
+# spec.resourceRelease is intentionally omitted — the binding stays pending
+# until promoted to a specific ResourceRelease. See the README's "Promote
+# resources" step.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-nats-development
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-nats
+  environment: development
+  retainPolicy: Delete
+  resourceTypeEnvironmentConfigs:
+    # Demo only — exposes NATS's built-in /varz monitoring at the gateway.
+    # The endpoint is unauthenticated and read-only; safe for the demo but
+    # avoid enabling in production.
+    adminEnabled: true

--- a/samples/from-image/doclet/bindings/development/postgres.yaml
+++ b/samples/from-image/doclet/bindings/development/postgres.yaml
@@ -1,0 +1,19 @@
+# ResourceReleaseBinding for the Postgres resource in the `development` env.
+# spec.resourceRelease is intentionally omitted — the binding stays pending
+# until promoted to a specific ResourceRelease. See the README's "Promote
+# resources" step.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-postgres-development
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-postgres
+  environment: development
+  retainPolicy: Delete
+  resourceTypeEnvironmentConfigs:
+    # Demo only — exposes Adminer with a `demo`/`demo` superuser at the
+    # gateway. Do not enable in production environments.
+    adminEnabled: true

--- a/samples/from-image/doclet/components/frontend.yaml
+++ b/samples/from-image/doclet/components/frontend.yaml
@@ -1,0 +1,45 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: doclet-frontend
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/web-application
+  autoDeploy: true
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: doclet-frontend
+  namespace: default
+spec:
+  owner:
+    componentName: doclet-frontend
+    projectName: doclet
+  endpoints:
+    http:
+      type: HTTP
+      port: 80
+      visibility: [external]
+  dependencies:
+    endpoints:
+      - project: doclet
+        component: doclet-document
+        name: http
+        visibility: project
+        envBindings:
+          address: DOC_SERVICE_URL
+      - project: doclet
+        component: doclet-collab
+        name: ws
+        visibility: project
+        envBindings:
+          address: COLLAB_SERVICE_URL
+  container:
+    image: ghcr.io/openchoreo/samples/doclet-frontend:latest

--- a/samples/from-image/doclet/components/service-collab.yaml
+++ b/samples/from-image/doclet/components/service-collab.yaml
@@ -1,0 +1,36 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: doclet-collab
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/service
+  autoDeploy: true
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: doclet-collab
+  namespace: default
+spec:
+  owner:
+    componentName: doclet-collab
+    projectName: doclet
+  endpoints:
+    ws:
+      type: HTTP
+      port: 8090
+      visibility: [project]
+  dependencies:
+    resources:
+      - ref: doclet-nats
+        envBindings:
+          url: DOCLET_NATS_URL
+  container:
+    image: ghcr.io/openchoreo/samples/doclet-collab:latest

--- a/samples/from-image/doclet/components/service-document.yaml
+++ b/samples/from-image/doclet/components/service-document.yaml
@@ -1,0 +1,43 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: doclet-document
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/service
+  autoDeploy: true
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: doclet-document
+  namespace: default
+spec:
+  owner:
+    componentName: doclet-document
+    projectName: doclet
+  endpoints:
+    http:
+      type: HTTP
+      port: 8080
+      visibility: [project]
+  dependencies:
+    resources:
+      - ref: doclet-postgres
+        envBindings:
+          host: DB_HOST
+          port: DB_PORT
+          username: DB_USER
+          password: DB_PASSWORD
+          database: DB_NAME
+      - ref: doclet-nats
+        envBindings:
+          url: DOCLET_NATS_URL
+  container:
+    image: ghcr.io/openchoreo/samples/doclet-document:latest

--- a/samples/from-image/doclet/project.yaml
+++ b/samples/from-image/doclet/project.yaml
@@ -1,0 +1,13 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Project
+metadata:
+  annotations:
+    openchoreo.dev/description: Doclet Demo — anonymous real-time collaboration on rich-text documents
+    openchoreo.dev/display-name: Doclet
+  labels:
+    openchoreo.dev/name: doclet
+  name: doclet
+  namespace: default
+spec:
+  deploymentPipelineRef:
+    name: default

--- a/samples/from-image/doclet/resources/nats.yaml
+++ b/samples/from-image/doclet/resources/nats.yaml
@@ -1,0 +1,11 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-nats
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: nats

--- a/samples/from-image/doclet/resources/postgres.yaml
+++ b/samples/from-image/doclet/resources/postgres.yaml
@@ -1,0 +1,13 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-postgres
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: postgres
+  parameters:
+    database: doclet

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -1015,6 +1015,15 @@ spec:
       secretKeyRef:
         name: "${metadata.name}-creds"
         key: password
+    # Convenience output: full Postgres connection URL with the application
+    # user's password embedded. Composed on the data plane by ESO's secret
+    # template; the password bytes never reach the control plane (same
+    # guarantee as the `password` output). sslmode=disable matches the
+    # CRT's plaintext StatefulSet config.
+    - name: url
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: url
     # Adminer URL with driver=pgsql, server, username=demo (deliberately weak
     # superuser created for the demo UI), db pre-filled via query params.
     # Paste the value of adminPassword on the Adminer login form.
@@ -1103,6 +1112,10 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once. The Password generator is stateless — every call
+          # returns a NEW random value, so a non-zero refreshInterval would
+          # rotate the password and break the postgres user (whose password
+          # is baked in at initdb).
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds-postgres
@@ -1141,10 +1154,19 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once — see note above the `creds-postgres` ExternalSecret.
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds
             creationPolicy: Owner
+            # ESO templates the Secret data DP-side using the fetched
+            # password. The control plane only stores the literal `{{ .password }}`
+            # placeholder, never the resolved bytes.
+            template:
+              type: Opaque
+              data:
+                password: "{{ .password }}"
+                url: "postgres://${metadata.resourceName}-user:{{ .password }}@${metadata.name}.${metadata.namespace}.svc.cluster.local:5432/${parameters.database}?sslmode=disable"
           dataFrom:
             - sourceRef:
                 generatorRef:
@@ -1378,6 +1400,10 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once. The Password generator is stateless — every call
+          # returns a NEW random value, so a non-zero refreshInterval would
+          # rotate the password periodically and desync running consumers
+          # whose env vars were resolved at pod-start.
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds
@@ -1557,6 +1583,13 @@ spec:
       secretKeyRef:
         name: "${metadata.name}-creds"
         key: password
+    # Convenience output: full NATS client URL with the token embedded.
+    # Composed on the data plane by ESO's secret template; the token bytes
+    # never reach the control plane (same guarantee as the `token` output).
+    - name: url
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: url
     # Admin URL points at NATS's built-in HTTP monitoring endpoint (port
     # 8222), which serves JSON diagnostics like /varz, /connz, /subsz. The
     # endpoint is unauthenticated and read-only; the dev opens the URL and
@@ -1599,10 +1632,22 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once. The Password generator is stateless — every call
+          # returns a NEW random value, so a non-zero refreshInterval would
+          # rotate the password periodically and desync running consumers
+          # whose env vars were resolved at pod-start.
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds
             creationPolicy: Owner
+            # ESO templates the Secret data DP-side using the fetched
+            # password. The control plane only stores the literal `{{ .password }}`
+            # placeholder, never the resolved bytes.
+            template:
+              type: Opaque
+              data:
+                password: "{{ .password }}"
+                url: "nats://{{ .password }}@${metadata.name}.${metadata.namespace}.svc.cluster.local:4222"
           dataFrom:
             - sourceRef:
                 generatorRef:

--- a/samples/getting-started/cluster-resource-types/nats.yaml
+++ b/samples/getting-started/cluster-resource-types/nats.yaml
@@ -31,6 +31,13 @@ spec:
       secretKeyRef:
         name: "${metadata.name}-creds"
         key: password
+    # Convenience output: full NATS client URL with the token embedded.
+    # Composed on the data plane by ESO's secret template; the token bytes
+    # never reach the control plane (same guarantee as the `token` output).
+    - name: url
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: url
     # Admin URL points at NATS's built-in HTTP monitoring endpoint (port
     # 8222), which serves JSON diagnostics like /varz, /connz, /subsz. The
     # endpoint is unauthenticated and read-only; the dev opens the URL and
@@ -73,10 +80,22 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once. The Password generator is stateless — every call
+          # returns a NEW random value, so a non-zero refreshInterval would
+          # rotate the password periodically and desync running consumers
+          # whose env vars were resolved at pod-start.
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds
             creationPolicy: Owner
+            # ESO templates the Secret data DP-side using the fetched
+            # password. The control plane only stores the literal `{{ .password }}`
+            # placeholder, never the resolved bytes.
+            template:
+              type: Opaque
+              data:
+                password: "{{ .password }}"
+                url: "nats://{{ .password }}@${metadata.name}.${metadata.namespace}.svc.cluster.local:4222"
           dataFrom:
             - sourceRef:
                 generatorRef:

--- a/samples/getting-started/cluster-resource-types/postgres.yaml
+++ b/samples/getting-started/cluster-resource-types/postgres.yaml
@@ -47,6 +47,15 @@ spec:
       secretKeyRef:
         name: "${metadata.name}-creds"
         key: password
+    # Convenience output: full Postgres connection URL with the application
+    # user's password embedded. Composed on the data plane by ESO's secret
+    # template; the password bytes never reach the control plane (same
+    # guarantee as the `password` output). sslmode=disable matches the
+    # CRT's plaintext StatefulSet config.
+    - name: url
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: url
     # Adminer URL with driver=pgsql, server, username=demo (deliberately weak
     # superuser created for the demo UI), db pre-filled via query params.
     # Paste the value of adminPassword on the Adminer login form.
@@ -135,6 +144,10 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once. The Password generator is stateless — every call
+          # returns a NEW random value, so a non-zero refreshInterval would
+          # rotate the password and break the postgres user (whose password
+          # is baked in at initdb).
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds-postgres
@@ -173,10 +186,19 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once — see note above the `creds-postgres` ExternalSecret.
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds
             creationPolicy: Owner
+            # ESO templates the Secret data DP-side using the fetched
+            # password. The control plane only stores the literal `{{ .password }}`
+            # placeholder, never the resolved bytes.
+            template:
+              type: Opaque
+              data:
+                password: "{{ .password }}"
+                url: "postgres://${metadata.resourceName}-user:{{ .password }}@${metadata.name}.${metadata.namespace}.svc.cluster.local:5432/${parameters.database}?sslmode=disable"
           dataFrom:
             - sourceRef:
                 generatorRef:

--- a/samples/getting-started/cluster-resource-types/valkey.yaml
+++ b/samples/getting-started/cluster-resource-types/valkey.yaml
@@ -72,6 +72,10 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
+          # Sync once. The Password generator is stateless — every call
+          # returns a NEW random value, so a non-zero refreshInterval would
+          # rotate the password periodically and desync running consumers
+          # whose env vars were resolved at pod-start.
           refreshInterval: "0"
           target:
             name: ${metadata.name}-creds


### PR DESCRIPTION
## Purpose

Add a multi-service sample demonstrating consumption of the new Resource abstraction, and extend the shipped Postgres and NATS ClusterResourceTypes with a composite `url` output so consumers can wire a full connection string with a single envBinding.

## Approach

- Extend `nats` and `postgres` ClusterResourceTypes with a `url` output composed on the data plane via ESO `target.template` — credential bytes never reach the control plane.
- Add `samples/from-image/doclet/` — React frontend + 2 Go services consuming managed Postgres and NATS Resources.
- Postgres wired atomically (`DB_HOST`/`DB_PORT`/`DB_USER`/`DB_PASSWORD`/`DB_NAME`); NATS wired via the single composite `url` envBinding.
- Per-env `ResourceReleaseBinding`s under `bindings/development/` enable Adminer and NATS `/varz` admin UIs.
- README walks through the apply + promote flow, plus the one-time `HTTPListenerPolicy` needed to enable WebSocket upgrades at the data-plane gateway.

## Related Issues

Related #3340

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)