### PR TITLE
refactor: precompute CEL macro results into typed derived context

### DIFF
--- a/internal/pipeline/component/context/builder_test.go
+++ b/internal/pipeline/component/context/builder_test.go
@@ -380,8 +380,12 @@ metadata:
 				return
 			}
 
-			// Compare the entire result using cmp.Diff
-			if diff := cmp.Diff(tt.want, got.ToMap()); diff != "" {
+			gotMap := got.ToMap()
+			if _, ok := gotMap["derived"]; !ok {
+				t.Fatal("BuildComponentContext() result missing 'derived' key")
+			}
+			delete(gotMap, "derived")
+			if diff := cmp.Diff(tt.want, gotMap); diff != "" {
 				t.Errorf("BuildComponentContext() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -699,10 +703,11 @@ spec:
 				return
 			}
 
-			// Convert to map for comparison
 			got := traitCtx.ToMap()
-
-			// Compare the entire result using cmp.Diff
+			if _, ok := got["derived"]; !ok {
+				t.Fatal("BuildTraitContext() result missing 'derived' key")
+			}
+			delete(got, "derived")
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("BuildTraitContext() mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/pipeline/component/context/cel_extensions.go
+++ b/internal/pipeline/component/context/cel_extensions.go
@@ -4,79 +4,65 @@
 package context
 
 import (
-	"fmt"
-	"hash/fnv"
-	"math"
-	"sort"
-	"strings"
-
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
-
-	"github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
 )
 
 const (
 	configurationsIdentifier = "configurations"
 	dependenciesIdentifier   = "dependencies"
-	protocolTCP              = "TCP"
-	protocolUDP              = "UDP"
+	derivedIdentifier        = "derived"
 )
 
-// CELExtensions and CELValidationExtensions are generated from helperFuncRegistry
-// in cel_return_types.go. To add a new helper function, add an entry there.
-
-// buildPrefixExpr creates an AST expression for: metadata.componentName + "-" + metadata.environmentName
-func buildPrefixExpr(eh parser.ExprHelper) ast.Expr {
-	componentNameExpr := eh.NewSelect(eh.NewIdent("metadata"), "componentName")
-	environmentNameExpr := eh.NewSelect(eh.NewIdent("metadata"), "environmentName")
-	componentWithDash := eh.NewCall("_+_", componentNameExpr, eh.NewLiteral(types.String("-")))
-	// metadata.componentName + "-" + metadata.environmentName
-	return eh.NewCall("_+_", componentWithDash, environmentNameExpr)
+// CELExtensions returns CEL environment options for configuration, workload,
+// and dependency helpers. All macros rewrite method-call syntax to field
+// selects on the precomputed "derived" context variable.
+func CELExtensions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Macros(
+			toConfigFileListMacro,
+			toSecretFileListMacro,
+			toContainerEnvFromMacro,
+			toContainerVolumeMountsMacro,
+			toVolumesMacro,
+			toConfigEnvsByContainerMacro,
+			toSecretEnvsByContainerMacro,
+			toServicePortsMacro,
+			toContainerEnvsMacro,
+		),
+	}
 }
 
-// toConfigFileListMacro transforms configurations.toConfigFileList() into
-// configurationsToConfigFileList(configurations, prefix) at compile time.
+func derivedField(eh parser.ExprHelper, fieldName string) ast.Expr {
+	return eh.NewSelect(eh.NewIdent(derivedIdentifier), fieldName)
+}
+
 var toConfigFileListMacro = cel.ReceiverMacro("toConfigFileList", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() == ast.IdentKind && target.AsIdent() == configurationsIdentifier {
-			prefixExpr := buildPrefixExpr(eh)
-			return eh.NewCall("configurationsToConfigFileList", target, prefixExpr), nil
+			return derivedField(eh, "configFileList"), nil
 		}
 		return nil, nil
 	})
 
-// toSecretFileListMacro transforms configurations.toSecretFileList() into
-// configurationsToSecretFileList(configurations, prefix) at compile time.
 var toSecretFileListMacro = cel.ReceiverMacro("toSecretFileList", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() == ast.IdentKind && target.AsIdent() == configurationsIdentifier {
-			prefixExpr := buildPrefixExpr(eh)
-			return eh.NewCall("configurationsToSecretFileList", target, prefixExpr), nil
+			return derivedField(eh, "secretFileList"), nil
 		}
 		return nil, nil
 	})
 
-// toContainerEnvFromMacro transforms configurations.toContainerEnvFrom() into
-// configurationsToContainerEnvFrom(configurations, prefix) at compile time.
 var toContainerEnvFromMacro = cel.ReceiverMacro("toContainerEnvFrom", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() == ast.IdentKind && target.AsIdent() == configurationsIdentifier {
-			prefixExpr := buildPrefixExpr(eh)
-			return eh.NewCall("configurationsToContainerEnvFrom", target, prefixExpr), nil
+			return derivedField(eh, "containerEnvFrom"), nil
 		}
 		return nil, nil
 	})
 
-// toContainerVolumeMountsMacro transforms either:
-//   - configurations.toContainerVolumeMounts() into configurationsToContainerVolumeMounts(configurations)
-//   - dependencies.toContainerVolumeMounts() into dependencies.volumeMounts (field select)
-//
-// at compile time. The receiver guard disambiguates which rewrite applies.
 var toContainerVolumeMountsMacro = cel.ReceiverMacro("toContainerVolumeMounts", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() != ast.IdentKind {
@@ -84,18 +70,13 @@ var toContainerVolumeMountsMacro = cel.ReceiverMacro("toContainerVolumeMounts", 
 		}
 		switch target.AsIdent() {
 		case configurationsIdentifier:
-			return eh.NewCall("configurationsToContainerVolumeMounts", target), nil
+			return derivedField(eh, "configVolumeMounts"), nil
 		case dependenciesIdentifier:
-			return eh.NewSelect(target, "volumeMounts"), nil
+			return derivedField(eh, "dependencyVolumeMounts"), nil
 		}
 		return nil, nil
 	})
 
-// toVolumesMacro transforms either:
-//   - configurations.toVolumes() into configurationsToVolumes(configurations, prefix)
-//   - dependencies.toVolumes() into dependencies.volumes (field select)
-//
-// at compile time. The receiver guard disambiguates which rewrite applies.
 var toVolumesMacro = cel.ReceiverMacro("toVolumes", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() != ast.IdentKind {
@@ -103,680 +84,41 @@ var toVolumesMacro = cel.ReceiverMacro("toVolumes", 0,
 		}
 		switch target.AsIdent() {
 		case configurationsIdentifier:
-			prefixExpr := buildPrefixExpr(eh)
-			return eh.NewCall("configurationsToVolumes", target, prefixExpr), nil
+			return derivedField(eh, "configVolumes"), nil
 		case dependenciesIdentifier:
-			return eh.NewSelect(target, "volumes"), nil
+			return derivedField(eh, "dependencyVolumes"), nil
 		}
 		return nil, nil
 	})
 
-// toConfigEnvsByContainerMacro transforms configurations.toConfigEnvsByContainer() into
-// configurationsToConfigEnvsByContainer(configurations, prefix) at compile time.
 var toConfigEnvsByContainerMacro = cel.ReceiverMacro("toConfigEnvsByContainer", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() == ast.IdentKind && target.AsIdent() == configurationsIdentifier {
-			prefixExpr := buildPrefixExpr(eh)
-			return eh.NewCall("configurationsToConfigEnvsByContainer", target, prefixExpr), nil
+			return derivedField(eh, "configEnvs"), nil
 		}
 		return nil, nil
 	})
 
-// toSecretEnvsByContainerMacro transforms configurations.toSecretEnvsByContainer() into
-// configurationsToSecretEnvsByContainer(configurations, prefix) at compile time.
 var toSecretEnvsByContainerMacro = cel.ReceiverMacro("toSecretEnvsByContainer", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() == ast.IdentKind && target.AsIdent() == configurationsIdentifier {
-			prefixExpr := buildPrefixExpr(eh)
-			return eh.NewCall("configurationsToSecretEnvsByContainer", target, prefixExpr), nil
+			return derivedField(eh, "secretEnvs"), nil
 		}
 		return nil, nil
 	})
 
-// toServicePortsMacro transforms workload.toServicePorts() into
-// workloadToServicePorts(workload) at compile time.
 var toServicePortsMacro = cel.ReceiverMacro("toServicePorts", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
-		// Check if target is workload
 		if target.Kind() == ast.IdentKind && target.AsIdent() == "workload" {
-			return eh.NewCall("workloadToServicePorts", target), nil
+			return derivedField(eh, "servicePorts"), nil
 		}
 		return nil, nil
 	})
 
-// toContainerEnvsMacro rewrites dependencies.toContainerEnvs() to dependencies.envVars at compile time.
 var toContainerEnvsMacro = cel.ReceiverMacro("toContainerEnvs", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if target.Kind() == ast.IdentKind && target.AsIdent() == dependenciesIdentifier {
-			return eh.NewSelect(target, "envVars"), nil
+			return derivedField(eh, "dependencyEnvVars"), nil
 		}
 		return nil, nil
 	})
