### PR TITLE
test: add extended e2e coverage for build and gitops

### DIFF
--- a/.github/workflows/test-e2e-extended.yml
+++ b/.github/workflows/test-e2e-extended.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -54,13 +56,26 @@ jobs:
           echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
           sudo install /tmp/yq /usr/local/bin/yq
 
+      - name: Validate Helm chart version
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
       - name: Run extended e2e tests (tier 3)
         run: |
           make e2e \
             E2E_HELM_SOURCE=oci \
-            HELM_CHART_VERSION=${{ env.HELM_CHART_VERSION }} \
-            E2E_WITH_BUILD=${{ env.E2E_WITH_BUILD }} \
-            E2E_WITH_OBSERVABILITY=${{ env.E2E_WITH_OBSERVABILITY }} \
+            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_WITH_BUILD="${E2E_WITH_BUILD}" \
+            E2E_WITH_OBSERVABILITY="${E2E_WITH_OBSERVABILITY}" \
             E2E_TEST_TIMEOUT=120m \
             E2E_LABEL_FILTER='tier3'
 

--- a/.github/workflows/test-e2e-extended.yml
+++ b/.github/workflows/test-e2e-extended.yml
@@ -1,0 +1,73 @@
+name: E2E Tests Extended
+
+on:
+  workflow_dispatch:
+    inputs:
+      helm_chart_version:
+        description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<commit-sha>)"
+        required: false
+        default: "0.0.0-latest-dev"
+  schedule:
+    # Weekly: Sunday 03:00 UTC (08:30 IST). Stays off the nightly path so the
+    # extended suite's wall-clock budget (~90-120 min) does not encroach on the
+    # nightly's ~45 min slot.
+    - cron: "0 3 * * 0"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-extended-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HELM_CHART_VERSION: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
+  E2E_WITH_BUILD: "true"
+  E2E_WITH_OBSERVABILITY: "true"
+  K3D_VERSION: v5.8.3
+  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
+  YQ_VERSION: v4.45.4
+  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
+
+jobs:
+  e2e-extended:
+    name: E2E Extended (Tier 3)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Run extended e2e tests (tier 3)
+        run: |
+          make e2e \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION=${{ env.HELM_CHART_VERSION }} \
+            E2E_WITH_BUILD=${{ env.E2E_WITH_BUILD }} \
+            E2E_WITH_OBSERVABILITY=${{ env.E2E_WITH_OBSERVABILITY }} \
+            E2E_TEST_TIMEOUT=120m \
+            E2E_LABEL_FILTER='tier3'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-extended-diagnostics
+          path: test/e2e/_diagnostics/
+          retention-days: 7

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -328,6 +328,11 @@ _e2e.configure-dp:
 _e2e.configure-wp:
 	@$(call log_info, Registering WorkflowPlane)
 	$(call e2e_register_plane,$(E2E_WP_NS),$(E2E_K3D_DIR)/workflowplane.yaml)
+	@$(call log_info, Applying ClusterWorkflowTemplates used by the builder workflows)
+	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/checkout-source.yaml
+	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates.yaml
+	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/publish-image-k3d.yaml
+	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
 
 .PHONY: _e2e.configure-op
 _e2e.configure-op:

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -43,6 +43,7 @@ GATEWAY_API_VERSION    ?= v1.4.1
 CERT_MANAGER_VERSION   ?= v1.19.4
 ESO_VERSION            ?= 2.0.1
 KGATEWAY_VERSION       ?= v2.2.1
+OPENBAO_CHART_VERSION  ?= 0.25.6
 THUNDER_VERSION        ?= 0.28.0
 
 # Helm chart references: local chart dirs or OCI registry
@@ -187,6 +188,7 @@ e2e.setup-install: ## Install all planes via Helm
 	@$(MAKE) _e2e.install-thunder
 	@$(MAKE) _e2e.install-cp
 	@$(MAKE) _e2e.install-dp
+	@if [ "$(E2E_WITH_BUILD)" = "true" ]; then $(MAKE) _e2e.install-openbao; fi
 	@if [ "$(E2E_WITH_BUILD)" = "true" ]; then $(MAKE) _e2e.install-wp; fi
 	@if [ "$(E2E_WITH_OBSERVABILITY)" = "true" ]; then $(MAKE) _e2e.install-op; fi
 	@$(call log_success, All planes installed)
@@ -254,6 +256,18 @@ _e2e.install-dp:
 	$(call e2e_patch_gateway,$(E2E_DP_NS))
 	$(E2E_KUBECTL) wait -n $(E2E_DP_NS) \
 		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+.PHONY: _e2e.install-openbao
+_e2e.install-openbao:
+	@$(call log_info, Installing OpenBao $(OPENBAO_CHART_VERSION))
+	$(E2E_HELM) upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
+		--namespace openbao --create-namespace \
+		--version $(OPENBAO_CHART_VERSION) \
+		--values $(PROJECT_DIR)/install/k3d/common/values-openbao.yaml \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Replacing fake ClusterSecretStore with openbao-backed default)
+	$(E2E_KUBECTL) delete clustersecretstore default --ignore-not-found
+	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/openbao-secretstore.yaml
 
 .PHONY: _e2e.install-wp
 _e2e.install-wp:
@@ -328,11 +342,19 @@ _e2e.configure-dp:
 _e2e.configure-wp:
 	@$(call log_info, Registering WorkflowPlane)
 	$(call e2e_register_plane,$(E2E_WP_NS),$(E2E_K3D_DIR)/workflowplane.yaml)
+	@$(call log_info, Registering ClusterWorkflowPlane)
+	$(call e2e_register_plane,$(E2E_WP_NS),$(E2E_K3D_DIR)/clusterworkflowplane.yaml)
 	@$(call log_info, Applying ClusterWorkflowTemplates used by the builder workflows)
 	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/checkout-source.yaml
 	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates.yaml
-	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/publish-image-k3d.yaml
-	$(E2E_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
+	@# Apply the e2e-specific publish-image template instead of the
+	@# shared sample (samples/.../publish-image-k3d.yaml hardcodes
+	@# host.k3d.internal:10082, which collides with a parallel
+	@# single-cluster install; e2e uses port 20082 — see config.yaml).
+	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/workflow-templates/publish-image-e2e.yaml
+	@# Same reason as publish-image-e2e — the sample template hardcodes
+	@# host.k3d.internal:8080 for the CP gateway (OAuth + API). e2e uses 28080.
+	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/workflow-templates/generate-workload-e2e.yaml
 
 .PHONY: _e2e.configure-op
 _e2e.configure-op:

--- a/test/e2e/fixtures/build/no-workload/Dockerfile
+++ b/test/e2e/fixtures/build/no-workload/Dockerfile
@@ -2,8 +2,9 @@
 # Minimal busybox-based HTTP echo container. Used by the
 # workload-auto-generation e2e spec — there is intentionally NO workload.yaml
 # alongside this Dockerfile so the build pipeline must auto-generate a Workload.
-FROM busybox:1.36
-COPY server.sh /server.sh
-RUN chmod +x /server.sh
+FROM docker.io/library/busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+COPY --chown=10001:10001 server.sh /server.sh
+RUN chmod 0555 /server.sh
+USER 10001:10001
 EXPOSE 8080
 ENTRYPOINT ["/server.sh"]

--- a/test/e2e/fixtures/build/no-workload/Dockerfile
+++ b/test/e2e/fixtures/build/no-workload/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1.6
+# Minimal busybox-based HTTP echo container. Used by the
+# workload-auto-generation e2e spec — there is intentionally NO workload.yaml
+# alongside this Dockerfile so the build pipeline must auto-generate a Workload.
+FROM busybox:1.36
+COPY server.sh /server.sh
+RUN chmod +x /server.sh
+EXPOSE 8080
+ENTRYPOINT ["/server.sh"]

--- a/test/e2e/fixtures/build/no-workload/server.sh
+++ b/test/e2e/fixtures/build/no-workload/server.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Trivial HTTP responder used by the no-workload e2e fixture. busybox's httpd
+# serves the working directory; we just need any 2xx on /.
+echo "no-workload e2e ok" > /tmp/index.html
+exec httpd -f -p 8080 -h /tmp

--- a/test/e2e/fixtures/build/paketo-node/package.json
+++ b/test/e2e/fixtures/build/paketo-node/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "paketo-node-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "20.*"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/test/e2e/fixtures/build/paketo-node/server.js
+++ b/test/e2e/fixtures/build/paketo-node/server.js
@@ -1,0 +1,16 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal HTTP server used by the e2e paketo-buildpacks-builder spec. The
+// paketo node buildpack auto-detects this via `npm start`. The server replies
+// 200 on every path so the in-cluster reachability probe is deterministic.
+
+const http = require('http');
+const port = parseInt(process.env.PORT || '8080', 10);
+
+http.createServer((_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('paketo-node e2e ok\n');
+}).listen(port, () => {
+  console.log(`paketo-node e2e listening on :${port}`);
+});

--- a/test/e2e/fixtures/build/paketo-node/workload.yaml
+++ b/test/e2e/fixtures/build/paketo-node/workload.yaml
@@ -1,15 +1,17 @@
+# Workload descriptor (parsed by `occ workload create --descriptor`).
+# This is NOT a Workload CR — fields live at the top level, not under `spec:`.
+# Match the openchoreo/sample-workloads convention.
 apiVersion: openchoreo.dev/v1alpha1
-kind: Workload
 metadata:
   name: pkt-svc
-spec:
-  endpoints:
-    http:
-      type: HTTP
-      port: 8080
-      visibility:
-        - project
-  container:
-    env:
-      - key: PORT
-        value: "8080"
+endpoints:
+  - name: http
+    type: HTTP
+    port: 8080
+    visibility:
+      - project
+      - external
+configurations:
+  env:
+    - name: PORT
+      value: "8080"

--- a/test/e2e/fixtures/build/paketo-node/workload.yaml
+++ b/test/e2e/fixtures/build/paketo-node/workload.yaml
@@ -1,0 +1,15 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: pkt-svc
+spec:
+  endpoints:
+    http:
+      type: HTTP
+      port: 8080
+      visibility:
+        - project
+  container:
+    env:
+      - key: PORT
+        value: "8080"

--- a/test/e2e/framework/flux.go
+++ b/test/e2e/framework/flux.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FluxNamespace is the namespace Flux's controllers live in after InstallFlux.
+const FluxNamespace = "flux-system"
+
+// fluxInstallManifest is the pinned URL of the upstream Flux installer YAML.
+// Pinned to a release so e2e behaviour is reproducible week-over-week — bump
+// alongside the rest of the e2e dependency versions in make/e2e.mk when the
+// minimum-supported Flux version moves.
+const fluxInstallManifest = "https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml"
+
+// InstallFlux applies the upstream Flux v2 install bundle (CRDs + source +
+// kustomize controllers) and waits for the core deployments to reach
+// Available. We do not need the helm/notification controllers for the gitops
+// suite, but applying the bundle is the path of least resistance.
+func InstallFlux(kubeContext string) error {
+	if _, err := Kubectl(kubeContext, "apply", "--server-side", "-f", fluxInstallManifest); err != nil {
+		return fmt.Errorf("failed to apply flux install manifest: %w", err)
+	}
+	// The install manifest creates the namespace; wait for the two controllers
+	// we exercise. `kubectl wait` retries internally — short timeout is fine.
+	for _, dep := range []string{"source-controller", "kustomize-controller"} {
+		if _, err := Kubectl(kubeContext,
+			"-n", FluxNamespace,
+			"wait", "--for=condition=available",
+			"deployment/"+dep,
+			"--timeout=5m",
+		); err != nil {
+			return fmt.Errorf("flux %s did not become available: %w", dep, err)
+		}
+	}
+	return nil
+}
+
+// ApplyGitRepository applies a Flux GitRepository pointing at the given URL.
+// Branch defaults to "main" when empty. The poll interval is intentionally
+// short (15s) so e2e specs don't burn time waiting for Flux to notice an edit.
+func ApplyGitRepository(kubeContext, namespace, name, repoURL, branch string) error {
+	if branch == "" {
+		branch = "main"
+	}
+	manifest := fmt.Sprintf(`apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  interval: 15s
+  url: %[3]s
+  ref:
+    branch: %[4]s
+  # In-cluster Gitea is HTTP-only and serves no signed commits.
+  ignore: |
+    /.git
+`, name, namespace, repoURL, branch)
+	if _, err := KubectlApplyLiteral(kubeContext, manifest); err != nil {
+		return fmt.Errorf("failed to apply GitRepository %q: %w", name, err)
+	}
+	return nil
+}
+
+// ApplyKustomization applies a Flux Kustomization that reconciles `path`
+// (relative to the GitRepository root) into `targetNamespace`. Setting
+// targetNamespace empty leaves each object's own metadata.namespace untouched
+// — required when the git tree contains both CP-namespaced and other resources.
+func ApplyKustomization(kubeContext, namespace, name, sourceName, path, targetNamespace string) error {
+	tnLine := ""
+	if targetNamespace != "" {
+		tnLine = fmt.Sprintf("  targetNamespace: %s\n", targetNamespace)
+	}
+	manifest := fmt.Sprintf(`apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  interval: 15s
+  retryInterval: 15s
+  sourceRef:
+    kind: GitRepository
+    name: %[3]s
+  path: %[4]s
+  prune: true
+%[5]s`, name, namespace, sourceName, ensureLeadingSlash(path), tnLine)
+	if _, err := KubectlApplyLiteral(kubeContext, manifest); err != nil {
+		return fmt.Errorf("failed to apply Kustomization %q: %w", name, err)
+	}
+	return nil
+}
+
+// WaitForKustomizationReady polls until the Flux Kustomization reports the
+// Ready=True condition with an `ApplySucceeded` reason. Returns the time the
+// condition flipped (useful for timing assertions on reconciliation).
+func WaitForKustomizationReady(kubeContext, namespace, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := KubectlGetJsonpath(kubeContext, namespace, "kustomization", name,
+			`{.status.conditions[?(@.type=="Ready")].status}`)
+		if err == nil && strings.TrimSpace(out) == "True" {
+			return nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return fmt.Errorf("kustomization %s/%s did not become Ready within %s", namespace, name, timeout)
+}
+
+func ensureLeadingSlash(p string) string {
+	if p == "" {
+		return "./"
+	}
+	if !strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "./") {
+		return "./" + p
+	}
+	return p
+}

--- a/test/e2e/framework/flux.go
+++ b/test/e2e/framework/flux.go
@@ -98,8 +98,8 @@ spec:
 }
 
 // WaitForKustomizationReady polls until the Flux Kustomization reports the
