### PR TITLE
test: add coverage for workload types and microservices demo suites

### DIFF
--- a/test/e2e/framework/invoke.go
+++ b/test/e2e/framework/invoke.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import "strconv"
+
+// InvokeFromPodByLabel resolves a Running pod by label selector and runs
+// `wget -q -O /dev/null -T <seconds> <url>` from the given container.
+// Returns the combined wget output (empty on success) and the exec error.
+// BusyBox-compatible (uses `-T` not `--timeout`). Treats non-2xx HTTP
+// responses as failures, so this is suitable when callers expect 2xx.
+// Use CheckTCPReachableFromPodByLabel for plain TCP reachability checks.
+func InvokeFromPodByLabel(kubeContext, namespace, labelSelector, container, url string, timeoutSeconds int) (string, error) {
+	return KubectlExecByLabel(kubeContext, namespace, labelSelector, container,
+		"wget", "-q", "-O", "/dev/null", "-T", strconv.Itoa(timeoutSeconds), url)
+}
+
+// CheckTCPReachableFromPodByLabel resolves a Running pod by label selector and
+// runs `nc -z -w <seconds> <host> <port>` from the given container. Returns
+// the combined output and the exec error. nc exits 0 if the TCP port is
+// reachable, non-zero otherwise. Use this when the workload may respond with
+// any HTTP status (e.g. 404 on /) and you only care about TCP reachability.
+func CheckTCPReachableFromPodByLabel(kubeContext, namespace, labelSelector, container, host, port string, timeoutSeconds int) (string, error) {
+	return KubectlExecByLabel(kubeContext, namespace, labelSelector, container,
+		"nc", "-z", "-w", strconv.Itoa(timeoutSeconds), host, port)
+}

--- a/test/e2e/framework/repo.go
+++ b/test/e2e/framework/repo.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// RepoRoot returns the absolute path of the OpenChoreo checkout by walking up
+// from this file's location until it finds a `go.mod`. Suites use this to
+// apply files under `samples/` regardless of where `go test` was invoked.
+func RepoRoot() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed to resolve framework path")
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found walking up from %s", filepath.Dir(thisFile))
+		}
+		dir = parent
+	}
+}

--- a/test/e2e/framework/wait.go
+++ b/test/e2e/framework/wait.go
@@ -118,3 +118,53 @@ func AssertJsonpathEquals(g gomega.Gomega, kubeContext, namespace, resource, nam
 	g.Expect(output).To(gomega.Equal(expected),
 		fmt.Sprintf("%s/%s jsonpath %s: got %q, want %q", resource, name, jsonpath, output, expected))
 }
+
+// AssertReleaseBindingReady checks that a ReleaseBinding has condition Ready=True.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertReleaseBindingReady(g gomega.Gomega, kubeContext, namespace, name string) {
+	AssertJsonpathEquals(g, kubeContext, namespace, "releasebinding", name,
+		`{.status.conditions[?(@.type=="Ready")].status}`, "True")
+}
+
+// AssertPodsRunning checks that at least one pod matches the label selector in the namespace
+// and that every non-completed pod for that selector is in phase Running.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertPodsRunning(g gomega.Gomega, kubeContext, namespace, labelSelector string) {
+	output, err := KubectlGet(kubeContext, namespace, "pods",
+		"-l", labelSelector,
+		"--field-selector=status.phase!=Succeeded,status.phase!=Failed",
+		"-o", "custom-columns=NAME:.metadata.name,PHASE:.status.phase",
+		"--no-headers")
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		fmt.Sprintf("failed to query pods in %s with selector %q", namespace, labelSelector))
+	g.Expect(strings.TrimSpace(output)).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("no pods in %s matching selector %q", namespace, labelSelector))
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		g.Expect(fields[1]).To(gomega.Equal("Running"),
+			fmt.Sprintf("pod %s in %s is %s (selector %q)", fields[0], namespace, fields[1], labelSelector))
+	}
+}
+
+// AssertResourceGone checks that a named resource does not exist in the namespace.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertResourceGone(g gomega.Gomega, kubeContext, namespace, resource, name string) {
+	_, err := KubectlGetJsonpath(kubeContext, namespace, resource, name, "{.metadata.name}")
+	g.Expect(err).To(gomega.HaveOccurred(),
+		fmt.Sprintf("%s/%s should not exist in namespace %s", resource, name, namespace))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("NotFound"),
+		fmt.Sprintf("expected NotFound for %s/%s in %s, got: %v", resource, name, namespace, err))
+}
+
+// AssertNamespaceGone checks that a namespace does not exist.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertNamespaceGone(g gomega.Gomega, kubeContext, namespace string) {
+	_, err := Kubectl(kubeContext, "get", "namespace", namespace, "-o", "jsonpath={.metadata.name}")
+	g.Expect(err).To(gomega.HaveOccurred(),
+		fmt.Sprintf("namespace %s should not exist", namespace))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("NotFound"),
+		fmt.Sprintf("expected NotFound for namespace %s, got: %v", namespace, err))
+}