-
-// configurationsToConfigFileListFunction is the CEL binding for configurations.toConfigFileList().
-// The macro automatically injects prefix (metadata.componentName + "-" + metadata.environmentName) as the prefix parameter.
-// Returns a list of maps, each containing: name, mountPath, value, resourceName, and optionally remoteRef.
-func configurationsToConfigFileListFunction(configurations, prefix ref.Val) ref.Val {
-	prefixStr, ok := prefix.Value().(string)
-	if !ok {
-		return types.NewErr("toConfigFileList: prefix must be a string")
-	}
-
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toConfigFileList: expected map[string]any, got %T", configurations.Value())
-	}
-	result := makeConfigFileList(containerConfig, prefixStr)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// configurationsToSecretFileListFunction is the CEL binding for configurations.toSecretFileList().
-// The macro automatically injects prefix (metadata.componentName + "-" + metadata.environmentName) as the prefix parameter.
-// Returns a list of maps, each containing: name, mountPath, resourceName, and remoteRef.
-// Note: Secret files do not have inline values, only remoteRef for external secret references.
-func configurationsToSecretFileListFunction(configurations, prefix ref.Val) ref.Val {
-	prefixStr, ok := prefix.Value().(string)
-	if !ok {
-		return types.NewErr("toSecretFileList: prefix must be a string")
-	}
-
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toSecretFileList: expected map[string]any, got %T", configurations.Value())
-	}
-	result := makeSecretFileList(containerConfig, prefixStr)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// configurationsToContainerEnvFromFunction is the CEL binding for configurations.toContainerEnvFrom().
-// The macro automatically injects prefix (metadata.componentName + "-" + metadata.environmentName) as the second parameter.
-// Returns a list of envFrom entries (configMapRef and/or secretRef) based on container config.
-func configurationsToContainerEnvFromFunction(configurations, prefix ref.Val) ref.Val {
-	prefixStr, ok := prefix.Value().(string)
-	if !ok {
-		return types.NewErr("toContainerEnvFrom: prefix must be a string")
-	}
-
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toContainerEnvFrom: expected map[string]any, got %T", configurations.Value())
-	}
-
-	result := makeEnvFromList(containerConfig, prefixStr)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// makeConfigFileList extracts configs.files from the container configuration and returns a list of maps.
-// Each map contains: name, mountPath, value, resourceName, and optionally remoteRef.
-func makeConfigFileList(containerConfig map[string]any, prefix string) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0)
-
-	configs, ok := containerConfig["configs"].(map[string]any)
-	if !ok {
-		return result
-	}
-	files, ok := configs["files"].([]any)
-	if !ok {
-		return result
-	}
-
-	for _, fileVal := range files {
-		file, ok := fileVal.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		name, _ := file["name"].(string)
-		mountPath, _ := file["mountPath"].(string)
-		value, _ := file["value"].(string)
-
-		entry := map[string]any{
-			"name":         name,
-			"mountPath":    mountPath,
-			"value":        value,
-			"resourceName": generateConfigResourceName(prefix, name),
-		}
-		if remoteRef, ok := file["remoteRef"].(map[string]any); ok {
-			entry["remoteRef"] = remoteRef
-		}
-		result = append(result, entry)
-	}
-	return result
-}
-
-// makeSecretFileList extracts secrets.files from the container configuration and returns a list of maps.
-// Each map contains: name, mountPath, resourceName, and remoteRef.
-func makeSecretFileList(containerConfig map[string]any, prefix string) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0)
-
-	secrets, ok := containerConfig["secrets"].(map[string]any)
-	if !ok {
-		return result
-	}
-	files, ok := secrets["files"].([]any)
-	if !ok {
-		return result
-	}
-
-	for _, fileVal := range files {
-		file, ok := fileVal.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		name, _ := file["name"].(string)
-		mountPath, _ := file["mountPath"].(string)
-
-		entry := map[string]any{
-			"name":         name,
-			"mountPath":    mountPath,
-			"resourceName": generateSecretResourceName(prefix, name),
-		}
-		if remoteRef, ok := file["remoteRef"].(map[string]any); ok {
-			entry["remoteRef"] = remoteRef
-		}
-		result = append(result, entry)
-	}
-	return result
-}
-
-// generateConfigResourceName generates a Kubernetes-compliant resource name for a config file.
-func generateConfigResourceName(prefix, filename string) string {
-	return kubernetes.GenerateK8sNameWithLengthLimit(
-		kubernetes.MaxResourceNameLength,
-		prefix,
-		"config",
-		strings.ReplaceAll(filename, ".", "-"),
-	)
-}
-
-// configurationsToContainerVolumeMountsFunction is the CEL binding for configurations.toContainerVolumeMounts().
-// Returns a list of volumeMount entries based on the container's config files.
-func configurationsToContainerVolumeMountsFunction(configurations ref.Val) ref.Val {
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toContainerVolumeMounts: expected map[string]any, got %T", configurations.Value())
-	}
-
-	result := makeVolumeMountsList(containerConfig)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// configurationsToVolumesFunction is the CEL binding for configurations.toVolumes().
-// The macro automatically injects prefix (metadata.componentName + "-" + metadata.environmentName) as the prefix parameter.
-// Returns a list of volume entries for the container's files.
-func configurationsToVolumesFunction(configurations, prefix ref.Val) ref.Val {
-	prefixStr, ok := prefix.Value().(string)
-	if !ok {
-		return types.NewErr("toVolumes: prefix must be a string")
-	}
-
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toVolumes: expected map[string]any, got %T", configurations.Value())
-	}
-	result := makeVolumesList(containerConfig, prefixStr)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// makeEnvFromList generates envFrom entries for a single container configuration.
-// Returns a list containing configMapRef and/or secretRef based on what envs are available.
-func makeEnvFromList(containerConfig map[string]any, prefix string) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0)
-
-	// Check for config environment variables
-	if configs, ok := containerConfig["configs"].(map[string]any); ok {
-		if envs, ok := configs["envs"].([]any); ok && len(envs) > 0 {
-			configMapName := generateEnvResourceName(prefix, "env-configs")
-			result = append(result, map[string]any{
-				"configMapRef": map[string]any{
-					"name": configMapName,
-				},
-			})
-		}
-	}
-
-	// Check for secret environment variables
-	if secrets, ok := containerConfig["secrets"].(map[string]any); ok {
-		if envs, ok := secrets["envs"].([]any); ok && len(envs) > 0 {
-			secretName := generateEnvResourceName(prefix, "env-secrets")
-			result = append(result, map[string]any{
-				"secretRef": map[string]any{
-					"name": secretName,
-				},
-			})
-		}
-	}
-
-	return result
-}
-
-// generateSecretResourceName generates a Kubernetes-compliant resource name for a secret file.
-func generateSecretResourceName(prefix, filename string) string {
-	return kubernetes.GenerateK8sNameWithLengthLimit(
-		kubernetes.MaxResourceNameLength,
-		prefix,
-		"secret",
-		strings.ReplaceAll(filename, ".", "-"),
-	)
-}
-
-// makeVolumeMountsList generates volumeMount entries for a single container configuration.
-// Returns a list containing volumeMount entries for all files (both config and secret files).
-func makeVolumeMountsList(containerConfig map[string]any) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0)
-
-	// Process config files
-	if configs, ok := containerConfig["configs"].(map[string]any); ok {
-		if files, ok := configs["files"].([]any); ok {
-			for _, fileVal := range files {
-				if file, ok := fileVal.(map[string]any); ok {
-					name, _ := file["name"].(string)
-					mountPath, _ := file["mountPath"].(string)
-					volumeName := "file-mount-" + generateVolumeHash(mountPath, name)
-
-					result = append(result, map[string]any{
-						"name":      volumeName,
-						"mountPath": mountPath + "/" + name,
-						"subPath":   name,
-					})
-				}
-			}
-		}
-	}
-
-	// Process secret files
-	if secrets, ok := containerConfig["secrets"].(map[string]any); ok {
-		if files, ok := secrets["files"].([]any); ok {
-			for _, fileVal := range files {
-				if file, ok := fileVal.(map[string]any); ok {
-					name, _ := file["name"].(string)
-					mountPath, _ := file["mountPath"].(string)
-					volumeName := "file-mount-" + generateVolumeHash(mountPath, name)
-
-					result = append(result, map[string]any{
-						"name":      volumeName,
-						"mountPath": mountPath + "/" + name,
-						"subPath":   name,
-					})
-				}
-			}
-		}
-	}
-
-	return result
-}
-
-// makeVolumesList generates volume entries for the container's files.
-// Returns a list containing volume definitions for all files (both config and secret files).
-func makeVolumesList(containerConfig map[string]any, prefix string) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0)
-	volumes := make(map[string]map[string]any)
-
-	// Process config files
-	if configs, ok := containerConfig["configs"].(map[string]any); ok {
-		if files, ok := configs["files"].([]any); ok {
-			for _, fileVal := range files {
-				if file, ok := fileVal.(map[string]any); ok {
-					name, _ := file["name"].(string)
-					mountPath, _ := file["mountPath"].(string)
-					volumeName := "file-mount-" + generateVolumeHash(mountPath, name)
-					configMapName := generateConfigResourceName(prefix, name)
-
-					volumes[volumeName] = map[string]any{
-						"name": volumeName,
-						"configMap": map[string]any{
-							"name": configMapName,
-						},
-					}
-				}
-			}
-		}
-	}
-
-	// Process secret files
-	if secrets, ok := containerConfig["secrets"].(map[string]any); ok {
-		if files, ok := secrets["files"].([]any); ok {
-			for _, fileVal := range files {
-				if file, ok := fileVal.(map[string]any); ok {
-					name, _ := file["name"].(string)
-					mountPath, _ := file["mountPath"].(string)
-					volumeName := "file-mount-" + generateVolumeHash(mountPath, name)
-					secretName := generateSecretResourceName(prefix, name)
-
-					volumes[volumeName] = map[string]any{
-						"name": volumeName,
-						"secret": map[string]any{
-							"secretName": secretName,
-						},
-					}
-				}
-			}
-		}
-	}
-
-	// Sort by name so the slice order is stable across renders; otherwise
-	// the Deployment's pod-template-hash flips on every reconcile.
-	names := make([]string, 0, len(volumes))
-	for name := range volumes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		result = append(result, volumes[name])
-	}
-
-	return result
-}
-
-// configurationsToConfigEnvsByContainerFunction is the CEL binding for configurations.toConfigEnvsByContainer().
-// The macro automatically injects prefix (metadata.componentName + "-" + metadata.environmentName) as the prefix parameter.
-// Returns a list of objects with resourceName and envs for the container with config envs.
-func configurationsToConfigEnvsByContainerFunction(configurations, prefix ref.Val) ref.Val {
-	prefixStr, ok := prefix.Value().(string)
-	if !ok {
-		return types.NewErr("toConfigEnvsByContainer: prefix must be a string")
-	}
-
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toConfigEnvsByContainer: expected map[string]any, got %T", configurations.Value())
-	}
-
-	result := makeConfigEnvList(containerConfig, prefixStr)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// makeConfigEnvList creates a list of objects with resourceName and envs.
-// Returns a single-item list if the container has config envs, empty list otherwise.
-func makeConfigEnvList(containerConfig map[string]any, prefix string) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0, 1)
-
-	configs, ok := containerConfig["configs"].(map[string]any)
-	if !ok {
-		return result
-	}
-
-	envs, ok := configs["envs"].([]any)
-	if !ok || len(envs) == 0 {
-		return result
-	}
-
-	resourceName := generateEnvResourceName(prefix, "env-configs")
-
-	entry := map[string]any{
-		"resourceName": resourceName,
-		"envs":         envs,
-	}
-	result = append(result, entry)
-
-	return result
-}
-
-// configurationsToSecretEnvsByContainerFunction is the CEL binding for configurations.toSecretEnvsByContainer().
-// The macro automatically injects prefix (metadata.componentName + "-" + metadata.environmentName) as the prefix parameter.
-// Returns a list of objects with resourceName and envs for the container with secret envs.
-func configurationsToSecretEnvsByContainerFunction(configurations, prefix ref.Val) ref.Val {
-	prefixStr, ok := prefix.Value().(string)
-	if !ok {
-		return types.NewErr("toSecretEnvsByContainer: prefix must be a string")
-	}
-
-	containerConfig, ok := configurations.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toSecretEnvsByContainer: expected map[string]any, got %T", configurations.Value())
-	}
-
-	result := makeSecretEnvList(containerConfig, prefixStr)
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// makeSecretEnvList creates a list of objects with resourceName and envs.
-// Returns a single-item list if the container has secret envs, empty list otherwise.
-func makeSecretEnvList(containerConfig map[string]any, prefix string) []map[string]any {
-	if len(containerConfig) == 0 {
-		return []map[string]any{}
-	}
-
-	result := make([]map[string]any, 0, 1)
-
-	secrets, ok := containerConfig["secrets"].(map[string]any)
-	if !ok {
-		return result
-	}
-
-	envs, ok := secrets["envs"].([]any)
-	if !ok || len(envs) == 0 {
-		return result
-	}
-
-	resourceName := generateEnvResourceName(prefix, "env-secrets")
-
-	entry := map[string]any{
-		"resourceName": resourceName,
-		"envs":         envs,
-	}
-	result = append(result, entry)
-
-	return result
-}
-
-// generateVolumeHash generates a hash for volume names to match the template pattern.
-// This uses the same hash function as the oc_hash CEL function (FNV-1a 32-bit).
-func generateVolumeHash(mountPath, filename string) string {
-	input := mountPath + "/" + filename
-	h := fnv.New32a()
-	h.Write([]byte(input))
-	return fmt.Sprintf("%08x", h.Sum32())
-}
-
-func generateEnvResourceName(prefix, suffix string) string {
-	return kubernetes.GenerateK8sNameWithLengthLimit(
-		kubernetes.MaxResourceNameLength,
-		prefix,
-		suffix,
-	)
-}
-
-// toInt64 converts a numeric value (int, int32, int64, float64) to int64.
-// Returns (value, true) on success, or (0, false) if the value is not a supported numeric type.
-// For float64 values, returns an error-indicating (0, false) if the value is not a whole number.
-func toInt64(v any) (int64, bool) {
-	switch n := v.(type) {
-	case int64:
-		return n, true
-	case float64:
-		if math.Trunc(n) != n {
-			return 0, false
-		}
-		return int64(n), true
-	case int:
-		return int64(n), true
-	case int32:
-		return int64(n), true
-	default:
-		return 0, false
-	}
-}
-
-// workloadToServicePortsFunction is the CEL binding for workload.toServicePorts().
-// Returns a list of Service port definitions, each containing: name, port, targetPort, protocol.
-func workloadToServicePortsFunction(workload ref.Val) ref.Val {
-	workloadMap, ok := workload.Value().(map[string]any)
-	if !ok {
-		return types.NewErr("toServicePorts: expected workload to be a map, got %T", workload.Value())
-	}
-
-	endpointsVal, hasEndpoints := workloadMap["endpoints"]
-	if !hasEndpoints {
-		return types.DefaultTypeAdapter.NativeToValue([]map[string]any{})
-	}
-
-	endpointsMap, ok := endpointsVal.(map[string]any)
-	if !ok {
-		return types.NewErr("toServicePorts: workload.endpoints must be a map, got %T", endpointsVal)
-	}
-
-	if len(endpointsMap) == 0 {
-		return types.DefaultTypeAdapter.NativeToValue([]map[string]any{})
-	}
-
-	// Sort endpoint names for deterministic output
-	endpointNames := make([]string, 0, len(endpointsMap))
-	for endpointName := range endpointsMap {
-		endpointNames = append(endpointNames, endpointName)
-	}
-	sort.Strings(endpointNames)
-
-	result := make([]map[string]any, 0, len(endpointsMap))
-	usedNames := make(map[string]bool)
-	// Kubernetes Services require (port, protocol) to be unique across ports[],
-	// so skip endpoints that would produce a duplicate entry.
-	seenPortProto := make(map[string]bool)
-
-	for _, endpointName := range endpointNames {
-		endpointVal := endpointsMap[endpointName]
-		endpoint, ok := endpointVal.(map[string]any)
-		if !ok {
-			return types.NewErr("toServicePorts: endpoint '%s' must be an object, got %T", endpointName, endpointVal)
-		}
-
-		portVal := endpoint["port"]
-		if portVal == nil {
-			return types.NewErr("toServicePorts: endpoint '%s' is missing required 'port' field", endpointName)
-		}
-		port, ok := toInt64(portVal)
-		if !ok {
-			return types.NewErr("toServicePorts: endpoint '%s' must have a numeric integer port, got %v (%T)", endpointName, portVal, portVal)
-		}
-
-		// targetPort is already resolved by ExtractWorkloadData (defaults to port when unset),
-		// so read it directly; fall back to port only for raw/unresolved data.
-		targetPort := port
-		if tpVal := endpoint["targetPort"]; tpVal != nil {
-			if tp, ok := toInt64(tpVal); ok && tp != 0 {
-				targetPort = tp
-			}
-		}
-
-		endpointType, _ := endpoint["type"].(string)
-		protocol := mapEndpointTypeToProtocol(endpointType)
-
-		portProtoKey := fmt.Sprintf("%d/%s", port, protocol)
-		if seenPortProto[portProtoKey] {
-			continue
-		}
-		seenPortProto[portProtoKey] = true
-
-		// Sanitize endpoint name for Kubernetes port naming
-		sanitizedName := sanitizePortName(endpointName)
-		if sanitizedName == "" {
-			sanitizedName = fmt.Sprintf("port-%d", port)
-		}
-
-		// Ensure uniqueness by adding suffix if needed
-		finalName := sanitizedName
-		counter := 2
-		for usedNames[finalName] {
-			finalName = fmt.Sprintf("%s-%d", sanitizedName, counter)
-			// Ensure the final name doesn't exceed 15 characters
-			if len(finalName) > 15 {
-				// Truncate the base name to make room for suffix
-				maxBaseLen := 15 - len(fmt.Sprintf("-%d", counter))
-				if maxBaseLen > 0 {
-					finalName = fmt.Sprintf("%s-%d", sanitizedName[:maxBaseLen], counter)
-				} else {
-					// If counter is too large, use minimal name
-					finalName = fmt.Sprintf("p-%d", counter)
-				}
-			}
-			counter++
-		}
-		usedNames[finalName] = true
-
-		result = append(result, map[string]any{
-			"name":       finalName,
-			"port":       port,
-			"targetPort": targetPort,
-			"protocol":   protocol,
-		})
-	}
-
-	return types.DefaultTypeAdapter.NativeToValue(result)
-}
-
-// mapEndpointTypeToProtocol maps WorkloadEndpoint.Type to Kubernetes Service protocol.
-func mapEndpointTypeToProtocol(endpointType string) string {
-	switch endpointType {
-	case protocolTCP:
-		return protocolTCP
-	case protocolUDP:
-		return protocolUDP
-	default:
-		// HTTP, gRPC, GraphQL, Websocket all use TCP
-		return protocolTCP
-	}
-}
-
-// sanitizePortName sanitizes endpoint names for use as Kubernetes port names.
-// Kubernetes port names must be:
-// - lowercase alphanumeric + hyphens
-// - start and end with alphanumeric (not hyphen)
-// - max 15 characters (IANA service name limit)
-// Returns empty string if name cannot be sanitized.
-func sanitizePortName(name string) string {
-	// Convert to lowercase
-	name = strings.ToLower(name)
-	// Replace underscores with hyphens
-	name = strings.ReplaceAll(name, "_", "-")
-
-	// Remove invalid characters (keep only alphanumeric and hyphens)
-	var result strings.Builder
-	for _, ch := range name {
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
-			result.WriteRune(ch)
-		}
-	}
-	sanitized := result.String()
-
-	// Trim leading and trailing hyphens (Kubernetes requirement)
-	sanitized = strings.Trim(sanitized, "-")
-
-	// If empty after sanitization, return empty (caller must handle)
-	if len(sanitized) == 0 {
-		return ""
-	}
-
-	// Limit to 15 characters (IANA service name limit)
-	if len(sanitized) > 15 {
-		sanitized = sanitized[:15]
-		// Trim trailing hyphen if we cut in the middle of a word
-		sanitized = strings.TrimRight(sanitized, "-")
-	}
-
-	return sanitized
-}

--- a/internal/pipeline/component/context/cel_extensions_test.go
+++ b/internal/pipeline/component/context/cel_extensions_test.go
@@ -13,174 +13,99 @@ import (
 	"github.com/openchoreo/openchoreo/internal/template"
 )
 