-// Ready=True condition with an `ApplySucceeded` reason. Returns the time the
-// condition flipped (useful for timing assertions on reconciliation).
+// Ready=True condition and returns an error if it does not become ready before
+// the timeout.
 func WaitForKustomizationReady(kubeContext, namespace, name string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/test/e2e/framework/gitea.go
+++ b/test/e2e/framework/gitea.go
@@ -88,7 +88,13 @@ func MigrateRepo(kubeContext, giteaNamespace, repoName, cloneAddr string) error 
 	resp, err := giteaCurl(kubeContext, giteaNamespace,
 		"POST", "/api/v1/repos/migrate", string(body))
 	if err != nil {
-		return fmt.Errorf("gitea migrate %q failed: %w (body: %s)", repoName, err, resp)
+		// Repo may already exist (e.g. when the suite re-runs against a
+		// gitea namespace that survived a previous AfterAll's
+		// --wait=false delete). Verify with GET — match EnsureGiteaRepo.
+		if _, getErr := giteaCurl(kubeContext, giteaNamespace, "GET",
+			fmt.Sprintf("/api/v1/repos/%s/%s", GiteaAdminUser, repoName), ""); getErr != nil {
+			return fmt.Errorf("gitea migrate %q failed: %w (body: %s)", repoName, err, resp)
+		}
 	}
 	return nil
 }

--- a/test/e2e/framework/gitea.go
+++ b/test/e2e/framework/gitea.go
@@ -46,10 +46,7 @@ func InstallGitea(kubeContext, namespace string) error {
 	); err != nil {
 		return fmt.Errorf("gitea deployment did not become ready: %w", err)
 	}
