### PR TITLE
fix: add pods/exec RBAC to data plane cluster-agent for occ component exec

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -39,6 +39,11 @@ rules:
   - pods/status
   - events
   verbs: ["get", "list"]
+# Pod exec (required for occ component exec / interactive shell into pods)
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  verbs: ["create", "get"]
 # Batch jobs
 - apiGroups: ["batch"]
   resources:


### PR DESCRIPTION
## Summary
- Adds `pods/exec` permission (`create`, `get`) to the data plane cluster-agent ClusterRole
- Required for `occ component exec` to create exec sessions on target pods via the cluster-gateway → cluster-agent path

### Without this change
The cluster-agent receives the exec request from the gateway but cannot create the exec subresource on the target pod, resulting in a 403 from the Kubernetes API server on the data plane.

## Test plan
- [ ] `occ component exec` works against components on the data plane
- [ ] Existing pod listing/log functionality unaffected