--- a/test/e2e/suites/microservicesdemo/microservicesdemo_fixtures_test.go
+++ b/test/e2e/suites/microservicesdemo/microservicesdemo_fixtures_test.go
@@ -40,7 +40,7 @@ func testerPodYAML(dpNamespace string) string {
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{
 			Name:    "tester",
 			Image:   "busybox:1.36",
-			Command: []string{"sleep", "3600"},
+			Command: []string{"sleep", "infinity"},
 		}}},
 	}
 	return mustYAMLDocs(pod)

--- a/test/e2e/suites/microservicesdemo/microservicesdemo_fixtures_test.go
+++ b/test/e2e/suites/microservicesdemo/microservicesdemo_fixtures_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+// testerPodYAML returns a busybox pod that sleeps forever, used as the source
+// of in-cluster wget probes against the demo's rendered Services.
+func testerPodYAML(dpNamespace string) string {
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "msd-tester",
+			Namespace: dpNamespace,
+			Labels: map[string]string{
+				"app":                       "msd-tester",
+				"openchoreo.dev/managed-by": "e2e-microservicesdemo",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    "tester",
+			Image:   "busybox:1.36",
+			Command: []string{"sleep", "3600"},
+		}}},
+	}
+	return mustYAMLDocs(pod)
+}

--- a/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
+++ b/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -26,8 +25,11 @@ const (
 
 	demoSampleSubpath = "samples/gcp-microservices-demo"
 
-	demoFrontend  = "frontend"
-	demoCatalog   = "productcatalog"
+	demoFrontend = "frontend"
+	demoCatalog  = "productcatalog"
+
+	// Stable product ID from the demo's productcatalogservice/products.json.
+	demoProductID = "OLJCESPC7Z"
 
 	demoTesterLabel     = "app=msd-tester"
 	demoTesterContainer = "tester"
@@ -114,43 +116,86 @@ var _ = Describe("GCP Microservices Demo", Ordered, func() {
 			}, 8*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("frontend serves traffic and reaches productcatalog over gRPC", func() {
-			// External invoke goes through kgateway; for a deterministic
-			// cross-service signal we hit the rendered ClusterIP Service for
-			// frontend from inside the DP namespace. If frontend's `/` returns
-			// 200, the rendered page included the product list, which means
-			// the in-pod gRPC client successfully reached productcatalog.
-			host, port := serviceForComponent(demoDPNs, demoFrontend)
+		It("frontend home page is reachable over the public URL", func() {
+			// Probe goes through the kgateway external listener — this is the
+			// URL a real user would hit. A 200 on `/` transitively proves the
+			// frontend → productcatalog gRPC hop, because the home template
+			// renders the product list and the handler 5xx's if that gRPC fails.
+			base := frontendExternalHTTPURL()
+			homeURL := base + "/"
 			Eventually(func() error {
 				_, err := framework.InvokeFromPodByLabel(
 					kubeContext, demoDPNs, demoTesterLabel, demoTesterContainer,
-					fmt.Sprintf("http://%s:%s/", host, port), 10,
+					homeURL, 10,
 				)
 				return err
 			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
-				"frontend at %s:%s should return success (proves frontend → %s connectivity)",
-				host, port, demoCatalog)
+				"frontend home %s should return 200 (proves frontend → %s connectivity)",
+				homeURL, demoCatalog)
+		})
+
+		It("frontend product detail page returns 200 for a known product", func() {
+			// /product/<id> drives a GetProduct gRPC to productcatalog plus a
+			// currency conversion via the currency service. 200 means both
+			// downstream RPCs succeeded.
+			productURL := frontendExternalHTTPURL() + "/product/" + demoProductID
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, demoDPNs, demoTesterLabel, demoTesterContainer,
+					productURL, 10,
+				)
+				return err
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"frontend product page %s should return 200 (proves %s GetProduct + currency)",
+				productURL, demoCatalog)
+		})
+
+		It("frontend cart page returns 200", func() {
+			// /cart drives a GetCart RPC to the cart service (empty cart on a
+			// fresh session is still a successful 200). This covers the cart
+			// service which is otherwise only verified at the pod-running level.
+			cartURL := frontendExternalHTTPURL() + "/cart"
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, demoDPNs, demoTesterLabel, demoTesterContainer,
+					cartURL, 10,
+				)
+				return err
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"frontend cart page %s should return 200 (proves cart GetCart)",
+				cartURL)
 		})
 	})
 })
 
