### PR TITLE
test: add e2e test suite for occ CLI

### DIFF
--- a/.github/workflows/test-e2e-extended.yml
+++ b/.github/workflows/test-e2e-extended.yml
@@ -69,6 +69,9 @@ jobs:
               ;;
           esac
 
+      - name: Add e2e host entries
+        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
+
       - name: Run extended e2e tests (tier 3)
         run: |
           make e2e \

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -59,6 +59,9 @@ jobs:
           echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
           sudo install /tmp/yq /usr/local/bin/yq
 
+      - name: Add e2e host entries
+        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
+
       - name: Run e2e tests
         run: |
           make e2e \

--- a/test/e2e/framework/gateway.go
+++ b/test/e2e/framework/gateway.go
@@ -4,9 +4,15 @@
 package framework
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	"github.com/onsi/gomega"
 )
 
@@ -57,4 +63,59 @@ func GetHTTPRouteNames(kubeContext, namespace, labelSelector string) ([]string, 
 		return nil, nil
 	}
 	return strings.Fields(trimmed), nil
+}
+
+// WaitForHTTP polls a URL until it returns HTTP 200 or the timeout expires.
+// Use this to verify that a service is reachable through the external gateway
+// before running tests that depend on it.
+func WaitForHTTP(targetURL string, timeout time.Duration) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(targetURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				fmt.Fprintf(GinkgoWriter, "gateway ready: %s\n", targetURL)
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	Fail(fmt.Sprintf("gateway not reachable at %s within %s", targetURL, timeout))
+}
+
+// FetchClientCredentialsToken obtains an access token via the OAuth2
+// client_credentials grant from the given token endpoint.
+func FetchClientCredentialsToken(tokenEndpoint, clientID, clientSecret string) (string, error) {
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", clientID)
+	data.Set("client_secret", clientSecret)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Post(tokenEndpoint, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("token request to %s failed: %w", tokenEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read token response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("missing access_token in token response: %s", string(body))
+	}
+	return tokenResp.AccessToken, nil
 }

--- a/test/e2e/framework/occ.go
+++ b/test/e2e/framework/occ.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+)
+
+type OCCRunner struct {
+	BinaryPath string   // Path to compiled occ binary
+	HomeDir    string   // Isolated $HOME directory for occ config files
+	APIServer  string   // Base URL of the openchoreo-api (e.g., "http://localhost:12345")
+	Env        []string // Additional environment variables (KEY=VALUE format)
+}
+
+// NewOCCRunner creates an isolated occ runner for e2e tests.
+func NewOCCRunner(apiServer string) (*OCCRunner, error) {
+	tempDir, err := os.MkdirTemp("", "openchoreo-occ-e2e-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create occ temp dir: %w", err)
+	}
+
+	homeDir := filepath.Join(tempDir, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("failed to create occ home dir: %w", err)
+	}
+
+	return &OCCRunner{
+		BinaryPath: filepath.Join(tempDir, "occ"),
+		HomeDir:    homeDir,
+		APIServer:  apiServer,
+	}, nil
+}
+
+// Build compiles the occ CLI binary into the runner's temp directory.
+func (r *OCCRunner) Build() error {
+	repoRoot, err := RepoRoot()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	args := []string{"build", "-o", r.BinaryPath, "./cmd/occ/"}
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = repoRoot
+	fmt.Fprintf(GinkgoWriter, "running: go %s\n", strings.Join(args, " "))
+
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if output != "" {
+		fmt.Fprintf(GinkgoWriter, "output:\n%s\n", output)
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("go build timed out after 5m")
+	}
+	if err != nil {
+		return fmt.Errorf("go %s failed: %w\n%s", strings.Join(args, " "), err, output)
+	}
+	return nil
+}
+
+// Run executes occ with an isolated HOME and returns trimmed stdout and stderr.
+func (r *OCCRunner) Run(args ...string) (stdout string, stderr string, err error) {
+	return r.RunWithEnv(nil, args...)
+}
+
+// RunWithEnv executes occ with additional per-call environment variables.
+// Extra env vars are appended last so they can override inherited values.
+func (r *OCCRunner) RunWithEnv(extraEnv []string, args ...string) (stdout string, stderr string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, r.BinaryPath, args...)
+	// GODEBUG=netdns=go forces the pure-Go DNS resolver, bypassing macOS mDNS
+	// which adds a 5s timeout per request for .local domains.
+	cmd.Env = append(os.Environ(), "HOME="+r.HomeDir, "GODEBUG=netdns=go")
+	cmd.Env = append(cmd.Env, r.Env...)
+	cmd.Env = append(cmd.Env, extraEnv...)
+
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+	cmd.Stderr = &stderrBuffer
+
+	fmt.Fprintf(GinkgoWriter, "running: %s %s\n", r.BinaryPath, strings.Join(args, " "))
+	err = cmd.Run()
+
+	stdout = strings.TrimSpace(stdoutBuffer.String())
+	stderr = strings.TrimSpace(stderrBuffer.String())
+	if stdout != "" {
+		fmt.Fprintf(GinkgoWriter, "stdout:\n%s\n", stdout)
+	}
+	if stderr != "" {
+		fmt.Fprintf(GinkgoWriter, "stderr:\n%s\n", stderr)
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		err = ctx.Err()
+	}
+	if err != nil {
+		return stdout, stderr, fmt.Errorf("occ %s failed: %w\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout, stderr, nil
+}
+
+// SeedConfig writes an occ config file into the runner's isolated HOME.
+func (r *OCCRunner) SeedConfig(token string) error {
+	configDir := filepath.Join(r.HomeDir, ".openchoreo")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create occ config dir: %w", err)
+	}
+
+	config := fmt.Sprintf(`currentContext: e2e
+controlplanes:
+  - name: e2e
+    url: %s
+credentials:
+  - name: e2e-creds
+    clientId: customer-portal-client
+    clientSecret: supersecret
+    token: %s
+    authMethod: client_credentials
+contexts:
+  - name: e2e
+    controlplane: e2e
+    credentials: e2e-creds
+`, r.APIServer, token)
+
+	configPath := filepath.Join(configDir, "config")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		return fmt.Errorf("failed to write occ config: %w", err)
+	}
+	return nil
+}
+
+// WriteFixtureFile writes YAML content to a unique fixture file for occ apply.
+func (r *OCCRunner) WriteFixtureFile(content string) (string, error) {
+	fixturesDir := filepath.Join(r.HomeDir, "fixtures")
+	if err := os.MkdirAll(fixturesDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create occ fixtures dir: %w", err)
+	}
+
+	fixturePath := filepath.Join(fixturesDir, fmt.Sprintf("fixture-%d.yaml", time.Now().UnixNano()))
+	if err := os.WriteFile(fixturePath, []byte(content), 0o600); err != nil {
+		return "", fmt.Errorf("failed to write occ fixture file: %w", err)
+	}
+	return fixturePath, nil
+}
+
+// Cleanup removes the runner's temp directory containing the binary and HOME.
+func (r *OCCRunner) Cleanup() {
+	if r == nil || r.BinaryPath == "" {
+		return
+	}
+	_ = os.RemoveAll(filepath.Dir(r.BinaryPath))
+}

