### PR TITLE
test: add componentrelease and delete command coverage to occ e2e suite

### DIFF
--- a/test/e2e/suites/occ/occ_commands_test.go
+++ b/test/e2e/suites/occ/occ_commands_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -48,6 +49,39 @@ func describeResourceCommands() {
 				g.Expect(stdout).To(ContainSubstring(componentName),
 					"expected component name in releasebinding list output")
 			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("lists component releases for component", func() {
+			Eventually(func(g Gomega) {
+				stdout, _, err := occ.Run("componentrelease", "list", "-n", cpNs,
+					"--component", componentName)
+				g.Expect(err).NotTo(HaveOccurred(), "occ componentrelease list failed")
+				g.Expect(stdout).To(ContainSubstring(componentName),
+					"expected component name in componentrelease list output")
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		})
+
+		It("gets a specific component release", func() {
+			var crName string
+			Eventually(func(g Gomega) {
+				stdout, _, err := occ.Run("componentrelease", "list", "-n", cpNs,
+					"--component", componentName)
+				g.Expect(err).NotTo(HaveOccurred(), "occ componentrelease list failed")
+				for _, line := range strings.Split(stdout, "\n") {
+					fields := strings.Fields(line)
+					if len(fields) >= 2 && fields[1] == componentName {
+						crName = fields[0]
+						return
+					}
+				}
+				g.Expect(crName).NotTo(BeEmpty(),
+					"could not find componentrelease name in list output:\n%s", stdout)
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			stdout, _, err := occ.Run("componentrelease", "get", crName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ componentrelease get failed")
+			Expect(stdout).To(ContainSubstring(crName),
+				"expected componentrelease name in get output")
 		})
 
 		DescribeTable("cluster-scoped list and get",

--- a/test/e2e/suites/occ/occ_delete_test.go
+++ b/test/e2e/suites/occ/occ_delete_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+// expectDeleted verifies a resource is either fully removed or terminating.
+// Resources with finalizers may linger with a deletionTimestamp after the
+// delete command succeeds; both outcomes confirm the CLI delete worked.
+func expectDeleted(resource, name string, args ...string) {
+	Eventually(func(g Gomega) {
+		getArgs := append([]string{resource, "get", name}, args...)
+		stdout, stderr, err := occ.Run(getArgs...)
+		if err != nil {
+			g.Expect(stderr).To(ContainSubstring("not found"),
+				"expected not-found error for %s/%s, got: %s", resource, name, stderr)
+			return
+		}
+		g.Expect(stdout).To(ContainSubstring("deletionTimestamp"),
+			"%s/%s still exists and is not terminating", resource, name)
+	}, 2*time.Minute, 2*time.Second).Should(Succeed())
+}
+
+func describeDeleteCommands() {
+	Context("delete resources", Ordered, func() {
+		DescribeTable("delete namespace-scoped leaf resources",
+			func(resource, name string) {
+				By(fmt.Sprintf("deleting %s/%s", resource, name))
+				_, _, err := occ.Run(resource, "delete", name, "-n", cpNs)
+				Expect(err).NotTo(HaveOccurred(), "occ %s delete %s failed", resource, name)
+
+				By(fmt.Sprintf("verifying %s/%s is deleted or terminating", resource, name))
+				expectDeleted(resource, name, "-n", cpNs)
+			},
+			Entry("observabilityalertsnotificationchannel",
+				"observabilityalertsnotificationchannel", oancName),
+			Entry("secretreference", "secretreference", secretRefName),
+			Entry("authzrolebinding", "authzrolebinding", authzRoleBindingName),
+			Entry("authzrole", "authzrole", authzRoleName),
+		)
+
+		It("deletes component and verifies cascade cleanup", func() {
+			_, _, err := occ.Run("component", "delete", componentName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ component delete failed")
+
+			By("verifying component is deleted or terminating")
+			expectDeleted("component", componentName, "-n", cpNs)
+
+			By("verifying workload was cascade-deleted")
+			expectDeleted("workload", componentName, "-n", cpNs)
+		})
+
+		It("deletes project", func() {
+			_, _, err := occ.Run("project", "delete", projectName, "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ project delete failed")
+
+			expectDeleted("project", projectName, "-n", cpNs)
+		})
+
+		It("deletes deployment pipeline", func() {
+			_, _, err := occ.Run("deploymentpipeline", "delete", "default", "-n", cpNs)
+			Expect(err).NotTo(HaveOccurred(), "occ deploymentpipeline delete failed")
+
+			expectDeleted("deploymentpipeline", "default", "-n", cpNs)
+		})
+
+		It("deletes environments", func() {
+			for _, env := range []string{envDev, envStaging} {
+				By(fmt.Sprintf("deleting environment %s", env))
+				_, _, err := occ.Run("environment", "delete", env, "-n", cpNs)
+				Expect(err).NotTo(HaveOccurred(),
+					"occ environment delete %s failed", env)
+			}
+
+			for _, env := range []string{envDev, envStaging} {
+				By(fmt.Sprintf("verifying environment %s is deleted or terminating", env))
+				expectDeleted("environment", env, "-n", cpNs)
+			}
+		})
+
+		It("deletes cluster-scoped authz role", func() {
+			_, _, err := occ.Run("clusterauthzrole", "delete", clusterAuthzRoleName)
+			Expect(err).NotTo(HaveOccurred(), "occ clusterauthzrole delete failed")
+
+			expectDeleted("clusterauthzrole", clusterAuthzRoleName)
+		})
+	})
+}

--- a/test/e2e/suites/occ/occ_test.go
+++ b/test/e2e/suites/occ/occ_test.go
@@ -37,6 +37,7 @@ var _ = Describe("OCC CLI", Ordered, Label("tier2"), func() {
 	describeSecretCommands()
 	describeLoginCommands()
 	describeNegative()
+	describeDeleteCommands()
 
 	AfterAll(func() {
 		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> $subject

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3616

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
