### PR TITLE
feat: add build pipeline integration to k3d registry cache

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -366,6 +366,30 @@ $(echo "$AGENT_CA" | sed 's/^/        /')
 EOF
 ```
 
+### Route Build Pulls Through Registry Cache (Optional)
+
+Speed up build-time image pulls (buildpacks, base images, tools) by routing them through a
+local registry cache. Start the cache, then patch the build pipeline:
+
+```bash
+# Start the registry cache (if not already running)
+docker compose -f install/k3d/registry-cache/compose.yaml up -d
+
+# Patch ClusterWorkflows on the control plane cluster
+install/k3d/registry-cache/patch-build-workflows.sh --context k3d-openchoreo-cp
+
+# Patch ClusterWorkflowTemplates on the workflow plane cluster
+install/k3d/registry-cache/patch-build-templates.sh --context k3d-openchoreo-wp
+```
+
+Optionally, warm the cache by pre-pulling common build images:
+
+```bash
+kubectl --context k3d-openchoreo-wp apply -f install/k3d/registry-cache/preload-build-images.yaml
+```
+
+See [registry-cache/README.md](../registry-cache/README.md) for details and how to revert.
+
 ## 5. Observability Plane (Optional)
 
 ```bash

--- a/install/k3d/registry-cache/README.md
+++ b/install/k3d/registry-cache/README.md
@@ -29,6 +29,7 @@ registry.
 | 5602 | docker.io       |
 | 5603 | quay.io         |
 | 5604 | cr.kgateway.dev |
+| 5605 | gcr.io          |
 
 ## Quick Start
 
@@ -47,6 +48,9 @@ Then create your k3d cluster with the registry mirrors. Add this to your k3d con
 registries:
   config: |
     mirrors:
+      "host.k3d.internal:10082":
+        endpoint:
+          - http://host.k3d.internal:10082
       "ghcr.io":
         endpoint:
           - http://host.k3d.internal:5601
@@ -59,6 +63,9 @@ registries:
       "cr.kgateway.dev":
         endpoint:
           - http://host.k3d.internal:5604
+      "gcr.io":
+        endpoint:
+          - http://host.k3d.internal:5605
 ```
 
 ## Browsing Cached Images
@@ -94,6 +101,56 @@ Use the purge script to invalidate stale images:
 # Purge everything from all caches
 ./purge-cache.sh --all
 ```
+
+## Build Pipeline Integration
+
+The registry cache can also accelerate build-time image pulls (buildpacks, base images, tools).
+This requires patching two resource types:
+
+1. **ClusterWorkflows** (control plane) — injects a `registries-conf` ConfigMap resource into each
+   WorkflowRun so the cache mirror configuration is available to build pods.
+2. **ClusterWorkflowTemplates** (data/workflow plane) — mounts that ConfigMap at
+   `/etc/containers/registries.conf` so podman/buildah in build containers pull through the cache.
+
+Both scripts are idempotent and support `--revert`. They require `kubectl` and `docker`.
+
+### Single-cluster setup
+
+```bash
+# Patch ClusterWorkflows (control plane context)
+./patch-build-workflows.sh
+
+# Patch ClusterWorkflowTemplates (same context for single-cluster)
+./patch-build-templates.sh
+```
+
+### Multi-cluster setup
+
+```bash
+# Patch ClusterWorkflows on the control plane cluster
+./patch-build-workflows.sh --context k3d-openchoreo-cp
+
+# Patch ClusterWorkflowTemplates on the workflow plane cluster
+./patch-build-templates.sh --context k3d-openchoreo-wp
+```
+
+### Reverting
+
+```bash
+./patch-build-workflows.sh --revert
+./patch-build-templates.sh --revert
+```
+
+### Preloading Build Images
+
+After patching, you can warm the cache by running a Job that pulls common build images
+(buildpacks, git, yq, jq, etc.) through the mirrors:
+
+```bash
+kubectl apply -f preload-build-images.yaml
+```
+
+The Job runs in the `default` namespace and auto-deletes after 5 minutes.
 
 ## Cleanup
 

--- a/install/k3d/registry-cache/compose.yaml
+++ b/install/k3d/registry-cache/compose.yaml
@@ -50,8 +50,19 @@ services:
       REGISTRY_PROXY_REMOTEURL: https://cr.kgateway.dev
     restart: unless-stopped
 
