### PR TITLE
feat(api): add resource family MCP tools

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -329,6 +329,9 @@ func buildMCPToolsets(cfg *config.Config, svc *handlerservices.Services, logger 
 		case tools.ToolsetPE:
 			toolsets.PEToolset = handler
 			logger.Debug("Enabled MCP toolset", slog.String("toolset", "pe"))
+		case tools.ToolsetResource:
+			toolsets.ResourceToolset = handler
+			logger.Debug("Enabled MCP toolset", slog.String("toolset", "resource"))
 		default:
 			logger.Warn("Unknown toolset type", slog.String("toolset", string(toolsetType)))
 		}

--- a/internal/openchoreo-api/config/mcp.go
+++ b/internal/openchoreo-api/config/mcp.go
@@ -30,6 +30,7 @@ func MCPDefaults() MCPConfig {
 			string(tools.ToolsetComponent),
 			string(tools.ToolsetDeployment),
 			string(tools.ToolsetBuild),
+			string(tools.ToolsetResource),
 		},
 	}
 }
@@ -42,6 +43,7 @@ var validToolsets = map[string]bool{
 	string(tools.ToolsetDeployment): true,
 	string(tools.ToolsetBuild):      true,
 	string(tools.ToolsetPE):         true,
+	string(tools.ToolsetResource):   true,
 }
 
 // ValidateMCPConfig validates the MCP configuration.

--- a/internal/openchoreo-api/config/mcp_test.go
+++ b/internal/openchoreo-api/config/mcp_test.go
@@ -19,7 +19,7 @@ func TestNewMCPConfig_Defaults(t *testing.T) {
 		t.Error("expected Enabled to be true by default")
 	}
 
-	expectedToolsets := []string{"namespace", "project", "component", "deployment", "build"}
+	expectedToolsets := []string{"namespace", "project", "component", "deployment", "build", "resource"}
 	if diff := cmp.Diff(expectedToolsets, cfg.Toolsets); diff != "" {
 		t.Errorf("default toolsets mismatch (-want +got):\n%s", diff)
 	}
@@ -43,7 +43,7 @@ func TestNewMCPConfig_ValidateToolsets(t *testing.T) {
 			name: "all valid toolsets",
 			cfg: MCPConfig{
 				Enabled:  true,
-				Toolsets: []string{"namespace", "project", "component", "deployment", "build", "pe"},
+				Toolsets: []string{"namespace", "project", "component", "deployment", "build", "pe", "resource"},
 			},
 			expectedErrors: nil,
 		},
@@ -54,7 +54,7 @@ func TestNewMCPConfig_ValidateToolsets(t *testing.T) {
 				Toolsets: []string{"invalid"},
 			},
 			expectedErrors: config.ValidationErrors{
-				{Field: "mcp.toolsets[0]", Message: `unknown toolset "invalid"; valid toolsets: build, component, deployment, namespace, pe, project`},
+				{Field: "mcp.toolsets[0]", Message: `unknown toolset "invalid"; valid toolsets: build, component, deployment, namespace, pe, project, resource`},
 			},
 		},
 		{
@@ -64,7 +64,7 @@ func TestNewMCPConfig_ValidateToolsets(t *testing.T) {
 				Toolsets: []string{"namespace", "unknown", "component"},
 			},
 			expectedErrors: config.ValidationErrors{
-				{Field: "mcp.toolsets[1]", Message: `unknown toolset "unknown"; valid toolsets: build, component, deployment, namespace, pe, project`},
+				{Field: "mcp.toolsets[1]", Message: `unknown toolset "unknown"; valid toolsets: build, component, deployment, namespace, pe, project, resource`},
 			},
 		},
 	}

--- a/internal/openchoreo-api/mcphandlers/resource_types.go
+++ b/internal/openchoreo-api/mcphandlers/resource_types.go
@@ -5,6 +5,7 @@ package mcphandlers
 
 import (
 	"context"
+	"errors"
 	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +14,22 @@ import (
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
 	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
 )
+
+// mergeAnnotations applies the create-path annotation sanitizer to incoming
+// annotations and merges the cleaned result into dst. Used by Update handlers
+// to keep parity with Create paths.
+func mergeAnnotations(dst, incoming map[string]string) map[string]string {
+	cleaned := maps.Clone(incoming)
+	cleanAnnotations(cleaned)
+	if len(cleaned) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = map[string]string{}
+	}
+	maps.Copy(dst, cleaned)
+	return dst
+}
 
 // ---------------------------------------------------------------------------
 // ResourceType (namespace-scoped)