--- a/test/e2e/framework/portforward.go
+++ b/test/e2e/framework/portforward.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+)
+
+// PortForward manages a kubectl port-forward background process.
+type PortForward struct {
+	KubeContext string
+	Namespace   string
+	Service     string
+	LocalPort   int
+	RemotePort  int
+	cmd         *exec.Cmd
+}
+
+// Start begins port-forwarding in the background and waits until the port is
+// accepting connections (or 15 s elapse).
+func (pf *PortForward) Start() error {
+	args := []string{
+		"--context", pf.KubeContext,
+		"port-forward",
+		"-n", pf.Namespace,
+		fmt.Sprintf("svc/%s", pf.Service),
+		fmt.Sprintf("%d:%d", pf.LocalPort, pf.RemotePort),
+	}
+
+	pf.cmd = exec.Command("kubectl", args...)
+	fmt.Fprintf(GinkgoWriter, "starting: kubectl %s\n", strings.Join(args, " "))
+
+	stderr, err := pf.cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("port-forward stderr pipe: %w", err)
+	}
+
+	if err := pf.cmd.Start(); err != nil {
+		return fmt.Errorf("port-forward start: %w", err)
+	}
+
+	// Drain stderr in background so the process doesn't block.
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			fmt.Fprintf(GinkgoWriter, "port-forward[%s/%s]: %s\n", pf.Namespace, pf.Service, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(GinkgoWriter, "port-forward[%s/%s] stderr read error: %v\n", pf.Namespace, pf.Service, err)
+		}
+	}()
+
+	// Poll until the local port accepts TCP connections.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, dialErr := net.DialTimeout("tcp", pf.LocalAddress(), 500*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			fmt.Fprintf(GinkgoWriter, "port-forward ready: %s → %s/%s:%d\n",
+				pf.LocalAddress(), pf.Namespace, pf.Service, pf.RemotePort)
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	pf.Stop()
+	return fmt.Errorf("port-forward to %s/%s:%d did not become ready within 15s", pf.Namespace, pf.Service, pf.RemotePort)
+}
+
+// Stop terminates the port-forward process.
+func (pf *PortForward) Stop() {
+	if pf.cmd != nil && pf.cmd.Process != nil {
+		_ = pf.cmd.Process.Kill()
+		_ = pf.cmd.Wait()
+		fmt.Fprintf(GinkgoWriter, "port-forward stopped: %s\n", pf.LocalAddress())
+	}
+}
+
+// LocalAddress returns "localhost:<LocalPort>".
+func (pf *PortForward) LocalAddress() string {
+	return fmt.Sprintf("localhost:%d", pf.LocalPort)
+}

--- a/test/e2e/k3d/values-cp.yaml
+++ b/test/e2e/k3d/values-cp.yaml
@@ -29,3 +29,7 @@ gateway:
   httpsPort: 8443
   tls:
     enabled: false
+
+features:
+  secretManagement:
+    enabled: true

