### PR TITLE
feat: add --namespace flag to componentrelease generate

### DIFF
--- a/internal/occ/cmd/componentrelease/cmd.go
+++ b/internal/occ/cmd/componentrelease/cmd.go
@@ -66,6 +66,7 @@ func newGenerateCmd() *cobra.Command {
 			}
 
 			params := GenerateParams{
+				Namespace:  flags.GetNamespace(cmd),
 				OutputPath: flags.GetOutputPath(cmd),
 				DryRun:     flags.GetDryRun(cmd),
 				Mode:       flags.GetMode(cmd),
@@ -89,6 +90,7 @@ func newGenerateCmd() *cobra.Command {
 	}
 	cmd.Flags().String("name", "", "Name of the resource (must be lowercase letters, numbers, or hyphens)")
 	flags.AddAll(cmd)
+	flags.AddNamespace(cmd)
 	flags.AddProject(cmd)
 	flags.AddComponent(cmd)
 	flags.AddOutputPath(cmd)

--- a/internal/occ/cmd/componentrelease/componentrelease.go
+++ b/internal/occ/cmd/componentrelease/componentrelease.go
@@ -85,10 +85,11 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 		return fmt.Errorf("componentrelease generate only supports file-system mode; use --mode file-system (got %q)", mode)
 	}
 
-	// 2. Load context for namespace fallback. Skip entirely if --namespace is set,
-	//    so the flag can be used without a configured context.
-	var ctx *config.Context
-	if params.Namespace == "" {
+	// 2. Resolve namespace: prefer --namespace flag, fall back to current context.
+	//    Skip the context lookup entirely when --namespace is set, so the flag
+	//    can be used without a configured context.
+	namespace := params.Namespace
+	if namespace == "" {
 		cfg, err := config.LoadStoredConfig()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
@@ -98,6 +99,7 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 			return fmt.Errorf("no current context set")
 		}
 
+		var ctx *config.Context
 		for _, c := range cfg.Contexts {
 			if c.Name == cfg.CurrentContext {
 				ctxCopy := c
@@ -109,6 +111,12 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 		if ctx == nil {
 			return fmt.Errorf("current context %q not found in config", cfg.CurrentContext)
 		}
+
+		namespace = ctx.Namespace
+	}
+
+	if namespace == "" {
+		return fmt.Errorf("namespace is required (set via --namespace or current context)")
 	}
 
 	repoPath := params.RootDir
@@ -145,16 +153,7 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 	baseDir := repoPath
 	customOutputPath := params.OutputPath
 
-	// 6. Resolve namespace: prefer --namespace flag, fall back to current context
-	namespace := params.Namespace
-	if namespace == "" && ctx != nil {
-		namespace = ctx.Namespace
-	}
-	if namespace == "" {
-		return fmt.Errorf("namespace is required (set via --namespace or current context)")
-	}
-
-	// 7. Build output directory resolver for when no release-config.yaml exists
+	// 6. Build output directory resolver for when no release-config.yaml exists
 	resolver := buildOutputDirResolver(ocIndex, namespace)
 
 	// 8. Generate releases based on scope

--- a/internal/occ/cmd/componentrelease/componentrelease.go
+++ b/internal/occ/cmd/componentrelease/componentrelease.go
@@ -85,28 +85,30 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 		return fmt.Errorf("componentrelease generate only supports file-system mode; use --mode file-system (got %q)", mode)
 	}
 
-	// 2. Load context for other defaults (namespace, etc.)
-	cfg, err := config.LoadStoredConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	if cfg.CurrentContext == "" {
-		return fmt.Errorf("no current context set")
-	}
-
-	// Find current context
+	// 2. Load context for namespace fallback. Skip entirely if --namespace is set,
+	//    so the flag can be used without a configured context.
 	var ctx *config.Context
-	for _, c := range cfg.Contexts {
-		if c.Name == cfg.CurrentContext {
-			ctxCopy := c
-			ctx = &ctxCopy
-			break
+	if params.Namespace == "" {
+		cfg, err := config.LoadStoredConfig()
+		if err != nil {
+			return fmt.Errorf("failed to load config: %w", err)
 		}
-	}
 
-	if ctx == nil {
-		return fmt.Errorf("current context %q not found in config", cfg.CurrentContext)
+		if cfg.CurrentContext == "" {
+			return fmt.Errorf("no current context set")
+		}
+
+		for _, c := range cfg.Contexts {
+			if c.Name == cfg.CurrentContext {
+				ctxCopy := c
+				ctx = &ctxCopy
+				break
+			}
+		}
+
+		if ctx == nil {
+			return fmt.Errorf("current context %q not found in config", cfg.CurrentContext)
+		}
 	}
 
 	repoPath := params.RootDir
@@ -145,7 +147,7 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 
 	// 6. Resolve namespace: prefer --namespace flag, fall back to current context
 	namespace := params.Namespace
-	if namespace == "" {
+	if namespace == "" && ctx != nil {
 		namespace = ctx.Namespace
 	}
 	if namespace == "" {

--- a/internal/occ/cmd/componentrelease/componentrelease.go
+++ b/internal/occ/cmd/componentrelease/componentrelease.go
@@ -143,10 +143,13 @@ func (cr *ComponentRelease) Generate(params GenerateParams) error {
 	baseDir := repoPath
 	customOutputPath := params.OutputPath
 
-	// 6. Get namespace from context (same as namespace)
-	namespace := ctx.Namespace
+	// 6. Resolve namespace: prefer --namespace flag, fall back to current context
+	namespace := params.Namespace
 	if namespace == "" {
-		return fmt.Errorf("namespace is required in context")
+		namespace = ctx.Namespace
+	}
+	if namespace == "" {
+		return fmt.Errorf("namespace is required (set via --namespace or current context)")
 	}
 
 	// 7. Build output directory resolver for when no release-config.yaml exists

--- a/internal/occ/cmd/componentrelease/generate_test.go
+++ b/internal/occ/cmd/componentrelease/generate_test.go
@@ -113,7 +113,7 @@ func TestGenerate_EmptyNamespaceInContext(t *testing.T) {
 		RootDir: repoDir,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "namespace is required in context")
+	assert.Contains(t, err.Error(), "namespace is required")
 }
 
 // --- Generate: component requires project ---

--- a/internal/occ/cmd/componentrelease/params.go
+++ b/internal/occ/cmd/componentrelease/params.go
@@ -6,6 +6,7 @@ package componentrelease
 // GenerateParams defines parameters for generating component releases
 type GenerateParams struct {
 	All           bool   // Generate for all components
+	Namespace     string // Optional: override namespace from context
 	ProjectName   string // Generate for all components in this project
 	ComponentName string // Generate for specific component
 	ReleaseName   string // Optional: custom release name (only valid with --component)


### PR DESCRIPTION
## Purpose

`occ componentrelease generate` previously read the namespace only from the current CLI context, failing with `namespace is required in context` when no context was set. This adds a `--namespace` flag so users can run the command without first switching contexts, matching the behavior of `list`, `get`, and `delete`.

## Approach

- Add `--namespace` flag to the `generate` subcommand alongside the existing flags.
- Add `Namespace` field to `GenerateParams`.
- Resolve namespace by preferring the flag value, falling back to the context namespace, and erroring only when both are empty.
- Update the existing empty-context test to assert against the new error message.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)