+  gcr-cache:
+    image: registry:2
+    ports:
+      - "5605:5000"
+    volumes:
+      - gcr-cache:/var/lib/registry
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://gcr.io
+    restart: unless-stopped
+
 volumes:
   ghcr-cache:
   dockerhub-cache:
   quay-cache:
   kgateway-cache:
+  gcr-cache:

--- a/install/k3d/registry-cache/list-cached.sh
+++ b/install/k3d/registry-cache/list-cached.sh
@@ -11,8 +11,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/compose.yaml"
 REPO_BASE="/var/lib/registry/docker/registry/v2/repositories"
 
-SERVICES=("ghcr-cache" "dockerhub-cache" "quay-cache" "kgateway-cache")
-UPSTREAMS=("ghcr.io" "docker.io" "quay.io" "cr.kgateway.dev")
+SERVICES=("ghcr-cache" "dockerhub-cache" "quay-cache" "kgateway-cache" "gcr-cache")
+UPSTREAMS=("ghcr.io" "docker.io" "quay.io" "cr.kgateway.dev" "gcr.io")
 
 # Filter to a specific service if provided
 if [[ -n "$1" ]]; then
@@ -22,9 +22,10 @@ if [[ -n "$1" ]]; then
     dockerhub-cache) UPSTREAMS=("docker.io") ;;
     quay-cache)      UPSTREAMS=("quay.io") ;;
     kgateway-cache)  UPSTREAMS=("cr.kgateway.dev") ;;
+    gcr-cache)       UPSTREAMS=("gcr.io") ;;
     *)
       echo "Unknown service: $1"
-      echo "Available: ghcr-cache, dockerhub-cache, quay-cache, kgateway-cache"
+      echo "Available: ghcr-cache, dockerhub-cache, quay-cache, kgateway-cache, gcr-cache"
       exit 1
       ;;
   esac