-	// Idempotent admin-user create — Gitea exits 0 if the user already exists
-	// with the same admin flag, non-zero on conflict. We tolerate non-zero and
-	// rely on the subsequent API auth probe to confirm credentials are valid.
-	_, _ = Kubectl(kubeContext,
+	adminCreateOutput, adminCreateErr := Kubectl(kubeContext,
 		"-n", namespace,
 		"exec", "deployment/"+giteaAppName, "--",
 		"su", "git", "-c", fmt.Sprintf(
@@ -57,6 +54,17 @@ func InstallGitea(kubeContext, namespace string) error {
 			GiteaAdminUser, GiteaAdminPassword, GiteaAdminEmail,
 		),
 	)
+	probeOutput, probeErr := giteaCurl(kubeContext, namespace, "GET", "/api/v1/user", "")
+	if adminCreateErr != nil {
+		if probeErr != nil {
+			return fmt.Errorf("failed to create gitea admin user: %w (output: %s); auth probe also failed: %v (body: %s)",
+				adminCreateErr, adminCreateOutput, probeErr, probeOutput)
+		}
+		return fmt.Errorf("failed to create gitea admin user: %w (output: %s)", adminCreateErr, adminCreateOutput)
+	}
+	if probeErr != nil {
+		return fmt.Errorf("gitea admin auth probe failed: %w (body: %s)", probeErr, probeOutput)
+	}
 	return nil
 }
 
@@ -103,10 +111,10 @@ func MigrateRepo(kubeContext, giteaNamespace, repoName, cloneAddr string) error 
 // exist. It accepts a 409 conflict response (repo already exists) as success.
 func EnsureGiteaRepo(kubeContext, giteaNamespace, repoName string) error {
 	body, err := json.Marshal(map[string]any{
-		"name":      repoName,
-		"auto_init": true,
+		"name":           repoName,
+		"auto_init":      true,
 		"default_branch": "main",
-		"private":   false,
+		"private":        false,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal repo body: %w", err)

--- a/test/e2e/framework/gitea.go
+++ b/test/e2e/framework/gitea.go
@@ -1,0 +1,313 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Gitea credentials used by InstallGitea and the API helpers below. The values
+// are intentionally fixed and only meaningful inside the e2e cluster — no
+// secrets cross the cluster boundary.
+const (
+	GiteaAdminUser     = "e2eadmin"
+	GiteaAdminPassword = "e2eAdmin12345!"
+	GiteaAdminEmail    = "e2eadmin@e2e.local"
+	GiteaImage         = "gitea/gitea:1.22.6"
+	giteaAppName       = "gitea"
+	giteaContainerPort = 3000
+)
+
+// InstallGitea applies a minimal single-replica Gitea Deployment + Service into
+// the given namespace, waits for it to come up, and creates the admin user used
+// by the rest of the helper API. Idempotent — re-running is a no-op once the
+// deployment is Ready and the admin user exists.
+func InstallGitea(kubeContext, namespace string) error {
+	if _, err := Kubectl(kubeContext, "create", "namespace", namespace,
+		"--dry-run=client", "-o", "yaml"); err != nil {
+		return fmt.Errorf("failed to render namespace %q manifest: %w", namespace, err)
+	}
+	if _, err := KubectlApplyLiteral(kubeContext, giteaNamespaceYAML(namespace)); err != nil {
+		return fmt.Errorf("failed to apply gitea namespace %q: %w", namespace, err)
+	}
+	if _, err := KubectlApplyLiteral(kubeContext, giteaWorkloadYAML(namespace)); err != nil {
+		return fmt.Errorf("failed to apply gitea workload: %w", err)
+	}
+	if _, err := Kubectl(kubeContext,
+		"-n", namespace,
+		"rollout", "status", "deployment/"+giteaAppName, "--timeout=5m",
+	); err != nil {
+		return fmt.Errorf("gitea deployment did not become ready: %w", err)
+	}
+	// Idempotent admin-user create — Gitea exits 0 if the user already exists
+	// with the same admin flag, non-zero on conflict. We tolerate non-zero and
+	// rely on the subsequent API auth probe to confirm credentials are valid.
+	_, _ = Kubectl(kubeContext,
+		"-n", namespace,
+		"exec", "deployment/"+giteaAppName, "--",
+		"su", "git", "-c", fmt.Sprintf(
+			"gitea admin user create --username %s --password %s --email %s --admin --must-change-password=false",
+			GiteaAdminUser, GiteaAdminPassword, GiteaAdminEmail,
+		),
+	)
+	return nil
+}
+
+// GiteaInClusterURL returns the http:// URL the builder pods use to reach the
+// Gitea HTTP service from inside the cluster.
+func GiteaInClusterURL(namespace string) string {
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", giteaAppName, namespace, giteaContainerPort)
+}
+
+// GiteaRepoCloneURL returns the clone URL for a repo owned by the e2e admin
+// user in the in-cluster Gitea. Suitable for ClusterWorkflow `repository.url`.
+func GiteaRepoCloneURL(namespace, repoName string) string {
+	return fmt.Sprintf("%s/%s/%s.git", GiteaInClusterURL(namespace), GiteaAdminUser, repoName)
+}
+
+// MigrateRepo asks Gitea to clone an upstream HTTPS git URL into the admin
+// user's namespace. Suitable for mirroring openchoreo/sample-workloads into
+// the in-cluster Gitea so the build matrix is self-contained.
+func MigrateRepo(kubeContext, giteaNamespace, repoName, cloneAddr string) error {
+	body, err := json.Marshal(map[string]any{
+		"clone_addr": cloneAddr,
+		"repo_name":  repoName,
+		"private":    false,
+		"mirror":     false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal migrate body: %w", err)
+	}
+	resp, err := giteaCurl(kubeContext, giteaNamespace,
+		"POST", "/api/v1/repos/migrate", string(body))
+	if err != nil {
+		return fmt.Errorf("gitea migrate %q failed: %w (body: %s)", repoName, err, resp)
+	}
+	return nil
+}
+
+// EnsureGiteaRepo creates an empty repo under the admin user if it does not
+// exist. It accepts a 409 conflict response (repo already exists) as success.
+func EnsureGiteaRepo(kubeContext, giteaNamespace, repoName string) error {
+	body, err := json.Marshal(map[string]any{
+		"name":      repoName,
+		"auto_init": true,
+		"default_branch": "main",
+		"private":   false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal repo body: %w", err)
+	}
+	if _, err := giteaCurl(kubeContext, giteaNamespace,
+		"POST", "/api/v1/user/repos", string(body)); err != nil {
+		// Repo may already exist — verify by GET.
+		if _, getErr := giteaCurl(kubeContext, giteaNamespace, "GET",
+			fmt.Sprintf("/api/v1/repos/%s/%s", GiteaAdminUser, repoName), ""); getErr != nil {
+			return fmt.Errorf("failed to ensure repo %q: create=%v, get=%v", repoName, err, getErr)
+		}
+	}
+	return nil
+}
+
+// PushFile upserts a single file in a Gitea repo on the given branch.
+// content is the raw file body (no base64 needed — the helper handles that).
+// When `commitMessage` is empty a default is used.
+func PushFile(kubeContext, giteaNamespace, repoName, branch, relPath string, content []byte, commitMessage string) error {
+	if commitMessage == "" {
+		commitMessage = fmt.Sprintf("e2e: write %s", relPath)
+	}
+	encoded := base64.StdEncoding.EncodeToString(content)
+	apiPath := fmt.Sprintf("/api/v1/repos/%s/%s/contents/%s",
+		GiteaAdminUser, repoName, strings.TrimPrefix(relPath, "/"))
+	// First try PUT (update). If the file does not exist, Gitea returns 422 —
+	// fall back to POST (create) on that path.
+	body, err := json.Marshal(map[string]any{
+		"message": commitMessage,
+		"content": encoded,
+		"branch":  branch,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal file body: %w", err)
+	}
+	resp, postErr := giteaCurl(kubeContext, giteaNamespace, "POST", apiPath, string(body))
+	if postErr == nil {
+		return nil
+	}
+	// Try PUT for updates: PUT requires an `sha` field for the previous blob.
+	prev, getErr := giteaCurl(kubeContext, giteaNamespace, "GET",
+		fmt.Sprintf("%s?ref=%s", apiPath, branch), "")
+	if getErr != nil {
+		return fmt.Errorf("push %s POST failed (%v) and GET for sha failed: %v\nPOST resp: %s",
+			relPath, postErr, getErr, resp)
+	}
+	var meta struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.Unmarshal([]byte(prev), &meta); err != nil || meta.SHA == "" {
+		return fmt.Errorf("could not decode existing file sha for %s: %w", relPath, err)
+	}
+	putBody, err := json.Marshal(map[string]any{
+		"message": commitMessage,
+		"content": encoded,
+		"branch":  branch,
+		"sha":     meta.SHA,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal PUT body: %w", err)
+	}
+	if _, err := giteaCurl(kubeContext, giteaNamespace, "PUT", apiPath, string(putBody)); err != nil {
+		return fmt.Errorf("push %s PUT failed: %w", relPath, err)
+	}
+	return nil
+}
+
+// PushTree walks sourceDir on the local filesystem and pushes every regular
+// file under it into repoName at the same relative path on `branch`. Skips
+// .git and any dotfiles at the top level. Files are pushed sequentially to
+// keep individual API calls small and predictable; a multi-file tree of a
+// handful of YAMLs takes a few seconds.
+func PushTree(kubeContext, giteaNamespace, repoName, branch, sourceDir string) error {
+	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			if strings.HasPrefix(info.Name(), ".") && path != sourceDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return PushFile(kubeContext, giteaNamespace, repoName, branch, filepath.ToSlash(rel), content,
+			fmt.Sprintf("e2e: sync %s", rel))
+	})
+}
+
+// giteaCurl runs `kubectl exec deploy/gitea -- curl ...` against Gitea's
+// in-pod loopback. Doing the curl from inside the Gitea pod avoids both
+// port-forwarding and adding a separate helper pod with curl baked in. The
+// gitea image ships curl by default.
+func giteaCurl(kubeContext, namespace, method, path, body string) (string, error) {
+	args := []string{
+		"-n", namespace,
+		"exec", "deployment/" + giteaAppName, "--",
+		"curl", "-sS", "--fail-with-body",
+		"-u", fmt.Sprintf("%s:%s", GiteaAdminUser, GiteaAdminPassword),
+		"-H", "Content-Type: application/json",
+		"-X", method,
+		fmt.Sprintf("http://127.0.0.1:%d%s", giteaContainerPort, path),
+	}
+	if body != "" {
+		args = append(args, "--data-binary", body)
+	}
+	// Retry briefly — `gitea admin user create` returns before the HTTP server
+	// is fully ready in cold-start scenarios.
+	var (
+		out string
+		err error
+	)
+	for attempt := 0; attempt < 10; attempt++ {
+		out, err = Kubectl(kubeContext, args...)
+		if err == nil {
+			return out, nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return out, err
+}
+
+func giteaNamespaceYAML(namespace string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels:
+    openchoreo.dev/e2e-managed: "true"
+`, namespace)
+}
+
+// giteaWorkloadYAML is intentionally a string template so the helper has zero
+// dependency on the openchoreo API types — Gitea isn't an openchoreo concern,
+// and keeping it as raw YAML matches the texture of `coredns-custom.yaml` and
+// `secretstore.yaml` under test/e2e/k3d/.
+func giteaWorkloadYAML(namespace string) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %[1]s
+  template:
+    metadata:
+      labels:
+        app: %[1]s
+    spec:
+      containers:
+        - name: %[1]s
+          image: %[3]s
+          env:
+            - name: INSTALL_LOCK
+              value: "true"
+            - name: RUN_MODE
+              value: prod
+            - name: GITEA__server__DISABLE_SSH
+              value: "true"
+            - name: GITEA__server__OFFLINE_MODE
+              value: "true"
+            - name: GITEA__service__DISABLE_REGISTRATION
+              value: "true"
+            - name: GITEA__database__DB_TYPE
+              value: sqlite3
+            - name: GITEA__security__INSTALL_LOCK
+              value: "true"
+          ports:
+            - containerPort: %[4]d
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  selector:
+    app: %[1]s
+  ports:
+    - port: %[4]d
+      targetPort: http
+      name: http
+`, giteaAppName, namespace, GiteaImage, giteaContainerPort)
+}

--- a/test/e2e/framework/workflow.go
+++ b/test/e2e/framework/workflow.go
@@ -4,7 +4,6 @@
 package framework
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -59,23 +58,30 @@ func AssertComponentReleasePresent(g gomega.Gomega, kubeContext, namespace, comp
 // pointer copied from WorkflowRun.status.runReference. Returns ("", "", "")
 // (all empty) when the controller has not populated runReference yet.
 func WorkflowRunReference(kubeContext, namespace, workflowRunName string) (kind, name, ns string, err error) {
-	out, err := KubectlGetJsonpath(kubeContext, namespace, "workflowrun", workflowRunName,
-		`{.status.runReference}`)
+	kind, err = workflowRunReferenceField(kubeContext, namespace, workflowRunName, "kind")
 	if err != nil {
 		return "", "", "", err
 	}
+	name, err = workflowRunReferenceField(kubeContext, namespace, workflowRunName, "name")
+	if err != nil {
+		return "", "", "", err
+	}
+	ns, err = workflowRunReferenceField(kubeContext, namespace, workflowRunName, "namespace")
+	if err != nil {
+		return "", "", "", err
+	}
+	return kind, name, ns, nil
+}
+
+func workflowRunReferenceField(kubeContext, namespace, workflowRunName, field string) (string, error) {
+	out, err := KubectlGetJsonpath(kubeContext, namespace, "workflowrun", workflowRunName,
+		fmt.Sprintf(`{.status.runReference.%s}`, field))
+	if err != nil {
+		return "", err
+	}
 	out = strings.TrimSpace(out)
 	if out == "" || out == "null" {
-		return "", "", "", nil
+		return "", nil
 	}
-	var ref struct {
-		APIVersion string `json:"apiVersion"`
-		Kind       string `json:"kind"`
-		Name       string `json:"name"`
-		Namespace  string `json:"namespace"`
-	}
-	if err := json.Unmarshal([]byte(out), &ref); err != nil {
-		return "", "", "", fmt.Errorf("decode runReference: %w (raw: %s)", err, out)
-	}
-	return ref.Kind, ref.Name, ref.Namespace, nil
+	return out, nil
 }

--- a/test/e2e/framework/workflow.go
+++ b/test/e2e/framework/workflow.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+)
+
+// AssertWorkflowRunSucceeded checks the WorkflowRun's
+// status.conditions[type==WorkflowSucceeded].status == True.
+// The controller sets this once the underlying Argo Workflow reports success.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertWorkflowRunSucceeded(g gomega.Gomega, kubeContext, namespace, name string) {
+	AssertJsonpathEquals(g, kubeContext, namespace, "workflowrun", name,
+		`{.status.conditions[?(@.type=="WorkflowSucceeded")].status}`, "True")
+}
+
+// AssertWorkflowRunCompleted checks the WorkflowRun reports
+// status.conditions[type==WorkflowCompleted].status == True. Use this when a
+// spec wants to wait for the run to finish but does not care whether it
+// succeeded — e.g., when a deliberately failing build is being asserted.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertWorkflowRunCompleted(g gomega.Gomega, kubeContext, namespace, name string) {
+	AssertJsonpathEquals(g, kubeContext, namespace, "workflowrun", name,
+		`{.status.conditions[?(@.type=="WorkflowCompleted")].status}`, "True")
+}
+
+// AssertComponentReleasePresent checks that at least one ComponentRelease in
+// the namespace has spec.owner.componentName == component. ComponentRelease
+// has no Ready status (and no labels), so existence is the meaningful signal
+// that the build pipeline produced a release artifact.
+// Designed for use inside Eventually(func(g Gomega) { ... }).
+func AssertComponentReleasePresent(g gomega.Gomega, kubeContext, namespace, component string) {
+	output, err := Kubectl(kubeContext,
+		"get", "componentrelease",
+		"-n", namespace,
+		"-o", `jsonpath={.items[*].spec.owner.componentName}`,
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		fmt.Sprintf("failed to list ComponentReleases in %s", namespace))
+	found := false
+	for _, name := range strings.Fields(output) {
+		if name == component {
+			found = true
+			break
+		}
+	}
+	g.Expect(found).To(gomega.BeTrue(),
+		fmt.Sprintf("expected at least one ComponentRelease for component %q in %s, got: %q",
+			component, namespace, output))
+}
+
+// WorkflowRunReference returns the rendered workflow's Kind/Name/Namespace
+// pointer copied from WorkflowRun.status.runReference. Returns ("", "", "")
+// (all empty) when the controller has not populated runReference yet.
+func WorkflowRunReference(kubeContext, namespace, workflowRunName string) (kind, name, ns string, err error) {
+	out, err := KubectlGetJsonpath(kubeContext, namespace, "workflowrun", workflowRunName,
+		`{.status.runReference}`)
+	if err != nil {
+		return "", "", "", err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return "", "", "", nil
+	}
+	var ref struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Name       string `json:"name"`
+		Namespace  string `json:"namespace"`
+	}
+	if err := json.Unmarshal([]byte(out), &ref); err != nil {
+		return "", "", "", fmt.Errorf("decode runReference: %w (raw: %s)", err, out)
+	}
+	return ref.Kind, ref.Name, ref.Namespace, nil
+}

--- a/test/e2e/k3d/clusterworkflowplane.yaml
+++ b/test/e2e/k3d/clusterworkflowplane.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ClusterWorkflowPlane CR for e2e testing.
+# Cluster-scoped WorkflowPlane that can be referenced from any control plane
+# namespace — required because the built-in ClusterWorkflow builders
+# (dockerfile-builder, paketo-buildpacks-builder, …) carry
+# `workflowPlaneRef.kind: ClusterWorkflowPlane`.
+# The clusterAgent.clientCA.value is replaced at apply time by the Makefile.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterWorkflowPlane
+metadata:
+  name: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: default

--- a/test/e2e/k3d/config.yaml
+++ b/test/e2e/k3d/config.yaml
@@ -23,7 +23,10 @@ ports:
   - port: 29443:19443
     nodeFilters:
       - loadbalancer
-  # Workflow Plane — port range 20xxx (only used when E2E_WITH_BUILD=true)
+  # Workflow Plane — port range 20xxx (only used when E2E_WITH_BUILD=true).
+  # 20082 host-side avoids collision with a parallel single-cluster install
+  # (which uses 10082). _e2e.configure-wp applies an e2e-specific
+  # publish-image template that pushes to host.k3d.internal:20082 to match.
   - port: 20082:10082
     nodeFilters:
       - loadbalancer

--- a/test/e2e/k3d/openbao-secretstore.yaml
+++ b/test/e2e/k3d/openbao-secretstore.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# OpenBao-backed ClusterSecretStore for e2e tests that need a real secret
+# backend (E2E_WITH_BUILD=true — the workflow plane's ExternalSecrets read
+# build-time credentials from this store).
+#
+# Replaces the fake ClusterSecretStore created in e2e.setup-prerequisites
+# (test/e2e/k3d/secretstore.yaml) by reusing the same name `default`, which
+# is referenced by DataPlane/WorkflowPlane CRs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-openbao
+  namespace: openbao
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: default
+spec:
+  provider:
+    vault:
+      server: "http://openbao.openbao.svc:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "openchoreo-secret-writer-role"
+          serviceAccountRef:
+            name: "external-secrets-openbao"
+            namespace: "openbao"

--- a/test/e2e/k3d/values-wp.yaml
+++ b/test/e2e/k3d/values-wp.yaml
@@ -1,19 +1,10 @@
 # Helm values for OpenChoreo Workflow Plane in e2e testing setup
 # Only used when E2E_WITH_BUILD=true
+#
+# OpenBao is installed as an independent Helm release by _e2e.install-openbao
+# (see make/e2e.mk), mirroring install/k3d/k3d-prerequisites.sh — it is not a
+# subchart of openchoreo-workflow-plane.
 
 argo-workflows:
   server:
     enabled: false
-
-defaultResources:
-  enabled: true
-  registry:
-    # Port 20082 is the host-side port mapped to container port 10082 in k3d config.
-    # Inside the cluster, host.k3d.internal resolves to the k3d load balancer which
-    # routes 20082 → 10082, so pods can push/pull images through the LB.
-    host: "host.k3d.internal:20082"
-
-openbao:
-  server:
-    dev:
-      enabled: true

--- a/test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml
+++ b/test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml
@@ -1,0 +1,298 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# E2E variant of samples/getting-started/workflow-templates/generate-workload-k3d.yaml.
+#
+# The shared k3d sample template hardcodes `host.k3d.internal:8080` for the
+# CP gateway (OAuth + openchoreo-api), which is the single-cluster port. The
+# e2e k3d cluster maps host port 28080 -> container 8080 (see
+# test/e2e/k3d/config.yaml) to avoid collision with a parallel
+# single-cluster install, so this variant points the OAuth + API endpoints
+# at `host.k3d.internal:28080`.
+#
+# Keep in sync with samples/getting-started/workflow-templates/generate-workload-k3d.yaml
+# until the upstream template is parameterised.
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: generate-workload
+spec:
+  templates:
+    - name: generate-workload-cr
+      inputs:
+        parameters:
+          - name: image
+          - name: run-name
+          # --- IDP / OAuth Configuration ---
+          - name: oauth-token-url
+            default: "http://host.k3d.internal:28080/oauth2/token"
+          - name: oauth-host-header
+            default: "thunder.e2e-cp.local"
+          - name: oauth-client-id
+            default: "openchoreo-workload-publisher-client"
+          - name: oauth-client-secret
+            default: "openchoreo-workload-publisher-secret"
+          - name: oauth-scope
+            default: ""
+          # --- OpenChoreo API Server Configuration ---
+          - name: api-server-url
+            default: "http://host.k3d.internal:28080"
+          - name: api-server-host-header
+            default: "api.e2e-cp.local"
+      container:
+        image: ghcr.io/openchoreo/podman-runner:v1.1
+        command:
+          - sh
+          - -c
+        args:
+          - |-
+            set -e
+
+            IMAGE={{inputs.parameters.image}}
+            RUN_NAME={{inputs.parameters.run-name}}
+            PROJECT_NAME={{workflow.parameters.project-name}}
+            COMPONENT_NAME={{workflow.parameters.component-name}}
+            NAMESPACE_NAME={{workflow.parameters.namespace-name}}
+            APP_PATH="{{workflow.parameters.app-path}}"
+
+            DESCRIPTOR_PATH="/mnt/vol/source${APP_PATH:+/${APP_PATH#/}}"
+            OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+
+            echo ">> Image: ${IMAGE}"
+            echo ">> Descriptor path: ${DESCRIPTOR_PATH}"
+            echo ">> Namespace: ${NAMESPACE_NAME}, Project: ${PROJECT_NAME}, Component: ${COMPONENT_NAME}"
+            if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
+              echo ">> Workload descriptor: found (${DESCRIPTOR_PATH}/workload.yaml)"
+            else
+              echo ">> Workload descriptor: not found (will generate default workload)"
+            fi
+
+            if [ ! -d "$DESCRIPTOR_PATH" ]; then
+              echo ">> Error: The specified application path '$APP_PATH' does not exist in the repository"
+              echo ">> Hint: Verify that the application path points to a valid directory in your repository."
+              echo ">> Repository contents:"
+              ls -la /mnt/vol/source/
+              exit 1
+            fi
+
+            mkdir -p /etc/containers
+            cat <<EOF > /etc/containers/storage.conf
+            [storage]
+            driver = "overlay"
+            runroot = "/run/containers/storage"
+            graphroot = "/var/lib/containers/storage"
+            [storage.options.overlay]
+            mount_program = "/usr/bin/fuse-overlayfs"
+            EOF
+
+            # --- Step 1: Generate workload CR using occ ---
+            WORKLOAD_FROM_SOURCE="false"
+            if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
+              WORKLOAD_FROM_SOURCE="true"
+              echo ">> Generating workload CR from workload descriptor"
+              podman run --rm --network=none \
+              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+                workload create \
+                --namespace "${NAMESPACE_NAME}" \
+                --project "${PROJECT_NAME}" \
+                --component "${COMPONENT_NAME}" \
+                --image "${IMAGE}" \
+                --descriptor "workload.yaml" \
+                -o "workload-cr.yaml"
+            else
+              echo ">> Generating default workload CR"
+              podman run --rm --network=none \
+              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+                workload create \
+                --namespace "${NAMESPACE_NAME}" \
+                --project "${PROJECT_NAME}" \
+                --component "${COMPONENT_NAME}" \
+                --image "${IMAGE}" \
+                -o "workload-cr.yaml"
+            fi
+
+            cp -f "${DESCRIPTOR_PATH}/workload-cr.yaml" "${OUTPUT_PATH}"
+
+            # --- Step 2: Convert workload CR YAML to JSON (strip apiVersion and kind) ---
+             podman run --rm \
+               -v /mnt/vol:/data:rw \
+               mikefarah/yq -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
+               > /mnt/vol/workload-cr-raw.json
+             podman run --rm \
+               -v /mnt/vol:/data:rw \
+               ghcr.io/jqlang/jq:1.7.1 -c '.' /data/workload-cr-raw.json \
+               > /mnt/vol/workload-cr.json
+            echo ">> Generated workload JSON payload:"
+            cat /mnt/vol/workload-cr.json
+
+            # --- Step 3: Get OAuth token ---
+            OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
+            OAUTH_HOST="{{inputs.parameters.oauth-host-header}}"
+            CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
+            CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
+            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
+
+            echo ">> Requesting OAuth token from ${OAUTH_URL}"
+            if [ -n "${OAUTH_SCOPE}" ]; then
+              TOKEN_RESPONSE=$(curl -s --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                -H "Host: ${OAUTH_HOST}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}" \
+                --data-urlencode "scope=${OAUTH_SCOPE}")
+            else
+              TOKEN_RESPONSE=$(curl -s --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                -H "Host: ${OAUTH_HOST}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}")
+            fi
+
+            ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+
+            if [ -z "${ACCESS_TOKEN}" ]; then
+              echo ">> Failed to get access token: ${TOKEN_RESPONSE}"
+              exit 1
+            fi
+
+            echo ">> Successfully obtained access token"
+
+            # --- Step 4: Create or update workload via API server ---
+            API_URL="{{inputs.parameters.api-server-url}}"
+            API_HOST="{{inputs.parameters.api-server-host-header}}"
+
+            WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq -r '.metadata.name' /data/workload-cr.json)
+
+            echo ">> Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads"
+            RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X POST "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads" \
+              -H "Host: ${API_HOST}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -d @/mnt/vol/workload-cr.json)
+
+            HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+            BODY=$(echo "${RESPONSE}" | sed '$d')
+
+            if [ "${HTTP_CODE}" -ge 200 ] && [ "${HTTP_CODE}" -lt 300 ]; then
+              echo ">> Workload created successfully (HTTP ${HTTP_CODE}): ${BODY}"
+            elif [ "${HTTP_CODE}" -eq 409 ]; then
+              if [ "${WORKLOAD_FROM_SOURCE}" = "true" ]; then
+                echo ">> Workload already exists, updating via PUT (full replace - source-defined)"
+                RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d @/mnt/vol/workload-cr.json)
+              else
+                echo ">> Workload already exists, updating only container image (auto-generated)"
+                GET_RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X GET "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}")
+
+                GET_HTTP_CODE=$(echo "${GET_RESPONSE}" | tail -1)
+                GET_BODY=$(echo "${GET_RESPONSE}" | sed '$d')
+
+                if [ "${GET_HTTP_CODE}" -lt 200 ] || [ "${GET_HTTP_CODE}" -ge 300 ]; then
+                  echo ">> Failed to get existing workload (HTTP ${GET_HTTP_CODE}): ${GET_BODY}"
+                  exit 1
+                fi
+
+                echo "${GET_BODY}" > /mnt/vol/workload-existing.json
+                NEW_IMAGE=$(podman run --rm \
+                  -v /mnt/vol:/data:ro \
+                  ghcr.io/jqlang/jq:1.7.1 -r '.spec.container.image' /data/workload-cr.json)
+
+                echo ">> Updating container image to: ${NEW_IMAGE}"
+                podman run --rm \
+                  -v /mnt/vol:/data:rw \
+                  ghcr.io/jqlang/jq:1.7.1 \
+                  --arg img "${NEW_IMAGE}" \
+                  '.spec.container.image = $img' \
+                  /data/workload-existing.json \
+                  > /mnt/vol/workload-merged.json
+
+                RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d @/mnt/vol/workload-merged.json)
+              fi
+
+              HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+              BODY=$(echo "${RESPONSE}" | sed '$d')
+
+              if [ "${HTTP_CODE}" -ge 200 ] && [ "${HTTP_CODE}" -lt 300 ]; then
+                echo ">> Workload updated successfully (HTTP ${HTTP_CODE}): ${BODY}"
+              else
+                echo ">> Failed to update workload (HTTP ${HTTP_CODE}): ${BODY}"
+                exit 1
+              fi
+            else
+              echo ">> Failed to create workload (HTTP ${HTTP_CODE}): ${BODY}"
+              exit 1
+            fi
+
+            # --- Step 5: Annotate the WorkflowRun with the workload CR ---
+            echo ">> Getting WorkflowRun ${RUN_NAME}"
+            WF_RUN_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X GET "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workflowruns/${RUN_NAME}" \
+              -H "Host: ${API_HOST}" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}")
+
+            WF_RUN_HTTP_CODE=$(echo "${WF_RUN_RESPONSE}" | tail -1)
+            WF_RUN_BODY=$(echo "${WF_RUN_RESPONSE}" | sed '$d')
+
+            if [ "${WF_RUN_HTTP_CODE}" -lt 200 ] || [ "${WF_RUN_HTTP_CODE}" -ge 300 ]; then
+              echo ">> Failed to get WorkflowRun (HTTP ${WF_RUN_HTTP_CODE}): ${WF_RUN_BODY}"
+              exit 1
+            fi
+
+            echo "${WF_RUN_BODY}" > /mnt/vol/workflowrun-get.json
+            if [ "${WORKLOAD_FROM_SOURCE}" = "true" ]; then
+              podman run --rm \
+                -v /mnt/vol:/data:rw \
+                ghcr.io/jqlang/jq:1.7.1 \
+                --rawfile wl /data/workload-cr.json \
+                '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "true"' \
+                /data/workflowrun-get.json \
+                > /mnt/vol/workflowrun-updated.json
+            else
+              podman run --rm \
+                -v /mnt/vol:/data:rw \
+                ghcr.io/jqlang/jq:1.7.1 \
+                --rawfile wl /data/workload-cr.json \
+                '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "false"' \
+                /data/workflowrun-get.json \
+                > /mnt/vol/workflowrun-updated.json
+            fi
+
+            echo ">> Updating WorkflowRun with workload annotation"
+            UPDATE_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workflowruns/${RUN_NAME}" \
+              -H "Host: ${API_HOST}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -d @/mnt/vol/workflowrun-updated.json)
+
+            UPDATE_HTTP_CODE=$(echo "${UPDATE_RESPONSE}" | tail -1)
+            UPDATE_BODY=$(echo "${UPDATE_RESPONSE}" | sed '$d')
+
+            if [ "${UPDATE_HTTP_CODE}" -ge 200 ] && [ "${UPDATE_HTTP_CODE}" -lt 300 ]; then
+              echo ">> WorkflowRun annotated successfully (HTTP ${UPDATE_HTTP_CODE})"
+            else
+              echo ">> Failed to update WorkflowRun (HTTP ${UPDATE_HTTP_CODE}): ${UPDATE_BODY}"
+              exit 1
+            fi
+        volumeMounts:
+          - name: workspace
+            mountPath: /mnt/vol
+        securityContext:
+          privileged: true