--- a/test/e2e/suites/occ/occ_apply_test.go
+++ b/test/e2e/suites/occ/occ_apply_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+func describeApply() {
+	Context("apply platform resources", Ordered, func() {
+		It("creates the control-plane namespace via kubectl", func() {
+			out, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
+			Expect(err).NotTo(HaveOccurred(), "kubectl apply namespace failed: %s", out)
+
+			By("verifying namespace exists via kubectl")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, "", "namespace", cpNs)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying occ can see the namespace")
+			Eventually(func(g Gomega) {
+				stdout, _, err := occ.Run("namespace", "get", cpNs)
+				g.Expect(err).NotTo(HaveOccurred(), "occ namespace get failed")
+				g.Expect(stdout).To(ContainSubstring(cpNs))
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("creates project, pipeline, and environments via occ apply", func() {
+			stdout, _, err := occApply(platformResourcesYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply platform resources failed")
+			expectApplySucceeded(stdout)
+
+			By("verifying project exists via kubectl")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "project", projectName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying deployment pipeline exists via kubectl")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "deploymentpipeline", "default")
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying environments exist via kubectl")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "environment", envDev)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "environment", envStaging)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("apply user resources", Ordered, func() {
+		It("creates component and workload via occ apply", func() {
+			stdout, _, err := occApply(componentWithWorkloadYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply component+workload failed")
+			expectApplySucceeded(stdout)
+
+			By("verifying component exists via kubectl")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "component", componentName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying ComponentRelease is created (release chain triggered)")
+			Eventually(func(g Gomega) {
+				out, err := framework.KubectlGet(kubeContext, cpNs, "componentrelease",
+					"-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				found := false
+				for _, name := range strings.Fields(out) {
+					if strings.HasPrefix(name, componentName+"-") {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "no ComponentRelease found for component %s", componentName)
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("updates existing workload via occ apply", func() {
+			stdout, _, err := occApply(workloadUpdatedYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply workload update failed")
+			expectApplySucceeded(stdout)
+
+			By("verifying workload has the updated label")
+			Eventually(func(g Gomega) {
+				val, err := framework.KubectlGetJsonpath(kubeContext, cpNs,
+					"workload", componentName, `{.metadata.labels.e2e-updated}`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(val).To(Equal("true"), "expected e2e-updated=true label on workload")
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("apply additional resources", Ordered, func() {
+		It("creates ClusterAuthzRole via occ apply", func() {
+			stdout, _, err := occApply(clusterAuthzRoleYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply ClusterAuthzRole failed")
+			expectApplySucceeded(stdout)
+
+			Eventually(func(g Gomega) {
+				framework.AssertClusterResourceExists(g, kubeContext, "clusterauthzrole", clusterAuthzRoleName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("creates AuthzRole and AuthzRoleBinding via occ apply", func() {
+			stdout, _, err := occApply(authzRoleWithBindingYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply AuthzRole+AuthzRoleBinding failed")
+			expectApplySucceeded(stdout)
+
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "authzrole", authzRoleName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "authzrolebinding", authzRoleBindingName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("creates SecretReference via occ apply", func() {
+			stdout, _, err := occApply(secretReferenceYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply SecretReference failed")
+			expectApplySucceeded(stdout)
+
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs, "secretreference", secretRefName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("creates ObservabilityAlertsNotificationChannel via occ apply", func() {
+			stdout, _, err := occApply(oancWebhookYAML())
+			Expect(err).NotTo(HaveOccurred(), "occ apply OANC failed")
+			expectApplySucceeded(stdout)
+
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, cpNs,
+					"observabilityalertsnotificationchannel", oancName)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+		})
+	})
+}

--- a/test/e2e/suites/occ/occ_commands_test.go
+++ b/test/e2e/suites/occ/occ_commands_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+func describeResourceCommands() {
+	Context("resource list and get", func() {
+		It("lists projects in namespace", func() {
+			stdout, _, err := occ.Run("project", "list", "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ project list failed")
+			Expect(stdout).To(ContainSubstring(projectName),
+				"expected project %q in list output", projectName)
+		})
+
+		It("gets specific project", func() {
+			stdout, _, err := occ.Run("project", "get", projectName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ project get failed")
+			Expect(stdout).To(ContainSubstring(projectName),
+				"expected project name in get output")
+		})
+
+		It("lists components in namespace", func() {
+			stdout, _, err := occ.Run("component", "list", "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ component list failed")
+			Expect(stdout).To(ContainSubstring(componentName),
+				"expected component %q in list output", componentName)
+		})
+
+		It("gets specific component", func() {
+			stdout, _, err := occ.Run("component", "get", componentName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ component get failed")
+			Expect(stdout).To(ContainSubstring(componentName),
+				"expected component name in get output")
+		})
+
+		It("lists release bindings in namespace", func() {
+			Eventually(func(g Gomega) {
+				stdout, _, err := occ.Run("releasebinding", "list", "-n", cpNs)
+				g.Expect(err).NotTo(HaveOccurred(), "occ releasebinding list failed")
+				g.Expect(stdout).To(ContainSubstring(componentName),
+					"expected component name in releasebinding list output")
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		DescribeTable("cluster-scoped list and get",
+			func(resource, getName string) {
+				By(fmt.Sprintf("listing %s", resource))
+				_, _, err := occ.Run(resource, "list")
+				Expect(err).NotTo(HaveOccurred(), "occ %s list failed", resource)
+
+				By(fmt.Sprintf("getting %s/%s", resource, getName))
+				stdout, _, err := occ.Run(resource, "get", getName)
+				Expect(err).NotTo(HaveOccurred(), "occ %s get %s failed", resource, getName)
+				Expect(stdout).To(ContainSubstring(getName))
+			},
+			Entry("namespace", "namespace", cpNs),
+			Entry("clustercomponenttype", "clustercomponenttype", "service"),
+			Entry("clustertrait", "clustertrait", "observability-alert-rule"),
+			Entry("clusterdataplane", "clusterdataplane", "default"),
+			Entry("clusterauthzrole", "clusterauthzrole", clusterAuthzRoleName),
+			Entry("clusterauthzrolebinding", "clusterauthzrolebinding", clusterAuthzBindingName),
+			Entry("clusterworkflow", "clusterworkflow", "dockerfile-builder"),
+		)
+
+		DescribeTable("namespace-scoped list and get",
+			func(resource, ns, getName string) {
+				By(fmt.Sprintf("listing %s in %s", resource, ns))
+				_, _, err := occ.Run(resource, "list", "-n", ns)
+				Expect(err).NotTo(HaveOccurred(), "occ %s list failed", resource)
+
+				By(fmt.Sprintf("getting %s/%s in %s", resource, getName, ns))
+				stdout, _, err := occ.Run(resource, "get", getName, "-n", ns)
+				Expect(err).NotTo(HaveOccurred(), "occ %s get %s failed", resource, getName)
+				Expect(stdout).To(ContainSubstring(getName))
+			},
+			Entry("project (default ns)", "project", "default", "default"),
+			Entry("deploymentpipeline (default ns)", "deploymentpipeline", "default", "default"),
+			Entry("environment (default ns)", "environment", "default", "development"),
+			Entry("component", "component", cpNs, componentName),
+			Entry("workload", "workload", cpNs, componentName),
+			Entry("authzrole", "authzrole", cpNs, authzRoleName),
+			Entry("authzrolebinding", "authzrolebinding", cpNs, authzRoleBindingName),
+			Entry("secretreference", "secretreference", cpNs, secretRefName),
+		)
+
+		DescribeTable("list-only (empty or no instances)",
+			func(resource string, args ...string) {
+				allArgs := append([]string{resource, "list"}, args...)
+				_, _, err := occ.Run(allArgs...)
+				Expect(err).NotTo(HaveOccurred(),
+					"occ %s list should succeed even with no resources", resource)
+			},
+			Entry("clusterworkflowplane", "clusterworkflowplane"),
+			Entry("clusterobservabilityplane", "clusterobservabilityplane"),
+			Entry("clusterresourcetype", "clusterresourcetype"),
+			Entry("componenttype", "componenttype", "-n", cpNs),
+			Entry("trait", "trait", "-n", cpNs),
+			Entry("dataplane", "dataplane", "-n", cpNs),
+			Entry("workflowplane", "workflowplane", "-n", cpNs),
+			Entry("observabilityplane", "observabilityplane", "-n", cpNs),
+			Entry("workflow", "workflow", "-n", cpNs),
+			Entry("workflowrun", "workflowrun", "-n", cpNs),
+			Entry("secret", "secret", "-n", cpNs),
+			Entry("resource", "resource", "-n", cpNs),
+			Entry("resourcerelease", "resourcerelease", "-n", cpNs),
+			Entry("resourcereleasebinding", "resourcereleasebinding", "-n", cpNs),
+			Entry("resourcetype", "resourcetype", "-n", cpNs),
+			Entry("observabilityalertsnotificationchannel",
+				"observabilityalertsnotificationchannel", "-n", cpNs),
+		)
+	})
+}

--- a/test/e2e/suites/occ/occ_config_test.go
+++ b/test/e2e/suites/occ/occ_config_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+func describeConfigCommands() {
+	Context("config commands", func() {
+		Context("controlplane CRUD", Ordered, func() {
+			It("adds a controlplane", func() {
+				_, _, err := occ.Run("config", "controlplane", "add", "test-cp", "--url", "http://localhost:9999")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("lists controlplanes and shows both", func() {
+				stdout, _, err := occ.Run("config", "controlplane", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("e2e"))
+				Expect(stdout).To(ContainSubstring("test-cp"))
+			})
+			It("updates the controlplane URL", func() {
+				_, _, err := occ.Run("config", "controlplane", "update", "test-cp", "--url", "http://localhost:8888")
+				Expect(err).NotTo(HaveOccurred())
+
+				stdout, _, err := occ.Run("config", "controlplane", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("http://localhost:8888"))
+			})
+			It("deletes the controlplane", func() {
+				_, _, err := occ.Run("config", "controlplane", "delete", "test-cp")
+				Expect(err).NotTo(HaveOccurred())
+
+				stdout, _, err := occ.Run("config", "controlplane", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).NotTo(ContainSubstring("test-cp"))
+			})
+		})
+
+		Context("context CRUD", Ordered, func() {
+			It("adds a context", func() {
+				_, _, err := occ.Run("config", "context", "add", "test-ctx",
+					"--controlplane", "e2e", "--credentials", "e2e-creds")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("lists contexts and shows both", func() {
+				stdout, _, err := occ.Run("config", "context", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("e2e"))
+				Expect(stdout).To(ContainSubstring("test-ctx"))
+			})
+			It("switches to the new context", func() {
+				_, _, err := occ.Run("config", "context", "use", "test-ctx")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("updates the context", func() {
+				_, _, err := occ.Run("config", "context", "update", "test-ctx",
+					"--namespace", "default", "--project", "default")
+				Expect(err).NotTo(HaveOccurred())
+
+				stdout, _, err := occ.Run("config", "context", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("default"),
+					"expected updated namespace/project in context list")
+			})
+			It("switches back to original context and deletes test context", func() {
+				_, _, err := occ.Run("config", "context", "use", "e2e")
+				Expect(err).NotTo(HaveOccurred())
+
+				_, _, err = occ.Run("config", "context", "delete", "test-ctx")
+				Expect(err).NotTo(HaveOccurred())
+
+				stdout, _, err := occ.Run("config", "context", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).NotTo(ContainSubstring("test-ctx"))
+			})
+		})
+
+		Context("credentials CRUD", Ordered, func() {
+			It("adds credentials", func() {
+				_, _, err := occ.Run("config", "credentials", "add", "test-creds")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("lists credentials and shows both", func() {
+				stdout, _, err := occ.Run("config", "credentials", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("e2e-creds"))
+				Expect(stdout).To(ContainSubstring("test-creds"))
+			})
+			It("deletes credentials", func() {
+				_, _, err := occ.Run("config", "credentials", "delete", "test-creds")
+				Expect(err).NotTo(HaveOccurred())
+
+				stdout, _, err := occ.Run("config", "credentials", "list")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).NotTo(ContainSubstring("test-creds"))
+			})
+		})
+	})
+}

--- a/test/e2e/suites/occ/occ_fixtures_test.go
+++ b/test/e2e/suites/occ/occ_fixtures_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+const (
+	openChoreoAPIVer   = "openchoreo.dev/v1alpha1"
+	kubernetesAPIVerV1 = "v1"
+	clusterDataPlane   = "e2e-shared"
+	projectName        = "occ-proj"
+	envDev             = "development"
+	envStaging         = "staging"
+	componentName      = "occ-echo"
+)
+
+var occRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+
+var cpNs = fmt.Sprintf("e2e-occ-%s", occRunID)
+
+// Cluster-scoped names include the run ID to avoid collisions between parallel runs.
+var (
+	clusterAuthzRoleName    = fmt.Sprintf("occ-e2e-role-%s", occRunID)
+	clusterAuthzBindingName = fmt.Sprintf("occ-e2e-binding-%s", occRunID)
+)
+
+const (
+	authzRoleName        = "occ-e2e-reader"
+	authzRoleBindingName = "occ-e2e-reader-binding"
+	secretRefName        = "occ-e2e-secret"
+	oancName             = "occ-e2e-webhook"
+)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+func cpNamespaceYAML() string {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: kubernetesAPIVerV1, Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/control-plane": "true",
+			},
+		},
+	}
+	return mustYAMLDocs(ns)
+}
+
+func platformResourcesYAML() string {
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "DeploymentPipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": "default"},
+		},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{{
+				SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: envDev},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{
+					{Name: envStaging},
+				},
+			}},
+		},
+	}
+	envs := make([]any, 0, 2)
+	for _, name := range []string{envDev, envStaging} {
+		envs = append(envs, &openchoreov1alpha1.Environment{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: cpNs,
+				Labels:    map[string]string{"openchoreo.dev/name": name},
+			},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+					Name: clusterDataPlane,
+				},
+			},
+		})
+	}
+	proj := &openchoreov1alpha1.Project{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": projectName},
+		},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+		},
+	}
+	docs := []any{pipeline}
+	docs = append(docs, envs...)
+	docs = append(docs, proj)
+	return mustYAMLDocs(docs...)
+}
+
+func componentWithWorkloadYAML() string {
+	comp := &openchoreov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      componentName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": componentName},
+		},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: projectName},
+			ComponentType: openchoreov1alpha1.ComponentTypeRef{
+				Kind: openchoreov1alpha1.ComponentTypeRefKindClusterComponentType,
+				Name: "deployment/service",
+			},
+			AutoDeploy: true,
+		},
+	}
+	workload := occWorkload(map[string]string{"openchoreo.dev/name": componentName})
+	return mustYAMLDocs(comp, workload)
+}
+
+func workloadUpdatedYAML() string {
+	return mustYAMLDocs(occWorkload(map[string]string{
+		"openchoreo.dev/name": componentName,
+		"e2e-updated":         "true",
+	}))
+}
+
+func renderedReleaseYAML() string {
+	rr := map[string]any{
+		"apiVersion": openChoreoAPIVer,
+		"kind":       "RenderedRelease",
+		"metadata": map[string]any{
+			"name":      "fake-rr",
+			"namespace": cpNs,
+		},
+		"spec": map[string]any{},
+	}
+	data, err := yaml.Marshal(rr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal yaml: %v", err))
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func occWorkload(labels map[string]string) *openchoreov1alpha1.Workload {
+	return &openchoreov1alpha1.Workload{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Workload"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      componentName,
+			Namespace: cpNs,
+			Labels:    labels,
+		},
+		Spec: openchoreov1alpha1.WorkloadSpec{
+			Owner: openchoreov1alpha1.WorkloadOwner{
+				ProjectName:   projectName,
+				ComponentName: componentName,
+			},
+			WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{
+				Endpoints: map[string]openchoreov1alpha1.WorkloadEndpoint{
+					"http": {
+						Type: openchoreov1alpha1.EndpointType("HTTP"),
+						Port: 8080,
+						Visibility: []openchoreov1alpha1.EndpointVisibility{
+							openchoreov1alpha1.EndpointVisibilityProject,
+						},
+					},
+				},
+				Container: openchoreov1alpha1.Container{
+					Image: "hashicorp/http-echo:0.2.3",
+					Args:  []string{"-listen=:8080", "-text=occ-e2e"},
+				},
+			},
+		},
+	}
+}
+
+func clusterAuthzRoleYAML() string {
+	role := &openchoreov1alpha1.ClusterAuthzRole{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ClusterAuthzRole"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterAuthzRoleName,
+			Labels: map[string]string{"openchoreo.dev/name": clusterAuthzRoleName},
+		},
+		Spec: openchoreov1alpha1.ClusterAuthzRoleSpec{
+			Actions: []string{"read"},
+		},
+	}
+	return mustYAMLDocs(role)
+}
+
+func authzRoleWithBindingYAML() string {
+	role := &openchoreov1alpha1.AuthzRole{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "AuthzRole"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      authzRoleName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": authzRoleName},
+		},
+		Spec: openchoreov1alpha1.AuthzRoleSpec{
+			Actions: []string{"read", "write"},
+		},
+	}
+	binding := &openchoreov1alpha1.AuthzRoleBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "AuthzRoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      authzRoleBindingName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": authzRoleBindingName},
+		},
+		Spec: openchoreov1alpha1.AuthzRoleBindingSpec{
+			Entitlement: openchoreov1alpha1.EntitlementClaim{
+				Claim: "sub",
+				Value: "customer-portal-client",
+			},
+			RoleMappings: []openchoreov1alpha1.RoleMapping{{
+				RoleRef: openchoreov1alpha1.RoleRef{
+					Name: authzRoleName,
+					Kind: openchoreov1alpha1.RoleRefKindAuthzRole,
+				},
+			}},
+			Effect: openchoreov1alpha1.EffectAllow,
+		},
+	}
+	return mustYAMLDocs(role, binding)
+}
+
+func secretReferenceYAML() string {
+	ref := &openchoreov1alpha1.SecretReference{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "SecretReference"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretRefName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": secretRefName},
+		},
+		Spec: openchoreov1alpha1.SecretReferenceSpec{
+			TargetPlane: &openchoreov1alpha1.TargetPlaneRef{
+				Kind: "ClusterDataPlane",
+				Name: "default",
+			},
+			Template: openchoreov1alpha1.SecretTemplate{
+				Type: corev1.SecretTypeOpaque,
+			},
+			Data: []openchoreov1alpha1.SecretDataSource{{
+				SecretKey: "token",
+				RemoteRef: openchoreov1alpha1.RemoteReference{
+					Key:      "dev/dummy-token",
+					Property: "value",
+				},
+			}},
+		},
+	}
+	return mustYAMLDocs(ref)
+}
+
+func oancWebhookYAML() string {
+	channel := &openchoreov1alpha1.ObservabilityAlertsNotificationChannel{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ObservabilityAlertsNotificationChannel"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oancName,
+			Namespace: cpNs,
+			Labels:    map[string]string{"openchoreo.dev/name": oancName},
+		},
+		Spec: openchoreov1alpha1.ObservabilityAlertsNotificationChannelSpec{
+			Type:        openchoreov1alpha1.NotificationChannelTypeWebhook,
+			Environment: envDev,
+			WebhookConfig: &openchoreov1alpha1.WebhookConfig{
+				URL: "http://localhost:9999/webhook",
+			},
+		},
+	}
+	return mustYAMLDocs(channel)
+}

--- a/test/e2e/suites/occ/occ_login_test.go
+++ b/test/e2e/suites/occ/occ_login_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+func describeLoginCommands() {
+	Context("client-credentials login", Ordered, func() {
+		It("logs in with --client-credentials flags", func() {
+			stdout, _, err := occ.Run("login",
+				"--client-credentials",
+				"--client-id", clientID,
+				"--client-secret", clientSecret)
+			Expect(err).NotTo(HaveOccurred(), "occ login --client-credentials failed")
+			Expect(stdout).To(ContainSubstring("Authentication successful"),
+				"expected success message in login output")
+		})
+
+		It("verifies API access works after login", func() {
+			_, _, err := occ.Run("namespace", "list")
+			Expect(err).NotTo(HaveOccurred(),
+				"occ namespace list should succeed after client-credentials login")
+		})
+
+		It("logs in with --credential flag to create a named credential", func() {
+			stdout, _, err := occ.Run("login",
+				"--client-credentials",
+				"--client-id", clientID,
+				"--client-secret", clientSecret,
+				"--credential", "login-e2e-creds")
+			Expect(err).NotTo(HaveOccurred(), "occ login with --credential failed")
+			Expect(stdout).To(ContainSubstring("Authentication successful"))
+
+			By("verifying the named credential appears in config")
+			stdout, _, err = occ.Run("config", "credentials", "list")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).To(ContainSubstring("login-e2e-creds"),
+				"expected named credential in credentials list")
+		})
+	})
+
+	Context("login via environment variables", Ordered, func() {
+		It("logs in using OCC_CLIENT_ID and OCC_CLIENT_SECRET env vars", func() {
+			envVars := []string{
+				fmt.Sprintf("OCC_CLIENT_ID=%s", clientID),
+				fmt.Sprintf("OCC_CLIENT_SECRET=%s", clientSecret),
+			}
+			stdout, _, err := occ.RunWithEnv(envVars,
+				"login", "--client-credentials")
+			Expect(err).NotTo(HaveOccurred(), "occ login with env vars failed")
+			Expect(stdout).To(ContainSubstring("Authentication successful"),
+				"expected success message in env-var login output")
+		})
+
+		It("verifies API access works after env var login", func() {
+			_, _, err := occ.Run("namespace", "list")
+			Expect(err).NotTo(HaveOccurred(),
+				"occ namespace list should succeed after env-var login")
+		})
+	})
+
+	Context("logout", Ordered, func() {
+		It("logs out successfully", func() {
+			stdout, _, err := occ.Run("logout")
+			Expect(err).NotTo(HaveOccurred(), "occ logout failed")
+			Expect(stdout).To(ContainSubstring("Logged out successfully"),
+				"expected logout success message")
+		})
+
+		It("fails API calls after logout", func() {
+			_, stderr, err := occ.Run("namespace", "list")
+			Expect(err).To(HaveOccurred(),
+				"occ namespace list should fail after logout")
+			Expect(stderr).To(ContainSubstring("Authentication required"),
+				"expected authentication required message after logout")
+		})
+
+		It("can re-login after logout", func() {
+			stdout, _, err := occ.Run("login",
+				"--client-credentials",
+				"--client-id", clientID,
+				"--client-secret", clientSecret)
+			Expect(err).NotTo(HaveOccurred(), "occ login after logout failed")
+			Expect(stdout).To(ContainSubstring("Authentication successful"))
+		})
+
+		It("verifies API access works after re-login", func() {
+			_, _, err := occ.Run("namespace", "list")
+			Expect(err).NotTo(HaveOccurred(),
+				"occ namespace list should succeed after re-login")
+		})
+	})
+
+	Context("login negative cases", func() {
+		It("fails without --client-id and --client-secret", func() {
+			clearEnv := []string{"OCC_CLIENT_ID=", "OCC_CLIENT_SECRET="}
+			_, stderr, err := occ.RunWithEnv(clearEnv,
+				"login", "--client-credentials")
+			Expect(err).To(HaveOccurred(),
+				"occ login should fail without client-id and client-secret")
+			Expect(stderr).To(ContainSubstring("client ID and client secret are required"),
+				"expected missing credentials message")
+		})
+
+		It("fails without --client-secret", func() {
+			clearEnv := []string{"OCC_CLIENT_SECRET="}
+			_, stderr, err := occ.RunWithEnv(clearEnv,
+				"login", "--client-credentials", "--client-id", clientID)
+			Expect(err).To(HaveOccurred(),
+				"occ login should fail without client-secret")
+			Expect(stderr).To(ContainSubstring("client ID and client secret are required"),
+				"expected missing credentials message")
+		})
+
+		It("fails with invalid credentials", func() {
+			clearEnv := []string{"OCC_CLIENT_ID=", "OCC_CLIENT_SECRET="}
+			_, stderr, err := occ.RunWithEnv(clearEnv,
+				"login", "--client-credentials",
+				"--client-id", "invalid-id",
+				"--client-secret", "invalid-secret")
+			Expect(err).To(HaveOccurred(),
+				"occ login should fail with invalid credentials")
+			Expect(stderr).To(ContainSubstring("failed to get access token"),
+				"expected token failure message for invalid credentials")
+		})
+	})
+
+	AfterAll(func() {
+		By("re-seeding occ config to restore state for subsequent tests")
+		token, err := framework.FetchClientCredentialsToken(tokenURL, clientID, clientSecret)
+		Expect(err).NotTo(HaveOccurred(), "failed to fetch token for config re-seed")
+		Expect(occ.SeedConfig(token)).To(Succeed(), "failed to re-seed occ config")
+	})
+}

--- a/test/e2e/suites/occ/occ_secret_test.go
+++ b/test/e2e/suites/occ/occ_secret_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+func describeSecretCommands() {
+	Context("secret commands", Ordered, func() {
+		const secretName = "occ-e2e-test-secret"
+
+		It("creates a generic secret", func() {
+			_, _, err := occ.Run("secret", "create", "generic", secretName,
+				"-n", cpNs,
+				"--target-plane", "ClusterDataPlane/default",
+				"--from-literal", "username=admin",
+				"--from-literal", "password=s3cret")
+			Expect(err).NotTo(HaveOccurred(), "occ secret create generic failed")
+		})
+
+		It("lists secrets and shows the created secret", func() {
+			stdout, _, err := occ.Run("secret", "list", "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ secret list failed")
+			Expect(stdout).To(ContainSubstring(secretName))
+		})
+
+		It("gets the secret by name", func() {
+			stdout, _, err := occ.Run("secret", "get", secretName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ secret get failed")
+			Expect(stdout).To(ContainSubstring(secretName))
+		})
+
+		It("updates the secret", func() {
+			_, _, err := occ.Run("secret", "update", secretName,
+				"-n", cpNs,
+				"--from-literal", "password=n3ws3cret")
+			Expect(err).NotTo(HaveOccurred(), "occ secret update failed")
+		})
+
+		It("creates a docker-registry secret", func() {
+			_, _, err := occ.Run("secret", "create", "docker-registry", "occ-e2e-regcred",
+				"-n", cpNs,
+				"--target-plane", "ClusterDataPlane/default",
+				"--docker-server", "https://index.docker.io/v1/",
+				"--docker-username", "testuser",
+				"--docker-password", "testpass")
+			Expect(err).NotTo(HaveOccurred(), "occ secret create docker-registry failed")
+		})
+
+		It("deletes the secrets", func() {
+			_, _, err := occ.Run("secret", "delete", secretName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ secret delete failed")
+
+			_, _, err = occ.Run("secret", "delete", "occ-e2e-regcred", "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ secret delete docker-registry failed")
+		})
+	})
+}

--- a/test/e2e/suites/occ/occ_smoke_test.go
+++ b/test/e2e/suites/occ/occ_smoke_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+func describeSmoke() {
+	Context("smoke", func() {
+		It("occ version returns version info", func() {
+			stdout, _, err := occ.Run("version")
+			Expect(err).NotTo(HaveOccurred(), "occ version failed")
+			Expect(stdout).To(ContainSubstring("Version:"), "expected version info in output")
+		})
+
+		It("occ namespace list succeeds", func() {
+			_, _, err := occ.Run("namespace", "list")
+			Expect(err).NotTo(HaveOccurred(), "occ namespace list failed")
+		})
+	})
+}
+
+func describeNegative() {
+	Context("negative", func() {
+		It("rejects apply of read-only RenderedRelease resource", func() {
+			stdout, stderr, err := occApply(renderedReleaseYAML())
+			Expect(err).To(HaveOccurred(), "occ apply should have rejected RenderedRelease")
+			combined := stdout + "\n" + stderr
+			Expect(combined).To(ContainSubstring("read-only resource"),
+				"expected read-only rejection message in output")
+		})
+	})
+}

--- a/test/e2e/suites/occ/occ_test.go
+++ b/test/e2e/suites/occ/occ_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+// occApply writes YAML to a temp file and runs occ apply -f <file>.
+func occApply(yamlContent string) (string, string, error) {
+	path, err := occ.WriteFixtureFile(yamlContent)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to write fixture file")
+	return occ.Run("apply", "-f", path)
+}
+
+// expectApplySucceeded asserts the apply output indicates a resource was created or configured.
+func expectApplySucceeded(stdout string) {
+	ExpectWithOffset(1, stdout).To(Or(
+		ContainSubstring("created"),
+		ContainSubstring("configured"),
+	))
+}
+
+var _ = Describe("OCC CLI", Ordered, Label("tier2"), func() {
+	describeSmoke()
+	describeApply()
+	describeResourceCommands()
+	describeConfigCommands()
+	describeSecretCommands()
+	describeLoginCommands()
+	describeNegative()
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+
+		By("cleaning up data-plane namespaces created by the controller")
+		dpPrefix := fmt.Sprintf("dp-%s", cpNs[:20])
+		out, _ := framework.Kubectl(kubeContext, "get", "ns", "-o", "name")
+		for _, line := range strings.Split(out, "\n") {
+			ns := strings.TrimPrefix(line, "namespace/")
+			if strings.HasPrefix(ns, dpPrefix) {
+				framework.Kubectl(kubeContext, "delete", "namespace", ns, "--ignore-not-found", "--wait=false") //nolint:errcheck
+			}
+		}
+
+		By(fmt.Sprintf("cleaning up namespace %s", cpNs))
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs, "--ignore-not-found", "--wait=false")
+	})
+})

--- a/test/e2e/suites/occ/suite_test.go
+++ b/test/e2e/suites/occ/suite_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+// Shared state initialised in BeforeSuite and used by test cases.
+var occ *framework.OCCRunner
+
+const (
+	cpNamespace = "openchoreo-control-plane"
+
+	apiURL   = "http://api.e2e-cp.local:28080"
+	tokenURL = "http://thunder.e2e-cp.local:28080/oauth2/token"
+
+	clientID     = "customer-portal-client"
+	clientSecret = "supersecret"
+)
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EOCC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo OCC CLI e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E OCC Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying e2e host entries resolve to 127.0.0.1")
+	for _, host := range []string{"api.e2e-cp.local", "thunder.e2e-cp.local", "openchoreo.e2e-cp.local"} {
+		addrs, err := net.LookupHost(host)
+		Expect(err).NotTo(HaveOccurred(),
+			"%s does not resolve — add '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' to /etc/hosts", host)
+		Expect(addrs).To(ContainElement("127.0.0.1"),
+			"%s resolves to %v instead of 127.0.0.1 — check /etc/hosts", host, addrs)
+	}
+
+	By("verifying cluster is accessible")
+	out, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, out)
+
+	By("granting admin ABAC role to the client_credentials subject")
+	abacBinding := fmt.Sprintf(`apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: %s
+spec:
+  roleMappings:
+    - roleRef:
+        name: admin
+        kind: ClusterAuthzRole
+  entitlement:
+    claim: sub
+    value: customer-portal-client
+  effect: allow`, clusterAuthzBindingName)
+	out, err = framework.KubectlApplyLiteral(kubeContext, abacBinding)
+	Expect(err).NotTo(HaveOccurred(), "failed to create ABAC binding: %s", out)
+
+	By("waiting for gateway to be reachable")
+	framework.WaitForHTTP(apiURL+"/.well-known/oauth-protected-resource", 60*time.Second)
+
+	By("obtaining OAuth2 token from Thunder")
+	token, err := framework.FetchClientCredentialsToken(tokenURL, clientID, clientSecret)
+	Expect(err).NotTo(HaveOccurred(), "failed to obtain access token")
+	Expect(token).NotTo(BeEmpty(), "access token is empty")
+	fmt.Fprintf(GinkgoWriter, "Obtained access token (length=%d)\n", len(token))
+
+	By("building occ binary")
+	runner, err := framework.NewOCCRunner(apiURL)
+	Expect(err).NotTo(HaveOccurred(), "failed to create OCC runner")
+	Expect(runner.Build()).To(Succeed(), "failed to build occ binary")
+	occ = runner
+
+	By("seeding occ config with token")
+	Expect(occ.SeedConfig(token)).To(Succeed(), "failed to seed occ config")
+	fmt.Fprintf(GinkgoWriter, "OCC runner ready: binary=%s home=%s api=%s\n",
+		occ.BinaryPath, occ.HomeDir, occ.APIServer)
+})
+
+var _ = AfterSuite(func() {
+	if occ != nil {
+		occ.Cleanup()
+	}
+	framework.Kubectl(kubeContext, "delete", "clusterauthzrolebinding", clusterAuthzBindingName, "--ignore-not-found", "--wait=false") //nolint:errcheck
+	framework.Kubectl(kubeContext, "delete", "clusterauthzrole", clusterAuthzRoleName, "--ignore-not-found", "--wait=false")        //nolint:errcheck
+})
+


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

Drive the occ binary as a subprocess against the k3d e2e cluster via port-forwarded openchoreo-api, validating the binary-to-cluster path end-to-end. Tests cover apply, list, get, update, negative cases, and cleanup across namespaces, projects, components, and workloads.

## Approach
> Summarize the solution and implementation details.

## Related Issues
closes https://github.com/openchoreo/openchoreo/issues/3616

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