--- a/install/k3d/registry-cache/patch-build-templates.sh
+++ b/install/k3d/registry-cache/patch-build-templates.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Patch or revert ClusterWorkflowTemplates in the data plane cluster to route
+# build-time image pulls through the local registry cache.
+#
+# Usage:
+#   ./patch-build-templates.sh                          # patch, current context
+#   ./patch-build-templates.sh --context k3d-dp         # patch, specific context
+#   ./patch-build-templates.sh --revert                 # revert, current context
+#   ./patch-build-templates.sh --revert --context k3d-dp
+#
+# Idempotent — safe to run multiple times.
+# Prerequisites: kubectl, docker (for mikefarah/yq)
+
+set -euo pipefail
+
+REVERT=false
+KUBECTL="kubectl"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context)  KUBECTL="kubectl --context $2"; shift 2 ;;
+    --revert)   REVERT=true; shift ;;
+    *)          echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+YQ="docker run --rm -i mikefarah/yq"
+
+BUILD_TEMPLATES=(
+  containerfile-build
+  paketo-buildpacks-build
+  ballerina-buildpack-build
+  gcp-buildpacks-build
+  generate-workload
+)
+
+VOLUME_ENTRY='{
+  "name": "registries-conf",
+  "configMap": {
+    "name": "{{workflow.parameters.workflowrun-name}}-registries-conf",
+    "optional": true
+  }
+}'
+
+MOUNT_ENTRY='{
+  "mountPath": "/etc/containers/registries.conf",
+  "subPath": "registries.conf",
+  "name": "registries-conf",
+  "readOnly": true
+}'
+
+has_patch() {
+  local name="$1"
+  $KUBECTL get clusterworkflowtemplate "$name" -o yaml \
+    | $YQ '.spec.templates[0].volumes[] | select(.name == "registries-conf") | .name' 2>/dev/null || true
+}
+
+apply_patch() {
+  local name="$1"
+  echo ">> Patching ClusterWorkflowTemplate/${name}"
+  $KUBECTL get clusterworkflowtemplate "$name" -o yaml \
+    | $YQ '
+      del(.spec.templates[0].volumes[] | select(.name == "registries-conf")) |
+      del(.spec.templates[0].container.volumeMounts[] | select(.name == "registries-conf")) |
+      .spec.templates[0].volumes = (.spec.templates[0].volumes // []) + ['"${VOLUME_ENTRY}"'] |
+      .spec.templates[0].container.volumeMounts = (.spec.templates[0].container.volumeMounts // []) + ['"${MOUNT_ENTRY}"']
+    ' \
+    | $KUBECTL apply -f -
+}
+
+revert_patch() {
+  local name="$1"
+  echo ">> Reverting ClusterWorkflowTemplate/${name}"
+  $KUBECTL get clusterworkflowtemplate "$name" -o yaml \
+    | $YQ '
+      del(.spec.templates[0].volumes[] | select(.name == "registries-conf")) |
+      del(.spec.templates[0].container.volumeMounts[] | select(.name == "registries-conf"))
+    ' \
+    | $YQ 'del(.spec.templates[0] | select(.volumes | length == 0) | .volumes)' \
+    | $KUBECTL apply -f -
+}
+
+for tmpl in "${BUILD_TEMPLATES[@]}"; do
+  if ! $KUBECTL get clusterworkflowtemplate "$tmpl" &>/dev/null; then
+    echo ">> Skipping ClusterWorkflowTemplate/${tmpl} (not found)"
+    continue
+  fi
+
+  patched=$(has_patch "$tmpl")
+
+  if [[ "$REVERT" == true ]]; then
+    if [[ "$patched" != "registries-conf" ]]; then
+      echo ">> ClusterWorkflowTemplate/${tmpl} already clean, skipping"
+    else
+      revert_patch "$tmpl"
+    fi
+  else
+    if [[ "$patched" == "registries-conf" ]]; then
+      echo ">> ClusterWorkflowTemplate/${tmpl} already patched, skipping"
+    else
+      apply_patch "$tmpl"
+    fi
+  fi
+done
+
+echo ">> Done."

--- a/install/k3d/registry-cache/patch-build-workflows.sh
+++ b/install/k3d/registry-cache/patch-build-workflows.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Patch or revert ClusterWorkflows in the control plane cluster to create a
+# registries-conf ConfigMap per WorkflowRun for the registry cache.
+#
+# Usage:
+#   ./patch-build-workflows.sh                          # patch, current context
+#   ./patch-build-workflows.sh --context k3d-cp         # patch, specific context
+#   ./patch-build-workflows.sh --revert                 # revert, current context
+#   ./patch-build-workflows.sh --revert --context k3d-cp
+#
+# Idempotent — safe to run multiple times.
+# Prerequisites: kubectl, docker (for mikefarah/yq)
+
+set -euo pipefail
+
+REVERT=false
+KUBECTL="kubectl"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context)  KUBECTL="kubectl --context $2"; shift 2 ;;
+    --revert)   REVERT=true; shift ;;
+    *)          echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+YQ="docker run --rm -i mikefarah/yq"
+
+REGISTRIES_CONF_FILE=$(mktemp)
+trap 'rm -f "${REGISTRIES_CONF_FILE}"' EXIT
+cat > "${REGISTRIES_CONF_FILE}" <<'REGEOF'
+unqualified-search-registries = ["docker.io"]
+
+[[registry]]
+location = "host.k3d.internal:10082"
+insecure = true
+
+[[registry]]
+location = "docker.io"
+[[registry.mirror]]
+location = "host.k3d.internal:5602"
+insecure = true
+
+[[registry]]
+location = "ghcr.io"
+[[registry.mirror]]
+location = "host.k3d.internal:5601"
+insecure = true
+
+[[registry]]
+location = "quay.io"
+[[registry.mirror]]
+location = "host.k3d.internal:5603"
+insecure = true
+
+[[registry]]
+location = "cr.kgateway.dev"
+[[registry.mirror]]
+location = "host.k3d.internal:5604"
+insecure = true
+
+[[registry]]
+location = "gcr.io"
+[[registry.mirror]]
+location = "host.k3d.internal:5605"
+insecure = true
+REGEOF
+
+CI_WORKFLOWS=(
+  dockerfile-builder
+  paketo-buildpacks-builder
+  ballerina-buildpack-builder
+  gcp-buildpacks-builder
+)
+
+CONFIGMAP_RESOURCE='{
+  "id": "build-registries-conf",
+  "template": {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "${metadata.workflowRunName}-registries-conf",
+      "namespace": "${metadata.namespace}"
+    },
+    "data": {
+      "registries.conf": ""
+    }
+  }
+}'
+
+has_patch() {
+  local name="$1"
+  $KUBECTL get clusterworkflow "$name" -o yaml \
+    | $YQ '.spec.resources[] | select(.id == "build-registries-conf") | .id' 2>/dev/null || true
+}
+
+apply_patch() {
+  local name="$1"
+  echo ">> Patching ClusterWorkflow/${name}"
+  $KUBECTL get clusterworkflow "$name" -o yaml \
+    | $YQ 'del(.spec.resources[] | select(.id == "build-registries-conf"))' \
+    | $YQ '.spec.resources = (.spec.resources // []) + ['"${CONFIGMAP_RESOURCE}"']' \
+    | REGISTRIES_CONF_CONTENT="$(cat "${REGISTRIES_CONF_FILE}")" \
+      docker run --rm -i -e REGISTRIES_CONF_CONTENT mikefarah/yq '
+        (.spec.resources[] | select(.id == "build-registries-conf")).template.data."registries.conf" = strenv(REGISTRIES_CONF_CONTENT) |
+        (.spec.resources[] | select(.id == "build-registries-conf")).template.data."registries.conf" style="literal"
+      ' \
+    | $KUBECTL apply -f -
+}
+
+revert_patch() {
+  local name="$1"
+  echo ">> Reverting ClusterWorkflow/${name}"
+  $KUBECTL get clusterworkflow "$name" -o yaml \
+    | $YQ 'del(.spec.resources[] | select(.id == "build-registries-conf"))' \
+    | $KUBECTL apply -f -
+}
+
+for wf in "${CI_WORKFLOWS[@]}"; do
+  if ! $KUBECTL get clusterworkflow "$wf" &>/dev/null; then
+    echo ">> Skipping ClusterWorkflow/${wf} (not found)"
+    continue
+  fi
+
+  patched=$(has_patch "$wf")
+
+  if [[ "$REVERT" == true ]]; then
+    if [[ "$patched" != "build-registries-conf" ]]; then
+      echo ">> ClusterWorkflow/${wf} already clean, skipping"
+    else
+      revert_patch "$wf"
+    fi
+  else
+    if [[ "$patched" == "build-registries-conf" ]]; then
+      echo ">> ClusterWorkflow/${wf} already patched, skipping"
+    else
+      apply_patch "$wf"
+    fi
+  fi
+done
+
+echo ">> Done."

