### PR TITLE
fix(api): allow empty string values for env vars and config files

### DIFF
--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -11,7 +11,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // EnvVar represents an environment variable present in the container.
-// +kubebuilder:validation:XValidation:rule="has(self.value) != has(self.valueFrom)",message="exactly one of value or valueFrom must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.value) && has(self.valueFrom))",message="value and valueFrom are mutually exclusive"
 type EnvVar struct {
 	// The environment variable key.
 	// +required
@@ -36,7 +36,7 @@ type EnvVarValueFrom struct {
 }
 
 // FileVar represents a file configuration in a container.
-// +kubebuilder:validation:XValidation:rule="has(self.value) != has(self.valueFrom)",message="exactly one of value or valueFrom must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.value) && has(self.valueFrom))",message="value and valueFrom are mutually exclusive"
 type FileVar struct {
 	// The file key/name.
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -664,8 +664,8 @@ spec:
                           - key
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                       files:
                         description: File configurations.
@@ -708,8 +708,8 @@ spec:
                           - mountPath
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                       image:
                         description: OCI image to run (digest or tag).

--- a/config/crd/bases/openchoreo.dev_releasebindings.yaml
+++ b/config/crd/bases/openchoreo.dev_releasebindings.yaml
@@ -154,8 +154,8 @@ spec:
                           - key
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                       files:
                         description: File configurations.
@@ -198,8 +198,8 @@ spec:
                           - mountPath
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                     type: object
                 type: object

--- a/config/crd/bases/openchoreo.dev_workloads.yaml
+++ b/config/crd/bases/openchoreo.dev_workloads.yaml
@@ -98,8 +98,8 @@ spec:
                       - key
                       type: object
                       x-kubernetes-validations:
-                      - message: exactly one of value or valueFrom must be set
-                        rule: has(self.value) != has(self.valueFrom)
+                      - message: value and valueFrom are mutually exclusive
+                        rule: '!(has(self.value) && has(self.valueFrom))'
                     type: array
                   files:
                     description: File configurations.
@@ -141,8 +141,8 @@ spec:
                       - mountPath
                       type: object
                       x-kubernetes-validations:
-                      - message: exactly one of value or valueFrom must be set
-                        rule: has(self.value) != has(self.valueFrom)
+                      - message: value and valueFrom are mutually exclusive
+                        rule: '!(has(self.value) && has(self.valueFrom))'
                     type: array
                   image:
                     description: OCI image to run (digest or tag).

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -663,8 +663,8 @@ spec:
                           - key
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                       files:
                         description: File configurations.
@@ -707,8 +707,8 @@ spec:
                           - mountPath
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                       image:
                         description: OCI image to run (digest or tag).

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
@@ -153,8 +153,8 @@ spec:
                           - key
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                       files:
                         description: File configurations.
@@ -197,8 +197,8 @@ spec:
                           - mountPath
                           type: object
                           x-kubernetes-validations:
-                          - message: exactly one of value or valueFrom must be set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: value and valueFrom are mutually exclusive
+                            rule: '!(has(self.value) && has(self.valueFrom))'
                         type: array
                     type: object
                 type: object

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
@@ -97,8 +97,8 @@ spec:
                       - key
                       type: object
                       x-kubernetes-validations:
-                      - message: exactly one of value or valueFrom must be set
-                        rule: has(self.value) != has(self.valueFrom)
+                      - message: value and valueFrom are mutually exclusive
+                        rule: '!(has(self.value) && has(self.valueFrom))'
                     type: array
                   files:
                     description: File configurations.
@@ -140,8 +140,8 @@ spec:
                       - mountPath
                       type: object
                       x-kubernetes-validations:
-                      - message: exactly one of value or valueFrom must be set
-                        rule: has(self.value) != has(self.valueFrom)
+                      - message: value and valueFrom are mutually exclusive
+                        rule: '!(has(self.value) && has(self.valueFrom))'
                     type: array
                   image:
                     description: OCI image to run (digest or tag).

--- a/internal/pipeline/component/context/configuration.go
+++ b/internal/pipeline/component/context/configuration.go
@@ -30,36 +30,28 @@ func ExtractConfigurationsFromWorkload(secretReferences map[string]*v1alpha1.Sec
 
 	container := workload.Spec.Container
 
-	// Process environment variables from container
+	// Process environment variables from container.
+	// CRD-level CEL guarantees value and valueFrom are not both set, so a missing
+	// valueFrom means the literal value (possibly empty string) is intended.
 	for _, env := range container.Env {
-		if env.Value != "" {
-			// Direct value - goes to configs
-			result.Configs.Envs = append(result.Configs.Envs, EnvConfiguration{
-				Name:  env.Key,
-				Value: env.Value,
-			})
-		} else if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
-			// Resolve secret reference and add to secrets
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 			if remoteRef := resolveSecretRef(secretReferences, env.ValueFrom.SecretKeyRef); remoteRef != nil {
 				result.Secrets.Envs = append(result.Secrets.Envs, EnvConfiguration{
 					Name:      env.Key,
 					RemoteRef: remoteRef,
 				})
 			}
+		} else {
+			result.Configs.Envs = append(result.Configs.Envs, EnvConfiguration{
+				Name:  env.Key,
+				Value: env.Value,
+			})
 		}
 	}
 
-	// Process file configurations from container
+	// Process file configurations from container.
 	for _, file := range container.Files {
-		if file.Value != "" {
-			// Direct content - goes to configs
-			result.Configs.Files = append(result.Configs.Files, FileConfiguration{
-				Name:      file.Key,
-				MountPath: file.MountPath,
-				Value:     file.Value,
-			})
-		} else if file.ValueFrom != nil && file.ValueFrom.SecretKeyRef != nil {
-			// Resolve secret reference and add to secrets
+		if file.ValueFrom != nil && file.ValueFrom.SecretKeyRef != nil {
 			if remoteRef := resolveSecretRef(secretReferences, file.ValueFrom.SecretKeyRef); remoteRef != nil {
 				result.Secrets.Files = append(result.Secrets.Files, FileConfiguration{
 					Name:      file.Key,
@@ -67,6 +59,12 @@ func ExtractConfigurationsFromWorkload(secretReferences map[string]*v1alpha1.Sec
 					RemoteRef: remoteRef,
 				})
 			}
+		} else {
+			result.Configs.Files = append(result.Configs.Files, FileConfiguration{
+				Name:      file.Key,
+				MountPath: file.MountPath,
+				Value:     file.Value,
+			})
 		}
 	}
 

--- a/internal/pipeline/component/context/configuration_test.go
+++ b/internal/pipeline/component/context/configuration_test.go
@@ -390,6 +390,92 @@ func TestExtractConfigurationsFromWorkload(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "workload with empty env value is preserved",
+			secretReferences: map[string]*v1alpha1.SecretReference{},
+			workload: &v1alpha1.Workload{
+				Spec: v1alpha1.WorkloadSpec{
+					WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+						Container: v1alpha1.Container{
+							Image: "test:latest",
+							Env: []v1alpha1.EnvVar{
+								{Key: "EMPTY_VAR", Value: ""},
+								{Key: "REAL_VAR", Value: "set"},
+							},
+						},
+					},
+				},
+			},
+			want: ContainerConfigurations{
+				Configs: ConfigurationItems{
+					Envs: []EnvConfiguration{
+						{Name: "EMPTY_VAR", Value: ""},
+						{Name: "REAL_VAR", Value: "set"},
+					},
+					Files: []FileConfiguration{},
+				},
+				Secrets: ConfigurationItems{
+					Envs:  []EnvConfiguration{},
+					Files: []FileConfiguration{},
+				},
+			},
+		},
+		{
+			name:             "workload with env having neither value nor valueFrom is treated as empty",
+			secretReferences: map[string]*v1alpha1.SecretReference{},
+			workload: &v1alpha1.Workload{
+				Spec: v1alpha1.WorkloadSpec{
+					WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+						Container: v1alpha1.Container{
+							Image: "test:latest",
+							Env: []v1alpha1.EnvVar{
+								{Key: "BARE"},
+							},
+						},
+					},
+				},
+			},
+			want: ContainerConfigurations{
+				Configs: ConfigurationItems{
+					Envs: []EnvConfiguration{
+						{Name: "BARE", Value: ""},
+					},
+					Files: []FileConfiguration{},
+				},
+				Secrets: ConfigurationItems{
+					Envs:  []EnvConfiguration{},
+					Files: []FileConfiguration{},
+				},
+			},
+		},
+		{
+			name:             "workload with empty file value is preserved",
+			secretReferences: map[string]*v1alpha1.SecretReference{},
+			workload: &v1alpha1.Workload{
+				Spec: v1alpha1.WorkloadSpec{
+					WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+						Container: v1alpha1.Container{
+							Image: "test:latest",
+							Files: []v1alpha1.FileVar{
+								{Key: "empty-file", MountPath: "/etc/empty", Value: ""},
+							},
+						},
+					},
+				},
+			},
+			want: ContainerConfigurations{
+				Configs: ConfigurationItems{
+					Envs: []EnvConfiguration{},
+					Files: []FileConfiguration{
+						{Name: "empty-file", MountPath: "/etc/empty", Value: ""},
+					},
+				},
+				Secrets: ConfigurationItems{
+					Envs:  []EnvConfiguration{},
+					Files: []FileConfiguration{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -326,9 +326,11 @@ type ConfigurationItems struct {
 }
 
 // EnvConfiguration represents an environment variable configuration.
+// Value is always emitted (no omitempty) so that empty-string literals survive
+// the JSON round-trip into the CEL evaluation context.
 type EnvConfiguration struct {
 	Name      string         `json:"name"`
-	Value     string         `json:"value,omitempty"`
+	Value     string         `json:"value"`
 	RemoteRef *RemoteRefData `json:"remoteRef,omitempty"`
 }
 
@@ -336,7 +338,7 @@ type EnvConfiguration struct {
 type FileConfiguration struct {
 	Name      string         `json:"name"`
 	MountPath string         `json:"mountPath"`
-	Value     string         `json:"value,omitempty"`
+	Value     string         `json:"value"`
 	RemoteRef *RemoteRefData `json:"remoteRef,omitempty"`
 }
 


### PR DESCRIPTION
## Purpose

`EnvVar`/`FileVar` rejected `value: ""` because of a CEL rule stricter than upstream Kubernetes (`has(value) != has(valueFrom)`), making it impossible to clear inherited env defaults like `JAVA_TOOL_OPTIONS=""` on a workload or via `ReleaseBinding.workloadOverrides`. Even when admission was bypassed, the rendering pipeline silently dropped empty values, so the variable never reached the container's environ. This PR brings OpenChoreo in line with kube core semantics where an env var set to empty string is a first-class state distinct from unset.

End-to-end verified on a k3d cluster: every variant (empty value, bare entry, valueFrom-only, both-set rejection) lands correctly in the rendered ConfigMap and the running container's environment.

## Approach

- Relax the `EnvVar`/`FileVar` CEL rule to `!(has(value) && has(valueFrom))` — only the genuinely ambiguous both-set case is rejected; empty and unset are both accepted, matching upstream `corev1.EnvVar`
- Update `ExtractConfigurationsFromWorkload` to branch on `ValueFrom == nil` instead of `Value != ""`, so empty literals land in `Configs.Envs`/`Configs.Files` instead of being silently dropped
- Drop `omitempty` from `EnvConfiguration.Value` and `FileConfiguration.Value` so empty strings survive the JSON round-trip into the CEL evaluation context (this was the second filter that dropped empties even after the renderer fix)
- Regenerate CRD manifests in `config/crd/bases/` and `install/helm/openchoreo-control-plane/crds/` for `workloads`, `releasebindings`, `componentreleases`
- Add three test cases to `configuration_test.go` covering empty env value, bare env entry, and empty file value

## Related Issues

Closes #3537

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)