--- a/test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml
+++ b/test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml
@@ -92,7 +92,7 @@ spec:
               echo ">> Generating workload CR from workload descriptor"
               podman run --rm --network=none \
               -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+              ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
                 workload create \
                 --namespace "${NAMESPACE_NAME}" \
                 --project "${PROJECT_NAME}" \
@@ -104,7 +104,7 @@ spec:
               echo ">> Generating default workload CR"
               podman run --rm --network=none \
               -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:latest-dev \
+              ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
                 workload create \
                 --namespace "${NAMESPACE_NAME}" \
                 --project "${PROJECT_NAME}" \
@@ -118,7 +118,7 @@ spec:
             # --- Step 2: Convert workload CR YAML to JSON (strip apiVersion and kind) ---
              podman run --rm \
                -v /mnt/vol:/data:rw \
-               mikefarah/yq -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
+               mikefarah/yq:4.45.4 -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
                > /mnt/vol/workload-cr-raw.json
              podman run --rm \
                -v /mnt/vol:/data:rw \
@@ -152,7 +152,7 @@ spec:
                 --data-urlencode "client_secret=${CLIENT_SECRET}")
             fi
 
-            ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+            ACCESS_TOKEN=$(printf '%s' "${TOKEN_RESPONSE}" | podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.access_token')
 
             if [ -z "${ACCESS_TOKEN}" ]; then
               echo ">> Failed to get access token: ${TOKEN_RESPONSE}"
@@ -165,7 +165,7 @@ spec:
             API_URL="{{inputs.parameters.api-server-url}}"
             API_HOST="{{inputs.parameters.api-server-host-header}}"
 
-            WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq -r '.metadata.name' /data/workload-cr.json)
+            WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq:4.45.4 -r '.metadata.name' /data/workload-cr.json)
 
             echo ">> Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads"
             RESPONSE=$(curl -s -w "\n%{http_code}" \

--- a/test/e2e/k3d/workflow-templates/publish-image-e2e.yaml
+++ b/test/e2e/k3d/workflow-templates/publish-image-e2e.yaml
@@ -34,7 +34,7 @@ spec:
             optional: true
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.1
+        image: ghcr.io/openchoreo/podman-runner@sha256:2165f0d5ca5c8286c234388d542f50ede8f38108fc25a57ce141fcdf5cc87b00
         command:
           - sh
           - -c

--- a/test/e2e/k3d/workflow-templates/publish-image-e2e.yaml
+++ b/test/e2e/k3d/workflow-templates/publish-image-e2e.yaml
@@ -1,0 +1,94 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# E2E variant of samples/getting-started/workflow-templates/publish-image-k3d.yaml.
+#
+# The shared k3d sample template hardcodes `host.k3d.internal:10082` which
+# collides with a parallel single-cluster install on the same host. The e2e
+# k3d cluster uses host port 20082 -> container 10082 (see
+# test/e2e/k3d/config.yaml) to avoid that collision, so this variant pushes
+# to `host.k3d.internal:20082`. The published image ref also uses :20082 so
+# containerd's mirror config (host.k3d.internal:20082 -> http://host.k3d.internal:20082)
+# applies on pull.
+#
+# Keep in sync with samples/getting-started/workflow-templates/publish-image-k3d.yaml
+# until the upstream template is parameterised.
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: publish-image
+spec:
+  templates:
+    - name: publish-image
+      inputs:
+        parameters:
+          - name: git-revision
+      outputs:
+        parameters:
+          - name: image
+            valueFrom:
+              path: /tmp/image.txt
+      volumes:
+        - name: registry-push-secret
+          secret:
+            optional: true
+            secretName: '{{workflow.parameters.registry-push-secret}}'
+      container:
+        image: ghcr.io/openchoreo/podman-runner:v1.1
+        command:
+          - sh
+          - -c
+        args:
+          - |-
+            set -e
+
+            GIT_REVISION={{inputs.parameters.git-revision}}
+            IMAGE_NAME={{workflow.parameters.image-name}}
+            IMAGE_TAG={{workflow.parameters.image-tag}}
+            SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
+
+            REGISTRY_ENDPOINT="host.k3d.internal:20082"
+            AUTH_FILE="/etc/secrets/registry-push-secret/.dockerconfigjson"
+
+            # --- Parameter Validation ---
+            echo ">> Source image: $SRC_IMAGE"
+            echo ">> Registry: $REGISTRY_ENDPOINT"
+            echo ">> Authentication: $([ -f "$AUTH_FILE" ] && echo "registry secret found" || echo "no registry secret (anonymous push)")"
+
+            if [ ! -f "/mnt/vol/app-image.tar" ]; then
+              echo ">> Error: Built image tar not found at /mnt/vol/app-image.tar"
+              echo ">> Hint: The build step may have failed to produce an image. Check the build step logs."
+              exit 1
+            fi
+
+            mkdir -p /etc/containers
+            cat <<EOF > /etc/containers/storage.conf
+            [storage]
+            driver = "overlay"
+            runroot = "/run/containers/storage"
+            graphroot = "/var/lib/containers/storage"
+            [storage.options.overlay]
+            mount_program = "/usr/bin/fuse-overlayfs"
+            EOF
+
+            podman load -i /mnt/vol/app-image.tar
+
+            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+
+            echo ">> Pushing image to registry"
+            if [ -f "$AUTH_FILE" ]; then
+              podman push --tls-verify=false --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+            else
+              podman push --tls-verify=false $REGISTRY_ENDPOINT/$SRC_IMAGE
+            fi
+
+            echo ">> Image published successfully: $REGISTRY_ENDPOINT/$SRC_IMAGE"
+            echo -n "$REGISTRY_ENDPOINT/$SRC_IMAGE" > /tmp/image.txt
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /mnt/vol
+            name: workspace
+          - mountPath: /etc/secrets/registry-push-secret
+            name: registry-push-secret
+            readOnly: true

--- a/test/e2e/suites/build/build_fixtures_test.go
+++ b/test/e2e/suites/build/build_fixtures_test.go
@@ -1,0 +1,348 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+const (
+	clusterDataPlane   = "e2e-shared"
+	openChoreoAPIVer   = "openchoreo.dev/v1alpha1"
+	kubernetesAPIVerV1 = "v1"
+
+	projectName = "build-proj"
+	envDev      = "development"
+	envStaging  = "staging"
+
+	// In-cluster Gitea sits in its own namespace so it survives across builds
+	// in the same e2e session and so the WP namespace stays uncluttered.
+	giteaNamespace = "e2e-gitea"
+	// Public sample-workloads repo we mirror into Gitea. Pinned by branch so
+	// the build matrix is reproducible.
+	upstreamSampleWorkloads = "https://github.com/openchoreo/sample-workloads.git"
+	sampleWorkloadsRepo     = "sample-workloads"
+	noWorkloadRepo          = "no-workload-sample"
+	paketoNodeRepo          = "paketo-node-sample"
+	externalRefsRepo        = "externalrefs-sample"
+
+	// Component / workflow names. Kept short so the rendered Argo Workflow's
+	// generated names don't blow past Kubernetes' 63-char DNS label limit.
+	componentDockerfile      = "df-svc"
+	componentDockerfileReact = "df-spa"
+	componentGCP             = "gcp-svc"
+	componentPaketo          = "pkt-svc"
+	componentBallerina       = "bal-svc"
+	componentNoWorkload      = "auto-wl"
+	componentExternalRefs    = "extref-svc"
+	componentLogs            = "logs-svc"
+
+	releaseBindingSuffix = "-" + envDev
+
+	testerLabel     = "app=build-tester"
+	testerContainer = "tester"
+)
+
+var buildRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+
+var cpNs = fmt.Sprintf("e2e-build-%s", buildRunID)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+func cpNamespaceYAML() string {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/control-plane": "true",
+			},
+		},
+	}
+	return mustYAMLDocs(ns)
+}
+
+func platformResourcesYAML() string {
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "DeploymentPipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": "default"},
+		},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{{
+				SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: envDev},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{
+					{Name: envStaging},
+				},
+			}},
+		},
+	}
+	envs := make([]any, 0, 2)
+	for _, name := range []string{envDev, envStaging} {
+		envs = append(envs, &openchoreov1alpha1.Environment{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: cpNs,
+				Labels:    map[string]string{"openchoreo.dev/name": name},
+			},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+					Name: clusterDataPlane,
+				},
+			},
+		})
+	}
+	proj := &openchoreov1alpha1.Project{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": projectName},
+		},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+		},
+	}
+	docs := []any{pipeline}
+	docs = append(docs, envs...)
+	docs = append(docs, proj)
+	return mustYAMLDocs(docs...)
+}
+
+// buildComponentYAML returns a Component CR with the given builder workflow
+// configured. The Component uses autoDeploy=true so the build pipeline's
+// generated Workload triggers a ComponentRelease + ReleaseBinding automatically.
+func buildComponentYAML(name, componentType, workflowName, gitURL, appPath, dockerfilePath string) string {
+	params := map[string]any{
+		"repository": map[string]any{
+			"url":     gitURL,
+			"appPath": appPath,
+			"revision": map[string]any{
+				"branch": "main",
+			},
+		},
+	}
+	if dockerfilePath != "" {
+		params["docker"] = map[string]any{
+			"context":  appPath,
+			"filePath": dockerfilePath,
+		}
+	}
+	raw, err := yaml.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	comp := &openchoreov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/name":      name,
+				"openchoreo.dev/project":   projectName,
+				"openchoreo.dev/component": name,
+			},
+		},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: projectName},
+			ComponentType: openchoreov1alpha1.ComponentTypeRef{
+				Kind: openchoreov1alpha1.ComponentTypeRefKindClusterComponentType,
+				Name: componentType,
+			},
+			AutoDeploy: true,
+			Workflow: &openchoreov1alpha1.ComponentWorkflowConfig{
+				Kind:       openchoreov1alpha1.WorkflowRefKindClusterWorkflow,
+				Name:       workflowName,
+				Parameters: &runtime.RawExtension{Raw: raw},
+			},
+		},
+	}
+	return mustYAMLDocs(comp)
+}
+
+// workflowRunYAML pairs with buildComponentYAML to actually kick off the build.
+// The Component carries the workflow config for `autoDeploy`/`autoBuild`
+// bookkeeping; the WorkflowRun is the active trigger.
+func workflowRunYAML(componentName, runName, workflowName, gitURL, appPath, dockerfilePath string) string {
+	params := map[string]any{
+		"repository": map[string]any{
+			"url":     gitURL,
+			"appPath": appPath,
+			"revision": map[string]any{
+				"branch": "main",
+			},
+		},
+	}
+	if dockerfilePath != "" {
+		params["docker"] = map[string]any{
+			"context":  appPath,
+			"filePath": dockerfilePath,
+		}
+	}
+	raw, err := yaml.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	wfr := &openchoreov1alpha1.WorkflowRun{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "WorkflowRun"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runName,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/project":   projectName,
+				"openchoreo.dev/component": componentName,
+			},
+		},
+		Spec: openchoreov1alpha1.WorkflowRunSpec{
+			Workflow: openchoreov1alpha1.WorkflowRunConfig{
+				Kind:       openchoreov1alpha1.WorkflowRefKindClusterWorkflow,
+				Name:       workflowName,
+				Parameters: &runtime.RawExtension{Raw: raw},
+			},
+		},
+	}
+	return mustYAMLDocs(wfr)
+}
+
+// testerPodYAML returns a busybox pod used as the source of in-cluster
+// reachability probes against rendered Services.
+func testerPodYAML(dpNamespace string) string {
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "build-tester",
+			Namespace: dpNamespace,
+			Labels: map[string]string{
+				"app":                       "build-tester",
+				"openchoreo.dev/project":    projectName,
+				"openchoreo.dev/managed-by": "e2e-build",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    testerContainer,
+			Image:   "busybox:1.36",
+			Command: []string{"sleep", "3600"},
+		}}},
+	}
+	return mustYAMLDocs(pod)
+}
+
+// externalRefsFixtureYAML returns a SecretReference + Workflow + WorkflowRun
+// triple used by the externalrefs-in-cel spec. The Workflow's runTemplate
+// emits a trivial Argo Workflow whose top-level metadata carries a label
+// populated from `${externalRefs['app-config'].spec.refreshInterval}`. We then
+// kubectl-get that rendered Argo Workflow and assert the label matches the
+// SecretReference's refreshInterval — proving the externalRef spec landed in
+// the CEL context.
+//
+// We deliberately bind to a benign field (refreshInterval) rather than
+// fabricating a custom value because SecretReference's schema is fixed.
+func externalRefsFixtureYAML() string {
+	secretRefName := componentExternalRefs + "-ref"
+	wfName := componentExternalRefs + "-wf"
+	runName := componentExternalRefs + "-run-01"
+
+	secretRef := map[string]any{
+		"apiVersion": openChoreoAPIVer,
+		"kind":       "SecretReference",
+		"metadata": map[string]any{
+			"name":      secretRefName,
+			"namespace": cpNs,
+			"labels":    map[string]string{"openchoreo.dev/managed-by": "e2e-build"},
+		},
+		"spec": map[string]any{
+			"template":        map[string]any{"type": "Opaque"},
+			"refreshInterval": "7m42s",
+			"data": []any{map[string]any{
+				"secretKey": "marker",
+				"remoteRef": map[string]any{"key": "secret/data/e2e/marker"},
+			}},
+		},
+	}
+
+	workflow := map[string]any{
+		"apiVersion": openChoreoAPIVer,
+		"kind":       "Workflow",
+		"metadata": map[string]any{
+			"name":      wfName,
+			"namespace": cpNs,
+		},
+		"spec": map[string]any{
+			"workflowPlaneRef":   map[string]any{"kind": "ClusterWorkflowPlane", "name": "default"},
+			"ttlAfterCompletion": "1h",
+			"externalRefs": []any{map[string]any{
+				"id":         "app-config",
+				"apiVersion": openChoreoAPIVer,
+				"kind":       "SecretReference",
+				"name":       secretRefName,
+			}},
+			"runTemplate": map[string]any{
+				"apiVersion": "argoproj.io/v1alpha1",
+				"kind":       "Workflow",
+				"metadata": map[string]any{
+					"name":      "${metadata.workflowRunName}",
+					"namespace": "${metadata.namespace}",
+					"labels": map[string]any{
+						"openchoreo.dev/e2e-cel-probe": "${externalRefs['app-config'].spec.refreshInterval}",
+					},
+				},
+				"spec": map[string]any{
+					"entrypoint": "echo",
+					"templates": []any{map[string]any{
+						"name": "echo",
+						"container": map[string]any{
+							"image": "busybox:1.36",
+							"command": []any{
+								"sh", "-c", "echo cel-probe complete",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	wfRun := map[string]any{
+		"apiVersion": openChoreoAPIVer,
+		"kind":       "WorkflowRun",
+		"metadata": map[string]any{
+			"name":      runName,
+			"namespace": cpNs,
+			"labels": map[string]string{
+				"openchoreo.dev/managed-by": "e2e-build",
+			},
+		},
+		"spec": map[string]any{
+			"workflow": map[string]any{
+				"kind": "Workflow",
+				"name": wfName,
+			},
+		},
+	}
+
+	return mustYAMLDocs(secretRef, workflow, wfRun)
+}

--- a/test/e2e/suites/build/build_fixtures_test.go
+++ b/test/e2e/suites/build/build_fixtures_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -152,7 +153,10 @@ func buildComponentYAML(name, componentType, workflowName, gitURL, appPath, dock
 			"filePath": dockerfilePath,
 		}
 	}
-	raw, err := yaml.Marshal(params)
+	// RawExtension.Raw is JSON, not YAML — using sigs.k8s.io/yaml.Marshal here
+	// produces YAML bytes which RawExtension.MarshalJSON later rejects with
+	// "cannot convert RawExtension with unrecognized content type to unstructured".
+	raw, err := json.Marshal(params)
 	if err != nil {
 		panic(err)
 	}
@@ -203,7 +207,10 @@ func workflowRunYAML(componentName, runName, workflowName, gitURL, appPath, dock
 			"filePath": dockerfilePath,
 		}
 	}
-	raw, err := yaml.Marshal(params)
+	// RawExtension.Raw is JSON, not YAML — using sigs.k8s.io/yaml.Marshal here
+	// produces YAML bytes which RawExtension.MarshalJSON later rejects with
+	// "cannot convert RawExtension with unrecognized content type to unstructured".
+	raw, err := json.Marshal(params)
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/suites/build/build_test.go
+++ b/test/e2e/suites/build/build_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 				repoName:     sampleWorkloadsRepo,
 				appPath:      "/service-go-greeter",
 				dockerfile:   "/service-go-greeter/Dockerfile",
+				endpoint:     "greeter-api",
 				assertReach:  true,
 			})
 		})
@@ -93,8 +94,9 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 				componentTyp: "deployment/web-application",
 				workflow:     "dockerfile-builder",
 				repoName:     sampleWorkloadsRepo,
-				appPath:      "/web-app-react-starter",
-				dockerfile:   "/web-app-react-starter/Dockerfile",
+				appPath:      "/webapp-react-nginx",
+				dockerfile:   "/webapp-react-nginx/Dockerfile",
+				endpoint:     "webapp-endpoint",
 				assertReach:  true,
 			})
 		})
