### PR TITLE
test: add gateway e2e test suite for visibility and routing

### DIFF
--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -42,7 +42,7 @@ E2E_OP_NS              := openchoreo-observability-plane
 GATEWAY_API_VERSION    ?= v1.4.1
 CERT_MANAGER_VERSION   ?= v1.19.4
 ESO_VERSION            ?= 2.0.1
-KGATEWAY_VERSION       ?= v2.1.1
+KGATEWAY_VERSION       ?= v2.2.1
 THUNDER_VERSION        ?= 0.28.0
 
 # Helm chart references: local chart dirs or OCI registry

--- a/test/e2e/framework/gateway.go
+++ b/test/e2e/framework/gateway.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+)
+
+// AssertHTTPRouteAccepted asserts that the named HTTPRoute has at least one
+// parent reporting Accepted=True in status.parents[].conditions.
+func AssertHTTPRouteAccepted(g gomega.Gomega, kubeContext, namespace, name string) {
+	out, err := KubectlGetJsonpath(
+		kubeContext, namespace,
+		"httproute.gateway.networking.k8s.io", name,
+		`{.status.parents[0].conditions[?(@.type=="Accepted")].status}`,
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"failed to read HTTPRoute %s/%s accepted condition", namespace, name)
+	g.Expect(out).To(gomega.Equal("True"),
+		"HTTPRoute %s/%s should be Accepted", namespace, name)
+}
+
+// CountHTTPRoutesByLabel returns the number of HTTPRoutes matching a label selector.
+func CountHTTPRoutesByLabel(kubeContext, namespace, labelSelector string) (int, error) {
+	out, err := Kubectl(kubeContext,
+		"get", "httproute.gateway.networking.k8s.io",
+		"-n", namespace,
+		"-l", labelSelector,
+		"-o", "name",
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list httproutes in %s with selector %s: %w", namespace, labelSelector, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return 0, nil
+	}
+	return len(strings.Split(strings.TrimSpace(out), "\n")), nil
+}
+
+// GetHTTPRouteNames returns the names of HTTPRoutes matching a label selector.
+func GetHTTPRouteNames(kubeContext, namespace, labelSelector string) ([]string, error) {
+	out, err := Kubectl(kubeContext,
+		"get", "httproute.gateway.networking.k8s.io",
+		"-n", namespace,
+		"-l", labelSelector,
+		"-o", "jsonpath={.items[*].metadata.name}",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list httproutes in %s with selector %s: %w", namespace, labelSelector, err)
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Fields(trimmed), nil
+}

--- a/test/e2e/framework/wait.go
+++ b/test/e2e/framework/wait.go
@@ -192,3 +192,11 @@ func AssertNamespaceGone(g gomega.Gomega, kubeContext, namespace string) {
 	g.Expect(err.Error()).To(gomega.ContainSubstring("NotFound"),
 		fmt.Sprintf("expected NotFound for namespace %s, got: %v", namespace, err))
 }
+
+// WaitForReleaseBindingReady polls until the named ReleaseBinding has condition Ready=True.
+func WaitForReleaseBindingReady(kubeContext, namespace, name string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		AssertReleaseBindingReady(g, kubeContext, namespace, name)
+	}, DefaultTimeout, 5*time.Second).Should(gomega.Succeed(),
+		"ReleaseBinding %s/%s should be Ready", namespace, name)
+}

--- a/test/e2e/k3d/coredns-custom.yaml
+++ b/test/e2e/k3d/coredns-custom.yaml
@@ -17,6 +17,10 @@ data:
       answer auto
     }
     rewrite stop {
+      name regex (.+\.)?e2e-dp-internal\.local gateway-internal.openchoreo-data-plane.svc.cluster.local
+      answer auto
+    }
+    rewrite stop {
       name regex (.+\.)?e2e-wp\.local host.k3d.internal
       answer auto
     }

