### PR TITLE
feat: stream Cilium Hubble wirelogs via openchoreo-api

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -249,11 +249,22 @@ func main() {
 		}
 		execHandler := openapihandlers.NewExecHandler(k8sClient, gwClient, gatewayURL, gwTLSConf, execAuthzChecker, logger)
 		authedExecHandler := jwtMiddleware(execHandler)
+
+		// Wirelogs handler shares the same gateway TLS config and authz checker
+		// (authz reuses logs:view at the component scope).
+		wirelogsAuthzChecker := svcpkg.NewAuthzChecker(runtime.pdp, logger.With("component", "wirelogs-authz"))
+		wirelogsHandler := openapihandlers.NewWirelogsHandler(
+			k8sClient, gwClient, gatewayURL, gwTLSConf, wirelogsAuthzChecker, logger,
+		)
+		authedWirelogsHandler := jwtMiddleware(wirelogsHandler)
+
 		topMux := http.NewServeMux()
 		topMux.Handle("/exec/", authedExecHandler)
+		topMux.Handle("/wirelogs/", authedWirelogsHandler)
 		topMux.Handle("/", handler)
 		topHandler = topMux
 		logger.Info("Exec endpoint registered", "path", "/exec/namespaces/{ns}/components/{name}")
+		logger.Info("Wirelogs endpoint registered", "path", "/wirelogs/namespaces/{ns}/components/{name}")
 	}
 
 	// Create server from configuration

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -260,11 +260,11 @@ func main() {
 
 		topMux := http.NewServeMux()
 		topMux.Handle("/exec/", authedExecHandler)
-		topMux.Handle("/wirelogs/", authedWirelogsHandler)
+		topMux.Handle("GET /namespaces/{namespace}/environments/{environment}/wirelogs", authedWirelogsHandler)
 		topMux.Handle("/", handler)
 		topHandler = topMux
 		logger.Info("Exec endpoint registered", "path", "/exec/namespaces/{ns}/components/{name}")
-		logger.Info("Wirelogs endpoint registered", "path", "/wirelogs/namespaces/{ns}/components/{name}")
+		logger.Info("Wirelogs endpoint registered", "path", "/namespaces/{namespace}/environments/{environment}/wirelogs")
 	}
 
 	// Create server from configuration

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/casbin/casbin/v2 v2.135.0
-	github.com/cilium/cilium v1.16.5
+	github.com/cilium/cilium v1.16.19
 	github.com/getkin/kin-openapi v0.138.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-playground/validator/v10 v10.30.2

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/casbin/casbin/v2 v2.135.0
+	github.com/cilium/cilium v1.16.5
 	github.com/getkin/kin-openapi v0.138.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-playground/validator/v10 v10.30.2
