### PR TITLE
fix: observability-traces-opensearch release name in multicluster setup guide

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -652,7 +652,7 @@ helm upgrade --install observability-logs-opensearch \
 Install the tracing receiver in the observability plane cluster. Since the logs module already installed OpenSearch, disable it here:
 
 ```bash
-helm upgrade --install observability-tracing-opensearch \
+helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --kube-context k3d-openchoreo-op \
   --create-namespace \


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> to match docs & single cluster guides. Previous versions used `observability-tracing-opensearch` as the release name.
https://github.com/openchoreo/openchoreo/blob/v1.0.0/install/k3d/multi-cluster/README.md#tracing-observability-tracing-opensearch

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
