### PR TITLE
test: label e2e tests and scope nightly e2e test run 

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -65,7 +65,8 @@ jobs:
             E2E_HELM_SOURCE=oci \
             HELM_CHART_VERSION=${{ env.HELM_CHART_VERSION }} \
             E2E_WITH_BUILD=${{ env.E2E_WITH_BUILD }} \
-            E2E_WITH_OBSERVABILITY=${{ env.E2E_WITH_OBSERVABILITY }}
+            E2E_WITH_OBSERVABILITY=${{ env.E2E_WITH_OBSERVABILITY }} \
+            E2E_LABEL_FILTER='tier1 || tier2'
 
       - name: Upload diagnostics
         if: failure()

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -13,6 +13,19 @@ E2E_WITH_OBSERVABILITY ?= false
 E2E_TEST_TIMEOUT       ?= 20m
 # Go duration for each individual helm install and kubectl wait (not the overall setup timeout)
 E2E_SETUP_TIMEOUT      ?= 5m
+# Ginkgo label-filter expression to select which specs run. Empty = run everything.
+# Suites are labeled `tier1`, `tier2`, … on their top-level Describe; see proposal #3509.
+# Examples: `tier1`, `tier1 || tier2`, `tier1 && !tier2`.
+E2E_LABEL_FILTER       ?=
+
+# Conditionally render the Ginkgo label-filter flag so the unfiltered command line stays clean.
+# Single-quote the value so shell metacharacters in the expression (e.g. `||`, `&&`) are not
+# interpreted by the shell when Make substitutes the variable into the recipe.
+ifneq ($(strip $(E2E_LABEL_FILTER)),)
+  E2E_GINKGO_LABEL_FLAG := --ginkgo.label-filter='$(E2E_LABEL_FILTER)'
+else
+  E2E_GINKGO_LABEL_FLAG :=
+endif
 
 # Directories
 E2E_DIR                := $(PROJECT_DIR)/test/e2e
@@ -336,12 +349,12 @@ _e2e.link-observability:
 # ---------------------------------------------------------------------------
 
 .PHONY: e2e.test
-e2e.test: ## Run e2e test suite
-	@$(call log_info, Running e2e tests)
+e2e.test: ## Run e2e test suite (set E2E_LABEL_FILTER to scope by tier)
+	@$(call log_info, Running e2e tests$(if $(E2E_GINKGO_LABEL_FLAG), with label filter '$(E2E_LABEL_FILTER)'))
 	go test $(E2E_DIR)/ -v -ginkgo.v -timeout $(E2E_TEST_TIMEOUT) \
-		--e2e.kubecontext=$(E2E_KUBECONTEXT)
+		--e2e.kubecontext=$(E2E_KUBECONTEXT) $(E2E_GINKGO_LABEL_FLAG)
 	go test $(E2E_DIR)/suites/... -v -ginkgo.v -timeout $(E2E_TEST_TIMEOUT) \
-		--e2e.kubecontext=$(E2E_KUBECONTEXT)
+		--e2e.kubecontext=$(E2E_KUBECONTEXT) $(E2E_GINKGO_LABEL_FLAG)
 
 # ---------------------------------------------------------------------------
 # Utility targets

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
-var _ = Describe("Platform Health", Ordered, func() {
+var _ = Describe("Platform Health", Ordered, Label("tier1"), func() {
 	const (
 		cpNamespace = "openchoreo-control-plane"
 		dpNamespace = "openchoreo-data-plane"

--- a/test/e2e/suites/connections/connections_test.go
+++ b/test/e2e/suites/connections/connections_test.go
@@ -20,7 +20,7 @@ var (
 	dpNs string // data plane namespace for cpNs/proj1/development
 )
 
-var _ = Describe("Connection Resolution", Ordered, func() {
+var _ = Describe("Connection Resolution", Ordered, Label("tier1"), func() {
 	// assertRBConditionInNs checks a ReleaseBinding condition in a specific namespace.
 	assertRBConditionInNs := func(namespace, rbName, condType, expectedStatus, expectedReason string) {
 		Eventually(func(g Gomega) {

--- a/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
+++ b/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
@@ -44,7 +44,7 @@ var demoComponents = []string{
 
 var demoDPNs string
 
-var _ = Describe("GCP Microservices Demo", Ordered, func() {
+var _ = Describe("GCP Microservices Demo", Ordered, Label("tier1"), func() {
 	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
 	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 

--- a/test/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/test/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -34,7 +34,7 @@ type connectivityScenario struct {
 	expectAllow bool
 }
 
-var _ = Describe("NetworkPolicy Enforcement", Ordered, func() {
+var _ = Describe("NetworkPolicy Enforcement", Ordered, Label("tier1"), func() {
 	containsAny := func(text string, patterns ...string) bool {
 		for _, pattern := range patterns {
 			if strings.Contains(text, pattern) {

--- a/test/e2e/suites/workloadtypes/workloadtypes_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_test.go
@@ -27,7 +27,7 @@ const (
 
 var dpNs string
 
-var _ = Describe("Workload Type Matrix", Ordered, func() {
+var _ = Describe("Workload Type Matrix", Ordered, Label("tier1"), func() {
 	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
 	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds a labeling to separate the tiers as suggested in: https://github.com/openchoreo/openchoreo/discussions/3509
Also, the nightly e2e test run is scoped to run only the tests from tier1 and tier2

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
