### PR TITLE
fix: populate the actual cost value in the report from the value received in the alert

### DIFF
--- a/finops-agent/src/agent/agent.py
+++ b/finops-agent/src/agent/agent.py
@@ -24,7 +24,7 @@ from src.auth import get_oauth2_auth
 from src.clients import MCPClient, get_model, get_report_backend
 from src.config import settings
 from src.logging_config import request_id_context
-from src.models import FinOpsReport, FieldChange, RemediationAction, ResourceChange
+from src.models import CostBreakdown, FinOpsReport, FieldChange, RemediationAction, ResourceChange
 from src.template_manager import render
 
 if TYPE_CHECKING:
@@ -273,6 +273,16 @@ async def run_analysis(
                 _synthesize_remediation_actions(finops_report)
                 if settings.remediation_enabled
                 else []
+            )
+
+            inbound_actual = request_context["actual_cost"]
+            finops_report.actual_cost = CostBreakdown(
+                cpu_cost=None,
+                memory_cost=None,
+                total_cost=inbound_actual["amount"],
+                currency=inbound_actual["currency"],
+                is_estimated=False,
+                breakdown_source="observer_alert_value",
             )
 
             report_data = finops_report.model_dump()

--- a/finops-agent/src/models/__init__.py
+++ b/finops-agent/src/models/__init__.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from src.models.base import BaseModel, get_current_utc
-from src.models.finops_report import FinOpsReport
+from src.models.finops_report import CostBreakdown, FinOpsReport
 from src.models.remediation_action import FieldChange, RemediationAction, ResourceChange
 
 __all__ = [
     "BaseModel",
     "get_current_utc",
+    "CostBreakdown",
     "FinOpsReport",
     "FieldChange",
     "RemediationAction",

--- a/finops-agent/src/templates/api/finops_request.j2
+++ b/finops-agent/src/templates/api/finops_request.j2
@@ -13,8 +13,11 @@ Analyze the following component that has exceeded its budget:
 - **Amount**: {{ budgeted_cost.amount }} {{ budgeted_cost.currency }}
 - **Period**: {{ budgeted_cost.period }}
 
-## Actual Cost
+## Actual Cost (authoritative — from the triggering budget alert)
 - **Amount**: {{ actual_cost.amount }} {{ actual_cost.currency }}
+
+> The `actual_cost` field in your final report will be populated deterministically
+> from this value; do not re-query or recompute it.
 
 Please investigate this budget overrun by:
 1. Querying resource metrics (CPU and memory requests, limits, and actual usage) for this component over the budget period ({{ budgeted_cost.period }})

--- a/finops-agent/src/templates/prompts/finops_agent_prompt.j2
+++ b/finops-agent/src/templates/prompts/finops_agent_prompt.j2
@@ -4,11 +4,17 @@ You are a FinOps analysis agent for OpenChoreo. Your task is to analyze componen
 
 Given a component that has triggered a budget alert, you must:
 1. Query resource metrics (CPU/memory requests, limits, and actual usage) from the Observability MCP server
-2. Query cost allocation data from the cost analytics MCP server
+2. Query cost allocation data from the cost analytics MCP server (for budgeted-cost breakdown only — see note below)
 3. Compare actual resource usage against configured requests/limits to determine overprovisioning
-4. Compare actual cost against budgeted cost
+4. Compare actual cost (provided in the request) against budgeted cost
 5. If overprovisioned, calculate recommended CPU/memory requests and limits based on actual usage (P95 + safety headroom)
 6. Produce a structured FinOps report with your findings and recommendations
+
+> **Note on `actual_cost`**: The `actual_cost` field in the final report is populated
+> deterministically by the runtime from the value supplied in the request (the alert-
+> triggering cost from Observer). You do not need to compute or query it. Fill the
+> field with placeholder zeros if required by the schema — the runtime will overwrite
+> it before the report is persisted.
 
 ## Available Tools
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The FinOps report's actual_cost did not match the actualCost value Observer sends in the budget-alert webhook. The report must echo Observer's value verbatim.

## Approach
- In finops-agent/src/agent/agent.py (run_analysis), after the agent returns, deterministically overwrite finops_report.actual_cost with a CostBreakdown built from request_context


## Related Issues
https://github.com/openchoreo/openchoreo/issues/3356

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