--- a/install/k3d/registry-cache/preload-build-images.yaml
+++ b/install/k3d/registry-cache/preload-build-images.yaml
@@ -1,0 +1,90 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: preload-build-images
+  namespace: default
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 2
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      initContainers:
+        - name: cache-git
+          image: alpine/git:v2.52.0
+          command: ["sh", "-c", "echo 'alpine/git cached on node'"]
+
+      containers:
+        - name: pull
+          image: ghcr.io/openchoreo/podman-runner:v1.1
+          command: ["sh", "-c"]
+          args:
+            - |-
+              set -e
+
+              mkdir -p /etc/containers
+              cat > /etc/containers/registries.conf <<'EOF'
+              unqualified-search-registries = ["docker.io"]
+
+              [[registry]]
+              location = "host.k3d.internal:10082"
+              insecure = true
+
+              [[registry]]
+              location = "docker.io"
+              [[registry.mirror]]
+              location = "host.k3d.internal:5602"
+              insecure = true
+
+              [[registry]]
+              location = "ghcr.io"
+              [[registry.mirror]]
+              location = "host.k3d.internal:5601"
+              insecure = true
+
+              [[registry]]
+              location = "quay.io"
+              [[registry.mirror]]
+              location = "host.k3d.internal:5603"
+              insecure = true
+
+              [[registry]]
+              location = "cr.kgateway.dev"
+              [[registry.mirror]]
+              location = "host.k3d.internal:5604"
+              insecure = true
+
+              [[registry]]
+              location = "gcr.io"
+              [[registry.mirror]]
+              location = "host.k3d.internal:5605"
+              insecure = true
+              EOF
+
+              IMAGES="
+              docker.io/alpine/git:v2.52.0
+              ghcr.io/jqlang/jq:1.7.1
+              docker.io/mikefarah/yq
+              docker.io/paketobuildpacks/builder-jammy-full:0.3.603
+              docker.io/paketobuildpacks/run-jammy-full:0.1.130
+              gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1
+              gcr.io/buildpacks/google-22/run:latest
+              ghcr.io/openchoreo/buildpack/ballerina:18
+              ghcr.io/openchoreo/openchoreo-cli:latest-dev
+              "
+
+              BATCH_SIZE=3
+              count=0
+              for img in $IMAGES; do
+                echo ">> Pulling $img"
+                podman pull --quiet "$img" &
+                count=$((count + 1))
+                if [ $((count % BATCH_SIZE)) -eq 0 ]; then
+                  wait
+                fi
+              done
+              wait
+              echo ">> All build images preloaded"
+          securityContext:
+            privileged: true

