### PR TITLE
fix: force HTTP/1.1 for exec WebSocket dialer

### DIFF
--- a/internal/occ/cmd/component/exec.go
+++ b/internal/occ/cmd/component/exec.go
@@ -5,6 +5,7 @@ package component
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -114,7 +115,12 @@ func dialExecWebSocket(ctx context.Context, params ExecParams) (*websocket.Conn,
 		headers.Set("Authorization", "Bearer "+currentToken)
 	}
 
-	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, headers)
+	dialer := websocket.Dialer{
+		TLSClientConfig: &tls.Config{
+			NextProtos: []string{"http/1.1"},
+		},
+	}
+	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
 		if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
 			return nil, fmt.Errorf("exec connection failed (HTTP %d): %w", resp.StatusCode, err)


### PR DESCRIPTION
## Summary
- Forces HTTP/1.1 ALPN negotiation on the exec WebSocket dialer via `NextProtos: []string{"http/1.1"}`
- Fixes `occ component exec` failing with HTTP 400 on clusters where envoy negotiates HTTP/2 via TLS ALPN (e.g., AWS NLB with TCP passthrough to kgateway)

### Why
HTTP/2 supports WebSocket via RFC 8441 (Extended CONNECT), but the `gorilla/websocket` library only implements the HTTP/1.1 upgrade mechanism (`Connection: Upgrade` header). When Go's TLS client negotiates HTTP/2 via ALPN, the HTTP/1.1 upgrade headers are invalid and envoy returns 400. Forcing `http/1.1` in the ALPN ensures compatibility with the library's WebSocket handshake.

## Test plan
- [ ] `occ component exec` works on clusters with HTTP/2-capable gateways (AWS NLB + kgateway)
- [ ] `occ component exec` continues to work on clusters with HTTP/1.1 gateways
- [ ] Windows cross-compilation passes