+func derivedInputs(configs ContainerConfigurations, workload WorkloadData, deps ConnectionsContextData) map[string]any {
+	derived := BuildDerivedContext(configs, workload, deps, "app-dev")
+	derivedMap, err := structToMap(&derived)
+	if err != nil {
+		panic("structToMap failed for DerivedContext: " + err.Error())
+	}
+	return map[string]any{"derived": derivedMap}
+}
+
+func configInputs(configs ContainerConfigurations) map[string]any {
+	return derivedInputs(configs, WorkloadData{}, ConnectionsContextData{})
+}
+
+func workloadInputs(workload WorkloadData) map[string]any {
+	return derivedInputs(ContainerConfigurations{}, workload, ConnectionsContextData{})
+}
+
+func depInputs(deps ConnectionsContextData) map[string]any {
+	return derivedInputs(ContainerConfigurations{}, WorkloadData{}, deps)
+}
+
 func TestConfigurationsToConfigFileListMacro(t *testing.T) {
 	tests := []struct {
 		name   string
 		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "single container with single config file",
+			name: "single config file",
 			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{
+					Files: []FileConfiguration{{Name: "config.yaml", MountPath: "/etc/config/config.yaml", Value: "key: value"}},
 				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{
-								"name":      "config.yaml",
-								"mountPath": "/etc/config/config.yaml",
-								"value":     "key: value",
-							},
-						},
+			}),
+			want: []any{
+				map[string]any{"name": "config.yaml", "mountPath": "/etc/config/config.yaml", "value": "key: value", "resourceName": generateConfigResourceName("app-dev", "config.yaml")},
+			},
+		},
+		{
+			name: "multiple config files",
+			expr: `configurations.toConfigFileList()`,
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{
+					Files: []FileConfiguration{
+						{Name: "app.yaml", MountPath: "/etc/app.yaml", Value: "app config"},
+						{Name: "logging.properties", MountPath: "/etc/logging.properties", Value: "log.level=INFO"},
 					},
-					"secrets": map[string]any{"files": []any{}},
 				},
-			},
-			want: []map[string]any{
-				{
-					"name":         "config.yaml",
-					"mountPath":    "/etc/config/config.yaml",
-					"value":        "key: value",
-					"resourceName": generateConfigResourceName("app-dev", "config.yaml"),
-				},
+			}),
+			want: []any{
+				map[string]any{"name": "app.yaml", "mountPath": "/etc/app.yaml", "value": "app config", "resourceName": generateConfigResourceName("app-dev", "app.yaml")},
+				map[string]any{"name": "logging.properties", "mountPath": "/etc/logging.properties", "value": "log.level=INFO", "resourceName": generateConfigResourceName("app-dev", "logging.properties")},
 			},
 		},
 		{
-			name: "single container with multiple config files",
-			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{"name": "app.yaml", "mountPath": "/etc/app.yaml", "value": "app config"},
-							map[string]any{"name": "logging.properties", "mountPath": "/etc/logging.properties", "value": "log.level=INFO"},
-						},
-					},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{
-				{"name": "app.yaml", "mountPath": "/etc/app.yaml", "value": "app config", "resourceName": generateConfigResourceName("app-dev", "app.yaml")},
-				{"name": "logging.properties", "mountPath": "/etc/logging.properties", "value": "log.level=INFO", "resourceName": generateConfigResourceName("app-dev", "logging.properties")},
-			},
+			name:   "no config files returns empty list",
+			expr:   `configurations.toConfigFileList()`,
+			inputs: configInputs(ContainerConfigurations{Configs: ConfigurationItems{Files: []FileConfiguration{}}}),
+			want:   []any{},
 		},
 		{
-			name: "no config files returns empty list",
-			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "empty configurations returns empty list",
-			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{},
-			},
-			want: []map[string]any{},
+			name:   "empty configurations returns empty list",
+			expr:   `configurations.toConfigFileList()`,
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 		{
 			name: "config file with remoteRef",
 			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{
+					Files: []FileConfiguration{{Name: "config.yaml", MountPath: "/etc/config.yaml", RemoteRef: &RemoteRefData{Key: "my-config-key", Property: "config.yaml"}}},
 				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{
-								"name":      "config.yaml",
-								"mountPath": "/etc/config.yaml",
-								"remoteRef": map[string]any{
-									"key":      "my-config-key",
-									"property": "config.yaml",
-								},
-							},
-						},
-					},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{
-				{
-					"name":         "config.yaml",
-					"mountPath":    "/etc/config.yaml",
-					"value":        "",
+			}),
+			want: []any{
+				map[string]any{
+					"name": "config.yaml", "mountPath": "/etc/config.yaml", "value": "",
 					"resourceName": generateConfigResourceName("app-dev", "config.yaml"),
-					"remoteRef": map[string]any{
-						"key":      "my-config-key",
-						"property": "config.yaml",
-					},
+					"remoteRef":    map[string]any{"key": "my-config-key", "property": "config.yaml"},
 				},
 			},
 		},
 		{
-			name: "dots in filename are replaced with hyphens in resourceName",
+			name: "ignores secret files",
 			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{"name": "application.properties", "mountPath": "/etc/application.properties", "value": "prop=value"},
-						},
-					},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{
-				{"name": "application.properties", "mountPath": "/etc/application.properties", "value": "prop=value", "resourceName": generateConfigResourceName("app-dev", "application.properties")},
-			},
-		},
-		{
-			name: "ignores secret files (only returns config files)",
-			expr: `configurations.toConfigFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{"name": "config.yaml", "mountPath": "/etc/config.yaml", "value": "config"},
-						},
-					},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{"name": "secret.yaml", "mountPath": "/etc/secret.yaml", "value": "secret"},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "config.yaml", "mountPath": "/etc/config.yaml", "value": "config", "resourceName": generateConfigResourceName("app-dev", "config.yaml")},
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Files: []FileConfiguration{{Name: "config.yaml", MountPath: "/etc/config.yaml", Value: "config"}}},
+				Secrets: ConfigurationItems{Files: []FileConfiguration{{Name: "secret.yaml", MountPath: "/etc/secret.yaml", RemoteRef: &RemoteRefData{Key: "s"}}}},
+			}),
+			want: []any{
+				map[string]any{"name": "config.yaml", "mountPath": "/etc/config.yaml", "value": "config", "resourceName": generateConfigResourceName("app-dev", "config.yaml")},
 			},
 		},
 	}
@@ -192,16 +117,10 @@ func TestConfigurationsToConfigFileListMacro(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b map[string]any) bool {
-				return a["name"].(string) < b["name"].(string)
+			if diff := cmp.Diff(tt.want, result, cmpopts.SortSlices(func(a, b any) bool {
+				return a.(map[string]any)["name"].(string) < b.(map[string]any)["name"].(string)
 			})); diff != "" {
-				t.Errorf("toConfigFileList() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -210,111 +129,47 @@ func TestConfigurationsToConfigFileListMacro(t *testing.T) {
 func TestToConfigFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
-	// This should work - configurations is the expected receiver
-	_, err := engine.Render(`${configurations.toConfigFileList()}`, map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{},
-	})
+	_, err := engine.Render(`${configurations.toConfigFileList()}`, configInputs(ContainerConfigurations{}))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// This should fail - "other" is not a valid receiver for the macro
-	_, err = engine.Render(`${other.toConfigFileList()}`, map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"other": map[string]any{},
-	})
+	inputs := configInputs(ContainerConfigurations{})
+	inputs["other"] = map[string]any{}
+	_, err = engine.Render(`${other.toConfigFileList()}`, inputs)
 	if err == nil {
 		t.Error("expected error for non-configurations receiver")
-	}
-
-	// Field access should not be affected by the macro
-	result, err := engine.Render(`${parameters.configFiles.map(f, f.name)}`, map[string]any{
-		"parameters": map[string]any{
-			"configFiles": []any{
-				map[string]any{"name": "a.yaml"},
-				map[string]any{"name": "b.yaml"},
-			},
-		},
-	})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	want := []any{"a.yaml", "b.yaml"}
-	if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-		return a.(string) < b.(string)
-	})); diff != "" {
-		t.Errorf("field access mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestToConfigFileListCanBeUsedWithCELOperations(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-
-	inputs := map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{
-			"configs": map[string]any{
-				"files": []any{
-					map[string]any{"name": "a.yaml", "mountPath": "/a.yaml", "value": "a"},
-					map[string]any{"name": "b.yaml", "mountPath": "/b.yaml", "value": "b"},
-				},
+	inputs := configInputs(ContainerConfigurations{
+		Configs: ConfigurationItems{
+			Files: []FileConfiguration{
+				{Name: "a.yaml", MountPath: "/a.yaml", Value: "a"},
+				{Name: "b.yaml", MountPath: "/b.yaml", Value: "b"},
 			},
-			"secrets": map[string]any{"files": []any{}},
 		},
-	}
+	})
 
-	t.Run("size() operation", func(t *testing.T) {
+	t.Run("size", func(t *testing.T) {
 		result, err := engine.Render(`${size(configurations.toConfigFileList())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if diff := cmp.Diff(int64(2), result); diff != "" {
-			t.Errorf("size() mismatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 
-	t.Run("map() operation", func(t *testing.T) {
+	t.Run("map", func(t *testing.T) {
 		result, err := engine.Render(`${configurations.toConfigFileList().map(f, f.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := []any{"a.yaml", "b.yaml"}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			return a.(string) < b.(string)
-		})); diff != "" {
-			t.Errorf("map() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("list concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toConfigFileList() + [{"name": "inline.yaml", "mountPath": "/inline.yaml"}]}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{
-			map[string]any{"name": "a.yaml", "mountPath": "/a.yaml", "value": "a", "resourceName": generateConfigResourceName("app-dev", "a.yaml")},
-			map[string]any{"name": "b.yaml", "mountPath": "/b.yaml", "value": "b", "resourceName": generateConfigResourceName("app-dev", "b.yaml")},
-			map[string]any{"name": "inline.yaml", "mountPath": "/inline.yaml"},
-		}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			aMap, aOk := a.(map[string]any)
-			bMap, bOk := b.(map[string]any)
-			if aOk && bOk {
-				return aMap["name"].(string) < bMap["name"].(string)
-			}
-			return false
-		})); diff != "" {
-			t.Errorf("concatenation mismatch (-want +got):\n%s", diff)
+		if diff := cmp.Diff([]any{"a.yaml", "b.yaml"}, result, cmpopts.SortSlices(func(a, b any) bool { return a.(string) < b.(string) })); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -322,182 +177,37 @@ func TestToConfigFileListCanBeUsedWithCELOperations(t *testing.T) {
 func TestConfigurationsToSecretFileListMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "single container with single secret file",
-			expr: `configurations.toSecretFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
+			name: "single secret file",
+			inputs: configInputs(ContainerConfigurations{
+				Secrets: ConfigurationItems{
+					Files: []FileConfiguration{{Name: "secret.yaml", MountPath: "/etc/secret.yaml", RemoteRef: &RemoteRefData{Key: "my-secret", Property: "password"}}},
 				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{
-								"name":      "secret.yaml",
-								"mountPath": "/etc/secret/secret.yaml",
-								"remoteRef": map[string]any{
-									"key":      "my-secret",
-									"property": "password",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{
-					"name":         "secret.yaml",
-					"mountPath":    "/etc/secret/secret.yaml",
+			}),
+			want: []any{
+				map[string]any{
+					"name": "secret.yaml", "mountPath": "/etc/secret.yaml",
 					"resourceName": generateSecretResourceName("app-dev", "secret.yaml"),
-					"remoteRef": map[string]any{
-						"key":      "my-secret",
-						"property": "password",
-					},
+					"remoteRef":    map[string]any{"key": "my-secret", "property": "password"},
 				},
 			},
 		},
 		{
-			name: "single container with multiple secret files",
-			expr: `configurations.toSecretFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{
-								"name":      "db.env",
-								"mountPath": "/etc/db.env",
-								"remoteRef": map[string]any{"key": "db-credentials"},
-							},
-							map[string]any{
-								"name":      "api.key",
-								"mountPath": "/etc/api.key",
-								"remoteRef": map[string]any{"key": "api-credentials"},
-							},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{
-					"name":         "db.env",
-					"mountPath":    "/etc/db.env",
-					"resourceName": generateSecretResourceName("app-dev", "db.env"),
-					"remoteRef":    map[string]any{"key": "db-credentials"},
-				},
-				{
-					"name":         "api.key",
-					"mountPath":    "/etc/api.key",
-					"resourceName": generateSecretResourceName("app-dev", "api.key"),
-					"remoteRef":    map[string]any{"key": "api-credentials"},
-				},
-			},
+			name:   "empty returns empty list",
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 		{
-			name: "no secret files returns empty list",
-			expr: `configurations.toSecretFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "empty configurations returns empty list",
-			expr: `configurations.toSecretFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "secret file with remoteRef properties",
-			expr: `configurations.toSecretFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{
-								"name":      "secret.yaml",
-								"mountPath": "/etc/secret.yaml",
-								"remoteRef": map[string]any{
-									"key":      "my-secret-key",
-									"property": "secret.yaml",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{
-					"name":         "secret.yaml",
-					"mountPath":    "/etc/secret.yaml",
-					"resourceName": generateSecretResourceName("app-dev", "secret.yaml"),
-					"remoteRef": map[string]any{
-						"key":      "my-secret-key",
-						"property": "secret.yaml",
-					},
-				},
-			},
-		},
-		{
-			name: "ignores config files (only returns secret files)",
-			expr: `configurations.toSecretFileList()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{"name": "config.yaml", "mountPath": "/etc/config.yaml", "value": "config"},
-						},
-					},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{
-								"name":      "secret.yaml",
-								"mountPath": "/etc/secret.yaml",
-								"remoteRef": map[string]any{"key": "app-secret"},
-							},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{
-					"name":         "secret.yaml",
-					"mountPath":    "/etc/secret.yaml",
-					"resourceName": generateSecretResourceName("app-dev", "secret.yaml"),
-					"remoteRef":    map[string]any{"key": "app-secret"},
-				},
+			name: "ignores config files",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Files: []FileConfiguration{{Name: "config.yaml", MountPath: "/c", Value: "c"}}},
+				Secrets: ConfigurationItems{Files: []FileConfiguration{{Name: "secret.yaml", MountPath: "/s", RemoteRef: &RemoteRefData{Key: "k"}}}},
+			}),
+			want: []any{
+				map[string]any{"name": "secret.yaml", "mountPath": "/s", "resourceName": generateSecretResourceName("app-dev", "secret.yaml"), "remoteRef": map[string]any{"key": "k"}},
 			},
 		},
 	}
@@ -505,286 +215,61 @@ func TestConfigurationsToSecretFileListMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${configurations.toSecretFileList()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b map[string]any) bool {
-				return a["name"].(string) < b["name"].(string)
+			if diff := cmp.Diff(tt.want, result, cmpopts.SortSlices(func(a, b any) bool {
+				return a.(map[string]any)["name"].(string) < b.(map[string]any)["name"].(string)
 			})); diff != "" {
-				t.Errorf("toSecretFileList() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestToSecretFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
-	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-
-	// This should work - configurations is the expected receiver
-	_, err := engine.Render(`${configurations.toSecretFileList()}`, map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{},
-	})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// This should fail - "other" is not a valid receiver for the macro
-	_, err = engine.Render(`${other.toSecretFileList()}`, map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"other": map[string]any{},
-	})
-	if err == nil {
-		t.Error("expected error for non-configurations receiver")
-	}
-}
-
-func TestToSecretFileListCanBeUsedWithCELOperations(t *testing.T) {
-	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-
-	inputs := map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{
-			"configs": map[string]any{"files": []any{}},
-			"secrets": map[string]any{
-				"files": []any{
-					map[string]any{
-						"name":      "a.secret",
-						"mountPath": "/a.secret",
-						"remoteRef": map[string]any{"key": "a-secret"},
-					},
-					map[string]any{
-						"name":      "b.secret",
-						"mountPath": "/b.secret",
-						"remoteRef": map[string]any{"key": "b-secret"},
-					},
-				},
-			},
-		},
-	}
-
-	t.Run("size() operation", func(t *testing.T) {
-		result, err := engine.Render(`${size(configurations.toSecretFileList())}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if diff := cmp.Diff(int64(2), result); diff != "" {
-			t.Errorf("size() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("map() operation", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toSecretFileList().map(f, f.name)}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{"a.secret", "b.secret"}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			return a.(string) < b.(string)
-		})); diff != "" {
-			t.Errorf("map() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("list concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toSecretFileList() + [{"name": "inline.secret", "mountPath": "/inline.secret"}]}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{
-			map[string]any{"name": "a.secret", "mountPath": "/a.secret", "resourceName": generateSecretResourceName("app-dev", "a.secret"), "remoteRef": map[string]any{"key": "a-secret"}},
-			map[string]any{"name": "b.secret", "mountPath": "/b.secret", "resourceName": generateSecretResourceName("app-dev", "b.secret"), "remoteRef": map[string]any{"key": "b-secret"}},
-			map[string]any{"name": "inline.secret", "mountPath": "/inline.secret"},
-		}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			aMap, aOk := a.(map[string]any)
-			bMap, bOk := b.(map[string]any)
-			if aOk && bOk {
-				return aMap["name"].(string) < bMap["name"].(string)
-			}
-			return false
-		})); diff != "" {
-			t.Errorf("concatenation mismatch (-want +got):\n%s", diff)
-		}
-	})
-}
-
 func TestContainerConfigEnvFromMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "container with both config and secret envs",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "LOG_LEVEL", "value": "info"},
-						},
-					},
-					"secrets": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "API_KEY", "remoteRef": map[string]any{"key": "api-secret", "property": "key"}},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
-				{"secretRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-secrets")}},
+			name: "both config and secret envs",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Envs: []EnvConfiguration{{Name: "LOG_LEVEL", Value: "info"}}},
+				Secrets: ConfigurationItems{Envs: []EnvConfiguration{{Name: "API_KEY", RemoteRef: &RemoteRefData{Key: "api-secret", Property: "key"}}}},
+			}),
+			want: []any{
+				map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
+				map[string]any{"secretRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-secrets")}},
 			},
 		},
 		{
-			name: "container with only config envs",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "DEBUG", "value": "true"},
-							map[string]any{"name": "PORT", "value": "8080"},
-						},
-					},
-					"secrets": map[string]any{"envs": []any{}},
-				},
-			},
-			want: []map[string]any{
-				{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
+			name: "only config envs",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Envs: []EnvConfiguration{{Name: "DEBUG", Value: "true"}}},
+			}),
+			want: []any{
+				map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
 			},
 		},
 		{
-			name: "container with only secret envs",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"envs": []any{}},
-					"secrets": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "DB_PASSWORD", "remoteRef": map[string]any{"key": "db-secret", "property": "password"}},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"secretRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-secrets")}},
-			},
-		},
-		{
-			name: "container with no envs returns empty list",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"envs": []any{}},
-					"secrets": map[string]any{"envs": []any{}},
-				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "empty container config returns empty list",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "container missing configs section",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"secrets": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "SECRET_KEY", "remoteRef": map[string]any{"key": "app-secret", "property": "key"}},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"secretRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-secrets")}},
-			},
-		},
-		{
-			name: "container missing secrets section",
-			expr: `configurations.toContainerEnvFrom()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "CONFIG_VAR", "value": "value"},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
-			},
+			name:   "no envs returns empty",
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 	}
 
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${configurations.toContainerEnvFrom()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("envFrom() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tt.want, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -793,359 +278,44 @@ func TestContainerConfigEnvFromMacro(t *testing.T) {
 func TestEnvFromMacroValidation(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
-	// This should work - accessing container config from configurations
-	_, err := engine.Render(`${configurations.toContainerEnvFrom()}`, map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{
-			"configs": map[string]any{"envs": []any{}},
-			"secrets": map[string]any{"envs": []any{}},
-		},
-	})
+	_, err := engine.Render(`${configurations.toContainerEnvFrom()}`, configInputs(ContainerConfigurations{}))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// toContainerEnvFrom only works on configurations, not arbitrary variables
-	_, err = engine.Render(`${someVar.toContainerEnvFrom()}`, map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"someVar": map[string]any{
-			"configs": map[string]any{"envs": []any{}},
-			"secrets": map[string]any{"envs": []any{}},
-		},
-	})
+	inputs := configInputs(ContainerConfigurations{})
+	inputs["someVar"] = map[string]any{}
+	_, err = engine.Render(`${someVar.toContainerEnvFrom()}`, inputs)
 	if err == nil {
-		t.Error("expected error for non-configurations target, got nil")
+		t.Error("expected error for non-configurations target")
 	}
 }
 
 func TestEnvFromCanBeUsedWithCELOperations(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	inputs := configInputs(ContainerConfigurations{
+		Configs: ConfigurationItems{Envs: []EnvConfiguration{{Name: "C1", Value: "v1"}}},
+		Secrets: ConfigurationItems{Envs: []EnvConfiguration{{Name: "S1", RemoteRef: &RemoteRefData{Key: "s", Property: "k"}}}},
+	})
 
-	inputs := map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{
-			"configs": map[string]any{
-				"envs": []any{
-					map[string]any{"name": "CONFIG1", "value": "value1"},
-				},
-			},
-			"secrets": map[string]any{
-				"envs": []any{
-					map[string]any{"name": "SECRET1", "remoteRef": map[string]any{"key": "secret", "property": "key"}},
-				},
-			},
-		},
-	}
-
-	t.Run("size() operation", func(t *testing.T) {
+	t.Run("size", func(t *testing.T) {
 		result, err := engine.Render(`${size(configurations.toContainerEnvFrom())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if diff := cmp.Diff(int64(2), result); diff != "" {
-			t.Errorf("size() mismatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 
-	t.Run("map() operation to extract names", func(t *testing.T) {
+	t.Run("map extract names", func(t *testing.T) {
 		result, err := engine.Render(`${configurations.toContainerEnvFrom().map(e, has(e.configMapRef) ? e.configMapRef.name : e.secretRef.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := []any{generateEnvResourceName("app-dev", "env-configs"), generateEnvResourceName("app-dev", "env-secrets")}
 		if diff := cmp.Diff(want, result); diff != "" {
-			t.Errorf("map() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toContainerEnvFrom() + [{"configMapRef": {"name": "extra-config"}}]}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{
-			map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
-			map[string]any{"secretRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-secrets")}},
-			map[string]any{"configMapRef": map[string]any{"name": "extra-config"}},
-		}
-		if diff := cmp.Diff(want, result); diff != "" {
-			t.Errorf("concatenation mismatch (-want +got):\n%s", diff)
-		}
-	})
-}
-
-func TestConnectionsContextData(t *testing.T) {
-	t.Run("newDependenciesContextData merges env vars from items", func(t *testing.T) {
-		data := ConnectionsData{
-			Items: []ConnectionItem{
-				{
-					Namespace: "ns1", Project: "proj1", Component: "svc-a",
-					Endpoint: "http", Visibility: "project",
-					EnvVars: []EnvVarEntry{
-						{Name: "SVC_A_URL", Value: "http://svc-a:8080"},
-					},
-				},
-				{
-					Namespace: "ns1", Project: "proj1", Component: "svc-b",
-					Endpoint: "grpc", Visibility: "namespace",
-					EnvVars: []EnvVarEntry{
-						{Name: "SVC_B_URL", Value: "grpc://svc-b:9090"},
-						{Name: "SVC_B_HOST", Value: "svc-b"},
-					},
-				},
-			},
-		}
-
-		ctx := newDependenciesContextData(data)
-
-		wantEnvVars := []EnvVarEntry{
-			{Name: "SVC_A_URL", Value: "http://svc-a:8080"},
-			{Name: "SVC_B_URL", Value: "grpc://svc-b:9090"},
-			{Name: "SVC_B_HOST", Value: "svc-b"},
-		}
-		if diff := cmp.Diff(wantEnvVars, ctx.EnvVars); diff != "" {
-			t.Errorf("merged envVars mismatch (-want +got):\n%s", diff)
-		}
-		if diff := cmp.Diff(data.Items, ctx.Items); diff != "" {
-			t.Errorf("items should be preserved (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("newDependenciesContextData with no items returns empty slices", func(t *testing.T) {
-		ctx := newDependenciesContextData(ConnectionsData{})
-		if ctx.EnvVars == nil || len(ctx.EnvVars) != 0 {
-			t.Errorf("expected empty envVars, got %v", ctx.EnvVars)
-		}
-		if ctx.Items == nil || len(ctx.Items) != 0 {
-			t.Errorf("expected empty items, got %v", ctx.Items)
-		}
-	})
-
-	t.Run("nil item envVars normalized to empty slices", func(t *testing.T) {
-		data := ConnectionsData{
-			Items: []ConnectionItem{
-				{
-					Namespace: "ns1", Project: "proj1", Component: "svc-a",
-					Endpoint: "http", Visibility: "project",
-					EnvVars: nil,
-				},
-				{
-					Namespace: "ns1", Project: "proj1", Component: "svc-b",
-					Endpoint: "http", Visibility: "project",
-					EnvVars: []EnvVarEntry{
-						{Name: "SVC_B_URL", Value: "http://svc-b:8080"},
-					},
-				},
-			},
-		}
-
-		ctx := newDependenciesContextData(data)
-
-		// Merged top-level envVars should only contain svc-b's env var
-		wantEnvVars := []EnvVarEntry{
-			{Name: "SVC_B_URL", Value: "http://svc-b:8080"},
-		}
-		if diff := cmp.Diff(wantEnvVars, ctx.EnvVars); diff != "" {
-			t.Errorf("merged envVars mismatch (-want +got):\n%s", diff)
-		}
-
-		// nil EnvVars on source item must be normalized to empty slice
-		if ctx.Items[0].EnvVars == nil {
-			t.Error("expected items[0].EnvVars to be empty slice, got nil")
-		}
-		if len(ctx.Items[0].EnvVars) != 0 {
-			t.Errorf("expected items[0].EnvVars to be empty, got %v", ctx.Items[0].EnvVars)
-		}
-	})
-
-	t.Run("dependencies.toContainerEnvs() macro rewrites to dependencies.envVars", func(t *testing.T) {
-		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-		inputs := map[string]any{
-			"dependencies": map[string]any{
-				"items": []any{
-					map[string]any{
-						"namespace": "ns1", "project": "proj1", "component": "svc-a",
-						"endpoint": "http", "visibility": "project",
-						"envVars": []any{
-							map[string]any{"name": "SVC_A_URL", "value": "http://svc-a:8080"},
-						},
-					},
-					map[string]any{
-						"namespace": "ns1", "project": "proj1", "component": "svc-b",
-						"endpoint": "grpc", "visibility": "namespace",
-						"envVars": []any{
-							map[string]any{"name": "SVC_B_URL", "value": "grpc://svc-b:9090"},
-						},
-					},
-				},
-				"envVars": []any{
-					map[string]any{"name": "SVC_A_URL", "value": "http://svc-a:8080"},
-					map[string]any{"name": "SVC_B_URL", "value": "grpc://svc-b:9090"},
-				},
-			},
-		}
-
-		result, err := engine.Render(`${dependencies.toContainerEnvs()}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		want := []any{
-			map[string]any{"name": "SVC_A_URL", "value": "http://svc-a:8080"},
-			map[string]any{"name": "SVC_B_URL", "value": "grpc://svc-b:9090"},
-		}
-		if diff := cmp.Diff(want, result); diff != "" {
-			t.Errorf("dependencies.toContainerEnvs() mismatch (-want +got):\n%s", diff)
-		}
-	})
-}
-
-func TestDependenciesVolumeMacros(t *testing.T) {
-	t.Run("dependencies.toContainerVolumeMounts_rewrites_to_volumeMounts_field", func(t *testing.T) {
-		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-		inputs := map[string]any{
-			"dependencies": map[string]any{
-				"volumeMounts": []any{
-					map[string]any{"name": "r-abc", "mountPath": "/etc/db", "subPath": "password"},
-					map[string]any{"name": "r-def", "mountPath": "/etc/tls", "subPath": "ca.crt"},
-				},
-			},
-		}
-
-		result, err := engine.Render(`${dependencies.toContainerVolumeMounts()}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		want := []any{
-			map[string]any{"name": "r-abc", "mountPath": "/etc/db", "subPath": "password"},
-			map[string]any{"name": "r-def", "mountPath": "/etc/tls", "subPath": "ca.crt"},
-		}
-		if diff := cmp.Diff(want, result); diff != "" {
-			t.Errorf("dependencies.toContainerVolumeMounts() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("dependencies.toVolumes_rewrites_to_volumes_field", func(t *testing.T) {
-		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-		inputs := map[string]any{
-			"dependencies": map[string]any{
-				"volumes": []any{
-					map[string]any{"name": "r-abc", "secret": map[string]any{"secretName": "db-conn"}},
-					map[string]any{"name": "r-def", "configMap": map[string]any{"name": "db-tls"}},
-				},
-			},
-		}
-
-		result, err := engine.Render(`${dependencies.toVolumes()}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		want := []any{
-			map[string]any{"name": "r-abc", "secret": map[string]any{"secretName": "db-conn"}},
-			map[string]any{"name": "r-def", "configMap": map[string]any{"name": "db-tls"}},
-		}
-		if diff := cmp.Diff(want, result); diff != "" {
-			t.Errorf("dependencies.toVolumes() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("configurations_receiver_unaffected_by_dependencies_extension", func(t *testing.T) {
-		// Regression: extending the toVolumes/toContainerVolumeMounts macros to handle
-		// the dependencies receiver must not break the existing configurations behavior.
-		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-		inputs := map[string]any{
-			"metadata": map[string]any{
-				"componentName":   "app",
-				"environmentName": "dev",
-			},
-			"configurations": map[string]any{
-				"configs": map[string]any{
-					"files": []any{
-						map[string]any{"name": "app.conf", "mountPath": "/etc/app"},
-					},
-				},
-				"secrets": map[string]any{},
-			},
-		}
-
-		mountsResult, err := engine.Render(`${configurations.toContainerVolumeMounts()}`, inputs)
-		if err != nil {
-			t.Fatalf("toContainerVolumeMounts unexpected error: %v", err)
-		}
-		// configurations.* macros return []map[string]any (see cel_extensions.go:configurationsToContainerVolumeMountsFunction).
-		mounts, ok := mountsResult.([]map[string]any)
-		if !ok || len(mounts) != 1 {
-			t.Fatalf("expected 1 mount as []map[string]any, got %T: %v", mountsResult, mountsResult)
-		}
-		if mounts[0]["mountPath"] != "/etc/app/app.conf" {
-			t.Errorf("configurations mount path drifted: %v", mounts[0])
-		}
-
-		volumesResult, err := engine.Render(`${configurations.toVolumes()}`, inputs)
-		if err != nil {
-			t.Fatalf("toVolumes unexpected error: %v", err)
-		}
-		volumes, ok := volumesResult.([]map[string]any)
-		if !ok || len(volumes) != 1 {
-			t.Fatalf("expected 1 volume as []map[string]any, got %T: %v", volumesResult, volumesResult)
-		}
-		// Existing prefix contract: file-mount-* (NOT r-*).
-		volName, _ := volumes[0]["name"].(string)
-		if !strings.HasPrefix(volName, "file-mount-") {
-			t.Errorf("expected file-mount- prefix from configurations side, got %q", volName)
-		}
-	})
-
-	t.Run("dependencies_and_configurations_volumes_concat_in_single_template", func(t *testing.T) {
-		// Locks the canonical CCT pattern: volumes: ${configurations.toVolumes() + dependencies.toVolumes()}
-		// Both sides contribute to the rendered Pod's volumes field.
-		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-		inputs := map[string]any{
-			"metadata": map[string]any{
-				"componentName":   "app",
-				"environmentName": "dev",
-			},
-			"configurations": map[string]any{
-				"configs": map[string]any{
-					"files": []any{
-						map[string]any{"name": "app.conf", "mountPath": "/etc/app"},
-					},
-				},
-				"secrets": map[string]any{},
-			},
-			"dependencies": map[string]any{
-				"volumes": []any{
-					map[string]any{"name": "r-abc", "secret": map[string]any{"secretName": "db-conn"}},
-				},
-			},
-		}
-
-		result, err := engine.Render(`${configurations.toVolumes() + dependencies.toVolumes()}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		// Concat across two macros that return different element types coalesces to []any in CEL.
-		volumes, ok := result.([]any)
-		if !ok || len(volumes) != 2 {
-			t.Fatalf("expected 2 volumes (1 cfg + 1 dep), got %T: %v", result, result)
-		}
-		// Order: configurations first (left side of +), dependencies second.
-		if name, _ := volumes[0].(map[string]any)["name"].(string); !strings.HasPrefix(name, "file-mount-") {
-			t.Errorf("expected configurations volume first; got %q", name)
-		}
-		if name := volumes[1].(map[string]any)["name"]; name != "r-abc" {
-			t.Errorf("expected dependencies volume second; got %q", name)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -1153,72 +323,44 @@ func TestDependenciesVolumeMacros(t *testing.T) {
 func TestContainerConfigVolumeMountsMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "container with both config and secret files",
-			expr: `configurations.toContainerVolumeMounts()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{"name": "app.properties", "mountPath": "/etc/config"},
-							map[string]any{"name": "config.json", "mountPath": "/etc/config"},
-						},
-					},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{"name": "tls.crt", "mountPath": "/etc/tls"},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "file-mount-" + generateVolumeHash("/etc/config", "app.properties"), "mountPath": "/etc/config/app.properties", "subPath": "app.properties"},
-				{"name": "file-mount-" + generateVolumeHash("/etc/config", "config.json"), "mountPath": "/etc/config/config.json", "subPath": "config.json"},
-				{"name": "file-mount-" + generateVolumeHash("/etc/tls", "tls.crt"), "mountPath": "/etc/tls/tls.crt", "subPath": "tls.crt"},
+			name: "config and secret files",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Files: []FileConfiguration{
+					{Name: "app.properties", MountPath: "/etc/config"},
+					{Name: "config.json", MountPath: "/etc/config"},
+				}},
+				Secrets: ConfigurationItems{Files: []FileConfiguration{
+					{Name: "tls.crt", MountPath: "/etc/tls", RemoteRef: &RemoteRefData{Key: "tls"}},
+				}},
+			}),
+			want: []any{
+				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/config", "app.properties"), "mountPath": "/etc/config/app.properties", "subPath": "app.properties"},
+				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/config", "config.json"), "mountPath": "/etc/config/config.json", "subPath": "config.json"},
+				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/tls", "tls.crt"), "mountPath": "/etc/tls/tls.crt", "subPath": "tls.crt"},
 			},
 		},
 		{
-			name: "container with no files returns empty list",
-			expr: `configurations.toContainerVolumeMounts()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{},
+			name:   "no files returns empty",
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 	}
 
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${configurations.toContainerVolumeMounts()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b map[string]any) bool {
-				return a["name"].(string) < b["name"].(string)
+			if diff := cmp.Diff(tt.want, result, cmpopts.SortSlices(func(a, b any) bool {
+				return a.(map[string]any)["name"].(string) < b.(map[string]any)["name"].(string)
 			})); diff != "" {
-				t.Errorf("volumeMounts() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1227,178 +369,84 @@ func TestContainerConfigVolumeMountsMacro(t *testing.T) {
 func TestConfigurationsToVolumesMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "single container with config and secret files",
-			expr: `configurations.toVolumes()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"files": []any{
-							map[string]any{"name": "app.properties", "mountPath": "/etc/config"},
-						},
-					},
-					"secrets": map[string]any{
-						"files": []any{
-							map[string]any{"name": "tls.crt", "mountPath": "/etc/tls"},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{
-					"name": "file-mount-" + generateVolumeHash("/etc/config", "app.properties"),
-					"configMap": map[string]any{
-						"name": generateConfigResourceName("app-dev", "app.properties"),
-					},
-				},
-				{
-					"name": "file-mount-" + generateVolumeHash("/etc/tls", "tls.crt"),
-					"secret": map[string]any{
-						"secretName": generateSecretResourceName("app-dev", "tls.crt"),
-					},
-				},
+			name: "config and secret files",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Files: []FileConfiguration{{Name: "app.properties", MountPath: "/etc/config"}}},
+				Secrets: ConfigurationItems{Files: []FileConfiguration{{Name: "tls.crt", MountPath: "/etc/tls", RemoteRef: &RemoteRefData{Key: "tls"}}}},
+			}),
+			want: []any{
+				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/config", "app.properties"), "configMap": map[string]any{"name": generateConfigResourceName("app-dev", "app.properties")}},
+				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/tls", "tls.crt"), "secret": map[string]any{"secretName": generateSecretResourceName("app-dev", "tls.crt")}},
 			},
 		},
 		{
-			name: "no files returns empty list",
-			expr: `configurations.toVolumes()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"files": []any{}},
-					"secrets": map[string]any{"files": []any{}},
-				},
-			},
-			want: []map[string]any{},
+			name:   "no files returns empty",
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 	}
 
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${configurations.toVolumes()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b map[string]any) bool {
-				return a["name"].(string) < b["name"].(string)
+			if diff := cmp.Diff(tt.want, result, cmpopts.SortSlices(func(a, b any) bool {
+				return a.(map[string]any)["name"].(string) < b.(map[string]any)["name"].(string)
 			})); diff != "" {
-				t.Errorf("volumes() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-// TestConfigurationsToVolumesMacro_DeterministicOrder guards against rollout loops
-// caused by Go's randomized map iteration. With many file mounts the rendered
-// volumes slice must be in a stable, sorted order — otherwise SSA persists a
-// different order each render, the Deployment's pod-template-hash changes, and
-// pods needlessly roll. See issue #3302.
 func TestConfigurationsToVolumesMacro_DeterministicOrder(t *testing.T) {
-	configFiles := []any{
-		map[string]any{"name": "alpha.properties", "mountPath": "/etc/alpha"},
-		map[string]any{"name": "bravo.properties", "mountPath": "/etc/bravo"},
-		map[string]any{"name": "charlie.properties", "mountPath": "/etc/charlie"},
-		map[string]any{"name": "delta.properties", "mountPath": "/etc/delta"},
-	}
-	secretFiles := []any{
-		map[string]any{"name": "echo.crt", "mountPath": "/etc/echo"},
-		map[string]any{"name": "foxtrot.crt", "mountPath": "/etc/foxtrot"},
-	}
-	inputs := map[string]any{
-		"metadata": map[string]any{
-			"componentName":   "app",
-			"environmentName": "dev",
-		},
-		"configurations": map[string]any{
-			"configs": map[string]any{"files": configFiles},
-			"secrets": map[string]any{"files": secretFiles},
-		},
-	}
-
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	inputs := configInputs(ContainerConfigurations{
+		Configs: ConfigurationItems{Files: []FileConfiguration{
+			{Name: "b.yaml", MountPath: "/m"},
+			{Name: "a.yaml", MountPath: "/m"},
+		}},
+	})
 
-	render := func() []map[string]any {
-		result, err := engine.Render("${configurations.toVolumes()}", inputs)
+	var prev []any
+	for i := 0; i < 10; i++ {
+		result, err := engine.Render(`${configurations.toVolumes()}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		got, ok := result.([]map[string]any)
-		if !ok {
-			t.Fatalf("expected []map[string]any, got %T", result)
+		got := result.([]any)
+		if prev != nil {
+			if diff := cmp.Diff(prev, got); diff != "" {
+				t.Fatalf("non-deterministic order on iteration %d:\n%s", i, diff)
+			}
 		}
-		return got
-	}
-
-	first := render()
-
-	if len(first) != len(configFiles)+len(secretFiles) {
-		t.Fatalf("expected %d volumes, got %d", len(configFiles)+len(secretFiles), len(first))
-	}
-
-	names := make([]string, 0, len(first))
-	for _, v := range first {
-		names = append(names, v["name"].(string))
-	}
-	for i := 1; i < len(names); i++ {
-		if names[i-1] >= names[i] {
-			t.Errorf("volumes not sorted by name: %v", names)
-			break
-		}
-	}
-
-	for i := 0; i < 50; i++ {
-		next := render()
-		if diff := cmp.Diff(first, next); diff != "" {
-			t.Fatalf("volume order is non-deterministic across renders (-first +iter%d):\n%s", i, diff)
-		}
+		prev = got
 	}
 }
 
 func TestConfigurationsToConfigEnvsByContainerMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "single container with config envs",
-			expr: `configurations.toConfigEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "LOG_LEVEL", "value": "info"},
-							map[string]any{"name": "DEBUG_MODE", "value": "true"},
-						},
-					},
-					"secrets": map[string]any{"envs": []any{}},
-				},
-			},
-			want: []map[string]any{
-				{
+			name: "with config envs",
+			inputs: configInputs(ContainerConfigurations{
+				Configs: ConfigurationItems{Envs: []EnvConfiguration{
+					{Name: "LOG_LEVEL", Value: "info"},
+					{Name: "DEBUG_MODE", Value: "true"},
+				}},
+			}),
+			want: []any{
+				map[string]any{
 					"resourceName": generateEnvResourceName("app-dev", "env-configs"),
 					"envs": []any{
 						map[string]any{"name": "LOG_LEVEL", "value": "info"},
@@ -1408,67 +456,28 @@ func TestConfigurationsToConfigEnvsByContainerMacro(t *testing.T) {
 			},
 		},
 		{
-			name: "container with no config envs returns empty list",
-			expr: `configurations.toConfigEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"envs": []any{}},
-					"secrets": map[string]any{"envs": []any{}},
-				},
-			},
-			want: []map[string]any{},
+			name:   "no config envs returns empty",
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 		{
-			name: "container with only secrets (no configs) returns empty list",
-			expr: `configurations.toConfigEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"secrets": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "SECRET_KEY", "value": "secret"},
-						},
-					},
-				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "empty configurations returns empty list",
-			expr: `configurations.toConfigEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{},
-			},
-			want: []map[string]any{},
+			name: "only secrets returns empty",
+			inputs: configInputs(ContainerConfigurations{
+				Secrets: ConfigurationItems{Envs: []EnvConfiguration{{Name: "S", Value: "v"}}},
+			}),
+			want: []any{},
 		},
 	}
 
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${configurations.toConfigEnvsByContainer()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("toConfigEnvsByContainer() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tt.want, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1477,451 +486,192 @@ func TestConfigurationsToConfigEnvsByContainerMacro(t *testing.T) {
 func TestConfigurationsToSecretEnvsByContainerMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
-			name: "single container with secret envs",
-			expr: `configurations.toSecretEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"envs": []any{}},
-					"secrets": map[string]any{
-						"envs": []any{
-							map[string]any{
-								"name": "DB_PASSWORD",
-								"remoteRef": map[string]any{
-									"key":      "db-password",
-									"property": "password",
-								},
-							},
-							map[string]any{
-								"name": "API_KEY",
-								"remoteRef": map[string]any{
-									"key": "api-key",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{
+			name: "with secret envs",
+			inputs: configInputs(ContainerConfigurations{
+				Secrets: ConfigurationItems{Envs: []EnvConfiguration{
+					{Name: "DB_PASSWORD", RemoteRef: &RemoteRefData{Key: "db-password", Property: "password"}},
+				}},
+			}),
+			want: []any{
+				map[string]any{
 					"resourceName": generateEnvResourceName("app-dev", "env-secrets"),
 					"envs": []any{
-						map[string]any{
-							"name": "DB_PASSWORD",
-							"remoteRef": map[string]any{
-								"key":      "db-password",
-								"property": "password",
-							},
-						},
-						map[string]any{
-							"name": "API_KEY",
-							"remoteRef": map[string]any{
-								"key": "api-key",
-							},
-						},
+						map[string]any{"name": "DB_PASSWORD", "value": "", "remoteRef": map[string]any{"key": "db-password", "property": "password"}},
 					},
 				},
 			},
 		},
 		{
-			name: "container with no secret envs returns empty list",
-			expr: `configurations.toSecretEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{"envs": []any{}},
-					"secrets": map[string]any{"envs": []any{}},
-				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "container with only configs (no secrets) returns empty list",
-			expr: `configurations.toSecretEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{
-					"configs": map[string]any{
-						"envs": []any{
-							map[string]any{"name": "CONFIG_VAR", "value": "value"},
-						},
-					},
-				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "empty configurations returns empty list",
-			expr: `configurations.toSecretEnvsByContainer()`,
-			inputs: map[string]any{
-				"metadata": map[string]any{
-					"componentName":   "app",
-					"environmentName": "dev",
-				},
-				"configurations": map[string]any{},
-			},
-			want: []map[string]any{},
+			name:   "no secret envs returns empty",
+			inputs: configInputs(ContainerConfigurations{}),
+			want:   []any{},
 		},
 	}
 
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${configurations.toSecretEnvsByContainer()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("toSecretEnvsByContainer() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tt.want, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func TestDependenciesEnvVarsMacro(t *testing.T) {
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	inputs := depInputs(ConnectionsContextData{
+		EnvVars: []EnvVarEntry{
+			{Name: "SVC_A_URL", Value: "http://svc-a:8080"},
+			{Name: "SVC_B_URL", Value: "grpc://svc-b:9090"},
+		},
+	})
+
+	result, err := engine.Render(`${dependencies.toContainerEnvs()}`, inputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []any{
+		map[string]any{"name": "SVC_A_URL", "value": "http://svc-a:8080"},
+		map[string]any{"name": "SVC_B_URL", "value": "grpc://svc-b:9090"},
+	}
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDependenciesVolumeMacros(t *testing.T) {
+	t.Run("toContainerVolumeMounts", func(t *testing.T) {
+		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+		inputs := depInputs(ConnectionsContextData{
+			VolumeMounts: []VolumeMountEntry{
+				{Name: "r-abc", MountPath: "/etc/db", SubPath: "password"},
+				{Name: "r-def", MountPath: "/etc/tls", SubPath: "ca.crt"},
+			},
+		})
+
+		result, err := engine.Render(`${dependencies.toContainerVolumeMounts()}`, inputs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []any{
+			map[string]any{"name": "r-abc", "mountPath": "/etc/db", "subPath": "password"},
+			map[string]any{"name": "r-def", "mountPath": "/etc/tls", "subPath": "ca.crt"},
+		}
+		if diff := cmp.Diff(want, result); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("toVolumes", func(t *testing.T) {
+		engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+		inputs := depInputs(ConnectionsContextData{
+			Volumes: []VolumeEntry{
+				{Name: "r-abc", Secret: &SecretVolume{SecretName: "db-conn"}},
+				{Name: "r-def", ConfigMap: &ConfigMapVolume{Name: "db-tls"}},
+			},
+		})
+
+		result, err := engine.Render(`${dependencies.toVolumes()}`, inputs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []any{
+			map[string]any{"name": "r-abc", "secret": map[string]any{"secretName": "db-conn"}},
+			map[string]any{"name": "r-def", "configMap": map[string]any{"name": "db-tls"}},
+		}
+		if diff := cmp.Diff(want, result); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 	tests := []struct {
 		name   string
-		expr   string
 		inputs map[string]any
-		want   []map[string]any
+		want   []any
 	}{
 		{
 			name: "single HTTP endpoint",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"http": {Port: 8080, TargetPort: 8080, Type: "HTTP"},
 				},
-			},
-			want: []map[string]any{
-				{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
+			}),
+			want: []any{
+				map[string]any{"name": "http", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
 			},
 		},
 		{
-			name: "multiple endpoints with different types",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-						"grpc": map[string]any{
-							"type": "gRPC",
-							"port": int64(9090),
-						},
-						"metrics": map[string]any{
-							"type": "HTTP",
-							"port": int64(9091),
-						},
-					},
+			name: "multiple endpoints sorted by name",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"grpc":  {Port: 9090, TargetPort: 9090, Type: "gRPC"},
+					"admin": {Port: 9091, TargetPort: 9091, Type: "HTTP"},
 				},
-			},
-			want: []map[string]any{
-				{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-				{"name": "grpc", "port": int64(9090), "targetPort": int64(9090), "protocol": "TCP"},
-				{"name": "metrics", "port": int64(9091), "targetPort": int64(9091), "protocol": "TCP"},
+			}),
+			want: []any{
+				map[string]any{"name": "admin", "port": float64(9091), "targetPort": float64(9091), "protocol": "TCP"},
+				map[string]any{"name": "grpc", "port": float64(9090), "targetPort": float64(9090), "protocol": "TCP"},
 			},
 		},
 		{
-			name: "empty endpoints returns empty list",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{},
+			name: "UDP endpoint",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"dns": {Port: 53, TargetPort: 53, Type: "UDP"},
 				},
-			},
-			want: []map[string]any{},
-		},
-		{
-			name: "TCP endpoint maps to TCP protocol",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"custom": map[string]any{
-							"type": "TCP",
-							"port": int64(5432),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "custom", "port": int64(5432), "targetPort": int64(5432), "protocol": "TCP"},
+			}),
+			want: []any{
+				map[string]any{"name": "dns", "port": float64(53), "targetPort": float64(53), "protocol": "UDP"},
 			},
 		},
 		{
-			name: "UDP endpoint maps to UDP protocol",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"dns": map[string]any{
-							"type": "UDP",
-							"port": int64(53),
-						},
-					},
+			name: "duplicate port+protocol deduplicated",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"api": {Port: 8080, TargetPort: 8080, Type: "HTTP"},
+					"web": {Port: 8080, TargetPort: 8080, Type: "HTTP"},
 				},
-			},
-			want: []map[string]any{
-				{"name": "dns", "port": int64(53), "targetPort": int64(53), "protocol": "UDP"},
+			}),
+			want: []any{
+				map[string]any{"name": "api", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
 			},
 		},
 		{
-			name: "GraphQL endpoint maps to TCP protocol",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"graphql": map[string]any{
-							"type": "GraphQL",
-							"port": int64(8000),
-						},
-					},
+			name:   "no endpoints returns empty",
+			inputs: workloadInputs(WorkloadData{}),
+			want:   []any{},
+		},
+		{
+			name: "targetPort defaults to port when zero",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"http": {Port: 8080, TargetPort: 0, Type: "HTTP"},
 				},
-			},
-			want: []map[string]any{
-				{"name": "graphql", "port": int64(8000), "targetPort": int64(8000), "protocol": "TCP"},
+			}),
+			want: []any{
+				map[string]any{"name": "http", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
 			},
 		},
 		{
-			name: "Websocket endpoint maps to TCP protocol",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"websocket": map[string]any{
-							"type": "Websocket",
-							"port": int64(8080),
-						},
-					},
+			name: "port name sanitized",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"My_HTTP_Endpoint": {Port: 8080, TargetPort: 8080, Type: "HTTP"},
 				},
-			},
-			want: []map[string]any{
-				{"name": "websocket", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "targetPort differs from port",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type":       "HTTP",
-							"port":       int64(80),
-							"targetPort": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "http", "port": int64(80), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoint name with underscores converts to hyphens",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"api_endpoint": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "api-endpoint", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoint name with mixed case converts to lowercase",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"HttpAPI": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "httpapi", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoint name with invalid characters removed",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"api@endpoint!": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "apiendpoint", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoint name with leading/trailing hyphens trimmed",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"-api-": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "api", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoint name longer than 15 characters truncated",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"verylongendpointname": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "verylongendpoin", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoint name with only invalid characters uses port number",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"@@@": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "port-8080", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "duplicate names after sanitization get unique suffixes",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-						"http_": map[string]any{
-							"type": "HTTP",
-							"port": int64(8081),
-						},
-						"HTTP": map[string]any{
-							"type": "HTTP",
-							"port": int64(8082),
-						},
-					},
-				},
-			},
-			// With alphabetical sorting: "HTTP" (8082) -> "http", then "http" (8080) -> "http-2", then "http_" (8081) -> "http-3"
-			want: []map[string]any{
-				{"name": "http", "port": int64(8082), "targetPort": int64(8082), "protocol": "TCP"},
-				{"name": "http-2", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-				{"name": "http-3", "port": int64(8081), "targetPort": int64(8081), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "endpoints sharing the same (port, protocol) are deduplicated",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-						"rest": map[string]any{
-							"type": "REST",
-							"port": int64(8080),
-						},
-						"grpc": map[string]any{
-							"type": "gRPC",
-							"port": int64(9090),
-						},
-					},
-				},
-			},
-			// "http" and "rest" both resolve to (8080, TCP); alphabetical sort keeps "http" first.
-			want: []map[string]any{
-				{"name": "grpc", "port": int64(9090), "targetPort": int64(9090), "protocol": "TCP"},
-				{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			},
-		},
-		{
-			name: "same port with different protocols is kept",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-							"port": int64(8080),
-						},
-						"udp": map[string]any{
-							"type": "UDP",
-							"port": int64(8080),
-						},
-					},
-				},
-			},
-			want: []map[string]any{
-				{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-				{"name": "udp", "port": int64(8080), "targetPort": int64(8080), "protocol": "UDP"},
+			}),
+			want: []any{
+				map[string]any{"name": "my-http-endpoin", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
 			},
 		},
 	}
@@ -1929,84 +679,12 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(`${workload.toServicePorts()}`, tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			got, ok := result.([]map[string]any)
-			if !ok {
-				t.Fatalf("expected []map[string]any, got %T", result)
-			}
-
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b map[string]any) bool {
-				return a["name"].(string) < b["name"].(string)
-			})); diff != "" {
-				t.Errorf("toServicePorts() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestWorkloadEndpointsToServicePortsMacroErrors(t *testing.T) {
-	tests := []struct {
-		name        string
-		expr        string
-		inputs      map[string]any
-		expectError string
-	}{
-		{
-			name: "endpoint not an object returns error",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": "invalid",
-					},
-				},
-			},
-			expectError: "endpoint 'http' must be an object",
-		},
-		{
-			name: "endpoint missing port field returns error",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-						},
-					},
-				},
-			},
-			expectError: "endpoint 'http' is missing required 'port' field",
-		},
-		{
-			name: "endpoint with non-numeric port returns error",
-			expr: `workload.toServicePorts()`,
-			inputs: map[string]any{
-				"workload": map[string]any{
-					"endpoints": map[string]any{
-						"http": map[string]any{
-							"type": "HTTP",
-							"port": "8080",
-						},
-					},
-				},
-			},
-			expectError: "endpoint 'http' must have a numeric integer port",
-		},
-	}
-
-	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := engine.Render("${"+tt.expr+"}", tt.inputs)
-			if err == nil {
-				t.Fatal("expected error but got none")
-			}
-			if !strings.Contains(err.Error(), tt.expectError) {
-				t.Errorf("expected error containing %q, got: %v", tt.expectError, err)
+			if diff := cmp.Diff(tt.want, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2015,137 +693,223 @@ func TestWorkloadEndpointsToServicePortsMacroErrors(t *testing.T) {
 func TestToServicePortsMacroOnlyExpandsForWorkloadEndpoints(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
-	// This should work - workload.endpoints is the expected receiver
-	_, err := engine.Render(`${workload.toServicePorts()}`, map[string]any{
-		"workload": map[string]any{
-			"endpoints": map[string]any{},
-		},
-	})
+	_, err := engine.Render(`${workload.toServicePorts()}`, workloadInputs(WorkloadData{}))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// This should fail - "other" is not a valid receiver for the macro
-	_, err = engine.Render(`${other.toServicePorts()}`, map[string]any{
-		"other": map[string]any{
-			"endpoints": map[string]any{},
-		},
-	})
+	inputs := workloadInputs(WorkloadData{})
+	inputs["other"] = map[string]any{}
+	_, err = engine.Render(`${other.toServicePorts()}`, inputs)
 	if err == nil {
 		t.Error("expected error for non-workload receiver")
-	}
-
-	// This should fail - direct call on non-endpoints field
-	_, err = engine.Render(`${workload.containers.toServicePorts()}`, map[string]any{
-		"workload": map[string]any{
-			"containers": map[string]any{},
-		},
-	})
-	if err == nil {
-		t.Error("expected error for non-endpoints field")
 	}
 }
 
 func TestToServicePortsCanBeUsedWithCELOperations(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
-
-	inputs := map[string]any{
-		"workload": map[string]any{
-			"endpoints": map[string]any{
-				"http": map[string]any{
-					"type": "HTTP",
-					"port": int64(8080),
-				},
-				"grpc": map[string]any{
-					"type": "gRPC",
-					"port": int64(9090),
-				},
-			},
+	inputs := workloadInputs(WorkloadData{
+		Endpoints: map[string]EndpointData{
+			"http": {Port: 8080, TargetPort: 8080, Type: "HTTP"},
+			"grpc": {Port: 9090, TargetPort: 9090, Type: "gRPC"},
 		},
-	}
+	})
 
-	t.Run("size() operation", func(t *testing.T) {
+	t.Run("size", func(t *testing.T) {
 		result, err := engine.Render(`${size(workload.toServicePorts())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if diff := cmp.Diff(int64(2), result); diff != "" {
-			t.Errorf("size() mismatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 
-	t.Run("map() operation to extract port names", func(t *testing.T) {
+	t.Run("map port names", func(t *testing.T) {
 		result, err := engine.Render(`${workload.toServicePorts().map(p, p.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := []any{"http", "grpc"}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			return a.(string) < b.(string)
-		})); diff != "" {
-			t.Errorf("map() mismatch (-want +got):\n%s", diff)
+		want := []any{"grpc", "http"}
+		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool { return a.(string) < b.(string) })); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
 
-	t.Run("map() operation to extract port numbers", func(t *testing.T) {
-		result, err := engine.Render(`${workload.toServicePorts().map(p, p.port)}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{int64(8080), int64(9090)}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			return a.(int64) < b.(int64)
-		})); diff != "" {
-			t.Errorf("map() mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("filter() operation by protocol", func(t *testing.T) {
-		udpInputs := map[string]any{
-			"workload": map[string]any{
-				"endpoints": map[string]any{
-					"http": map[string]any{
-						"type": "HTTP",
-						"port": int64(8080),
-					},
-					"dns": map[string]any{
-						"type": "UDP",
-						"port": int64(53),
-					},
-				},
+func TestNewDependenciesContextData(t *testing.T) {
+	t.Run("merges endpoint env vars", func(t *testing.T) {
+		data := ConnectionsData{
+			Items: []ConnectionItem{
+				{Namespace: "ns1", Project: "proj1", Component: "svc-a", Endpoint: "http", Visibility: "project", EnvVars: []EnvVarEntry{{Name: "SVC_A_URL", Value: "http://svc-a:8080"}}},
+				{Namespace: "ns1", Project: "proj1", Component: "svc-b", Endpoint: "grpc", Visibility: "namespace", EnvVars: []EnvVarEntry{{Name: "SVC_B_URL", Value: "grpc://svc-b:9090"}, {Name: "SVC_B_HOST", Value: "svc-b"}}},
 			},
 		}
-		result, err := engine.Render(`${workload.toServicePorts().filter(p, p.protocol == "UDP")}`, udpInputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{
-			map[string]any{"name": "dns", "port": int64(53), "targetPort": int64(53), "protocol": "UDP"},
-		}
-		if diff := cmp.Diff(want, result); diff != "" {
-			t.Errorf("filter() mismatch (-want +got):\n%s", diff)
+		ctx := newDependenciesContextData(data)
+		wantEnvVars := []EnvVarEntry{{Name: "SVC_A_URL", Value: "http://svc-a:8080"}, {Name: "SVC_B_URL", Value: "grpc://svc-b:9090"}, {Name: "SVC_B_HOST", Value: "svc-b"}}
+		if diff := cmp.Diff(wantEnvVars, ctx.EnvVars); diff != "" {
+			t.Errorf("merged envVars mismatch:\n%s", diff)
 		}
 	})
 
-	t.Run("list concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${workload.toServicePorts() + [{"name": "admin", "port": 9999, "targetPort": 9999, "protocol": "TCP"}]}`, inputs)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []any{
-			map[string]any{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
-			map[string]any{"name": "grpc", "port": int64(9090), "targetPort": int64(9090), "protocol": "TCP"},
-			map[string]any{"name": "admin", "port": int64(9999), "targetPort": int64(9999), "protocol": "TCP"},
-		}
-		if diff := cmp.Diff(want, result, cmpopts.SortSlices(func(a, b any) bool {
-			aMap, aOk := a.(map[string]any)
-			bMap, bOk := b.(map[string]any)
-			if aOk && bOk {
-				return aMap["name"].(string) < bMap["name"].(string)
-			}
-			return false
-		})); diff != "" {
-			t.Errorf("concatenation mismatch (-want +got):\n%s", diff)
+	t.Run("empty returns empty slices", func(t *testing.T) {
+		ctx := newDependenciesContextData(ConnectionsData{})
+		if len(ctx.EnvVars) != 0 || ctx.EnvVars == nil {
+			t.Errorf("expected empty non-nil envVars, got %v", ctx.EnvVars)
 		}
 	})
+
+	t.Run("nil item envVars normalized", func(t *testing.T) {
+		data := ConnectionsData{
+			Items: []ConnectionItem{
+				{Namespace: "ns1", Project: "proj1", Component: "svc-a", Endpoint: "http", Visibility: "project", EnvVars: nil},
+			},
+		}
+		ctx := newDependenciesContextData(data)
+		if ctx.Items[0].EnvVars == nil {
+			t.Error("expected items[0].EnvVars to be empty slice, got nil")
+		}
+	})
+}
+
+func TestSanitizePortName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"http", "http"},
+		{"HTTP", "http"},
+		{"my_endpoint", "my-endpoint"},
+		{"my-endpoint-with-a-very-long-name", "my-endpoint-wit"},
+		{"---invalid---", "invalid"},
+		{"", ""},
+		{"special!@#chars", "specialchars"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := sanitizePortName(tt.input); got != tt.want {
+				t.Errorf("sanitizePortName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapEndpointTypeToProtocol(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"TCP", "TCP"},
+		{"UDP", "UDP"},
+		{"HTTP", "TCP"},
+		{"gRPC", "TCP"},
+		{"", "TCP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := mapEndpointTypeToProtocol(tt.input); got != tt.want {
+				t.Errorf("mapEndpointTypeToProtocol(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDependenciesMacroReceiverGuards(t *testing.T) {
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	inputs := depInputs(ConnectionsContextData{
+		EnvVars:      []EnvVarEntry{},
+		VolumeMounts: []VolumeMountEntry{},
+		Volumes:      []VolumeEntry{},
+	})
+
+	// toContainerEnvs only expands for dependencies
+	inputs["other"] = map[string]any{}
+	_, err := engine.Render(`${other.toContainerEnvs()}`, inputs)
+	if err == nil {
+		t.Error("expected error for non-dependencies receiver on toContainerEnvs")
+	}
+
+	// toContainerVolumeMounts also works on configurations
+	_, err = engine.Render(`${dependencies.toContainerVolumeMounts()}`, inputs)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// toVolumes also works on configurations
+	_, err = engine.Render(`${dependencies.toVolumes()}`, inputs)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigurationsVolumeMountsConcatWithDependencies(t *testing.T) {
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	inputs := derivedInputs(
+		ContainerConfigurations{
+			Configs: ConfigurationItems{Files: []FileConfiguration{{Name: "app.yaml", MountPath: "/etc/config"}}},
+		},
+		WorkloadData{},
+		ConnectionsContextData{
+			VolumeMounts: []VolumeMountEntry{{Name: "dep-vol", MountPath: "/dep", SubPath: "key"}},
+		},
+	)
+
+	result, err := engine.Render(`${configurations.toContainerVolumeMounts() + dependencies.toContainerVolumeMounts()}`, inputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := result.([]any)
+	if len(got) != 2 {
+		t.Errorf("expected 2 volume mounts, got %d", len(got))
+	}
+}
+
+func TestBuildDerivedContext_EmptyInputs(t *testing.T) {
+	derived := BuildDerivedContext(ContainerConfigurations{}, WorkloadData{}, ConnectionsContextData{}, "app-dev")
+
+	if derived.ConfigFileList == nil {
+		t.Error("ConfigFileList should be non-nil")
+	}
+	if derived.SecretFileList == nil {
+		t.Error("SecretFileList should be non-nil")
+	}
+	if derived.ServicePorts == nil {
+		t.Error("ServicePorts should be non-nil")
+	}
+	if derived.DependencyEnvVars == nil {
+		t.Error("DependencyEnvVars should be non-nil")
+	}
+	if derived.DependencyVolumeMounts == nil {
+		t.Error("DependencyVolumeMounts should be non-nil")
+	}
+	if derived.DependencyVolumes == nil {
+		t.Error("DependencyVolumes should be non-nil")
+	}
+}
+
+func TestMacroDoesNotExpandOnWrongReceiver(t *testing.T) {
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	inputs := configInputs(ContainerConfigurations{})
+	inputs["other"] = map[string]any{}
+
+	macros := []string{
+		`other.toConfigFileList()`,
+		`other.toSecretFileList()`,
+		`other.toContainerEnvFrom()`,
+		`other.toConfigEnvsByContainer()`,
+		`other.toSecretEnvsByContainer()`,
+	}
+
+	for _, macro := range macros {
+		t.Run(macro, func(t *testing.T) {
+			_, err := engine.Render("${"+macro+"}", inputs)
+			if err == nil {
+				t.Fatalf("expected error for %s on wrong receiver", macro)
+			}
+			if !strings.Contains(err.Error(), "undeclared reference") && !strings.Contains(err.Error(), "unrecognized") {
+				t.Logf("error (expected macro guard): %v", err)
+			}
+		})
+	}
 }

--- a/internal/pipeline/component/context/cel_integration_test.go
+++ b/internal/pipeline/component/context/cel_integration_test.go
@@ -138,7 +138,7 @@ func TestCELMacroIntegration(t *testing.T) {
 	}
 	sort.Slice(sortedVols, func(i, j int) bool { return sortedVols[i].name < sortedVols[j].name })
 
-	expectedConfigVolumes := make([]map[string]any, len(sortedVols))
+	expectedConfigVolumes := make([]any, len(sortedVols))
 	for i, v := range sortedVols {
 		expectedConfigVolumes[i] = map[string]any{
 			"name":      v.name,
@@ -181,14 +181,14 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("configurations.toConfigFileList", func(t *testing.T) {
 		got := eval(t, "configurations.toConfigFileList()", buildContext(t, workload, nil, ConnectionsData{}))
-		want := []map[string]any{
-			{
+		want := []any{
+			map[string]any{
 				"name":         "app.yaml",
 				"mountPath":    "/etc/config",
 				"value":        "server:\n  port: 8080",
 				"resourceName": appYamlConfigRes,
 			},
-			{
+			map[string]any{
 				"name":         "logging.properties",
 				"mountPath":    "/etc/config",
 				"value":        "log.level=INFO",
@@ -202,15 +202,15 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("configurations.toSecretFileList_empty", func(t *testing.T) {
 		got := eval(t, "configurations.toSecretFileList()", buildContext(t, workload, nil, ConnectionsData{}))
-		if diff := cmp.Diff([]map[string]any{}, got, diffOpts...); diff != "" {
+		if diff := cmp.Diff([]any{}, got, diffOpts...); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 
 	t.Run("configurations.toContainerEnvFrom_config_only", func(t *testing.T) {
 		got := eval(t, "configurations.toContainerEnvFrom()", buildContext(t, workload, nil, ConnectionsData{}))
-		want := []map[string]any{
-			{
+		want := []any{
+			map[string]any{
 				"configMapRef": map[string]any{"name": envConfigsRes},
 			},
 		}
@@ -221,11 +221,11 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("configurations.toContainerEnvFrom_with_secrets", func(t *testing.T) {
 		got := eval(t, "configurations.toContainerEnvFrom()", buildContext(t, workloadWithSecrets, secretRefs, ConnectionsData{}))
-		want := []map[string]any{
-			{
+		want := []any{
+			map[string]any{
 				"configMapRef": map[string]any{"name": envConfigsRes},
 			},
-			{
+			map[string]any{
 				"secretRef": map[string]any{"name": envSecretsRes},
 			},
 		}
@@ -236,13 +236,13 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("configurations.toContainerVolumeMounts", func(t *testing.T) {
 		got := eval(t, "configurations.toContainerVolumeMounts()", buildContext(t, workload, nil, ConnectionsData{}))
-		want := []map[string]any{
-			{
+		want := []any{
+			map[string]any{
 				"name":      appYamlVolName,
 				"mountPath": "/etc/config/app.yaml",
 				"subPath":   "app.yaml",
 			},
-			{
+			map[string]any{
 				"name":      loggingVolName,
 				"mountPath": "/etc/config/logging.properties",
 				"subPath":   "logging.properties",
@@ -262,8 +262,8 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("configurations.toConfigEnvsByContainer", func(t *testing.T) {
 		got := eval(t, "configurations.toConfigEnvsByContainer()", buildContext(t, workload, nil, ConnectionsData{}))
-		want := []map[string]any{
-			{
+		want := []any{
+			map[string]any{
 				"resourceName": envConfigsRes,
 				"envs": []any{
 					map[string]any{"name": "LOG_LEVEL", "value": "info"},
@@ -278,8 +278,8 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("configurations.toSecretEnvsByContainer", func(t *testing.T) {
 		got := eval(t, "configurations.toSecretEnvsByContainer()", buildContext(t, workloadWithSecrets, secretRefs, ConnectionsData{}))
-		want := []map[string]any{
-			{
+		want := []any{
+			map[string]any{
 				"resourceName": envSecretsRes,
 				"envs": []any{
 					map[string]any{
@@ -300,9 +300,9 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("workload.toServicePorts", func(t *testing.T) {
 		got := eval(t, "workload.toServicePorts()", buildContext(t, workload, nil, ConnectionsData{}))
-		want := []map[string]any{
-			{"name": "grpc", "port": int64(9090), "targetPort": int64(9090), "protocol": "TCP"},
-			{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
+		want := []any{
+			map[string]any{"name": "grpc", "port": float64(9090), "targetPort": float64(9090), "protocol": "TCP"},
+			map[string]any{"name": "http", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
 		}
 		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -346,14 +346,13 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("volume_concat_configurations_plus_dependencies", func(t *testing.T) {
 		got := eval(t, "configurations.toVolumes() + dependencies.toVolumes()", buildContext(t, workload, nil, depData))
-		want := make([]any, 0, len(expectedConfigVolumes)+1)
-		for _, v := range expectedConfigVolumes {
-			want = append(want, v)
-		}
-		want = append(want, map[string]any{
-			"name":   "db-creds",
-			"secret": map[string]any{"secretName": "db-conn-secret"},
-		})
+		want := append(
+			append([]any{}, expectedConfigVolumes...),
+			map[string]any{
+				"name":   "db-creds",
+				"secret": map[string]any{"secretName": "db-conn-secret"},
+			},
+		)
 		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
@@ -361,9 +360,7 @@ func TestCELMacroIntegration(t *testing.T) {
 
 	t.Run("all_macros_empty_inputs", func(t *testing.T) {
 		ctxMap := buildContext(t, nil, nil, ConnectionsData{})
-
-		// Configuration and workload runtime functions return []map[string]any.
-		typedMacros := []string{
+		macros := []string{
 			"configurations.toConfigFileList()",
 			"configurations.toSecretFileList()",
 			"configurations.toContainerEnvFrom()",
@@ -372,23 +369,11 @@ func TestCELMacroIntegration(t *testing.T) {
 			"configurations.toConfigEnvsByContainer()",
 			"configurations.toSecretEnvsByContainer()",
 			"workload.toServicePorts()",
-		}
-		for _, macro := range typedMacros {
-			t.Run(macro, func(t *testing.T) {
-				got := eval(t, macro, ctxMap)
-				if diff := cmp.Diff([]map[string]any{}, got, diffOpts...); diff != "" {
-					t.Errorf("expected empty list, mismatch (-want +got):\n%s", diff)
-				}
-			})
-		}
-
-		// Dependency macros return []any.
-		depMacros := []string{
 			"dependencies.toContainerEnvs()",
 			"dependencies.toContainerVolumeMounts()",
 			"dependencies.toVolumes()",
 		}
-		for _, macro := range depMacros {
+		for _, macro := range macros {
 			t.Run(macro, func(t *testing.T) {
 				got := eval(t, macro, ctxMap)
 				if diff := cmp.Diff([]any{}, got, diffOpts...); diff != "" {

--- a/internal/pipeline/component/context/cel_integration_test.go
+++ b/internal/pipeline/component/context/cel_integration_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/template"
+)
+
+// TestCELMacroIntegration exercises the full path from ComponentContextInput through
+// BuildComponentContext, ToMap, and CEL macro evaluation. Every assertion uses deep
+// equality so that any change in output shape is caught, serving as a behavioral
+// equivalence check across refactors.
+func TestCELMacroIntegration(t *testing.T) {
+	workload := &v1alpha1.Workload{
+		Spec: v1alpha1.WorkloadSpec{
+			WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+				Container: v1alpha1.Container{
+					Image: "myapp:v1",
+					Env: []v1alpha1.EnvVar{
+						{Key: "LOG_LEVEL", Value: "info"},
+						{Key: "DEBUG", Value: "true"},
+					},
+					Files: []v1alpha1.FileVar{
+						{Key: "app.yaml", MountPath: "/etc/config", Value: "server:\n  port: 8080"},
+						{Key: "logging.properties", MountPath: "/etc/config", Value: "log.level=INFO"},
+					},
+				},
+				Endpoints: map[string]v1alpha1.WorkloadEndpoint{
+					"http": {Port: 8080, Type: v1alpha1.EndpointTypeHTTP},
+					"grpc": {Port: 9090, Type: v1alpha1.EndpointTypeGRPC},
+				},
+			},
+		},
+	}
+
+	secretRefs := map[string]*v1alpha1.SecretReference{
+		"db-secret": {
+			Spec: v1alpha1.SecretReferenceSpec{
+				Data: []v1alpha1.SecretDataSource{
+					{SecretKey: "password", RemoteRef: v1alpha1.RemoteReference{Key: "db/password", Property: "value"}},
+				},
+			},
+		},
+	}
+
+	workloadWithSecrets := &v1alpha1.Workload{
+		Spec: v1alpha1.WorkloadSpec{
+			WorkloadTemplateSpec: v1alpha1.WorkloadTemplateSpec{
+				Container: v1alpha1.Container{
+					Image: "myapp:v1",
+					Env: []v1alpha1.EnvVar{
+						{Key: "LOG_LEVEL", Value: "info"},
+						{Key: "DB_PASSWORD", ValueFrom: &v1alpha1.EnvVarValueFrom{
+							SecretKeyRef: &v1alpha1.SecretKeyRef{Name: "db-secret", Key: "password"},
+						}},
+					},
+					Files: []v1alpha1.FileVar{
+						{Key: "app.yaml", MountPath: "/etc/config", Value: "server:\n  port: 8080"},
+					},
+				},
+				Endpoints: map[string]v1alpha1.WorkloadEndpoint{
+					"http": {Port: 8080, Type: v1alpha1.EndpointTypeHTTP},
+				},
+			},
+		},
+	}
+
+	depData := ConnectionsData{
+		Items: []ConnectionItem{
+			{
+				Namespace: "ns1", Project: "proj1", Component: "svc-a",
+				Endpoint: "http", Visibility: "project",
+				EnvVars: []EnvVarEntry{
+					{Name: "SVC_A_URL", Value: "http://svc-a.ns1:8080"},
+					{Name: "SVC_A_HOST", Value: "svc-a.ns1"},
+				},
+			},
+		},
+		Resources: []ResourceDependencyItem{
+			{
+				Ref: "my-db",
+				EnvVars: []EnvVarEntry{
+					{Name: "DB_HOST", Value: "db.example.com"},
+				},
+				VolumeMounts: []VolumeMountEntry{
+					{Name: "db-creds", MountPath: "/etc/db", SubPath: "password"},
+				},
+				Volumes: []VolumeEntry{
+					{Name: "db-creds", Secret: &SecretVolume{SecretName: "db-conn-secret"}},
+				},
+			},
+		},
+	}
+
+	metadata := MetadataContext{
+		Name:               "myapp-dev-12345678",
+		Namespace:          "dp-test-ns",
+		ComponentName:      "myapp",
+		ComponentUID:       "uid-1234",
+		ComponentNamespace: "cp-test-ns",
+		ProjectName:        "test-project",
+		ProjectUID:         "proj-uid",
+		DataPlaneName:      "test-dp",
+		DataPlaneUID:       "dp-uid",
+		EnvironmentName:    "dev",
+		EnvironmentUID:     "env-uid",
+		Labels:             map[string]string{},
+		Annotations:        map[string]string{},
+		PodSelectors:       map[string]string{"openchoreo.dev/component-uid": "uid-1234"},
+	}
+
+	prefix := "myapp-dev"
+
+	// Pre-compute resource names and volume hashes used in expected values.
+	appYamlVolName := "file-mount-" + generateVolumeHash("/etc/config", "app.yaml")
+	loggingVolName := "file-mount-" + generateVolumeHash("/etc/config", "logging.properties")
+	appYamlConfigRes := generateConfigResourceName(prefix, "app.yaml")
+	loggingConfigRes := generateConfigResourceName(prefix, "logging.properties")
+	envConfigsRes := generateEnvResourceName(prefix, "env-configs")
+	envSecretsRes := generateEnvResourceName(prefix, "env-secrets")
+
+	// buildVolumes sorts output by volume name; compute the sorted order.
+	type volInfo struct {
+		name     string
+		fileName string
+	}
+	sortedVols := []volInfo{
+		{appYamlVolName, "app.yaml"},
+		{loggingVolName, "logging.properties"},
+	}
+	sort.Slice(sortedVols, func(i, j int) bool { return sortedVols[i].name < sortedVols[j].name })
+
+	expectedConfigVolumes := make([]map[string]any, len(sortedVols))
+	for i, v := range sortedVols {
+		expectedConfigVolumes[i] = map[string]any{
+			"name":      v.name,
+			"configMap": map[string]any{"name": generateConfigResourceName(prefix, v.fileName)},
+		}
+	}
+
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+	diffOpts := cmp.Options{cmpopts.EquateEmpty()}
+
+	buildContext := func(t *testing.T, w *v1alpha1.Workload, secrets map[string]*v1alpha1.SecretReference, deps ConnectionsData) map[string]any {
+		t.Helper()
+		input := &ComponentContextInput{
+			Component:     &v1alpha1.Component{},
+			ComponentType: &v1alpha1.ComponentType{},
+			DataPlane:     &v1alpha1.DataPlane{},
+			Environment: &v1alpha1.Environment{Spec: v1alpha1.EnvironmentSpec{
+				DataPlaneRef: &v1alpha1.DataPlaneRef{Kind: v1alpha1.DataPlaneRefKindDataPlane, Name: "test-dp"},
+			}},
+			WorkloadData:   ExtractWorkloadData(w),
+			Configurations: ExtractConfigurationsFromWorkload(secrets, w),
+			Dependencies:   deps,
+			Metadata:       metadata,
+		}
+		ctx, err := BuildComponentContext(input)
+		if err != nil {
+			t.Fatalf("BuildComponentContext failed: %v", err)
+		}
+		return ctx.ToMap()
+	}
+
+	eval := func(t *testing.T, expr string, ctxMap map[string]any) any {
+		t.Helper()
+		result, err := engine.Render("${"+expr+"}", ctxMap)
+		if err != nil {
+			t.Fatalf("CEL error for %q: %v", expr, err)
+		}
+		return result
+	}
+
+	t.Run("configurations.toConfigFileList", func(t *testing.T) {
+		got := eval(t, "configurations.toConfigFileList()", buildContext(t, workload, nil, ConnectionsData{}))
+		want := []map[string]any{
+			{
+				"name":         "app.yaml",
+				"mountPath":    "/etc/config",
+				"value":        "server:\n  port: 8080",
+				"resourceName": appYamlConfigRes,
+			},
+			{
+				"name":         "logging.properties",
+				"mountPath":    "/etc/config",
+				"value":        "log.level=INFO",
+				"resourceName": loggingConfigRes,
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toSecretFileList_empty", func(t *testing.T) {
+		got := eval(t, "configurations.toSecretFileList()", buildContext(t, workload, nil, ConnectionsData{}))
+		if diff := cmp.Diff([]map[string]any{}, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toContainerEnvFrom_config_only", func(t *testing.T) {
+		got := eval(t, "configurations.toContainerEnvFrom()", buildContext(t, workload, nil, ConnectionsData{}))
+		want := []map[string]any{
+			{
+				"configMapRef": map[string]any{"name": envConfigsRes},
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toContainerEnvFrom_with_secrets", func(t *testing.T) {
+		got := eval(t, "configurations.toContainerEnvFrom()", buildContext(t, workloadWithSecrets, secretRefs, ConnectionsData{}))
+		want := []map[string]any{
+			{
+				"configMapRef": map[string]any{"name": envConfigsRes},
+			},
+			{
+				"secretRef": map[string]any{"name": envSecretsRes},
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toContainerVolumeMounts", func(t *testing.T) {
+		got := eval(t, "configurations.toContainerVolumeMounts()", buildContext(t, workload, nil, ConnectionsData{}))
+		want := []map[string]any{
+			{
+				"name":      appYamlVolName,
+				"mountPath": "/etc/config/app.yaml",
+				"subPath":   "app.yaml",
+			},
+			{
+				"name":      loggingVolName,
+				"mountPath": "/etc/config/logging.properties",
+				"subPath":   "logging.properties",
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toVolumes", func(t *testing.T) {
+		got := eval(t, "configurations.toVolumes()", buildContext(t, workload, nil, ConnectionsData{}))
+		if diff := cmp.Diff(expectedConfigVolumes, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toConfigEnvsByContainer", func(t *testing.T) {
+		got := eval(t, "configurations.toConfigEnvsByContainer()", buildContext(t, workload, nil, ConnectionsData{}))
+		want := []map[string]any{
+			{
+				"resourceName": envConfigsRes,
+				"envs": []any{
+					map[string]any{"name": "LOG_LEVEL", "value": "info"},
+					map[string]any{"name": "DEBUG", "value": "true"},
+				},
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("configurations.toSecretEnvsByContainer", func(t *testing.T) {
+		got := eval(t, "configurations.toSecretEnvsByContainer()", buildContext(t, workloadWithSecrets, secretRefs, ConnectionsData{}))
+		want := []map[string]any{
+			{
+				"resourceName": envSecretsRes,
+				"envs": []any{
+					map[string]any{
+						"name":  "DB_PASSWORD",
+						"value": "",
+						"remoteRef": map[string]any{
+							"key":      "db/password",
+							"property": "value",
+						},
+					},
+				},
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("workload.toServicePorts", func(t *testing.T) {
+		got := eval(t, "workload.toServicePorts()", buildContext(t, workload, nil, ConnectionsData{}))
+		want := []map[string]any{
+			{"name": "grpc", "port": int64(9090), "targetPort": int64(9090), "protocol": "TCP"},
+			{"name": "http", "port": int64(8080), "targetPort": int64(8080), "protocol": "TCP"},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("dependencies.toContainerEnvs", func(t *testing.T) {
+		got := eval(t, "dependencies.toContainerEnvs()", buildContext(t, workload, nil, depData))
+		want := []any{
+			map[string]any{"name": "SVC_A_URL", "value": "http://svc-a.ns1:8080"},
+			map[string]any{"name": "SVC_A_HOST", "value": "svc-a.ns1"},
+			map[string]any{"name": "DB_HOST", "value": "db.example.com"},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("dependencies.toContainerVolumeMounts", func(t *testing.T) {
+		got := eval(t, "dependencies.toContainerVolumeMounts()", buildContext(t, workload, nil, depData))
+		want := []any{
+			map[string]any{"name": "db-creds", "mountPath": "/etc/db", "subPath": "password"},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("dependencies.toVolumes", func(t *testing.T) {
+		got := eval(t, "dependencies.toVolumes()", buildContext(t, workload, nil, depData))
+		want := []any{
+			map[string]any{
+				"name":   "db-creds",
+				"secret": map[string]any{"secretName": "db-conn-secret"},
+			},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("volume_concat_configurations_plus_dependencies", func(t *testing.T) {
+		got := eval(t, "configurations.toVolumes() + dependencies.toVolumes()", buildContext(t, workload, nil, depData))
+		want := make([]any, 0, len(expectedConfigVolumes)+1)
+		for _, v := range expectedConfigVolumes {
+			want = append(want, v)
+		}
+		want = append(want, map[string]any{
+			"name":   "db-creds",
+			"secret": map[string]any{"secretName": "db-conn-secret"},
+		})
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("all_macros_empty_inputs", func(t *testing.T) {
+		ctxMap := buildContext(t, nil, nil, ConnectionsData{})
+
+		// Configuration and workload runtime functions return []map[string]any.
+		typedMacros := []string{
+			"configurations.toConfigFileList()",
+			"configurations.toSecretFileList()",
+			"configurations.toContainerEnvFrom()",
+			"configurations.toContainerVolumeMounts()",
+			"configurations.toVolumes()",
+			"configurations.toConfigEnvsByContainer()",
+			"configurations.toSecretEnvsByContainer()",
+			"workload.toServicePorts()",
+		}
+		for _, macro := range typedMacros {
+			t.Run(macro, func(t *testing.T) {
+				got := eval(t, macro, ctxMap)
+				if diff := cmp.Diff([]map[string]any{}, got, diffOpts...); diff != "" {
+					t.Errorf("expected empty list, mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+
+		// Dependency macros return []any.
+		depMacros := []string{
+			"dependencies.toContainerEnvs()",
+			"dependencies.toContainerVolumeMounts()",
+			"dependencies.toVolumes()",
+		}
+		for _, macro := range depMacros {
+			t.Run(macro, func(t *testing.T) {
+				got := eval(t, macro, ctxMap)
+				if diff := cmp.Diff([]any{}, got, diffOpts...); diff != "" {
+					t.Errorf("expected empty list, mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/internal/pipeline/component/context/cel_return_types.go
+++ b/internal/pipeline/component/context/cel_return_types.go
@@ -3,19 +3,12 @@
 
 package context
 
-import (
-	"reflect"
-	"strings"
+// Type structs for DerivedContext fields. These define the shape of
+// precomputed views accessible via CEL macros (e.g. derived.configFileList).
+// The validation environment uses struct reflection on DerivedContext to
+// register these types with the CEL type checker.
 
-	"github.com/google/cel-go/cel"
-)
-
-// Return type structs for CEL helper functions.
-// These mirror the map[string]any shapes returned at runtime and are used
-// by the validation environment to provide typed function declarations so
-// that CEL's type checker can catch invalid field access in forEach loops.
-
-// ConfigFileListEntry represents an element returned by configurations.toConfigFileList().
+// ConfigFileListEntry represents an element of derived.configFileList.
 type ConfigFileListEntry struct {
 	Name         string         `json:"name"`
 	MountPath    string         `json:"mountPath"`
@@ -24,7 +17,7 @@ type ConfigFileListEntry struct {
 	RemoteRef    *RemoteRefData `json:"remoteRef,omitempty"`
 }
 
-// SecretFileListEntry represents an element returned by configurations.toSecretFileList().
+// SecretFileListEntry represents an element of derived.secretFileList.
 type SecretFileListEntry struct {
 	Name         string         `json:"name"`
 	MountPath    string         `json:"mountPath"`
@@ -32,7 +25,7 @@ type SecretFileListEntry struct {
 	RemoteRef    *RemoteRefData `json:"remoteRef,omitempty"`
 }
 
-// EnvFromEntry represents an element returned by configurations.toContainerEnvFrom().
+// EnvFromEntry represents an element of derived.containerEnvFrom.
 type EnvFromEntry struct {
 	ConfigMapRef *NameRef `json:"configMapRef,omitempty"`
 	SecretRef    *NameRef `json:"secretRef,omitempty"`
@@ -46,9 +39,7 @@ type NameRef struct {
 // EnvVarEntry mirrors corev1.EnvVar for the subset of shapes the platform emits when
 // merging endpoint connection env vars and resource dependency env vars into
 // ${dependencies.envVars}. JSON-compatible with corev1.EnvVar so the rendered Pod spec is
-// unchanged. Kept local (instead of importing corev1) so the validation env's CEL element
-// type matches across configurations.* and dependencies.* helpers, enabling concat with
-// the `+` operator without a type-check error.
+// unchanged.
 type EnvVarEntry struct {
 	Name      string             `json:"name"`
 	Value     string             `json:"value,omitempty"`
@@ -56,29 +47,25 @@ type EnvVarEntry struct {
 }
 
 // EnvVarSourceEntry mirrors corev1.EnvVarSource for the two ref kinds the platform emits.
-// FieldRef / ResourceFieldRef / FileKeyRef are deliberately not modeled — resource outputs
-// produce literal value, secretKeyRef, or configMapKeyRef only.
 type EnvVarSourceEntry struct {
 	SecretKeyRef    *KeyRef `json:"secretKeyRef,omitempty"`
 	ConfigMapKeyRef *KeyRef `json:"configMapKeyRef,omitempty"`
 }
 
-// KeyRef references a single key within a Secret or ConfigMap. JSON-compatible with the
-// {name, key} projection of corev1.SecretKeySelector / corev1.ConfigMapKeySelector that
-// the platform emits.
+// KeyRef references a single key within a Secret or ConfigMap.
 type KeyRef struct {
 	Name string `json:"name"`
 	Key  string `json:"key"`
 }
 
-// VolumeMountEntry represents an element returned by configurations.toContainerVolumeMounts().
+// VolumeMountEntry represents an element of derived.containerVolumeMounts.
 type VolumeMountEntry struct {
 	Name      string `json:"name"`
 	MountPath string `json:"mountPath"`
 	SubPath   string `json:"subPath,omitempty"`
 }
 
-// VolumeEntry represents an element returned by configurations.toVolumes().
+// VolumeEntry represents an element of derived.volumes.
 type VolumeEntry struct {
 	Name      string           `json:"name"`
 	ConfigMap *ConfigMapVolume `json:"configMap,omitempty"`
@@ -95,158 +82,16 @@ type SecretVolume struct {
 	SecretName string `json:"secretName"`
 }
 
-// EnvsByContainerEntry represents an element returned by
-// configurations.toConfigEnvsByContainer() or configurations.toSecretEnvsByContainer().
+// EnvsByContainerEntry represents an element of derived.configEnvs or derived.secretEnvs.
 type EnvsByContainerEntry struct {
 	ResourceName string             `json:"resourceName"`
 	Envs         []EnvConfiguration `json:"envs"`
 }
 
-// ServicePortEntry represents an element returned by workload.toServicePorts().
+// ServicePortEntry represents an element of derived.servicePorts.
 type ServicePortEntry struct {
 	Name       string `json:"name"`
 	Port       int64  `json:"port"`
 	TargetPort int64  `json:"targetPort"`
 	Protocol   string `json:"protocol"`
-}
-
-// helperFuncDef defines a CEL helper function for the shared registry.
-type helperFuncDef struct {
-	funcName       string
-	paramTypes     []*cel.Type
-	returnGoType   reflect.Type
-	runtimeBinding cel.OverloadOpt
-}
-
-// helperFuncRegistry is the single source of truth for all CEL helper functions.
-// CELExtensions(), CELValidationExtensions(), and FunctionReturnTypes() all
-// derive from this registry so the three cannot drift independently.
-// When adding a new helper function, add an entry here.
-var helperFuncRegistry = []helperFuncDef{
-	{
-		funcName:       "configurationsToConfigFileList",
-		paramTypes:     []*cel.Type{cel.DynType, cel.StringType},
-		returnGoType:   reflect.TypeFor[ConfigFileListEntry](),
-		runtimeBinding: cel.BinaryBinding(configurationsToConfigFileListFunction),
-	},
-	{
-		funcName:       "configurationsToSecretFileList",
-		paramTypes:     []*cel.Type{cel.DynType, cel.StringType},
-		returnGoType:   reflect.TypeFor[SecretFileListEntry](),
-		runtimeBinding: cel.BinaryBinding(configurationsToSecretFileListFunction),
-	},
-	{
-		funcName:       "configurationsToContainerEnvFrom",
-		paramTypes:     []*cel.Type{cel.DynType, cel.StringType},
-		returnGoType:   reflect.TypeFor[EnvFromEntry](),
-		runtimeBinding: cel.BinaryBinding(configurationsToContainerEnvFromFunction),
-	},
-	{
-		funcName:       "configurationsToContainerVolumeMounts",
-		paramTypes:     []*cel.Type{cel.DynType},
-		returnGoType:   reflect.TypeFor[VolumeMountEntry](),
-		runtimeBinding: cel.UnaryBinding(configurationsToContainerVolumeMountsFunction),
-	},
-	{
-		funcName:       "configurationsToVolumes",
-		paramTypes:     []*cel.Type{cel.DynType, cel.StringType},
-		returnGoType:   reflect.TypeFor[VolumeEntry](),
-		runtimeBinding: cel.BinaryBinding(configurationsToVolumesFunction),
-	},
-	{
-		funcName:       "configurationsToConfigEnvsByContainer",
-		paramTypes:     []*cel.Type{cel.DynType, cel.StringType},
-		returnGoType:   reflect.TypeFor[EnvsByContainerEntry](),
-		runtimeBinding: cel.BinaryBinding(configurationsToConfigEnvsByContainerFunction),
-	},
-	{
-		funcName:       "configurationsToSecretEnvsByContainer",
-		paramTypes:     []*cel.Type{cel.DynType, cel.StringType},
-		returnGoType:   reflect.TypeFor[EnvsByContainerEntry](),
-		runtimeBinding: cel.BinaryBinding(configurationsToSecretEnvsByContainerFunction),
-	},
-	{
-		funcName:       "workloadToServicePorts",
-		paramTypes:     []*cel.Type{cel.DynType},
-		returnGoType:   reflect.TypeFor[ServicePortEntry](),
-		runtimeBinding: cel.UnaryBinding(workloadToServicePortsFunction),
-	},
-}
-
-// helperMacros is the shared set of CEL macros registered by both
-// CELExtensions() and CELValidationExtensions().
-var helperMacros = []cel.Macro{
-	toConfigFileListMacro, toSecretFileListMacro, toContainerEnvFromMacro,
-	toContainerVolumeMountsMacro, toVolumesMacro, toConfigEnvsByContainerMacro,
-	toSecretEnvsByContainerMacro, toServicePortsMacro, toContainerEnvsMacro,
-}
-
-// FunctionReturnTypes returns the unique Go types used as return types by CEL helper functions.
-// Used by the validation environment to register DeclTypes for field-access validation.
-func FunctionReturnTypes() []reflect.Type {
-	seen := make(map[reflect.Type]struct{})
-	var types []reflect.Type
-	for _, def := range helperFuncRegistry {
-		if _, ok := seen[def.returnGoType]; !ok {
-			seen[def.returnGoType] = struct{}{}
-			types = append(types, def.returnGoType)
-		}
-	}
-	return types
-}
-
-// CELExtensions returns CEL environment options for configuration helpers used by the runtime template engine.
-// Function overloads return list(dyn) and include runtime bindings.
-func CELExtensions() []cel.EnvOption {
-	opts := make([]cel.EnvOption, 0, 1+len(helperFuncRegistry))
-	opts = append(opts, cel.Macros(helperMacros...))
-	for _, def := range helperFuncRegistry {
-		overloadID := def.funcName + "_" + paramTypeSuffix(def.paramTypes)
-		opts = append(opts, cel.Function(def.funcName,
-			cel.Overload(overloadID, def.paramTypes, cel.ListType(cel.DynType), def.runtimeBinding),
-		))
-	}
-	return opts
-}
-
-// CELValidationExtensions returns CEL environment options for the validation environment.
-// Unlike CELExtensions(), function overloads declare typed return types instead of dyn,
-// enabling the type checker to validate field access on forEach loop variables.
-// No binding functions are registered since validation never evaluates expressions.
-func CELValidationExtensions() []cel.EnvOption {
-	opts := make([]cel.EnvOption, 0, 1+len(helperFuncRegistry))
-	opts = append(opts, cel.Macros(helperMacros...))
-	for _, def := range helperFuncRegistry {
-		overloadID := def.funcName + "_" + paramTypeSuffix(def.paramTypes) + "_typed"
-		typedReturn := cel.ListType(cel.ObjectType(def.returnGoType.Name()))
-		opts = append(opts, cel.Function(def.funcName,
-			cel.Overload(overloadID, def.paramTypes, typedReturn),
-		))
-	}
-	return opts
-}
-
-// paramTypeSuffix generates an overload ID suffix from parameter types.
-func paramTypeSuffix(paramTypes []*cel.Type) string {
-	parts := make([]string, len(paramTypes))
-	for i, pt := range paramTypes {
-		parts[i] = celTypeShortName(pt)
-	}
-	return strings.Join(parts, "_")
-}
-
-// celTypeShortName returns a short identifier for a CEL type, used in overload IDs.
-func celTypeShortName(t *cel.Type) string {
-	switch {
-	case t.IsEquivalentType(cel.DynType):
-		return "dyn"
-	case t.IsEquivalentType(cel.StringType):
-		return "string"
-	case t.IsEquivalentType(cel.IntType):
-		return "int"
-	case t.IsEquivalentType(cel.BoolType):
-		return "bool"
-	default:
-		return t.String()
-	}
 }

--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -67,6 +67,9 @@ func BuildComponentContext(input *ComponentContextInput) (*ComponentContext, err
 	ctx.Environment = extractEnvironmentData(input.Environment, input.DataPlane, input.DefaultNotificationChannel)
 	ctx.Gateway = ctx.Environment.Gateway
 
+	prefix := input.Metadata.ComponentName + "-" + input.Metadata.EnvironmentName
+	ctx.Derived = BuildDerivedContext(ctx.Configurations, ctx.Workload, ctx.Dependencies, prefix)
+
 	return ctx, nil
 }
 

--- a/internal/pipeline/component/context/derived.go
+++ b/internal/pipeline/component/context/derived.go
@@ -1,0 +1,325 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strings"
+
+	"github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
+)
+
+const (
+	protocolTCP = "TCP"
+	protocolUDP = "UDP"
+)
+
+// DerivedContext holds precomputed derived views of configurations, workload,
+// and dependency data. CEL macros rewrite helper method calls (e.g.
+// configurations.toConfigFileList()) to field selects on this struct
+// (e.g. derived.configFileList), eliminating runtime map[string]any traversal.
+type DerivedContext struct {
+	ConfigFileList     []ConfigFileListEntry  `json:"configFileList"`
+	SecretFileList     []SecretFileListEntry  `json:"secretFileList"`
+	ContainerEnvFrom   []EnvFromEntry         `json:"containerEnvFrom"`
+	ConfigVolumeMounts []VolumeMountEntry     `json:"configVolumeMounts"`
+	ConfigVolumes      []VolumeEntry          `json:"configVolumes"`
+	ConfigEnvs         []EnvsByContainerEntry `json:"configEnvs"`
+	SecretEnvs         []EnvsByContainerEntry `json:"secretEnvs"`
+
+	ServicePorts []ServicePortEntry `json:"servicePorts"`
+
+	DependencyEnvVars      []EnvVarEntry      `json:"dependencyEnvVars"`
+	DependencyVolumeMounts []VolumeMountEntry `json:"dependencyVolumeMounts"`
+	DependencyVolumes      []VolumeEntry      `json:"dependencyVolumes"`
+}
+
+// BuildDerivedContext precomputes all derived views from typed inputs.
+func BuildDerivedContext(
+	configurations ContainerConfigurations,
+	workload WorkloadData,
+	dependencies ConnectionsContextData,
+	prefix string,
+) DerivedContext {
+	return DerivedContext{
+		ConfigFileList:         buildConfigFileList(configurations, prefix),
+		SecretFileList:         buildSecretFileList(configurations, prefix),
+		ContainerEnvFrom:       buildEnvFrom(configurations, prefix),
+		ConfigVolumeMounts:     buildVolumeMounts(configurations),
+		ConfigVolumes:          buildVolumes(configurations, prefix),
+		ConfigEnvs:             buildConfigEnvs(configurations, prefix),
+		SecretEnvs:             buildSecretEnvs(configurations, prefix),
+		ServicePorts:           buildServicePorts(workload),
+		DependencyEnvVars:      nonNilEnvVars(dependencies.EnvVars),
+		DependencyVolumeMounts: nonNilVolumeMounts(dependencies.VolumeMounts),
+		DependencyVolumes:      nonNilVolumes(dependencies.Volumes),
+	}
+}
+
+func buildConfigFileList(cc ContainerConfigurations, prefix string) []ConfigFileListEntry {
+	files := cc.Configs.Files
+	result := make([]ConfigFileListEntry, len(files))
+	for i, f := range files {
+		result[i] = ConfigFileListEntry{
+			Name:         f.Name,
+			MountPath:    f.MountPath,
+			Value:        f.Value,
+			ResourceName: generateConfigResourceName(prefix, f.Name),
+			RemoteRef:    f.RemoteRef,
+		}
+	}
+	return result
+}
+
+func buildSecretFileList(cc ContainerConfigurations, prefix string) []SecretFileListEntry {
+	files := cc.Secrets.Files
+	result := make([]SecretFileListEntry, len(files))
+	for i, f := range files {
+		result[i] = SecretFileListEntry{
+			Name:         f.Name,
+			MountPath:    f.MountPath,
+			ResourceName: generateSecretResourceName(prefix, f.Name),
+			RemoteRef:    f.RemoteRef,
+		}
+	}
+	return result
+}
+
+func buildEnvFrom(cc ContainerConfigurations, prefix string) []EnvFromEntry {
+	result := make([]EnvFromEntry, 0, 2)
+	if len(cc.Configs.Envs) > 0 {
+		result = append(result, EnvFromEntry{
+			ConfigMapRef: &NameRef{Name: generateEnvResourceName(prefix, "env-configs")},
+		})
+	}
+	if len(cc.Secrets.Envs) > 0 {
+		result = append(result, EnvFromEntry{
+			SecretRef: &NameRef{Name: generateEnvResourceName(prefix, "env-secrets")},
+		})
+	}
+	return result
+}
+
+func buildVolumeMounts(cc ContainerConfigurations) []VolumeMountEntry {
+	result := make([]VolumeMountEntry, 0, len(cc.Configs.Files)+len(cc.Secrets.Files))
+	for _, f := range cc.Configs.Files {
+		result = append(result, VolumeMountEntry{
+			Name:      "file-mount-" + generateVolumeHash(f.MountPath, f.Name),
+			MountPath: f.MountPath + "/" + f.Name,
+			SubPath:   f.Name,
+		})
+	}
+	for _, f := range cc.Secrets.Files {
+		result = append(result, VolumeMountEntry{
+			Name:      "file-mount-" + generateVolumeHash(f.MountPath, f.Name),
+			MountPath: f.MountPath + "/" + f.Name,
+			SubPath:   f.Name,
+		})
+	}
+	return result
+}
+
+func buildVolumes(cc ContainerConfigurations, prefix string) []VolumeEntry {
+	byName := make(map[string]VolumeEntry)
+	for _, f := range cc.Configs.Files {
+		name := "file-mount-" + generateVolumeHash(f.MountPath, f.Name)
+		byName[name] = VolumeEntry{
+			Name:      name,
+			ConfigMap: &ConfigMapVolume{Name: generateConfigResourceName(prefix, f.Name)},
+		}
+	}
+	for _, f := range cc.Secrets.Files {
+		name := "file-mount-" + generateVolumeHash(f.MountPath, f.Name)
+		byName[name] = VolumeEntry{
+			Name:   name,
+			Secret: &SecretVolume{SecretName: generateSecretResourceName(prefix, f.Name)},
+		}
+	}
+
+	names := make([]string, 0, len(byName))
+	for n := range byName {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	result := make([]VolumeEntry, len(names))
+	for i, n := range names {
+		result[i] = byName[n]
+	}
+	return result
+}
+
+func buildConfigEnvs(cc ContainerConfigurations, prefix string) []EnvsByContainerEntry {
+	if len(cc.Configs.Envs) == 0 {
+		return []EnvsByContainerEntry{}
+	}
+	return []EnvsByContainerEntry{{
+		ResourceName: generateEnvResourceName(prefix, "env-configs"),
+		Envs:         cc.Configs.Envs,
+	}}
+}
+
+func buildSecretEnvs(cc ContainerConfigurations, prefix string) []EnvsByContainerEntry {
+	if len(cc.Secrets.Envs) == 0 {
+		return []EnvsByContainerEntry{}
+	}
+	return []EnvsByContainerEntry{{
+		ResourceName: generateEnvResourceName(prefix, "env-secrets"),
+		Envs:         cc.Secrets.Envs,
+	}}
+}
+
+func buildServicePorts(workload WorkloadData) []ServicePortEntry {
+	if len(workload.Endpoints) == 0 {
+		return []ServicePortEntry{}
+	}
+
+	endpointNames := make([]string, 0, len(workload.Endpoints))
+	for name := range workload.Endpoints {
+		endpointNames = append(endpointNames, name)
+	}
+	sort.Strings(endpointNames)
+
+	result := make([]ServicePortEntry, 0, len(workload.Endpoints))
+	usedNames := make(map[string]bool)
+	seenPortProto := make(map[string]bool)
+
+	for _, epName := range endpointNames {
+		ep := workload.Endpoints[epName]
+		port := int64(ep.Port)
+		targetPort := int64(ep.TargetPort)
+		if targetPort == 0 {
+			targetPort = port
+		}
+		protocol := mapEndpointTypeToProtocol(ep.Type)
+
+		portProtoKey := fmt.Sprintf("%d/%s", port, protocol)
+		if seenPortProto[portProtoKey] {
+			continue
+		}
+		seenPortProto[portProtoKey] = true
+
+		finalName := uniquePortName(epName, port, usedNames)
+		usedNames[finalName] = true
+
+		result = append(result, ServicePortEntry{
+			Name:       finalName,
+			Port:       port,
+			TargetPort: targetPort,
+			Protocol:   protocol,
+		})
+	}
+	return result
+}
+
+func uniquePortName(endpointName string, port int64, usedNames map[string]bool) string {
+	sanitized := sanitizePortName(endpointName)
+	if sanitized == "" {
+		sanitized = fmt.Sprintf("port-%d", port)
+	}
+
+	name := sanitized
+	counter := 2
+	for usedNames[name] {
+		name = fmt.Sprintf("%s-%d", sanitized, counter)
+		if len(name) > 15 {
+			maxBase := 15 - len(fmt.Sprintf("-%d", counter))
+			if maxBase > 0 {
+				name = fmt.Sprintf("%s-%d", sanitized[:maxBase], counter)
+			} else {
+				name = fmt.Sprintf("p-%d", counter)
+			}
+		}
+		counter++
+	}
+	return name
+}
+
+func nonNilEnvVars(s []EnvVarEntry) []EnvVarEntry {
+	if s == nil {
+		return []EnvVarEntry{}
+	}
+	return s
+}
+
+func nonNilVolumeMounts(s []VolumeMountEntry) []VolumeMountEntry {
+	if s == nil {
+		return []VolumeMountEntry{}
+	}
+	return s
+}
+
+func nonNilVolumes(s []VolumeEntry) []VolumeEntry {
+	if s == nil {
+		return []VolumeEntry{}
+	}
+	return s
+}
+
+func sanitizePortName(name string) string {
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, "_", "-")
+
+	var result strings.Builder
+	for _, ch := range name {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+			result.WriteRune(ch)
+		}
+	}
+	sanitized := strings.Trim(result.String(), "-")
+
+	if len(sanitized) == 0 {
+		return ""
+	}
+	if len(sanitized) > 15 {
+		sanitized = strings.TrimRight(sanitized[:15], "-")
+	}
+	return sanitized
+}
+
+func generateVolumeHash(mountPath, filename string) string {
+	input := mountPath + "/" + filename
+	h := fnv.New32a()
+	h.Write([]byte(input))
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+func generateConfigResourceName(prefix, filename string) string {
+	return kubernetes.GenerateK8sNameWithLengthLimit(
+		kubernetes.MaxResourceNameLength,
+		prefix,
+		"config",
+		strings.ReplaceAll(filename, ".", "-"),
+	)
+}
+
+func generateSecretResourceName(prefix, filename string) string {
+	return kubernetes.GenerateK8sNameWithLengthLimit(
+		kubernetes.MaxResourceNameLength,
+		prefix,
+		"secret",
+		strings.ReplaceAll(filename, ".", "-"),
+	)
+}
+
+func generateEnvResourceName(prefix, suffix string) string {
+	return kubernetes.GenerateK8sNameWithLengthLimit(
+		kubernetes.MaxResourceNameLength,
+		prefix,
+		suffix,
+	)
+}
+
+func mapEndpointTypeToProtocol(endpointType string) string {
+	switch endpointType {
+	case protocolTCP:
+		return protocolTCP
+	case protocolUDP:
+		return protocolUDP
+	default:
+		return protocolTCP
+	}
+}

--- a/internal/pipeline/component/context/trait.go
+++ b/internal/pipeline/component/context/trait.go
@@ -122,6 +122,9 @@ func makeTraitContext(input *TraitContextInput, parameters, envConfigs map[strin
 	ctx.Configurations = base.Configurations
 	ctx.Dependencies = newDependenciesContextData(base.Dependencies)
 
+	prefix := base.Metadata.ComponentName + "-" + base.Metadata.EnvironmentName
+	ctx.Derived = BuildDerivedContext(ctx.Configurations, ctx.Workload, ctx.Dependencies, prefix)
+
 	return ctx
 }
 

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -240,6 +240,9 @@ type ComponentContext struct {
 	// Dependencies contains dependency metadata and merged env vars for templates.
 	// Accessed via ${dependencies.items} and ${dependencies.envVars}.
 	Dependencies ConnectionsContextData `json:"dependencies"`
+
+	// Derived holds precomputed views that CEL macros resolve to via field selects.
+	Derived DerivedContext `json:"derived"`
 }
 
 // DataPlaneData provides data plane configuration in templates.
@@ -472,6 +475,9 @@ type TraitContext struct {
 	// Dependencies contains dependency metadata and merged env vars for templates.
 	// Accessed via ${dependencies.items} and ${dependencies.envVars}.
 	Dependencies ConnectionsContextData `json:"dependencies"`
+
+	// Derived holds precomputed views that CEL macros resolve to via field selects.
+	Derived DerivedContext `json:"derived"`
 }
 
 // TraitMetadata contains trait-specific metadata.

--- a/internal/validation/component/cel_env.go
+++ b/internal/validation/component/cel_env.go
@@ -28,18 +28,6 @@ var (
 	traitContextFields     = decltype.ExtractFields(reflect.TypeFor[context.TraitContext](), schemaBasedFields)
 )
 
-// functionReturnDeclTypes are DeclTypes for the return types of CEL helper functions.
-// Derived from context.FunctionReturnTypes() so the type list stays in sync
-// with CELExtensions() and CELValidationExtensions() automatically.
-var functionReturnDeclTypes = func() []*apiservercel.DeclType {
-	returnTypes := context.FunctionReturnTypes()
-	result := make([]*apiservercel.DeclType, len(returnTypes))
-	for i, t := range returnTypes {
-		result[i] = decltype.FromGoType(t)
-	}
-	return result
-}()
-
 // SchemaOptions provides schema configuration for CEL environment and validation.
 // Used by both component and trait CEL environments.
 type SchemaOptions struct {
@@ -72,7 +60,7 @@ func buildCELEnv(contextFields []decltype.FieldInfo, opts SchemaOptions) (*cel.E
 	}
 
 	numFields := len(contextFields) + len(schemaBasedFields)
-	declTypes := make([]*apiservercel.DeclType, 0, numFields+len(functionReturnDeclTypes))
+	declTypes := make([]*apiservercel.DeclType, 0, numFields)
 	varOpts := make([]cel.EnvOption, 0, numFields)
 
 	// Register schema-based fields
@@ -89,9 +77,6 @@ func buildCELEnv(contextFields []decltype.FieldInfo, opts SchemaOptions) (*cel.E
 		declTypes = append(declTypes, f.DeclType)
 		varOpts = append(varOpts, cel.Variable(f.Name, f.DeclType.CelType()))
 	}
-
-	// Register function return types so the type checker can validate field access
-	declTypes = append(declTypes, functionReturnDeclTypes...)
 
 	provider := apiservercel.NewDeclTypeProvider(declTypes...)
 	providerOpts, err := provider.EnvOptions(baseEnv.CELTypeProvider())
@@ -110,7 +95,7 @@ func buildCELEnv(contextFields []decltype.FieldInfo, opts SchemaOptions) (*cel.E
 // createBaseEnv creates the base CEL environment with standard extensions.
 func createBaseEnv() (*cel.Env, error) {
 	baseEnvOpts := template.BaseCELExtensions()
-	baseEnvOpts = append(baseEnvOpts, context.CELValidationExtensions()...)
+	baseEnvOpts = append(baseEnvOpts, context.CELExtensions()...)
 	return cel.NewEnv(baseEnvOpts...)
 }
 

--- a/test/e2e/suites/workloadtypes/workloadtypes_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_test.go
@@ -20,9 +20,9 @@ const (
 	// github-issue-reporter come from the public OpenChoreo sample images;
 	// the web-app slot uses hashicorp/http-echo because the react sample
 	// image is not consistently reachable from CI.
-	imageService     = "ghcr.io/openchoreo/samples/greeter-service:latest"
-	imageWebApp      = "hashicorp/http-echo:1.0.0"
-	imageScheduled   = "ghcr.io/openchoreo/samples/github-issue-reporter:latest"
+	imageService   = "ghcr.io/openchoreo/samples/greeter-service:latest"
+	imageWebApp    = "hashicorp/http-echo:1.0.0"
+	imageScheduled = "ghcr.io/openchoreo/samples/github-issue-reporter:latest"
 )
 
 var dpNs string


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Replace runtime map[string]any traversal in CEL helper functions with
a precomputed typed DerivedContext struct. Macros now rewrite to field
selects (e.g. derived.configFileList) instead of function calls.

- Typed Go struct builders instead of untyped map walking with nested
  type assertions — more readable, testable, and easier to extend
- Validation type checking via struct reflection instead of a separate
  function return type registry — single source of truth
  
Some of the earlier tests might be redundant due to the newer tests added to verify integration from render input to rendered result of the macros. Will cleanup separately.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
