### PR TITLE
fix(helm): resolve webhook race condition on first install

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/authz/bootstrap-authz-hook.yaml
+++ b/install/helm/openchoreo-control-plane/templates/authz/bootstrap-authz-hook.yaml
@@ -1,0 +1,170 @@
+{{- if .Values.security.authz.enabled }}
+{{- if or .Values.openchoreoApi.config.security.authorization.bootstrap.roles .Values.openchoreoApi.config.security.authorization.bootstrap.mappings }}
+---
+# ServiceAccount used by the bootstrap-authz hook Job to apply
+# bootstrap authz resources after the webhook is ready.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+# ClusterRole granting the minimum permissions needed to create/update
+# bootstrap authz CRs.  Uses server-side apply so repeated runs are
+# idempotent.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - openchoreo.dev
+    resources:
+      - clusterauthzroles
+      - authzroles
+      - clusterauthzrolebindings
+      - authzrolebindings
+    verbs:
+      - create
+      - update
+      - patch
+      - get
+      - list
+  # Needed so the Job can read the ConfigMap containing the YAML to apply.
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+    namespace: {{ .Release.Namespace }}
+---
+# Post-install/post-upgrade Job that:
+#   1. Waits for the controller-manager Deployment to be fully rolled out
+#      (ensuring the validating webhook is ready to serve requests).
+#   2. Applies the bootstrap authz resources via `kubectl apply --server-side`.
+#
+# Using hook-weight "5" so it runs after the ServiceAccount/RBAC (weight "0")
+# and the bootstrap ConfigMap (weight "0") are already created.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.bootstrapJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "openchoreo-control-plane.labels" . | nindent 8 }}
+        app.kubernetes.io/component: bootstrap-authz
+    spec:
+      serviceAccountName: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      # ------------------------------------------------------------------ #
+      # Init container: wait for the admission webhook to be fully ready.    #
+      # This performs a server-side dry-run apply of the bootstrap payload.  #
+      # If the webhook is not ready, the dry-run will be rejected. Once it   #
+      # succeeds, we have strict proof the webhook admission path is working.#
+      # ------------------------------------------------------------------ #
+      initContainers:
+        - name: wait-for-webhook
+          image: {{ .Values.bootstrapJob.image.repository }}:{{ .Values.bootstrapJob.image.tag }}
+          imagePullPolicy: {{ .Values.bootstrapJob.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -ec
+            - |
+              echo "Waiting up to {{ .Values.bootstrapJob.webhookReadyTimeoutSeconds }}s for the validating webhook to serve requests..."
+              end=$(($(date +%s) + {{ .Values.bootstrapJob.webhookReadyTimeoutSeconds }}))
+              while true; do
+                if kubectl get configmap {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz \
+                    --namespace {{ .Release.Namespace }} \
+                    -o jsonpath='{.data.bootstrap\.yaml}' \
+                  | kubectl apply --server-side --dry-run=server -f - ; then
+                    echo "Webhook is ready and accepting requests."
+                    exit 0
+                fi
+                if [ $(date +%s) -gt $end ]; then
+                  echo "Timeout waiting for webhook."
+                  exit 1
+                fi
+                sleep 5
+              done
+      # ------------------------------------------------------------------ #
+      # Main container: apply bootstrap resources using server-side apply.   #
+      # ------------------------------------------------------------------ #
+      containers:
+        - name: apply-bootstrap
+          image: {{ .Values.bootstrapJob.image.repository }}:{{ .Values.bootstrapJob.image.tag }}
+          imagePullPolicy: {{ .Values.bootstrapJob.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -ec
+            - |
+              echo "Applying bootstrap authz resources..."
+              kubectl get configmap {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz \
+                --namespace {{ .Release.Namespace }} \
+                -o jsonpath='{.data.bootstrap\.yaml}' \
+              | kubectl apply --server-side --field-manager=helm-bootstrap-authz -f -
+              echo "Bootstrap authz resources applied successfully."
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/authz/bootstrap-authz.yaml
+++ b/install/helm/openchoreo-control-plane/templates/authz/bootstrap-authz.yaml
@@ -1,127 +1,138 @@
 {{- if .Values.security.authz.enabled }}
-{{- if .Values.openchoreoApi.config.security.authorization.bootstrap.roles }}
-{{- range .Values.openchoreoApi.config.security.authorization.bootstrap.roles }}
-{{- if eq (default "" .namespace) "" }}
+{{- if or .Values.openchoreoApi.config.security.authorization.bootstrap.roles .Values.openchoreoApi.config.security.authorization.bootstrap.mappings }}
 ---
-# Cluster-scoped role
-apiVersion: openchoreo.dev/v1alpha1
-kind: ClusterAuthzRole
+# ConfigMap holding all bootstrap authz resources (ClusterAuthzRole, AuthzRole,
+# ClusterAuthzRoleBinding, AuthzRoleBinding). Applied by the post-install Job
+# (bootstrap-authz-hook.yaml) AFTER the controller-manager webhook is ready,
+# eliminating the race condition described in issue #3524.
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: {{ .name }}
+  name: {{ include "openchoreo-control-plane.name" . }}-bootstrap-authz
+  namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
-    openchoreo.io/bootstrap: "true"
-    {{- if .system }}
-    openchoreo.io/system: "true"
-    {{- end }}
-spec:
-  {{- if and .description (ne .description "") }}
-  description: {{ .description | quote }}
-  {{- end }}
-  actions:
-    {{- range .actions }}
-    - {{ . | quote }}
-    {{- end }}
-{{- else }}
----
-# Namespace-scoped role
-apiVersion: openchoreo.dev/v1alpha1
-kind: AuthzRole
-metadata:
-  name: {{ .name }}
-  namespace: {{ .namespace }}
-  labels:
-    {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
-    openchoreo.io/bootstrap: "true"
-    {{- if .system }}
-    openchoreo.io/system: "true"
-    {{- end }}
-spec:
-  {{- if and .description (ne .description "") }}
-  description: {{ .description | quote }}
-  {{- end }}
-  actions:
-    {{- range .actions }}
-    - {{ . | quote }}
-    {{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{- if .Values.openchoreoApi.config.security.authorization.bootstrap.mappings }}
-{{- range .Values.openchoreoApi.config.security.authorization.bootstrap.mappings }}
-{{- $bindingKind := default "ClusterAuthzRoleBinding" .kind }}
-{{- if eq $bindingKind "ClusterAuthzRoleBinding" }}
----
-# Cluster-scoped binding
-apiVersion: openchoreo.dev/v1alpha1
-kind: ClusterAuthzRoleBinding
-metadata:
-  name: {{ .name }}
-  labels:
-    {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
-    openchoreo.io/bootstrap: "true"
-    {{- if .system }}
-    openchoreo.io/system: "true"
-    {{- end }}
-spec:
-  roleMappings:
-    {{- range .roleMappings }}
-    - roleRef:
-        name: {{ .roleRef.name }}
-        kind: {{ .roleRef.kind }}
-      {{- if and .scope (or .scope.namespace .scope.project .scope.component) }}
-      scope:
-        {{- if .scope.namespace }}
-        namespace: {{ .scope.namespace }}
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  bootstrap.yaml: |
+    {{- if .Values.openchoreoApi.config.security.authorization.bootstrap.roles }}
+    {{- range .Values.openchoreoApi.config.security.authorization.bootstrap.roles }}
+    {{- if eq (default "" .namespace) "" }}
+    ---
+    apiVersion: openchoreo.dev/v1alpha1
+    kind: ClusterAuthzRole
+    metadata:
+      name: {{ .name }}
+      labels:
+        openchoreo.io/bootstrap: "true"
+        {{- if .system }}
+        openchoreo.io/system: "true"
         {{- end }}
-        {{- if .scope.project }}
-        project: {{ .scope.project }}
-        {{- end }}
-        {{- if .scope.component }}
-        component: {{ .scope.component }}
-        {{- end }}
+    spec:
+      {{- if and .description (ne .description "") }}
+      description: {{ .description | quote }}
       {{- end }}
-    {{- end }}
-  entitlement:
-    claim: {{ .entitlement.claim }}
-    value: {{ .entitlement.value }}
-  effect: {{ .effect }}
-{{- else }}
----
-# Namespace-scoped binding
-apiVersion: openchoreo.dev/v1alpha1
-kind: AuthzRoleBinding
-metadata:
-  name: {{ .name }}
-  namespace: {{ .namespace }}
-  labels:
-    {{- include "openchoreo-control-plane.labels" $ | nindent 4 }}
-    openchoreo.io/bootstrap: "true"
-    {{- if .system }}
-    openchoreo.io/system: "true"
-    {{- end }}
-spec:
-  roleMappings:
-    {{- range .roleMappings }}
-    - roleRef:
-        name: {{ .roleRef.name }}
-        kind: {{ .roleRef.kind }}
-      {{- if and .scope (or .scope.project .scope.component) }}
-      scope:
-        {{- if .scope.project }}
-        project: {{ .scope.project }}
+      actions:
+        {{- range .actions }}
+        - {{ . | quote }}
         {{- end }}
-        {{- if .scope.component }}
-        component: {{ .scope.component }}
+    {{- else }}
+    ---
+    apiVersion: openchoreo.dev/v1alpha1
+    kind: AuthzRole
+    metadata:
+      name: {{ .name }}
+      namespace: {{ .namespace }}
+      labels:
+        openchoreo.io/bootstrap: "true"
+        {{- if .system }}
+        openchoreo.io/system: "true"
         {{- end }}
+    spec:
+      {{- if and .description (ne .description "") }}
+      description: {{ .description | quote }}
       {{- end }}
+      actions:
+        {{- range .actions }}
+        - {{ . | quote }}
+        {{- end }}
     {{- end }}
-  entitlement:
-    claim: {{ .entitlement.claim }}
-    value: {{ .entitlement.value }}
-  effect: {{ .effect }}
-{{- end }}
-{{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.openchoreoApi.config.security.authorization.bootstrap.mappings }}
+    {{- range .Values.openchoreoApi.config.security.authorization.bootstrap.mappings }}
+    {{- $bindingKind := default "ClusterAuthzRoleBinding" .kind }}
+    {{- if eq $bindingKind "ClusterAuthzRoleBinding" }}
+    ---
+    apiVersion: openchoreo.dev/v1alpha1
+    kind: ClusterAuthzRoleBinding
+    metadata:
+      name: {{ .name }}
+      labels:
+        openchoreo.io/bootstrap: "true"
+        {{- if .system }}
+        openchoreo.io/system: "true"
+        {{- end }}
+    spec:
+      roleMappings:
+        {{- range .roleMappings }}
+        - roleRef:
+            name: {{ .roleRef.name }}
+            kind: {{ .roleRef.kind }}
+          {{- if and .scope (or .scope.namespace .scope.project .scope.component) }}
+          scope:
+            {{- if .scope.namespace }}
+            namespace: {{ .scope.namespace }}
+            {{- end }}
+            {{- if .scope.project }}
+            project: {{ .scope.project }}
+            {{- end }}
+            {{- if .scope.component }}
+            component: {{ .scope.component }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      entitlement:
+        claim: {{ .entitlement.claim }}
+        value: {{ .entitlement.value }}
+      effect: {{ .effect }}
+    {{- else }}
+    ---
+    apiVersion: openchoreo.dev/v1alpha1
+    kind: AuthzRoleBinding
+    metadata:
+      name: {{ .name }}
+      namespace: {{ .namespace }}
+      labels:
+        openchoreo.io/bootstrap: "true"
+        {{- if .system }}
+        openchoreo.io/system: "true"
+        {{- end }}
+    spec:
+      roleMappings:
+        {{- range .roleMappings }}
+        - roleRef:
+            name: {{ .roleRef.name }}
+            kind: {{ .roleRef.kind }}
+          {{- if and .scope (or .scope.project .scope.component) }}
+          scope:
+            {{- if .scope.project }}
+            project: {{ .scope.project }}
+            {{- end }}
+            {{- if .scope.component }}
+            component: {{ .scope.component }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      entitlement:
+        claim: {{ .entitlement.claim }}
+        value: {{ .entitlement.value }}
+      effect: {{ .effect }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1479,10 +1479,66 @@
       "title": "clusterGateway",
       "type": "object"
     },
+    "bootstrapJob": {
+      "additionalProperties": false,
+      "description": "Configuration for the post-install/post-upgrade hook Job that applies bootstrap authz resources after the controller-manager webhook is ready",
+      "properties": {
+        "backoffLimit": {
+          "default": 3,
+          "description": "Number of retries before marking the Job as failed",
+          "minimum": 0,
+          "title": "backoffLimit",
+          "type": "integer"
+        },
+        "image": {
+          "additionalProperties": false,
+          "description": "Container image for the hook Job (needs kubectl)",
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "description": "Image pull policy",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ],
+              "required": [],
+              "title": "pullPolicy"
+            },
+            "repository": {
+              "default": "bitnami/kubectl",
+              "description": "Image repository providing kubectl",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "1.30.2",
+              "description": "Image tag",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "image",
+          "type": "object"
+        },
+        "webhookReadyTimeoutSeconds": {
+          "default": 120,
+          "description": "Seconds to wait for the controller-manager Deployment to become ready before applying bootstrap authz resources",
+          "minimum": 30,
+          "title": "webhookReadyTimeoutSeconds",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "bootstrapJob",
+      "type": "object"
+    },
     "controllerManager": {
       "additionalProperties": false,
       "description": "Controller Manager configuration - the main controller for OpenChoreo CRDs",
       "properties": {
+
         "affinity": {
           "additionalProperties": false,
           "default": {},

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -741,6 +741,54 @@ controllerManager:
       insecure: false
 
 # @schema
+# type: object
+# description: Configuration for the post-install/post-upgrade hook Job that applies bootstrap
+#   authz resources (ClusterAuthzRole, AuthzRole, ClusterAuthzRoleBinding, AuthzRoleBinding)
+#   AFTER the controller-manager webhook is ready, preventing the race condition on first install.
+# @schema
+bootstrapJob:
+  # @schema
+  # type: object
+  # description: Container image for the hook Job (needs kubectl)
+  # @schema
+  image:
+    # @schema
+    # type: string
+    # description: Image repository providing kubectl
+    # default: bitnami/kubectl
+    # @schema
+    repository: bitnami/kubectl
+    # @schema
+    # type: string
+    # description: Image tag. Pinned to a specific version for reproducibility.
+    # default: "1.30.2"
+    # @schema
+    tag: "1.30.2"
+    # @schema
+    # description: Image pull policy
+    # enum: [Always, IfNotPresent, Never]
+    # default: IfNotPresent
+    # @schema
+    pullPolicy: IfNotPresent
+
+  # @schema
+  # type: integer
+  # description: Number of retries before marking the Job as failed
+  # minimum: 0
+  # default: 3
+  # @schema
+  backoffLimit: 3
+
+  # @schema
+  # type: integer
+  # description: Seconds to wait for the controller-manager Deployment to become ready
+  #   before applying bootstrap authz resources. Increase this on slow clusters.
+  # minimum: 30
+  # default: 120
+  # @schema
+  webhookReadyTimeoutSeconds: 120
+
+# @schema
 # type: string
 # description: Kubernetes cluster domain suffix
 # default: cluster.local


### PR DESCRIPTION



## Purpose
Fixes #3524 by extracting bootstrap ClusterAuthzRoleBinding resources into a post-install Job, ensuring they are only applied via server-side apply after a dry-run strictly verifies the validating webhook is successfully serving admission requests.

## Approach
Move bootstrap ClusterAuthzRoleBinding creation to a post-install Job that waits for the webhook to be serving.

## Related Issues
closes #3524

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
Fixes webhook readiness race during fresh installs by deferring bootstrap `ClusterAuthzRoleBinding` creation until the validating webhook server is available.