@@ -106,6 +108,7 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 				workflow:     "gcp-buildpacks-builder",
 				repoName:     sampleWorkloadsRepo,
 				appPath:      "/service-go-reading-list",
+				endpoint:     "reading-list-api",
 				assertReach:  false, // upstream sample's port surface varies; deploy + ComponentRelease are the meaningful signal
 			})
 		})
@@ -117,6 +120,7 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 				workflow:     "paketo-buildpacks-builder",
 				repoName:     paketoNodeRepo,
 				appPath:      "/",
+				endpoint:     "http",
 				assertReach:  true,
 			})
 		})
@@ -128,6 +132,7 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 				workflow:     "ballerina-buildpack-builder",
 				repoName:     sampleWorkloadsRepo,
 				appPath:      "/service-ballerina-patient-management",
+				endpoint:     "patient-management-api",
 				assertReach:  false,
 			})
 		})
@@ -135,14 +140,20 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 
 	Context("solo specs", func() {
 		It("workload-auto-generation: build without a workload.yaml lands a Workload+ComponentRelease", func() {
+			// Worker (not service) because `occ workload create` without a
+			// descriptor produces a Workload with zero endpoints, and the
+			// service CCT's CEL validation requires `size(workload.endpoints) > 0`
+			// — it would reject the rendered release. worker requires == 0,
+			// which matches the auto-generation output. Reachability is N/A
+			// for workers (no endpoints), so assertReach is false.
 			runDeployableBuildSpec(buildSpec{
 				component:    componentNoWorkload,
-				componentTyp: "deployment/service",
+				componentTyp: "deployment/worker",
 				workflow:     "dockerfile-builder",
 				repoName:     noWorkloadRepo,
 				appPath:      "/",
 				dockerfile:   "/Dockerfile",
-				assertReach:  true,
+				assertReach:  false,
 			})
 
 			By("Workload CR was created by the pipeline (auto-generated)")
@@ -235,6 +246,7 @@ type buildSpec struct {
 	repoName     string
 	appPath      string
 	dockerfile   string // optional — leave empty for buildpacks
+	endpoint     string // endpoint name as declared in the workload.yaml the build checks out
 	assertReach  bool   // whether to assert in-cluster HTTP reachability of the rendered Service
 }
 
@@ -298,7 +310,7 @@ func runDeployableBuildSpec(spec buildSpec) {
 	}, 3*time.Minute, 3*time.Second).Should(Succeed())
 
 	By("rendered Service is TCP-reachable from the tester pod")
-	host, port := endpointHostPort(spec.component, "http")
+	host, port := endpointHostPort(spec.component, spec.endpoint)
 	Eventually(func() error {
 		_, err := framework.CheckTCPReachableFromPodByLabel(
 			kubeContext, dpNs, testerLabel, testerContainer, host, port, 5,

--- a/test/e2e/suites/build/build_test.go
+++ b/test/e2e/suites/build/build_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+const (
+	// Builds take longer than image-pull deploys; bound generously to avoid
+	// flakes when the CI runner is under load.
+	buildTimeout       = 20 * time.Minute
+	releasePropagation = 5 * time.Minute
+)
+
+var dpNs string
+
+var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
+	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
+	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
+
+	BeforeAll(func() {
+		By("installing in-cluster Gitea")
+		Expect(framework.InstallGitea(kubeContext, giteaNamespace)).To(Succeed())
+
+		By("mirroring openchoreo/sample-workloads into Gitea")
+		Expect(framework.MigrateRepo(kubeContext, giteaNamespace,
+			sampleWorkloadsRepo, upstreamSampleWorkloads)).To(Succeed())
+
+		By("seeding the no-workload fixture into Gitea")
+		Expect(framework.EnsureGiteaRepo(kubeContext, giteaNamespace, noWorkloadRepo)).To(Succeed())
+		repoRoot, err := framework.RepoRoot()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.PushTree(kubeContext, giteaNamespace, noWorkloadRepo, "main",
+			filepath.Join(repoRoot, "test/e2e/fixtures/build/no-workload"))).To(Succeed())
+
+		By("seeding the paketo-node fixture into Gitea")
+		Expect(framework.EnsureGiteaRepo(kubeContext, giteaNamespace, paketoNodeRepo)).To(Succeed())
+		Expect(framework.PushTree(kubeContext, giteaNamespace, paketoNodeRepo, "main",
+			filepath.Join(repoRoot, "test/e2e/fixtures/build/paketo-node"))).To(Succeed())
+
+		By("creating control plane namespace")
+		output, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
+		Expect(err).NotTo(HaveOccurred(), "failed to create CP namespace: %s", output)
+
+		By("applying platform resources (pipeline, environments, project)")
+		output, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML())
+		Expect(err).NotTo(HaveOccurred(), "failed to apply platform resources: %s", output)
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+		By("cleaning up control plane namespace (cascades to DP and WP)")
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
+			"--ignore-not-found", "--wait=false")
+		if dpNs != "" {
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+				"--ignore-not-found", "--wait=false")
+		}
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", giteaNamespace,
+			"--ignore-not-found", "--wait=false")
+	})
+
+	Context("builder matrix", func() {
+		It("dockerfile-builder: builds, deploys, and is reachable (service)", func() {
+			runDeployableBuildSpec(buildSpec{
+				component:    componentDockerfile,
+				componentTyp: "deployment/service",
+				workflow:     "dockerfile-builder",
+				repoName:     sampleWorkloadsRepo,
+				appPath:      "/service-go-greeter",
+				dockerfile:   "/service-go-greeter/Dockerfile",
+				assertReach:  true,
+			})
+		})
+
+		It("dockerfile-builder: react web-application builds and is reachable", func() {
+			runDeployableBuildSpec(buildSpec{
+				component:    componentDockerfileReact,
+				componentTyp: "deployment/web-application",
+				workflow:     "dockerfile-builder",
+				repoName:     sampleWorkloadsRepo,
+				appPath:      "/web-app-react-starter",
+				dockerfile:   "/web-app-react-starter/Dockerfile",
+				assertReach:  true,
+			})
+		})
+
+		It("gcp-buildpacks-builder: builds and deploys reading-list", func() {
+			runDeployableBuildSpec(buildSpec{
+				component:    componentGCP,
+				componentTyp: "deployment/service",
+				workflow:     "gcp-buildpacks-builder",
+				repoName:     sampleWorkloadsRepo,
+				appPath:      "/service-go-reading-list",
+				assertReach:  false, // upstream sample's port surface varies; deploy + ComponentRelease are the meaningful signal
+			})
+		})
+
+		It("paketo-buildpacks-builder: builds and deploys the in-tree node fixture", func() {
+			runDeployableBuildSpec(buildSpec{
+				component:    componentPaketo,
+				componentTyp: "deployment/service",
+				workflow:     "paketo-buildpacks-builder",
+				repoName:     paketoNodeRepo,
+				appPath:      "/",
+				assertReach:  true,
+			})
+		})
+
+		It("ballerina-buildpack-builder: builds and deploys patient-management", func() {
+			runDeployableBuildSpec(buildSpec{
+				component:    componentBallerina,
+				componentTyp: "deployment/service",
+				workflow:     "ballerina-buildpack-builder",
+				repoName:     sampleWorkloadsRepo,
+				appPath:      "/service-ballerina-patient-management",
+				assertReach:  false,
+			})
+		})
+	})
+
+	Context("solo specs", func() {
+		It("workload-auto-generation: build without a workload.yaml lands a Workload+ComponentRelease", func() {
+			runDeployableBuildSpec(buildSpec{
+				component:    componentNoWorkload,
+				componentTyp: "deployment/service",
+				workflow:     "dockerfile-builder",
+				repoName:     noWorkloadRepo,
+				appPath:      "/",
+				dockerfile:   "/Dockerfile",
+				assertReach:  true,
+			})
+
+			By("Workload CR was created by the pipeline (auto-generated)")
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "workload",
+					"-n", cpNs,
+					"-o", "jsonpath={.items[?(@.spec.owner.componentName==\""+componentNoWorkload+"\")].metadata.name}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).NotTo(BeEmpty(),
+					"expected an auto-generated Workload for component %s", componentNoWorkload)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("externalrefs-in-cel: SecretReference spec surfaces in the rendered Argo Workflow", func() {
+			By("applying SecretReference + Workflow + WorkflowRun")
+			output, err := framework.KubectlApplyLiteral(kubeContext, externalRefsFixtureYAML())
+			Expect(err).NotTo(HaveOccurred(), "failed to apply externalrefs fixture: %s", output)
+
+			runName := componentExternalRefs + "-run-01"
+			By("waiting for WorkflowRun.status.runReference to populate")
+			var kind, refName, refNs string
+			Eventually(func(g Gomega) {
+				k, n, ns, e := framework.WorkflowRunReference(kubeContext, cpNs, runName)
+				g.Expect(e).NotTo(HaveOccurred())
+				g.Expect(k).NotTo(BeEmpty(), "runReference.kind not populated yet")
+				g.Expect(n).NotTo(BeEmpty(), "runReference.name not populated yet")
+				kind, refName, refNs = k, n, ns
+			}, 3*time.Minute, 3*time.Second).Should(Succeed())
+			fmt.Fprintf(GinkgoWriter, "rendered workflow ref: %s %s/%s\n", kind, refNs, refName)
+
+			By("rendered Argo Workflow carries the resolved externalRef value as a label")
+			Eventually(func(g Gomega) {
+				out, err := framework.KubectlGetJsonpath(kubeContext, refNs,
+					"workflow.argoproj.io", refName,
+					`{.metadata.labels['openchoreo\.dev/e2e-cel-probe']}`,
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(Equal("7m42s"),
+					"expected label to equal SecretReference.spec.refreshInterval, got %q", out)
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("build-logs-via-k8s: live logs reachable from a running WorkflowRun pod", func() {
+			component := componentLogs
+			runName := component + "-run-01"
+
+			By("applying component + workflowrun")
+			gitURL := framework.GiteaRepoCloneURL(giteaNamespace, sampleWorkloadsRepo)
+			output, err := framework.KubectlApplyLiteral(kubeContext, buildComponentYAML(
+				component, "deployment/service", "dockerfile-builder",
+				gitURL, "/service-go-greeter", "/service-go-greeter/Dockerfile",
+			))
+			Expect(err).NotTo(HaveOccurred(), "failed to apply component: %s", output)
+			output, err = framework.KubectlApplyLiteral(kubeContext, workflowRunYAML(
+				component, runName, "dockerfile-builder",
+				gitURL, "/service-go-greeter", "/service-go-greeter/Dockerfile",
+			))
+			Expect(err).NotTo(HaveOccurred(), "failed to apply workflow run: %s", output)
+
+			By("waiting for the build Argo Workflow pod to appear")
+			wfNs := "workflows-" + cpNs
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "pods", "-n", wfNs,
+					"-l", "workflows.argoproj.io/workflow="+runName,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
+					"no pod found yet for WorkflowRun %s in %s", runName, wfNs)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("kubectl logs against the build pod returns non-empty content")
+			Eventually(func(g Gomega) {
+				out, err := framework.KubectlLogs(kubeContext, wfNs,
+					"workflows.argoproj.io/workflow="+runName, 50)
+				g.Expect(err).NotTo(HaveOccurred(), "kubectl logs failed: %s", out)
+				g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
+					"expected non-empty build pod logs while WorkflowRun is running")
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+		})
+	})
+})
+
+type buildSpec struct {
+	component    string
+	componentTyp string
+	workflow     string
+	repoName     string
+	appPath      string
+	dockerfile   string // optional — leave empty for buildpacks
+	assertReach  bool   // whether to assert in-cluster HTTP reachability of the rendered Service
+}
+
+// runDeployableBuildSpec drives a Component + WorkflowRun through the build
+// pipeline and asserts the post-build artifacts (ComponentRelease, ReleaseBinding,
+// pod Running). Optionally probes the rendered Service for TCP reachability.
+// Shared by every spec in the builder matrix so the assertions stay in lockstep.
+func runDeployableBuildSpec(spec buildSpec) {
+	runName := spec.component + "-run-01"
+	gitURL := framework.GiteaRepoCloneURL(giteaNamespace, spec.repoName)
+
+	By(fmt.Sprintf("applying Component %s with workflow %s", spec.component, spec.workflow))
+	output, err := framework.KubectlApplyLiteral(kubeContext, buildComponentYAML(
+		spec.component, spec.componentTyp, spec.workflow, gitURL, spec.appPath, spec.dockerfile,
+	))
+	Expect(err).NotTo(HaveOccurred(), "failed to apply component: %s", output)
+
+	By(fmt.Sprintf("applying WorkflowRun %s", runName))
+	output, err = framework.KubectlApplyLiteral(kubeContext, workflowRunYAML(
+		spec.component, runName, spec.workflow, gitURL, spec.appPath, spec.dockerfile,
+	))
+	Expect(err).NotTo(HaveOccurred(), "failed to apply workflow run: %s", output)
+
+	By("waiting for WorkflowRun to succeed")
+	Eventually(func(g Gomega) {
+		framework.AssertWorkflowRunSucceeded(g, kubeContext, cpNs, runName)
+	}, buildTimeout, 10*time.Second).Should(Succeed())
+
+	By("ComponentRelease appears for the component")
+	Eventually(func(g Gomega) {
+		framework.AssertComponentReleasePresent(g, kubeContext, cpNs, spec.component)
+	}, releasePropagation, 5*time.Second).Should(Succeed())
+
+	By("ReleaseBinding reaches Ready")
+	Eventually(func(g Gomega) {
+		framework.AssertReleaseBindingReady(g, kubeContext, cpNs, spec.component+releaseBindingSuffix)
+	}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+	By("discovering the data plane namespace")
+	Eventually(func() error {
+		var discoverErr error
+		dpNs, discoverErr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+		return discoverErr
+	}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+	By("workload pod is Running")
+	Eventually(func(g Gomega) {
+		framework.AssertPodsRunning(g, kubeContext, dpNs,
+			"openchoreo.dev/component="+spec.component)
+	}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+	if !spec.assertReach {
+		return
+	}
+
+	By("ensuring a tester pod is available in the DP namespace")
+	output, err = framework.KubectlApplyLiteral(kubeContext, testerPodYAML(dpNs))
+	Expect(err).NotTo(HaveOccurred(), "failed to apply tester pod: %s", output)
+	Eventually(func(g Gomega) {
+		framework.AssertPodsRunning(g, kubeContext, dpNs, testerLabel)
+	}, 3*time.Minute, 3*time.Second).Should(Succeed())
+
+	By("rendered Service is TCP-reachable from the tester pod")
+	host, port := endpointHostPort(spec.component, "http")
+	Eventually(func() error {
+		_, err := framework.CheckTCPReachableFromPodByLabel(
+			kubeContext, dpNs, testerLabel, testerContainer, host, port, 5,
+		)
+		return err
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+		"%s:%s should be TCP-reachable for component %s", host, port, spec.component)
+}
+
+// endpointHostPort reads the rendered Service URL host+port for a named endpoint
+// off the ReleaseBinding status. Same shape as the workloadtypes suite — kept
+// inline so the build suite doesn't pull a dependency on that test package.
+func endpointHostPort(component, endpoint string) (host, port string) {
+	rbName := component + releaseBindingSuffix
+	var hostOut, portOut string
+	Eventually(func(g Gomega) {
+		var err error
+		hostOut, err = framework.KubectlGetJsonpath(
+			kubeContext, cpNs, "releasebinding", rbName,
+			fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].serviceURL.host}`, endpoint),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(hostOut).NotTo(BeEmpty(), "serviceURL.host empty on %s endpoint %s", rbName, endpoint)
+
+		portOut, err = framework.KubectlGetJsonpath(
+			kubeContext, cpNs, "releasebinding", rbName,
+			fmt.Sprintf(`{.status.endpoints[?(@.name=="%s")].serviceURL.port}`, endpoint),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(portOut).NotTo(BeEmpty(), "serviceURL.port empty on %s endpoint %s", rbName, endpoint)
+	}, 3*time.Minute, 2*time.Second).Should(Succeed())
+	return hostOut, portOut
+}

--- a/test/e2e/suites/build/suite_test.go
+++ b/test/e2e/suites/build/suite_test.go
@@ -44,4 +44,13 @@ var _ = BeforeSuite(func() {
 	_, err = framework.Kubectl(kubeContext, "get", "clusterworkflow", "dockerfile-builder")
 	Expect(err).NotTo(HaveOccurred(),
 		"dockerfile-builder ClusterWorkflow not found; check the platform sample install")
+	_, err = framework.Kubectl(kubeContext, "get", "clusterworkflow", "gcp-buildpacks-builder")
+	Expect(err).NotTo(HaveOccurred(),
+		"gcp-buildpacks-builder ClusterWorkflow not found; check the platform sample install")
+	_, err = framework.Kubectl(kubeContext, "get", "clusterworkflow", "paketo-buildpacks-builder")
+	Expect(err).NotTo(HaveOccurred(),
+		"paketo-buildpacks-builder ClusterWorkflow not found; check the platform sample install")
+	_, err = framework.Kubectl(kubeContext, "get", "clusterworkflow", "ballerina-buildpack-builder")
+	Expect(err).NotTo(HaveOccurred(),
+		"ballerina-buildpack-builder ClusterWorkflow not found; check the platform sample install")
 })

--- a/test/e2e/suites/build/suite_test.go
+++ b/test/e2e/suites/build/suite_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EBuild(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo build e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E Build Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying cluster is accessible")
+	output, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, output)
+
+	By("verifying workflow plane is present (E2E_WITH_BUILD=true)")
+	_, err = framework.Kubectl(kubeContext, "get", "namespace", "openchoreo-workflow-plane")
+	Expect(err).NotTo(HaveOccurred(),
+		"workflow plane not installed; build suite requires E2E_WITH_BUILD=true")
+
+	_, err = framework.Kubectl(kubeContext, "get", "clusterworkflow", "dockerfile-builder")
+	Expect(err).NotTo(HaveOccurred(),
+		"dockerfile-builder ClusterWorkflow not found; check the platform sample install")
+})

--- a/test/e2e/suites/gitops/gitops_fixtures_test.go
+++ b/test/e2e/suites/gitops/gitops_fixtures_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+const (
+	clusterDataPlane   = "e2e-shared"
+	openChoreoAPIVer   = "openchoreo.dev/v1alpha1"
+	kubernetesAPIVerV1 = "v1"
+
+	projectName = "gitops-proj"
+	envDev      = "development"
+	envStaging  = "staging"
+
+	giteaNamespace = "e2e-gitea-gitops"
+	gitopsRepo     = "gitops-platform"
+
+	componentSingle = "echo-svc"
+	componentBulkA  = "bulk-a"
+	componentBulkB  = "bulk-b"
+	componentBulkC  = "bulk-c"
+
+	imageInitial = "hashicorp/http-echo:1.0.0"
+	imageUpdated = "hashicorp/http-echo:0.2.3"
+
+	releaseBindingSuffix = "-" + envDev
+)
+
+var (
+	gitopsRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+	cpNs        = fmt.Sprintf("e2e-gitops-%s", gitopsRunID)
+	fluxNs      = "flux-system"
+)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+func cpNamespaceYAML() string {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/control-plane": "true",
+			},
+		},
+	}
+	return mustYAMLDocs(ns)
+}
+
+// platformResourcesYAML renders the CP namespace's pipeline + environments +
+// project. Flux applies these (along with the per-spec components) but the
+// project + environments live in the same YAML tree so a single Kustomization
+// covers the lot.
+func platformResourcesYAML() string {
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "DeploymentPipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": "default"},
+		},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{{
+				SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: envDev},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{
+					{Name: envStaging},
+				},
+			}},
+		},
+	}
+	envs := []any{}
+	for _, name := range []string{envDev, envStaging} {
+		envs = append(envs, &openchoreov1alpha1.Environment{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: cpNs,
+				Labels:    map[string]string{"openchoreo.dev/name": name},
+			},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+					Name: clusterDataPlane,
+				},
+			},
+		})
+	}
+	proj := &openchoreov1alpha1.Project{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": projectName},
+		},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+		},
+	}
+	docs := []any{pipeline}
+	docs = append(docs, envs...)
+	docs = append(docs, proj)
+	return mustYAMLDocs(docs...)
+}
+
+// componentWithImageYAML builds a Component + Workload pair for a deployment-
+// style component, with the supplied image. Identical shape to the workloadtypes
+// suite so the two suites read alike — the components here are deliberately
+// thin so Flux is the interesting variable.
+func componentWithImageYAML(name, image, echoText string) string {
+	comp := &openchoreov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: projectName},
+			ComponentType: openchoreov1alpha1.ComponentTypeRef{
+				Kind: openchoreov1alpha1.ComponentTypeRefKindClusterComponentType,
+				Name: "deployment/service",
+			},
+			AutoDeploy: true,
+		},
+	}
+	workload := &openchoreov1alpha1.Workload{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Workload"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": name},
+		},
+		Spec: openchoreov1alpha1.WorkloadSpec{
+			Owner: openchoreov1alpha1.WorkloadOwner{
+				ProjectName:   projectName,
+				ComponentName: name,
+			},
+			WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
+				Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+					"http": {
+						Type:       openchoreov1alpha1.EndpointType("HTTP"),
+						Port:       8080,
+						Visibility: []openchoreov1alpha1.EndpointVisibility{"project"},
+					},
+				},
+				Container: openchoreov1alpha1.Container{
+					Image: image,
+					Args:  []string{"-listen=:8080", "-text=" + echoText},
+				},
+			},
+		},
+	}
+	return mustYAMLDocs(comp, workload)
+}

--- a/test/e2e/suites/gitops/gitops_test.go
+++ b/test/e2e/suites/gitops/gitops_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var _ = Describe("GitOps with Flux", Ordered, Label("tier3"), func() {
+	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
+	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
+
+	var dpNs string
+
+	BeforeAll(func() {
+		By("installing Flux")
+		Expect(framework.InstallFlux(kubeContext)).To(Succeed())
+
+		By("installing in-cluster Gitea")
+		Expect(framework.InstallGitea(kubeContext, giteaNamespace)).To(Succeed())
+
+		By("creating the gitops platform repo and seeding the CP namespace + platform doc")
+		Expect(framework.EnsureGiteaRepo(kubeContext, giteaNamespace, gitopsRepo)).To(Succeed())
+		Expect(framework.PushFile(kubeContext, giteaNamespace, gitopsRepo, "main",
+			"platform/namespace.yaml", []byte(cpNamespaceYAML()), "")).To(Succeed())
+		Expect(framework.PushFile(kubeContext, giteaNamespace, gitopsRepo, "main",
+			"platform/platform.yaml", []byte(platformResourcesYAML()), "")).To(Succeed())
+
+		By("applying the GitRepository pointing Flux at the in-cluster Gitea")
+		Expect(framework.ApplyGitRepository(kubeContext, fluxNs, gitopsRepo,
+			framework.GiteaRepoCloneURL(giteaNamespace, gitopsRepo), "main")).To(Succeed())
+
+		By("applying the platform Kustomization")
+		Expect(framework.ApplyKustomization(kubeContext, fluxNs, "platform",
+			gitopsRepo, "platform", "")).To(Succeed())
+		Expect(framework.WaitForKustomizationReady(kubeContext, fluxNs, "platform", 3*time.Minute)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+		_, _ = framework.Kubectl(kubeContext, "delete", "kustomization", "platform",
+			"-n", fluxNs, "--ignore-not-found", "--wait=false")
+		_, _ = framework.Kubectl(kubeContext, "delete", "kustomization", "echo-app",
+			"-n", fluxNs, "--ignore-not-found", "--wait=false")
+		_, _ = framework.Kubectl(kubeContext, "delete", "kustomization", "bulk",
+			"-n", fluxNs, "--ignore-not-found", "--wait=false")
+		_, _ = framework.Kubectl(kubeContext, "delete", "gitrepository", gitopsRepo,
+			"-n", fluxNs, "--ignore-not-found")
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
+			"--ignore-not-found", "--wait=false")
+		if dpNs != "" {
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+				"--ignore-not-found", "--wait=false")
+		}
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", giteaNamespace,
+			"--ignore-not-found", "--wait=false")
+	})
+
+	Context("single component lifecycle", func() {
+		It("flux-reconcile: push a Component + Workload, Flux reconciles it onto the cluster", func() {
+			By("pushing the echo-svc Component + Workload doc to Gitea")
+			Expect(framework.PushFile(kubeContext, giteaNamespace, gitopsRepo, "main",
+				"apps/echo-svc.yaml",
+				[]byte(componentWithImageYAML(componentSingle, imageInitial, "echo-initial")),
+				"")).To(Succeed())
+
+			By("applying the echo-app Kustomization")
+			Expect(framework.ApplyKustomization(kubeContext, fluxNs, "echo-app",
+				gitopsRepo, "apps", "")).To(Succeed())
+			Expect(framework.WaitForKustomizationReady(kubeContext, fluxNs, "echo-app", 3*time.Minute)).
+				To(Succeed())
+
+			By("Component appears in the CP namespace")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "component", componentSingle)
+			}, 2*time.Minute, 3*time.Second).Should(Succeed())
+
+			By("ReleaseBinding becomes Ready")
+			Eventually(func(g Gomega) {
+				framework.AssertReleaseBindingReady(g, kubeContext, cpNs, componentSingle+releaseBindingSuffix)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("discovering the data plane namespace")
+			Eventually(func() error {
+				var err error
+				dpNs, err = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+				return err
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("pod is Running with the initial image")
+			Eventually(func(g Gomega) {
+				framework.AssertPodsRunning(g, kubeContext, dpNs,
+					"openchoreo.dev/component="+componentSingle)
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("flux-update: push an image bump, Flux rolls the Deployment", func() {
+			Expect(dpNs).NotTo(BeEmpty(),
+				"flux-reconcile must run first to populate dpNs")
+
+			By("pushing an updated Workload (different image tag) to Gitea")
+			Expect(framework.PushFile(kubeContext, giteaNamespace, gitopsRepo, "main",
+				"apps/echo-svc.yaml",
+				[]byte(componentWithImageYAML(componentSingle, imageUpdated, "echo-updated")),
+				"e2e: bump echo-svc image")).To(Succeed())
+
+			By("rendered Deployment image updates to the new tag")
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(kubeContext,
+					"get", "deployment",
+					"-n", dpNs,
+					"-l", "openchoreo.dev/component="+componentSingle,
+					"-o", "jsonpath={.items[0].spec.template.spec.containers[0].image}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(Equal(imageUpdated),
+					"deployment image should equal the new tag, got %q", out)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("pod is Running on the new image")
+			Eventually(func(g Gomega) {
+				framework.AssertPodsRunning(g, kubeContext, dpNs,
+					"openchoreo.dev/component="+componentSingle)
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("bulk promote", func() {
+		It("bulk-promote: a single commit promotes multiple components into the env", func() {
+			By("pushing 3 bulk component docs to Gitea under apps/bulk/")
+			components := []string{componentBulkA, componentBulkB, componentBulkC}
+			for _, c := range components {
+				Expect(framework.PushFile(kubeContext, giteaNamespace, gitopsRepo, "main",
+					fmt.Sprintf("apps-bulk/%s.yaml", c),
+					[]byte(componentWithImageYAML(c, imageInitial, c)),
+					"e2e: add bulk components")).To(Succeed())
+			}
+
+			By("applying the bulk Kustomization")
+			Expect(framework.ApplyKustomization(kubeContext, fluxNs, "bulk",
+				gitopsRepo, "apps-bulk", "")).To(Succeed())
+			Expect(framework.WaitForKustomizationReady(kubeContext, fluxNs, "bulk", 3*time.Minute)).
+				To(Succeed())
+
+			By("all 3 ReleaseBindings reach Ready")
+			for _, c := range components {
+				rb := c + releaseBindingSuffix
+				Eventually(func(g Gomega) {
+					framework.AssertReleaseBindingReady(g, kubeContext, cpNs, rb)
+				}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+					"ReleaseBinding %s did not reach Ready", rb)
+			}
+
+			By("all 3 component pods are Running")
+			for _, c := range components {
+				Eventually(func(g Gomega) {
+					framework.AssertPodsRunning(g, kubeContext, dpNs,
+						"openchoreo.dev/component="+c)
+				}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+					"pods for component %s never reached Running", c)
+			}
+		})
+	})
+})

--- a/test/e2e/suites/gitops/suite_test.go
+++ b/test/e2e/suites/gitops/suite_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EGitOps(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo gitops e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E GitOps Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying cluster is accessible")
+	output, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, output)
+})


### PR DESCRIPTION
## Purpose
This PR adds Tier 3 end-to-end coverage from the discussion: https://github.com/openchoreo/openchoreo/discussions/3509 for the build-from-source and GitOps workflows, plus the shared framework helpers (Gitea, Flux, workflow assertions) and workflow-plane template wiring they depend on. A weekly extended CI workflow runs the new `tier3`-labeled specs with build and observability features enabled.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
The extended workflow sets `E2E_WITH_OBSERVABILITY=true` so the sibling Tier 3 observability-plane PR drops in with no workflow edits.