-// serviceForComponent returns the name + first port of the rendered Service
-// for an OpenChoreo component in the given DP namespace. Looked up by label.
-func serviceForComponent(dpNamespace, component string) (name, port string) {
-	var svcName, svcPort string
-	Eventually(func(g Gomega) {
-		out, err := framework.Kubectl(kubeContext,
-			"get", "service",
-			"-n", dpNamespace,
-			"-l", "openchoreo.dev/component="+component,
-			"-o", "jsonpath={.items[0].metadata.name}|{.items[0].spec.ports[0].port}",
+// frontendExternalHTTPURL polls the frontend ReleaseBinding until its `http`
+// endpoint has an externally-resolved HTTP gateway URL, then returns the
+// assembled base URL (scheme://host:port, no trailing slash). This is what a
+// caller outside the cluster — or here, the tester pod going through CoreDNS
+// rewrite + k3d port-forward — would actually hit on kgateway.
+func frontendExternalHTTPURL() string {
+	rbName := demoFrontend + "-" + demoEnvironment
+	jp := func(expr string) (string, error) {
+		return framework.KubectlGetJsonpath(
+			kubeContext, demoCPNamespace, "releasebinding", rbName,
+			fmt.Sprintf(`{.status.endpoints[?(@.name=="http")].externalURLs.http.%s}`, expr),
 		)
+	}
+	var url string
+	Eventually(func(g Gomega) {
+		scheme, err := jp("scheme")
 		g.Expect(err).NotTo(HaveOccurred())
-		parts := strings.SplitN(out, "|", 2)
-		g.Expect(parts).To(HaveLen(2), "unexpected output from service lookup: %q", out)
-		svcName, svcPort = parts[0], parts[1]
-		g.Expect(svcName).NotTo(BeEmpty(), "no Service found for component %s in %s", component, dpNamespace)
-		g.Expect(svcPort).NotTo(BeEmpty(), "Service for component %s has no port", component)
+		g.Expect(scheme).NotTo(BeEmpty(), "externalURLs.http.scheme not populated on %s", rbName)
+
+		host, err := jp("host")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(host).NotTo(BeEmpty(), "externalURLs.http.host not populated on %s", rbName)
+
+		port, err := jp("port")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(port).NotTo(BeEmpty(), "externalURLs.http.port not populated on %s", rbName)
+
+		url = fmt.Sprintf("%s://%s:%s", scheme, host, port)
 	}, 3*time.Minute, 2*time.Second).Should(Succeed())
-	return svcName, svcPort
+	return url
 }

--- a/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
+++ b/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+const (
+	// The demo's project + components target the `default` namespace and rely
+	// on the getting-started default DeploymentPipeline + Environments which
+	// `e2e.setup-configure` already installs.
+	demoCPNamespace = "default"
+	demoProject     = "gcp-microservice-demo"
+	demoEnvironment = "development"
+
+	demoSampleSubpath = "samples/gcp-microservices-demo"
+
+	demoFrontend  = "frontend"
+	demoCatalog   = "productcatalog"
+
+	demoTesterLabel     = "app=msd-tester"
+	demoTesterContainer = "tester"
+)
+
+// All components shipped by the demo. Used to wait for each RB to reach Ready.
+var demoComponents = []string{
+	"ad", "cart", "checkout", "currency", "email",
+	"frontend", "payment", "productcatalog",
+	"recommendation", "redis", "shipping",
+}
+
+var demoDPNs string
+
+var _ = Describe("GCP Microservices Demo", Ordered, func() {
+	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
+	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
+
+	BeforeAll(func() {
+		By("resolving repo root for sample manifests")
+		repoRoot, err := framework.RepoRoot()
+		Expect(err).NotTo(HaveOccurred(), "failed to locate repo root")
+		sampleDir := filepath.Join(repoRoot, demoSampleSubpath)
+		_, err = os.Stat(sampleDir)
+		Expect(err).NotTo(HaveOccurred(), "sample directory missing: %s", sampleDir)
+
+		By("applying gcp-microservices-demo sample manifests")
+		output, err := framework.Kubectl(kubeContext, "apply", "-f", sampleDir, "-R")
+		Expect(err).NotTo(HaveOccurred(), "kubectl apply failed: %s", output)
+
+		By("waiting for project DP namespace discovery")
+		Eventually(func() error {
+			var discoverErr error
+			demoDPNs, discoverErr = framework.GetDPNamespace(
+				kubeContext, demoCPNamespace, demoProject, demoEnvironment,
+			)
+			return discoverErr
+		}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+			"dp namespace for %s/%s not found", demoProject, demoEnvironment)
+		fmt.Fprintf(GinkgoWriter, "discovered dp namespace: %s\n", demoDPNs)
+
+		By("deploying tester pod in the project DP namespace")
+		output, err = framework.KubectlApplyLiteral(kubeContext, testerPodYAML(demoDPNs))
+		Expect(err).NotTo(HaveOccurred(), "failed to create tester pod: %s", output)
+
+		By("waiting for tester pod to be Running")
+		Eventually(func(g Gomega) {
+			framework.AssertPodsRunning(g, kubeContext, demoDPNs, demoTesterLabel)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+
+		By("deleting tester pod")
+		if demoDPNs != "" {
+			_, _ = framework.Kubectl(kubeContext, "delete", "pod", "msd-tester",
+				"-n", demoDPNs, "--ignore-not-found", "--wait=false")
+		}
+
+		By("deleting demo project (cascades to all components + RBs + DP resources)")
+		_, _ = framework.Kubectl(kubeContext, "delete", "project", demoProject,
+			"-n", demoCPNamespace, "--ignore-not-found", "--wait=false")
+	})
+
+	Context("multi-service deployment", func() {
+		It("all ReleaseBindings reach Ready", func() {
+			for _, comp := range demoComponents {
+				rbName := comp + "-" + demoEnvironment
+				By("waiting on ReleaseBinding " + rbName)
+				Eventually(func(g Gomega) {
+					framework.AssertReleaseBindingReady(g, kubeContext, demoCPNamespace, rbName)
+				}, 8*time.Minute, 5*time.Second).Should(Succeed(),
+					"ReleaseBinding %s should be Ready", rbName)
+			}
+		})
+
+		It("all demo pods are Running in the project DP namespace", func() {
+			Eventually(func(g Gomega) {
+				framework.AssertAllPodsRunning(g, kubeContext, demoDPNs)
+			}, 8*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("frontend serves traffic and reaches productcatalog over gRPC", func() {
+			// External invoke goes through kgateway; for a deterministic
+			// cross-service signal we hit the rendered ClusterIP Service for
+			// frontend from inside the DP namespace. If frontend's `/` returns
+			// 200, the rendered page included the product list, which means
+			// the in-pod gRPC client successfully reached productcatalog.
+			host, port := serviceForComponent(demoDPNs, demoFrontend)
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, demoDPNs, demoTesterLabel, demoTesterContainer,
+					fmt.Sprintf("http://%s:%s/", host, port), 10,
+				)
+				return err
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"frontend at %s:%s should return success (proves frontend → %s connectivity)",
+				host, port, demoCatalog)
+		})
+	})
+})
+
+// serviceForComponent returns the name + first port of the rendered Service
+// for an OpenChoreo component in the given DP namespace. Looked up by label.
+func serviceForComponent(dpNamespace, component string) (name, port string) {
+	var svcName, svcPort string
+	Eventually(func(g Gomega) {
+		out, err := framework.Kubectl(kubeContext,
+			"get", "service",
+			"-n", dpNamespace,
+			"-l", "openchoreo.dev/component="+component,
+			"-o", "jsonpath={.items[0].metadata.name}|{.items[0].spec.ports[0].port}",
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		parts := strings.SplitN(out, "|", 2)
+		g.Expect(parts).To(HaveLen(2), "unexpected output from service lookup: %q", out)
+		svcName, svcPort = parts[0], parts[1]
+		g.Expect(svcName).NotTo(BeEmpty(), "no Service found for component %s in %s", component, dpNamespace)
+		g.Expect(svcPort).NotTo(BeEmpty(), "Service for component %s has no port", component)
+	}, 3*time.Minute, 2*time.Second).Should(Succeed())
+	return svcName, svcPort
+}

--- a/test/e2e/suites/microservicesdemo/suite_test.go
+++ b/test/e2e/suites/microservicesdemo/suite_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EMicroservicesDemo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo microservices-demo e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E Microservices Demo Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying cluster is accessible")
+	output, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, output)
+	fmt.Fprintf(GinkgoWriter, "Cluster accessible\n")
+})

--- a/test/e2e/suites/workloadtypes/suite_test.go
+++ b/test/e2e/suites/workloadtypes/suite_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EWorkloadTypes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo workload-types e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E Workload Types Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying cluster is accessible")
+	output, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, output)
+	fmt.Fprintf(GinkgoWriter, "Cluster accessible\n")
+})

--- a/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
@@ -154,9 +154,13 @@ func componentWithImageYAML(name, componentType, image string, port int, args []
 			WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
 				Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
 					"http": {
-						Type:       openchoreov1alpha1.EndpointType("HTTP"),
-						Port:       int32(port),
-						Visibility: []openchoreov1alpha1.EndpointVisibility{"project"},
+						Type: openchoreov1alpha1.EndpointType("HTTP"),
+						Port: int32(port),
+						// project keeps the in-cluster ClusterIP probe alive;
+						// external renders an HTTPRoute on the data plane's
+						// external kgateway listener so the same workload is
+						// reachable through the public URL too.
+						Visibility: []openchoreov1alpha1.EndpointVisibility{"project", "external"},
 					},
 				},
 				Container: openchoreov1alpha1.Container{

--- a/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+const (
+	clusterDataPlane   = "e2e-shared"
+	openChoreoAPIVer   = "openchoreo.dev/v1alpha1"
+	kubernetesAPIVerV1 = "v1"
+
+	projectName = "wt-proj"
+	envDev      = "development"
+	envStaging  = "staging"
+
+	componentService     = "greeter"
+	componentWebApp      = "react-spa"
+	componentScheduled   = "issue-reporter"
+	releaseBindingSuffix = "-" + envDev
+
+	servicePort = 9090
+	webAppPort  = 8080
+
+	testerLabel     = "app=wt-tester"
+	testerContainer = "tester"
+)
+
+var wtRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+
+var cpNs = fmt.Sprintf("e2e-wt-%s", wtRunID)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+func cpNamespaceYAML() string {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/control-plane": "true",
+			},
+		},
+	}
+	return mustYAMLDocs(ns)
+}
+
+func platformResourcesYAML() string {
+	// Pipeline must have a root environment — at least one env that is a
+	// source but not a target. We deploy to `development` (the root) and add
+	// `staging` as a downstream-only env to satisfy that invariant; staging
+	// is never actually exercised by this suite.
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "DeploymentPipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": "default"},
+		},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{{
+				SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: envDev},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{
+					{Name: envStaging},
+				},
+			}},
+		},
+	}
+	envs := make([]any, 0, 2)
+	for _, name := range []string{envDev, envStaging} {
+		envs = append(envs, &openchoreov1alpha1.Environment{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: cpNs,
+				Labels:    map[string]string{"openchoreo.dev/name": name},
+			},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+					Name: clusterDataPlane,
+				},
+			},
+		})
+	}
+	proj := &openchoreov1alpha1.Project{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": projectName},
+		},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+		},
+	}
+	docs := []any{pipeline}
+	docs = append(docs, envs...)
+	docs = append(docs, proj)
+	return mustYAMLDocs(docs...)
+}
+
+// componentWithImageYAML returns a Component + Workload pair for a deployment-style
+// component type (service / web-application). Port and image are caller-provided.
+func componentWithImageYAML(name, componentType, image string, port int, args []string) string {
+	comp := &openchoreov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: projectName},
+			ComponentType: openchoreov1alpha1.ComponentTypeRef{
+				Kind: openchoreov1alpha1.ComponentTypeRefKindClusterComponentType,
+				Name: componentType,
+			},
+			AutoDeploy: true,
+		},
+	}
+	workload := &openchoreov1alpha1.Workload{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Workload"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.WorkloadSpec{
+			Owner: openchoreov1alpha1.WorkloadOwner{
+				ProjectName:   projectName,
+				ComponentName: name,
+			},
+			WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
+				Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+					"http": {
+						Type:       openchoreov1alpha1.EndpointType("HTTP"),
+						Port:       int32(port),
+						Visibility: []openchoreov1alpha1.EndpointVisibility{"project"},
+					},
+				},
+				Container: openchoreov1alpha1.Container{
+					Image: image,
+					Args:  args,
+				},
+			},
+		},
+	}
+	return mustYAMLDocs(comp, workload)
+}
+
+// scheduledTaskComponentYAML returns a Component + Workload + ReleaseBinding for
+// the cronjob/scheduled-task ClusterComponentType. The ReleaseBinding sets a
+// minute-frequency schedule so the test can observe a scheduled Job within ~60s.
+func scheduledTaskComponentYAML(name, image string) string {
+	comp := &openchoreov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: projectName},
+			ComponentType: openchoreov1alpha1.ComponentTypeRef{
+				Kind: openchoreov1alpha1.ComponentTypeRefKindClusterComponentType,
+				Name: "cronjob/scheduled-task",
+			},
+			AutoDeploy: true,
+		},
+	}
+	workload := &openchoreov1alpha1.Workload{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Workload"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.WorkloadSpec{
+			Owner: openchoreov1alpha1.WorkloadOwner{
+				ProjectName:   projectName,
+				ComponentName: name,
+			},
+			WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
+				Container: openchoreov1alpha1.Container{
+					Image: image,
+				},
+			},
+		},
+	}
+	// ReleaseBinding override forces a 1-minute schedule so the test does not
+	// have to wait the sample's default 5 minutes for `lastScheduleTime`.
+	rb := map[string]any{
+		"apiVersion": openChoreoAPIVer,
+		"kind":       "ReleaseBinding",
+		"metadata": map[string]any{
+			"name":      name + releaseBindingSuffix,
+			"namespace": cpNs,
+		},
+		"spec": map[string]any{
+			"owner": map[string]any{
+				"projectName":   projectName,
+				"componentName": name,
+			},
+			"environment": envDev,
+			"componentTypeEnvironmentConfigs": map[string]any{
+				"schedule": "* * * * *",
+			},
+		},
+	}
+	return mustYAMLDocs(comp, workload, rb)
+}
+
+// testerPodYAML returns a busybox pod that sleeps forever, used as the source
+// of in-cluster wget probes against project-visibility workloads. Deployed in
+// the data plane namespace so it shares the project network policy scope.
+func testerPodYAML(dpNamespace string) string {
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wt-tester",
+			Namespace: dpNamespace,
+			Labels: map[string]string{
+				"app":                       "wt-tester",
+				"openchoreo.dev/project":    projectName,
+				"openchoreo.dev/managed-by": "e2e-workloadtypes",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    testerContainer,
+			Image:   "busybox:1.36",
+			Command: []string{"sleep", "3600"},
+		}}},
+	}
+	return mustYAMLDocs(pod)
+}

