### PR TITLE
fix: add credentials support to Observer CORS middleware

### DIFF
--- a/internal/observer/middleware/middleware.go
+++ b/internal/observer/middleware/middleware.go
@@ -82,6 +82,7 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 				w.Header().Set("Access-Control-Max-Age", "3600")
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
 				w.Header().Set("Vary", "Origin")
 			}
 

--- a/internal/observer/middleware/middleware_test.go
+++ b/internal/observer/middleware/middleware_test.go
@@ -47,12 +47,12 @@ func TestCORS(t *testing.T) {
 			expectNext:     true,
 			expectStatus:   http.StatusOK,
 			expectHeaders: map[string]string{
-				"Access-Control-Allow-Origin":  "http://localhost:3000",
-				"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-				"Access-Control-Allow-Headers":      "Content-Type, Authorization",
-				"Access-Control-Max-Age":            "3600",
-				"Access-Control-Allow-Credentials":  "true",
-				"Vary":                              "Origin",
+				"Access-Control-Allow-Origin":      "http://localhost:3000",
+				"Access-Control-Allow-Methods":     "GET, POST, PUT, DELETE, OPTIONS",
+				"Access-Control-Allow-Headers":     "Content-Type, Authorization",
+				"Access-Control-Max-Age":           "3600",
+				"Access-Control-Allow-Credentials": "true",
+				"Vary":                             "Origin",
 			},
 		},
 		{

--- a/internal/observer/middleware/middleware_test.go
+++ b/internal/observer/middleware/middleware_test.go
@@ -49,9 +49,10 @@ func TestCORS(t *testing.T) {
 			expectHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "http://localhost:3000",
 				"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-				"Access-Control-Allow-Headers": "Content-Type, Authorization",
-				"Access-Control-Max-Age":       "3600",
-				"Vary":                         "Origin",
+				"Access-Control-Allow-Headers":      "Content-Type, Authorization",
+				"Access-Control-Max-Age":            "3600",
+				"Access-Control-Allow-Credentials":  "true",
+				"Vary":                              "Origin",
 			},
 		},
 		{
@@ -74,7 +75,8 @@ func TestCORS(t *testing.T) {
 			expectNext:   false,
 			expectStatus: http.StatusNoContent,
 			expectHeaders: map[string]string{
-				"Access-Control-Allow-Origin": "http://localhost:3000",
+				"Access-Control-Allow-Origin":      "http://localhost:3000",
+				"Access-Control-Allow-Credentials": "true",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Add Access-Control-Allow-Credentials: true to CORS responses when the origin is allowed
- Allows credentialed cross-origin requests from the Backstage console to Observer

Fixes #3536

## Test plan
- Updated existing CORS middleware unit tests to verify the new header
- go test ./internal/observer/middleware/...