### PR TITLE
fix: include remoteRef content in ExternalSecret resource name hash

### DIFF
--- a/internal/dataplane/kubernetes/name.go
+++ b/internal/dataplane/kubernetes/name.go
@@ -41,6 +41,18 @@ func GenerateK8sName(names ...string) string {
 // This is useful when the name must be within a specific length limit, that is different from the default limit.
 // Example: CronJob names must be within 52 characters.
 func GenerateK8sNameWithLengthLimit(limit int, names ...string) string {
+	return generateK8sName(limit, "", names)
+}
+
+// GenerateK8sNameWithExtraHashInput generates a Kubernetes-compliant name like
+// GenerateK8sNameWithLengthLimit, but includes extraHashInput in the SHA-256
+// hash computation without adding it to the visible base name. Use this when
+// a value must influence uniqueness but should not appear in the resource name.
+func GenerateK8sNameWithExtraHashInput(limit int, extraHashInput string, names ...string) string {
+	return generateK8sName(limit, extraHashInput, names)
+}
+
+func generateK8sName(limit int, extraHashInput string, names []string) string {
 	// Clean and sanitize each name part
 	cleanedNames := make([]string, 0, len(names))
 	for _, name := range names {
@@ -49,8 +61,11 @@ func GenerateK8sNameWithLengthLimit(limit int, names ...string) string {
 	}
 
 	// Generate a hash from the full original concatenated names for uniqueness
-	fullName := strings.Join(names, separator)
-	hashBytes := sha256.Sum256([]byte(fullName))
+	hashInput := strings.Join(names, separator)
+	if extraHashInput != "" {
+		hashInput += separator + extraHashInput
+	}
+	hashBytes := sha256.Sum256([]byte(hashInput))
 	hashString := hex.EncodeToString(hashBytes[:])[:hashLength]
 
 	// Calculate the maximum allowed length for the base name

--- a/internal/pipeline/component/context/cel_extensions_test.go
+++ b/internal/pipeline/component/context/cel_extensions_test.go
@@ -190,7 +190,7 @@ func TestConfigurationsToSecretFileListMacro(t *testing.T) {
 			want: []any{
 				map[string]any{
 					"name": "secret.yaml", "mountPath": "/etc/secret.yaml",
-					"resourceName": generateSecretResourceName("app-dev", "secret.yaml"),
+					"resourceName": generateSecretResourceName("app-dev", "secret.yaml", &RemoteRefData{Key: "my-secret", Property: "password"}),
 					"remoteRef":    map[string]any{"key": "my-secret", "property": "password"},
 				},
 			},
@@ -207,7 +207,7 @@ func TestConfigurationsToSecretFileListMacro(t *testing.T) {
 				Secrets: ConfigurationItems{Files: []FileConfiguration{{Name: "secret.yaml", MountPath: "/s", RemoteRef: &RemoteRefData{Key: "k"}}}},
 			}),
 			want: []any{
-				map[string]any{"name": "secret.yaml", "mountPath": "/s", "resourceName": generateSecretResourceName("app-dev", "secret.yaml"), "remoteRef": map[string]any{"key": "k"}},
+				map[string]any{"name": "secret.yaml", "mountPath": "/s", "resourceName": generateSecretResourceName("app-dev", "secret.yaml", &RemoteRefData{Key: "k"}), "remoteRef": map[string]any{"key": "k"}},
 			},
 		},
 	}
@@ -241,8 +241,8 @@ func TestContainerConfigEnvFromMacro(t *testing.T) {
 				Secrets: ConfigurationItems{Envs: []EnvConfiguration{{Name: "API_KEY", RemoteRef: &RemoteRefData{Key: "api-secret", Property: "key"}}}},
 			}),
 			want: []any{
-				map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
-				map[string]any{"secretRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-secrets")}},
+				map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev")}},
+				map[string]any{"secretRef": map[string]any{"name": generateSecretEnvResourceName("app-dev", []EnvConfiguration{{Name: "API_KEY", RemoteRef: &RemoteRefData{Key: "api-secret", Property: "key"}}})}},
 			},
 		},
 		{
@@ -251,7 +251,7 @@ func TestContainerConfigEnvFromMacro(t *testing.T) {
 				Configs: ConfigurationItems{Envs: []EnvConfiguration{{Name: "DEBUG", Value: "true"}}},
 			}),
 			want: []any{
-				map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev", "env-configs")}},
+				map[string]any{"configMapRef": map[string]any{"name": generateEnvResourceName("app-dev")}},
 			},
 		},
 		{
@@ -313,7 +313,10 @@ func TestEnvFromCanBeUsedWithCELOperations(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := []any{generateEnvResourceName("app-dev", "env-configs"), generateEnvResourceName("app-dev", "env-secrets")}
+		want := []any{
+			generateEnvResourceName("app-dev"),
+			generateSecretEnvResourceName("app-dev", []EnvConfiguration{{Name: "S1", RemoteRef: &RemoteRefData{Key: "s", Property: "k"}}}),
+		}
 		if diff := cmp.Diff(want, result); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
@@ -380,7 +383,7 @@ func TestConfigurationsToVolumesMacro(t *testing.T) {
 			}),
 			want: []any{
 				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/config", "app.properties"), "configMap": map[string]any{"name": generateConfigResourceName("app-dev", "app.properties")}},
-				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/tls", "tls.crt"), "secret": map[string]any{"secretName": generateSecretResourceName("app-dev", "tls.crt")}},
+				map[string]any{"name": "file-mount-" + generateVolumeHash("/etc/tls", "tls.crt"), "secret": map[string]any{"secretName": generateSecretResourceName("app-dev", "tls.crt", &RemoteRefData{Key: "tls"})}},
 			},
 		},
 		{
@@ -447,7 +450,7 @@ func TestConfigurationsToConfigEnvsByContainerMacro(t *testing.T) {
 			}),
 			want: []any{
 				map[string]any{
-					"resourceName": generateEnvResourceName("app-dev", "env-configs"),
+					"resourceName": generateEnvResourceName("app-dev"),
 					"envs": []any{
 						map[string]any{"name": "LOG_LEVEL", "value": "info"},
 						map[string]any{"name": "DEBUG_MODE", "value": "true"},
@@ -498,7 +501,7 @@ func TestConfigurationsToSecretEnvsByContainerMacro(t *testing.T) {
 			}),
 			want: []any{
 				map[string]any{
-					"resourceName": generateEnvResourceName("app-dev", "env-secrets"),
+					"resourceName": generateSecretEnvResourceName("app-dev", []EnvConfiguration{{Name: "DB_PASSWORD", RemoteRef: &RemoteRefData{Key: "db-password", Property: "password"}}}),
 					"envs": []any{
 						map[string]any{"name": "DB_PASSWORD", "value": "", "remoteRef": map[string]any{"key": "db-password", "property": "password"}},
 					},

--- a/internal/pipeline/component/context/cel_integration_test.go
+++ b/internal/pipeline/component/context/cel_integration_test.go
@@ -124,8 +124,8 @@ func TestCELMacroIntegration(t *testing.T) {
 	loggingVolName := "file-mount-" + generateVolumeHash("/etc/config", "logging.properties")
 	appYamlConfigRes := generateConfigResourceName(prefix, "app.yaml")
 	loggingConfigRes := generateConfigResourceName(prefix, "logging.properties")
-	envConfigsRes := generateEnvResourceName(prefix, "env-configs")
-	envSecretsRes := generateEnvResourceName(prefix, "env-secrets")
+	envConfigsRes := generateEnvResourceName(prefix)
+	envSecretsRes := generateSecretEnvResourceName(prefix, []EnvConfiguration{{Name: "DB_PASSWORD", RemoteRef: &RemoteRefData{Key: "db/password", Property: "value"}}})
 
 	// buildVolumes sorts output by volume name; compute the sorted order.
 	type volInfo struct {

--- a/internal/pipeline/component/context/derived.go
+++ b/internal/pipeline/component/context/derived.go
@@ -81,7 +81,7 @@ func buildSecretFileList(cc ContainerConfigurations, prefix string) []SecretFile
 		result[i] = SecretFileListEntry{
 			Name:         f.Name,
 			MountPath:    f.MountPath,
-			ResourceName: generateSecretResourceName(prefix, f.Name),
+			ResourceName: generateSecretResourceName(prefix, f.Name, f.RemoteRef),
 			RemoteRef:    f.RemoteRef,
 		}
 	}
@@ -92,12 +92,12 @@ func buildEnvFrom(cc ContainerConfigurations, prefix string) []EnvFromEntry {
 	result := make([]EnvFromEntry, 0, 2)
 	if len(cc.Configs.Envs) > 0 {
 		result = append(result, EnvFromEntry{
-			ConfigMapRef: &NameRef{Name: generateEnvResourceName(prefix, "env-configs")},
+			ConfigMapRef: &NameRef{Name: generateEnvResourceName(prefix)},
 		})
 	}
 	if len(cc.Secrets.Envs) > 0 {
 		result = append(result, EnvFromEntry{
-			SecretRef: &NameRef{Name: generateEnvResourceName(prefix, "env-secrets")},
+			SecretRef: &NameRef{Name: generateSecretEnvResourceName(prefix, cc.Secrets.Envs)},
 		})
 	}
 	return result
@@ -135,7 +135,7 @@ func buildVolumes(cc ContainerConfigurations, prefix string) []VolumeEntry {
 		name := "file-mount-" + generateVolumeHash(f.MountPath, f.Name)
 		byName[name] = VolumeEntry{
 			Name:   name,
-			Secret: &SecretVolume{SecretName: generateSecretResourceName(prefix, f.Name)},
+			Secret: &SecretVolume{SecretName: generateSecretResourceName(prefix, f.Name, f.RemoteRef)},
 		}
 	}
 
@@ -157,7 +157,7 @@ func buildConfigEnvs(cc ContainerConfigurations, prefix string) []EnvsByContaine
 		return []EnvsByContainerEntry{}
 	}
 	return []EnvsByContainerEntry{{
-		ResourceName: generateEnvResourceName(prefix, "env-configs"),
+		ResourceName: generateEnvResourceName(prefix),
 		Envs:         cc.Configs.Envs,
 	}}
 }
@@ -167,7 +167,7 @@ func buildSecretEnvs(cc ContainerConfigurations, prefix string) []EnvsByContaine
 		return []EnvsByContainerEntry{}
 	}
 	return []EnvsByContainerEntry{{
-		ResourceName: generateEnvResourceName(prefix, "env-secrets"),
+		ResourceName: generateSecretEnvResourceName(prefix, cc.Secrets.Envs),
 		Envs:         cc.Secrets.Envs,
 	}}
 }
@@ -296,20 +296,60 @@ func generateConfigResourceName(prefix, filename string) string {
 	)
 }
 
-func generateSecretResourceName(prefix, filename string) string {
-	return kubernetes.GenerateK8sNameWithLengthLimit(
+// generateSecretResourceName generates a resource name for a secret file.
+// The remoteRef content is included in the hash computation so that a change
+// in secret reference produces a new ExternalSecret (and K8s Secret),
+// preventing pods from reading stale values.
+func generateSecretResourceName(prefix, filename string, remoteRef *RemoteRefData) string {
+	return kubernetes.GenerateK8sNameWithExtraHashInput(
 		kubernetes.MaxResourceNameLength,
+		remoteRefContentHash(remoteRef),
 		prefix,
 		"secret",
 		strings.ReplaceAll(filename, ".", "-"),
 	)
 }
 
-func generateEnvResourceName(prefix, suffix string) string {
+// generateSecretEnvResourceName generates a resource name for secret env resources.
+// The remoteRef content from all env entries is included in the hash computation
+// so that a change in secret references produces a new ExternalSecret.
+func generateSecretEnvResourceName(prefix string, envs []EnvConfiguration) string {
+	return kubernetes.GenerateK8sNameWithExtraHashInput(
+		kubernetes.MaxResourceNameLength,
+		secretEnvsContentHash(envs),
+		prefix,
+		"env-secrets",
+	)
+}
+
+func remoteRefContentHash(ref *RemoteRefData) string {
+	if ref == nil {
+		return ""
+	}
+	h := fnv.New32a()
+	fmt.Fprintf(h, "%s\x00%s\x00%s", ref.Key, ref.Property, ref.Version)
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+func secretEnvsContentHash(envs []EnvConfiguration) string {
+	if len(envs) == 0 {
+		return ""
+	}
+	h := fnv.New32a()
+	for _, env := range envs {
+		if env.RemoteRef == nil {
+			continue
+		}
+		fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00", env.Name, env.RemoteRef.Key, env.RemoteRef.Property, env.RemoteRef.Version)
+	}
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+func generateEnvResourceName(prefix string) string {
 	return kubernetes.GenerateK8sNameWithLengthLimit(
 		kubernetes.MaxResourceNameLength,
 		prefix,
-		suffix,
+		"env-configs",
 	)
 }
 

--- a/internal/pipeline/component/testdata/configurations-and-secrets/expected-resources-with-config-helpers.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/expected-resources-with-config-helpers.yaml
@@ -75,7 +75,7 @@
               - configMapRef:
                   name: test-app-dev-env-configs-6f21fc92
               - secretRef:
-                  name: test-app-dev-env-secrets-8271181d
+                  name: test-app-dev-env-secrets-757009dd
             volumeMounts:
               - name: file-mount-6c698306
                 mountPath: /etc/config/config.json
@@ -98,14 +98,14 @@
               name: test-app-dev-config-app-properties-ac691794
           - name: file-mount-9b2ef275
             secret:
-              secretName: test-app-dev-secret-tls-crt-82109527
+              secretName: test-app-dev-secret-tls-crt-1381e562
           - name: file-mount-5953ef7b
             secret:
-              secretName: test-app-dev-secret-application-yaml-b333f692
+              secretName: test-app-dev-secret-application-yaml-07d48de3
 - apiVersion: external-secrets.io/v1
   kind: ExternalSecret
   metadata:
-    name: test-app-dev-env-secrets-8271181d
+    name: test-app-dev-env-secrets-757009dd
     namespace: test-namespace
     labels:
       openchoreo.dev/component: test-app
@@ -121,7 +121,7 @@
       name: dev-vault-store
       kind: ClusterSecretStore
     target:
-      name: test-app-dev-env-secrets-8271181d
+      name: test-app-dev-env-secrets-757009dd
       creationPolicy: Owner
     data:
       - secretKey: DB_PASSWORD
@@ -135,7 +135,7 @@
 - apiVersion: external-secrets.io/v1
   kind: ExternalSecret
   metadata:
-    name: test-app-dev-secret-application-yaml-b333f692
+    name: test-app-dev-secret-application-yaml-07d48de3
     namespace: test-namespace
     labels:
       openchoreo.dev/component: test-app
@@ -151,7 +151,7 @@
       name: dev-vault-store
       kind: ClusterSecretStore
     target:
-      name: test-app-dev-secret-application-yaml-b333f692
+      name: test-app-dev-secret-application-yaml-07d48de3
       creationPolicy: Owner
     data:
       - secretKey: application.yaml
@@ -161,7 +161,7 @@
 - apiVersion: external-secrets.io/v1
   kind: ExternalSecret
   metadata:
-    name: test-app-dev-secret-tls-crt-82109527
+    name: test-app-dev-secret-tls-crt-1381e562
     namespace: test-namespace
     labels:
       openchoreo.dev/component: test-app
@@ -177,7 +177,7 @@
       name: dev-vault-store
       kind: ClusterSecretStore
     target:
-      name: test-app-dev-secret-tls-crt-82109527
+      name: test-app-dev-secret-tls-crt-1381e562
       creationPolicy: Owner
     data:
       - secretKey: tls.crt


### PR DESCRIPTION
## Purpose
closes https://github.com/openchoreo/openchoreo/issues/3608
When a SecretReference remoteRef is updated, the ExternalSecret was modified in place because its name was derived only from metadata. The dp-resource-hash triggered a rollout, but pods could start before ESO synced the new secret value.



## Approach
Include remoteRef fields (key, property, version) in the SHA-256 hash computation via GenerateK8sNameWithExtraHashInput. A change in remoteRef now produces a different resource name, creating a new ExternalSecret and K8s Secret. Pods referencing the new Secret block in ContainerCreating until ESO syncs, naturally gating the rollout.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Kubernetes secret and configuration resource naming to incorporate additional context for improved uniqueness and consistency.

* **Tests**
  * Updated test cases and fixtures to reflect changes in secret, config, volume, and environment variable resource naming behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/openchoreo/pull/3610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->