--- a/test/e2e/suites/workloadtypes/workloadtypes_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+const (
+	// Image references for the 3 workload types. greeter-service and
+	// github-issue-reporter come from the public OpenChoreo sample images;
+	// the web-app slot uses hashicorp/http-echo because the react sample
+	// image is not consistently reachable from CI.
+	imageService     = "ghcr.io/openchoreo/samples/greeter-service:latest"
+	imageWebApp      = "hashicorp/http-echo:1.0.0"
+	imageScheduled   = "ghcr.io/openchoreo/samples/github-issue-reporter:latest"
+)
+
+var dpNs string
+
+var _ = Describe("Workload Type Matrix", Ordered, func() {
+	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
+	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
+
+	BeforeAll(func() {
+		By("creating control plane namespace")
+		output, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
+		Expect(err).NotTo(HaveOccurred(), "failed to create CP namespace: %s", output)
+
+		By("applying platform resources (pipeline, environment, project)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML())
+		Expect(err).NotTo(HaveOccurred(), "failed to apply platform resources: %s", output)
+
+		// The DP namespace is created lazily by the controller on the first
+		// Component reconcile, so deploy components first then poll for it.
+		By("deploying service component (greeter)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentWithImageYAML(
+			componentService, "deployment/service", imageService, servicePort,
+			[]string{"--port", strconv.Itoa(servicePort)},
+		))
+		Expect(err).NotTo(HaveOccurred(), "failed to create service component: %s", output)
+
+		By("deploying web-application component (http-echo stand-in)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentWithImageYAML(
+			componentWebApp, "deployment/web-application", imageWebApp, webAppPort,
+			[]string{"-listen=:" + strconv.Itoa(webAppPort), "-text=react-spa"},
+		))
+		Expect(err).NotTo(HaveOccurred(), "failed to create web-app component: %s", output)
+
+		By("deploying scheduled-task component (issue-reporter)")
+		output, err = framework.KubectlApplyLiteral(kubeContext,
+			scheduledTaskComponentYAML(componentScheduled, imageScheduled))
+		Expect(err).NotTo(HaveOccurred(), "failed to create scheduled-task component: %s", output)
+
+		By("waiting for data plane namespace discovery")
+		Eventually(func() error {
+			var discoverErr error
+			dpNs, discoverErr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+			return discoverErr
+		}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+			"dp namespace for %s/%s not found", projectName, envDev)
+		fmt.Fprintf(GinkgoWriter, "discovered dp namespace: %s\n", dpNs)
+
+		By("deploying tester pod for in-cluster invoke")
+		output, err = framework.KubectlApplyLiteral(kubeContext, testerPodYAML(dpNs))
+		Expect(err).NotTo(HaveOccurred(), "failed to create tester pod: %s", output)
+
+		By("waiting for tester pod to be Running")
+		Eventually(func(g Gomega) {
+			framework.AssertPodsRunning(g, kubeContext, dpNs, testerLabel)
+		}, 4*time.Minute, 3*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+		By("cleaning up control plane namespace (cascades to DP namespace)")
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
+			"--ignore-not-found", "--wait=false")
+		if dpNs != "" {
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+				"--ignore-not-found", "--wait=false")
+		}
+	})
+
+	Context("rendering and reachability", func() {
+		It("service: ReleaseBinding becomes Ready and endpoint is reachable", func() {
+			By("waiting for ReleaseBinding Ready")
+			Eventually(func(g Gomega) {
+				framework.AssertReleaseBindingReady(g, kubeContext, cpNs, componentService+releaseBindingSuffix)
+			}, 5*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("workload pod is Running")
+			Eventually(func(g Gomega) {
+				framework.AssertPodsRunning(g, kubeContext, dpNs,
+					"openchoreo.dev/component="+componentService)
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("TCP port is reachable from tester pod")
+			host, port := endpointHostPort(componentService, "http")
+			Eventually(func() error {
+				_, err := framework.CheckTCPReachableFromPodByLabel(
+					kubeContext, dpNs, testerLabel, testerContainer, host, port, 5,
+				)
+				return err
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"service endpoint %s:%s should be TCP-reachable", host, port)
+		})
+
+		It("web-application: ReleaseBinding becomes Ready and endpoint is reachable", func() {
+			By("waiting for ReleaseBinding Ready")
+			Eventually(func(g Gomega) {
+				framework.AssertReleaseBindingReady(g, kubeContext, cpNs, componentWebApp+releaseBindingSuffix)
+			}, 5*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("workload pod is Running")
+			Eventually(func(g Gomega) {
+				framework.AssertPodsRunning(g, kubeContext, dpNs,
+					"openchoreo.dev/component="+componentWebApp)
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("TCP port is reachable from tester pod")
+			host, port := endpointHostPort(componentWebApp, "http")
+			Eventually(func() error {
+				_, err := framework.CheckTCPReachableFromPodByLabel(
+					kubeContext, dpNs, testerLabel, testerContainer, host, port, 5,
+				)
+				return err
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"web-app endpoint %s:%s should be TCP-reachable", host, port)
+		})
+
+		It("scheduled-task: ReleaseBinding becomes Ready and CronJob gets scheduled", func() {
+			By("waiting for ReleaseBinding Ready")
+			Eventually(func(g Gomega) {
+				framework.AssertReleaseBindingReady(g, kubeContext, cpNs, componentScheduled+releaseBindingSuffix)
+			}, 5*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("CronJob exists in the DP namespace")
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "cronjob",
+					"-n", dpNs,
+					"-l", "openchoreo.dev/component="+componentScheduled,
+					"-o", "jsonpath={.items[0].metadata.name}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).NotTo(BeEmpty(), "no CronJob found for component %s in %s", componentScheduled, dpNs)
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("CronJob status.lastScheduleTime is populated (Job was scheduled)")
+			// Schedule is * * * * * so the kube-controller-manager should fire
+			// the first Job within ~60s. We do not assert Job completion: the
+			// sample image needs unreachable MySQL/SMTP/GitHub and will exit
+			// non-zero, but scheduling is the meaningful signal here.
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "cronjob",
+					"-n", dpNs,
+					"-l", "openchoreo.dev/component="+componentScheduled,
+					"-o", "jsonpath={.items[0].status.lastScheduleTime}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).NotTo(BeEmpty(),
+					"CronJob for %s should have status.lastScheduleTime populated", componentScheduled)
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("deletion drains rendered resources", func() {
+		It("Component delete drains the workload from the DP namespace", func() {
+			By("deleting the web-application component")
+			output, err := framework.Kubectl(kubeContext,
+				"delete", "component", componentWebApp,
+				"-n", cpNs, "--wait=true", "--timeout=3m")
+			Expect(err).NotTo(HaveOccurred(),
+				"failed to delete component %s: %s", componentWebApp, output)
+
+			By("ReleaseBinding for the deleted component is gone")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceGone(g, kubeContext, cpNs, "releasebinding",
+					componentWebApp+releaseBindingSuffix)
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("no Deployment for the deleted component remains in DP namespace")
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "deployment",
+					"-n", dpNs,
+					"-l", "openchoreo.dev/component="+componentWebApp,
+					"-o", "jsonpath={.items[*].metadata.name}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(BeEmpty(),
+					"Deployment for deleted component %s still present: %s", componentWebApp, out)
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("the service component is untouched")
+			Eventually(func(g Gomega) {
+				framework.AssertReleaseBindingReady(g, kubeContext, cpNs, componentService+releaseBindingSuffix)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("Project delete drains the DP namespace", func() {
+			By("deleting the project")
+			output, err := framework.Kubectl(kubeContext,
+				"delete", "project", projectName,
+				"-n", cpNs, "--wait=false")
+			Expect(err).NotTo(HaveOccurred(),
+				"failed to delete project %s: %s", projectName, output)
+
+			By("all remaining ReleaseBindings under the project disappear")
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "releasebinding",
+					"-n", cpNs,
+					"-o", "jsonpath={.items[*].metadata.name}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(BeEmpty(),
+					"ReleaseBindings still present after project delete: %s", out)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("DP namespace fully drains (no Deployment/Service/CronJob left)")
+			Eventually(func(g Gomega) {
+				deployments, err := framework.Kubectl(kubeContext,
+					"get", "deployment", "-n", dpNs,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(deployments).To(BeEmpty(), "deployments remain in %s: %s", dpNs, deployments)
+
+				services, err := framework.Kubectl(kubeContext,
+					"get", "service", "-n", dpNs,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(services).To(BeEmpty(), "services remain in %s: %s", dpNs, services)
+
+				cronjobs, err := framework.Kubectl(kubeContext,
+					"get", "cronjob", "-n", dpNs,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cronjobs).To(BeEmpty(), "cronjobs remain in %s: %s", dpNs, cronjobs)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+		})
+	})
+})
+
+// endpointHostPort reads the rendered Service URL host+port for a named endpoint
+// off the ReleaseBinding status. Returns string host + string port (port is
+// decimal as serialised in jsonpath).
+func endpointHostPort(component, endpoint string) (host, port string) {
+	rbName := component + releaseBindingSuffix
+	var hostOut, portOut string
+	Eventually(func(g Gomega) {
+		var err error
+		hostOut, err = framework.KubectlGetJsonpath(
+			kubeContext, cpNs, "releasebinding", rbName,
+			fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].serviceURL.host}`, endpoint),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(hostOut).NotTo(BeEmpty(), "serviceURL.host empty on %s endpoint %s", rbName, endpoint)
+
+		portOut, err = framework.KubectlGetJsonpath(
+			kubeContext, cpNs, "releasebinding", rbName,
+			fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].serviceURL.port}`, endpoint),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(portOut).NotTo(BeEmpty(), "serviceURL.port empty on %s endpoint %s", rbName, endpoint)
+	}, 3*time.Minute, 2*time.Second).Should(Succeed())
+	return hostOut, portOut
+}

--- a/test/e2e/suites/workloadtypes/workloadtypes_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_test.go
@@ -176,6 +176,39 @@ var _ = Describe("Workload Type Matrix", Ordered, func() {
 					"CronJob for %s should have status.lastScheduleTime populated", componentScheduled)
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		})
+
+		It("service: public URL is reachable through kgateway", func() {
+			// visibility includes external, so the controller renders an
+			// HTTPRoute on the data plane's external gateway. The service
+			// ClusterComponentType matches /<componentName>-<endpoint> and
+			// URL-rewrites that prefix back to "/" before forwarding to the
+			// backend — so we append the greeter sample's documented REST
+			// path (/greeter/greet) to hit a known-200 handler.
+			base := endpointExternalHTTPURL(componentService, "http")
+			url := base + "/greeter/greet"
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, dpNs, testerLabel, testerContainer, url, 10,
+				)
+				return err
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"service public URL %s should return 200", url)
+		})
+
+		It("web-application: public URL is reachable through kgateway", func() {
+			// The web-application template forwards all paths without a
+			// prefix rewrite, and http-echo replies 200 with the configured
+			// text on any path — so a plain GET of the externalURL is enough.
+			base := endpointExternalHTTPURL(componentWebApp, "http")
+			url := base + "/"
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, dpNs, testerLabel, testerContainer, url, 10,
+				)
+				return err
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"web-application public URL %s should return 200", url)
+		})
 	})
 
 	Context("deletion drains rendered resources", func() {
@@ -255,6 +288,35 @@ var _ = Describe("Workload Type Matrix", Ordered, func() {
 		})
 	})
 })
+
+// endpointExternalHTTPURL reads the rendered external HTTP gateway URL for a
+// named endpoint off the ReleaseBinding status, assembled from scheme/host/
+// port/path. This is the URL a real caller would hit through kgateway.
+// Path is optional — the web-application template renders no path prefix,
+// while the service template uses /<componentName>-<endpointKey>.
+func endpointExternalHTTPURL(component, endpoint string) string {
+	rbName := component + releaseBindingSuffix
+	jp := func(g Gomega, field string) string {
+		out, err := framework.KubectlGetJsonpath(
+			kubeContext, cpNs, "releasebinding", rbName,
+			fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].externalURLs.http.%s}`, endpoint, field),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		return out
+	}
+	var url string
+	Eventually(func(g Gomega) {
+		scheme := jp(g, "scheme")
+		host := jp(g, "host")
+		port := jp(g, "port")
+		path := jp(g, "path") // empty for web-application; "/<componentName>-<endpointKey>" for service
+		g.Expect(scheme).NotTo(BeEmpty(), "externalURLs.http.scheme empty on %s endpoint %s", rbName, endpoint)
+		g.Expect(host).NotTo(BeEmpty(), "externalURLs.http.host empty on %s endpoint %s", rbName, endpoint)
+		g.Expect(port).NotTo(BeEmpty(), "externalURLs.http.port empty on %s endpoint %s", rbName, endpoint)
+		url = fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+	}, 3*time.Minute, 2*time.Second).Should(Succeed())
+	return url
+}
 
 // endpointHostPort reads the rendered Service URL host+port for a named endpoint
 // off the ReleaseBinding status. Returns string host + string port (port is


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR addresses the task `Implement Tier 1 e2e tests` in https://github.com/openchoreo/openchoreo/issues/3588.

Adds the following test suites
### 1. `workloadtypes` — workload type matrix

- **Setup:** unique CP namespace, apply pipeline + envs + project, deploy 3 components (`greeter` service, `react-spa` web-app, `issue-reporter` scheduled-task) with `visibility: [project, external]`, drop a busybox tester pod in the DP namespace.
- **service:** `ReleaseBinding` Ready → pod Running → ClusterIP TCP-reachable.
- **web-application:** same flow — Ready + Running + TCP-reachable.
- **scheduled-task:** `ReleaseBinding` Ready → `CronJob` exists → `lastScheduleTime` populated.
- **service public URL:** `wget <externalURL>/greeter/greet` → 200.
- **web-application public URL:** `wget <externalURL>/` → 200.
- **Component delete:** web-app `ReleaseBinding` + `Deployment` drain; service untouched.
- **Project delete:** all `ReleaseBindings` gone, DP namespace fully drained.

### 2. `microservicesdemo` — GCP microservices demo smoke

- **Setup:** apply `samples/gcp-microservices-demo`, drop a busybox tester pod in the DP namespace.
- **Rollout:** all 11 `ReleaseBindings` Ready, all pods Running.
- **Home (public URL):** `wget /` → 200 (proves `frontend → productcatalog`).
- **Product detail (public URL):** `wget /product/OLJCESPC7Z` → 200 (proves `productcatalog.GetProduct` + `currency`).
- **Cart (public URL):** `wget /cart` → 200 (proves `cart.GetCart`).
- **Teardown:** delete project, cascades to all resources.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)