### PR TITLE
fix: remove effort level for mini models for perch

### DIFF
--- a/perch-agent/src/clients/llm.py
+++ b/perch-agent/src/clients/llm.py
@@ -9,6 +9,16 @@ from langchain_core.language_models import BaseChatModel
 from src.config import settings
 
 
+def _requires_responses_api(model_name: str) -> bool:
+    # gpt-5.x-mini / gpt-5.x-nano / o-series-mini reject ``reasoning_effort``
+    # on /v1/chat/completions when function tools are bound and require
+    # /v1/responses instead. langchain-openai routes to the responses
+    # endpoint when ``use_responses_api=True``. Match on the model segment
+    # after the optional ``provider:`` prefix.
+    base = model_name.split(":", 1)[-1].lower()
+    return base.endswith("-mini") or base.endswith("-nano")
+
+
 def get_model(
     model_name: str | None = None,
     api_key: str | None = None,
@@ -25,4 +35,9 @@ def get_model(
     # ping) can override without touching configuration.
     if settings.perch_reasoning_effort and "reasoning_effort" not in kwargs:
         kwargs["reasoning_effort"] = settings.perch_reasoning_effort
+        if (
+            _requires_responses_api(model_name)
+            and "use_responses_api" not in kwargs
+        ):
+            kwargs["use_responses_api"] = True
     return init_chat_model(model=model_name, api_key=api_key, **kwargs)

--- a/perch-agent/src/main.py
+++ b/perch-agent/src/main.py
@@ -73,13 +73,15 @@ async def lifespan(_app: FastAPI):
         # Minimal probe: we only need to verify the endpoint is reachable
         # and the API key is valid — we don't need a useful response.
         # "Reply with exactly: Pong" steers the model to a 1-token answer;
-        # max_tokens=5 caps billing even if a model ignores the prompt
-        # framing (reasoning models occasionally do). Both knobs together
-        # turn the per-pod-startup probe from ~50 tokens down to ~2.
+        # max_tokens caps billing even if a model ignores the prompt framing
+        # (reasoning models occasionally do). 16 is the floor required by
+        # OpenAI's /v1/responses API (max_output_tokens >= 16); using a
+        # lower value (e.g. 5) trips a 400 on gpt-5*-mini variants that
+        # route through the responses endpoint.
         model = get_model()
         test_response = await model.ainvoke(
             "Reply with exactly: Pong",
-            max_tokens=5,
+            max_tokens=16,
         )
         logger.info("LLM test successful: %s", str(test_response.content)[:50])
     except Exception as e:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Mini models do not support the effort levels hence drop that param for mini and nano models

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