--- a/test/e2e/suites/gateway/gateway_fixtures_test.go
+++ b/test/e2e/suites/gateway/gateway_fixtures_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+const (
+	clusterDataPlane   = "e2e-shared"
+	openChoreoAPIVer   = "openchoreo.dev/v1alpha1"
+	kubernetesAPIVerV1 = "v1"
+
+	projectName = "default"
+	envDev      = "development"
+	envStaging  = "staging"
+
+	componentTypeService = "deployment/service"
+
+	testerLabel     = "app=gw-tester"
+	testerContainer = "tester"
+
+	gwDefaultNS    = "openchoreo-data-plane"
+	gwInternalName = "gateway-internal"
+
+	// Staging environment gateway override.
+	stagingGWHost = "e2e-gw-staging.local"
+	stagingGWPort = 18080
+)
+
+type endpointDef struct {
+	epType     string
+	port       int
+	visibility []string
+	basePath   string
+}
+
+var runID = fmt.Sprintf("%d", time.Now().UnixNano())
+
+var cpNs = fmt.Sprintf("e2e-gw-%s", runID)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+func cpNamespaceYAML() string {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/control-plane": "true",
+			},
+		},
+	}
+	return mustYAMLDocs(ns)
+}
+
+func platformResourcesYAML() string {
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "DeploymentPipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": "default"},
+		},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{{
+				SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: envDev},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{
+					{Name: envStaging},
+				},
+			}},
+		},
+	}
+
+	envDevObj := &openchoreov1alpha1.Environment{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envDev,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": envDev},
+		},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+				Name: clusterDataPlane,
+			},
+		},
+	}
+
+	// Staging environment with gateway override pointing to gateway-internal.
+	envStgObj := &openchoreov1alpha1.Environment{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envStaging,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": envStaging},
+		},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+				Name: clusterDataPlane,
+			},
+			Gateway: openchoreov1alpha1.GatewaySpec{
+				Ingress: &openchoreov1alpha1.GatewayNetworkSpec{
+					External: &openchoreov1alpha1.GatewayEndpointSpec{
+						Name:      gwInternalName,
+						Namespace: gwDefaultNS,
+						HTTP: &openchoreov1alpha1.GatewayListenerSpec{
+							Port: stagingGWPort,
+							Host: stagingGWHost,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	proj := &openchoreov1alpha1.Project{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": projectName},
+		},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+		},
+	}
+
+	return mustYAMLDocs(pipeline, envDevObj, envStgObj, proj)
+}
+
+func componentYAML(name, image string, args []string, endpoints map[string]endpointDef, traits []openchoreov1alpha1.ComponentTrait) string {
+	comp := &openchoreov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner:    openchoreov1alpha1.ComponentOwner{ProjectName: projectName},
+			ComponentType: openchoreov1alpha1.ComponentTypeRef{
+				Kind: openchoreov1alpha1.ComponentTypeRefKindClusterComponentType,
+				Name: componentTypeService,
+			},
+			AutoDeploy: true,
+			Traits:     traits,
+		},
+	}
+
+	workload := &openchoreov1alpha1.Workload{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Workload"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.WorkloadSpec{
+			Owner: openchoreov1alpha1.WorkloadOwner{
+				ProjectName:   projectName,
+				ComponentName: name,
+			},
+			WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
+				Container: openchoreov1alpha1.Container{
+					Image: image,
+					Args:  args,
+				},
+			},
+		},
+	}
+
+	populateEndpoints(workload, endpoints)
+	return mustYAMLDocs(comp, workload)
+}
+
+func populateEndpoints(workload *openchoreov1alpha1.Workload, endpoints map[string]endpointDef) {
+	if len(endpoints) == 0 {
+		return
+	}
+	workload.Spec.Endpoints = make(map[string]openchoreov1alpha1.WorkloadEndpoint, len(endpoints))
+	for epName, ep := range endpoints {
+		visibility := make([]openchoreov1alpha1.EndpointVisibility, 0, len(ep.visibility))
+		for _, v := range ep.visibility {
+			visibility = append(visibility, openchoreov1alpha1.EndpointVisibility(v))
+		}
+		we := openchoreov1alpha1.WorkloadEndpoint{
+			Type:       openchoreov1alpha1.EndpointType(ep.epType),
+			Port:       int32(ep.port),
+			Visibility: visibility,
+		}
+		if ep.basePath != "" {
+			we.BasePath = ep.basePath
+		}
+		workload.Spec.Endpoints[epName] = we
+	}
+}
+
+func releaseBindingYAML(component, releaseName, environment string) string {
+	rb := map[string]any{
+		"apiVersion": openChoreoAPIVer,
+		"kind":       "ReleaseBinding",
+		"metadata": map[string]any{
+			"name":      component + "-" + environment,
+			"namespace": cpNs,
+		},
+		"spec": map[string]any{
+			"owner": map[string]any{
+				"projectName":   projectName,
+				"componentName": component,
+			},
+			"releaseName": releaseName,
+			"environment":          environment,
+		},
+	}
+	data, err := yaml.Marshal(rb)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal ReleaseBinding: %v", err))
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func testerPodYAML(dpNamespace string) string {
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-tester",
+			Namespace: dpNamespace,
+			Labels: map[string]string{
+				"app":                       "gw-tester",
+				"openchoreo.dev/project":    projectName,
+				"openchoreo.dev/managed-by": "e2e-gateway",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    testerContainer,
+			Image:   "busybox:1.36",
+			Command: []string{"sleep", "3600"},
+		}}},
+	}
+	return mustYAMLDocs(pod)
+}
+

