### PR TITLE
fix: update wirelogs endpoint to include API version

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -260,11 +260,12 @@ func main() {
 
 		topMux := http.NewServeMux()
 		topMux.Handle("/exec/", authedExecHandler)
-		topMux.Handle("GET /namespaces/{namespace}/environments/{environment}/wirelogs", authedWirelogsHandler)
+		topMux.Handle("GET /api/v1/namespaces/{namespace}/environments/{environment}/wirelogs", authedWirelogsHandler)
 		topMux.Handle("/", handler)
 		topHandler = topMux
 		logger.Info("Exec endpoint registered", "path", "/exec/namespaces/{ns}/components/{name}")
-		logger.Info("Wirelogs endpoint registered", "path", "/namespaces/{namespace}/environments/{environment}/wirelogs")
+		logger.Info("Wirelogs endpoint registered",
+			"path", "/api/v1/namespaces/{namespace}/environments/{environment}/wirelogs")
 	}
 
 	// Create server from configuration

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -74,11 +74,11 @@ func NewWirelogsHandler(k8sClient client.Client, gwClient *gatewayClient.Client,
 
 // ServeHTTP authorizes the caller, resolves the target data plane, and proxies
 // the gateway's SSE stream to the client.
-// URL: /namespaces/{namespace}/environments/{environment}/wirelogs?project=&component=
+// URL: /api/v1/namespaces/{namespace}/environments/{environment}/wirelogs?project=&component=
 func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	namespace, environment, ok := parseWirelogsPath(r)
 	if !ok {
-		http.Error(w, "invalid wirelogs URL: expected /namespaces/{namespace}/environments/{environment}/wirelogs", http.StatusBadRequest)
+		http.Error(w, "invalid wirelogs URL: expected /api/v1/namespaces/{namespace}/environments/{environment}/wirelogs", http.StatusBadRequest)
 		return
 	}
 
@@ -317,7 +317,7 @@ func (h *WirelogsHandler) buildGatewayWirelogsURL(plane execPlaneInfo, namespace
 }
 
 // parseWirelogsPath extracts (namespace, environment) from the request path.
-// Expected form: /namespaces/{namespace}/environments/{environment}/wirelogs
+// Expected form: /api/v1/namespaces/{namespace}/environments/{environment}/wirelogs
 func parseWirelogsPath(r *http.Request) (namespace, environment string, ok bool) {
 	namespace = r.PathValue("namespace")
 	environment = r.PathValue("environment")
@@ -326,14 +326,14 @@ func parseWirelogsPath(r *http.Request) (namespace, environment string, ok bool)
 	}
 
 	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-	if len(parts) != 5 {
+	if len(parts) != 7 {
 		return "", "", false
 	}
-	if parts[0] != "namespaces" || parts[2] != "environments" || parts[4] != "wirelogs" {
+	if parts[0] != "api" || parts[1] != "v1" || parts[2] != "namespaces" || parts[4] != "environments" || parts[6] != "wirelogs" {
 		return "", "", false
 	}
-	if parts[1] == "" || parts[3] == "" {
+	if parts[3] == "" || parts[5] == "" {
 		return "", "", false
 	}
-	return parts[1], parts[3], true
+	return parts[3], parts[5], true
 }

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -44,12 +44,12 @@ func TestWirelogsHandler_RejectsMalformedPath(t *testing.T) {
 		name string
 		path string
 	}{
-		{"missing namespaces segment", "/environments/development/wirelogs"},
-		{"missing environments segment", "/namespaces/ns-a/wirelogs"},
-		{"wrong final segment", "/namespaces/ns-a/environments/development/foo"},
-		{"empty namespace", "/namespaces//environments/development/wirelogs"},
-		{"empty environment", "/namespaces/ns-a/environments//wirelogs"},
-		{"extra trailing path", "/namespaces/ns-a/environments/development/wirelogs/extra"},
+		{"missing namespaces segment", "/api/v1/environments/development/wirelogs"},
+		{"missing environments segment", "/api/v1/namespaces/ns-a/wirelogs"},
+		{"wrong final segment", "/api/v1/namespaces/ns-a/environments/development/foo"},
+		{"empty namespace", "/api/v1/namespaces//environments/development/wirelogs"},
+		{"empty environment", "/api/v1/namespaces/ns-a/environments//wirelogs"},
+		{"extra trailing path", "/api/v1/namespaces/ns-a/environments/development/wirelogs/extra"},
 	}
 
 	for _, tt := range tests {
@@ -82,7 +82,7 @@ func TestWirelogsHandler_AcceptsEnvironmentWideRequest(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
@@ -91,7 +91,7 @@ func TestWirelogsHandler_AuthzNotConfigured(t *testing.T) {
 	h := &WirelogsHandler{logger: slog.Default()}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Contains(t, rec.Body.String(), "authorization not configured")
@@ -108,7 +108,7 @@ func TestWirelogsHandler_Forbidden(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout"))
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
@@ -141,7 +141,7 @@ func captureAuthzRequest(t *testing.T, path string) *authz.EvaluateRequest {
 }
 
 func TestWirelogsHandler_AuthzScope_Component(t *testing.T) {
-	req := captureAuthzRequest(t, "/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout")
+	req := captureAuthzRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout")
 
 	assert.Equal(t, authz.ActionViewWirelogs, req.Action, "wirelogs must check its own action, not logs:view")
 	assert.Equal(t, "component", req.Resource.Type)
@@ -154,7 +154,7 @@ func TestWirelogsHandler_AuthzScope_Component(t *testing.T) {
 }
 
 func TestWirelogsHandler_AuthzScope_ProjectOnly(t *testing.T) {
-	req := captureAuthzRequest(t, "/namespaces/ns-a/environments/development/wirelogs?project=demo")
+	req := captureAuthzRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo")
 
 	assert.Equal(t, "project", req.Resource.Type)
 	assert.Equal(t, "demo", req.Resource.ID)
@@ -171,14 +171,14 @@ func TestWirelogsHandler_ComponentWithoutProjectRejected(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs?component=checkout"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs?component=checkout"))
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "component filter requires project filter")
 }
 
 func TestWirelogsHandler_AuthzScope_EnvironmentWide(t *testing.T) {
-	req := captureAuthzRequest(t, "/namespaces/ns-a/environments/development/wirelogs")
+	req := captureAuthzRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs")
 
 	assert.Equal(t, "environment", req.Resource.Type)
 	assert.Equal(t, "development", req.Resource.ID)
@@ -272,11 +272,11 @@ func TestWirelogsHandler_RejectsInvalidNameParams(t *testing.T) {
 		path string
 		want string
 	}{
-		{"namespace too long", "/namespaces/" + strings.Repeat("a", 64) + "/environments/development/wirelogs", "invalid namespace parameter"},
-		{"namespace uppercase", "/namespaces/NS_A/environments/development/wirelogs", "invalid namespace parameter"},
-		{"environment uppercase", "/namespaces/ns-a/environments/DEV/wirelogs", "invalid environment parameter"},
-		{"project uppercase", "/namespaces/ns-a/environments/development/wirelogs?project=DEMO", "invalid project parameter"},
-		{"component uppercase", "/namespaces/ns-a/environments/development/wirelogs?project=demo&component=Checkout", "invalid component parameter"},
+		{"namespace too long", "/api/v1/namespaces/" + strings.Repeat("a", 64) + "/environments/development/wirelogs", "invalid namespace parameter"},
+		{"namespace uppercase", "/api/v1/namespaces/NS_A/environments/development/wirelogs", "invalid namespace parameter"},
+		{"environment uppercase", "/api/v1/namespaces/ns-a/environments/DEV/wirelogs", "invalid environment parameter"},
+		{"project uppercase", "/api/v1/namespaces/ns-a/environments/development/wirelogs?project=DEMO", "invalid project parameter"},
+		{"component uppercase", "/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo&component=Checkout", "invalid component parameter"},
 	}
 
 	for _, tc := range cases {
@@ -305,7 +305,7 @@ func TestWirelogsHandler_AuthzCheckInternalError(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Contains(t, rec.Body.String(), "authorization check failed")
@@ -320,7 +320,7 @@ func TestWirelogsHandler_PlaneResolve_EnvironmentNotFound(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "failed to resolve data plane")
@@ -340,7 +340,7 @@ func TestWirelogsHandler_PlaneResolve_EnvironmentMissingDataPlaneRef(t *testing.
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "no data plane reference")
@@ -364,7 +364,7 @@ func TestWirelogsHandler_NoFlusherSupport(t *testing.T) {
 	}
 
 	rec := &wirelogsNoFlushRecorder{rec: httptest.NewRecorder()}
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusInternalServerError, rec.rec.Code)
 	assert.Contains(t, rec.rec.Body.String(), "streaming unsupported")
@@ -384,7 +384,7 @@ func TestWirelogsHandler_GatewayDialError(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
 	assert.Contains(t, rec.Body.String(), "failed to connect to data plane")
@@ -405,7 +405,7 @@ func TestWirelogsHandler_GatewayNonOKStatus(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
 		"503 from the gateway must be propagated, not collapsed to 502")
@@ -430,7 +430,7 @@ func TestWirelogsHandler_GatewayWeirdStatusCoercedTo502(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, wirelogsRequest(t, "/namespaces/ns-a/environments/development/wirelogs"))
+	h.ServeHTTP(rec, wirelogsRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs"))
 
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
 }
@@ -471,7 +471,7 @@ func TestWirelogsHandler_HappyPath(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, wirelogsRequest(t,
-		"/namespaces/ns-a/environments/development/wirelogs?project=shopfront"))
+		"/api/v1/namespaces/ns-a/environments/development/wirelogs?project=shopfront"))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request updates the wirelogs API endpoint to follow a versioned RESTful path under `/api/v1/`. All handler logic, path parsing, and associated tests are updated to match the new endpoint structure, ensuring consistency and correctness throughout the codebase.

**API endpoint update:**

* Changed the wirelogs endpoint from `/namespaces/{namespace}/environments/{environment}/wirelogs` to `/api/v1/namespaces/{namespace}/environments/{environment}/wirelogs` in the main API router, handler logic, and log messages. [[1]](diffhunk://#diff-6a30d8830ceafb48dc9652d4195eb1b085bffe2a673ffc3680173690a84ec707L263-R267) [[2]](diffhunk://#diff-3844dabf2447b340a3ad0b965cebc1f246d181191054efc570853f6780052688L77-R81)

**Handler and path parsing adjustments:**

* Updated the path parsing logic in `parseWirelogsPath` to expect and correctly extract parameters from the new versioned path format. [[1]](diffhunk://#diff-3844dabf2447b340a3ad0b965cebc1f246d181191054efc570853f6780052688L320-R320) [[2]](diffhunk://#diff-3844dabf2447b340a3ad0b965cebc1f246d181191054efc570853f6780052688L329-R338)

**Test suite updates:**

* Updated all wirelogs handler tests to use the new `/api/v1/...` endpoint format, ensuring tests accurately reflect the new API structure. [[1]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL47-R52) [[2]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL85-R85) [[3]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL94-R94) [[4]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL111-R111) [[5]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL144-R144) [[6]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL157-R157) [[7]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL174-R181) [[8]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL275-R279) [[9]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL308-R308) [[10]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL323-R323) [[11]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL343-R343) [[12]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL367-R367) [[13]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL387-R387) [[14]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL408-R408) [[15]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL433-R433) [[16]](diffhunk://#diff-4d71fae1479b00fd5be7283cbe124825912dbcc0f88175d5c786df333b0badebL474-R474)
## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3294

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
Follow up to https://github.com/openchoreo/openchoreo/pull/3571