@@ -41,6 +58,9 @@ func (h *MCPHandler) GetResourceTypeSchema(ctx context.Context, namespaceName, r
 func (h *MCPHandler) CreateResourceType(
 	ctx context.Context, namespaceName string, req *gen.CreateResourceTypeJSONRequestBody,
 ) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
 	annotations := map[string]string{}
 	if req.Metadata.Annotations != nil {
 		maps.Copy(annotations, *req.Metadata.Annotations)
@@ -72,16 +92,16 @@ func (h *MCPHandler) CreateResourceType(
 func (h *MCPHandler) UpdateResourceType(
 	ctx context.Context, namespaceName string, req *gen.UpdateResourceTypeJSONRequestBody,
 ) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
 	existing, err := h.services.ResourceTypeService.GetResourceType(ctx, namespaceName, req.Metadata.Name)
 	if err != nil {
 		return nil, err
 	}
 
 	if req.Metadata.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = map[string]string{}
-		}
-		maps.Copy(existing.Annotations, *req.Metadata.Annotations)
+		existing.Annotations = mergeAnnotations(existing.Annotations, *req.Metadata.Annotations)
 	}
 	if req.Spec != nil {
 		spec, err := convertSpec[gen.ResourceTypeSpec, openchoreov1alpha1.ResourceTypeSpec](*req.Spec)
@@ -136,6 +156,9 @@ func (h *MCPHandler) GetClusterResourceTypeSchema(ctx context.Context, crtName s
 func (h *MCPHandler) CreateClusterResourceType(
 	ctx context.Context, req *gen.CreateClusterResourceTypeJSONRequestBody,
 ) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
 	annotations := map[string]string{}
 	if req.Metadata.Annotations != nil {
 		maps.Copy(annotations, *req.Metadata.Annotations)
@@ -166,16 +189,16 @@ func (h *MCPHandler) CreateClusterResourceType(
 func (h *MCPHandler) UpdateClusterResourceType(
 	ctx context.Context, req *gen.UpdateClusterResourceTypeJSONRequestBody,
 ) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
 	existing, err := h.services.ClusterResourceTypeService.GetClusterResourceType(ctx, req.Metadata.Name)
 	if err != nil {
 		return nil, err
 	}
 
 	if req.Metadata.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = map[string]string{}
-		}
-		maps.Copy(existing.Annotations, *req.Metadata.Annotations)
+		existing.Annotations = mergeAnnotations(existing.Annotations, *req.Metadata.Annotations)
 	}
 	if req.Spec != nil {
 		spec, err := convertSpec[gen.ResourceTypeSpec, openchoreov1alpha1.ClusterResourceTypeSpec](*req.Spec)

--- a/internal/openchoreo-api/mcphandlers/resource_types.go
+++ b/internal/openchoreo-api/mcphandlers/resource_types.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+// ---------------------------------------------------------------------------
+// ResourceType (namespace-scoped)
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListResourceTypes(ctx context.Context, namespaceName string, opts tools.ListOpts) (any, error) {
+	result, err := h.services.ResourceTypeService.ListResourceTypes(ctx, namespaceName, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList("resource_types", result.Items, result.NextCursor, resourceTypeSummary), nil
+}
+
+func (h *MCPHandler) GetResourceType(ctx context.Context, namespaceName, rtName string) (any, error) {
+	rt, err := h.services.ResourceTypeService.GetResourceType(ctx, namespaceName, rtName)
+	if err != nil {
+		return nil, err
+	}
+	return resourceTypeDetail(rt), nil
+}
+
+func (h *MCPHandler) GetResourceTypeSchema(ctx context.Context, namespaceName, rtName string) (any, error) {
+	return h.services.ResourceTypeService.GetResourceTypeSchema(ctx, namespaceName, rtName)
+}
+
+func (h *MCPHandler) CreateResourceType(
+	ctx context.Context, namespaceName string, req *gen.CreateResourceTypeJSONRequestBody,
+) (any, error) {
+	annotations := map[string]string{}
+	if req.Metadata.Annotations != nil {
+		maps.Copy(annotations, *req.Metadata.Annotations)
+	}
+	cleanAnnotations(annotations)
+
+	rt := &openchoreov1alpha1.ResourceType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        req.Metadata.Name,
+			Namespace:   namespaceName,
+			Annotations: annotations,
+		},
+	}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.ResourceTypeSpec, openchoreov1alpha1.ResourceTypeSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		rt.Spec = spec
+	}
+
+	created, err := h.services.ResourceTypeService.CreateResourceType(ctx, namespaceName, rt)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateResourceType(
+	ctx context.Context, namespaceName string, req *gen.UpdateResourceTypeJSONRequestBody,
+) (any, error) {
+	existing, err := h.services.ResourceTypeService.GetResourceType(ctx, namespaceName, req.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Metadata.Annotations != nil {
+		if existing.Annotations == nil {
+			existing.Annotations = map[string]string{}
+		}
+		maps.Copy(existing.Annotations, *req.Metadata.Annotations)
+	}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.ResourceTypeSpec, openchoreov1alpha1.ResourceTypeSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		existing.Spec = spec
+	}
+
+	updated, err := h.services.ResourceTypeService.UpdateResourceType(ctx, namespaceName, existing)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteResourceType(ctx context.Context, namespaceName, rtName string) (any, error) {
+	if err := h.services.ResourceTypeService.DeleteResourceType(ctx, namespaceName, rtName); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"name":      rtName,
+		"namespace": namespaceName,
+		"action":    "deleted",
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ClusterResourceType (cluster-scoped)
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListClusterResourceTypes(ctx context.Context, opts tools.ListOpts) (any, error) {
+	result, err := h.services.ClusterResourceTypeService.ListClusterResourceTypes(ctx, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList("cluster_resource_types", result.Items, result.NextCursor, clusterResourceTypeSummary), nil
+}
+
+func (h *MCPHandler) GetClusterResourceType(ctx context.Context, crtName string) (any, error) {
+	crt, err := h.services.ClusterResourceTypeService.GetClusterResourceType(ctx, crtName)
+	if err != nil {
+		return nil, err
+	}
+	return clusterResourceTypeDetail(crt), nil
+}
+
+func (h *MCPHandler) GetClusterResourceTypeSchema(ctx context.Context, crtName string) (any, error) {
+	return h.services.ClusterResourceTypeService.GetClusterResourceTypeSchema(ctx, crtName)
+}
+
+func (h *MCPHandler) CreateClusterResourceType(
+	ctx context.Context, req *gen.CreateClusterResourceTypeJSONRequestBody,
+) (any, error) {
+	annotations := map[string]string{}
+	if req.Metadata.Annotations != nil {
+		maps.Copy(annotations, *req.Metadata.Annotations)
+	}
+	cleanAnnotations(annotations)
+
+	crt := &openchoreov1alpha1.ClusterResourceType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        req.Metadata.Name,
+			Annotations: annotations,
+		},
+	}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.ResourceTypeSpec, openchoreov1alpha1.ClusterResourceTypeSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		crt.Spec = spec
+	}
+
+	created, err := h.services.ClusterResourceTypeService.CreateClusterResourceType(ctx, crt)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateClusterResourceType(
+	ctx context.Context, req *gen.UpdateClusterResourceTypeJSONRequestBody,
+) (any, error) {
+	existing, err := h.services.ClusterResourceTypeService.GetClusterResourceType(ctx, req.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Metadata.Annotations != nil {
+		if existing.Annotations == nil {
+			existing.Annotations = map[string]string{}
+		}
+		maps.Copy(existing.Annotations, *req.Metadata.Annotations)
+	}
+	if req.Spec != nil {
+		spec, err := convertSpec[gen.ResourceTypeSpec, openchoreov1alpha1.ClusterResourceTypeSpec](*req.Spec)
+		if err != nil {
+			return nil, err
+		}
+		existing.Spec = spec
+	}
+
+	updated, err := h.services.ClusterResourceTypeService.UpdateClusterResourceType(ctx, existing)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteClusterResourceType(ctx context.Context, crtName string) (any, error) {
+	if err := h.services.ClusterResourceTypeService.DeleteClusterResourceType(ctx, crtName); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"name":   crtName,
+		"action": "deleted",
+	}, nil
+}

--- a/internal/openchoreo-api/mcphandlers/resource_types_test.go
+++ b/internal/openchoreo-api/mcphandlers/resource_types_test.go
@@ -1,0 +1,575 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+	clusterresourcetypemocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clusterresourcetype/mocks"
+	resourcetypemocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resourcetype/mocks"
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+const (
+	testResourceTypeName        = "postgres"
+	testClusterResourceTypeName = "managed-redis"
+)
+
+func sampleResourceType() *openchoreov1alpha1.ResourceType {
+	return &openchoreov1alpha1.ResourceType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testResourceTypeName,
+			Namespace: testNS,
+		},
+		Spec: openchoreov1alpha1.ResourceTypeSpec{
+			RetainPolicy: openchoreov1alpha1.ResourceRetainPolicy("Delete"),
+			Resources: []openchoreov1alpha1.ResourceTypeManifest{{
+				ID: "claim",
+			}},
+		},
+	}
+}
+
+func sampleClusterResourceType() *openchoreov1alpha1.ClusterResourceType {
+	return &openchoreov1alpha1.ClusterResourceType{
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterResourceTypeName},
+		Spec: openchoreov1alpha1.ClusterResourceTypeSpec{
+			RetainPolicy: openchoreov1alpha1.ResourceRetainPolicy("Retain"),
+			Resources: []openchoreov1alpha1.ResourceTypeManifest{{
+				ID: "claim",
+			}},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResourceType
+// ---------------------------------------------------------------------------
+
+func TestListResourceTypes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns wrapped list with pagination cursor", func(t *testing.T) {
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			ListResourceTypes(mock.Anything, testNS, mock.Anything).
+			Return(&services.ListResult[openchoreov1alpha1.ResourceType]{
+				Items:      []openchoreov1alpha1.ResourceType{*sampleResourceType()},
+				NextCursor: "next-token",
+			}, nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		result, err := h.ListResourceTypes(ctx, testNS, tools.ListOpts{Limit: 10})
+		require.NoError(t, err)
+
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "next-token", m["next_cursor"])
+		items, ok := m["resource_types"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, items, 1)
+		assert.Equal(t, testResourceTypeName, items[0]["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("list failed")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			ListResourceTypes(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.ListResourceTypes(ctx, testNS, tools.ListOpts{})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns detail map", func(t *testing.T) {
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(sampleResourceType(), nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		result, err := h.GetResourceType(ctx, testNS, testResourceTypeName)
+		require.NoError(t, err)
+
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testResourceTypeName, m["name"])
+		assert.NotNil(t, m["spec"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("not found")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.GetResourceType(ctx, testNS, testResourceTypeName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetResourceTypeSchema(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns service schema map", func(t *testing.T) {
+		schema := map[string]any{"type": "object", "properties": map[string]any{}}
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceTypeSchema(mock.Anything, testNS, testResourceTypeName).
+			Return(schema, nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		result, err := h.GetResourceTypeSchema(ctx, testNS, testResourceTypeName)
+		require.NoError(t, err)
+		assert.Equal(t, schema, result)
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("schema lookup failed")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceTypeSchema(mock.Anything, testNS, testResourceTypeName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.GetResourceTypeSchema(ctx, testNS, testResourceTypeName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestCreateResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("converts gen spec to CRD spec and cleans annotations", func(t *testing.T) {
+		annotations := map[string]string{
+			"openchoreo.dev/display-name": "",
+			"openchoreo.dev/description":  "Postgres template",
+			"custom":                      "keep",
+		}
+		retain := gen.ResourceTypeSpecRetainPolicyRetain
+		req := &gen.CreateResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceTypeName, Annotations: &annotations},
+			Spec: &gen.ResourceTypeSpec{
+				RetainPolicy: &retain,
+				Resources: []gen.ResourceTypeManifest{{
+					Id: "claim",
+				}},
+			},
+		}
+
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			CreateResourceType(mock.Anything, testNS, mock.MatchedBy(func(rt *openchoreov1alpha1.ResourceType) bool {
+				_, hasDisplay := rt.Annotations["openchoreo.dev/display-name"]
+				return rt.Name == testResourceTypeName &&
+					rt.Namespace == testNS &&
+					!hasDisplay &&
+					rt.Annotations["openchoreo.dev/description"] == "Postgres template" &&
+					rt.Annotations["custom"] == "keep" &&
+					rt.Spec.RetainPolicy == openchoreov1alpha1.ResourceRetainPolicy("Retain") &&
+					len(rt.Spec.Resources) == 1 &&
+					rt.Spec.Resources[0].ID == "claim"
+			})).
+			Return(sampleResourceType(), nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		result, err := h.CreateResourceType(ctx, testNS, req)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "created", m["action"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("create failed")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			CreateResourceType(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.CreateResourceType(ctx, testNS, &gen.CreateResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceTypeName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestUpdateResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("fetches existing then applies spec and annotation merge", func(t *testing.T) {
+		existing := sampleResourceType()
+		existing.Annotations = map[string]string{"custom": "keep"}
+		newAnnotations := map[string]string{"openchoreo.dev/display-name": "Postgres"}
+		req := &gen.UpdateResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceTypeName, Annotations: &newAnnotations},
+			Spec: &gen.ResourceTypeSpec{
+				Resources: []gen.ResourceTypeManifest{{Id: "claim-v2"}},
+			},
+		}
+
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(existing, nil)
+
+		var sent *openchoreov1alpha1.ResourceType
+		rtSvc.EXPECT().
+			UpdateResourceType(mock.Anything, testNS, mock.Anything).
+			Run(func(_ context.Context, _ string, rt *openchoreov1alpha1.ResourceType) {
+				sent = rt
+			}).
+			Return(existing, nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		result, err := h.UpdateResourceType(ctx, testNS, req)
+		require.NoError(t, err)
+
+		require.NotNil(t, sent)
+		assert.Equal(t, "keep", sent.Annotations["custom"])
+		assert.Equal(t, "Postgres", sent.Annotations["openchoreo.dev/display-name"])
+		require.Len(t, sent.Spec.Resources, 1)
+		assert.Equal(t, "claim-v2", sent.Spec.Resources[0].ID)
+
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "updated", m["action"])
+	})
+
+	t.Run("propagates get error before attempting update", func(t *testing.T) {
+		expected := errors.New("missing")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.UpdateResourceType(ctx, testNS, &gen.UpdateResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceTypeName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("propagates update error", func(t *testing.T) {
+		expected := errors.New("conflict")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(sampleResourceType(), nil)
+		rtSvc.EXPECT().
+			UpdateResourceType(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.UpdateResourceType(ctx, testNS, &gen.UpdateResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceTypeName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestDeleteResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns action deleted", func(t *testing.T) {
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			DeleteResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		result, err := h.DeleteResourceType(ctx, testNS, testResourceTypeName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "deleted", m["action"])
+		assert.Equal(t, testResourceTypeName, m["name"])
+		assert.Equal(t, testNS, m["namespace"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("delete failed")
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			DeleteResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(expected)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.DeleteResourceType(ctx, testNS, testResourceTypeName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ClusterResourceType
+// ---------------------------------------------------------------------------
+
+func TestListClusterResourceTypes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns wrapped list", func(t *testing.T) {
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			ListClusterResourceTypes(mock.Anything, mock.Anything).
+			Return(&services.ListResult[openchoreov1alpha1.ClusterResourceType]{
+				Items: []openchoreov1alpha1.ClusterResourceType{*sampleClusterResourceType()},
+			}, nil)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		result, err := h.ListClusterResourceTypes(ctx, tools.ListOpts{})
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		items, ok := m["cluster_resource_types"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, items, 1)
+		assert.Equal(t, testClusterResourceTypeName, items[0]["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("list failed")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			ListClusterResourceTypes(mock.Anything, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.ListClusterResourceTypes(ctx, tools.ListOpts{})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetClusterResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns detail map", func(t *testing.T) {
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(sampleClusterResourceType(), nil)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		result, err := h.GetClusterResourceType(ctx, testClusterResourceTypeName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testClusterResourceTypeName, m["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("missing")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(nil, expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.GetClusterResourceType(ctx, testClusterResourceTypeName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetClusterResourceTypeSchema(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns service schema map", func(t *testing.T) {
+		schema := map[string]any{"type": "object"}
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceTypeSchema(mock.Anything, testClusterResourceTypeName).
+			Return(schema, nil)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		result, err := h.GetClusterResourceTypeSchema(ctx, testClusterResourceTypeName)
+		require.NoError(t, err)
+		assert.Equal(t, schema, result)
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("schema lookup failed")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceTypeSchema(mock.Anything, testClusterResourceTypeName).
+			Return(nil, expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.GetClusterResourceTypeSchema(ctx, testClusterResourceTypeName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestCreateClusterResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("converts gen spec to ClusterResourceTypeSpec and cleans annotations", func(t *testing.T) {
+		annotations := map[string]string{
+			"openchoreo.dev/description": "",
+			"custom":                     "keep",
+		}
+		req := &gen.CreateClusterResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testClusterResourceTypeName, Annotations: &annotations},
+			Spec: &gen.ResourceTypeSpec{
+				Resources: []gen.ResourceTypeManifest{{Id: "claim"}},
+			},
+		}
+
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			CreateClusterResourceType(mock.Anything, mock.MatchedBy(func(crt *openchoreov1alpha1.ClusterResourceType) bool {
+				_, hasDesc := crt.Annotations["openchoreo.dev/description"]
+				return crt.Name == testClusterResourceTypeName &&
+					crt.Namespace == "" &&
+					!hasDesc &&
+					crt.Annotations["custom"] == "keep" &&
+					len(crt.Spec.Resources) == 1 &&
+					crt.Spec.Resources[0].ID == "claim"
+			})).
+			Return(sampleClusterResourceType(), nil)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		result, err := h.CreateClusterResourceType(ctx, req)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "created", m["action"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("conflict")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			CreateClusterResourceType(mock.Anything, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.CreateClusterResourceType(ctx, &gen.CreateClusterResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testClusterResourceTypeName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestUpdateClusterResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("fetches existing then applies spec and annotation merge", func(t *testing.T) {
+		existing := sampleClusterResourceType()
+		existing.Annotations = map[string]string{"custom": "keep"}
+		newAnnotations := map[string]string{"openchoreo.dev/display-name": "Managed Redis"}
+		req := &gen.UpdateClusterResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testClusterResourceTypeName, Annotations: &newAnnotations},
+			Spec: &gen.ResourceTypeSpec{
+				Resources: []gen.ResourceTypeManifest{{Id: "claim-v2"}},
+			},
+		}
+
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(existing, nil)
+
+		var sent *openchoreov1alpha1.ClusterResourceType
+		crtSvc.EXPECT().
+			UpdateClusterResourceType(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, crt *openchoreov1alpha1.ClusterResourceType) {
+				sent = crt
+			}).
+			Return(existing, nil)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		result, err := h.UpdateClusterResourceType(ctx, req)
+		require.NoError(t, err)
+
+		require.NotNil(t, sent)
+		assert.Equal(t, "keep", sent.Annotations["custom"])
+		assert.Equal(t, "Managed Redis", sent.Annotations["openchoreo.dev/display-name"])
+		require.Len(t, sent.Spec.Resources, 1)
+		assert.Equal(t, "claim-v2", sent.Spec.Resources[0].ID)
+
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "updated", m["action"])
+	})
+
+	t.Run("propagates get error", func(t *testing.T) {
+		expected := errors.New("missing")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(nil, expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.UpdateClusterResourceType(ctx, &gen.UpdateClusterResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testClusterResourceTypeName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("propagates update error", func(t *testing.T) {
+		expected := errors.New("conflict")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			GetClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(sampleClusterResourceType(), nil)
+		crtSvc.EXPECT().
+			UpdateClusterResourceType(mock.Anything, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.UpdateClusterResourceType(ctx, &gen.UpdateClusterResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testClusterResourceTypeName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestDeleteClusterResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns action deleted", func(t *testing.T) {
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			DeleteClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(nil)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		result, err := h.DeleteClusterResourceType(ctx, testClusterResourceTypeName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "deleted", m["action"])
+		assert.Equal(t, testClusterResourceTypeName, m["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("delete failed")
+		crtSvc := clusterresourcetypemocks.NewMockService(t)
+		crtSvc.EXPECT().
+			DeleteClusterResourceType(mock.Anything, testClusterResourceTypeName).
+			Return(expected)
+
+		h := newTestHandler(withClusterResourceTypeService(crtSvc))
+		_, err := h.DeleteClusterResourceType(ctx, testClusterResourceTypeName)
+		require.ErrorIs(t, err, expected)
+	})
+}

--- a/internal/openchoreo-api/mcphandlers/resource_types_test.go
+++ b/internal/openchoreo-api/mcphandlers/resource_types_test.go
@@ -212,6 +212,13 @@ func TestCreateResourceType(t *testing.T) {
 		})
 		require.ErrorIs(t, err, expected)
 	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.CreateResourceType(ctx, testNS, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request body is required")
+	})
 }
 
 func TestUpdateResourceType(t *testing.T) {
@@ -285,6 +292,52 @@ func TestUpdateResourceType(t *testing.T) {
 			Metadata: gen.ObjectMeta{Name: testResourceTypeName},
 		})
 		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.UpdateResourceType(ctx, testNS, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request body is required")
+	})
+
+	t.Run("strips empty display-name and description on merge", func(t *testing.T) {
+		existing := sampleResourceType()
+		existing.Annotations = map[string]string{
+			"openchoreo.dev/display-name": "Existing Name",
+			"keep-me":                     "value",
+		}
+		incoming := map[string]string{
+			"openchoreo.dev/display-name": "",
+			"openchoreo.dev/description":  "",
+			"new-key":                     "new-value",
+		}
+
+		rtSvc := resourcetypemocks.NewMockService(t)
+		rtSvc.EXPECT().
+			GetResourceType(mock.Anything, testNS, testResourceTypeName).
+			Return(existing, nil)
+
+		var sent *openchoreov1alpha1.ResourceType
+		rtSvc.EXPECT().
+			UpdateResourceType(mock.Anything, testNS, mock.Anything).
+			Run(func(_ context.Context, _ string, rt *openchoreov1alpha1.ResourceType) {
+				sent = rt
+			}).
+			Return(existing, nil)
+
+		h := newTestHandler(withResourceTypeService(rtSvc))
+		_, err := h.UpdateResourceType(ctx, testNS, &gen.UpdateResourceTypeJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceTypeName, Annotations: &incoming},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sent)
+		assert.Equal(t, "Existing Name", sent.Annotations["openchoreo.dev/display-name"],
+			"empty display-name in incoming must not overwrite existing value")
+		_, hasDesc := sent.Annotations["openchoreo.dev/description"]
+		assert.False(t, hasDesc, "empty description annotation must be stripped, not added")
+		assert.Equal(t, "value", sent.Annotations["keep-me"])
+		assert.Equal(t, "new-value", sent.Annotations["new-key"])
 	})
 }
 
@@ -467,6 +520,13 @@ func TestCreateClusterResourceType(t *testing.T) {
 		})
 		require.ErrorIs(t, err, expected)
 	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.CreateClusterResourceType(ctx, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request body is required")
+	})
 }
 
 func TestUpdateClusterResourceType(t *testing.T) {
@@ -540,6 +600,13 @@ func TestUpdateClusterResourceType(t *testing.T) {
 			Metadata: gen.ObjectMeta{Name: testClusterResourceTypeName},
 		})
 		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.UpdateClusterResourceType(ctx, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request body is required")
 	})
 }
 

--- a/internal/openchoreo-api/mcphandlers/resources.go
+++ b/internal/openchoreo-api/mcphandlers/resources.go
@@ -75,8 +75,11 @@ func (h *MCPHandler) CreateResource(
 	if req.Spec.Type.Kind != nil {
 		r.Spec.Type.Kind = openchoreov1alpha1.ResourceTypeRefKind(*req.Spec.Type.Kind)
 	}
-	if req.Spec.Owner.ProjectName != "" {
-		r.Spec.Owner.ProjectName = req.Spec.Owner.ProjectName
+	if req.Spec.Owner.ProjectName != "" && req.Spec.Owner.ProjectName != projectName {
+		return nil, fmt.Errorf(
+			"spec.owner.projectName (%s) must match projectName (%s)",
+			req.Spec.Owner.ProjectName, projectName,
+		)
 	}
 	if req.Spec.Parameters != nil {
 		paramsBytes, err := json.Marshal(*req.Spec.Parameters)
@@ -111,10 +114,7 @@ func (h *MCPHandler) UpdateResource(
 	}
 
 	if req.Metadata.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = map[string]string{}
-		}
-		maps.Copy(existing.Annotations, *req.Metadata.Annotations)
+		existing.Annotations = mergeAnnotations(existing.Annotations, *req.Metadata.Annotations)
 	}
 	if req.Spec != nil && req.Spec.Parameters != nil {
 		paramsBytes, err := json.Marshal(*req.Spec.Parameters)

--- a/internal/openchoreo-api/mcphandlers/resources.go
+++ b/internal/openchoreo-api/mcphandlers/resources.go
@@ -1,0 +1,281 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListResources(
+	ctx context.Context, namespaceName, projectName string, opts tools.ListOpts,
+) (any, error) {
+	result, err := h.services.ResourceService.ListResources(ctx, namespaceName, projectName, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList("resources", result.Items, result.NextCursor, resourceSummary), nil
+}
+
+func (h *MCPHandler) GetResource(ctx context.Context, namespaceName, resourceName string) (any, error) {
+	r, err := h.services.ResourceService.GetResource(ctx, namespaceName, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return resourceDetail(r), nil
+}
+
+func (h *MCPHandler) CreateResource(
+	ctx context.Context, namespaceName, projectName string,
+	req *gen.CreateResourceJSONRequestBody,
+) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
+	if req.Spec == nil {
+		return nil, errors.New("spec is required")
+	}
+
+	annotations := map[string]string{}
+	if req.Metadata.Annotations != nil {
+		maps.Copy(annotations, *req.Metadata.Annotations)
+	}
+	cleanAnnotations(annotations)
+
+	r := &openchoreov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        req.Metadata.Name,
+			Namespace:   namespaceName,
+			Annotations: annotations,
+		},
+		Spec: openchoreov1alpha1.ResourceSpec{
+			Owner: openchoreov1alpha1.ResourceOwner{
+				ProjectName: projectName,
+			},
+			Type: openchoreov1alpha1.ResourceTypeRef{
+				Name: req.Spec.Type.Name,
+			},
+		},
+	}
+	if req.Spec.Type.Kind != nil {
+		r.Spec.Type.Kind = openchoreov1alpha1.ResourceTypeRefKind(*req.Spec.Type.Kind)
+	}
+	if req.Spec.Owner.ProjectName != "" {
+		r.Spec.Owner.ProjectName = req.Spec.Owner.ProjectName
+	}
+	if req.Spec.Parameters != nil {
+		paramsBytes, err := json.Marshal(*req.Spec.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("marshal parameters: %w", err)
+		}
+		r.Spec.Parameters = &runtime.RawExtension{Raw: paramsBytes}
+	}
+
+	created, err := h.services.ResourceService.CreateResource(ctx, namespaceName, r)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created", map[string]any{
+		"type": map[string]any{
+			"kind": string(created.Spec.Type.Kind),
+			"name": created.Spec.Type.Name,
+		},
+	}), nil
+}
+
+func (h *MCPHandler) UpdateResource(
+	ctx context.Context, namespaceName string, req *gen.UpdateResourceJSONRequestBody,
+) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
+
+	existing, err := h.services.ResourceService.GetResource(ctx, namespaceName, req.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Metadata.Annotations != nil {
+		if existing.Annotations == nil {
+			existing.Annotations = map[string]string{}
+		}
+		maps.Copy(existing.Annotations, *req.Metadata.Annotations)
+	}
+	if req.Spec != nil && req.Spec.Parameters != nil {
+		paramsBytes, err := json.Marshal(*req.Spec.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("marshal parameters: %w", err)
+		}
+		existing.Spec.Parameters = &runtime.RawExtension{Raw: paramsBytes}
+	}
+
+	updated, err := h.services.ResourceService.UpdateResource(ctx, namespaceName, existing)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteResource(ctx context.Context, namespaceName, resourceName string) (any, error) {
+	if err := h.services.ResourceService.DeleteResource(ctx, namespaceName, resourceName); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"name":      resourceName,
+		"namespace": namespaceName,
+		"action":    "deleted",
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ResourceRelease
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListResourceReleases(
+	ctx context.Context, namespaceName, resourceName string, opts tools.ListOpts,
+) (any, error) {
+	result, err := h.services.ResourceReleaseService.ListResourceReleases(
+		ctx, namespaceName, resourceName, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList("resource_releases", result.Items, result.NextCursor, resourceReleaseSummary), nil
+}
+
+func (h *MCPHandler) GetResourceRelease(
+	ctx context.Context, namespaceName, releaseName string,
+) (any, error) {
+	rr, err := h.services.ResourceReleaseService.GetResourceRelease(ctx, namespaceName, releaseName)
+	if err != nil {
+		return nil, err
+	}
+	return resourceReleaseDetail(rr), nil
+}
+
+func (h *MCPHandler) CreateResourceRelease(
+	ctx context.Context, namespaceName string,
+	req *gen.CreateResourceReleaseJSONRequestBody,
+) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
+	rr, err := convertSpec[gen.ResourceRelease, openchoreov1alpha1.ResourceRelease](*req)
+	if err != nil {
+		return nil, err
+	}
+	rr.Namespace = namespaceName
+
+	created, err := h.services.ResourceReleaseService.CreateResourceRelease(ctx, namespaceName, &rr)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) DeleteResourceRelease(
+	ctx context.Context, namespaceName, resourceReleaseName string,
+) (any, error) {
+	if err := h.services.ResourceReleaseService.DeleteResourceRelease(ctx, namespaceName, resourceReleaseName); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"name":      resourceReleaseName,
+		"namespace": namespaceName,
+		"action":    "deleted",
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ResourceReleaseBinding
+// ---------------------------------------------------------------------------
+
+func (h *MCPHandler) ListResourceReleaseBindings(
+	ctx context.Context, namespaceName, resourceName string, opts tools.ListOpts,
+) (any, error) {
+	result, err := h.services.ResourceReleaseBindingService.ListResourceReleaseBindings(
+		ctx, namespaceName, resourceName, toServiceListOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapTransformedList(
+		"resource_release_bindings", result.Items, result.NextCursor, resourceReleaseBindingSummary,
+	), nil
+}
+
+func (h *MCPHandler) GetResourceReleaseBinding(
+	ctx context.Context, namespaceName, bindingName string,
+) (any, error) {
+	rb, err := h.services.ResourceReleaseBindingService.GetResourceReleaseBinding(ctx, namespaceName, bindingName)
+	if err != nil {
+		return nil, err
+	}
+	return resourceReleaseBindingDetail(rb), nil
+}
+
+func (h *MCPHandler) CreateResourceReleaseBinding(
+	ctx context.Context, namespaceName string,
+	req *gen.CreateResourceReleaseBindingJSONRequestBody,
+) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
+	rb, err := convertSpec[gen.ResourceReleaseBinding, openchoreov1alpha1.ResourceReleaseBinding](*req)
+	if err != nil {
+		return nil, err
+	}
+	rb.Namespace = namespaceName
+
+	created, err := h.services.ResourceReleaseBindingService.CreateResourceReleaseBinding(ctx, namespaceName, &rb)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(created, "created"), nil
+}
+
+func (h *MCPHandler) UpdateResourceReleaseBinding(
+	ctx context.Context, namespaceName string,
+	req *gen.UpdateResourceReleaseBindingJSONRequestBody,
+) (any, error) {
+	if req == nil {
+		return nil, errors.New("request body is required")
+	}
+	rb, err := convertSpec[gen.ResourceReleaseBinding, openchoreov1alpha1.ResourceReleaseBinding](*req)
+	if err != nil {
+		return nil, err
+	}
+	rb.Namespace = namespaceName
+
+	updated, err := h.services.ResourceReleaseBindingService.UpdateResourceReleaseBinding(ctx, namespaceName, &rb)
+	if err != nil {
+		return nil, err
+	}
+	return mutationResult(updated, "updated"), nil
+}
+
+func (h *MCPHandler) DeleteResourceReleaseBinding(
+	ctx context.Context, namespaceName, bindingName string,
+) (any, error) {
+	if err := h.services.ResourceReleaseBindingService.DeleteResourceReleaseBinding(ctx, namespaceName, bindingName); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"name":      bindingName,
+		"namespace": namespaceName,
+		"action":    "deleted",
+	}, nil
+}

--- a/internal/openchoreo-api/mcphandlers/resources_test.go
+++ b/internal/openchoreo-api/mcphandlers/resources_test.go
@@ -203,11 +203,29 @@ func TestCreateResource(t *testing.T) {
 		assert.Equal(t, "created", m["action"])
 	})
 
-	t.Run("prefers explicit body project owner over arg", func(t *testing.T) {
+	t.Run("rejects when body project owner mismatches path-scoped projectName", func(t *testing.T) {
+		// Defense-in-depth: the path-scoped projectName is the authz boundary; the body
+		// must not be allowed to broaden it.
+		h := newTestHandler()
+		req := &gen.CreateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName},
+			Spec: &gen.ResourceInstanceSpec{
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: "other-project"},
+				Type: gen.ResourceTypeRef{Name: "postgres"},
+			},
+		}
+		_, err := h.CreateResource(ctx, testNS, testProject, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must match projectName")
+	})
+
+	t.Run("accepts matching body project owner", func(t *testing.T) {
 		rSvc := resourcemocks.NewMockService(t)
 		rSvc.EXPECT().
 			CreateResource(mock.Anything, testNS, mock.MatchedBy(func(r *openchoreov1alpha1.Resource) bool {
-				return r.Spec.Owner.ProjectName == "from-body"
+				return r.Spec.Owner.ProjectName == testProject
 			})).
 			Return(sampleResource(), nil)
 
@@ -216,7 +234,7 @@ func TestCreateResource(t *testing.T) {
 			Spec: &gen.ResourceInstanceSpec{
 				Owner: struct {
 					ProjectName string `json:"projectName"`
-				}{ProjectName: "from-body"},
+				}{ProjectName: testProject},
 				Type: gen.ResourceTypeRef{Name: "postgres"},
 			},
 		}

--- a/internal/openchoreo-api/mcphandlers/resources_test.go
+++ b/internal/openchoreo-api/mcphandlers/resources_test.go
@@ -1,0 +1,803 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+	resourcemocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resource/mocks"
+	resourcereleasemocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resourcerelease/mocks"
+	resourcereleasebindingmocks "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resourcereleasebinding/mocks"
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+const (
+	testResourceName               = "analytics-shared-db"
+	testResourceReleaseName        = "analytics-shared-db-abc123"
+	testResourceReleaseBindingName = "analytics-shared-db-dev"
+	testResourceEnvironment        = "development"
+)
+
+func sampleResource() *openchoreov1alpha1.Resource {
+	return &openchoreov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: testResourceName, Namespace: testNS},
+		Spec: openchoreov1alpha1.ResourceSpec{
+			Owner: openchoreov1alpha1.ResourceOwner{ProjectName: testProject},
+			Type: openchoreov1alpha1.ResourceTypeRef{
+				Kind: openchoreov1alpha1.ResourceTypeRefKindResourceType,
+				Name: "postgres",
+			},
+		},
+	}
+}
+
+func sampleResourceRelease() *openchoreov1alpha1.ResourceRelease {
+	return &openchoreov1alpha1.ResourceRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: testResourceReleaseName, Namespace: testNS},
+		Spec: openchoreov1alpha1.ResourceReleaseSpec{
+			Owner: openchoreov1alpha1.ResourceReleaseOwner{
+				ProjectName:  testProject,
+				ResourceName: testResourceName,
+			},
+			ResourceType: openchoreov1alpha1.ResourceReleaseResourceType{
+				Kind: openchoreov1alpha1.ResourceTypeRefKindResourceType,
+				Name: "postgres",
+			},
+		},
+	}
+}
+
+func sampleResourceReleaseBinding() *openchoreov1alpha1.ResourceReleaseBinding {
+	return &openchoreov1alpha1.ResourceReleaseBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: testResourceReleaseBindingName, Namespace: testNS},
+		Spec: openchoreov1alpha1.ResourceReleaseBindingSpec{
+			Owner: openchoreov1alpha1.ResourceReleaseBindingOwner{
+				ProjectName:  testProject,
+				ResourceName: testResourceName,
+			},
+			Environment:     testResourceEnvironment,
+			ResourceRelease: testResourceReleaseName,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+func TestListResources(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns wrapped list", func(t *testing.T) {
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			ListResources(mock.Anything, testNS, testProject, mock.Anything).
+			Return(&services.ListResult[openchoreov1alpha1.Resource]{
+				Items:      []openchoreov1alpha1.Resource{*sampleResource()},
+				NextCursor: "next-token",
+			}, nil)
+
+		h := newTestHandler(withResourceService(rSvc))
+		result, err := h.ListResources(ctx, testNS, testProject, tools.ListOpts{Limit: 5})
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "next-token", m["next_cursor"])
+		items, ok := m["resources"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, items, 1)
+		assert.Equal(t, testResourceName, items[0]["name"])
+		assert.Equal(t, testProject, items[0]["projectName"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("list failed")
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			ListResources(mock.Anything, testNS, testProject, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceService(rSvc))
+		_, err := h.ListResources(ctx, testNS, testProject, tools.ListOpts{})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns detail map", func(t *testing.T) {
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			GetResource(mock.Anything, testNS, testResourceName).
+			Return(sampleResource(), nil)
+
+		h := newTestHandler(withResourceService(rSvc))
+		result, err := h.GetResource(ctx, testNS, testResourceName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testResourceName, m["name"])
+		typeMap, ok := m["type"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "ResourceType", typeMap["kind"])
+		assert.Equal(t, "postgres", typeMap["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("not found")
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			GetResource(mock.Anything, testNS, testResourceName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceService(rSvc))
+		_, err := h.GetResource(ctx, testNS, testResourceName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestCreateResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("builds CRD from req with project owner, type, and parameters", func(t *testing.T) {
+		kind := gen.ResourceTypeRefKindResourceType
+		params := map[string]interface{}{"version": "8.0"}
+		annotations := map[string]string{"openchoreo.dev/display-name": "Analytics DB"}
+		req := &gen.CreateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName, Annotations: &annotations},
+			Spec: &gen.ResourceInstanceSpec{
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: ""},
+				Type:       gen.ResourceTypeRef{Kind: &kind, Name: "postgres"},
+				Parameters: &params,
+			},
+		}
+
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			CreateResource(mock.Anything, testNS, mock.MatchedBy(func(r *openchoreov1alpha1.Resource) bool {
+				if r.Name != testResourceName || r.Namespace != testNS {
+					return false
+				}
+				if r.Spec.Owner.ProjectName != testProject {
+					return false
+				}
+				if r.Spec.Type.Name != "postgres" ||
+					r.Spec.Type.Kind != openchoreov1alpha1.ResourceTypeRefKindResourceType {
+					return false
+				}
+				if r.Annotations["openchoreo.dev/display-name"] != "Analytics DB" {
+					return false
+				}
+				if r.Spec.Parameters == nil {
+					return false
+				}
+				var got map[string]any
+				if err := json.Unmarshal(r.Spec.Parameters.Raw, &got); err != nil {
+					return false
+				}
+				return got["version"] == "8.0"
+			})).
+			Return(sampleResource(), nil)
+
+		h := newTestHandler(withResourceService(rSvc))
+		result, err := h.CreateResource(ctx, testNS, testProject, req)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "created", m["action"])
+	})
+
+	t.Run("prefers explicit body project owner over arg", func(t *testing.T) {
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			CreateResource(mock.Anything, testNS, mock.MatchedBy(func(r *openchoreov1alpha1.Resource) bool {
+				return r.Spec.Owner.ProjectName == "from-body"
+			})).
+			Return(sampleResource(), nil)
+
+		req := &gen.CreateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName},
+			Spec: &gen.ResourceInstanceSpec{
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: "from-body"},
+				Type: gen.ResourceTypeRef{Name: "postgres"},
+			},
+		}
+		h := newTestHandler(withResourceService(rSvc))
+		_, err := h.CreateResource(ctx, testNS, testProject, req)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects nil body and nil spec", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.CreateResource(ctx, testNS, testProject, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request body is required")
+
+		_, err = h.CreateResource(ctx, testNS, testProject, &gen.CreateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec is required")
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("create failed")
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			CreateResource(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceService(rSvc))
+		_, err := h.CreateResource(ctx, testNS, testProject, &gen.CreateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName},
+			Spec: &gen.ResourceInstanceSpec{
+				Type: gen.ResourceTypeRef{Name: "postgres"},
+			},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestUpdateResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("merges annotations and updates parameters", func(t *testing.T) {
+		existing := sampleResource()
+		existing.Annotations = map[string]string{"keep-me": "value"}
+		params := map[string]interface{}{"version": "8.4"}
+		newAnnotations := map[string]string{"openchoreo.dev/description": "Updated"}
+		req := &gen.UpdateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName, Annotations: &newAnnotations},
+			Spec:     &gen.ResourceInstanceSpec{Parameters: &params},
+		}
+
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			GetResource(mock.Anything, testNS, testResourceName).
+			Return(existing, nil)
+
+		var sent *openchoreov1alpha1.Resource
+		rSvc.EXPECT().
+			UpdateResource(mock.Anything, testNS, mock.Anything).
+			Run(func(_ context.Context, _ string, r *openchoreov1alpha1.Resource) {
+				sent = r
+			}).
+			Return(existing, nil)
+
+		h := newTestHandler(withResourceService(rSvc))
+		result, err := h.UpdateResource(ctx, testNS, req)
+		require.NoError(t, err)
+
+		require.NotNil(t, sent)
+		assert.Equal(t, "value", sent.Annotations["keep-me"])
+		assert.Equal(t, "Updated", sent.Annotations["openchoreo.dev/description"])
+		require.NotNil(t, sent.Spec.Parameters)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(sent.Spec.Parameters.Raw, &got))
+		assert.Equal(t, "8.4", got["version"])
+
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "updated", m["action"])
+	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.UpdateResource(ctx, testNS, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("propagates get error", func(t *testing.T) {
+		expected := errors.New("missing")
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			GetResource(mock.Anything, testNS, testResourceName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceService(rSvc))
+		_, err := h.UpdateResource(ctx, testNS, &gen.UpdateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestDeleteResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns action deleted", func(t *testing.T) {
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			DeleteResource(mock.Anything, testNS, testResourceName).
+			Return(nil)
+
+		h := newTestHandler(withResourceService(rSvc))
+		result, err := h.DeleteResource(ctx, testNS, testResourceName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "deleted", m["action"])
+		assert.Equal(t, testResourceName, m["name"])
+		assert.Equal(t, testNS, m["namespace"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("delete failed")
+		rSvc := resourcemocks.NewMockService(t)
+		rSvc.EXPECT().
+			DeleteResource(mock.Anything, testNS, testResourceName).
+			Return(expected)
+
+		h := newTestHandler(withResourceService(rSvc))
+		_, err := h.DeleteResource(ctx, testNS, testResourceName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ResourceRelease
+// ---------------------------------------------------------------------------
+
+func TestListResourceReleases(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns wrapped list", func(t *testing.T) {
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			ListResourceReleases(mock.Anything, testNS, testResourceName, mock.Anything).
+			Return(&services.ListResult[openchoreov1alpha1.ResourceRelease]{
+				Items: []openchoreov1alpha1.ResourceRelease{*sampleResourceRelease()},
+			}, nil)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		result, err := h.ListResourceReleases(ctx, testNS, testResourceName, tools.ListOpts{})
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		items, ok := m["resource_releases"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, items, 1)
+		assert.Equal(t, testResourceReleaseName, items[0]["name"])
+		assert.Equal(t, testResourceName, items[0]["resourceName"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("list failed")
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			ListResourceReleases(mock.Anything, testNS, testResourceName, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		_, err := h.ListResourceReleases(ctx, testNS, testResourceName, tools.ListOpts{})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetResourceRelease(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns detail map", func(t *testing.T) {
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			GetResourceRelease(mock.Anything, testNS, testResourceReleaseName).
+			Return(sampleResourceRelease(), nil)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		result, err := h.GetResourceRelease(ctx, testNS, testResourceReleaseName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testResourceReleaseName, m["name"])
+		assert.Equal(t, testResourceName, m["resourceName"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("not found")
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			GetResourceRelease(mock.Anything, testNS, testResourceReleaseName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		_, err := h.GetResourceRelease(ctx, testNS, testResourceReleaseName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestCreateResourceRelease(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("converts gen body to CRD with parameters", func(t *testing.T) {
+		params := map[string]interface{}{"version": "8.0"}
+		body := &gen.CreateResourceReleaseJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceReleaseName},
+			Spec: &gen.ResourceReleaseSpec{
+				Owner: struct {
+					ProjectName  string `json:"projectName"`
+					ResourceName string `json:"resourceName"`
+				}{ProjectName: testProject, ResourceName: testResourceName},
+				ResourceType: struct {
+					Kind gen.ResourceReleaseSpecResourceTypeKind `json:"kind"`
+					Name string                                  `json:"name"`
+					Spec gen.ResourceTypeSpec                    `json:"spec"`
+				}{
+					Kind: gen.ResourceReleaseSpecResourceTypeKindResourceType,
+					Name: "postgres",
+					Spec: gen.ResourceTypeSpec{
+						Resources: []gen.ResourceTypeManifest{{Id: "claim"}},
+					},
+				},
+				Parameters: &params,
+			},
+		}
+
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			CreateResourceRelease(mock.Anything, testNS, mock.MatchedBy(func(rr *openchoreov1alpha1.ResourceRelease) bool {
+				return rr.Name == testResourceReleaseName &&
+					rr.Namespace == testNS &&
+					rr.Spec.Owner.ProjectName == testProject &&
+					rr.Spec.Owner.ResourceName == testResourceName &&
+					rr.Spec.ResourceType.Name == "postgres" &&
+					len(rr.Spec.ResourceType.Spec.Resources) == 1 &&
+					rr.Spec.Parameters != nil
+			})).
+			Return(sampleResourceRelease(), nil)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		result, err := h.CreateResourceRelease(ctx, testNS, body)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "created", m["action"])
+	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.CreateResourceRelease(ctx, testNS, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request body is required")
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("create failed")
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			CreateResourceRelease(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		_, err := h.CreateResourceRelease(ctx, testNS, &gen.CreateResourceReleaseJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceReleaseName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestDeleteResourceRelease(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns action deleted", func(t *testing.T) {
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			DeleteResourceRelease(mock.Anything, testNS, testResourceReleaseName).
+			Return(nil)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		result, err := h.DeleteResourceRelease(ctx, testNS, testResourceReleaseName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "deleted", m["action"])
+		assert.Equal(t, testResourceReleaseName, m["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("delete failed")
+		rrSvc := resourcereleasemocks.NewMockService(t)
+		rrSvc.EXPECT().
+			DeleteResourceRelease(mock.Anything, testNS, testResourceReleaseName).
+			Return(expected)
+
+		h := newTestHandler(withResourceReleaseService(rrSvc))
+		_, err := h.DeleteResourceRelease(ctx, testNS, testResourceReleaseName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ResourceReleaseBinding
+// ---------------------------------------------------------------------------
+
+func TestListResourceReleaseBindings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns wrapped list", func(t *testing.T) {
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			ListResourceReleaseBindings(mock.Anything, testNS, testResourceName, mock.Anything).
+			Return(&services.ListResult[openchoreov1alpha1.ResourceReleaseBinding]{
+				Items: []openchoreov1alpha1.ResourceReleaseBinding{*sampleResourceReleaseBinding()},
+			}, nil)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		result, err := h.ListResourceReleaseBindings(ctx, testNS, testResourceName, tools.ListOpts{})
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		items, ok := m["resource_release_bindings"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, items, 1)
+		assert.Equal(t, testResourceReleaseBindingName, items[0]["name"])
+		assert.Equal(t, testResourceEnvironment, items[0]["environment"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("list failed")
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			ListResourceReleaseBindings(mock.Anything, testNS, testResourceName, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		_, err := h.ListResourceReleaseBindings(ctx, testNS, testResourceName, tools.ListOpts{})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestGetResourceReleaseBinding(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns detail map", func(t *testing.T) {
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			GetResourceReleaseBinding(mock.Anything, testNS, testResourceReleaseBindingName).
+			Return(sampleResourceReleaseBinding(), nil)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		result, err := h.GetResourceReleaseBinding(ctx, testNS, testResourceReleaseBindingName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testResourceReleaseBindingName, m["name"])
+		assert.Equal(t, testResourceReleaseName, m["resourceRelease"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("not found")
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			GetResourceReleaseBinding(mock.Anything, testNS, testResourceReleaseBindingName).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		_, err := h.GetResourceReleaseBinding(ctx, testNS, testResourceReleaseBindingName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestCreateResourceReleaseBinding(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("converts gen body to CRD", func(t *testing.T) {
+		release := testResourceReleaseName
+		retain := gen.ResourceReleaseBindingSpecRetainPolicyRetain
+		envConfigs := map[string]interface{}{"storageGB": float64(100)}
+		body := &gen.CreateResourceReleaseBindingJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceReleaseBindingName},
+			Spec: &gen.ResourceReleaseBindingSpec{
+				Environment: testResourceEnvironment,
+				Owner: struct {
+					ProjectName  string `json:"projectName"`
+					ResourceName string `json:"resourceName"`
+				}{ProjectName: testProject, ResourceName: testResourceName},
+				ResourceRelease:                &release,
+				RetainPolicy:                   &retain,
+				ResourceTypeEnvironmentConfigs: &envConfigs,
+			},
+		}
+
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			CreateResourceReleaseBinding(mock.Anything, testNS, mock.MatchedBy(
+				func(rb *openchoreov1alpha1.ResourceReleaseBinding) bool {
+					return rb.Name == testResourceReleaseBindingName &&
+						rb.Namespace == testNS &&
+						rb.Spec.Owner.ProjectName == testProject &&
+						rb.Spec.Owner.ResourceName == testResourceName &&
+						rb.Spec.Environment == testResourceEnvironment &&
+						rb.Spec.ResourceRelease == testResourceReleaseName &&
+						string(rb.Spec.RetainPolicy) == "Retain" &&
+						rb.Spec.ResourceTypeEnvironmentConfigs != nil
+				},
+			)).
+			Return(sampleResourceReleaseBinding(), nil)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		result, err := h.CreateResourceReleaseBinding(ctx, testNS, body)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "created", m["action"])
+	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.CreateResourceReleaseBinding(ctx, testNS, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("create failed")
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			CreateResourceReleaseBinding(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		_, err := h.CreateResourceReleaseBinding(ctx, testNS, &gen.CreateResourceReleaseBindingJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceReleaseBindingName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestUpdateResourceReleaseBinding(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("converts gen body to CRD", func(t *testing.T) {
+		newRelease := "analytics-shared-db-def456"
+		body := &gen.UpdateResourceReleaseBindingJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceReleaseBindingName},
+			Spec: &gen.ResourceReleaseBindingSpec{
+				Environment: testResourceEnvironment,
+				Owner: struct {
+					ProjectName  string `json:"projectName"`
+					ResourceName string `json:"resourceName"`
+				}{ProjectName: testProject, ResourceName: testResourceName},
+				ResourceRelease: &newRelease,
+			},
+		}
+
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			UpdateResourceReleaseBinding(mock.Anything, testNS, mock.MatchedBy(
+				func(rb *openchoreov1alpha1.ResourceReleaseBinding) bool {
+					return rb.Name == testResourceReleaseBindingName &&
+						rb.Namespace == testNS &&
+						rb.Spec.ResourceRelease == newRelease
+				},
+			)).
+			Return(sampleResourceReleaseBinding(), nil)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		result, err := h.UpdateResourceReleaseBinding(ctx, testNS, body)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "updated", m["action"])
+	})
+
+	t.Run("rejects nil body", func(t *testing.T) {
+		h := newTestHandler()
+		_, err := h.UpdateResourceReleaseBinding(ctx, testNS, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("update failed")
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			UpdateResourceReleaseBinding(mock.Anything, testNS, mock.Anything).
+			Return(nil, expected)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		_, err := h.UpdateResourceReleaseBinding(ctx, testNS, &gen.UpdateResourceReleaseBindingJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: testResourceReleaseBindingName},
+		})
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+func TestDeleteResourceReleaseBinding(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns action deleted", func(t *testing.T) {
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			DeleteResourceReleaseBinding(mock.Anything, testNS, testResourceReleaseBindingName).
+			Return(nil)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		result, err := h.DeleteResourceReleaseBinding(ctx, testNS, testResourceReleaseBindingName)
+		require.NoError(t, err)
+		m, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "deleted", m["action"])
+		assert.Equal(t, testResourceReleaseBindingName, m["name"])
+	})
+
+	t.Run("service error propagates", func(t *testing.T) {
+		expected := errors.New("delete failed")
+		rbSvc := resourcereleasebindingmocks.NewMockService(t)
+		rbSvc.EXPECT().
+			DeleteResourceReleaseBinding(mock.Anything, testNS, testResourceReleaseBindingName).
+			Return(expected)
+
+		h := newTestHandler(withResourceReleaseBindingService(rbSvc))
+		_, err := h.DeleteResourceReleaseBinding(ctx, testNS, testResourceReleaseBindingName)
+		require.ErrorIs(t, err, expected)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Transform helpers smoke
+// ---------------------------------------------------------------------------
+
+func TestResourceTransforms(t *testing.T) {
+	t.Run("resource detail includes parameters and status", func(t *testing.T) {
+		r := sampleResource()
+		paramsBytes, err := json.Marshal(map[string]any{"version": "8.0"})
+		require.NoError(t, err)
+		r.Spec.Parameters = &runtime.RawExtension{Raw: paramsBytes}
+		r.Status.LatestRelease = &openchoreov1alpha1.LatestResourceRelease{
+			Name: testResourceReleaseName,
+			Hash: "abc123",
+		}
+
+		m := resourceDetail(r)
+		assert.Equal(t, testResourceName, m["name"])
+		params, ok := m["parameters"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "8.0", params["version"])
+		latest, ok := m["latestRelease"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testResourceReleaseName, latest["name"])
+		assert.Equal(t, "abc123", latest["hash"])
+	})
+
+	t.Run("resource release binding detail surfaces resolved outputs", func(t *testing.T) {
+		rb := sampleResourceReleaseBinding()
+		rb.Status.Outputs = []openchoreov1alpha1.ResolvedResourceOutput{
+			{Name: "host", Value: "10.0.0.5"},
+			{Name: "password", SecretKeyRef: &openchoreov1alpha1.SecretKeyRef{Name: "conn", Key: "password"}},
+		}
+
+		m := resourceReleaseBindingDetail(rb)
+		outputs, ok := m["outputs"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, outputs, 2)
+		assert.Equal(t, "host", outputs[0]["name"])
+		assert.Equal(t, "10.0.0.5", outputs[0]["value"])
+		secretRef, ok := outputs[1]["secretKeyRef"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "conn", secretRef["name"])
+		assert.Equal(t, "password", secretRef["key"])
+	})
+
+	t.Run("resource type detail embeds spec", func(t *testing.T) {
+		rt := sampleResourceType()
+		m := resourceTypeDetail(rt)
+		assert.Equal(t, testResourceTypeName, m["name"])
+		assert.NotNil(t, m["spec"])
+	})
+}

--- a/internal/openchoreo-api/mcphandlers/test_helpers_test.go
+++ b/internal/openchoreo-api/mcphandlers/test_helpers_test.go
@@ -5,6 +5,7 @@ package mcphandlers
 
 import (
 	clustercomponenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustercomponenttype"
+	clusterresourcetypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clusterresourcetype"
 	componentsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/component"
 	componentreleasesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/componentrelease"
 	componenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/componenttype"
@@ -14,6 +15,10 @@ import (
 	namespacesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/namespace"
 	projectsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/project"
 	releasebindingsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/releasebinding"
+	resourcesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resource"
+	resourcereleasesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resourcerelease"
+	resourcereleasebindingsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resourcereleasebinding"
+	resourcetypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/resourcetype"
 	secretreferencesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/secretreference"
 	workflowrunsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workflowrun"
 	workloadsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/workload"
@@ -74,4 +79,24 @@ func withSecretReferenceService(s secretreferencesvc.Service) func(*handlerservi
 
 func withComponentReleaseService(s componentreleasesvc.Service) func(*handlerservices.Services) {
 	return func(svc *handlerservices.Services) { svc.ComponentReleaseService = s }
+}
+
+func withResourceTypeService(s resourcetypesvc.Service) func(*handlerservices.Services) {
+	return func(svc *handlerservices.Services) { svc.ResourceTypeService = s }
+}
+
+func withClusterResourceTypeService(s clusterresourcetypesvc.Service) func(*handlerservices.Services) {
+	return func(svc *handlerservices.Services) { svc.ClusterResourceTypeService = s }
+}
+
+func withResourceService(s resourcesvc.Service) func(*handlerservices.Services) {
+	return func(svc *handlerservices.Services) { svc.ResourceService = s }
+}
+
+func withResourceReleaseService(s resourcereleasesvc.Service) func(*handlerservices.Services) {
+	return func(svc *handlerservices.Services) { svc.ResourceReleaseService = s }
+}
+
+func withResourceReleaseBindingService(s resourcereleasebindingsvc.Service) func(*handlerservices.Services) {
+	return func(svc *handlerservices.Services) { svc.ResourceReleaseBindingService = s }
 }

--- a/internal/openchoreo-api/mcphandlers/transform_resources.go
+++ b/internal/openchoreo-api/mcphandlers/transform_resources.go
@@ -722,6 +722,196 @@ func resourceTreeDetail(result *k8sresourcessvc.K8sResourceTreeResult) map[strin
 }
 
 // ---------------------------------------------------------------------------
+// ResourceType
+// ---------------------------------------------------------------------------
+
+func resourceTypeSummary(rt openchoreov1alpha1.ResourceType) map[string]any {
+	m := extractCommonMeta(&rt)
+	if rt.Spec.RetainPolicy != "" {
+		m["retainPolicy"] = string(rt.Spec.RetainPolicy)
+	}
+	if names := resourceTypeOutputNames(rt.Spec.Outputs); len(names) > 0 {
+		m["outputs"] = names
+	}
+	return m
+}
+
+func resourceTypeDetail(rt *openchoreov1alpha1.ResourceType) map[string]any {
+	m := extractCommonMeta(rt)
+	if spec := specToMap(rt.Spec); len(spec) > 0 {
+		m["spec"] = spec
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// ClusterResourceType
+// ---------------------------------------------------------------------------
+
+func clusterResourceTypeSummary(crt openchoreov1alpha1.ClusterResourceType) map[string]any {
+	m := extractCommonMeta(&crt)
+	if crt.Spec.RetainPolicy != "" {
+		m["retainPolicy"] = string(crt.Spec.RetainPolicy)
+	}
+	if names := resourceTypeOutputNames(crt.Spec.Outputs); len(names) > 0 {
+		m["outputs"] = names
+	}
+	return m
+}
+
+func clusterResourceTypeDetail(crt *openchoreov1alpha1.ClusterResourceType) map[string]any {
+	m := extractCommonMeta(crt)
+	if spec := specToMap(crt.Spec); len(spec) > 0 {
+		m["spec"] = spec
+	}
+	return m
+}
+
+func resourceTypeOutputNames(outputs []openchoreov1alpha1.ResourceTypeOutput) []string {
+	if len(outputs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(outputs))
+	for i := range outputs {
+		names = append(names, outputs[i].Name)
+	}
+	return names
+}
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+func resourceSummary(r openchoreov1alpha1.Resource) map[string]any {
+	m := extractCommonMeta(&r)
+	m["projectName"] = r.Spec.Owner.ProjectName
+	m["type"] = map[string]any{
+		"kind": string(r.Spec.Type.Kind),
+		"name": r.Spec.Type.Name,
+	}
+	setIfNotEmpty(m, "status", readyStatus(r.Status.Conditions))
+	if r.Status.LatestRelease != nil {
+		m["latestRelease"] = r.Status.LatestRelease.Name
+	}
+	return m
+}
+
+func resourceDetail(r *openchoreov1alpha1.Resource) map[string]any {
+	m := extractCommonMeta(r)
+	m["projectName"] = r.Spec.Owner.ProjectName
+	m["type"] = map[string]any{
+		"kind": string(r.Spec.Type.Kind),
+		"name": r.Spec.Type.Name,
+	}
+	if r.Spec.Parameters != nil {
+		m["parameters"] = rawExtensionToAny(r.Spec.Parameters)
+	}
+	if r.Status.LatestRelease != nil {
+		m["latestRelease"] = map[string]any{
+			"name": r.Status.LatestRelease.Name,
+			"hash": r.Status.LatestRelease.Hash,
+		}
+	}
+	setIfNotEmpty(m, "status", readyStatus(r.Status.Conditions))
+	if conds := conditionsSummary(r.Status.Conditions); conds != nil {
+		m["conditions"] = conds
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// ResourceRelease
+// ---------------------------------------------------------------------------
+
+func resourceReleaseSummary(rr openchoreov1alpha1.ResourceRelease) map[string]any {
+	m := extractCommonMeta(&rr)
+	m["projectName"] = rr.Spec.Owner.ProjectName
+	m["resourceName"] = rr.Spec.Owner.ResourceName
+	m["resourceType"] = map[string]any{
+		"kind": string(rr.Spec.ResourceType.Kind),
+		"name": rr.Spec.ResourceType.Name,
+	}
+	return m
+}
+
+func resourceReleaseDetail(rr *openchoreov1alpha1.ResourceRelease) map[string]any {
+	m := extractCommonMeta(rr)
+	m["projectName"] = rr.Spec.Owner.ProjectName
+	m["resourceName"] = rr.Spec.Owner.ResourceName
+	m["resourceType"] = map[string]any{
+		"kind": string(rr.Spec.ResourceType.Kind),
+		"name": rr.Spec.ResourceType.Name,
+	}
+	if spec := specToMap(rr.Spec.ResourceType.Spec); len(spec) > 0 {
+		m["resourceTypeSpec"] = spec
+	}
+	if rr.Spec.Parameters != nil {
+		m["parameters"] = rawExtensionToAny(rr.Spec.Parameters)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// ResourceReleaseBinding
+// ---------------------------------------------------------------------------
+
+func resourceReleaseBindingSummary(rb openchoreov1alpha1.ResourceReleaseBinding) map[string]any {
+	m := extractCommonMeta(&rb)
+	m["projectName"] = rb.Spec.Owner.ProjectName
+	m["resourceName"] = rb.Spec.Owner.ResourceName
+	m["environment"] = rb.Spec.Environment
+	setIfNotEmpty(m, "resourceRelease", rb.Spec.ResourceRelease)
+	if rb.Spec.RetainPolicy != "" {
+		m["retainPolicy"] = string(rb.Spec.RetainPolicy)
+	}
+	setIfNotEmpty(m, "status", readyStatus(rb.Status.Conditions))
+	return m
+}
+
+func resourceReleaseBindingDetail(rb *openchoreov1alpha1.ResourceReleaseBinding) map[string]any {
+	m := extractCommonMeta(rb)
+	m["projectName"] = rb.Spec.Owner.ProjectName
+	m["resourceName"] = rb.Spec.Owner.ResourceName
+	m["environment"] = rb.Spec.Environment
+	setIfNotEmpty(m, "resourceRelease", rb.Spec.ResourceRelease)
+	if rb.Spec.RetainPolicy != "" {
+		m["retainPolicy"] = string(rb.Spec.RetainPolicy)
+	}
+	if rb.Spec.ResourceTypeEnvironmentConfigs != nil {
+		m["resourceTypeEnvironmentConfigs"] = rawExtensionToAny(rb.Spec.ResourceTypeEnvironmentConfigs)
+	}
+	if outputs := resolvedResourceOutputs(rb.Status.Outputs); len(outputs) > 0 {
+		m["outputs"] = outputs
+	}
+	setIfNotEmpty(m, "status", readyStatus(rb.Status.Conditions))
+	if conds := conditionsSummary(rb.Status.Conditions); conds != nil {
+		m["conditions"] = conds
+	}
+	return m
+}
+
+func resolvedResourceOutputs(outputs []openchoreov1alpha1.ResolvedResourceOutput) []map[string]any {
+	if len(outputs) == 0 {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(outputs))
+	for i := range outputs {
+		entry := map[string]any{"name": outputs[i].Name}
+		if outputs[i].Value != "" {
+			entry["value"] = outputs[i].Value
+		}
+		if ref := outputs[i].SecretKeyRef; ref != nil {
+			entry["secretKeyRef"] = map[string]any{"name": ref.Name, "key": ref.Key}
+		}
+		if ref := outputs[i].ConfigMapKeyRef; ref != nil {
+			entry["configMapKeyRef"] = map[string]any{"name": ref.Name, "key": ref.Key}
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/pkg/mcp/tools/crdschema.go
+++ b/pkg/mcp/tools/crdschema.go
@@ -21,6 +21,8 @@ var crdSpecSchemas struct {
 	clusterTrait               map[string]any
 	workflow                   map[string]any
 	clusterWorkflow            map[string]any
+	resourceType               map[string]any
+	clusterResourceType        map[string]any
 	authzRole                  map[string]any
 	clusterAuthzRole           map[string]any
 	authzRoleBinding           map[string]any
@@ -31,6 +33,8 @@ var crdSpecSchemas struct {
 	clusterTraitErr            error
 	workflowErr                error
 	clusterWorkflowErr         error
+	resourceTypeErr            error
+	clusterResourceTypeErr     error
 	authzRoleErr               error
 	clusterAuthzRoleErr        error
 	authzRoleBindingErr        error
@@ -76,6 +80,18 @@ func ClusterWorkflowCreationSchema() (map[string]any, error) {
 	return crdSpecSchemas.clusterWorkflow, crdSpecSchemas.clusterWorkflowErr
 }
 
+// ResourceTypeCreationSchema returns the JSON schema for the ResourceType spec.
+func ResourceTypeCreationSchema() (map[string]any, error) {
+	crdSpecSchemas.once.Do(parseCRDSchemas)
+	return crdSpecSchemas.resourceType, crdSpecSchemas.resourceTypeErr
+}
+
+// ClusterResourceTypeCreationSchema returns the JSON schema for the ClusterResourceType spec.
+func ClusterResourceTypeCreationSchema() (map[string]any, error) {
+	crdSpecSchemas.once.Do(parseCRDSchemas)
+	return crdSpecSchemas.clusterResourceType, crdSpecSchemas.clusterResourceTypeErr
+}
+
 // AuthzRoleCreationSchema returns the JSON schema for the AuthzRole spec.
 func AuthzRoleCreationSchema() (map[string]any, error) {
 	crdSpecSchemas.once.Do(parseCRDSchemas)
@@ -118,6 +134,12 @@ func parseCRDSchemas() {
 	)
 	crdSpecSchemas.clusterWorkflow, crdSpecSchemas.clusterWorkflowErr = extractSpecSchema(
 		"bases/openchoreo.dev_clusterworkflows.yaml",
+	)
+	crdSpecSchemas.resourceType, crdSpecSchemas.resourceTypeErr = extractSpecSchema(
+		"bases/openchoreo.dev_resourcetypes.yaml",
+	)
+	crdSpecSchemas.clusterResourceType, crdSpecSchemas.clusterResourceTypeErr = extractSpecSchema(
+		"bases/openchoreo.dev_clusterresourcetypes.yaml",
 	)
 	crdSpecSchemas.authzRole, crdSpecSchemas.authzRoleErr = extractSpecSchema(
 		"bases/openchoreo.dev_authzroles.yaml",

--- a/pkg/mcp/tools/deployment_specs_test.go
+++ b/pkg/mcp/tools/deployment_specs_test.go
@@ -13,6 +13,8 @@ func deploymentToolSpecs() []toolTestSpec {
 	specs = append(specs, deploymentBindingSpecs()...)
 	specs = append(specs, deploymentPipelineSpecs()...)
 	specs = append(specs, deploymentEnvironmentSpecs()...)
+	specs = append(specs, deploymentResourceReleaseSpecs()...)
+	specs = append(specs, deploymentResourceReleaseBindingSpecs()...)
 	return specs
 }
 

--- a/pkg/mcp/tools/mock_test.go
+++ b/pkg/mcp/tools/mock_test.go
@@ -841,3 +841,187 @@ func (m *MockCoreToolsetHandler) ListAuthzActions(ctx context.Context) (any, err
 	m.recordCall("ListAuthzActions")
 	return `{"actions":[{"name":"component:view","lowest_scope":"component"}]}`, nil
 }
+
+// Resource methods
+
+func (m *MockCoreToolsetHandler) CreateResource(
+	ctx context.Context, namespaceName, projectName string, req *gen.CreateResourceJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateResource", namespaceName, projectName, req)
+	return `{"name":"new-resource","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) ListResources(
+	ctx context.Context, namespaceName, projectName string, opts ListOpts,
+) (any, error) {
+	m.recordCall("ListResources", namespaceName, projectName, opts)
+	return `[{"name":"resource-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetResource(
+	ctx context.Context, namespaceName, resourceName string,
+) (any, error) {
+	m.recordCall("GetResource", namespaceName, resourceName)
+	return `{"name":"resource-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateResource(
+	ctx context.Context, namespaceName string, req *gen.UpdateResourceJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateResource", namespaceName, req)
+	return `{"name":"updated-resource","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteResource(
+	ctx context.Context, namespaceName, resourceName string,
+) (any, error) {
+	m.recordCall("DeleteResource", namespaceName, resourceName)
+	return deletedResponse, nil
+}
+
+// Resource type methods (namespace-scoped)
+
+func (m *MockCoreToolsetHandler) ListResourceTypes(
+	ctx context.Context, namespaceName string, opts ListOpts,
+) (any, error) {
+	m.recordCall("ListResourceTypes", namespaceName, opts)
+	return `[{"name":"resource-type-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetResourceType(
+	ctx context.Context, namespaceName, rtName string,
+) (any, error) {
+	m.recordCall("GetResourceType", namespaceName, rtName)
+	return `{"name":"resource-type-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetResourceTypeSchema(
+	ctx context.Context, namespaceName, rtName string,
+) (any, error) {
+	m.recordCall("GetResourceTypeSchema", namespaceName, rtName)
+	return emptyObjectSchema, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateResourceType(
+	ctx context.Context, namespaceName string, req *gen.CreateResourceTypeJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateResourceType", namespaceName, req)
+	return `{"name":"new-resource-type","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateResourceType(
+	ctx context.Context, namespaceName string, req *gen.UpdateResourceTypeJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateResourceType", namespaceName, req)
+	return `{"name":"updated-resource-type","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteResourceType(
+	ctx context.Context, namespaceName, rtName string,
+) (any, error) {
+	m.recordCall("DeleteResourceType", namespaceName, rtName)
+	return deletedResponse, nil
+}
+
+// Resource type methods (cluster-scoped)
+
+func (m *MockCoreToolsetHandler) ListClusterResourceTypes(ctx context.Context, opts ListOpts) (any, error) {
+	m.recordCall("ListClusterResourceTypes", opts)
+	return `[{"name":"cluster-resource-type-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterResourceType(ctx context.Context, crtName string) (any, error) {
+	m.recordCall("GetClusterResourceType", crtName)
+	return `{"name":"cluster-resource-type-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetClusterResourceTypeSchema(ctx context.Context, crtName string) (any, error) {
+	m.recordCall("GetClusterResourceTypeSchema", crtName)
+	return emptyObjectSchema, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateClusterResourceType(
+	ctx context.Context, req *gen.CreateClusterResourceTypeJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateClusterResourceType", req)
+	return `{"name":"new-cluster-resource-type","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateClusterResourceType(
+	ctx context.Context, req *gen.UpdateClusterResourceTypeJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateClusterResourceType", req)
+	return `{"name":"updated-cluster-resource-type","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteClusterResourceType(ctx context.Context, crtName string) (any, error) {
+	m.recordCall("DeleteClusterResourceType", crtName)
+	return deletedResponse, nil
+}
+
+// ResourceRelease methods
+
+func (m *MockCoreToolsetHandler) ListResourceReleases(
+	ctx context.Context, namespaceName, resourceName string, opts ListOpts,
+) (any, error) {
+	m.recordCall("ListResourceReleases", namespaceName, resourceName, opts)
+	return `[{"name":"resource-release-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateResourceRelease(
+	ctx context.Context, namespaceName string, req *gen.CreateResourceReleaseJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateResourceRelease", namespaceName, req)
+	return `{"name":"new-resource-release","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetResourceRelease(
+	ctx context.Context, namespaceName, releaseName string,
+) (any, error) {
+	m.recordCall("GetResourceRelease", namespaceName, releaseName)
+	return `{"name":"resource-release-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteResourceRelease(
+	ctx context.Context, namespaceName, resourceReleaseName string,
+) (any, error) {
+	m.recordCall("DeleteResourceRelease", namespaceName, resourceReleaseName)
+	return deletedResponse, nil
+}
+
+// ResourceReleaseBinding methods
+
+func (m *MockCoreToolsetHandler) ListResourceReleaseBindings(
+	ctx context.Context, namespaceName, resourceName string, opts ListOpts,
+) (any, error) {
+	m.recordCall("ListResourceReleaseBindings", namespaceName, resourceName, opts)
+	return `[{"name":"resource-release-binding-1"}]`, nil
+}
+
+func (m *MockCoreToolsetHandler) GetResourceReleaseBinding(
+	ctx context.Context, namespaceName, bindingName string,
+) (any, error) {
+	m.recordCall("GetResourceReleaseBinding", namespaceName, bindingName)
+	return `{"name":"resource-release-binding-1"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) CreateResourceReleaseBinding(
+	ctx context.Context, namespaceName string, req *gen.CreateResourceReleaseBindingJSONRequestBody,
+) (any, error) {
+	m.recordCall("CreateResourceReleaseBinding", namespaceName, req)
+	return `{"name":"new-resource-release-binding","action":"created"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) UpdateResourceReleaseBinding(
+	ctx context.Context, namespaceName string, req *gen.UpdateResourceReleaseBindingJSONRequestBody,
+) (any, error) {
+	m.recordCall("UpdateResourceReleaseBinding", namespaceName, req)
+	return `{"name":"updated-resource-release-binding","action":"updated"}`, nil
+}
+
+func (m *MockCoreToolsetHandler) DeleteResourceReleaseBinding(
+	ctx context.Context, namespaceName, bindingName string,
+) (any, error) {
+	m.recordCall("DeleteResourceReleaseBinding", namespaceName, bindingName)
+	return deletedResponse, nil
+}

--- a/pkg/mcp/tools/pe_specs_test.go
+++ b/pkg/mcp/tools/pe_specs_test.go
@@ -23,6 +23,8 @@ func peToolSpecs() []toolTestSpec {
 	specs = append(specs, peClusterSpecs()...)
 	specs = append(specs, peClusterPlatformStandardsSpecs()...)
 	specs = append(specs, pePlatformStandardsSpecs()...)
+	specs = append(specs, peResourceTypeSpecs()...)
+	specs = append(specs, peResourceReleaseSpecs()...)
 	specs = append(specs, peDiagnosticsSpecs()...)
 	specs = append(specs, peAuthzSpecs()...)
 	return specs

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -118,6 +118,12 @@ func (t *Toolsets) deploymentToolRegistrations() []RegisterFunc {
 		t.RegisterUpdateReleaseBinding,
 		t.RegisterDeleteReleaseBinding,
 		t.RegisterDeleteComponentRelease,
+		t.RegisterDeleteResourceRelease,
+		t.RegisterListResourceReleaseBindings,
+		t.RegisterGetResourceReleaseBinding,
+		t.RegisterCreateResourceReleaseBinding,
+		t.RegisterUpdateResourceReleaseBinding,
+		t.RegisterDeleteResourceReleaseBinding,
 		t.RegisterListDeploymentPipelines,
 		t.RegisterGetDeploymentPipeline,
 		t.RegisterListEnvironments,
@@ -165,6 +171,11 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 		t.RegisterPEGetComponentRelease,
 		t.RegisterPEGetComponentReleaseSchema,
 
+		// Resource releases (admin: list/get/create; delete lives on the deployment toolset).
+		t.RegisterPEListResourceReleases,
+		t.RegisterPECreateResourceRelease,
+		t.RegisterPEGetResourceRelease,
+
 		// Plane resources (scope-collapsed: pass scope="cluster" for cluster-scoped planes).
 		t.RegisterListDataPlanes,
 		t.RegisterGetDataPlane,
@@ -191,9 +202,13 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 		t.RegisterPEListWorkflows,
 		t.RegisterPEGetWorkflow,
 		t.RegisterPEGetWorkflowSchema,
+		t.RegisterPEListResourceTypes,
+		t.RegisterPEGetResourceType,
+		t.RegisterPEGetResourceTypeSchema,
 		t.RegisterGetComponentTypeCreationSchema,
 		t.RegisterGetTraitCreationSchema,
 		t.RegisterGetWorkflowCreationSchema,
+		t.RegisterGetResourceTypeCreationSchema,
 		t.RegisterCreateComponentType,
 		t.RegisterUpdateComponentType,
 		t.RegisterDeleteComponentType,
@@ -203,6 +218,9 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 		t.RegisterPECreateWorkflow,
 		t.RegisterPEUpdateWorkflow,
 		t.RegisterPEDeleteWorkflow,
+		t.RegisterCreateResourceType,
+		t.RegisterUpdateResourceType,
+		t.RegisterDeleteResourceType,
 
 		// Deprecated cluster-prefixed platform-standards aliases (hidden from the default tools/list).
 		t.RegisterGetClusterComponentTypeCreationSchema,
@@ -256,6 +274,26 @@ func (t *Toolsets) peToolRegistrations() []RegisterFunc {
 		t.RegisterGetResourceLogs,
 		t.RegisterEvaluateAuthz,
 		t.RegisterListAuthzActions,
+	}
+}
+
+// resourceToolRegistrations returns the dev-facing resource toolset.
+// Mirrors componentToolRegistrations' role: Resource CRUD plus read-only access to
+// (Cluster)ResourceType templates. Template writes, releases, and bindings live on
+// the pe / deployment toolsets.
+func (t *Toolsets) resourceToolRegistrations() []RegisterFunc {
+	return []RegisterFunc{
+		// Resource CRUD.
+		t.RegisterListResources,
+		t.RegisterGetResource,
+		t.RegisterCreateResource,
+		t.RegisterUpdateResource,
+		t.RegisterDeleteResource,
+
+		// Resource types (read-only, scope-collapsed: pass scope="cluster" for ClusterResourceType).
+		t.RegisterListResourceTypes,
+		t.RegisterGetResourceType,
+		t.RegisterGetResourceTypeSchema,
 	}
 }
 
@@ -313,6 +351,10 @@ func (t *Toolsets) Register(s *mcp.Server) (
 
 	if t.PEToolset != nil {
 		registerGroup(ToolsetPE, t.peToolRegistrations())
+	}
+
+	if t.ResourceToolset != nil {
+		registerGroup(ToolsetResource, t.resourceToolRegistrations())
 	}
 
 	return perms, toolToToolsets

--- a/pkg/mcp/tools/resource.go
+++ b/pkg/mcp/tools/resource.go
@@ -1,0 +1,187 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+//nolint:dupl // paginated list handlers share similar structure
+func (t *Toolsets) RegisterListResources(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_resources"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewResource}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "List resources in a project. Resources reference a ResourceType or " +
+			"ClusterResourceType template and represent managed infrastructure (databases, queues, " +
+			"caches) consumed by workloads via dependencies.resources[]. Supports pagination via " +
+			"limit and cursor.",
+		InputSchema: createSchema(addPaginationProperties(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"project_name":   defaultStringProperty(),
+		}), []string{"namespace_name", "project_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		ProjectName   string `json:"project_name"`
+		Limit         int    `json:"limit,omitempty"`
+		Cursor        string `json:"cursor,omitempty"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.ResourceToolset.ListResources(
+			ctx, args.NamespaceName, args.ProjectName, ListOpts{Limit: args.Limit, Cursor: args.Cursor})
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterGetResource(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_resource"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewResource}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Get the full definition of a resource including its type reference, parameters, " +
+			"and the latest ResourceRelease pointer. Use list_resources to discover valid names.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Resource name. Use list_resources to discover valid names"),
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Name          string `json:"name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.ResourceToolset.GetResource(ctx, args.NamespaceName, args.Name)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterCreateResource(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_resource"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateResource}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Create a new resource in a project. The resource references a ResourceType " +
+			"(namespace-scoped) or ClusterResourceType (cluster-scoped) template by name. Parameters " +
+			"must conform to the template's parameters schema; use get_resource_type_schema with the " +
+			"matching scope to inspect it.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"project_name":   defaultStringProperty(),
+			"name": stringProperty(
+				"DNS-compatible identifier (lowercase, alphanumeric, hyphens only, max 63 chars)"),
+			"type_name": stringProperty(
+				"Name of the (Cluster)ResourceType to reference. Use list_resource_types to discover names."),
+			"type_kind": stringProperty(
+				"Optional: \"ResourceType\" (default, namespace-scoped) or \"ClusterResourceType\" (cluster-scoped)."),
+			"display_name": stringProperty("Human-readable display name"),
+			"description":  stringProperty("Human-readable description"),
+			"parameters": map[string]any{
+				"type":        "object",
+				"description": "Optional: parameter values for the referenced (Cluster)ResourceType schema.",
+			},
+		}, []string{"namespace_name", "project_name", "name", "type_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string                 `json:"namespace_name"`
+		ProjectName   string                 `json:"project_name"`
+		Name          string                 `json:"name"`
+		TypeName      string                 `json:"type_name"`
+		TypeKind      string                 `json:"type_kind"`
+		DisplayName   string                 `json:"display_name"`
+		Description   string                 `json:"description"`
+		Parameters    map[string]interface{} `json:"parameters"`
+	}) (*mcp.CallToolResult, any, error) {
+		annotations := annotationsFromDisplayDesc(args.DisplayName, args.Description)
+		typeRef := gen.ResourceTypeRef{Name: args.TypeName}
+		if args.TypeKind != "" {
+			kind := gen.ResourceTypeRefKind(args.TypeKind)
+			typeRef.Kind = &kind
+		}
+		body := &gen.CreateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: args.Name, Annotations: &annotations},
+			Spec: &gen.ResourceInstanceSpec{
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: args.ProjectName},
+				Type: typeRef,
+			},
+		}
+		if args.Parameters != nil {
+			body.Spec.Parameters = &args.Parameters
+		}
+		result, err := t.ResourceToolset.CreateResource(ctx, args.NamespaceName, args.ProjectName, body)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterUpdateResource(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_resource"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateResource}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Update an existing resource (partial update). Only provided fields are applied; " +
+			"omitted fields remain unchanged. spec.owner and spec.type are immutable and cannot be " +
+			"changed after creation.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Resource name to update. Use list_resources to discover valid names"),
+			"display_name":   stringProperty("Optional: update the human-readable display name"),
+			"description":    stringProperty("Optional: update the human-readable description"),
+			"parameters": map[string]any{
+				"type":        "object",
+				"description": "Optional: replace parameter values for the referenced (Cluster)ResourceType schema.",
+			},
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string                 `json:"namespace_name"`
+		Name          string                 `json:"name"`
+		DisplayName   string                 `json:"display_name"`
+		Description   string                 `json:"description"`
+		Parameters    map[string]interface{} `json:"parameters"`
+	}) (*mcp.CallToolResult, any, error) {
+		annotations := annotationsFromDisplayDesc(args.DisplayName, args.Description)
+		body := &gen.UpdateResourceJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: args.Name, Annotations: &annotations},
+		}
+		if args.Parameters != nil {
+			body.Spec = &gen.ResourceInstanceSpec{Parameters: &args.Parameters}
+		}
+		result, err := t.ResourceToolset.UpdateResource(ctx, args.NamespaceName, body)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterDeleteResource(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_resource"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteResource}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Delete a resource. The owning project's finalizer cleans up the resource's " +
+			"ResourceReleases once any ResourceReleaseBindings are removed.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Resource name to delete. Use list_resources to discover valid names"),
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Name          string `json:"name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.ResourceToolset.DeleteResource(ctx, args.NamespaceName, args.Name)
+		return handleToolResult(result, err)
+	})
+}
+
+// annotationsFromDisplayDesc builds an annotations map with display name and description entries when set.
+// Returns an empty map (not nil) so JSON serialization of the request body is consistent.
+func annotationsFromDisplayDesc(displayName, description string) map[string]string {
+	a := map[string]string{}
+	if displayName != "" {
+		a["openchoreo.dev/display-name"] = displayName
+	}
+	if description != "" {
+		a["openchoreo.dev/description"] = description
+	}
+	return a
+}

--- a/pkg/mcp/tools/resource.go
+++ b/pkg/mcp/tools/resource.go
@@ -141,9 +141,12 @@ func (t *Toolsets) RegisterUpdateResource(s *mcp.Server, perms map[string]ToolPe
 		Description   string                 `json:"description"`
 		Parameters    map[string]interface{} `json:"parameters"`
 	}) (*mcp.CallToolResult, any, error) {
-		annotations := annotationsFromDisplayDesc(args.DisplayName, args.Description)
 		body := &gen.UpdateResourceJSONRequestBody{
-			Metadata: gen.ObjectMeta{Name: args.Name, Annotations: &annotations},
+			Metadata: gen.ObjectMeta{Name: args.Name},
+		}
+		if args.DisplayName != "" || args.Description != "" {
+			annotations := annotationsFromDisplayDesc(args.DisplayName, args.Description)
+			body.Metadata.Annotations = &annotations
 		}
 		if args.Parameters != nil {
 			body.Spec = &gen.ResourceInstanceSpec{Parameters: &args.Parameters}

--- a/pkg/mcp/tools/resource_release.go
+++ b/pkg/mcp/tools/resource_release.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+//nolint:dupl // paginated list handlers share similar structure
+func (t *Toolsets) RegisterPEListResourceReleases(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_resource_releases"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewResourceRelease}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "List all releases for a resource. ResourceReleases are immutable snapshots of " +
+			"Resource.spec plus the referenced (Cluster)ResourceType.spec at the time they were cut. " +
+			"Created automatically by the Resource controller; rarely created by hand. Supports " +
+			"pagination via limit and cursor.",
+		InputSchema: createSchema(addPaginationProperties(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"resource_name":  defaultStringProperty(),
+		}), []string{"namespace_name", "resource_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		ResourceName  string `json:"resource_name"`
+		Limit         int    `json:"limit,omitempty"`
+		Cursor        string `json:"cursor,omitempty"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.PEToolset.ListResourceReleases(
+			ctx, args.NamespaceName, args.ResourceName,
+			ListOpts{Limit: args.Limit, Cursor: args.Cursor})
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterPECreateResourceRelease(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_resource_release"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateResourceRelease}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Create a ResourceRelease (immutable snapshot of Resource.spec + the referenced " +
+			"(Cluster)ResourceType.spec). Normally created by the Resource controller; expose this for " +
+			"GitOps-style manual snapshots. The type_spec argument must contain the full ResourceType " +
+			"snapshot to embed in the release.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Release name. Convention: {resource}-{hash}."),
+			"project_name":   stringProperty("Name of the project that owns the resource."),
+			"resource_name":  stringProperty("Name of the parent Resource."),
+			"type_name":      stringProperty("Name of the (Cluster)ResourceType the snapshot was taken from."),
+			"type_kind": stringProperty(
+				"Optional: \"ResourceType\" (default, namespace-scoped) or \"ClusterResourceType\" (cluster-scoped)."),
+			"type_spec": map[string]any{
+				"type":        "object",
+				"description": "Full ResourceTypeSpec snapshot to embed in the release.",
+			},
+			"parameters": map[string]any{
+				"type":        "object",
+				"description": "Optional: parameter values captured from the source Resource at release time.",
+			},
+		}, []string{"namespace_name", "name", "project_name", "resource_name", "type_name", "type_spec"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string                 `json:"namespace_name"`
+		Name          string                 `json:"name"`
+		ProjectName   string                 `json:"project_name"`
+		ResourceName  string                 `json:"resource_name"`
+		TypeName      string                 `json:"type_name"`
+		TypeKind      string                 `json:"type_kind"`
+		TypeSpec      map[string]interface{} `json:"type_spec"`
+		Parameters    map[string]interface{} `json:"parameters"`
+	}) (*mcp.CallToolResult, any, error) {
+		typeSpec, err := buildSpec[gen.ResourceTypeSpec](args.TypeSpec)
+		if err != nil {
+			return nil, nil, err
+		}
+		kind := gen.ResourceReleaseSpecResourceTypeKind(args.TypeKind)
+		if args.TypeKind == "" {
+			kind = gen.ResourceReleaseSpecResourceTypeKindResourceType
+		}
+		spec := gen.ResourceReleaseSpec{
+			Owner: struct {
+				ProjectName  string `json:"projectName"`
+				ResourceName string `json:"resourceName"`
+			}{
+				ProjectName:  args.ProjectName,
+				ResourceName: args.ResourceName,
+			},
+			ResourceType: struct {
+				Kind gen.ResourceReleaseSpecResourceTypeKind `json:"kind"`
+				Name string                                  `json:"name"`
+				Spec gen.ResourceTypeSpec                    `json:"spec"`
+			}{
+				Kind: kind,
+				Name: args.TypeName,
+				Spec: *typeSpec,
+			},
+		}
+		if args.Parameters != nil {
+			spec.Parameters = &args.Parameters
+		}
+		body := &gen.CreateResourceReleaseJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: args.Name},
+			Spec:     &spec,
+		}
+		result, err := t.PEToolset.CreateResourceRelease(ctx, args.NamespaceName, body)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterPEGetResourceRelease(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_resource_release"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewResourceRelease}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Get the full definition of a resource release including the embedded ResourceType " +
+			"snapshot and captured parameter values.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Resource release name. Use list_resource_releases to discover valid names."),
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Name          string `json:"name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.PEToolset.GetResourceRelease(ctx, args.NamespaceName, args.Name)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterDeleteResourceRelease(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_resource_release"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteResourceRelease}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Delete a resource release. ResourceReleases are normally cleaned up by the owning " +
+			"Resource's finalizer; this is for ad-hoc cleanup of orphaned releases.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Resource release name. Use list_resource_releases to discover valid names."),
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Name          string `json:"name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.DeploymentToolset.DeleteResourceRelease(ctx, args.NamespaceName, args.Name)
+		return handleToolResult(result, err)
+	})
+}

--- a/pkg/mcp/tools/resource_release_binding.go
+++ b/pkg/mcp/tools/resource_release_binding.go
@@ -1,0 +1,214 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+//nolint:dupl // paginated list handlers share similar structure
+func (t *Toolsets) RegisterListResourceReleaseBindings(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "list_resource_release_bindings"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewResourceReleaseBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "List ResourceReleaseBindings for a resource. Each binding pins a ResourceRelease " +
+			"to an environment and carries per-env configuration overrides. Supports pagination via " +
+			"limit and cursor.",
+		InputSchema: createSchema(addPaginationProperties(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"resource_name":  defaultStringProperty(),
+		}), []string{"namespace_name", "resource_name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		ResourceName  string `json:"resource_name"`
+		Limit         int    `json:"limit,omitempty"`
+		Cursor        string `json:"cursor,omitempty"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.DeploymentToolset.ListResourceReleaseBindings(
+			ctx, args.NamespaceName, args.ResourceName,
+			ListOpts{Limit: args.Limit, Cursor: args.Cursor})
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterGetResourceReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "get_resource_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionViewResourceReleaseBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Get the full definition of a ResourceReleaseBinding including the current release pin, " +
+			"per-env configuration overrides, retain policy, conditions, and resolved outputs.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name": stringProperty(
+				"Binding name. Use list_resource_release_bindings to discover valid names."),
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Name          string `json:"name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.DeploymentToolset.GetResourceReleaseBinding(ctx, args.NamespaceName, args.Name)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterCreateResourceReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "create_resource_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionCreateResourceReleaseBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Create a ResourceReleaseBinding that pins a ResourceRelease to a specific environment. " +
+			"spec.owner and spec.environment are immutable after creation. The release pin " +
+			"(spec.resourceRelease) is advanced manually via update_resource_release_binding.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Binding name."),
+			"project_name":   stringProperty("Name of the project that owns the resource."),
+			"resource_name":  stringProperty("Name of the parent Resource."),
+			"environment":    stringProperty("Target environment name."),
+			"resource_release": stringProperty(
+				"Optional: name of the ResourceRelease to pin. Leave unset for a pending binding."),
+			"retain_policy": stringProperty(
+				"Optional: per-env retention override. \"Delete\" or \"Retain\". " +
+					"Falls back to ResourceType.spec.retainPolicy when unset."),
+			"resource_type_environment_configs": map[string]any{
+				"type": "object",
+				"description": "Optional: per-env values for the referenced ResourceType's " +
+					"environmentConfigs schema. Use get_resource_type_schema for the matching scope.",
+			},
+		}, []string{"namespace_name", "name", "project_name", "resource_name", "environment"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName                  string                 `json:"namespace_name"`
+		Name                           string                 `json:"name"`
+		ProjectName                    string                 `json:"project_name"`
+		ResourceName                   string                 `json:"resource_name"`
+		Environment                    string                 `json:"environment"`
+		ResourceRelease                string                 `json:"resource_release"`
+		RetainPolicy                   string                 `json:"retain_policy"`
+		ResourceTypeEnvironmentConfigs map[string]interface{} `json:"resource_type_environment_configs"`
+	}) (*mcp.CallToolResult, any, error) {
+		spec := gen.ResourceReleaseBindingSpec{
+			Environment: args.Environment,
+			Owner: struct {
+				ProjectName  string `json:"projectName"`
+				ResourceName string `json:"resourceName"`
+			}{
+				ProjectName:  args.ProjectName,
+				ResourceName: args.ResourceName,
+			},
+		}
+		if args.ResourceRelease != "" {
+			spec.ResourceRelease = &args.ResourceRelease
+		}
+		retainPolicy, err := parseResourceRetainPolicy(args.RetainPolicy)
+		if err != nil {
+			return nil, nil, err
+		}
+		if retainPolicy != nil {
+			spec.RetainPolicy = retainPolicy
+		}
+		if args.ResourceTypeEnvironmentConfigs != nil {
+			spec.ResourceTypeEnvironmentConfigs = &args.ResourceTypeEnvironmentConfigs
+		}
+		body := &gen.CreateResourceReleaseBindingJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: args.Name},
+			Spec:     &spec,
+		}
+		result, err := t.DeploymentToolset.CreateResourceReleaseBinding(ctx, args.NamespaceName, body)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterUpdateResourceReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "update_resource_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionUpdateResourceReleaseBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Update an existing ResourceReleaseBinding (partial update). spec.owner and " +
+			"spec.environment cannot be changed. Use this to advance the release pin (promote a new " +
+			"ResourceRelease into an environment), change the retain policy, or update environment " +
+			"configuration overrides.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Binding name. Use list_resource_release_bindings to discover valid names."),
+			"resource_release": stringProperty(
+				"Optional: name of the ResourceRelease to pin. Use list_resource_releases to discover names."),
+			"retain_policy": stringProperty(
+				"Optional: per-env retention override. \"Delete\" or \"Retain\"."),
+			"resource_type_environment_configs": map[string]any{
+				"type":        "object",
+				"description": "Optional: replace per-env values for the referenced ResourceType's environmentConfigs.",
+			},
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName                  string                 `json:"namespace_name"`
+		Name                           string                 `json:"name"`
+		ResourceRelease                string                 `json:"resource_release"`
+		RetainPolicy                   string                 `json:"retain_policy"`
+		ResourceTypeEnvironmentConfigs map[string]interface{} `json:"resource_type_environment_configs"`
+	}) (*mcp.CallToolResult, any, error) {
+		spec := &gen.ResourceReleaseBindingSpec{}
+		if args.ResourceRelease != "" {
+			spec.ResourceRelease = &args.ResourceRelease
+		}
+		retainPolicy, err := parseResourceRetainPolicy(args.RetainPolicy)
+		if err != nil {
+			return nil, nil, err
+		}
+		if retainPolicy != nil {
+			spec.RetainPolicy = retainPolicy
+		}
+		if args.ResourceTypeEnvironmentConfigs != nil {
+			spec.ResourceTypeEnvironmentConfigs = &args.ResourceTypeEnvironmentConfigs
+		}
+		body := &gen.UpdateResourceReleaseBindingJSONRequestBody{
+			Metadata: gen.ObjectMeta{Name: args.Name},
+			Spec:     spec,
+		}
+		result, err := t.DeploymentToolset.UpdateResourceReleaseBinding(ctx, args.NamespaceName, body)
+		return handleToolResult(result, err)
+	})
+}
+
+func (t *Toolsets) RegisterDeleteResourceReleaseBinding(s *mcp.Server, perms map[string]ToolPermission) {
+	const name = "delete_resource_release_binding"
+	perms[name] = ToolPermission{ToolName: name, Action: authzcore.ActionDeleteResourceReleaseBinding}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: name,
+		Description: "Delete a ResourceReleaseBinding. When retainPolicy=Delete (default), the underlying " +
+			"RenderedRelease is cascaded for cleanup; when retainPolicy=Retain, the finalizer blocks " +
+			"until manually removed.",
+		InputSchema: createSchema(map[string]any{
+			"namespace_name": defaultStringProperty(),
+			"name":           stringProperty("Binding name to delete. Use list_resource_release_bindings to discover names."),
+		}, []string{"namespace_name", "name"}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct {
+		NamespaceName string `json:"namespace_name"`
+		Name          string `json:"name"`
+	}) (*mcp.CallToolResult, any, error) {
+		result, err := t.DeploymentToolset.DeleteResourceReleaseBinding(ctx, args.NamespaceName, args.Name)
+		return handleToolResult(result, err)
+	})
+}
+
+func parseResourceRetainPolicy(raw string) (*gen.ResourceReleaseBindingSpecRetainPolicy, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	switch raw {
+	case string(gen.ResourceReleaseBindingSpecRetainPolicyDelete),
+		string(gen.ResourceReleaseBindingSpecRetainPolicyRetain):
+		policy := gen.ResourceReleaseBindingSpecRetainPolicy(raw)
+		return &policy, nil
+	default:
+		return nil, fmt.Errorf("retain_policy must be one of: Delete, Retain")
+	}
+}

--- a/pkg/mcp/tools/resource_release_binding_specs_test.go
+++ b/pkg/mcp/tools/resource_release_binding_specs_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"testing"
+)
+
+const testResourceReleaseBindingName = "analytics-shared-db-dev"
+
+// deploymentResourceReleaseBindingSpecs returns specs for ResourceReleaseBinding
+// tools surfaced through the deployment toolset (mirrors ReleaseBinding).
+func deploymentResourceReleaseBindingSpecs() []toolTestSpec {
+	return []toolTestSpec{
+		{
+			name:                "list_resource_release_bindings",
+			toolset:             "deployment",
+			descriptionKeywords: []string{"list", "resource", "release", "binding"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "resource_name"},
+			optionalParams:      []string{"limit", "cursor"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"resource_name":  testResourceName,
+			},
+			expectedMethod: "ListResourceReleaseBindings",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "get_resource_release_binding",
+			toolset:             "deployment",
+			descriptionKeywords: []string{"resource", "release", "binding"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceReleaseBindingName,
+			},
+			expectedMethod: "GetResourceReleaseBinding",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceReleaseBindingName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceReleaseBindingName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "create_resource_release_binding",
+			toolset:             "deployment",
+			descriptionKeywords: []string{"create", "resource", "release", "binding"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name", "project_name", "resource_name", "environment"},
+			optionalParams:      []string{"resource_release", "retain_policy", "resource_type_environment_configs"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceReleaseBindingName,
+				"project_name":   testProjectName,
+				"resource_name":  testResourceName,
+				"environment":    "development",
+			},
+			expectedMethod: "CreateResourceReleaseBinding",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "update_resource_release_binding",
+			toolset:             "deployment",
+			descriptionKeywords: []string{"update", "resource", "release", "binding"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			optionalParams:      []string{"resource_release", "retain_policy", "resource_type_environment_configs"},
+			testArgs: map[string]any{
+				"namespace_name":   testNamespaceName,
+				"name":             testResourceReleaseBindingName,
+				"resource_release": testResourceReleaseName,
+			},
+			expectedMethod: "UpdateResourceReleaseBinding",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "delete_resource_release_binding",
+			toolset:             "deployment",
+			descriptionKeywords: []string{"delete", "resource", "release", "binding"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceReleaseBindingName,
+			},
+			expectedMethod: "DeleteResourceReleaseBinding",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceReleaseBindingName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceReleaseBindingName, args[0], args[1])
+				}
+			},
+		},
+	}
+}

--- a/pkg/mcp/tools/resource_release_specs_test.go
+++ b/pkg/mcp/tools/resource_release_specs_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"testing"
+)
+
+const testResourceReleaseName = "analytics-shared-db-abc123"
+
+// peResourceReleaseSpecs returns ResourceRelease list/create/get specs
+// (PE-controlled administrative operations).
+func peResourceReleaseSpecs() []toolTestSpec {
+	return []toolTestSpec{
+		{
+			name:                "list_resource_releases",
+			toolset:             "pe",
+			descriptionKeywords: []string{"list", "resource", "release"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "resource_name"},
+			optionalParams:      []string{"limit", "cursor"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"resource_name":  testResourceName,
+			},
+			expectedMethod: "ListResourceReleases",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "create_resource_release",
+			toolset:             "pe",
+			descriptionKeywords: []string{"create", "resource", "release"},
+			descriptionMinLen:   10,
+			requiredParams: []string{
+				"namespace_name", "name", "project_name", "resource_name", "type_name", "type_spec",
+			},
+			optionalParams: []string{"type_kind", "parameters"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceReleaseName,
+				"project_name":   testProjectName,
+				"resource_name":  testResourceName,
+				"type_name":      "postgres",
+				"type_spec":      map[string]any{"resources": []any{}},
+			},
+			expectedMethod: "CreateResourceRelease",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "get_resource_release",
+			toolset:             "pe",
+			descriptionKeywords: []string{"resource", "release"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceReleaseName,
+			},
+			expectedMethod: "GetResourceRelease",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceReleaseName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceReleaseName, args[0], args[1])
+				}
+			},
+		},
+	}
+}
+
+// deploymentResourceReleaseSpecs returns the dev-side delete spec (mirrors
+// delete_component_release on the deployment toolset).
+func deploymentResourceReleaseSpecs() []toolTestSpec {
+	return []toolTestSpec{
+		{
+			name:                "delete_resource_release",
+			toolset:             "deployment",
+			descriptionKeywords: []string{"delete", "resource", "release"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceReleaseName,
+			},
+			expectedMethod: "DeleteResourceRelease",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceReleaseName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceReleaseName, args[0], args[1])
+				}
+			},
+		},
+	}
+}

--- a/pkg/mcp/tools/resource_specs_test.go
+++ b/pkg/mcp/tools/resource_specs_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"testing"
+)
+
+const testResourceName = "analytics-shared-db"
+
+// resourceToolSpecs returns the dev-facing resource toolset specs: Resource CRUD
+// plus the scope-collapsed read tools over (Cluster)ResourceType. Mirrors the
+// component toolset's mix of primary-CRD CRUD + type reads.
+func resourceToolSpecs() []toolTestSpec {
+	specs := make([]toolTestSpec, 0, 8)
+	specs = append(specs, resourceCRUDSpecs()...)
+	specs = append(specs, resourceResourceTypeSpecs()...)
+	return specs
+}
+
+// resourceCRUDSpecs returns test specs for the Resource CRUD surface.
+func resourceCRUDSpecs() []toolTestSpec {
+	return []toolTestSpec{
+		{
+			name:                "list_resources",
+			toolset:             "resource",
+			descriptionKeywords: []string{"list", "resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "project_name"},
+			optionalParams:      []string{"limit", "cursor"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"project_name":   testProjectName,
+			},
+			expectedMethod: "ListResources",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testProjectName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testProjectName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "get_resource",
+			toolset:             "resource",
+			descriptionKeywords: []string{"resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceName,
+			},
+			expectedMethod: "GetResource",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "create_resource",
+			toolset:             "resource",
+			descriptionKeywords: []string{"create", "resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "project_name", "name", "type_name"},
+			optionalParams:      []string{"type_kind", "parameters", "display_name", "description"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"project_name":   testProjectName,
+				"name":           testResourceName,
+				"type_name":      "postgres",
+			},
+			expectedMethod: "CreateResource",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testProjectName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testProjectName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "update_resource",
+			toolset:             "resource",
+			descriptionKeywords: []string{"update", "resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			optionalParams:      []string{"parameters", "display_name", "description"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceName,
+				"parameters":     map[string]any{"version": "8.0"},
+			},
+			expectedMethod: "UpdateResource",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "delete_resource",
+			toolset:             "resource",
+			descriptionKeywords: []string{"delete", "resource"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"namespace_name", "name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceName,
+			},
+			expectedMethod: "DeleteResource",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceName, args[0], args[1])
+				}
+			},
+		},
+	}
+}

--- a/pkg/mcp/tools/resource_type_specs_test.go
+++ b/pkg/mcp/tools/resource_type_specs_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"testing"
+)
+
+const testResourceTypeName = "postgres"
+
+// resourceResourceTypeSpecs returns specs for the (Cluster)ResourceType read tools
+// surfaced through the dev-facing resource toolset.
+func resourceResourceTypeSpecs() []toolTestSpec {
+	return resourceTypeReadSpecs("resource")
+}
+
+// peResourceTypeSpecs returns specs for the (Cluster)ResourceType tools surfaced
+// through the platform-engineering toolset: reads (dual-registered) plus writes
+// and the creation-schema getter.
+func peResourceTypeSpecs() []toolTestSpec {
+	specs := resourceTypeReadSpecs("pe")
+	specs = append(specs, []toolTestSpec{
+		{
+			name:                "get_resource_type_creation_schema",
+			toolset:             "pe",
+			descriptionKeywords: []string{"schema", "creating", "resource", "type"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope"},
+			testArgs:            map[string]any{},
+		},
+		{
+			name:                "create_resource_type",
+			toolset:             "pe",
+			descriptionKeywords: []string{"create", "resource", "type"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"name", "spec"},
+			optionalParams:      []string{"scope", "namespace_name", "display_name", "description"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           "my-resource-type",
+				"spec":           map[string]any{"resources": []any{}},
+			},
+			expectedMethod: "CreateResourceType",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "update_resource_type",
+			toolset:             "pe",
+			descriptionKeywords: []string{"update", "resource", "type"},
+			descriptionMinLen:   10,
+			requiredParams:      []string{"name", "spec"},
+			optionalParams:      []string{"scope", "namespace_name", "display_name", "description"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           "my-resource-type",
+				"spec":           map[string]any{"resources": []any{}},
+			},
+			expectedMethod: "UpdateResourceType",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "delete_resource_type",
+			toolset:             "pe",
+			descriptionKeywords: []string{"delete", "resource", "type"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope", "namespace_name"},
+			requiredParams:      []string{"name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           "my-resource-type",
+			},
+			expectedMethod: "DeleteResourceType",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != "my-resource-type" {
+					t.Errorf("Expected (%s, my-resource-type), got (%v, %v)",
+						testNamespaceName, args[0], args[1])
+				}
+			},
+		},
+	}...)
+	return specs
+}
+
+// resourceTypeReadSpecs returns the three scope-collapsed read specs (list, get,
+// get_schema) tagged with the given toolset. Read tools are dual-registered in
+// both `resource` and `pe`; the specs for each toolset differ only in the
+// `toolset` field.
+func resourceTypeReadSpecs(toolset string) []toolTestSpec {
+	return []toolTestSpec{
+		{
+			name:                "list_resource_types",
+			toolset:             toolset,
+			descriptionKeywords: []string{"list", "resource", "type"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope", "namespace_name", "limit", "cursor"},
+			testArgs:            map[string]any{"namespace_name": testNamespaceName},
+			expectedMethod:      "ListResourceTypes",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName {
+					t.Errorf("Expected namespace %q, got %v", testNamespaceName, args[0])
+				}
+			},
+		},
+		{
+			name:                "get_resource_type",
+			toolset:             toolset,
+			descriptionKeywords: []string{"resource", "type"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope", "namespace_name"},
+			requiredParams:      []string{"name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceTypeName,
+			},
+			expectedMethod: "GetResourceType",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceTypeName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceTypeName, args[0], args[1])
+				}
+			},
+		},
+		{
+			name:                "get_resource_type_schema",
+			toolset:             toolset,
+			descriptionKeywords: []string{"resource", "type", "schema"},
+			descriptionMinLen:   10,
+			optionalParams:      []string{"scope", "namespace_name"},
+			requiredParams:      []string{"name"},
+			testArgs: map[string]any{
+				"namespace_name": testNamespaceName,
+				"name":           testResourceTypeName,
+			},
+			expectedMethod: "GetResourceTypeSchema",
+			validateCall: func(t *testing.T, args []interface{}) {
+				if args[0] != testNamespaceName || args[1] != testResourceTypeName {
+					t.Errorf("Expected (%s, %s), got (%v, %v)",
+						testNamespaceName, testResourceTypeName, args[0], args[1])
+				}
+			},
+		},
+	}
+}

--- a/pkg/mcp/tools/scoped_resource_types.go
+++ b/pkg/mcp/tools/scoped_resource_types.go
@@ -1,0 +1,178 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/api/gen"
+)
+
+// ---------------------------------------------------------------------------
+// Resource types — scope-collapsed canonical tools
+// Reads are dual-registered: ResourceToolset (dev surface) and PEToolset (PE surface).
+// Writes and creation schema are PE-only.
+// ---------------------------------------------------------------------------
+
+func (t *Toolsets) RegisterPEListResourceTypes(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedListTool(s, perms, "list_resource_types", "resource type",
+		"List resource types. With scope=\"namespace\" (default) lists a namespace's resource types "+
+			"(requires namespace_name); with scope=\"cluster\" lists platform-wide ClusterResourceTypes. "+
+			"Resource types define managed-infrastructure templates (databases, queues, caches) that "+
+			"Resources reference. Supports pagination via limit and cursor.",
+		authzcore.ActionViewResourceType, authzcore.ActionViewClusterResourceType,
+		scopedListHandlers{
+			namespace: t.PEToolset.ListResourceTypes,
+			cluster:   t.PEToolset.ListClusterResourceTypes,
+		})
+}
+
+func (t *Toolsets) RegisterListResourceTypes(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedListTool(s, perms, "list_resource_types", "resource type",
+		"List resource types. With scope=\"namespace\" (default) lists a namespace's resource types "+
+			"(requires namespace_name); with scope=\"cluster\" lists platform-wide ClusterResourceTypes. "+
+			"Resource types define managed-infrastructure templates (databases, queues, caches) that "+
+			"Resources reference. Supports pagination via limit and cursor.",
+		authzcore.ActionViewResourceType, authzcore.ActionViewClusterResourceType,
+		scopedListHandlers{
+			namespace: t.ResourceToolset.ListResourceTypes,
+			cluster:   t.ResourceToolset.ListClusterResourceTypes,
+		})
+}
+
+func (t *Toolsets) RegisterPEGetResourceType(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "get_resource_type", "resource type",
+		"Get the full definition of a resource type including its complete spec. Use scope=\"cluster\" for a "+
+			"platform-wide ClusterResourceType. Call this before update_resource_type to retrieve the current spec.",
+		authzcore.ActionViewResourceType, authzcore.ActionViewClusterResourceType,
+		"name", "Resource type name. Use list_resource_types to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.GetResourceType,
+			cluster:   t.PEToolset.GetClusterResourceType,
+		})
+}
+
+func (t *Toolsets) RegisterGetResourceType(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "get_resource_type", "resource type",
+		"Get the full definition of a resource type including its complete spec. Use scope=\"cluster\" for a "+
+			"platform-wide ClusterResourceType.",
+		authzcore.ActionViewResourceType, authzcore.ActionViewClusterResourceType,
+		"name", "Resource type name. Use list_resource_types to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.ResourceToolset.GetResourceType,
+			cluster:   t.ResourceToolset.GetClusterResourceType,
+		})
+}
+
+func (t *Toolsets) RegisterPEGetResourceTypeSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "get_resource_type_schema", "resource type",
+		"Get the parameters JSON schema for a resource type (the schema that Resource.spec.parameters "+
+			"must conform to). Use scope=\"cluster\" for a platform-wide ClusterResourceType.",
+		authzcore.ActionViewResourceType, authzcore.ActionViewClusterResourceType,
+		"name", "Resource type name. Use list_resource_types to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.GetResourceTypeSchema,
+			cluster:   t.PEToolset.GetClusterResourceTypeSchema,
+		})
+}
+
+func (t *Toolsets) RegisterGetResourceTypeSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "get_resource_type_schema", "resource type",
+		"Get the parameters JSON schema for a resource type (the schema that Resource.spec.parameters "+
+			"must conform to). Use scope=\"cluster\" for a platform-wide ClusterResourceType.",
+		authzcore.ActionViewResourceType, authzcore.ActionViewClusterResourceType,
+		"name", "Resource type name. Use list_resource_types to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.ResourceToolset.GetResourceTypeSchema,
+			cluster:   t.ResourceToolset.GetClusterResourceTypeSchema,
+		})
+}
+
+func (t *Toolsets) RegisterGetResourceTypeCreationSchema(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSchemaTool(s, perms, "get_resource_type_creation_schema", "resource type",
+		"Get the spec schema for creating a resource type. Use scope=\"namespace\" (default) for a "+
+			"namespace-scoped ResourceType or scope=\"cluster\" for a platform-wide ClusterResourceType. "+
+			"Call this before create_resource_type to understand the spec structure.",
+		authzcore.ActionCreateResourceType, authzcore.ActionCreateClusterResourceType,
+		scopedSchemaProviders{
+			namespace: func() (any, error) { return ResourceTypeCreationSchema() },
+			cluster:   func() (any, error) { return ClusterResourceTypeCreationSchema() },
+		})
+}
+
+//nolint:dupl // create/update register helpers share a near-identical shape per resource
+func (t *Toolsets) RegisterCreateResourceType(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedWriteTool(s, perms, "create_resource_type", "resource type",
+		"Create a resource type. With scope=\"namespace\" (default) it is created in namespace_name; with "+
+			"scope=\"cluster\" it is a platform-wide ClusterResourceType available to all namespaces. Resource "+
+			"types declare the parameters, environment configs, outputs, and provisioned manifests for "+
+			"managed infrastructure templates that Resources reference.",
+		authzcore.ActionCreateResourceType, authzcore.ActionCreateClusterResourceType,
+		"DNS-compatible identifier (lowercase, alphanumeric, hyphens only, max 63 chars)",
+		"Use get_resource_type_creation_schema (with the matching scope) to check the schema",
+		scopedWriteHandlers{
+			namespace: func(ctx context.Context, ns, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ResourceTypeSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.CreateResourceType(ctx, ns, &gen.CreateResourceTypeJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+			cluster: func(ctx context.Context, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ResourceTypeSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.CreateClusterResourceType(ctx, &gen.CreateClusterResourceTypeJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+		})
+}
+
+//nolint:dupl // create/update register helpers share a near-identical shape per resource
+func (t *Toolsets) RegisterUpdateResourceType(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedWriteTool(s, perms, "update_resource_type", "resource type",
+		"Update an existing resource type (full replacement). Use scope=\"cluster\" for a platform-wide "+
+			"ClusterResourceType. Use get_resource_type to retrieve the current spec first.",
+		authzcore.ActionUpdateResourceType, authzcore.ActionUpdateClusterResourceType,
+		"Name of the resource type to update. Use list_resource_types to discover valid names",
+		"Full resource type spec to replace the existing one. Use get_resource_type to retrieve the current spec first.",
+		scopedWriteHandlers{
+			namespace: func(ctx context.Context, ns, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ResourceTypeSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.UpdateResourceType(ctx, ns, &gen.UpdateResourceTypeJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+			cluster: func(ctx context.Context, name string, anns map[string]string, specRaw map[string]any) (any, error) {
+				spec, err := buildSpec[gen.ResourceTypeSpec](specRaw)
+				if err != nil {
+					return nil, err
+				}
+				return t.PEToolset.UpdateClusterResourceType(ctx, &gen.UpdateClusterResourceTypeJSONRequestBody{
+					Metadata: gen.ObjectMeta{Name: name, Annotations: &anns}, Spec: spec,
+				})
+			},
+		})
+}
+
+func (t *Toolsets) RegisterDeleteResourceType(s *mcp.Server, perms map[string]ToolPermission) {
+	registerScopedSingleResourceTool(s, perms, "delete_resource_type", "resource type",
+		"Delete a resource type. Use scope=\"cluster\" for a platform-wide ClusterResourceType.",
+		authzcore.ActionDeleteResourceType, authzcore.ActionDeleteClusterResourceType,
+		"name", "Name of the resource type to delete. Use list_resource_types to discover valid names",
+		scopedSingleResourceHandlers{
+			namespace: t.PEToolset.DeleteResourceType,
+			cluster:   t.PEToolset.DeleteClusterResourceType,
+		})
+}

--- a/pkg/mcp/tools/setup_test.go
+++ b/pkg/mcp/tools/setup_test.go
@@ -34,6 +34,7 @@ func setupTestServer(t *testing.T) (*mcp.ClientSession, *MockCoreToolsetHandler)
 		DeploymentToolset: mockHandler,
 		BuildToolset:      mockHandler,
 		PEToolset:         mockHandler,
+		ResourceToolset:   mockHandler,
 	}
 	clientSession := setupTestServerWithToolset(t, toolsets)
 	return clientSession, mockHandler
@@ -186,5 +187,6 @@ var allToolSpecs = func() []toolTestSpec {
 	specs = append(specs, deploymentToolSpecs()...)
 	specs = append(specs, buildToolSpecs()...)
 	specs = append(specs, peToolSpecs()...)
+	specs = append(specs, resourceToolSpecs()...)
 	return specs
 }()

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -21,6 +21,7 @@ const (
 	ToolsetDeployment ToolsetType = "deployment"
 	ToolsetBuild      ToolsetType = "build"
 	ToolsetPE         ToolsetType = "pe"
+	ToolsetResource   ToolsetType = "resource"
 )
 
 // requestedToolsetsCtxKey is the context key used to carry the set of toolsets
@@ -116,6 +117,7 @@ type Toolsets struct {
 	DeploymentToolset DeploymentToolsetHandler
 	BuildToolset      BuildToolsetHandler
 	PEToolset         PEToolsetHandler
+	ResourceToolset   ResourceToolsetHandler
 }
 
 // PEToolsetHandler handles platform engineering operations on openchoreo
@@ -133,6 +135,16 @@ type PEToolsetHandler interface {
 	GetComponentReleaseSchema(
 		ctx context.Context, namespaceName, componentName, releaseName string,
 	) (any, error)
+
+	// Resource release operations
+	ListResourceReleases(
+		ctx context.Context, namespaceName, resourceName string, opts ListOpts,
+	) (any, error)
+	CreateResourceRelease(
+		ctx context.Context, namespaceName string,
+		req *gen.CreateResourceReleaseJSONRequestBody,
+	) (any, error)
+	GetResourceRelease(ctx context.Context, namespaceName, releaseName string) (any, error)
 
 	// DeploymentPipeline operations
 	CreateDeploymentPipeline(ctx context.Context, namespaceName string,
@@ -212,6 +224,34 @@ type PEToolsetHandler interface {
 	CreateClusterWorkflow(ctx context.Context, req *gen.CreateClusterWorkflowJSONRequestBody) (any, error)
 	UpdateClusterWorkflow(ctx context.Context, req *gen.UpdateClusterWorkflowJSONRequestBody) (any, error)
 	DeleteClusterWorkflow(ctx context.Context, clusterWorkflowName string) (any, error)
+
+	// Resource types (namespace-scoped) — read
+	ListResourceTypes(ctx context.Context, namespaceName string, opts ListOpts) (any, error)
+	GetResourceType(ctx context.Context, namespaceName, rtName string) (any, error)
+	GetResourceTypeSchema(ctx context.Context, namespaceName, rtName string) (any, error)
+
+	// Resource types (namespace-scoped) — write
+	CreateResourceType(
+		ctx context.Context, namespaceName string, req *gen.CreateResourceTypeJSONRequestBody,
+	) (any, error)
+	UpdateResourceType(
+		ctx context.Context, namespaceName string, req *gen.UpdateResourceTypeJSONRequestBody,
+	) (any, error)
+	DeleteResourceType(ctx context.Context, namespaceName, rtName string) (any, error)
+
+	// Resource types (cluster-scoped) — read
+	ListClusterResourceTypes(ctx context.Context, opts ListOpts) (any, error)
+	GetClusterResourceType(ctx context.Context, crtName string) (any, error)
+	GetClusterResourceTypeSchema(ctx context.Context, crtName string) (any, error)
+
+	// Resource types (cluster-scoped) — write
+	CreateClusterResourceType(
+		ctx context.Context, req *gen.CreateClusterResourceTypeJSONRequestBody,
+	) (any, error)
+	UpdateClusterResourceType(
+		ctx context.Context, req *gen.UpdateClusterResourceTypeJSONRequestBody,
+	) (any, error)
+	DeleteClusterResourceType(ctx context.Context, crtName string) (any, error)
 
 	// Diagnostics
 	GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (any, error)
@@ -356,6 +396,24 @@ type DeploymentToolsetHandler interface {
 	ListDeploymentPipelines(ctx context.Context, namespaceName string, opts ListOpts) (any, error)
 	GetDeploymentPipeline(ctx context.Context, namespaceName, pipelineName string) (any, error)
 	ListEnvironments(ctx context.Context, namespaceName string, opts ListOpts) (any, error)
+
+	// Resource release delete (dev-side cleanup; mirrors DeleteComponentRelease).
+	DeleteResourceRelease(ctx context.Context, namespaceName, resourceReleaseName string) (any, error)
+
+	// Resource release binding operations
+	ListResourceReleaseBindings(
+		ctx context.Context, namespaceName, resourceName string, opts ListOpts,
+	) (any, error)
+	GetResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string) (any, error)
+	CreateResourceReleaseBinding(
+		ctx context.Context, namespaceName string,
+		req *gen.CreateResourceReleaseBindingJSONRequestBody,
+	) (any, error)
+	UpdateResourceReleaseBinding(
+		ctx context.Context, namespaceName string,
+		req *gen.UpdateResourceReleaseBindingJSONRequestBody,
+	) (any, error)
+	DeleteResourceReleaseBinding(ctx context.Context, namespaceName, bindingName string) (any, error)
 }
 
 // BuildToolsetHandler handles workflow and CI/CD operations
@@ -383,6 +441,34 @@ type BuildToolsetHandler interface {
 	ListClusterWorkflows(ctx context.Context, opts ListOpts) (any, error)
 	GetClusterWorkflow(ctx context.Context, cwfName string) (any, error)
 	GetClusterWorkflowSchema(ctx context.Context, cwfName string) (any, error)
+}
+
+// ResourceToolsetHandler handles the dev-facing surface of the managed-infrastructure
+// resource family: Resource CRUD plus read-only access to ResourceType and
+// ClusterResourceType templates. Template writes, releases, and bindings live on
+// PEToolsetHandler / DeploymentToolsetHandler matching the component-family role split.
+type ResourceToolsetHandler interface {
+	// Resource operations
+	CreateResource(
+		ctx context.Context, namespaceName, projectName string,
+		req *gen.CreateResourceJSONRequestBody,
+	) (any, error)
+	ListResources(ctx context.Context, namespaceName, projectName string, opts ListOpts) (any, error)
+	GetResource(ctx context.Context, namespaceName, resourceName string) (any, error)
+	UpdateResource(
+		ctx context.Context, namespaceName string, req *gen.UpdateResourceJSONRequestBody,
+	) (any, error)
+	DeleteResource(ctx context.Context, namespaceName, resourceName string) (any, error)
+
+	// Resource types (read-only, namespace-scoped)
+	ListResourceTypes(ctx context.Context, namespaceName string, opts ListOpts) (any, error)
+	GetResourceType(ctx context.Context, namespaceName, rtName string) (any, error)
+	GetResourceTypeSchema(ctx context.Context, namespaceName, rtName string) (any, error)
+
+	// Resource types (read-only, cluster-scoped)
+	ListClusterResourceTypes(ctx context.Context, opts ListOpts) (any, error)
+	GetClusterResourceType(ctx context.Context, crtName string) (any, error)
+	GetClusterResourceTypeSchema(ctx context.Context, crtName string) (any, error)
 }
 
 // RegisterFunc is a function type for registering MCP tools.


### PR DESCRIPTION
## Purpose

Adds MCP tools for the managed-infrastructure resource family so AI agents (Claude, MCP clients) can manage ResourceType / ClusterResourceType templates and the Resource / ResourceRelease / ResourceReleaseBinding lifecycle the same way they manage components today.

## Approach

- New `resource` toolset (dev-facing, 8 tools): Resource CRUD + scope-collapsed read tools over (Cluster)ResourceType. Added to `MCPDefaults`.
- `pe` toolset gains 10 tools: ResourceType writes + creation-schema getter + ResourceRelease list/create/get. Type reads dual-registered with `resource`, mirroring how ComponentType reads live in both `component` and `pe`.
- `deployment` toolset gains 6 tools: ResourceRelease delete + ResourceReleaseBinding CRUD, mirroring `DeleteComponentRelease` and `ReleaseBinding` CRUD.
- Scope-collapsed only — no deprecated cluster-prefixed aliases.
- No `promote_resource` tool: promotion is `get_resource` + `update_resource_release_binding`, matching the component side.

## Related Issues

Closes #3338

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)