--- a/test/e2e/suites/gateway/gateway_test.go
+++ b/test/e2e/suites/gateway/gateway_test.go
@@ -1,0 +1,398 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var _ = Describe("Gateway Routing", Ordered, Label("tier2"), func() {
+	var (
+		dpDevNs string // data plane namespace for development
+		dpStgNs string // data plane namespace for staging (test 6)
+	)
+
+	endpointExternalHTTPURL := func(component, endpoint, env string) string {
+		rbName := component + "-" + env
+		jp := func(g Gomega, field string) string {
+			out, err := framework.KubectlGetJsonpath(
+				kubeContext, cpNs, "releasebinding", rbName,
+				fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].externalURLs.http.%s}`, endpoint, field),
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			return out
+		}
+		var url string
+		Eventually(func(g Gomega) {
+			scheme := jp(g, "scheme")
+			host := jp(g, "host")
+			port := jp(g, "port")
+			path := jp(g, "path")
+			g.Expect(scheme).NotTo(BeEmpty(), "externalURLs.http.scheme empty on %s", rbName)
+			g.Expect(host).NotTo(BeEmpty(), "externalURLs.http.host empty on %s", rbName)
+			g.Expect(port).NotTo(BeEmpty(), "externalURLs.http.port empty on %s", rbName)
+			url = fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+		}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		return url
+	}
+
+	endpointInternalHTTPURL := func(component, endpoint, env string) string {
+		rbName := component + "-" + env
+		jp := func(g Gomega, field string) string {
+			out, err := framework.KubectlGetJsonpath(
+				kubeContext, cpNs, "releasebinding", rbName,
+				fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].internalURLs.http.%s}`, endpoint, field),
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			return out
+		}
+		var url string
+		Eventually(func(g Gomega) {
+			scheme := jp(g, "scheme")
+			host := jp(g, "host")
+			port := jp(g, "port")
+			path := jp(g, "path")
+			g.Expect(scheme).NotTo(BeEmpty(), "internalURLs.http.scheme empty on %s", rbName)
+			g.Expect(host).NotTo(BeEmpty(), "internalURLs.http.host empty on %s", rbName)
+			g.Expect(port).NotTo(BeEmpty(), "internalURLs.http.port empty on %s", rbName)
+			url = fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+		}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		return url
+	}
+
+	BeforeAll(func() {
+		By("creating CP namespace")
+		output, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
+		Expect(err).NotTo(HaveOccurred(), "failed to create CP namespace: %s", output)
+
+		By("applying platform resources")
+		output, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML())
+		Expect(err).NotTo(HaveOccurred(), "failed to apply platform resources: %s", output)
+
+		By("deploying gw-ext (external visibility)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentYAML(
+			"gw-ext", "hashicorp/http-echo", []string{"-text=gw-ext", "-listen=:8080"},
+			map[string]endpointDef{
+				"http": {epType: "HTTP", port: 8080, visibility: []string{"external"}},
+			}, nil))
+		Expect(err).NotTo(HaveOccurred(), "failed to create gw-ext: %s", output)
+
+		By("deploying gw-proj (project-only visibility)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentYAML(
+			"gw-proj", "hashicorp/http-echo", []string{"-text=gw-proj", "-listen=:8080"},
+			map[string]endpointDef{
+				"http": {epType: "HTTP", port: 8080, visibility: []string{"project"}},
+			}, nil))
+		Expect(err).NotTo(HaveOccurred(), "failed to create gw-proj: %s", output)
+
+		By("deploying gw-int (internal visibility)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentYAML(
+			"gw-int", "hashicorp/http-echo", []string{"-text=gw-int", "-listen=:8080"},
+			map[string]endpointDef{
+				"http": {epType: "HTTP", port: 8080, visibility: []string{"internal"}},
+			}, nil))
+		Expect(err).NotTo(HaveOccurred(), "failed to create gw-int: %s", output)
+
+		By("deploying gw-multi (two external endpoints, same port)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentYAML(
+			"gw-multi", "hashicorp/http-echo", []string{"-text=gw-multi", "-listen=:8080"},
+			map[string]endpointDef{
+				"api":   {epType: "HTTP", port: 8080, visibility: []string{"external"}},
+				"admin": {epType: "HTTP", port: 8080, visibility: []string{"external"}},
+			}, nil))
+		Expect(err).NotTo(HaveOccurred(), "failed to create gw-multi: %s", output)
+
+		By("deploying gw-base (external with basePath)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, componentYAML(
+			"gw-base", "hashicorp/http-echo", []string{"-text=gw-base", "-listen=:8080"},
+			map[string]endpointDef{
+				"api": {epType: "HTTP", port: 8080, visibility: []string{"external"}, basePath: "/api/v1"},
+			}, nil))
+		Expect(err).NotTo(HaveOccurred(), "failed to create gw-base: %s", output)
+
+		By("discovering development DP namespace")
+		Eventually(func() error {
+			var discoverErr error
+			dpDevNs, discoverErr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+			return discoverErr
+		}, 3*time.Minute, 5*time.Second).Should(Succeed(), "dp namespace for development not found")
+		fmt.Fprintf(GinkgoWriter, "discovered dev dp namespace: %s\n", dpDevNs)
+
+		By("deploying tester pod in DP namespace")
+		output, err = framework.KubectlApplyLiteral(kubeContext, testerPodYAML(dpDevNs))
+		Expect(err).NotTo(HaveOccurred(), "failed to create tester pod: %s", output)
+
+		By("waiting for all pods running in dev DP namespace")
+		Eventually(func(g Gomega) {
+			framework.AssertAllPodsRunning(g, kubeContext, dpDevNs)
+		}, 3*time.Minute, 2*time.Second).Should(Succeed(),
+			"pods in %s not running in time", dpDevNs)
+
+		By("waiting for ReleaseBindings to become Ready")
+		for _, comp := range []string{"gw-ext", "gw-proj", "gw-int", "gw-multi", "gw-base"} {
+			framework.WaitForReleaseBindingReady(kubeContext, cpNs, comp+"-"+envDev)
+		}
+
+		By("promoting gw-ext to staging for environment override test")
+		var compRelease string
+		Eventually(func() error {
+			var discoverErr error
+			compRelease, discoverErr = framework.KubectlGetJsonpath(
+				kubeContext, cpNs, "component", "gw-ext",
+				"{.status.latestRelease.name}")
+			if discoverErr != nil {
+				return discoverErr
+			}
+			if compRelease == "" {
+				return fmt.Errorf("gw-ext latestRelease.name not yet populated")
+			}
+			return nil
+		}, 3*time.Minute, 5*time.Second).Should(Succeed(), "gw-ext ComponentRelease not created")
+
+		output, err = framework.KubectlApplyLiteral(kubeContext, releaseBindingYAML("gw-ext", compRelease, envStaging))
+		Expect(err).NotTo(HaveOccurred(), "failed to create staging ReleaseBinding: %s", output)
+
+		By("discovering staging DP namespace")
+		Eventually(func() error {
+			var discoverErr error
+			dpStgNs, discoverErr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envStaging)
+			return discoverErr
+		}, 3*time.Minute, 5*time.Second).Should(Succeed(), "dp namespace for staging not found")
+		fmt.Fprintf(GinkgoWriter, "discovered staging dp namespace: %s\n", dpStgNs)
+
+		By("waiting for staging pods running")
+		Eventually(func(g Gomega) {
+			framework.AssertAllPodsRunning(g, kubeContext, dpStgNs)
+		}, 3*time.Minute, 2*time.Second).Should(Succeed(),
+			"pods in %s not running in time", dpStgNs)
+
+		framework.WaitForReleaseBindingReady(kubeContext, cpNs, "gw-ext-"+envStaging)
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+
+		By("cleaning up CP namespace")
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs, "--ignore-not-found", "--wait=false")
+
+		By("cleaning up DP namespaces")
+		for _, ns := range []string{dpDevNs, dpStgNs} {
+			if ns != "" {
+				_, _ = framework.Kubectl(kubeContext, "delete", "namespace", ns, "--ignore-not-found", "--wait=false")
+			}
+		}
+	})
+
+	// ─── Visibility enforcement ─────────────────────────────────────────
+
+	Context("Visibility enforcement", func() {
+		It("routes external traffic through kgateway", func() {
+			By("verifying external HTTPRoute exists for gw-ext")
+			selector := "openchoreo.dev/component=gw-ext,openchoreo.dev/endpoint-visibility=external"
+			Eventually(func(g Gomega) {
+				count, err := framework.CountHTTPRoutesByLabel(kubeContext, dpDevNs, selector)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(1), "expected exactly 1 external HTTPRoute for gw-ext")
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying HTTPRoute is accepted")
+			names, err := framework.GetHTTPRouteNames(kubeContext, dpDevNs, selector)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(HaveLen(1))
+			Eventually(func(g Gomega) {
+				framework.AssertHTTPRouteAccepted(g, kubeContext, dpDevNs, names[0])
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying traffic through external gateway")
+			url := endpointExternalHTTPURL("gw-ext", "http", envDev)
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, dpDevNs, testerLabel, testerContainer, url, 10)
+				return err
+			}, 30*time.Second, 2*time.Second).Should(Succeed(),
+				"external URL %s should return 200", url)
+		})
+
+		It("does not create external HTTPRoute for project-only endpoint", func() {
+			By("verifying no external HTTPRoute exists for gw-proj")
+			selector := "openchoreo.dev/component=gw-proj,openchoreo.dev/endpoint-visibility=external"
+			Consistently(func(g Gomega) {
+				count, err := framework.CountHTTPRoutesByLabel(kubeContext, dpDevNs, selector)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(0), "project-only component should have no external HTTPRoute")
+			}, 10*time.Second, 2*time.Second).Should(Succeed())
+
+			By("verifying ReleaseBinding has no externalURLs for gw-proj")
+			rbName := "gw-proj-" + envDev
+			externalScheme, err := framework.KubectlGetJsonpath(
+				kubeContext, cpNs, "releasebinding", rbName,
+				`{.status.endpoints[?(@.name=="http")].externalURLs.http.scheme}`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(externalScheme).To(BeEmpty(), "project-only endpoint should have no externalURLs")
+		})
+
+		It("routes internal traffic through internal gateway only", func() {
+			By("verifying internal HTTPRoute exists for gw-int")
+			internalSelector := "openchoreo.dev/component=gw-int,openchoreo.dev/endpoint-visibility=internal"
+			Eventually(func(g Gomega) {
+				count, err := framework.CountHTTPRoutesByLabel(kubeContext, dpDevNs, internalSelector)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(1), "expected exactly 1 internal HTTPRoute for gw-int")
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying no external HTTPRoute exists for gw-int")
+			externalSelector := "openchoreo.dev/component=gw-int,openchoreo.dev/endpoint-visibility=external"
+			count, err := framework.CountHTTPRoutesByLabel(kubeContext, dpDevNs, externalSelector)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0), "internal-only component should have no external HTTPRoute")
+
+			By("verifying internal HTTPRoute is accepted")
+			names, err := framework.GetHTTPRouteNames(kubeContext, dpDevNs, internalSelector)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(HaveLen(1))
+			Eventually(func(g Gomega) {
+				framework.AssertHTTPRouteAccepted(g, kubeContext, dpDevNs, names[0])
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying traffic through internal gateway")
+			url := endpointInternalHTTPURL("gw-int", "http", envDev)
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, dpDevNs, testerLabel, testerContainer, url, 10)
+				return err
+			}, 30*time.Second, 2*time.Second).Should(Succeed(),
+				"internal URL %s should return 200", url)
+
+			By("verifying no externalURLs on ReleaseBinding")
+			rbName := "gw-int-" + envDev
+			externalScheme, err := framework.KubectlGetJsonpath(
+				kubeContext, cpNs, "releasebinding", rbName,
+				`{.status.endpoints[?(@.name=="http")].externalURLs.http.scheme}`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(externalScheme).To(BeEmpty(), "internal-only endpoint should have no externalURLs")
+		})
+	})
+
+	// ─── Routing correctness ────────────────────────────────────────────
+
+	Context("Routing correctness", func() {
+		It("creates distinct HTTPRoutes for multiple endpoints on same component", func() {
+			By("verifying two external HTTPRoutes exist for gw-multi")
+			selector := "openchoreo.dev/component=gw-multi,openchoreo.dev/endpoint-visibility=external"
+			Eventually(func(g Gomega) {
+				count, err := framework.CountHTTPRoutesByLabel(kubeContext, dpDevNs, selector)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(2), "expected 2 external HTTPRoutes for gw-multi")
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying each endpoint has its own HTTPRoute")
+			for _, epName := range []string{"api", "admin"} {
+				epSelector := fmt.Sprintf("openchoreo.dev/component=gw-multi,openchoreo.dev/endpoint-name=%s", epName)
+				names, err := framework.GetHTTPRouteNames(kubeContext, dpDevNs, epSelector)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(names).To(HaveLen(1), "expected 1 HTTPRoute for endpoint %s", epName)
+
+				Eventually(func(g Gomega) {
+					framework.AssertHTTPRouteAccepted(g, kubeContext, dpDevNs, names[0])
+				}, 2*time.Minute, 2*time.Second).Should(Succeed(),
+					"HTTPRoute for endpoint %s should be accepted", epName)
+			}
+
+			By("verifying both endpoints have externalURLs")
+			for _, epName := range []string{"api", "admin"} {
+				rbName := "gw-multi-" + envDev
+				scheme, err := framework.KubectlGetJsonpath(
+					kubeContext, cpNs, "releasebinding", rbName,
+					fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].externalURLs.http.scheme}`, epName))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(scheme).NotTo(BeEmpty(), "endpoint %s should have externalURLs", epName)
+			}
+		})
+
+		It("configures basePath URL rewrite on HTTPRoute", func() {
+			By("finding the HTTPRoute for gw-base")
+			selector := "openchoreo.dev/component=gw-base,openchoreo.dev/endpoint-name=api"
+			var routeName string
+			Eventually(func(g Gomega) {
+				names, err := framework.GetHTTPRouteNames(kubeContext, dpDevNs, selector)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(names).To(HaveLen(1))
+				routeName = names[0]
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying URLRewrite replacePrefixMatch is /api/v1")
+			Eventually(func(g Gomega) {
+				rewrite, err := framework.KubectlGetJsonpath(
+					kubeContext, dpDevNs,
+					"httproute.gateway.networking.k8s.io", routeName,
+					`{.spec.rules[0].filters[0].urlRewrite.path.replacePrefixMatch}`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(rewrite).To(Equal("/api/v1"),
+					"basePath should be configured as replacePrefixMatch")
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying HTTPRoute is accepted and traffic succeeds")
+			Eventually(func(g Gomega) {
+				framework.AssertHTTPRouteAccepted(g, kubeContext, dpDevNs, routeName)
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			url := endpointExternalHTTPURL("gw-base", "api", envDev)
+			Eventually(func() error {
+				_, err := framework.InvokeFromPodByLabel(
+					kubeContext, dpDevNs, testerLabel, testerContainer, url+"/", 10)
+				return err
+			}, 30*time.Second, 2*time.Second).Should(Succeed(),
+				"basePath URL %s should be routable", url)
+		})
+	})
+
+	// ─── Gateway configuration ──────────────────────────────────────────
+
+	Context("Gateway configuration", func() {
+		It("uses Environment gateway override when specified", func() {
+			By("finding the external HTTPRoute for gw-ext in staging DP namespace")
+			selector := "openchoreo.dev/component=gw-ext,openchoreo.dev/endpoint-visibility=external"
+			var routeName string
+			Eventually(func(g Gomega) {
+				names, err := framework.GetHTTPRouteNames(kubeContext, dpStgNs, selector)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(names).To(HaveLen(1))
+				routeName = names[0]
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying parentRef points to the override gateway (gateway-internal)")
+			Eventually(func(g Gomega) {
+				parentName, err := framework.KubectlGetJsonpath(
+					kubeContext, dpStgNs,
+					"httproute.gateway.networking.k8s.io", routeName,
+					`{.spec.parentRefs[0].name}`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(parentName).To(Equal(gwInternalName),
+					"staging HTTPRoute should reference the environment override gateway, not gateway-default")
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying hostname uses the override host")
+			Eventually(func(g Gomega) {
+				hostname, err := framework.KubectlGetJsonpath(
+					kubeContext, dpStgNs,
+					"httproute.gateway.networking.k8s.io", routeName,
+					`{.spec.hostnames[0]}`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hostname).To(ContainSubstring(stagingGWHost),
+					"staging HTTPRoute hostname should use the environment override host")
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+		})
+	})
+
+})

--- a/test/e2e/suites/gateway/suite_test.go
+++ b/test/e2e/suites/gateway/suite_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EGateway(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo gateway e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E Gateway Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying cluster is accessible")
+	output, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, output)
+	fmt.Fprintf(GinkgoWriter, "Cluster accessible\n")
+})


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Cover HTTPRoute creation, visibility enforcement, URL rewriting, and environment-level gateway overrides. Bump kgateway to v2.2.1 for infrastructure.labels propagation and add CoreDNS rewrite for internal gateway hostname resolution in k3d.


## Approach
> Summarize the solution and implementation details.

## Related Issues
closes https://github.com/openchoreo/openchoreo/issues/3616

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