@@ -91,7 +92,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
-	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
@@ -152,8 +152,8 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
+	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apiserver v0.32.3

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cilium/cilium v1.16.5 h1:ecjhh98fl6Ki641+8Cdb0oynsy3toQ+oPLCSI3d+KLE=
-github.com/cilium/cilium v1.16.5/go.mod h1:EqOosPzJuv28Hz3Ulz6cCXfYKbll7vbIwMGZU5houOw=
+github.com/cilium/cilium v1.16.19 h1:t8UqCIzIeRuKOEZ9B5kj8usoVtjxMA1Z3dKVUMxozL0=
+github.com/cilium/cilium v1.16.19/go.mod h1:Swm409yI+AfaCJjWd0cyz2DiyacybettBeYHxqzU0Wc=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cilium/cilium v1.16.5 h1:ecjhh98fl6Ki641+8Cdb0oynsy3toQ+oPLCSI3d+KLE=
+github.com/cilium/cilium v1.16.5/go.mod h1:EqOosPzJuv28Hz3Ulz6cCXfYKbll7vbIwMGZU5houOw=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
@@ -119,14 +121,15 @@ github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oX
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -71,6 +71,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.clusterAgent.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.clusterAgent.resources | nindent 10 }}
         {{- with .Values.clusterAgent.securityContext }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -16,19 +16,65 @@
         },
         "extraEnvs": {
           "default": [],
-          "description": "Additional environment variables to set in the cluster agent container.",
+          "description": "Additional environment variables to set in the cluster agent container. Each entry must specify exactly one of 'value' (literal) or 'valueFrom.secretKeyRef' (reference to an existing Kubernetes Secret).",
           "items": {
+            "additionalProperties": false,
+            "oneOf": [
+              {
+                "required": [
+                  "name",
+                  "value"
+                ]
+              },
+              {
+                "required": [
+                  "name",
+                  "valueFrom"
+                ]
+              }
+            ],
             "properties": {
               "name": {
                 "description": "Name of the environment variable",
                 "type": "string"
               },
               "value": {
-                "description": "Value of the environment variable",
+                "description": "Literal value of the environment variable. Avoid for secret material; use valueFrom.secretKeyRef instead.",
                 "type": "string"
+              },
+              "valueFrom": {
+                "additionalProperties": false,
+                "description": "Source the value from an existing Kubernetes resource. Currently only secretKeyRef is supported.",
+                "properties": {
+                  "secretKeyRef": {
+                    "additionalProperties": false,
+                    "description": "Reference to a key in an existing Kubernetes Secret.",
+                    "properties": {
+                      "key": {
+                        "description": "Key within the Secret whose value to inject.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the Secret (must exist in the cluster-agent's namespace).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "key"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "secretKeyRef"
+                ],
+                "type": "object"
               }
             },
-            "required": [],
+            "required": [
+              "name"
+            ],
             "type": "object"
           },
           "title": "extraEnvs",

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -14,6 +14,26 @@
           "title": "affinity",
           "type": "object"
         },
+        "extraEnvs": {
+          "default": [],
+          "description": "Additional environment variables to set in the cluster agent container.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value of the environment variable",
+                "type": "string"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "title": "extraEnvs",
+          "type": "array"
+        },
         "heartbeatInterval": {
           "default": "30s",
           "description": "Interval between heartbeat messages to control plane",

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -402,6 +402,22 @@ clusterAgent:
   logLevel: info
 
   # @schema
+  # type: array
+  # description: Additional environment variables to set in the cluster agent container.
+  # items:
+  #   type: object
+  #   properties:
+  #     name:
+  #       type: string
+  #       description: Name of the environment variable
+  #     value:
+  #       type: string
+  #       description: Value of the environment variable
+  # default: []
+  # @schema
+  extraEnvs: []
+
+  # @schema
   # type: object
   # description: Resource limits and requests for cluster agent
   # @schema

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -403,16 +403,40 @@ clusterAgent:
 
   # @schema
   # type: array
-  # description: Additional environment variables to set in the cluster agent container.
+  # description: Additional environment variables to set in the cluster agent container. Each entry must specify exactly one of 'value' (literal) or 'valueFrom.secretKeyRef' (reference to an existing Kubernetes Secret).
   # items:
   #   type: object
+  #   additionalProperties: false
+  #   required:
+  #     - name
+  #   oneOf:
+  #     - required: [name, value]
+  #     - required: [name, valueFrom]
   #   properties:
   #     name:
   #       type: string
   #       description: Name of the environment variable
   #     value:
   #       type: string
-  #       description: Value of the environment variable
+  #       description: Literal value of the environment variable. Avoid for secret material; use valueFrom.secretKeyRef instead.
+  #     valueFrom:
+  #       type: object
+  #       additionalProperties: false
+  #       description: Source the value from an existing Kubernetes resource. Currently only secretKeyRef is supported.
+  #       required: [secretKeyRef]
+  #       properties:
+  #         secretKeyRef:
+  #           type: object
+  #           additionalProperties: false
+  #           description: Reference to a key in an existing Kubernetes Secret.
+  #           required: [name, key]
+  #           properties:
+  #             name:
+  #               type: string
+  #               description: Name of the Secret (must exist in the cluster-agent's namespace).
+  #             key:
+  #               type: string
+  #               description: Key within the Secret whose value to inject.
   # default: []
   # @schema
   extraEnvs: []

--- a/internal/authz/core/actions.go
+++ b/internal/authz/core/actions.go
@@ -227,6 +227,9 @@ const (
 	// Logs actions
 	ActionViewLogs = "logs:view"
 
+	// Wirelogs actions
+	ActionViewWirelogs = "wirelogs:view"
+
 	// Metrics actions
 	ActionViewMetrics = "metrics:view"
 
@@ -461,6 +464,9 @@ var systemActions = []Action{
 
 	// logs (dynamic scope: namespace or component depending on query)
 	{Name: ActionViewLogs, LowestScope: ScopeComponent, IsInternal: false},
+
+	// wirelogs (dynamic scope: environment, project, or component depending on query)
+	{Name: ActionViewWirelogs, LowestScope: ScopeComponent, IsInternal: false},
 
 	// metrics (dynamic scope: namespace or component depending on query)
 	{Name: ActionViewMetrics, LowestScope: ScopeComponent, IsInternal: false},

--- a/internal/authz/core/condition_registry.go
+++ b/internal/authz/core/condition_registry.go
@@ -62,6 +62,7 @@ var conditionRegistry = map[string][]AttributeSpec{
 	ActionUpdateResourceReleaseBinding: {AttrResourceEnvironment},
 	ActionDeleteResourceReleaseBinding: {AttrResourceEnvironment},
 	ActionViewLogs:                     {AttrResourceEnvironment},
+	ActionViewWirelogs:                 {AttrResourceEnvironment},
 	ActionViewMetrics:                  {AttrResourceEnvironment},
 	ActionViewTraces:                   {AttrResourceEnvironment},
 }

--- a/internal/cluster-agent/agent.go
+++ b/internal/cluster-agent/agent.go
@@ -46,6 +46,9 @@ type Agent struct {
 	// activeStreams tracks active exec streaming sessions indexed by requestID
 	activeStreams   map[string]*execSession
 	activeStreamsMu sync.Mutex
+	// hubbleStreams tracks active hubble flow streaming sessions indexed by requestID
+	hubbleStreams   map[string]*hubbleSession
+	hubbleStreamsMu sync.Mutex
 }
 
 func New(cfg *Config, k8sClient client.Client, k8sConfig *rest.Config, logger *slog.Logger) (*Agent, error) {
@@ -99,6 +102,7 @@ func New(cfg *Config, k8sClient client.Client, k8sConfig *rest.Config, logger *s
 		logger:        logger.With("component", "agent", "planeID", cfg.PlaneID),
 		stopChan:      make(chan struct{}),
 		activeStreams: make(map[string]*execSession),
+		hubbleStreams: make(map[string]*hubbleSession),
 	}, nil
 }
 
@@ -237,17 +241,27 @@ func (a *Agent) handleConnection(ctx context.Context) {
 			return
 		}
 
-		// Try to parse as stream init (exec requests)
+		// Try to parse as stream init (exec / hubble requests)
 		var streamInit messaging.HTTPTunnelStreamInit
 		if err := json.Unmarshal(message, &streamInit); err == nil && streamInit.IsUpgrade && streamInit.RequestID != "" {
-			go a.handleHTTPTunnelStreamInit(&streamInit)
+			switch streamInit.Target {
+			case "hubble":
+				go a.handleHubbleStreamInit(&streamInit)
+			default:
+				go a.handleHTTPTunnelStreamInit(&streamInit)
+			}
 			continue
 		}
 
-		// Try to parse as stream chunk (stdin data for active exec sessions)
+		// Try to parse as stream chunk (stdin data for active exec sessions, or
+		// the close signal for exec/hubble sessions). A close carries IsClose with
+		// no Data, so it must be accepted even when Data is nil — otherwise the
+		// session never cancels and leaks its goroutine/upstream stream.
 		var streamChunk messaging.HTTPTunnelStreamChunk
-		if err := json.Unmarshal(message, &streamChunk); err == nil && streamChunk.RequestID != "" && streamChunk.Data != nil {
-			a.routeStreamChunk(&streamChunk)
+		if err := json.Unmarshal(message, &streamChunk); err == nil && streamChunk.RequestID != "" && (streamChunk.Data != nil || streamChunk.IsClose) {
+			if !a.routeHubbleChunk(&streamChunk) {
+				a.routeStreamChunk(&streamChunk)
+			}
 			continue
 		}
 

--- a/internal/cluster-agent/agent.go
+++ b/internal/cluster-agent/agent.go
@@ -254,9 +254,7 @@ func (a *Agent) handleConnection(ctx context.Context) {
 		}
 
 		// Try to parse as stream chunk (stdin data for active exec sessions, or
-		// the close signal for exec/hubble sessions). A close carries IsClose with
-		// no Data, so it must be accepted even when Data is nil — otherwise the
-		// session never cancels and leaks its goroutine/upstream stream.
+		// the close signal for exec/hubble sessions).
 		var streamChunk messaging.HTTPTunnelStreamChunk
 		if err := json.Unmarshal(message, &streamChunk); err == nil && streamChunk.RequestID != "" && (streamChunk.Data != nil || streamChunk.IsClose) {
 			if !a.routeHubbleChunk(&streamChunk) {

--- a/internal/cluster-agent/agent.go
+++ b/internal/cluster-agent/agent.go
@@ -246,7 +246,7 @@ func (a *Agent) handleConnection(ctx context.Context) {
 		if err := json.Unmarshal(message, &streamInit); err == nil && streamInit.IsUpgrade && streamInit.RequestID != "" {
 			switch streamInit.Target {
 			case "hubble":
-				go a.handleHubbleStreamInit(&streamInit)
+				go a.handleHubbleStreamInit(ctx, &streamInit)
 			default:
 				go a.handleHTTPTunnelStreamInit(&streamInit)
 			}

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -155,6 +155,13 @@ func (a *Agent) handleHubbleStreamInit(parentCtx context.Context, init *messagin
 	}
 
 	a.hubbleStreamsMu.Lock()
+	if _, exists := a.hubbleStreams[init.RequestID]; exists {
+		a.hubbleStreamsMu.Unlock()
+		session.close()
+		logger.Warn("duplicate hubble stream requestID; rejecting new session")
+		a.sendStreamClose(init.RequestID, "duplicate hubble stream requestID")
+		return
+	}
 	a.hubbleStreams[init.RequestID] = session
 	a.hubbleStreamsMu.Unlock()
 

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cilium/cilium/api/v1/flow"
@@ -23,23 +24,27 @@ import (
 )
 
 // buildHubbleFlowFilters returns the OR'd whitelist of FlowFilters used to follow
-// Hubble flows for a component. The list contains two filters so flows match
-// when the component's pods are EITHER source OR destination.
+// Hubble flows for components in the specified environment. The list contains two filters
+// so flows match when the matching pods are EITHER source OR destination.
 func buildHubbleFlowFilters(component, project, environment, namespace string) []*flow.FlowFilter {
-	selector := fmt.Sprintf(
-		"k8s:%s=%s,k8s:%s=%s,k8s:%s=%s,k8s:%s=%s",
-		labels.LabelKeyComponentName, component,
-		labels.LabelKeyProjectName, project,
-		labels.LabelKeyEnvironmentName, environment,
-		labels.LabelKeyNamespaceName, namespace,
-	)
+	parts := []string{
+		fmt.Sprintf("k8s:%s=%s", labels.LabelKeyNamespaceName, namespace),
+		fmt.Sprintf("k8s:%s=%s", labels.LabelKeyEnvironmentName, environment),
+	}
+	if project != "" {
+		parts = append(parts, fmt.Sprintf("k8s:%s=%s", labels.LabelKeyProjectName, project))
+	}
+	if component != "" {
+		parts = append(parts, fmt.Sprintf("k8s:%s=%s", labels.LabelKeyComponentName, component))
+	}
+	selector := strings.Join(parts, ",")
 	return []*flow.FlowFilter{
 		{SourceLabel: []string{selector}},
 		{DestinationLabel: []string{selector}},
 	}
 }
 
-// newGetFlowsRequest assembles the live-tail flow request for a component.
+// newGetFlowsRequest assembles the live-tail flow request for the specified filters.
 func newGetFlowsRequest(component, project, environment, namespace string) *observer.GetFlowsRequest {
 	return &observer.GetFlowsRequest{
 		Follow:    true,
@@ -108,12 +113,12 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 		a.sendStreamClose(init.RequestID, fmt.Sprintf("invalid hubble query: %v", err))
 		return
 	}
-	component := params.Get("component")
-	project := params.Get("project")
 	environment := params.Get("environment")
 	namespace := params.Get("namespace")
-	if component == "" || project == "" || environment == "" || namespace == "" {
-		a.sendStreamClose(init.RequestID, "component, project, environment, namespace query params are required")
+	project := params.Get("project")
+	component := params.Get("component")
+	if environment == "" || namespace == "" {
+		a.sendStreamClose(init.RequestID, "environment and namespace query params are required")
 		return
 	}
 

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -1,0 +1,212 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteragent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sync"
+
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/observer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
+)
+
+// defaultHubbleRelayAddr is the in-cluster gRPC endpoint of the Hubble relay.
+// Override with the HUBBLE_RELAY_ADDR env var on the cluster-agent.
+const defaultHubbleRelayAddr = "hubble-relay.kube-system.svc.cluster.local:4245"
+
+// buildHubbleFlowFilters returns the OR'd whitelist of FlowFilters used to follow
+// Hubble flows for an OpenChoreo component. The list contains two filters so flows
+// match when the component's pods are EITHER source OR destination.
+//
+// Each entry in FlowFilter.SourceLabel / DestinationLabel is treated as an
+// independent label selector that is OR'd across the list; within a single
+// selector, comma-separated k8s-style terms are AND'd (k8s.io/labels.Parse
+// semantics). So all the component-identifying labels are joined into ONE
+// comma-separated string per filter to ensure they must ALL match.
+func buildHubbleFlowFilters(component, project, environment, controlPlaneNamespace string) []*flow.FlowFilter {
+	selector := fmt.Sprintf(
+		"k8s:openchoreo.dev/component=%s,k8s:openchoreo.dev/project=%s,k8s:openchoreo.dev/environment=%s,k8s:openchoreo.dev/namespace=%s",
+		component, project, environment, controlPlaneNamespace,
+	)
+	return []*flow.FlowFilter{
+		{SourceLabel: []string{selector}},
+		{DestinationLabel: []string{selector}},
+	}
+}
+
+// newGetFlowsRequest assembles the live-tail flow request for a component.
+func newGetFlowsRequest(component, project, environment, controlPlaneNamespace string) *observer.GetFlowsRequest {
+	return &observer.GetFlowsRequest{
+		Follow:    true,
+		Whitelist: buildHubbleFlowFilters(component, project, environment, controlPlaneNamespace),
+	}
+}
+
+// hubbleSession is a server-streaming session that forwards Hubble flow events
+// from hubble-relay to the gateway, framed as HTTPTunnelStreamChunks.
+type hubbleSession struct {
+	requestID string
+	cancel    context.CancelFunc
+	done      chan struct{}
+	once      sync.Once
+}
+
+// handleChunk: Hubble is server-streaming only — the API client never sends
+// payload chunks. Close is handled in Agent.routeHubbleChunk.
+func (s *hubbleSession) handleChunk(_ *messaging.HTTPTunnelStreamChunk) {}
+
+func (s *hubbleSession) close() {
+	s.once.Do(func() {
+		close(s.done)
+		s.cancel()
+	})
+}
+
+// routeHubbleChunk delivers an inbound chunk to its hubble session, if one exists
+// for the chunk's requestID. Hubble is server-streaming, so the only meaningful
+// inbound chunk is the close signal. Returns true if the chunk belonged to a
+// hubble session, letting the caller fall back to the exec router otherwise.
+func (a *Agent) routeHubbleChunk(chunk *messaging.HTTPTunnelStreamChunk) bool {
+	a.hubbleStreamsMu.Lock()
+	session, ok := a.hubbleStreams[chunk.RequestID]
+	a.hubbleStreamsMu.Unlock()
+
+	if !ok {
+		return false
+	}
+
+	if chunk.IsClose {
+		session.close()
+		return true
+	}
+
+	session.handleChunk(chunk)
+	return true
+}
+
+// hubbleRelayAddr returns the Hubble relay endpoint from the HUBBLE_RELAY_ADDR
+// env var, falling back to the in-cluster default when unset. It is read lazily
+// when the gateway invokes the hubble path, so wirelogs stay optional and the
+// address is not a required cluster-agent startup config.
+func hubbleRelayAddr() string {
+	if addr := os.Getenv("HUBBLE_RELAY_ADDR"); addr != "" {
+		return addr
+	}
+	return defaultHubbleRelayAddr
+}
+
+// handleHubbleStreamInit opens a server-streaming gRPC call to Hubble relay
+// and forwards each flow event as an HTTPTunnelStreamChunk back to the gateway.
+// Dispatched from Agent.handleHTTPTunnelStreamInit for Target == "hubble".
+//
+// Expected init.Query params: component, environment, namespace.
+func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
+	logger := a.logger.With("requestID", init.RequestID, "target", "hubble")
+	logger.Info("Received hubble stream init")
+
+	params, err := url.ParseQuery(init.Query)
+	if err != nil {
+		logger.Warn("invalid hubble query", "error", err, "query", init.Query)
+		a.sendStreamClose(init.RequestID, fmt.Sprintf("invalid hubble query: %v", err))
+		return
+	}
+	component := params.Get("component")
+	project := params.Get("project")
+	environment := params.Get("environment")
+	namespace := params.Get("namespace")
+	if component == "" || project == "" || environment == "" || namespace == "" {
+		a.sendStreamClose(init.RequestID, "component, project, environment, namespace query params are required")
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &hubbleSession{
+		requestID: init.RequestID,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+
+	a.hubbleStreamsMu.Lock()
+	a.hubbleStreams[init.RequestID] = session
+	a.hubbleStreamsMu.Unlock()
+
+	defer func() {
+		session.close()
+		a.hubbleStreamsMu.Lock()
+		delete(a.hubbleStreams, init.RequestID)
+		a.hubbleStreamsMu.Unlock()
+	}()
+
+	relayAddr := hubbleRelayAddr()
+	logger = logger.With("hubbleRelay", relayAddr, "component", component, "project", project, "environment", environment)
+
+	conn, err := grpc.NewClient(
+		relayAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		logger.Error("failed to create hubble-relay client", "error", err)
+		a.sendStreamClose(init.RequestID, fmt.Sprintf("failed to dial hubble-relay: %v", err))
+		return
+	}
+	defer conn.Close()
+
+	client := observer.NewObserverClient(conn)
+	stream, err := client.GetFlows(ctx, newGetFlowsRequest(component, project, environment, namespace))
+	if err != nil {
+		logger.Error("GetFlows failed", "error", err)
+		a.sendStreamClose(init.RequestID, fmt.Sprintf("hubble GetFlows failed: %v", err))
+		return
+	}
+
+	// Sentinel chunk so the gateway knows the stream is active (mirrors exec).
+	a.sendStreamChunkRaw(init.RequestID, []byte{}, 0)
+
+	logger.Info("Hubble flow stream started")
+
+	marshalOpts := protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				logger.Info("hubble stream closed")
+			} else {
+				logger.Warn("hubble stream ended with error", "error", err)
+			}
+			break
+		}
+
+		data, err := marshalOpts.Marshal(resp)
+		if err != nil {
+			logger.Warn("failed to marshal flow response", "error", err)
+			continue
+		}
+
+		chunk := &messaging.HTTPTunnelStreamChunk{
+			RequestID: init.RequestID,
+			Data:      data,
+		}
+		if err := a.sendStreamChunk(chunk); err != nil {
+			logger.Warn("failed to forward flow chunk; closing stream", "error", err)
+			return
+		}
+	}
+
+	logger.Info("Hubble flow stream completed")
+	a.sendStreamClose(init.RequestID, "")
+}

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -19,25 +19,19 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
+	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
-// defaultHubbleRelayAddr is the in-cluster gRPC endpoint of the Hubble relay.
-// Override with the HUBBLE_RELAY_ADDR env var on the cluster-agent.
-const defaultHubbleRelayAddr = "hubble-relay.kube-system.svc.cluster.local:4245"
-
 // buildHubbleFlowFilters returns the OR'd whitelist of FlowFilters used to follow
-// Hubble flows for an OpenChoreo component. The list contains two filters so flows
-// match when the component's pods are EITHER source OR destination.
-//
-// Each entry in FlowFilter.SourceLabel / DestinationLabel is treated as an
-// independent label selector that is OR'd across the list; within a single
-// selector, comma-separated k8s-style terms are AND'd (k8s.io/labels.Parse
-// semantics). So all the component-identifying labels are joined into ONE
-// comma-separated string per filter to ensure they must ALL match.
-func buildHubbleFlowFilters(component, project, environment, controlPlaneNamespace string) []*flow.FlowFilter {
+// Hubble flows for a component. The list contains two filters so flows match
+// when the component's pods are EITHER source OR destination.
+func buildHubbleFlowFilters(component, project, environment, namespace string) []*flow.FlowFilter {
 	selector := fmt.Sprintf(
-		"k8s:openchoreo.dev/component=%s,k8s:openchoreo.dev/project=%s,k8s:openchoreo.dev/environment=%s,k8s:openchoreo.dev/namespace=%s",
-		component, project, environment, controlPlaneNamespace,
+		"k8s:%s=%s,k8s:%s=%s,k8s:%s=%s,k8s:%s=%s",
+		labels.LabelKeyComponentName, component,
+		labels.LabelKeyProjectName, project,
+		labels.LabelKeyEnvironmentName, environment,
+		labels.LabelKeyNamespaceName, namespace,
 	)
 	return []*flow.FlowFilter{
 		{SourceLabel: []string{selector}},
@@ -46,10 +40,10 @@ func buildHubbleFlowFilters(component, project, environment, controlPlaneNamespa
 }
 
 // newGetFlowsRequest assembles the live-tail flow request for a component.
-func newGetFlowsRequest(component, project, environment, controlPlaneNamespace string) *observer.GetFlowsRequest {
+func newGetFlowsRequest(component, project, environment, namespace string) *observer.GetFlowsRequest {
 	return &observer.GetFlowsRequest{
 		Follow:    true,
-		Whitelist: buildHubbleFlowFilters(component, project, environment, controlPlaneNamespace),
+		Whitelist: buildHubbleFlowFilters(component, project, environment, namespace),
 	}
 }
 
@@ -74,9 +68,7 @@ func (s *hubbleSession) close() {
 }
 
 // routeHubbleChunk delivers an inbound chunk to its hubble session, if one exists
-// for the chunk's requestID. Hubble is server-streaming, so the only meaningful
-// inbound chunk is the close signal. Returns true if the chunk belonged to a
-// hubble session, letting the caller fall back to the exec router otherwise.
+// for the chunk's requestID.
 func (a *Agent) routeHubbleChunk(chunk *messaging.HTTPTunnelStreamChunk) bool {
 	a.hubbleStreamsMu.Lock()
 	session, ok := a.hubbleStreams[chunk.RequestID]
@@ -95,22 +87,17 @@ func (a *Agent) routeHubbleChunk(chunk *messaging.HTTPTunnelStreamChunk) bool {
 	return true
 }
 
-// hubbleRelayAddr returns the Hubble relay endpoint from the HUBBLE_RELAY_ADDR
-// env var, falling back to the in-cluster default when unset. It is read lazily
-// when the gateway invokes the hubble path, so wirelogs stay optional and the
-// address is not a required cluster-agent startup config.
-func hubbleRelayAddr() string {
-	if addr := os.Getenv("HUBBLE_RELAY_ADDR"); addr != "" {
-		return addr
+func hubbleRelayAddr() (string, error) {
+	addr := os.Getenv("HUBBLE_RELAY_ADDR")
+	if addr == "" {
+		return "", errors.New("HUBBLE_RELAY_ADDR env var is not set; it is required when configuring the Cilium module")
 	}
-	return defaultHubbleRelayAddr
+	return addr, nil
 }
 
 // handleHubbleStreamInit opens a server-streaming gRPC call to Hubble relay
 // and forwards each flow event as an HTTPTunnelStreamChunk back to the gateway.
 // Dispatched from Agent.handleHTTPTunnelStreamInit for Target == "hubble".
-//
-// Expected init.Query params: component, environment, namespace.
 func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 	logger := a.logger.With("requestID", init.RequestID, "target", "hubble")
 	logger.Info("Received hubble stream init")
@@ -148,8 +135,16 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 		a.hubbleStreamsMu.Unlock()
 	}()
 
-	relayAddr := hubbleRelayAddr()
-	logger = logger.With("hubbleRelay", relayAddr, "component", component, "project", project, "environment", environment)
+	relayAddr, err := hubbleRelayAddr()
+	if err != nil {
+		logger.Error("hubble relay address not configured", "error", err)
+		a.sendStreamClose(init.RequestID, err.Error())
+		return
+	}
+	logger = logger.With(
+		"hubbleRelay", relayAddr,
+		"component", component, "project", project, "environment", environment, "namespace", namespace,
+	)
 
 	conn, err := grpc.NewClient(
 		relayAddr,
@@ -170,7 +165,7 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 		return
 	}
 
-	// Sentinel chunk so the gateway knows the stream is active (mirrors exec).
+	// Sentinel chunk so the gateway knows the stream is active
 	a.sendStreamChunkRaw(init.RequestID, []byte{}, 0)
 
 	logger.Info("Hubble flow stream started")

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -179,6 +179,12 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 		UseProtoNames:   true,
 		EmitUnpopulated: false,
 	}
+	scope := wirelogsScope{
+		environment: environment,
+		namespace:   namespace,
+		project:     project,
+		component:   component,
+	}
 
 	for {
 		resp, err := stream.Recv()
@@ -189,6 +195,10 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 				logger.Warn("hubble stream ended with error", "error", err)
 			}
 			break
+		}
+
+		if !redactFlowResponse(resp, scope) {
+			continue
 		}
 
 		data, err := marshalOpts.Marshal(resp)

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -52,6 +52,27 @@ func newGetFlowsRequest(component, project, environment, namespace string) *obse
 	}
 }
 
+// hubbleFlowStream is the subset of observer.Observer_GetFlowsClient
+type hubbleFlowStream interface {
+	Recv() (*observer.GetFlowsResponse, error)
+}
+
+// openHubbleFlowStream dials hubble-relay over gRPC, opens a GetFlows server-stream,
+// and returns the stream plus a closer that tears down the connection.
+var openHubbleFlowStream = func(ctx context.Context, addr string, req *observer.GetFlowsRequest) (hubbleFlowStream, func(), error) {
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to dial hubble-relay: %w", err)
+	}
+	client := observer.NewObserverClient(conn)
+	stream, err := client.GetFlows(ctx, req)
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("hubble GetFlows failed: %w", err)
+	}
+	return stream, func() { _ = conn.Close() }, nil
+}
+
 // hubbleSession is a server-streaming session that forwards Hubble flow events
 // from hubble-relay to the gateway, framed as HTTPTunnelStreamChunks.
 type hubbleSession struct {
@@ -151,24 +172,13 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 		"component", component, "project", project, "environment", environment, "namespace", namespace,
 	)
 
-	conn, err := grpc.NewClient(
-		relayAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	stream, closer, err := openHubbleFlowStream(ctx, relayAddr, newGetFlowsRequest(component, project, environment, namespace))
 	if err != nil {
-		logger.Error("failed to create hubble-relay client", "error", err)
-		a.sendStreamClose(init.RequestID, fmt.Sprintf("failed to dial hubble-relay: %v", err))
+		logger.Error("failed to open hubble flow stream", "error", err)
+		a.sendStreamClose(init.RequestID, err.Error())
 		return
 	}
-	defer conn.Close()
-
-	client := observer.NewObserverClient(conn)
-	stream, err := client.GetFlows(ctx, newGetFlowsRequest(component, project, environment, namespace))
-	if err != nil {
-		logger.Error("GetFlows failed", "error", err)
-		a.sendStreamClose(init.RequestID, fmt.Sprintf("hubble GetFlows failed: %v", err))
-		return
-	}
+	defer closer()
 
 	// Sentinel chunk so the gateway knows the stream is active
 	a.sendStreamChunkRaw(init.RequestID, []byte{}, 0)

--- a/internal/cluster-agent/hubble.go
+++ b/internal/cluster-agent/hubble.go
@@ -124,7 +124,11 @@ func hubbleRelayAddr() (string, error) {
 // handleHubbleStreamInit opens a server-streaming gRPC call to Hubble relay
 // and forwards each flow event as an HTTPTunnelStreamChunk back to the gateway.
 // Dispatched from Agent.handleHTTPTunnelStreamInit for Target == "hubble".
-func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
+//
+// parentCtx is the agent's message-loop context, so a websocket disconnect (or
+// any cancel upstream) propagates into the gRPC Recv loop and tears the stream
+// down without relying on the gateway delivering a Close chunk.
+func (a *Agent) handleHubbleStreamInit(parentCtx context.Context, init *messaging.HTTPTunnelStreamInit) {
 	logger := a.logger.With("requestID", init.RequestID, "target", "hubble")
 	logger.Info("Received hubble stream init")
 
@@ -143,7 +147,7 @@ func (a *Agent) handleHubbleStreamInit(init *messaging.HTTPTunnelStreamInit) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(parentCtx)
 	session := &hubbleSession{
 		requestID: init.RequestID,
 		cancel:    cancel,

--- a/internal/cluster-agent/hubble_redact.go
+++ b/internal/cluster-agent/hubble_redact.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteragent
+
+import (
+	"strings"
+
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/observer"
+
+	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+// wirelogsScope is the caller-supplied scope (parsed from the gateway query)
+// used to classify each endpoint as in-scope (the tenant's own workloads) or
+// out-of-scope (peers — typically platform infra such as the otel-collector,
+// control-plane services, or sidecars in other tenants' namespaces).
+type wirelogsScope struct {
+	environment string
+	namespace   string
+	project     string
+	component   string
+}
+
+const k8sLabelPrefix = "k8s:"
+
+// redactFlowResponse mutates resp in place to strip fields that are not safe or
+// useful to forward to tenants. Returns false when the response should be
+// suppressed entirely (e.g. hubble-relay NodeStatusEvent heartbeats, which
+// leak the host node name and carry no flow payload).
+//
+// Filtering at the agent — rather than at the gateway or openchoreo-api — saves
+// bandwidth on both downstream hops and is the only point where the raw
+// flow.Flow proto is still in memory before protojson encoding.
+func redactFlowResponse(resp *observer.GetFlowsResponse, scope wirelogsScope) bool {
+	if resp == nil {
+		return false
+	}
+	if resp.GetNodeStatus() != nil {
+		return false
+	}
+	resp.NodeName = ""
+
+	f := resp.GetFlow()
+	if f == nil {
+		return true
+	}
+
+	f.NodeName = ""
+	f.NodeLabels = nil
+	f.Ethernet = nil
+	f.Interface = nil
+	f.EventType = nil
+	f.TraceObservationPoint = 0
+	f.TraceReason = 0
+	f.Reply = false //nolint:staticcheck // deprecated mirror of IsReply; clearing it is the point
+
+	redactEndpoint(f.Source, scope)
+	redactEndpoint(f.Destination, scope)
+	return true
+}
+
+func redactEndpoint(ep *flow.Endpoint, scope wirelogsScope) {
+	if ep == nil {
+		return
+	}
+	ep.ID = 0
+	ep.Identity = 0
+	inScope := endpointInScope(ep, scope)
+	ep.Labels = filterLabels(ep.Labels, inScope)
+	if !inScope {
+		ep.Workloads = nil
+	}
+}
+
+// endpointInScope returns true when the endpoint carries every openchoreo label
+// the caller requested. We match by label (not by k8s namespace) because the
+// hubble whitelist already does, and DP-side pods live in derived
+// `dp-<...>` namespaces that don't match the openchoreo namespace name.
+func endpointInScope(ep *flow.Endpoint, scope wirelogsScope) bool {
+	if ep == nil {
+		return false
+	}
+	want := map[string]string{
+		labels.LabelKeyNamespaceName:   scope.namespace,
+		labels.LabelKeyEnvironmentName: scope.environment,
+	}
+	if scope.project != "" {
+		want[labels.LabelKeyProjectName] = scope.project
+	}
+	if scope.component != "" {
+		want[labels.LabelKeyComponentName] = scope.component
+	}
+	matched := 0
+	for _, l := range ep.Labels {
+		k, v, ok := parseLabel(l)
+		if !ok {
+			continue
+		}
+		if w, needs := want[k]; needs && w == v {
+			matched++
+		}
+	}
+	return matched == len(want)
+}
+
+func filterLabels(in []string, inScope bool) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := in[:0]
+	for _, l := range in {
+		if strings.HasPrefix(l, k8sLabelPrefix+"io.cilium.") {
+			continue
+		}
+		if strings.Contains(l, "-uid=") {
+			continue
+		}
+		if inScope {
+			out = append(out, l)
+			continue
+		}
+		if strings.HasPrefix(l, k8sLabelPrefix+"io.kubernetes.pod.namespace=") {
+			out = append(out, l)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseLabel splits a hubble label like "k8s:openchoreo.dev/namespace=default"
+// into ("openchoreo.dev/namespace", "default", true). The "k8s:" source prefix
+// is dropped; entries without an "=" return ok=false.
+func parseLabel(l string) (key, value string, ok bool) {
+	l = strings.TrimPrefix(l, k8sLabelPrefix)
+	eq := strings.IndexByte(l, '=')
+	if eq < 0 {
+		return "", "", false
+	}
+	return l[:eq], l[eq+1:], true
+}

--- a/internal/cluster-agent/hubble_redact.go
+++ b/internal/cluster-agent/hubble_redact.go
@@ -92,17 +92,17 @@ func endpointInScope(ep *flow.Endpoint, scope wirelogsScope) bool {
 	if scope.component != "" {
 		want[labels.LabelKeyComponentName] = scope.component
 	}
-	matched := 0
+	matchedKeys := make(map[string]struct{}, len(want))
 	for _, l := range ep.Labels {
 		k, v, ok := parseLabel(l)
 		if !ok {
 			continue
 		}
 		if w, needs := want[k]; needs && w == v {
-			matched++
+			matchedKeys[k] = struct{}{}
 		}
 	}
-	return matched == len(want)
+	return len(matchedKeys) == len(want)
 }
 
 func filterLabels(in []string, inScope bool) []string {

--- a/internal/cluster-agent/hubble_redact_test.go
+++ b/internal/cluster-agent/hubble_redact_test.go
@@ -191,6 +191,21 @@ func TestEndpointInScope_ProjectMismatchRejects(t *testing.T) {
 		"a project mismatch is enough to mark the peer out-of-scope even if other labels line up")
 }
 
+func TestEndpointInScope_DuplicateLabelsDoNotInflateMatch(t *testing.T) {
+	// Regression: duplicate matching labels must not be counted twice.
+	// Here only two of the four required keys are actually present, but each
+	// appears twice — naive counting would treat it as a full match.
+	scope := tenantScope()
+	ep := &flow.Endpoint{Labels: []string{
+		"k8s:openchoreo.dev/namespace=default",
+		"k8s:openchoreo.dev/namespace=default",
+		"k8s:openchoreo.dev/environment=development",
+		"k8s:openchoreo.dev/environment=development",
+	}}
+	assert.False(t, endpointInScope(ep, scope),
+		"missing project+component must still mark endpoint out-of-scope despite duplicate matches on namespace/environment")
+}
+
 func TestFilterLabels_DropsCiliumAndUIDsForInScope(t *testing.T) {
 	got := filterLabels([]string{
 		"k8s:io.cilium.k8s.policy.cluster=default",

--- a/internal/cluster-agent/hubble_redact_test.go
+++ b/internal/cluster-agent/hubble_redact_test.go
@@ -1,0 +1,225 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteragent
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/observer"
+	relaypb "github.com/cilium/cilium/api/v1/relay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func tenantScope() wirelogsScope {
+	return wirelogsScope{
+		environment: "development",
+		namespace:   "default",
+		project:     "url-shortener",
+		component:   "snip-api-service",
+	}
+}
+
+// sampleFlow mirrors the shape of the live SSE events from hubble-relay: a
+// platform-infra source (otel-collector) talking to a tenant destination.
+func sampleFlow() *observer.GetFlowsResponse {
+	return &observer.GetFlowsResponse{
+		NodeName: "lima-rancher-desktop",
+		ResponseTypes: &observer.GetFlowsResponse_Flow{
+			Flow: &flow.Flow{
+				Uuid:    "5728f17b-5b61-4210-9ea3-fd3c7bd5f18c",
+				Verdict: flow.Verdict_FORWARDED,
+				Ethernet: &flow.Ethernet{
+					Source:      "4e:e6:10:a7:19:8e",
+					Destination: "86:bb:98:4a:de:a9",
+				},
+				NodeName:              "lima-rancher-desktop",
+				NodeLabels:            []string{"kubernetes.io/arch=arm64", "node-role.kubernetes.io/control-plane=true"},
+				EventType:             &flow.CiliumEventType{Type: 4},
+				TraceObservationPoint: flow.TraceObservationPoint_TO_ENDPOINT,
+				TraceReason:           flow.TraceReason_REPLY,
+				Reply:                 true,
+				IsReply:               wrapperspb.Bool(true),
+				Interface: &flow.NetworkInterface{
+					Index: 225,
+					Name:  "lxc6707a6f14d2f",
+				},
+				Source: &flow.Endpoint{
+					ID:        666,
+					Identity:  12476,
+					Namespace: "openchoreo-observability-plane",
+					PodName:   "opentelemetry-collector-74864bd658-z5nk6",
+					Labels: []string{
+						"k8s:app.kubernetes.io/instance=observability-traces-opensearch",
+						"k8s:app.kubernetes.io/name=opentelemetry-collector",
+						"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=openchoreo-observability-plane",
+						"k8s:io.cilium.k8s.policy.cluster=default",
+						"k8s:io.cilium.k8s.policy.serviceaccount=opentelemetry-collector",
+						"k8s:io.kubernetes.pod.namespace=openchoreo-observability-plane",
+					},
+					Workloads: []*flow.Workload{{Name: "opentelemetry-collector", Kind: "Deployment"}},
+				},
+				Destination: &flow.Endpoint{
+					ID:        1154,
+					Identity:  40143,
+					Namespace: "dp-default-url-shortener-development-a16f373a",
+					PodName:   "snip-api-service-development-53bed701-55687d7cd7-8zr7t",
+					Labels: []string{
+						"k8s:io.cilium.k8s.policy.cluster=default",
+						"k8s:io.cilium.k8s.policy.serviceaccount=default",
+						"k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a",
+						"k8s:openchoreo.dev/component-uid=43f3d9e0-15c3-4599-aa9a-34710da07e6e",
+						"k8s:openchoreo.dev/component=snip-api-service",
+						"k8s:openchoreo.dev/environment-uid=cb6b3d47-f636-4e2d-aaa3-1b2b70283401",
+						"k8s:openchoreo.dev/environment=development",
+						"k8s:openchoreo.dev/namespace=default",
+						"k8s:openchoreo.dev/project-uid=a0cf72ba-6573-4015-b8e3-f526e290a260",
+						"k8s:openchoreo.dev/project=url-shortener",
+					},
+					Workloads: []*flow.Workload{{Name: "snip-api-service-development-53bed701", Kind: "Deployment"}},
+				},
+			},
+		},
+	}
+}
+
+func TestRedactFlowResponse_StripsHostAndCiliumInternals(t *testing.T) {
+	resp := sampleFlow()
+	require.True(t, redactFlowResponse(resp, tenantScope()))
+
+	assert.Empty(t, resp.NodeName, "envelope node_name leaks the host identity")
+
+	f := resp.GetFlow()
+	require.NotNil(t, f)
+	assert.Empty(t, f.NodeName)
+	assert.Nil(t, f.NodeLabels)
+	assert.Nil(t, f.Ethernet, "MAC addresses are pure noise to tenants")
+	assert.Nil(t, f.Interface, "veth interface name leaks cilium internals")
+	assert.Nil(t, f.EventType)
+	assert.Equal(t, flow.TraceObservationPoint_UNKNOWN_POINT, f.TraceObservationPoint)
+	assert.Equal(t, flow.TraceReason_TRACE_REASON_UNKNOWN, f.TraceReason)
+	assert.False(t, f.Reply, "deprecated Reply field — IsReply is the source of truth") //nolint:staticcheck
+	assert.NotNil(t, f.IsReply, "IsReply must survive: it carries reply direction")
+
+	for _, ep := range []*flow.Endpoint{f.Source, f.Destination} {
+		assert.Zero(t, ep.ID, "cilium endpoint ID is a cluster-internal handle")
+		assert.Zero(t, ep.Identity, "cilium identity number is a cluster-internal handle")
+	}
+}
+
+func TestRedactFlowResponse_InScopePeerKeepsOpenChoreoLabels(t *testing.T) {
+	resp := sampleFlow()
+	require.True(t, redactFlowResponse(resp, tenantScope()))
+
+	dst := resp.GetFlow().GetDestination()
+	require.NotNil(t, dst)
+	assert.Equal(t, "snip-api-service-development-53bed701-55687d7cd7-8zr7t", dst.PodName)
+	assert.NotEmpty(t, dst.Workloads, "tenant's own workload metadata must remain")
+
+	for _, l := range dst.Labels {
+		assert.NotContains(t, l, "io.cilium.", "all cilium labels must be stripped")
+		assert.NotContains(t, l, "-uid=", "object UIDs are noise; not for the wire")
+	}
+	assert.Contains(t, dst.Labels, "k8s:openchoreo.dev/project=url-shortener")
+	assert.Contains(t, dst.Labels, "k8s:openchoreo.dev/component=snip-api-service")
+	assert.Contains(t, dst.Labels, "k8s:openchoreo.dev/environment=development")
+}
+
+func TestRedactFlowResponse_OutOfScopePeerCollapsesLabels(t *testing.T) {
+	resp := sampleFlow()
+	require.True(t, redactFlowResponse(resp, tenantScope()))
+
+	// The otel-collector source is platform infra, not in the tenant's scope.
+	// It must retain pod_name+namespace (so the tenant can see what they're
+	// talking to) but lose SA, instance name, and workload kind — those would
+	// leak platform implementation details.
+	src := resp.GetFlow().GetSource()
+	require.NotNil(t, src)
+	assert.Equal(t, "opentelemetry-collector-74864bd658-z5nk6", src.PodName)
+	assert.Equal(t, "openchoreo-observability-plane", src.Namespace)
+	assert.Nil(t, src.Workloads, "peer workload kind/name not exposed when out-of-scope")
+
+	assert.Equal(t,
+		[]string{"k8s:io.kubernetes.pod.namespace=openchoreo-observability-plane"},
+		src.Labels,
+		"out-of-scope peer keeps only its k8s namespace; SA + Helm labels stripped")
+}
+
+func TestRedactFlowResponse_SuppressesNodeStatusHeartbeat(t *testing.T) {
+	// hubble-relay emits these on connect/disconnect; they leak node_names and
+	// carry no flow payload — drop entirely so they never reach the gateway.
+	resp := &observer.GetFlowsResponse{
+		NodeName: "lima-rancher-desktop",
+		ResponseTypes: &observer.GetFlowsResponse_NodeStatus{
+			NodeStatus: &relaypb.NodeStatusEvent{
+				StateChange: relaypb.NodeState_NODE_CONNECTED,
+				NodeNames:   []string{"lima-rancher-desktop"},
+			},
+		},
+	}
+	assert.False(t, redactFlowResponse(resp, tenantScope()))
+}
+
+func TestRedactFlowResponse_NilSafe(t *testing.T) {
+	assert.False(t, redactFlowResponse(nil, tenantScope()))
+}
+
+func TestEndpointInScope_EnvironmentWide(t *testing.T) {
+	// Scope without project/component must accept any endpoint matching
+	// namespace+environment — used when callers tail a whole environment.
+	scope := wirelogsScope{environment: "development", namespace: "default"}
+	ep := &flow.Endpoint{Labels: []string{
+		"k8s:openchoreo.dev/namespace=default",
+		"k8s:openchoreo.dev/environment=development",
+		"k8s:openchoreo.dev/project=url-shortener",
+	}}
+	assert.True(t, endpointInScope(ep, scope))
+}
+
+func TestEndpointInScope_ProjectMismatchRejects(t *testing.T) {
+	scope := tenantScope()
+	ep := &flow.Endpoint{Labels: []string{
+		"k8s:openchoreo.dev/namespace=default",
+		"k8s:openchoreo.dev/environment=development",
+		"k8s:openchoreo.dev/project=other-project",
+		"k8s:openchoreo.dev/component=snip-api-service",
+	}}
+	assert.False(t, endpointInScope(ep, scope),
+		"a project mismatch is enough to mark the peer out-of-scope even if other labels line up")
+}
+
+func TestFilterLabels_DropsCiliumAndUIDsForInScope(t *testing.T) {
+	got := filterLabels([]string{
+		"k8s:io.cilium.k8s.policy.cluster=default",
+		"k8s:openchoreo.dev/project=url-shortener",
+		"k8s:openchoreo.dev/project-uid=abc-123",
+		"k8s:app.kubernetes.io/name=snip",
+	}, true)
+	assert.ElementsMatch(t, []string{
+		"k8s:openchoreo.dev/project=url-shortener",
+		"k8s:app.kubernetes.io/name=snip",
+	}, got)
+}
+
+func TestFilterLabels_OutOfScopeKeepsOnlyNamespace(t *testing.T) {
+	got := filterLabels([]string{
+		"k8s:io.cilium.k8s.policy.serviceaccount=opentelemetry-collector",
+		"k8s:app.kubernetes.io/instance=observability-traces-opensearch",
+		"k8s:io.kubernetes.pod.namespace=openchoreo-observability-plane",
+		"k8s:openchoreo.dev/namespace=openchoreo-observability-plane",
+	}, false)
+	assert.Equal(t, []string{"k8s:io.kubernetes.pod.namespace=openchoreo-observability-plane"}, got)
+}
+
+func TestParseLabel(t *testing.T) {
+	k, v, ok := parseLabel("k8s:openchoreo.dev/project=url-shortener")
+	require.True(t, ok)
+	assert.Equal(t, "openchoreo.dev/project", k)
+	assert.Equal(t, "url-shortener", v)
+
+	_, _, ok = parseLabel("no-equals-sign")
+	assert.False(t, ok)
+}

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -22,7 +22,7 @@ func TestBuildHubbleFlowFilters_ORsSourceAndDestination(t *testing.T) {
 	// component is EITHER side. Labels within a filter are comma-joined into one
 	// selector so they AND together — separate entries would OR.
 	require.Len(t, filters, 2)
-	expected := "k8s:openchoreo.dev/component=checkout,k8s:openchoreo.dev/project=shopfront,k8s:openchoreo.dev/environment=development,k8s:openchoreo.dev/namespace=my-team"
+	expected := "k8s:openchoreo.dev/namespace=my-team,k8s:openchoreo.dev/environment=development,k8s:openchoreo.dev/project=shopfront,k8s:openchoreo.dev/component=checkout"
 
 	require.Len(t, filters[0].GetSourceLabel(), 1, "must be a single comma-joined selector (AND), not multiple OR'd entries")
 	assert.Equal(t, expected, filters[0].GetSourceLabel()[0])
@@ -31,6 +31,38 @@ func TestBuildHubbleFlowFilters_ORsSourceAndDestination(t *testing.T) {
 	require.Len(t, filters[1].GetDestinationLabel(), 1)
 	assert.Equal(t, expected, filters[1].GetDestinationLabel()[0])
 	assert.Empty(t, filters[1].GetSourceLabel())
+}
+
+func TestBuildHubbleFlowFilters_EnvironmentWide(t *testing.T) {
+	filters := buildHubbleFlowFilters("", "", "development", "my-team")
+
+	require.Len(t, filters, 2)
+	expected := "k8s:openchoreo.dev/namespace=my-team,k8s:openchoreo.dev/environment=development"
+
+	require.Len(t, filters[0].GetSourceLabel(), 1)
+	assert.Equal(t, expected, filters[0].GetSourceLabel()[0])
+	assert.Empty(t, filters[0].GetDestinationLabel())
+
+	require.Len(t, filters[1].GetDestinationLabel(), 1)
+	assert.Equal(t, expected, filters[1].GetDestinationLabel()[0])
+}
+
+func TestBuildHubbleFlowFilters_ProjectOnly(t *testing.T) {
+	filters := buildHubbleFlowFilters("", "shopfront", "development", "my-team")
+
+	require.Len(t, filters, 2)
+	expected := "k8s:openchoreo.dev/namespace=my-team,k8s:openchoreo.dev/environment=development,k8s:openchoreo.dev/project=shopfront"
+	assert.Equal(t, expected, filters[0].GetSourceLabel()[0])
+	assert.Equal(t, expected, filters[1].GetDestinationLabel()[0])
+}
+
+func TestBuildHubbleFlowFilters_ComponentWithoutProject(t *testing.T) {
+	filters := buildHubbleFlowFilters("checkout", "", "development", "my-team")
+
+	require.Len(t, filters, 2)
+	expected := "k8s:openchoreo.dev/namespace=my-team,k8s:openchoreo.dev/environment=development,k8s:openchoreo.dev/component=checkout"
+	assert.Equal(t, expected, filters[0].GetSourceLabel()[0])
+	assert.Equal(t, expected, filters[1].GetDestinationLabel()[0])
 }
 
 func TestNewGetFlowsRequest_LiveTail(t *testing.T) {

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -400,6 +400,40 @@ func TestAgent_HandleHubbleStreamInit_ParentCtxCancelStopsStream(t *testing.T) {
 	assert.Empty(t, agent.hubbleStreams, "session must be deregistered after ctx cancel")
 }
 
+// Regression: a second init for an already-active RequestID must NOT overwrite
+// or evict the existing session. The guard rejects the duplicate with a
+// close chunk and leaves the original session intact.
+func TestAgent_HandleHubbleStreamInit_DuplicateRequestIDRejected(t *testing.T) {
+	agent, mock := newHubbleTestAgent(t)
+
+	cancelCalls := 0
+	existing := &hubbleSession{
+		requestID: "req-dup",
+		cancel:    func() { cancelCalls++ },
+		done:      make(chan struct{}),
+	}
+	agent.hubbleStreams["req-dup"] = existing
+
+	// The duplicate guard fires before HUBBLE_RELAY_ADDR is read or any stream
+	// is dialed, so neither the env var nor the dialer stub needs to be set.
+	agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
+		RequestID: "req-dup",
+		Target:    "hubble",
+		Query:     "environment=development&namespace=team-1",
+	})
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	require.Len(t, chunks, 1, "rejected duplicate should emit exactly one close chunk")
+	assert.Equal(t, "req-dup", chunks[0].RequestID)
+	assert.True(t, chunks[0].IsClose)
+	assert.Contains(t, string(chunks[0].Data), "duplicate hubble stream requestID")
+
+	assert.Same(t, existing, agent.hubbleStreams["req-dup"],
+		"duplicate init must not evict the original session")
+	assert.Zero(t, cancelCalls,
+		"the original session's cancel must not fire from the rejected duplicate")
+}
+
 // On a non-EOF stream error the handler still exits cleanly and emits the
 // terminal close chunk; the seam's closer must still fire (asserted by
 // stubOpenHubbleFlowStream's cleanup).

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -6,14 +6,78 @@ package clusteragent
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/observer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
 )
+
+// fakeFlowStream is a test double for hubbleFlowStream that yields canned
+// responses in order, then an optional terminal error (defaults to io.EOF).
+type fakeFlowStream struct {
+	responses []*observer.GetFlowsResponse
+	idx       int
+	endErr    error
+}
+
+func (f *fakeFlowStream) Recv() (*observer.GetFlowsResponse, error) {
+	if f.idx >= len(f.responses) {
+		if f.endErr != nil {
+			return nil, f.endErr
+		}
+		return nil, io.EOF
+	}
+	r := f.responses[f.idx]
+	f.idx++
+	return r, nil
+}
+
+// stubOpenHubbleFlowStream replaces the package-level dialer with a function
+// returning the supplied stream (or err). The original is restored via t.Cleanup.
+func stubOpenHubbleFlowStream(t *testing.T, stream hubbleFlowStream, err error) {
+	t.Helper()
+	prev := openHubbleFlowStream
+	closerCalls := 0
+	openHubbleFlowStream = func(_ context.Context, _ string, _ *observer.GetFlowsRequest) (hubbleFlowStream, func(), error) {
+		if err != nil {
+			return nil, nil, err
+		}
+		return stream, func() { closerCalls++ }, nil
+	}
+	t.Cleanup(func() {
+		openHubbleFlowStream = prev
+		// Closer must run exactly once on the happy/error-after-open paths.
+		if err == nil && closerCalls != 1 {
+			t.Errorf("closer expected to run exactly once, got %d", closerCalls)
+		}
+	})
+}
+
+// inScopeFlow returns a GetFlowsResponse whose Source labels mark it as
+// in-scope for the test scope, so redactFlowResponse keeps the chunk.
+func inScopeFlow(t *testing.T) *observer.GetFlowsResponse {
+	t.Helper()
+	return &observer.GetFlowsResponse{
+		ResponseTypes: &observer.GetFlowsResponse_Flow{
+			Flow: &flow.Flow{
+				Source: &flow.Endpoint{
+					Namespace: "dp-team-1",
+					Labels: []string{
+						"k8s:openchoreo.dev/namespace=team-1",
+						"k8s:openchoreo.dev/environment=development",
+					},
+				},
+			},
+		},
+	}
+}
 
 func TestBuildHubbleFlowFilters_ORsSourceAndDestination(t *testing.T) {
 	filters := buildHubbleFlowFilters("checkout", "shopfront", "development", "my-team")
@@ -144,4 +208,172 @@ func TestHubbleSession_CloseIsIdempotent(t *testing.T) {
 	s.close()
 	s.close()
 	assert.Equal(t, 1, cancelCalls)
+}
+
+// newHubbleTestAgent wires a fresh Agent + mockConnection together with the
+// hubbleStreams map initialized, which newTestAgent leaves nil.
+func newHubbleTestAgent(t *testing.T) (*Agent, *mockConnection) {
+	t.Helper()
+	agent := newTestAgent(t, "ws://unused", nil)
+	mock := &mockConnection{}
+	agent.conn = mock
+	agent.hubbleStreams = make(map[string]*hubbleSession)
+	return agent, mock
+}
+
+// decodeChunks unmarshals every captured websocket frame as an
+// HTTPTunnelStreamChunk. The handler only writes chunk messages, so a failure
+// here means the agent emitted an unexpected frame type.
+func decodeChunks(t *testing.T, raw [][]byte) []messaging.HTTPTunnelStreamChunk {
+	t.Helper()
+	out := make([]messaging.HTTPTunnelStreamChunk, 0, len(raw))
+	for _, b := range raw {
+		var c messaging.HTTPTunnelStreamChunk
+		require.NoError(t, json.Unmarshal(b, &c))
+		out = append(out, c)
+	}
+	return out
+}
+
+func TestAgent_HandleHubbleStreamInit_InvalidQuery(t *testing.T) {
+	agent, mock := newHubbleTestAgent(t)
+
+	// "%zz" is an invalid percent-escape — url.ParseQuery rejects it.
+	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+		RequestID: "req-1",
+		Target:    "hubble",
+		Query:     "%zz",
+	})
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	require.Len(t, chunks, 1, "should emit a single close chunk")
+	assert.Equal(t, "req-1", chunks[0].RequestID)
+	assert.True(t, chunks[0].IsClose)
+	assert.Contains(t, string(chunks[0].Data), "invalid hubble query")
+	assert.Empty(t, agent.hubbleStreams, "session must be removed before any registration")
+}
+
+func TestAgent_HandleHubbleStreamInit_MissingRequiredParams(t *testing.T) {
+	agent, mock := newHubbleTestAgent(t)
+
+	// "environment" is set but "namespace" is missing.
+	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+		RequestID: "req-2",
+		Target:    "hubble",
+		Query:     "environment=development",
+	})
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	require.Len(t, chunks, 1)
+	assert.True(t, chunks[0].IsClose)
+	assert.Contains(t, string(chunks[0].Data), "namespace")
+}
+
+func TestAgent_HandleHubbleStreamInit_RelayAddrUnset(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "")
+	agent, mock := newHubbleTestAgent(t)
+
+	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+		RequestID: "req-3",
+		Target:    "hubble",
+		Query:     "environment=development&namespace=team-1",
+	})
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	require.Len(t, chunks, 1)
+	assert.True(t, chunks[0].IsClose)
+	assert.Contains(t, string(chunks[0].Data), "HUBBLE_RELAY_ADDR")
+	assert.Empty(t, agent.hubbleStreams, "session must be cleaned up on early failure")
+}
+
+func TestAgent_HandleHubbleStreamInit_OpenStreamError(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "hubble-relay.test.svc:4245")
+	stubOpenHubbleFlowStream(t, nil, errors.New("dial refused"))
+
+	agent, mock := newHubbleTestAgent(t)
+	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+		RequestID: "req-4",
+		Target:    "hubble",
+		Query:     "environment=development&namespace=team-1",
+	})
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	require.Len(t, chunks, 1)
+	assert.True(t, chunks[0].IsClose)
+	assert.Contains(t, string(chunks[0].Data), "dial refused")
+	assert.Empty(t, agent.hubbleStreams)
+}
+
+func TestAgent_HandleHubbleStreamInit_HappyPath(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "hubble-relay.test.svc:4245")
+
+	stream := &fakeFlowStream{
+		responses: []*observer.GetFlowsResponse{inScopeFlow(t), inScopeFlow(t)},
+		// endErr unset → second Recv after responses returns io.EOF and the
+		// handler exits its loop cleanly.
+	}
+	stubOpenHubbleFlowStream(t, stream, nil)
+
+	agent, mock := newHubbleTestAgent(t)
+	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+		RequestID: "req-5",
+		Target:    "hubble",
+		Query:     "environment=development&namespace=team-1",
+	})
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	// Expected: 1 sentinel (empty Data) + 2 flow chunks + 1 final close.
+	require.Len(t, chunks, 4, "sentinel + 2 flows + close")
+
+	assert.False(t, chunks[0].IsClose)
+	assert.Empty(t, chunks[0].Data, "first frame is the activation sentinel")
+
+	for i, c := range chunks[1:3] {
+		assert.False(t, c.IsClose, "flow chunk %d must not be a close", i)
+		assert.NotEmpty(t, c.Data, "flow chunk %d must carry payload", i)
+		assert.Contains(t, string(c.Data), "openchoreo.dev/environment=development",
+			"protojson payload should carry the in-scope label")
+	}
+
+	assert.True(t, chunks[3].IsClose, "final frame must be the EOF close marker")
+	assert.Empty(t, chunks[3].Data, "clean EOF close carries no error message")
+
+	assert.Empty(t, agent.hubbleStreams, "session must be deregistered on stream completion")
+}
+
+// On a non-EOF stream error the handler still exits cleanly and emits the
+// terminal close chunk; the seam's closer must still fire (asserted by
+// stubOpenHubbleFlowStream's cleanup).
+func TestAgent_HandleHubbleStreamInit_StreamErrorAfterFlows(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "hubble-relay.test.svc:4245")
+
+	stream := &fakeFlowStream{
+		responses: []*observer.GetFlowsResponse{inScopeFlow(t)},
+		endErr:    errors.New("relay closed unexpectedly"),
+	}
+	stubOpenHubbleFlowStream(t, stream, nil)
+
+	agent, mock := newHubbleTestAgent(t)
+
+	done := make(chan struct{})
+	go func() {
+		agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+			RequestID: "req-6",
+			Target:    "hubble",
+			Query:     "environment=development&namespace=team-1",
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit after stream returned error")
+	}
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	// sentinel + 1 flow + final close.
+	require.Len(t, chunks, 3)
+	assert.True(t, chunks[2].IsClose)
+	assert.Empty(t, agent.hubbleStreams)
 }

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -239,7 +239,7 @@ func TestAgent_HandleHubbleStreamInit_InvalidQuery(t *testing.T) {
 	agent, mock := newHubbleTestAgent(t)
 
 	// "%zz" is an invalid percent-escape — url.ParseQuery rejects it.
-	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+	agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
 		RequestID: "req-1",
 		Target:    "hubble",
 		Query:     "%zz",
@@ -257,7 +257,7 @@ func TestAgent_HandleHubbleStreamInit_MissingRequiredParams(t *testing.T) {
 	agent, mock := newHubbleTestAgent(t)
 
 	// "environment" is set but "namespace" is missing.
-	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+	agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
 		RequestID: "req-2",
 		Target:    "hubble",
 		Query:     "environment=development",
@@ -273,7 +273,7 @@ func TestAgent_HandleHubbleStreamInit_RelayAddrUnset(t *testing.T) {
 	t.Setenv("HUBBLE_RELAY_ADDR", "")
 	agent, mock := newHubbleTestAgent(t)
 
-	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+	agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
 		RequestID: "req-3",
 		Target:    "hubble",
 		Query:     "environment=development&namespace=team-1",
@@ -291,7 +291,7 @@ func TestAgent_HandleHubbleStreamInit_OpenStreamError(t *testing.T) {
 	stubOpenHubbleFlowStream(t, nil, errors.New("dial refused"))
 
 	agent, mock := newHubbleTestAgent(t)
-	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+	agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
 		RequestID: "req-4",
 		Target:    "hubble",
 		Query:     "environment=development&namespace=team-1",
@@ -315,7 +315,7 @@ func TestAgent_HandleHubbleStreamInit_HappyPath(t *testing.T) {
 	stubOpenHubbleFlowStream(t, stream, nil)
 
 	agent, mock := newHubbleTestAgent(t)
-	agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+	agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
 		RequestID: "req-5",
 		Target:    "hubble",
 		Query:     "environment=development&namespace=team-1",
@@ -341,6 +341,65 @@ func TestAgent_HandleHubbleStreamInit_HappyPath(t *testing.T) {
 	assert.Empty(t, agent.hubbleStreams, "session must be deregistered on stream completion")
 }
 
+// ctxBlockingFlowStream blocks Recv until its ctx is cancelled, then returns
+// the ctx error. Used to drive the parent-cancellation regression test.
+type ctxBlockingFlowStream struct {
+	ctx context.Context
+}
+
+func (s *ctxBlockingFlowStream) Recv() (*observer.GetFlowsResponse, error) {
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+// Regression: canceling the parent ctx (e.g. websocket disconnect) must
+// propagate into the gRPC Recv loop so the hubble session tears down without
+// waiting for the gateway to deliver a Close chunk.
+func TestAgent_HandleHubbleStreamInit_ParentCtxCancelStopsStream(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "hubble-relay.test.svc:4245")
+
+	// Capture the ctx the handler hands to the dialer and route it into a
+	// stream that blocks until cancelled — so we can verify the parent ctx
+	// reaches the Recv loop end-to-end.
+	prev := openHubbleFlowStream
+	openHubbleFlowStream = func(ctx context.Context, _ string, _ *observer.GetFlowsRequest) (hubbleFlowStream, func(), error) {
+		return &ctxBlockingFlowStream{ctx: ctx}, func() {}, nil
+	}
+	t.Cleanup(func() { openHubbleFlowStream = prev })
+
+	agent, mock := newHubbleTestAgent(t)
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		agent.handleHubbleStreamInit(parentCtx, &messaging.HTTPTunnelStreamInit{
+			RequestID: "req-ctx",
+			Target:    "hubble",
+			Query:     "environment=development&namespace=team-1",
+		})
+		close(done)
+	}()
+
+	// Wait for the sentinel chunk so we know the handler has entered the Recv loop.
+	require.Eventually(t, func() bool {
+		return len(mock.getWrittenMessages()) >= 1
+	}, time.Second, 5*time.Millisecond, "sentinel chunk should fire once stream is active")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("parent ctx cancel did not unblock handleHubbleStreamInit")
+	}
+
+	chunks := decodeChunks(t, mock.getWrittenMessages())
+	require.GreaterOrEqual(t, len(chunks), 2, "expected at least sentinel + final close")
+	last := chunks[len(chunks)-1]
+	assert.True(t, last.IsClose, "final frame must be the close marker")
+	assert.Empty(t, agent.hubbleStreams, "session must be deregistered after ctx cancel")
+}
+
 // On a non-EOF stream error the handler still exits cleanly and emits the
 // terminal close chunk; the seam's closer must still fire (asserted by
 // stubOpenHubbleFlowStream's cleanup).
@@ -357,7 +416,7 @@ func TestAgent_HandleHubbleStreamInit_StreamErrorAfterFlows(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		agent.handleHubbleStreamInit(&messaging.HTTPTunnelStreamInit{
+		agent.handleHubbleStreamInit(context.Background(), &messaging.HTTPTunnelStreamInit{
 			RequestID: "req-6",
 			Target:    "hubble",
 			Query:     "environment=development&namespace=team-1",

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteragent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
+)
+
+func TestBuildHubbleFlowFilters_ORsSourceAndDestination(t *testing.T) {
+	filters := buildHubbleFlowFilters("checkout", "shopfront", "development", "my-team")
+
+	// Expect exactly two FlowFilters: one with SourceLabel, one with DestinationLabel,
+	// so flows match when the component pods are EITHER source OR destination.
+	require.Len(t, filters, 2)
+
+	// Each FlowFilter.SourceLabel entry is its own k8s label selector that is
+	// OR'd across the list. To require ALL labels match (AND semantics), the
+	// labels must be joined into a single comma-separated selector string.
+	// Each selector term is prefixed with `k8s:` so Hubble matches them against
+	// the pod's Kubernetes labels (which it surfaces in the `k8s:` namespace).
+	expected := "k8s:openchoreo.dev/component=checkout,k8s:openchoreo.dev/project=shopfront,k8s:openchoreo.dev/environment=development,k8s:openchoreo.dev/namespace=my-team"
+
+	require.Len(t, filters[0].GetSourceLabel(), 1, "source filter must be a single comma-joined selector (AND), not multiple OR'd entries")
+	assert.Equal(t, expected, filters[0].GetSourceLabel()[0])
+	assert.Empty(t, filters[0].GetDestinationLabel(),
+		"first filter must not constrain destination")
+
+	require.Len(t, filters[1].GetDestinationLabel(), 1, "destination filter must be a single comma-joined selector")
+	assert.Equal(t, expected, filters[1].GetDestinationLabel()[0])
+	assert.Empty(t, filters[1].GetSourceLabel(),
+		"second filter must not constrain source")
+}
+
+func TestNewGetFlowsRequest_LiveTail(t *testing.T) {
+	req := newGetFlowsRequest("checkout", "shopfront", "development", "my-team")
+
+	assert.True(t, req.GetFollow(), "wirelogs is a live tail; Follow must be true")
+	assert.Zero(t, req.GetNumber(), "v1 does not replay history; Number must be 0")
+	assert.Len(t, req.GetWhitelist(), 2, "request must carry both source and destination filters")
+}
+
+func TestHubbleRelayAddr_DefaultWhenUnset(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "")
+	assert.Equal(t, defaultHubbleRelayAddr, hubbleRelayAddr())
+}
+
+func TestHubbleRelayAddr_OverrideFromEnv(t *testing.T) {
+	t.Setenv("HUBBLE_RELAY_ADDR", "hubble-relay.custom.svc:4245")
+	assert.Equal(t, "hubble-relay.custom.svc:4245", hubbleRelayAddr())
+}
+
+func TestHubbleSession_HandleChunkIsNoOp(t *testing.T) {
+	// Hubble is server-streaming only; payload chunks from the API client are
+	// ignored. Verify handleChunk does not panic and does not mutate state.
+	s := &hubbleSession{requestID: "x", cancel: func() {}, done: make(chan struct{})}
+	require.NotPanics(t, func() {
+		s.handleChunk(nil)
+	})
+}
+
+// TestAgent_HandleConnection_RoutesHubbleCloseWithNilData guards the gateway↔agent
+// close protocol: the gateway signals close with IsClose set and no Data (see
+// internal/cluster-gateway/wirelogs.go). The agent must still route it to the
+// hubble session so the upstream gRPC stream is canceled. A nil-Data guard here
+// previously dropped the close, leaking the session and misrouting the message
+// as an HTTPTunnelRequest.
+func TestAgent_HandleConnection_RoutesHubbleCloseWithNilData(t *testing.T) {
+	closeChunk, err := json.Marshal(&messaging.HTTPTunnelStreamChunk{
+		RequestID: "hubble-req-1",
+		IsClose:   true, // Data intentionally left nil, mirroring the gateway
+	})
+	require.NoError(t, err)
+
+	mock := &mockConnection{readMessages: [][]byte{closeChunk}}
+
+	router := newTestRouter(t, map[string]*Route{})
+	agent := newTestAgent(t, "ws://unused", router)
+	agent.conn = mock
+	agent.hubbleStreams = make(map[string]*hubbleSession)
+
+	canceled := make(chan struct{})
+	agent.hubbleStreams["hubble-req-1"] = &hubbleSession{
+		requestID: "hubble-req-1",
+		cancel:    func() { close(canceled) },
+		done:      make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	agent.handleConnection(ctx)
+
+	// The close chunk must cancel the hubble session's gRPC context.
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("close chunk with nil Data did not cancel the hubble session")
+	}
+
+	// It must NOT be misrouted as an HTTPTunnelRequest (which would write a response).
+	assert.Empty(t, mock.getWrittenMessages(),
+		"close chunk must not be handled as an HTTP tunnel request")
+}
+
+func TestHubbleSession_CloseIsIdempotent(t *testing.T) {
+	cancelCalls := 0
+	s := &hubbleSession{
+		requestID: "x",
+		cancel:    func() { cancelCalls++ },
+		done:      make(chan struct{}),
+	}
+	s.close()
+	s.close() // second close must not panic on closed channel or recall cancel
+	assert.Equal(t, 1, cancelCalls)
+}

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -6,6 +6,7 @@ package clusteragent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -48,14 +49,18 @@ func TestNewGetFlowsRequest_LiveTail(t *testing.T) {
 	assert.Len(t, req.GetWhitelist(), 2, "request must carry both source and destination filters")
 }
 
-func TestHubbleRelayAddr_DefaultWhenUnset(t *testing.T) {
+func TestHubbleRelayAddr_ErrorWhenUnset(t *testing.T) {
 	t.Setenv("HUBBLE_RELAY_ADDR", "")
-	assert.Equal(t, defaultHubbleRelayAddr, hubbleRelayAddr())
+	addr, err := hubbleRelayAddr()
+	assert.ErrorIs(t, err, errors.New("HUBBLE_RELAY_ADDR env var is not set; it is required when configuring the Cilium module"))
+	assert.Empty(t, addr)
 }
 
-func TestHubbleRelayAddr_OverrideFromEnv(t *testing.T) {
+func TestHubbleRelayAddr_FromEnv(t *testing.T) {
 	t.Setenv("HUBBLE_RELAY_ADDR", "hubble-relay.custom.svc:4245")
-	assert.Equal(t, "hubble-relay.custom.svc:4245", hubbleRelayAddr())
+	addr, err := hubbleRelayAddr()
+	assert.NoError(t, err)
+	assert.Equal(t, "hubble-relay.custom.svc:4245", addr)
 }
 
 func TestHubbleSession_HandleChunkIsNoOp(t *testing.T) {

--- a/internal/cluster-agent/hubble_test.go
+++ b/internal/cluster-agent/hubble_test.go
@@ -6,7 +6,6 @@ package clusteragent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"testing"
 	"time"
 
@@ -19,26 +18,19 @@ import (
 func TestBuildHubbleFlowFilters_ORsSourceAndDestination(t *testing.T) {
 	filters := buildHubbleFlowFilters("checkout", "shopfront", "development", "my-team")
 
-	// Expect exactly two FlowFilters: one with SourceLabel, one with DestinationLabel,
-	// so flows match when the component pods are EITHER source OR destination.
+	// Two filters (source-only, destination-only) so flows match when the
+	// component is EITHER side. Labels within a filter are comma-joined into one
+	// selector so they AND together — separate entries would OR.
 	require.Len(t, filters, 2)
-
-	// Each FlowFilter.SourceLabel entry is its own k8s label selector that is
-	// OR'd across the list. To require ALL labels match (AND semantics), the
-	// labels must be joined into a single comma-separated selector string.
-	// Each selector term is prefixed with `k8s:` so Hubble matches them against
-	// the pod's Kubernetes labels (which it surfaces in the `k8s:` namespace).
 	expected := "k8s:openchoreo.dev/component=checkout,k8s:openchoreo.dev/project=shopfront,k8s:openchoreo.dev/environment=development,k8s:openchoreo.dev/namespace=my-team"
 
-	require.Len(t, filters[0].GetSourceLabel(), 1, "source filter must be a single comma-joined selector (AND), not multiple OR'd entries")
+	require.Len(t, filters[0].GetSourceLabel(), 1, "must be a single comma-joined selector (AND), not multiple OR'd entries")
 	assert.Equal(t, expected, filters[0].GetSourceLabel()[0])
-	assert.Empty(t, filters[0].GetDestinationLabel(),
-		"first filter must not constrain destination")
+	assert.Empty(t, filters[0].GetDestinationLabel())
 
-	require.Len(t, filters[1].GetDestinationLabel(), 1, "destination filter must be a single comma-joined selector")
+	require.Len(t, filters[1].GetDestinationLabel(), 1)
 	assert.Equal(t, expected, filters[1].GetDestinationLabel()[0])
-	assert.Empty(t, filters[1].GetSourceLabel(),
-		"second filter must not constrain source")
+	assert.Empty(t, filters[1].GetSourceLabel())
 }
 
 func TestNewGetFlowsRequest_LiveTail(t *testing.T) {
@@ -52,7 +44,8 @@ func TestNewGetFlowsRequest_LiveTail(t *testing.T) {
 func TestHubbleRelayAddr_ErrorWhenUnset(t *testing.T) {
 	t.Setenv("HUBBLE_RELAY_ADDR", "")
 	addr, err := hubbleRelayAddr()
-	assert.ErrorIs(t, err, errors.New("HUBBLE_RELAY_ADDR env var is not set; it is required when configuring the Cilium module"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HUBBLE_RELAY_ADDR")
 	assert.Empty(t, addr)
 }
 
@@ -64,24 +57,20 @@ func TestHubbleRelayAddr_FromEnv(t *testing.T) {
 }
 
 func TestHubbleSession_HandleChunkIsNoOp(t *testing.T) {
-	// Hubble is server-streaming only; payload chunks from the API client are
-	// ignored. Verify handleChunk does not panic and does not mutate state.
+	// Hubble is server-streaming only; client-side payload chunks are ignored.
 	s := &hubbleSession{requestID: "x", cancel: func() {}, done: make(chan struct{})}
 	require.NotPanics(t, func() {
 		s.handleChunk(nil)
 	})
 }
 
-// TestAgent_HandleConnection_RoutesHubbleCloseWithNilData guards the gateway↔agent
-// close protocol: the gateway signals close with IsClose set and no Data (see
-// internal/cluster-gateway/wirelogs.go). The agent must still route it to the
-// hubble session so the upstream gRPC stream is canceled. A nil-Data guard here
-// previously dropped the close, leaking the session and misrouting the message
-// as an HTTPTunnelRequest.
+// Regression: the gateway signals close with IsClose set and no Data. A nil-Data
+// guard in handleConnection previously dropped these, leaking the session and
+// misrouting the message as an HTTPTunnelRequest.
 func TestAgent_HandleConnection_RoutesHubbleCloseWithNilData(t *testing.T) {
 	closeChunk, err := json.Marshal(&messaging.HTTPTunnelStreamChunk{
 		RequestID: "hubble-req-1",
-		IsClose:   true, // Data intentionally left nil, mirroring the gateway
+		IsClose:   true,
 	})
 	require.NoError(t, err)
 
@@ -103,14 +92,12 @@ func TestAgent_HandleConnection_RoutesHubbleCloseWithNilData(t *testing.T) {
 	defer cancel()
 	agent.handleConnection(ctx)
 
-	// The close chunk must cancel the hubble session's gRPC context.
 	select {
 	case <-canceled:
 	case <-time.After(time.Second):
 		t.Fatal("close chunk with nil Data did not cancel the hubble session")
 	}
 
-	// It must NOT be misrouted as an HTTPTunnelRequest (which would write a response).
 	assert.Empty(t, mock.getWrittenMessages(),
 		"close chunk must not be handled as an HTTP tunnel request")
 }
@@ -123,6 +110,6 @@ func TestHubbleSession_CloseIsIdempotent(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 	s.close()
-	s.close() // second close must not panic on closed channel or recall cancel
+	s.close()
 	assert.Equal(t, 1, cancelCalls)
 }

--- a/internal/cluster-gateway/exec.go
+++ b/internal/cluster-gateway/exec.go
@@ -58,7 +58,7 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
-	if crNamespace == "_cluster" {
+	if crNamespace == crNamespaceClusterPlaceholder {
 		crNamespace = ""
 	}
 	crKey := fmt.Sprintf("%s/%s", crNamespace, crName)

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -116,8 +116,9 @@ func (s *Server) Start() error {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", s.handleWebSocket)
-	mux.HandleFunc("/api/proxy/", s.handleHTTPProxy) // HTTP proxy to data plane services
-	mux.HandleFunc("/api/exec/", s.handleExec)       // WebSocket exec proxy to data plane pods
+	mux.HandleFunc("/api/proxy/", s.handleHTTPProxy)   // HTTP proxy to data plane services
+	mux.HandleFunc("/api/exec/", s.handleExec)         // WebSocket exec proxy to data plane pods
+	mux.HandleFunc("/api/wirelogs/", s.handleWirelogs) // WebSocket wirelogs (Cilium Hubble flow) stream
 
 	// Register plane lifecycle API (for controller notifications and status queries)
 	planeAPI := NewPlaneAPI(s.connMgr, s, s.logger)

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	planeTypeDataPlane          = "dataplane"
-	planeTypeWorkflowPlane      = "workflowplane"
-	planeTypeObservabilityPlane = "observabilityplane"
+	planeTypeDataPlane            = "dataplane"
+	planeTypeWorkflowPlane        = "workflowplane"
+	planeTypeObservabilityPlane   = "observabilityplane"
+	crNamespaceClusterPlaceholder = "_cluster" // Special placeholder for cluster-scoped CRs (no namespace)
 )
 
 // Connection abstracts a WebSocket connection for testability.
@@ -443,9 +444,9 @@ func (s *Server) handleHTTPProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Construct identifiers for CR-aware routing
 	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
-	// Handle cluster-scoped CR namespace placeholder: "_cluster" maps to empty namespace
+	// Handle cluster-scoped CR namespace placeholder: crNamespaceClusterPlaceholder maps to empty namespace
 	// to match the key format "/name" used by getAllPlaneClientCAs for cluster-scoped resources
-	if crNamespace == "_cluster" {
+	if crNamespace == crNamespaceClusterPlaceholder {
 		crNamespace = ""
 	}
 	crKey := fmt.Sprintf("%s/%s", crNamespace, crName)

--- a/internal/cluster-gateway/wirelogs.go
+++ b/internal/cluster-gateway/wirelogs.go
@@ -15,6 +15,16 @@ import (
 	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
 )
 
+// wirelogsAgentConn is the subset of *AgentConnection that handleWirelogs uses.
+type wirelogsAgentConn interface {
+	SendRawMessage(data []byte) error
+}
+
+// getAgentConnectionForWirelogs defers to the server's ConnectionManager.
+var getAgentConnectionForWirelogs = func(s *Server, planeIdentifier, crKey string) (wirelogsAgentConn, error) {
+	return s.connMgr.GetForCR(planeIdentifier, crKey)
+}
+
 // handleWirelogs handles the wirelogs (Cilium Hubble flow) Server-Sent Events endpoint.
 // URL: /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}?environment=...&namespace=...[&project=...][&component=...]
 // project and component are optional Hubble flow filters; when both are omitted
@@ -75,7 +85,7 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 		logger.Warn("Failed to disable write deadline for SSE stream", "error", err)
 	}
 
-	conn, err := s.connMgr.GetForCR(planeIdentifier, crKey)
+	conn, err := getAgentConnectionForWirelogs(s, planeIdentifier, crKey)
 	if err != nil {
 		logger.Warn("No agent available for wirelogs", "error", err)
 		http.Error(w, fmt.Sprintf("no agent available: %v", err), http.StatusServiceUnavailable)

--- a/internal/cluster-gateway/wirelogs.go
+++ b/internal/cluster-gateway/wirelogs.go
@@ -16,7 +16,9 @@ import (
 )
 
 // handleWirelogs handles the wirelogs (Cilium Hubble flow) Server-Sent Events endpoint.
-// URL: /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}?component=...&environment=...&namespace=...
+// URL: /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}?environment=...&namespace=...[&project=...][&component=...]
+// project and component are optional Hubble flow filters; when both are omitted
+// the stream covers the entire environment.
 func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 	requestID := getOrGenerateRequestID(r)
 	logger := s.logger.With("requestId", requestID)
@@ -34,12 +36,12 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 	crName := parts[3]
 
 	query := r.URL.Query()
-	component := query.Get("component")
-	project := query.Get("project")
 	environment := query.Get("environment")
 	namespace := query.Get("namespace")
-	if component == "" || project == "" || environment == "" || namespace == "" {
-		http.Error(w, "component, project, environment, and namespace query parameters are required", http.StatusBadRequest)
+	project := query.Get("project")
+	component := query.Get("component")
+	if environment == "" || namespace == "" {
+		http.Error(w, "environment and namespace query parameters are required", http.StatusBadRequest)
 		return
 	}
 
@@ -52,9 +54,10 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 	logger.Info("Wirelogs request received",
 		"plane", planeIdentifier,
 		"cr", crKey,
-		"component", component,
-		"project", project,
+		"namespace", namespace,
 		"environment", environment,
+		"project", project,
+		"component", component,
 	)
 
 	flusher, ok := w.(http.Flusher)
@@ -89,10 +92,14 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 	defer s.unregisterStreamSession(requestID)
 
 	agentQuery := url.Values{}
-	agentQuery.Set("component", component)
-	agentQuery.Set("project", project)
-	agentQuery.Set("environment", environment)
 	agentQuery.Set("namespace", namespace)
+	agentQuery.Set("environment", environment)
+	if project != "" {
+		agentQuery.Set("project", project)
+	}
+	if component != "" {
+		agentQuery.Set("component", component)
+	}
 
 	streamInit := &messaging.HTTPTunnelStreamInit{
 		RequestID:    requestID,

--- a/internal/cluster-gateway/wirelogs.go
+++ b/internal/cluster-gateway/wirelogs.go
@@ -17,19 +17,6 @@ import (
 
 // handleWirelogs handles the wirelogs (Cilium Hubble flow) Server-Sent Events endpoint.
 // URL: /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}?component=...&environment=...&namespace=...
-//
-// Flow:
-//  1. Respond with text/event-stream; each Hubble flow JSON is emitted as a single SSE
-//     `data:` frame followed by a blank line.
-//  2. Send a HTTPTunnelStreamInit{Target: "hubble"} to the data-plane agent
-//     authorized for the CR; the agent opens a gRPC GetFlows stream against
-//     hubble-relay and forwards each flow as a HTTPTunnelStreamChunk.
-//  3. Forward chunks one-way (agent → API server). When the API server's request
-//     context is canceled (client disconnect / timeout) send IsClose to the agent
-//     so it cancels the gRPC stream.
-//
-// Note: the gateway↔agent hop is still the persistent multiplexed WebSocket
-// tunnel (`/ws`). Only the api↔gateway leg is SSE.
 func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 	requestID := getOrGenerateRequestID(r)
 	logger := s.logger.With("requestId", requestID)
@@ -57,7 +44,7 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
-	if crNamespace == "_cluster" {
+	if crNamespace == crNamespaceClusterPlaceholder {
 		crNamespace = ""
 	}
 	crKey := fmt.Sprintf("%s/%s", crNamespace, crName)
@@ -79,10 +66,8 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 
 	// The http.Server's WriteTimeout is an absolute deadline from when request
 	// headers are read; for a long-lived SSE stream it would kill the connection
-	// after that deadline regardless of activity (the classic "curl: (18) transfer
-	// closed with outstanding read data remaining" once nothing has been sent for
-	// a while). Clear the deadline on this connection only — other endpoints keep
-	// the server's default protection.
+	// after that deadline regardless of activity. Hence, clear the deadline on this connection only
+	// Other endpoints keep the server's default protection.
 	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
 		logger.Warn("Failed to disable write deadline for SSE stream", "error", err)
 	}
@@ -134,8 +119,7 @@ func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("Wirelogs stream init sent to agent")
 
-	// Wait for the agent's first chunk (sentinel) so we know the stream is live
-	// before we commit to a 200 SSE response.
+	// Wait for the agent's first chunk (sentinel) before commit to a 200 SSE response.
 	select {
 	case chunk := <-session.fromAgent:
 		if chunk == nil {
@@ -215,11 +199,7 @@ func writeSSEHeaders(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// writeSSEEvent serializes a single payload as one `data:` SSE frame and flushes
-// it. Each newline in the payload is emitted as a continuation `data:` line so
-// the framing remains valid even if Hubble's protojson output ever contains a
-// newline (it currently does not — `protojson.MarshalOptions` produces compact
-// JSON — but the cost of being defensive is one bytes.Index call per flow).
+// writeSSEEvent serializes a single payload as one `data:` SSE frame and flushes it.
 // Returns false if the write failed and the caller should stop streaming.
 func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, data []byte) bool {
 	var buf bytes.Buffer

--- a/internal/cluster-gateway/wirelogs.go
+++ b/internal/cluster-gateway/wirelogs.go
@@ -1,0 +1,245 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustergateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
+)
+
+// handleWirelogs handles the wirelogs (Cilium Hubble flow) Server-Sent Events endpoint.
+// URL: /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}?component=...&environment=...&namespace=...
+//
+// Flow:
+//  1. Respond with text/event-stream; each Hubble flow JSON is emitted as a single SSE
+//     `data:` frame followed by a blank line.
+//  2. Send a HTTPTunnelStreamInit{Target: "hubble"} to the data-plane agent
+//     authorized for the CR; the agent opens a gRPC GetFlows stream against
+//     hubble-relay and forwards each flow as a HTTPTunnelStreamChunk.
+//  3. Forward chunks one-way (agent → API server). When the API server's request
+//     context is canceled (client disconnect / timeout) send IsClose to the agent
+//     so it cancels the gRPC stream.
+//
+// Note: the gateway↔agent hop is still the persistent multiplexed WebSocket
+// tunnel (`/ws`). Only the api↔gateway leg is SSE.
+func (s *Server) handleWirelogs(w http.ResponseWriter, r *http.Request) {
+	requestID := getOrGenerateRequestID(r)
+	logger := s.logger.With("requestId", requestID)
+
+	// Parse URL: /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}
+	path := strings.TrimPrefix(r.URL.Path, "/api/wirelogs/")
+	parts := strings.SplitN(path, "/", 4)
+	if len(parts) < 4 {
+		http.Error(w, "invalid wirelogs URL: expected /api/wirelogs/{planeType}/{planeID}/{crNamespace}/{crName}", http.StatusBadRequest)
+		return
+	}
+	planeType := parts[0]
+	planeID := parts[1]
+	crNamespace := parts[2]
+	crName := parts[3]
+
+	query := r.URL.Query()
+	component := query.Get("component")
+	project := query.Get("project")
+	environment := query.Get("environment")
+	namespace := query.Get("namespace")
+	if component == "" || project == "" || environment == "" || namespace == "" {
+		http.Error(w, "component, project, environment, and namespace query parameters are required", http.StatusBadRequest)
+		return
+	}
+
+	planeIdentifier := fmt.Sprintf("%s/%s", planeType, planeID)
+	if crNamespace == "_cluster" {
+		crNamespace = ""
+	}
+	crKey := fmt.Sprintf("%s/%s", crNamespace, crName)
+
+	logger.Info("Wirelogs request received",
+		"plane", planeIdentifier,
+		"cr", crKey,
+		"component", component,
+		"project", project,
+		"environment", environment,
+	)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		logger.Error("ResponseWriter does not support flushing; cannot stream SSE")
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	// The http.Server's WriteTimeout is an absolute deadline from when request
+	// headers are read; for a long-lived SSE stream it would kill the connection
+	// after that deadline regardless of activity (the classic "curl: (18) transfer
+	// closed with outstanding read data remaining" once nothing has been sent for
+	// a while). Clear the deadline on this connection only — other endpoints keep
+	// the server's default protection.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+		logger.Warn("Failed to disable write deadline for SSE stream", "error", err)
+	}
+
+	conn, err := s.connMgr.GetForCR(planeIdentifier, crKey)
+	if err != nil {
+		logger.Warn("No agent available for wirelogs", "error", err)
+		http.Error(w, fmt.Sprintf("no agent available: %v", err), http.StatusServiceUnavailable)
+		return
+	}
+
+	session := &streamSession{
+		requestID: requestID,
+		fromAgent: make(chan *messaging.HTTPTunnelStreamChunk, 256),
+		done:      make(chan struct{}),
+	}
+
+	s.registerStreamSession(requestID, session)
+	defer s.unregisterStreamSession(requestID)
+
+	agentQuery := url.Values{}
+	agentQuery.Set("component", component)
+	agentQuery.Set("project", project)
+	agentQuery.Set("environment", environment)
+	agentQuery.Set("namespace", namespace)
+
+	streamInit := &messaging.HTTPTunnelStreamInit{
+		RequestID:    requestID,
+		Target:       "hubble",
+		Method:       "GET",
+		Path:         "/wirelogs",
+		Query:        agentQuery.Encode(),
+		IsUpgrade:    true,
+		UpgradeProto: "hubble/v1",
+	}
+
+	initData, err := json.Marshal(streamInit)
+	if err != nil {
+		logger.Error("Failed to marshal stream init", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := conn.SendRawMessage(initData); err != nil {
+		logger.Error("Failed to send stream init to agent", "error", err)
+		http.Error(w, fmt.Sprintf("failed to start stream: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	logger.Info("Wirelogs stream init sent to agent")
+
+	// Wait for the agent's first chunk (sentinel) so we know the stream is live
+	// before we commit to a 200 SSE response.
+	select {
+	case chunk := <-session.fromAgent:
+		if chunk == nil {
+			logger.Error("Stream session closed before wirelogs started")
+			http.Error(w, "stream closed before start", http.StatusBadGateway)
+			return
+		}
+		if chunk.IsClose {
+			logger.Warn("Agent closed wirelogs stream immediately", "data", string(chunk.Data))
+			http.Error(w, fmt.Sprintf("agent rejected stream: %s", string(chunk.Data)), http.StatusBadGateway)
+			return
+		}
+		// Commit to SSE: write headers + flush before any data frames.
+		writeSSEHeaders(w)
+		flusher.Flush()
+		if len(chunk.Data) > 0 {
+			if !writeSSEEvent(w, flusher, chunk.Data) {
+				return
+			}
+		}
+	case <-time.After(30 * time.Second):
+		logger.Error("Timeout waiting for agent to start wirelogs stream")
+		http.Error(w, "timeout waiting for agent", http.StatusGatewayTimeout)
+		return
+	case <-r.Context().Done():
+		logger.Info("Client disconnected before stream started")
+		return
+	case <-session.done:
+		http.Error(w, "stream closed before start", http.StatusBadGateway)
+		return
+	}
+
+	// Notify the agent when the client disconnects (request context canceled),
+	// so it can cancel the upstream gRPC stream against hubble-relay.
+	go func() {
+		<-r.Context().Done()
+		closeChunk, _ := json.Marshal(&messaging.HTTPTunnelStreamChunk{
+			RequestID: requestID,
+			IsClose:   true,
+		})
+		_ = conn.SendRawMessage(closeChunk)
+		session.close()
+	}()
+
+	// Agent → API server: forward each flow chunk as one SSE event.
+	for {
+		select {
+		case chunk, ok := <-session.fromAgent:
+			if !ok || chunk == nil {
+				return
+			}
+			if chunk.IsClose {
+				return
+			}
+			if len(chunk.Data) > 0 {
+				if !writeSSEEvent(w, flusher, chunk.Data) {
+					return
+				}
+			}
+		case <-session.done:
+			return
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// writeSSEHeaders sets the response headers required for a Server-Sent Events
+// stream. Must be called before the first response byte is written.
+func writeSSEHeaders(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache, no-transform")
+	h.Set("Connection", "keep-alive")
+	// Hint to intermediate proxies (e.g. nginx) not to buffer the stream.
+	h.Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+}
+
+// writeSSEEvent serializes a single payload as one `data:` SSE frame and flushes
+// it. Each newline in the payload is emitted as a continuation `data:` line so
+// the framing remains valid even if Hubble's protojson output ever contains a
+// newline (it currently does not — `protojson.MarshalOptions` produces compact
+// JSON — but the cost of being defensive is one bytes.Index call per flow).
+// Returns false if the write failed and the caller should stop streaming.
+func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, data []byte) bool {
+	var buf bytes.Buffer
+	for len(data) > 0 {
+		idx := bytes.IndexByte(data, '\n')
+		if idx < 0 {
+			buf.WriteString("data: ")
+			buf.Write(data)
+			buf.WriteByte('\n')
+			break
+		}
+		buf.WriteString("data: ")
+		buf.Write(data[:idx])
+		buf.WriteByte('\n')
+		data = data[idx+1:]
+	}
+	buf.WriteByte('\n')
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return false
+	}
+	flusher.Flush()
+	return true
+}

--- a/internal/cluster-gateway/wirelogs_test.go
+++ b/internal/cluster-gateway/wirelogs_test.go
@@ -4,10 +4,22 @@
 package clustergateway
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
 )
 
 // httptest.ResponseRecorder does not implement http.Flusher; writeSSEEvent
@@ -48,4 +60,246 @@ func TestWriteSSEEvent_MultiLineSplitsIntoDataLines(t *testing.T) {
 	ok := writeSSEEvent(rec, rec, []byte("alpha\nbeta\ngamma"))
 	assert.True(t, ok)
 	assert.Equal(t, "data: alpha\ndata: beta\ndata: gamma\n\n", rec.Body.String())
+}
+
+// --- handleWirelogs fake-stream tests ------------------------------------
+
+// fakeAgentConn captures the messages handleWirelogs would have written to the
+// agent. The onInit hook lets a test inject sentinel/flow/close chunks back
+// into the server's stream session, mimicking what the real agent would do.
+type fakeAgentConn struct {
+	mu       sync.Mutex
+	sent     [][]byte
+	sendErr  error
+	onInit   func(initData []byte)
+	initOnce atomic.Bool
+}
+
+func (f *fakeAgentConn) SendRawMessage(data []byte) error {
+	f.mu.Lock()
+	copyOf := make([]byte, len(data))
+	copy(copyOf, data)
+	f.sent = append(f.sent, copyOf)
+	hook := f.onInit
+	err := f.sendErr
+	f.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if hook != nil && f.initOnce.CompareAndSwap(false, true) {
+		hook(copyOf)
+	}
+	return nil
+}
+
+func (f *fakeAgentConn) sentMessages() [][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([][]byte, len(f.sent))
+	copy(out, f.sent)
+	return out
+}
+
+// stubGetAgentConnectionForWirelogs replaces the package-level getter and
+// restores it on test cleanup.
+func stubGetAgentConnectionForWirelogs(t *testing.T, conn wirelogsAgentConn, err error) {
+	t.Helper()
+	prev := getAgentConnectionForWirelogs
+	getAgentConnectionForWirelogs = func(_ *Server, _, _ string) (wirelogsAgentConn, error) {
+		if err != nil {
+			return nil, err
+		}
+		return conn, nil
+	}
+	t.Cleanup(func() { getAgentConnectionForWirelogs = prev })
+}
+
+// newWirelogsTestServer returns a Server with only the fields handleWirelogs
+// touches initialized. The connMgr is left nil because the seam bypasses it.
+func newWirelogsTestServer() *Server {
+	return &Server{
+		pendingStreamSessions: make(map[string]*streamSession),
+		logger:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func newWirelogsRequest(t *testing.T, target, query string) (*http.Request, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, target+"?"+query, nil)
+	req.Header.Set("X-Request-ID", "test-wirelogs-req")
+	return req, cancel
+}
+
+func TestHandleWirelogs_InvalidURL(t *testing.T) {
+	s := newWirelogsTestServer()
+	req, cancel := newWirelogsRequest(t, "/api/wirelogs/dataplane/p1", "environment=dev&namespace=ns")
+	defer cancel()
+	rec := newFlushingRecorder()
+
+	s.handleWirelogs(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid wirelogs URL")
+}
+
+func TestHandleWirelogs_MissingRequiredQueryParams(t *testing.T) {
+	s := newWirelogsTestServer()
+	req, cancel := newWirelogsRequest(t, "/api/wirelogs/dataplane/p1/ns1/cr1", "environment=dev")
+	defer cancel()
+	rec := newFlushingRecorder()
+
+	s.handleWirelogs(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "environment and namespace")
+}
+
+// noFlushRecorder forwards to httptest.ResponseRecorder but does NOT promote
+// its Flush method, so the http.Flusher type assertion in handleWirelogs fails.
+// (ResponseRecorder itself implements Flusher since Go 1.10.)
+type noFlushRecorder struct {
+	rec *httptest.ResponseRecorder
+}
+
+func (n *noFlushRecorder) Header() http.Header         { return n.rec.Header() }
+func (n *noFlushRecorder) Write(b []byte) (int, error) { return n.rec.Write(b) }
+func (n *noFlushRecorder) WriteHeader(code int)        { n.rec.WriteHeader(code) }
+
+func TestHandleWirelogs_NoFlusherSupport(t *testing.T) {
+	s := newWirelogsTestServer()
+	req, cancel := newWirelogsRequest(t, "/api/wirelogs/dataplane/p1/ns1/cr1", "environment=dev&namespace=ns")
+	defer cancel()
+	rec := &noFlushRecorder{rec: httptest.NewRecorder()}
+
+	s.handleWirelogs(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.rec.Code)
+	assert.Contains(t, rec.rec.Body.String(), "streaming unsupported")
+}
+
+func TestHandleWirelogs_NoAgentAvailable(t *testing.T) {
+	stubGetAgentConnectionForWirelogs(t, nil, errors.New("no connections registered"))
+
+	s := newWirelogsTestServer()
+	req, cancel := newWirelogsRequest(t, "/api/wirelogs/dataplane/p1/ns1/cr1", "environment=dev&namespace=ns")
+	defer cancel()
+	rec := newFlushingRecorder()
+
+	s.handleWirelogs(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no connections registered")
+}
+
+func TestHandleWirelogs_InitSendFailure(t *testing.T) {
+	fake := &fakeAgentConn{sendErr: errors.New("websocket closed")}
+	stubGetAgentConnectionForWirelogs(t, fake, nil)
+
+	s := newWirelogsTestServer()
+	req, cancel := newWirelogsRequest(t, "/api/wirelogs/dataplane/p1/ns1/cr1", "environment=dev&namespace=ns")
+	defer cancel()
+	rec := newFlushingRecorder()
+
+	s.handleWirelogs(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to start stream")
+	assert.Empty(t, s.pendingStreamSessions, "session must be unregistered on failure")
+}
+
+func TestHandleWirelogs_AgentRejectsImmediately(t *testing.T) {
+	// Agent sends an IsClose as the very first frame — handler must return 502
+	// before committing to SSE headers.
+	s := newWirelogsTestServer()
+	fake := &fakeAgentConn{
+		onInit: func(_ []byte) {
+			s.handleStreamChunk(&messaging.HTTPTunnelStreamChunk{
+				RequestID: "test-wirelogs-req",
+				Data:      []byte("hubble misconfigured"),
+				IsClose:   true,
+			})
+		},
+	}
+	stubGetAgentConnectionForWirelogs(t, fake, nil)
+
+	req, cancel := newWirelogsRequest(t, "/api/wirelogs/dataplane/p1/ns1/cr1", "environment=dev&namespace=ns")
+	defer cancel()
+	rec := newFlushingRecorder()
+
+	s.handleWirelogs(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "hubble misconfigured")
+}
+
+func TestHandleWirelogs_HappyPath(t *testing.T) {
+	s := newWirelogsTestServer()
+
+	// On init, push: empty-Data sentinel → two flow chunks → terminal IsClose.
+	// The handler's loop should write 2 SSE events and exit cleanly.
+	fake := &fakeAgentConn{
+		onInit: func(_ []byte) {
+			go func() {
+				s.handleStreamChunk(&messaging.HTTPTunnelStreamChunk{
+					RequestID: "test-wirelogs-req",
+				})
+				s.handleStreamChunk(&messaging.HTTPTunnelStreamChunk{
+					RequestID: "test-wirelogs-req",
+					Data:      []byte(`{"flow":"a"}`),
+				})
+				s.handleStreamChunk(&messaging.HTTPTunnelStreamChunk{
+					RequestID: "test-wirelogs-req",
+					Data:      []byte(`{"flow":"b"}`),
+				})
+				s.handleStreamChunk(&messaging.HTTPTunnelStreamChunk{
+					RequestID: "test-wirelogs-req",
+					IsClose:   true,
+				})
+			}()
+		},
+	}
+	stubGetAgentConnectionForWirelogs(t, fake, nil)
+
+	req, cancel := newWirelogsRequest(t,
+		"/api/wirelogs/dataplane/p1/ns1/cr1",
+		"environment=dev&namespace=ns&project=shopfront&component=checkout")
+	// Cancel the request after the handler returns so the watchdog goroutine
+	// inside handleWirelogs unblocks instead of leaking past the test.
+	defer cancel()
+	rec := newFlushingRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		s.handleWirelogs(rec, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not exit after IsClose chunk")
+	}
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	body := rec.Body.String()
+	assert.Equal(t, "data: {\"flow\":\"a\"}\n\ndata: {\"flow\":\"b\"}\n\n", body,
+		"two flow chunks should become two `data:` SSE frames; sentinel carries no payload")
+	assert.GreaterOrEqual(t, rec.flushed, 3,
+		"flush at least once for headers commit + once per event")
+
+	// Verify the init payload sent to the agent encodes the query params correctly.
+	sent := fake.sentMessages()
+	require.NotEmpty(t, sent)
+	var init messaging.HTTPTunnelStreamInit
+	require.NoError(t, json.Unmarshal(sent[0], &init))
+	assert.Equal(t, "hubble", init.Target)
+	assert.True(t, init.IsUpgrade)
+	assert.Equal(t, "test-wirelogs-req", init.RequestID)
+	assert.Contains(t, init.Query, "environment=dev")
+	assert.Contains(t, init.Query, "namespace=ns")
+	assert.Contains(t, init.Query, "project=shopfront")
+	assert.Contains(t, init.Query, "component=checkout")
+
+	assert.Empty(t, s.pendingStreamSessions, "session must be deregistered after stream ends")
 }

--- a/internal/cluster-gateway/wirelogs_test.go
+++ b/internal/cluster-gateway/wirelogs_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustergateway
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// flushingRecorder is an httptest.ResponseRecorder that also satisfies
+// http.Flusher so writeSSEEvent can flush against it. ResponseRecorder
+// itself does not implement Flusher.
+type flushingRecorder struct {
+	*httptest.ResponseRecorder
+	flushed int
+}
+
+func (f *flushingRecorder) Flush() { f.flushed++ }
+
+func newFlushingRecorder() *flushingRecorder {
+	return &flushingRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func TestWriteSSEHeaders(t *testing.T) {
+	rec := newFlushingRecorder()
+	writeSSEHeaders(rec)
+
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache, no-transform", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
+	assert.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"))
+}
+
+func TestWriteSSEEvent_SingleLineJSON(t *testing.T) {
+	rec := newFlushingRecorder()
+	ok := writeSSEEvent(rec, rec, []byte(`{"flow":1}`))
+	assert.True(t, ok)
+	// SSE frame: one `data:` line + blank terminator line.
+	assert.Equal(t, "data: {\"flow\":1}\n\n", rec.Body.String())
+	assert.Equal(t, 1, rec.flushed, "should flush exactly once per event")
+}
+
+func TestWriteSSEEvent_MultiLineSplitsIntoDataLines(t *testing.T) {
+	// Defensive: if the agent ever emits a payload containing a newline, each
+	// segment must become its own `data:` line so the SSE framing stays valid.
+	rec := newFlushingRecorder()
+	ok := writeSSEEvent(rec, rec, []byte("alpha\nbeta\ngamma"))
+	assert.True(t, ok)
+	assert.Equal(t, "data: alpha\ndata: beta\ndata: gamma\n\n", rec.Body.String())
+}

--- a/internal/cluster-gateway/wirelogs_test.go
+++ b/internal/cluster-gateway/wirelogs_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// flushingRecorder is an httptest.ResponseRecorder that also satisfies
-// http.Flusher so writeSSEEvent can flush against it. ResponseRecorder
-// itself does not implement Flusher.
+// httptest.ResponseRecorder does not implement http.Flusher; writeSSEEvent
+// requires one, so wrap it.
 type flushingRecorder struct {
 	*httptest.ResponseRecorder
 	flushed int
@@ -38,14 +37,13 @@ func TestWriteSSEEvent_SingleLineJSON(t *testing.T) {
 	rec := newFlushingRecorder()
 	ok := writeSSEEvent(rec, rec, []byte(`{"flow":1}`))
 	assert.True(t, ok)
-	// SSE frame: one `data:` line + blank terminator line.
 	assert.Equal(t, "data: {\"flow\":1}\n\n", rec.Body.String())
 	assert.Equal(t, 1, rec.flushed, "should flush exactly once per event")
 }
 
 func TestWriteSSEEvent_MultiLineSplitsIntoDataLines(t *testing.T) {
-	// Defensive: if the agent ever emits a payload containing a newline, each
-	// segment must become its own `data:` line so the SSE framing stays valid.
+	// Defensive: a payload containing a newline must become multiple `data:`
+	// lines so the SSE framing stays valid.
 	rec := newFlushingRecorder()
 	ok := writeSSEEvent(rec, rec, []byte("alpha\nbeta\ngamma"))
 	assert.True(t, ok)

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -23,6 +24,11 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
+
+// RFC1123 DNS label (the k8s name form accepted by the gateway).
+var wirelogsNameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+const wirelogsMaxNameLen = 63
 
 // WirelogsHandler streams Cilium Hubble flow events for an environment (optionally filtered by project/component)
 // as a Server-Sent Events response.
@@ -70,6 +76,23 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if component != "" && project == "" {
 		http.Error(w, "component filter requires project filter", http.StatusBadRequest)
+		return
+	}
+
+	if len(namespace) > wirelogsMaxNameLen || !wirelogsNameRE.MatchString(namespace) {
+		http.Error(w, "invalid namespace parameter", http.StatusBadRequest)
+		return
+	}
+	if len(environment) > wirelogsMaxNameLen || !wirelogsNameRE.MatchString(environment) {
+		http.Error(w, "invalid environment parameter", http.StatusBadRequest)
+		return
+	}
+	if project != "" && (len(project) > wirelogsMaxNameLen || !wirelogsNameRE.MatchString(project)) {
+		http.Error(w, "invalid project parameter", http.StatusBadRequest)
+		return
+	}
+	if component != "" && (len(component) > wirelogsMaxNameLen || !wirelogsNameRE.MatchString(component)) {
+		http.Error(w, "invalid component parameter", http.StatusBadRequest)
 		return
 	}
 
@@ -164,25 +187,26 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("Wirelogs SSE stream started")
 
-	// The gateway already emits valid SSE framing. Flush after every read so
-	// events reach the client immediately rather than being buffered.
-	buf := make([]byte, 32*1024)
-	for {
-		n, readErr := resp.Body.Read(buf)
-		if n > 0 {
-			if _, werr := w.Write(buf[:n]); werr != nil {
-				logger.Debug("Client write failed; ending stream", "error", werr)
-				return
-			}
-			flusher.Flush()
-		}
-		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) && !errors.Is(readErr, context.Canceled) {
-				logger.Debug("Gateway stream ended with error", "error", readErr)
-			}
-			return
+	// The gateway already emits valid SSE framing; flush after every chunk so events arrive without buffering.
+	if _, err := io.Copy(&sseFlushingWriter{w: w, flusher: flusher}, resp.Body); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			logger.Debug("Wirelogs stream ended with error", "error", err)
 		}
 	}
+}
+
+// sseFlushingWriter flushes the underlying ResponseWriter after each write.
+type sseFlushingWriter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+}
+
+func (fw *sseFlushingWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if err == nil {
+		fw.flusher.Flush()
+	}
+	return n, err
 }
 
 // wirelogsCheckRequest derives the most-specific authz scope from the supplied filters. The environment

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -53,8 +54,18 @@ func NewWirelogsHandler(k8sClient client.Client, gwClient *gatewayClient.Client,
 		gatewayTLSConf: gwTLSConf,
 		authzChecker:   authzChecker,
 		httpClient: &http.Client{
+			// No Client.Timeout: SSE streams are long-lived and a request-level deadline
+			// would abort them mid-stream. Bound the pre-stream phases via Transport timeouts.
 			Transport: &http.Transport{
 				TLSClientConfig: gwTLSConf,
+				DialContext: (&net.Dialer{
+					Timeout:   5 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ResponseHeaderTimeout: 30 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+				IdleConnTimeout:       90 * time.Second,
 			},
 		},
 		logger: logger.With("component", "wirelogs-handler"),

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -25,8 +25,7 @@ import (
 )
 
 // WirelogsHandler streams Cilium Hubble flow events for a component as a
-// Server-Sent Events response. It proxies an SSE stream from the cluster-gateway
-// which in turn fans the request out to the data-plane cluster-agent.
+// Server-Sent Events response.
 type WirelogsHandler struct {
 	k8sClient      client.Client
 	gatewayClient  *gatewayClient.Client
@@ -37,12 +36,9 @@ type WirelogsHandler struct {
 	logger         *slog.Logger
 }
 
-// NewWirelogsHandler creates a new wirelogs handler.
-//
-// The handler uses its own *http.Client (rather than the shared gatewayClient
-// httpClient) because the gateway client applies a request-level timeout that
-// is incompatible with the long-lived SSE stream; we rely on the inbound
-// request's context for cancellation instead.
+// NewWirelogsHandler creates a new wirelogs handler and uses its own *http.Client
+// (rather than the shared gatewayClient httpClient)
+// because the gateway client applies a request-level timeout that is incompatible with the long-lived SSE stream
 func NewWirelogsHandler(k8sClient client.Client, gwClient *gatewayClient.Client, gatewayURL string, gwTLSConf *tls.Config, authzChecker *svcpkg.AuthzChecker, logger *slog.Logger) *WirelogsHandler {
 	return &WirelogsHandler{
 		k8sClient:      k8sClient,
@@ -63,18 +59,23 @@ func NewWirelogsHandler(k8sClient client.Client, gwClient *gatewayClient.Client,
 // the gateway's SSE stream to the client.
 // URL: /wirelogs/namespaces/{namespace}/projects/{project}/components/{component}?environment=...
 func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	namespace, project, componentName, ok := parseWirelogsPath(r.URL.Path)
+	namespace, project, component, ok := parseWirelogsPath(r.URL.Path)
 	if !ok {
 		http.Error(w, "invalid wirelogs URL: expected /wirelogs/namespaces/{ns}/projects/{proj}/components/{name}", http.StatusBadRequest)
 		return
 	}
 
-	envName := r.URL.Query().Get("environment")
+	environment := r.URL.Query().Get("environment")
+	if environment == "" {
+		http.Error(w, "environment query parameter is required", http.StatusBadRequest)
+		return
+	}
 
 	ctx := r.Context()
-	logger := h.logger.With("namespace", namespace, "component", componentName)
+	logger := h.logger.With("namespace", namespace, "component", component)
 
 	// Authorize: caller must have logs:view on the component.
+	// TODO: Add a separate permission (wirelogs:view)
 	if h.authzChecker == nil {
 		logger.Error("Authorization checker not configured")
 		http.Error(w, "authorization not configured", http.StatusInternalServerError)
@@ -83,7 +84,7 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := h.authzChecker.Check(ctx, svcpkg.CheckRequest{
 		Action:       authz.ActionViewLogs,
 		ResourceType: "component",
-		ResourceID:   componentName,
+		ResourceID:   component,
 		Hierarchy: authz.ResourceHierarchy{
 			Namespace: namespace,
 			Project:   project,
@@ -98,14 +99,14 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	plane, err := h.resolvePlane(ctx, namespace, componentName, project, &envName)
+	plane, err := h.resolvePlane(ctx, namespace, component, environment)
 	if err != nil {
 		logger.Error("Failed to resolve data plane for wirelogs", "error", err)
 		http.Error(w, fmt.Sprintf("failed to resolve data plane: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	logger = logger.With("environment", envName,
+	logger = logger.With("environment", environment,
 		"planeType", plane.planeType, "planeID", plane.planeID)
 
 	flusher, ok := w.(http.Flusher)
@@ -114,18 +115,15 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 		return
 	}
-
 	// The http.Server's WriteTimeout is an absolute deadline from when request
 	// headers are read; for a long-lived SSE stream it would kill the connection
-	// after that deadline regardless of activity (the classic "curl: (18) transfer
-	// closed with outstanding read data remaining" once nothing has been sent for
-	// a while). Clear the deadline on this connection only — other endpoints keep
-	// the server's default protection.
+	// after that deadline regardless of activity. Hence, clear the deadline on this connection only
+	// Other endpoints keep the server's default protection.
 	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
 		logger.Warn("Failed to disable write deadline for SSE stream", "error", err)
 	}
 
-	gwURL, err := h.buildGatewayWirelogsURL(plane, componentName, project, envName, namespace)
+	gwURL, err := h.buildGatewayWirelogsURL(plane, component, project, environment, namespace)
 	if err != nil {
 		logger.Error("Failed to build gateway wirelogs URL", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -151,7 +149,6 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		logger.Error("Gateway returned non-OK status", "status", resp.StatusCode, "body", string(body))
-		// Surface the gateway's status code unless it's something we shouldn't pass through.
 		status := resp.StatusCode
 		if status < 400 || status >= 600 {
 			status = http.StatusBadGateway
@@ -171,9 +168,8 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("Wirelogs SSE stream started")
 
-	// The gateway already emits valid SSE framing — passing bytes through
-	// verbatim preserves event boundaries. Flush after every read so events
-	// reach the client immediately rather than being buffered.
+	// The gateway already emits valid SSE framing. Flush after every read so
+	// events reach the client immediately rather than being buffered.
 	buf := make([]byte, 32*1024)
 	for {
 		n, readErr := resp.Body.Read(buf)
@@ -193,31 +189,19 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// resolvePlane resolves the data plane for a component+environment without
-// requiring a specific pod (unlike exec). The flow filter targets pods by label.
-func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, componentName, project string, envName *string) (execPlaneInfo, error) {
+// resolvePlane resolves the data plane for a component+environment. The flow filter targets pods by label.
+func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, component, environment string) (execPlaneInfo, error) {
 	comp := &openchoreov1alpha1.Component{}
-	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: componentName}, comp); err != nil {
-		return execPlaneInfo{}, fmt.Errorf("component %q not found: %w", componentName, err)
-	}
-
-	if *envName == "" {
-		if project == "" {
-			return execPlaneInfo{}, fmt.Errorf("--project or --environment is required")
-		}
-		resolved, err := h.resolveLowestEnvironment(ctx, namespace, project)
-		if err != nil {
-			return execPlaneInfo{}, err
-		}
-		*envName = resolved
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: component}, comp); err != nil {
+		return execPlaneInfo{}, fmt.Errorf("component %q not found: %w", component, err)
 	}
 
 	env := &openchoreov1alpha1.Environment{}
-	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: *envName}, env); err != nil {
-		return execPlaneInfo{}, fmt.Errorf("environment %q not found: %w", *envName, err)
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: environment}, env); err != nil {
+		return execPlaneInfo{}, fmt.Errorf("environment %q not found: %w", environment, err)
 	}
 	if env.Spec.DataPlaneRef == nil {
-		return execPlaneInfo{}, fmt.Errorf("environment %q has no data plane reference", *envName)
+		return execPlaneInfo{}, fmt.Errorf("environment %q has no data plane reference", environment)
 	}
 
 	dpResult, err := controller.GetDataPlaneFromRef(ctx, h.k8sClient, env.Namespace, env.Spec.DataPlaneRef)
@@ -227,51 +211,12 @@ func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, component
 
 	plane := resolveExecPlaneInfo(dpResult)
 	if plane.planeID == "" {
-		return execPlaneInfo{}, fmt.Errorf("failed to determine plane ID for environment %q", *envName)
+		return execPlaneInfo{}, fmt.Errorf("failed to determine plane ID for environment %q", environment)
 	}
 	return plane, nil
 }
 
-// resolveLowestEnvironment finds the root environment from the project's deployment pipeline.
-func (h *WirelogsHandler) resolveLowestEnvironment(ctx context.Context, namespace, projectName string) (string, error) {
-	proj := &openchoreov1alpha1.Project{}
-	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: projectName}, proj); err != nil {
-		return "", fmt.Errorf("project %q not found: %w", projectName, err)
-	}
-
-	if proj.Spec.DeploymentPipelineRef.Name == "" {
-		return "", fmt.Errorf("project %q has no deployment pipeline configured", projectName)
-	}
-
-	pipeline := &openchoreov1alpha1.DeploymentPipeline{}
-	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: proj.Spec.DeploymentPipelineRef.Name}, pipeline); err != nil {
-		return "", fmt.Errorf("deployment pipeline not found: %w", err)
-	}
-
-	if len(pipeline.Spec.PromotionPaths) == 0 {
-		return "", fmt.Errorf("deployment pipeline has no promotion paths")
-	}
-
-	// Find root environment (source that is never a target)
-	targets := make(map[string]bool)
-	for _, path := range pipeline.Spec.PromotionPaths {
-		for _, target := range path.TargetEnvironmentRefs {
-			targets[target.Name] = true
-		}
-	}
-
-	for _, path := range pipeline.Spec.PromotionPaths {
-		if path.SourceEnvironmentRef.Name != "" && !targets[path.SourceEnvironmentRef.Name] {
-			return path.SourceEnvironmentRef.Name, nil
-		}
-	}
-
-	return "", fmt.Errorf("no root environment found in deployment pipeline")
-}
-
-// buildGatewayWirelogsURL constructs the HTTPS URL for the gateway wirelogs SSE
-// endpoint. The gateway↔agent hop remains WebSocket-based, but the api↔gateway
-// hop is now plain HTTP with SSE framing.
+// buildGatewayWirelogsURL constructs the HTTPS URL for the gateway wirelogs SSE endpoint.
 func (h *WirelogsHandler) buildGatewayWirelogsURL(plane execPlaneInfo, component, project, environment, namespace string) (string, error) {
 	u, err := url.Parse(h.gatewayURL)
 	if err != nil {

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -24,8 +24,8 @@ import (
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
 
-// WirelogsHandler streams Cilium Hubble flow events for a component as a
-// Server-Sent Events response.
+// WirelogsHandler streams Cilium Hubble flow events for an environment (optionally filtered by project/component)
+// as a Server-Sent Events response.
 type WirelogsHandler struct {
 	k8sClient      client.Client
 	gatewayClient  *gatewayClient.Client
@@ -57,41 +57,38 @@ func NewWirelogsHandler(k8sClient client.Client, gwClient *gatewayClient.Client,
 
 // ServeHTTP authorizes the caller, resolves the target data plane, and proxies
 // the gateway's SSE stream to the client.
-// URL: /wirelogs/namespaces/{namespace}/projects/{project}/components/{component}?environment=...
+// URL: /namespaces/{namespace}/environments/{environment}/wirelogs?project=&component=
 func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	namespace, project, component, ok := parseWirelogsPath(r.URL.Path)
+	namespace, environment, ok := parseWirelogsPath(r)
 	if !ok {
-		http.Error(w, "invalid wirelogs URL: expected /wirelogs/namespaces/{ns}/projects/{proj}/components/{name}", http.StatusBadRequest)
+		http.Error(w, "invalid wirelogs URL: expected /namespaces/{namespace}/environments/{environment}/wirelogs", http.StatusBadRequest)
 		return
 	}
 
-	environment := r.URL.Query().Get("environment")
-	if environment == "" {
-		http.Error(w, "environment query parameter is required", http.StatusBadRequest)
+	project := r.URL.Query().Get("project")
+	component := r.URL.Query().Get("component")
+
+	if component != "" && project == "" {
+		http.Error(w, "component filter requires project filter", http.StatusBadRequest)
 		return
 	}
 
 	ctx := r.Context()
-	logger := h.logger.With("namespace", namespace, "component", component)
+	logger := h.logger.With(
+		"namespace", namespace,
+		"environment", environment,
+		"project", project,
+		"component", component,
+	)
 
-	// Authorize: caller must have logs:view on the component.
-	// TODO: Add a separate permission (wirelogs:view)
 	if h.authzChecker == nil {
 		logger.Error("Authorization checker not configured")
 		http.Error(w, "authorization not configured", http.StatusInternalServerError)
 		return
 	}
-	if err := h.authzChecker.Check(ctx, svcpkg.CheckRequest{
-		Action:       authz.ActionViewLogs,
-		ResourceType: "component",
-		ResourceID:   component,
-		Hierarchy: authz.ResourceHierarchy{
-			Namespace: namespace,
-			Project:   project,
-		},
-	}); err != nil {
+	if err := h.authzChecker.Check(ctx, wirelogsCheckRequest(namespace, environment, project, component)); err != nil {
 		if errors.Is(err, svcpkg.ErrForbidden) {
-			http.Error(w, "you do not have permission to view wirelogs for this component", http.StatusForbidden)
+			http.Error(w, "you do not have permission to view wirelogs for this scope", http.StatusForbidden)
 			return
 		}
 		logger.Error("Authorization check failed", "error", err)
@@ -99,15 +96,14 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	plane, err := h.resolvePlane(ctx, namespace, component, environment)
+	plane, err := h.resolvePlane(ctx, namespace, environment)
 	if err != nil {
 		logger.Error("Failed to resolve data plane for wirelogs", "error", err)
 		http.Error(w, fmt.Sprintf("failed to resolve data plane: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	logger = logger.With("environment", environment,
-		"planeType", plane.planeType, "planeID", plane.planeID)
+	logger = logger.With("planeType", plane.planeType, "planeID", plane.planeID)
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -123,7 +119,7 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Warn("Failed to disable write deadline for SSE stream", "error", err)
 	}
 
-	gwURL, err := h.buildGatewayWirelogsURL(plane, component, project, environment, namespace)
+	gwURL, err := h.buildGatewayWirelogsURL(plane, namespace, environment, project, component)
 	if err != nil {
 		logger.Error("Failed to build gateway wirelogs URL", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -189,13 +185,49 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// resolvePlane resolves the data plane for a component+environment. The flow filter targets pods by label.
-func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, component, environment string) (execPlaneInfo, error) {
-	comp := &openchoreov1alpha1.Component{}
-	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: component}, comp); err != nil {
-		return execPlaneInfo{}, fmt.Errorf("component %q not found: %w", component, err)
-	}
+// wirelogsCheckRequest derives the most-specific authz scope from the supplied filters. The environment
+// is always exposed via Context so CEL policies can scope per-environment.
+func wirelogsCheckRequest(namespace, environment, project, component string) svcpkg.CheckRequest {
+	envAttr := svcpkg.FormatDualScopedResourceName(namespace, environment, false)
+	authzCtx := authz.Context{Resource: authz.ResourceAttribute{Environment: envAttr}}
 
+	switch {
+	case component != "":
+		return svcpkg.CheckRequest{
+			Action:       authz.ActionViewWirelogs,
+			ResourceType: "component",
+			ResourceID:   component,
+			Hierarchy: authz.ResourceHierarchy{
+				Namespace: namespace,
+				Project:   project,
+				Component: component,
+			},
+			Context: authzCtx,
+		}
+	case project != "":
+		return svcpkg.CheckRequest{
+			Action:       authz.ActionViewWirelogs,
+			ResourceType: "project",
+			ResourceID:   project,
+			Hierarchy: authz.ResourceHierarchy{
+				Namespace: namespace,
+				Project:   project,
+			},
+			Context: authzCtx,
+		}
+	default:
+		return svcpkg.CheckRequest{
+			Action:       authz.ActionViewWirelogs,
+			ResourceType: "environment",
+			ResourceID:   environment,
+			Hierarchy:    authz.ResourceHierarchy{Namespace: namespace},
+			Context:      authzCtx,
+		}
+	}
+}
+
+// resolvePlane resolves the data plane for an environment.
+func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, environment string) (execPlaneInfo, error) {
 	env := &openchoreov1alpha1.Environment{}
 	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: environment}, env); err != nil {
 		return execPlaneInfo{}, fmt.Errorf("environment %q not found: %w", environment, err)
@@ -217,7 +249,7 @@ func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, component
 }
 
 // buildGatewayWirelogsURL constructs the HTTPS URL for the gateway wirelogs SSE endpoint.
-func (h *WirelogsHandler) buildGatewayWirelogsURL(plane execPlaneInfo, component, project, environment, namespace string) (string, error) {
+func (h *WirelogsHandler) buildGatewayWirelogsURL(plane execPlaneInfo, namespace, environment, project, component string) (string, error) {
 	u, err := url.Parse(h.gatewayURL)
 	if err != nil {
 		return "", err
@@ -236,27 +268,37 @@ func (h *WirelogsHandler) buildGatewayWirelogsURL(plane execPlaneInfo, component
 		plane.planeType, plane.planeID, plane.crNamespace, plane.crName)
 
 	q := u.Query()
-	q.Set("component", component)
-	q.Set("project", project)
-	q.Set("environment", environment)
 	q.Set("namespace", namespace)
+	q.Set("environment", environment)
+	if project != "" {
+		q.Set("project", project)
+	}
+	if component != "" {
+		q.Set("component", component)
+	}
 	u.RawQuery = q.Encode()
 
 	return u.String(), nil
 }
 
-// parseWirelogsPath extracts (namespace, project, component) from the request path.
-// Expected form: /wirelogs/namespaces/{ns}/projects/{proj}/components/{comp}
-func parseWirelogsPath(p string) (namespace, project, component string, ok bool) {
-	parts := strings.Split(strings.Trim(p, "/"), "/")
-	if len(parts) != 7 {
-		return "", "", "", false
+// parseWirelogsPath extracts (namespace, environment) from the request path.
+// Expected form: /namespaces/{namespace}/environments/{environment}/wirelogs
+func parseWirelogsPath(r *http.Request) (namespace, environment string, ok bool) {
+	namespace = r.PathValue("namespace")
+	environment = r.PathValue("environment")
+	if namespace != "" && environment != "" {
+		return namespace, environment, true
 	}
-	if parts[0] != "wirelogs" || parts[1] != "namespaces" || parts[3] != "projects" || parts[5] != "components" {
-		return "", "", "", false
+
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) != 5 {
+		return "", "", false
 	}
-	if parts[2] == "" || parts[4] == "" || parts[6] == "" {
-		return "", "", "", false
+	if parts[0] != "namespaces" || parts[2] != "environments" || parts[4] != "wirelogs" {
+		return "", "", false
 	}
-	return parts[2], parts[4], parts[6], true
+	if parts[1] == "" || parts[3] == "" {
+		return "", "", false
+	}
+	return parts[1], parts[3], true
 }

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -1,0 +1,317 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	gatewayClient "github.com/openchoreo/openchoreo/internal/clients/gateway"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+)
+
+// WirelogsHandler streams Cilium Hubble flow events for a component as a
+// Server-Sent Events response. It proxies an SSE stream from the cluster-gateway
+// which in turn fans the request out to the data-plane cluster-agent.
+type WirelogsHandler struct {
+	k8sClient      client.Client
+	gatewayClient  *gatewayClient.Client
+	gatewayURL     string
+	gatewayTLSConf *tls.Config
+	authzChecker   *svcpkg.AuthzChecker
+	httpClient     *http.Client
+	logger         *slog.Logger
+}
+
+// NewWirelogsHandler creates a new wirelogs handler.
+//
+// The handler uses its own *http.Client (rather than the shared gatewayClient
+// httpClient) because the gateway client applies a request-level timeout that
+// is incompatible with the long-lived SSE stream; we rely on the inbound
+// request's context for cancellation instead.
+func NewWirelogsHandler(k8sClient client.Client, gwClient *gatewayClient.Client, gatewayURL string, gwTLSConf *tls.Config, authzChecker *svcpkg.AuthzChecker, logger *slog.Logger) *WirelogsHandler {
+	return &WirelogsHandler{
+		k8sClient:      k8sClient,
+		gatewayClient:  gwClient,
+		gatewayURL:     gatewayURL,
+		gatewayTLSConf: gwTLSConf,
+		authzChecker:   authzChecker,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: gwTLSConf,
+			},
+		},
+		logger: logger.With("component", "wirelogs-handler"),
+	}
+}
+
+// ServeHTTP authorizes the caller, resolves the target data plane, and proxies
+// the gateway's SSE stream to the client.
+// URL: /wirelogs/namespaces/{namespace}/projects/{project}/components/{component}?environment=...
+func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	namespace, project, componentName, ok := parseWirelogsPath(r.URL.Path)
+	if !ok {
+		http.Error(w, "invalid wirelogs URL: expected /wirelogs/namespaces/{ns}/projects/{proj}/components/{name}", http.StatusBadRequest)
+		return
+	}
+
+	envName := r.URL.Query().Get("environment")
+
+	ctx := r.Context()
+	logger := h.logger.With("namespace", namespace, "component", componentName)
+
+	// Authorize: caller must have logs:view on the component.
+	if h.authzChecker == nil {
+		logger.Error("Authorization checker not configured")
+		http.Error(w, "authorization not configured", http.StatusInternalServerError)
+		return
+	}
+	if err := h.authzChecker.Check(ctx, svcpkg.CheckRequest{
+		Action:       authz.ActionViewLogs,
+		ResourceType: "component",
+		ResourceID:   componentName,
+		Hierarchy: authz.ResourceHierarchy{
+			Namespace: namespace,
+			Project:   project,
+		},
+	}); err != nil {
+		if errors.Is(err, svcpkg.ErrForbidden) {
+			http.Error(w, "you do not have permission to view wirelogs for this component", http.StatusForbidden)
+			return
+		}
+		logger.Error("Authorization check failed", "error", err)
+		http.Error(w, "authorization check failed", http.StatusInternalServerError)
+		return
+	}
+
+	plane, err := h.resolvePlane(ctx, namespace, componentName, project, &envName)
+	if err != nil {
+		logger.Error("Failed to resolve data plane for wirelogs", "error", err)
+		http.Error(w, fmt.Sprintf("failed to resolve data plane: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	logger = logger.With("environment", envName,
+		"planeType", plane.planeType, "planeID", plane.planeID)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		logger.Error("ResponseWriter does not support flushing; cannot stream SSE")
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	// The http.Server's WriteTimeout is an absolute deadline from when request
+	// headers are read; for a long-lived SSE stream it would kill the connection
+	// after that deadline regardless of activity (the classic "curl: (18) transfer
+	// closed with outstanding read data remaining" once nothing has been sent for
+	// a while). Clear the deadline on this connection only — other endpoints keep
+	// the server's default protection.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+		logger.Warn("Failed to disable write deadline for SSE stream", "error", err)
+	}
+
+	gwURL, err := h.buildGatewayWirelogsURL(plane, componentName, project, envName, namespace)
+	if err != nil {
+		logger.Error("Failed to build gateway wirelogs URL", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	gwReq, err := http.NewRequestWithContext(ctx, http.MethodGet, gwURL, nil)
+	if err != nil {
+		logger.Error("Failed to build gateway request", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	gwReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := h.httpClient.Do(gwReq)
+	if err != nil {
+		logger.Error("Failed to connect to gateway wirelogs endpoint", "error", err)
+		http.Error(w, fmt.Sprintf("failed to connect to data plane: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		logger.Error("Gateway returned non-OK status", "status", resp.StatusCode, "body", string(body))
+		// Surface the gateway's status code unless it's something we shouldn't pass through.
+		status := resp.StatusCode
+		if status < 400 || status >= 600 {
+			status = http.StatusBadGateway
+		}
+		http.Error(w, fmt.Sprintf("gateway error: %s", strings.TrimSpace(string(body))), status)
+		return
+	}
+
+	// Commit to SSE: write headers (no Content-Length, force flush on each chunk).
+	hdr := w.Header()
+	hdr.Set("Content-Type", "text/event-stream")
+	hdr.Set("Cache-Control", "no-cache, no-transform")
+	hdr.Set("Connection", "keep-alive")
+	hdr.Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	logger.Info("Wirelogs SSE stream started")
+
+	// The gateway already emits valid SSE framing — passing bytes through
+	// verbatim preserves event boundaries. Flush after every read so events
+	// reach the client immediately rather than being buffered.
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				logger.Debug("Client write failed; ending stream", "error", werr)
+				return
+			}
+			flusher.Flush()
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) && !errors.Is(readErr, context.Canceled) {
+				logger.Debug("Gateway stream ended with error", "error", readErr)
+			}
+			return
+		}
+	}
+}
+
+// resolvePlane resolves the data plane for a component+environment without
+// requiring a specific pod (unlike exec). The flow filter targets pods by label.
+func (h *WirelogsHandler) resolvePlane(ctx context.Context, namespace, componentName, project string, envName *string) (execPlaneInfo, error) {
+	comp := &openchoreov1alpha1.Component{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: componentName}, comp); err != nil {
+		return execPlaneInfo{}, fmt.Errorf("component %q not found: %w", componentName, err)
+	}
+
+	if *envName == "" {
+		if project == "" {
+			return execPlaneInfo{}, fmt.Errorf("--project or --environment is required")
+		}
+		resolved, err := h.resolveLowestEnvironment(ctx, namespace, project)
+		if err != nil {
+			return execPlaneInfo{}, err
+		}
+		*envName = resolved
+	}
+
+	env := &openchoreov1alpha1.Environment{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: *envName}, env); err != nil {
+		return execPlaneInfo{}, fmt.Errorf("environment %q not found: %w", *envName, err)
+	}
+	if env.Spec.DataPlaneRef == nil {
+		return execPlaneInfo{}, fmt.Errorf("environment %q has no data plane reference", *envName)
+	}
+
+	dpResult, err := controller.GetDataPlaneFromRef(ctx, h.k8sClient, env.Namespace, env.Spec.DataPlaneRef)
+	if err != nil {
+		return execPlaneInfo{}, fmt.Errorf("failed to resolve data plane: %w", err)
+	}
+
+	plane := resolveExecPlaneInfo(dpResult)
+	if plane.planeID == "" {
+		return execPlaneInfo{}, fmt.Errorf("failed to determine plane ID for environment %q", *envName)
+	}
+	return plane, nil
+}
+
+// resolveLowestEnvironment finds the root environment from the project's deployment pipeline.
+func (h *WirelogsHandler) resolveLowestEnvironment(ctx context.Context, namespace, projectName string) (string, error) {
+	proj := &openchoreov1alpha1.Project{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: projectName}, proj); err != nil {
+		return "", fmt.Errorf("project %q not found: %w", projectName, err)
+	}
+
+	if proj.Spec.DeploymentPipelineRef.Name == "" {
+		return "", fmt.Errorf("project %q has no deployment pipeline configured", projectName)
+	}
+
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: proj.Spec.DeploymentPipelineRef.Name}, pipeline); err != nil {
+		return "", fmt.Errorf("deployment pipeline not found: %w", err)
+	}
+
+	if len(pipeline.Spec.PromotionPaths) == 0 {
+		return "", fmt.Errorf("deployment pipeline has no promotion paths")
+	}
+
+	// Find root environment (source that is never a target)
+	targets := make(map[string]bool)
+	for _, path := range pipeline.Spec.PromotionPaths {
+		for _, target := range path.TargetEnvironmentRefs {
+			targets[target.Name] = true
+		}
+	}
+
+	for _, path := range pipeline.Spec.PromotionPaths {
+		if path.SourceEnvironmentRef.Name != "" && !targets[path.SourceEnvironmentRef.Name] {
+			return path.SourceEnvironmentRef.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no root environment found in deployment pipeline")
+}
+
+// buildGatewayWirelogsURL constructs the HTTPS URL for the gateway wirelogs SSE
+// endpoint. The gateway↔agent hop remains WebSocket-based, but the api↔gateway
+// hop is now plain HTTP with SSE framing.
+func (h *WirelogsHandler) buildGatewayWirelogsURL(plane execPlaneInfo, component, project, environment, namespace string) (string, error) {
+	u, err := url.Parse(h.gatewayURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Normalize any leftover ws/wss schemes to their HTTP equivalents so callers
+	// passing the gateway base URL in either form Just Work.
+	switch u.Scheme {
+	case "wss":
+		u.Scheme = "https"
+	case "ws":
+		u.Scheme = "http"
+	}
+
+	u.Path = fmt.Sprintf("/api/wirelogs/%s/%s/%s/%s",
+		plane.planeType, plane.planeID, plane.crNamespace, plane.crName)
+
+	q := u.Query()
+	q.Set("component", component)
+	q.Set("project", project)
+	q.Set("environment", environment)
+	q.Set("namespace", namespace)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// parseWirelogsPath extracts (namespace, project, component) from the request path.
+// Expected form: /wirelogs/namespaces/{ns}/projects/{proj}/components/{comp}
+func parseWirelogsPath(p string) (namespace, project, component string, ok bool) {
+	parts := strings.Split(strings.Trim(p, "/"), "/")
+	if len(parts) != 7 {
+		return "", "", "", false
+	}
+	if parts[0] != "wirelogs" || parts[1] != "namespaces" || parts[3] != "projects" || parts[5] != "components" {
+		return "", "", "", false
+	}
+	if parts[2] == "" || parts[4] == "" || parts[6] == "" {
+		return "", "", "", false
+	}
+	return parts[2], parts[4], parts[6], true
+}

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -5,15 +5,21 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	authzmocks "github.com/openchoreo/openchoreo/internal/authz/core/mocks"
 	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
@@ -215,4 +221,275 @@ func TestBuildGatewayWirelogsURL_OmitsBlankFilters(t *testing.T) {
 	assert.Contains(t, got, "environment=development")
 	assert.NotContains(t, got, "project=")
 	assert.NotContains(t, got, "component=")
+}
+
+// --- ServeHTTP path coverage with a fake k8s client ----------------------
+
+func allowingAuthz(t *testing.T) *svcpkg.AuthzChecker {
+	t.Helper()
+	pdp := authzmocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Return(&authz.Decision{Decision: true, Context: &authz.DecisionContext{}}, nil).
+		Maybe()
+	return svcpkg.NewAuthzChecker(pdp, slog.Default())
+}
+
+// seedEnvAndDP returns objects representing an Environment "development" in
+// namespace "ns-a" referencing a DataPlane "prod-dp" in the same namespace.
+// Mirrors what resolvePlane expects to find via h.k8sClient.Get.
+func seedEnvAndDP() []client.Object {
+	return []client.Object{
+		&openchoreov1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: "development", Namespace: "ns-a"},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindDataPlane,
+					Name: "prod-dp",
+				},
+			},
+		},
+		&openchoreov1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-dp", Namespace: "ns-a"},
+		},
+	}
+}
+
+// newWirelogsK8sClient builds a controller-runtime fake client seeded with the
+// supplied objects, using the package's shared test scheme.
+func newWirelogsK8sClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objs...).
+		Build()
+}
+
+func TestWirelogsHandler_RejectsInvalidNameParams(t *testing.T) {
+	// Each case tweaks one path/query segment to fail the RFC1123 regex or
+	// length cap, with all others valid.
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"namespace too long", "/namespaces/" + strings.Repeat("a", 64) + "/environments/development/wirelogs", "invalid namespace parameter"},
+		{"namespace uppercase", "/namespaces/NS_A/environments/development/wirelogs", "invalid namespace parameter"},
+		{"environment uppercase", "/namespaces/ns-a/environments/DEV/wirelogs", "invalid environment parameter"},
+		{"project uppercase", "/namespaces/ns-a/environments/development/wirelogs?project=DEMO", "invalid project parameter"},
+		{"component uppercase", "/namespaces/ns-a/environments/development/wirelogs?project=demo&component=Checkout", "invalid component parameter"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &WirelogsHandler{
+				authzChecker: svcpkg.NewAuthzChecker(authzmocks.NewMockPDP(t), slog.Default()),
+				logger:       slog.Default(),
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, wirelogsRequest(t, tc.path))
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), tc.want)
+		})
+	}
+}
+
+func TestWirelogsHandler_AuthzCheckInternalError(t *testing.T) {
+	// PDP returning a non-Forbidden error must map to 500, not 403.
+	pdp := authzmocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Return(nil, errors.New("policy engine down"))
+
+	h := &WirelogsHandler{
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "authorization check failed")
+}
+
+func TestWirelogsHandler_PlaneResolve_EnvironmentNotFound(t *testing.T) {
+	// Empty fake client → resolvePlane's Get returns NotFound.
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to resolve data plane")
+	assert.Contains(t, rec.Body.String(), "environment \"development\" not found")
+}
+
+func TestWirelogsHandler_PlaneResolve_EnvironmentMissingDataPlaneRef(t *testing.T) {
+	// Environment exists but has no DataPlaneRef → resolvePlane returns the
+	// dedicated "no data plane reference" error before doing a DataPlane lookup.
+	env := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "development", Namespace: "ns-a"},
+	}
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, env),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no data plane reference")
+}
+
+// wirelogsNoFlushRecorder hides ResponseRecorder.Flush from the http.Flusher
+// type assertion so the handler's "streaming unsupported" branch triggers.
+type wirelogsNoFlushRecorder struct {
+	rec *httptest.ResponseRecorder
+}
+
+func (n *wirelogsNoFlushRecorder) Header() http.Header         { return n.rec.Header() }
+func (n *wirelogsNoFlushRecorder) Write(b []byte) (int, error) { return n.rec.Write(b) }
+func (n *wirelogsNoFlushRecorder) WriteHeader(code int)        { n.rec.WriteHeader(code) }
+
+func TestWirelogsHandler_NoFlusherSupport(t *testing.T) {
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, seedEnvAndDP()...),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+	}
+
+	rec := &wirelogsNoFlushRecorder{rec: httptest.NewRecorder()}
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.rec.Code)
+	assert.Contains(t, rec.rec.Body.String(), "streaming unsupported")
+}
+
+func TestWirelogsHandler_GatewayDialError(t *testing.T) {
+	// Start and immediately close a test server so the URL routes nowhere.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	srv.Close()
+
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, seedEnvAndDP()...),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+		gatewayURL:   srv.URL,
+		httpClient:   srv.Client(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to connect to data plane")
+}
+
+func TestWirelogsHandler_GatewayNonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no agent available: not connected", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, seedEnvAndDP()...),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+		gatewayURL:   srv.URL,
+		httpClient:   srv.Client(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"503 from the gateway must be propagated, not collapsed to 502")
+	assert.Contains(t, rec.Body.String(), "no agent available")
+}
+
+func TestWirelogsHandler_GatewayWeirdStatusCoercedTo502(t *testing.T) {
+	// Out-of-range status codes from the upstream must be normalised to 502 so
+	// http.Error doesn't panic / emit an unparsable status to the client.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(299)
+		_, _ = w.Write([]byte("weird"))
+	}))
+	defer srv.Close()
+
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, seedEnvAndDP()...),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+		gatewayURL:   srv.URL,
+		httpClient:   srv.Client(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestWirelogsHandler_HappyPath(t *testing.T) {
+	// Stand up a fake gateway that emits two SSE events and closes the stream.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// resolvePlane → resolveExecPlaneInfo: empty Spec.PlaneID falls back to
+		// the DataPlane name, so the URL path must encode "prod-dp" twice
+		// (planeID and crName) and "ns-a" as crNamespace.
+		require.Equal(t, "/api/wirelogs/dataplane/prod-dp/ns-a/prod-dp", r.URL.Path)
+
+		// Forwarded query params should reach the gateway intact.
+		require.Equal(t, "ns-a", r.URL.Query().Get("namespace"))
+		require.Equal(t, "development", r.URL.Query().Get("environment"))
+		require.Equal(t, "shopfront", r.URL.Query().Get("project"))
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		_, _ = w.Write([]byte("data: {\"flow\":\"a\"}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		_, _ = w.Write([]byte("data: {\"flow\":\"b\"}\n\n"))
+	}))
+	defer srv.Close()
+
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, seedEnvAndDP()...),
+		authzChecker: allowingAuthz(t),
+		logger:       slog.Default(),
+		gatewayURL:   srv.URL,
+		httpClient:   srv.Client(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t,
+		"/namespaces/ns-a/environments/development/wirelogs?project=shopfront"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache, no-transform", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"))
+	body := rec.Body.String()
+	assert.Contains(t, body, "data: {\"flow\":\"a\"}")
+	assert.Contains(t, body, "data: {\"flow\":\"b\"}")
+}
+
+func TestNewWirelogsHandler_InitialisesHTTPClient(t *testing.T) {
+	// The handler must own a *http.Client distinct from the gatewayClient's so
+	// the gateway client's request-level timeout doesn't kill a long-lived SSE
+	// stream. We can't reach in to verify the timeout difference directly, but
+	// we can at least assert the field is populated and the logger tag stuck.
+	h := NewWirelogsHandler(nil, nil, "https://gw.example.com", nil, nil, slog.Default())
+	require.NotNil(t, h)
+	assert.NotNil(t, h.httpClient, "httpClient must be initialized")
+	assert.Equal(t, "https://gw.example.com", h.gatewayURL)
+	assert.NotNil(t, h.logger)
 }

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -20,9 +20,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
 
-// wirelogsRequest builds an HTTP request that mimics what the JWT middleware
-// would hand the handler: a subject is attached to the request context so the
-// AuthzChecker can resolve it.
+// Mimics the JWT middleware by attaching a subject the AuthzChecker can resolve.
 func wirelogsRequest(t *testing.T, path string) *http.Request {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -50,9 +48,9 @@ func TestWirelogsHandler_RejectsMalformedPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// authzChecker is set so the handler can't short-circuit there;
-			// URL parsing runs before authz so this path must fail with 400.
-			pdp := authzmocks.NewMockPDP(t) // no expectations: panics if called
+			// Path parsing runs before authz, so a configured PDP with no
+			// expectations doubles as a guard that authz isn't reached.
+			pdp := authzmocks.NewMockPDP(t)
 			h := &WirelogsHandler{
 				authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
 				logger:       slog.Default(),
@@ -61,13 +59,28 @@ func TestWirelogsHandler_RejectsMalformedPath(t *testing.T) {
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, wirelogsRequest(t, tt.path))
 
-			assert.Equal(t, http.StatusBadRequest, rec.Code, "malformed URL must produce 400")
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		})
 	}
 }
 
+func TestWirelogsHandler_RequiresEnvironmentQueryParam(t *testing.T) {
+	// environment is mandatory — there's no lowest-environment fallback.
+	pdp := authzmocks.NewMockPDP(t)
+	h := &WirelogsHandler{
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "environment query parameter is required")
+}
+
 func TestWirelogsHandler_AuthzNotConfigured(t *testing.T) {
-	h := &WirelogsHandler{logger: slog.Default()} // authzChecker == nil
+	h := &WirelogsHandler{logger: slog.Default()}
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
@@ -93,8 +106,8 @@ func TestWirelogsHandler_Forbidden(t *testing.T) {
 }
 
 func TestWirelogsHandler_PassesActionViewLogs(t *testing.T) {
-	// Verify the handler asks the PDP about logs:view at the component scope.
-	// Capture the request via RunAndReturn so we can assert its shape.
+	// Capture the PDP request to assert the handler asks about logs:view at the
+	// component scope. Deny so the handler returns 403 before dialing the gateway.
 	var captured *authz.EvaluateRequest
 
 	pdp := authzmocks.NewMockPDP(t)
@@ -102,7 +115,6 @@ func TestWirelogsHandler_PassesActionViewLogs(t *testing.T) {
 		RunAndReturn(func(_ context.Context, req *authz.EvaluateRequest) (*authz.Decision, error) {
 			require.NotNil(t, req)
 			captured = req
-			// Deny so the handler returns 403 before attempting to dial the gateway.
 			return &authz.Decision{Decision: false, Context: &authz.DecisionContext{}}, nil
 		})
 
@@ -120,7 +132,7 @@ func TestWirelogsHandler_PassesActionViewLogs(t *testing.T) {
 	assert.Equal(t, "component", captured.Resource.Type)
 	assert.Equal(t, "checkout", captured.Resource.ID)
 	assert.Equal(t, "ns-a", captured.Resource.Hierarchy.Namespace)
-	assert.Equal(t, "demo", captured.Resource.Hierarchy.Project, "project must come from the URL path")
+	assert.Equal(t, "demo", captured.Resource.Hierarchy.Project)
 }
 
 func TestBuildGatewayWirelogsURL(t *testing.T) {

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -492,4 +492,15 @@ func TestNewWirelogsHandler_InitialisesHTTPClient(t *testing.T) {
 	assert.NotNil(t, h.httpClient, "httpClient must be initialized")
 	assert.Equal(t, "https://gw.example.com", h.gatewayURL)
 	assert.NotNil(t, h.logger)
+
+	// Client.Timeout must stay zero — an absolute request deadline would kill
+	// the long-lived SSE stream. Pre-stream phases are bounded via Transport.
+	assert.Zero(t, h.httpClient.Timeout,
+		"Client.Timeout must be unset; it would abort the long-lived SSE stream")
+
+	tr, ok := h.httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "Transport must be *http.Transport")
+	assert.NotZero(t, tr.TLSHandshakeTimeout, "TLSHandshakeTimeout must be set to bound the handshake")
+	assert.NotZero(t, tr.ResponseHeaderTimeout, "ResponseHeaderTimeout must be set so a stuck gateway can't block before the stream starts")
+	assert.NotNil(t, tr.DialContext, "DialContext must be set to bound TCP connect")
 }

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	authzmocks "github.com/openchoreo/openchoreo/internal/authz/core/mocks"
+	svcpkg "github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
+)
+
+// wirelogsRequest builds an HTTP request that mimics what the JWT middleware
+// would hand the handler: a subject is attached to the request context so the
+// AuthzChecker can resolve it.
+func wirelogsRequest(t *testing.T, path string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	ctx := auth.SetSubjectContext(req.Context(), &auth.SubjectContext{
+		ID:                "user-1",
+		Type:              "user",
+		EntitlementClaim:  "groups",
+		EntitlementValues: []string{"viewers"},
+	})
+	return req.WithContext(ctx)
+}
+
+func TestWirelogsHandler_RejectsMalformedPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"missing namespaces segment", "/wirelogs/checkout"},
+		{"missing projects segment", "/wirelogs/namespaces/ns-a/components/checkout"},
+		{"missing components segment", "/wirelogs/namespaces/ns-a/projects/demo"},
+		{"empty namespace", "/wirelogs/namespaces//projects/demo/components/checkout"},
+		{"empty project", "/wirelogs/namespaces/ns-a/projects//components/checkout"},
+		{"empty component", "/wirelogs/namespaces/ns-a/projects/demo/components/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// authzChecker is set so the handler can't short-circuit there;
+			// URL parsing runs before authz so this path must fail with 400.
+			pdp := authzmocks.NewMockPDP(t) // no expectations: panics if called
+			h := &WirelogsHandler{
+				authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+				logger:       slog.Default(),
+			}
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, wirelogsRequest(t, tt.path))
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "malformed URL must produce 400")
+		})
+	}
+}
+
+func TestWirelogsHandler_AuthzNotConfigured(t *testing.T) {
+	h := &WirelogsHandler{logger: slog.Default()} // authzChecker == nil
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "authorization not configured")
+}
+
+func TestWirelogsHandler_Forbidden(t *testing.T) {
+	pdp := authzmocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Return(&authz.Decision{Decision: false, Context: &authz.DecisionContext{Reason: "no logs:view"}}, nil)
+
+	h := &WirelogsHandler{
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestWirelogsHandler_PassesActionViewLogs(t *testing.T) {
+	// Verify the handler asks the PDP about logs:view at the component scope.
+	// Capture the request via RunAndReturn so we can assert its shape.
+	var captured *authz.EvaluateRequest
+
+	pdp := authzmocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, req *authz.EvaluateRequest) (*authz.Decision, error) {
+			require.NotNil(t, req)
+			captured = req
+			// Deny so the handler returns 403 before attempting to dial the gateway.
+			return &authz.Decision{Decision: false, Context: &authz.DecisionContext{}}, nil
+		})
+
+	h := &WirelogsHandler{
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, authz.ActionViewLogs, captured.Action, "wirelogs must reuse the logs:view permission")
+	assert.Equal(t, "component", captured.Resource.Type)
+	assert.Equal(t, "checkout", captured.Resource.ID)
+	assert.Equal(t, "ns-a", captured.Resource.Hierarchy.Namespace)
+	assert.Equal(t, "demo", captured.Resource.Hierarchy.Project, "project must come from the URL path")
+}
+
+func TestBuildGatewayWirelogsURL(t *testing.T) {
+	h := &WirelogsHandler{gatewayURL: "https://gw.example.com:8443"}
+
+	got, err := h.buildGatewayWirelogsURL(execPlaneInfo{
+		planeType:   "dataplane",
+		planeID:     "prod-cluster",
+		crNamespace: "team-a",
+		crName:      "prod-dp",
+	}, "checkout", "shopfront", "development", "ns-a")
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "https://gw.example.com:8443/api/wirelogs/dataplane/prod-cluster/team-a/prod-dp")
+	assert.Contains(t, got, "component=checkout")
+	assert.Contains(t, got, "project=shopfront")
+	assert.Contains(t, got, "environment=development")
+	assert.Contains(t, got, "namespace=ns-a")
+}

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -38,12 +38,12 @@ func TestWirelogsHandler_RejectsMalformedPath(t *testing.T) {
 		name string
 		path string
 	}{
-		{"missing namespaces segment", "/wirelogs/checkout"},
-		{"missing projects segment", "/wirelogs/namespaces/ns-a/components/checkout"},
-		{"missing components segment", "/wirelogs/namespaces/ns-a/projects/demo"},
-		{"empty namespace", "/wirelogs/namespaces//projects/demo/components/checkout"},
-		{"empty project", "/wirelogs/namespaces/ns-a/projects//components/checkout"},
-		{"empty component", "/wirelogs/namespaces/ns-a/projects/demo/components/"},
+		{"missing namespaces segment", "/environments/development/wirelogs"},
+		{"missing environments segment", "/namespaces/ns-a/wirelogs"},
+		{"wrong final segment", "/namespaces/ns-a/environments/development/foo"},
+		{"empty namespace", "/namespaces//environments/development/wirelogs"},
+		{"empty environment", "/namespaces/ns-a/environments//wirelogs"},
+		{"extra trailing path", "/namespaces/ns-a/environments/development/wirelogs/extra"},
 	}
 
 	for _, tt := range tests {
@@ -64,26 +64,28 @@ func TestWirelogsHandler_RejectsMalformedPath(t *testing.T) {
 	}
 }
 
-func TestWirelogsHandler_RequiresEnvironmentQueryParam(t *testing.T) {
-	// environment is mandatory — there's no lowest-environment fallback.
+func TestWirelogsHandler_AcceptsEnvironmentWideRequest(t *testing.T) {
+	// No project/component query params -> entire environment scope.
 	pdp := authzmocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Return(&authz.Decision{Decision: false, Context: &authz.DecisionContext{}}, nil)
+
 	h := &WirelogsHandler{
 		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
 		logger:       slog.Default(),
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "environment query parameter is required")
+	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
 func TestWirelogsHandler_AuthzNotConfigured(t *testing.T) {
 	h := &WirelogsHandler{logger: slog.Default()}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Contains(t, rec.Body.String(), "authorization not configured")
@@ -92,7 +94,7 @@ func TestWirelogsHandler_AuthzNotConfigured(t *testing.T) {
 func TestWirelogsHandler_Forbidden(t *testing.T) {
 	pdp := authzmocks.NewMockPDP(t)
 	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
-		Return(&authz.Decision{Decision: false, Context: &authz.DecisionContext{Reason: "no logs:view"}}, nil)
+		Return(&authz.Decision{Decision: false, Context: &authz.DecisionContext{Reason: "no wirelogs:view"}}, nil)
 
 	h := &WirelogsHandler{
 		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
@@ -100,16 +102,17 @@ func TestWirelogsHandler_Forbidden(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout"))
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
-func TestWirelogsHandler_PassesActionViewLogs(t *testing.T) {
-	// Capture the PDP request to assert the handler asks about logs:view at the
-	// component scope. Deny so the handler returns 403 before dialing the gateway.
-	var captured *authz.EvaluateRequest
+// captureAuthzRequest runs ServeHTTP with a PDP that records the EvaluateRequest
+// and denies, so the handler returns 403 before doing any data-plane lookups.
+func captureAuthzRequest(t *testing.T, path string) *authz.EvaluateRequest {
+	t.Helper()
 
+	var captured *authz.EvaluateRequest
 	pdp := authzmocks.NewMockPDP(t)
 	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
 		RunAndReturn(func(_ context.Context, req *authz.EvaluateRequest) (*authz.Decision, error) {
@@ -124,18 +127,62 @@ func TestWirelogsHandler_PassesActionViewLogs(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/wirelogs/namespaces/ns-a/projects/demo/components/checkout?environment=development"))
-
+	h.ServeHTTP(rec, wirelogsRequest(t, path))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+
 	require.NotNil(t, captured)
-	assert.Equal(t, authz.ActionViewLogs, captured.Action, "wirelogs must reuse the logs:view permission")
-	assert.Equal(t, "component", captured.Resource.Type)
-	assert.Equal(t, "checkout", captured.Resource.ID)
-	assert.Equal(t, "ns-a", captured.Resource.Hierarchy.Namespace)
-	assert.Equal(t, "demo", captured.Resource.Hierarchy.Project)
+	return captured
 }
 
-func TestBuildGatewayWirelogsURL(t *testing.T) {
+func TestWirelogsHandler_AuthzScope_Component(t *testing.T) {
+	req := captureAuthzRequest(t, "/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout")
+
+	assert.Equal(t, authz.ActionViewWirelogs, req.Action, "wirelogs must check its own action, not logs:view")
+	assert.Equal(t, "component", req.Resource.Type)
+	assert.Equal(t, "checkout", req.Resource.ID)
+	assert.Equal(t, "ns-a", req.Resource.Hierarchy.Namespace)
+	assert.Equal(t, "demo", req.Resource.Hierarchy.Project)
+	assert.Equal(t, "checkout", req.Resource.Hierarchy.Component)
+	assert.Equal(t, "ns-a/development", req.Context.Resource.Environment,
+		"resource.environment must always be set so CEL conditions can scope per env")
+}
+
+func TestWirelogsHandler_AuthzScope_ProjectOnly(t *testing.T) {
+	req := captureAuthzRequest(t, "/namespaces/ns-a/environments/development/wirelogs?project=demo")
+
+	assert.Equal(t, "project", req.Resource.Type)
+	assert.Equal(t, "demo", req.Resource.ID)
+	assert.Equal(t, "ns-a", req.Resource.Hierarchy.Namespace)
+	assert.Equal(t, "demo", req.Resource.Hierarchy.Project)
+	assert.Empty(t, req.Resource.Hierarchy.Component)
+}
+
+func TestWirelogsHandler_ComponentWithoutProjectRejected(t *testing.T) {
+	pdp := authzmocks.NewMockPDP(t)
+	h := &WirelogsHandler{
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs?component=checkout"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "component filter requires project filter")
+}
+
+func TestWirelogsHandler_AuthzScope_EnvironmentWide(t *testing.T) {
+	req := captureAuthzRequest(t, "/namespaces/ns-a/environments/development/wirelogs")
+
+	assert.Equal(t, "environment", req.Resource.Type)
+	assert.Equal(t, "development", req.Resource.ID)
+	assert.Equal(t, "ns-a", req.Resource.Hierarchy.Namespace)
+	assert.Empty(t, req.Resource.Hierarchy.Project)
+	assert.Empty(t, req.Resource.Hierarchy.Component)
+	assert.Equal(t, "ns-a/development", req.Context.Resource.Environment)
+}
+
+func TestBuildGatewayWirelogsURL_AllFilters(t *testing.T) {
 	h := &WirelogsHandler{gatewayURL: "https://gw.example.com:8443"}
 
 	got, err := h.buildGatewayWirelogsURL(execPlaneInfo{
@@ -143,12 +190,29 @@ func TestBuildGatewayWirelogsURL(t *testing.T) {
 		planeID:     "prod-cluster",
 		crNamespace: "team-a",
 		crName:      "prod-dp",
-	}, "checkout", "shopfront", "development", "ns-a")
+	}, "ns-a", "development", "shopfront", "checkout")
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "https://gw.example.com:8443/api/wirelogs/dataplane/prod-cluster/team-a/prod-dp")
-	assert.Contains(t, got, "component=checkout")
-	assert.Contains(t, got, "project=shopfront")
-	assert.Contains(t, got, "environment=development")
 	assert.Contains(t, got, "namespace=ns-a")
+	assert.Contains(t, got, "environment=development")
+	assert.Contains(t, got, "project=shopfront")
+	assert.Contains(t, got, "component=checkout")
+}
+
+func TestBuildGatewayWirelogsURL_OmitsBlankFilters(t *testing.T) {
+	h := &WirelogsHandler{gatewayURL: "https://gw.example.com:8443"}
+
+	got, err := h.buildGatewayWirelogsURL(execPlaneInfo{
+		planeType:   "dataplane",
+		planeID:     "prod-cluster",
+		crNamespace: "team-a",
+		crName:      "prod-dp",
+	}, "ns-a", "development", "", "")
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "namespace=ns-a")
+	assert.Contains(t, got, "environment=development")
+	assert.NotContains(t, got, "project=")
+	assert.NotContains(t, got, "component=")
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces support for streaming Cilium Hubble network flow logs ("wirelogs") through the OpenChoreo data plane and cluster gateway, along with improvements to configuration and authorization. The main changes include implementing the wirelogs streaming logic in the cluster agent, exposing a new wirelogs endpoint in the API, extending authorization for wirelogs, and adding configuration options for environment variables in the Helm chart.

**Wirelogs (Cilium Hubble) support:**

* Added a new `hubble.go` module to the cluster agent, implementing a server-streaming session that connects to Hubble Relay, filters flows by environment/project/component, and forwards them as framed chunks to the gateway. Includes tests for filter construction and session handling (`internal/cluster-agent/hubble.go`, `internal/cluster-agent/hubble_test.go`). [[1]](diffhunk://#diff-b1d50f6e90186cc855d446d909c5ef9f2002fb6aed75edde12421c4ce2f84d3bR1-R212) [[2]](diffhunk://#diff-7e7a274bdf471b994045bff37e7ea15fa0be36c78fe92d8adb6dd9994de5d53fR1-R147)
* Extended the cluster agent to manage hubble streaming sessions (`hubbleStreams`) and route incoming stream messages appropriately; added session lifecycle management in `agent.go`. [[1]](diffhunk://#diff-9cc3e5291431bebc6871b13de0bdbf27214d02b7f4c3c4f39c80fbd70865d9c6R49-R51) [[2]](diffhunk://#diff-9cc3e5291431bebc6871b13de0bdbf27214d02b7f4c3c4f39c80fbd70865d9c6R105) [[3]](diffhunk://#diff-9cc3e5291431bebc6871b13de0bdbf27214d02b7f4c3c4f39c80fbd70865d9c6L240-R262)

**API and routing changes:**

* Registered a new `/namespaces/{namespace}/environments/{environment}/wirelogs` endpoint in the API, protected by JWT middleware and a dedicated authorization checker; logs registration for observability.
* Added a WebSocket handler for `/api/wirelogs/` in the cluster gateway, with a placeholder constant for cluster-scoped CRs. [[1]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83R35) [[2]](diffhunk://#diff-f29198cc4c3955074fd82091d528cd27501ed3b3b70040d11a810251b1d46c83R122) [[3]](diffhunk://#diff-46191fdb54c67828ed2d60800f0e96cff9c3d4672ba233940eb38c87afba3a26L61-R61)

**Authorization and access control:**

* Introduced a new `wirelogs:view` action in the authorization core, with environment-level scoping and condition registry wiring. [[1]](diffhunk://#diff-264f336899ce0e5dd8a92ac2cbb4afeb0df49f4f42e5aecd24ff4e9aa2dce8d8R230-R232) [[2]](diffhunk://#diff-264f336899ce0e5dd8a92ac2cbb4afeb0df49f4f42e5aecd24ff4e9aa2dce8d8R468-R470) [[3]](diffhunk://#diff-6b95ee4dc7746c0800595de38da35b797bb6fd63eb53a75d8b71913e0104ac53R65)

**Helm chart and configuration:**

* Added support for specifying extra environment variables for the cluster agent via the Helm chart (`extraEnvs`), updating the schema and deployment template accordingly. [[1]](diffhunk://#diff-a1b50a38b97d8c07f88804aa9664c0dbc1ca0d4f09842ea3b39657e12380b459R17-R36) [[2]](diffhunk://#diff-342c1aa422ad171ca7d2aa5cce28fe8b0ff13365fc7ea11116b99fc679cc876eR404-R419) [[3]](diffhunk://#diff-4894598c663ef3d5b6f8fff89e3329f33b56289f60b00279cb76b1a8552b3f10R74-R76)

**Dependency updates:**

* Added `github.com/cilium/cilium` as a dependency and made minor adjustments to Go module requirements. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R7) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L93) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L154-R155)

## Approach
Usage (example):
- Request
```
curl 'https://api.openchoreo.localhost:8080/namespaces/default/environments/development/wirelogs?project=url-shortener' -H "Authorization: Bearer $TOKEN"
```
- Response
```
data: {"flow":{"time":"2026-05-25T10:01:06.106266953Z", "uuid":"6d99e34e-fe32-4014-a245-7b4198d93b78", "verdict":"FORWARDED", "IP":{"source":"10.0.0.134", "destination":"10.0.0.16", "ipVersion":"IPv4"}, "l4":{"TCP":{"source_port":39768, "destination_port":3000, "flags":{"PSH":true, "ACK":true}}}, "source":{"cluster_name":"default", "namespace":"openchoreo-data-plane", "labels":["k8s:io.kubernetes.pod.namespace=openchoreo-data-plane"], "pod_name":"gateway-default-675fdbb9d5-w444s"}, "destination":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":false, "proxy_port":11726, "Summary":"TCP Flags: ACK, PSH"}, "time":"2026-05-25T10:01:06.106266953Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.107804494Z", "uuid":"899cb464-25cc-476b-9843-4a6dba5f31fd", "verdict":"FORWARDED", "IP":{"source":"10.0.0.134", "destination":"10.0.0.16", "ipVersion":"IPv4"}, "l4":{"TCP":{"source_port":39768, "destination_port":3000}}, "source":{"cluster_name":"default", "namespace":"openchoreo-data-plane", "labels":["k8s:io.kubernetes.pod.namespace=openchoreo-data-plane"], "pod_name":"gateway-default-675fdbb9d5-w444s"}, "destination":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "Type":"L7", "l7":{"type":"REQUEST", "http":{"method":"GET", "url":"http://http-snip-frontend-development-default-04b79826.apps.openchoreo.192-168-64-2.nip.io:8080/api/analytics/top", "protocol":"HTTP/1.1", "headers":[{"key":":scheme", "value":"http"}, {"key":"Accept", "value":"*/*"}, {"key":"Accept-Encoding", "value":"gzip, deflate"}, {"key":"Accept-Language", "value":"en-US,en;q=0.9"}, {"key":"Referer", "value":"http://http-snip-frontend-development-default-04b79826.apps.openchoreo.192-168-64-2.nip.io:8080/"}, {"key":"User-Agent", "value":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"}, {"key":"X-Envoy-External-Address", "value":"10.0.0.134"}, {"key":"X-Forwarded-For", "value":"10.0.0.55"}, {"key":"X-Request-Id", "value":"d9aba4ca-e3a1-435b-91a1-efcc613faaec"}]}}, "traffic_direction":"INGRESS", "is_reply":false, "Summary":"HTTP/1.1 GET http://http-snip-frontend-development-default-04b79826.apps.openchoreo.192-168-64-2.nip.io:8080/api/analytics/top"}, "time":"2026-05-25T10:01:06.107804494Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.107828203Z", "uuid":"51b092cb-2cc1-4d16-b1f4-a85261d61969", "verdict":"FORWARDED", "IP":{"source":"10.0.0.55", "destination":"10.0.0.16", "ipVersion":"IPv4"}, "l4":{"TCP":{"source_port":52148, "destination_port":3000, "flags":{"PSH":true, "ACK":true}}}, "source":{"cluster_name":"default", "labels":["k8s:io.kubernetes.pod.namespace=openchoreo-data-plane"]}, "destination":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":false, "Summary":"TCP Flags: ACK, PSH"}, "time":"2026-05-25T10:01:06.107828203Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.115579328Z", "uuid":"ec5beb5c-aad2-45d1-8646-41875ce6b847", "verdict":"FORWARDED", "IP":{"source":"10.0.0.16", "destination":"10.0.0.139", "ipVersion":"IPv4"}, "l4":{"UDP":{"source_port":51262, "destination_port":53}}, "source":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "destination":{"cluster_name":"default", "namespace":"kube-system", "labels":["k8s:io.kubernetes.pod.namespace=kube-system"], "pod_name":"coredns-c4dbffb5f-m996f"}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":false, "Summary":"UDP"}, "time":"2026-05-25T10:01:06.115579328Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.115594744Z", "uuid":"17e455b7-bd85-4ce7-b033-9efaea9c27e4", "verdict":"FORWARDED", "IP":{"source":"10.0.0.16", "destination":"10.0.0.139", "ipVersion":"IPv4"}, "l4":{"UDP":{"source_port":60054, "destination_port":53}}, "source":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "destination":{"cluster_name":"default", "namespace":"kube-system", "labels":["k8s:io.kubernetes.pod.namespace=kube-system"], "pod_name":"coredns-c4dbffb5f-m996f"}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":false, "Summary":"UDP"}, "time":"2026-05-25T10:01:06.115594744Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.116319078Z", "uuid":"d91195a1-c6a9-4bba-ae5b-5c5418c983f7", "verdict":"FORWARDED", "IP":{"source":"10.0.0.139", "source_xlated":"10.43.0.10", "destination":"10.0.0.16", "ipVersion":"IPv4"}, "l4":{"UDP":{"source_port":53, "destination_port":51262}}, "source":{"cluster_name":"default", "namespace":"kube-system", "labels":["k8s:io.kubernetes.pod.namespace=kube-system"], "pod_name":"coredns-c4dbffb5f-m996f"}, "destination":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":true, "Summary":"UDP"}, "time":"2026-05-25T10:01:06.116319078Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.116414328Z", "uuid":"f7e87324-d043-402f-998a-cfc2f9ca5c68", "verdict":"FORWARDED", "IP":{"source":"10.0.0.139", "source_xlated":"10.43.0.10", "destination":"10.0.0.16", "ipVersion":"IPv4"}, "l4":{"UDP":{"source_port":53, "destination_port":60054}}, "source":{"cluster_name":"default", "namespace":"kube-system", "labels":["k8s:io.kubernetes.pod.namespace=kube-system"], "pod_name":"coredns-c4dbffb5f-m996f"}, "destination":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":true, "Summary":"UDP"}, "time":"2026-05-25T10:01:06.116414328Z"}

data: {"flow":{"time":"2026-05-25T10:01:06.117172161Z", "uuid":"81254dcc-4efe-4402-afd4-e274733f5c18", "verdict":"FORWARDED", "IP":{"source":"10.0.0.16", "destination":"10.0.0.139", "ipVersion":"IPv4"}, "l4":{"UDP":{"source_port":39569, "destination_port":53}}, "source":{"cluster_name":"default", "namespace":"dp-default-url-shortener-development-a16f373a", "labels":["k8s:io.kubernetes.pod.namespace=dp-default-url-shortener-development-a16f373a", "k8s:openchoreo.dev/component=snip-frontend", "k8s:openchoreo.dev/environment=development", "k8s:openchoreo.dev/namespace=default", "k8s:openchoreo.dev/project=url-shortener"], "pod_name":"snip-frontend-development-a3f3c5a1-95c5cdd-r2pwl", "workloads":[{"name":"snip-frontend-development-a3f3c5a1", "kind":"Deployment"}]}, "destination":{"cluster_name":"default", "namespace":"kube-system", "labels":["k8s:io.kubernetes.pod.namespace=kube-system"], "pod_name":"coredns-c4dbffb5f-m996f"}, "Type":"L3_L4", "traffic_direction":"EGRESS", "is_reply":false, "Summary":"UDP"}, "time":"2026-05-25T10:01:06.117172161Z"}

```

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3294

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