--- a/install/k3d/registry-cache/purge-cache.sh
+++ b/install/k3d/registry-cache/purge-cache.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/compose.yaml"
 REPO_BASE="/var/lib/registry/docker/registry/v2/repositories"
 
-ALL_SERVICES="ghcr-cache dockerhub-cache quay-cache kgateway-cache"
+ALL_SERVICES="ghcr-cache dockerhub-cache quay-cache kgateway-cache gcr-cache"
 
 compose_exec() {
   local service="$1"
@@ -24,6 +24,12 @@ compose_exec() {
 gc() {
   local service="$1"
   compose_exec "$service" registry garbage-collect /etc/docker/registry/config.yml --delete-untagged 2>/dev/null || true
+}
+
+restart_cache() {
+  local service="$1"
+  echo "Restarting ${service} to clear in-memory state..."
+  docker compose -f "$COMPOSE_FILE" restart "$service" 2>/dev/null || true
 }
 
 usage() {
@@ -60,6 +66,7 @@ if [[ "$1" == "--all" ]]; then
     echo "Purging all cached images from ${svc}..."
     compose_exec "$svc" sh -c "rm -rf ${REPO_BASE}/*" 2>/dev/null || true
     gc "$svc"
+    restart_cache "$svc"
   done
   echo "Done."
   exit 0
@@ -125,11 +132,12 @@ for ref in "$@"; do
   fi
 done
 
-# Run garbage collection on affected caches (deduplicated)
+# Run garbage collection and restart affected caches (deduplicated)
 for svc in $(echo "$gc_services" | tr ' ' '\n' | sort -u); do
   [[ -z "$svc" ]] && continue
   echo "Running garbage collection on ${svc}..."
   gc "$svc"
+  restart_cache "$svc"
 done
 
 echo "Done."

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -299,6 +299,30 @@ $(echo "$AGENT_CA" | sed 's/^/        /')
 EOF
 ```
 
+### Route Build Pulls Through Registry Cache (Optional)
+
+Speed up build-time image pulls (buildpacks, base images, tools) by routing them through a
+local registry cache. Start the cache, then patch the build pipeline:
+
+```bash
+# Start the registry cache (if not already running)
+docker compose -f install/k3d/registry-cache/compose.yaml up -d
+
+# Patch ClusterWorkflows to inject registries-conf ConfigMap per WorkflowRun
+install/k3d/registry-cache/patch-build-workflows.sh
+
+# Patch ClusterWorkflowTemplates to mount registries-conf into build containers
+install/k3d/registry-cache/patch-build-templates.sh
+```
+
+Optionally, warm the cache by pre-pulling common build images:
+
+```bash
+kubectl apply -f install/k3d/registry-cache/preload-build-images.yaml
+```
+
+See [registry-cache/README.md](../registry-cache/README.md) for details and how to revert.
+
 ## 7. Setup Observability Plane (Optional)
 
 ### Namespace and Certificates

--- a/samples/getting-started/workflow-templates/checkout-source.yaml
+++ b/samples/getting-started/workflow-templates/checkout-source.yaml
@@ -16,7 +16,7 @@ spec:
             secretName: '{{workflow.parameters.git-secret}}'
             optional: true
       container:
-        image: alpine/git
+        image: alpine/git:v2.52.0
         command:
           - sh
           - -c


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
- Extend the existing registry pull-through cache to accelerate **build-time** image pulls
  (buildpacks, base images, tools) by routing podman/buildah inside build containers through
  local mirrors
- Add two idempotent patch scripts (`patch-build-workflows.sh`, `patch-build-templates.sh`)
  that inject a `registries-conf` ConfigMap into WorkflowRuns and mount it into build containers
- Add a `preload-build-images.yaml` Job that warms both the node-level containerd cache
  (via init container) and the registry cache (via podman pulls) for common build images
- Pin `alpine/git` to `v2.52.0` in `checkout-source` template to avoid unnecessary re-pulls
  (untagged images default to `imagePullPolicy: Always`)
- Add `gcr.io` mirror (port 5605) for GCP buildpack images

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
