### PR TITLE
fix: add credentials support to FinOps and RCA agent middleware

### DIFF
--- a/finops-agent/src/main.py
+++ b/finops-agent/src/main.py
@@ -85,6 +85,7 @@ if settings.cors_allowed_origins:
         app.add_middleware(
             CORSMiddleware,  # type: ignore[arg-type]
             allow_origins=origins,
+            allow_credentials=True,
             allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
             allow_headers=["Content-Type", "Authorization"],
             max_age=3600,

--- a/rca-agent/src/main.py
+++ b/rca-agent/src/main.py
@@ -114,6 +114,7 @@ if settings.cors_allowed_origins:
         app.add_middleware(
             CORSMiddleware,  # type: ignore[arg-type]
             allow_origins=origins,
+            allow_credentials=True,
             allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
             allow_headers=["Content-Type", "Authorization"],
             max_age=3600,


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The Backstage console cannot make authenticated cross-origin requests to the finops-agent and rca-agent services because their CORS middleware does not emit the Access-Control-Allow-Credentials header. 

## Approach
Set allow_credentials=True on the Starlette CORSMiddleware configuration in finops-agent/src/main.py and rca-agent/src/main.py, so the agents return Access-Control-Allow-Credentials: true for whitelisted origins.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3356

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
