### PR TITLE
test: add MCP server e2e test suite

### DIFF
--- a/test/e2e/framework/mcp.go
+++ b/test/e2e/framework/mcp.go
@@ -1,0 +1,214 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const mcpCallTimeout = 30 * time.Second
+
+var httpClientWithTimeout = &http.Client{Timeout: mcpCallTimeout}
+
+// MCPClientConfig holds configuration for creating an MCP client session.
+type MCPClientConfig struct {
+	Endpoint               string
+	Token                  string
+	Toolsets                []string
+	FilterByAuthz          *bool
+	IncludeDeprecatedTools *bool
+}
+
+// bearerTransport injects an Authorization header into every outgoing request.
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	if t.token != "" {
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// NewMCPSession creates an MCP client session connected to the given endpoint.
+// The caller must close the returned session when done.
+func NewMCPSession(ctx context.Context, cfg MCPClientConfig) (*mcp.ClientSession, error) {
+	endpoint := cfg.Endpoint
+	if len(cfg.Toolsets) > 0 || cfg.FilterByAuthz != nil || cfg.IncludeDeprecatedTools != nil {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MCP endpoint URL: %w", err)
+		}
+		q := u.Query()
+		if len(cfg.Toolsets) > 0 {
+			q.Set("toolsets", strings.Join(cfg.Toolsets, ","))
+		}
+		if cfg.FilterByAuthz != nil {
+			q.Set("filterByAuthz", fmt.Sprintf("%t", *cfg.FilterByAuthz))
+		}
+		if cfg.IncludeDeprecatedTools != nil {
+			q.Set("includeDeprecatedTools", fmt.Sprintf("%t", *cfg.IncludeDeprecatedTools))
+		}
+		u.RawQuery = q.Encode()
+		endpoint = u.String()
+	}
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint: endpoint,
+		HTTPClient: &http.Client{
+			Transport: &bearerTransport{
+				token: cfg.Token,
+				base:  http.DefaultTransport,
+			},
+		},
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}
+
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, mcpCallTimeout)
+		defer cancel()
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "e2e-test-client",
+		Version: "1.0.0",
+	}, nil)
+
+	return client.Connect(ctx, transport, nil)
+}
+
+// ListMCPToolNames lists tools and returns just the tool names.
+func ListMCPToolNames(session *mcp.ClientSession) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), mcpCallTimeout)
+	defer cancel()
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("tools/list failed: %w", err)
+	}
+	names := make([]string, 0, len(result.Tools))
+	for _, t := range result.Tools {
+		names = append(names, t.Name)
+	}
+	return names, nil
+}
+
+// CallMCPTool calls a named tool with the given arguments and returns the result.
+// Returns an error if the tool call fails or the tool itself returns an error.
+func CallMCPTool(session *mcp.ClientSession, toolName string, args map[string]any) (*mcp.CallToolResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), mcpCallTimeout)
+	defer cancel()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: args,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return result, fmt.Errorf("tool %s returned error: %s", toolName, extractTextContent(result))
+	}
+	return result, nil
+}
+
+// CallMCPToolJSON calls a named tool and unmarshals the first text content into dest.
+func CallMCPToolJSON(session *mcp.ClientSession, toolName string, args map[string]any, dest any) error {
+	result, err := CallMCPTool(session, toolName, args)
+	if err != nil {
+		return fmt.Errorf("call %s failed: %w", toolName, err)
+	}
+	text := extractTextContent(result)
+	if text == "" {
+		return fmt.Errorf("tool %s returned no text content", toolName)
+	}
+	if dest != nil {
+		if err := json.Unmarshal([]byte(text), dest); err != nil {
+			return fmt.Errorf("failed to unmarshal %s result: %w\nraw: %s", toolName, err, text)
+		}
+	}
+	return nil
+}
+
+func extractTextContent(result *mcp.CallToolResult) string {
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}
+
+// MCPRawPOST sends a raw HTTP POST to the MCP endpoint without any token.
+// Useful for testing unauthenticated access (401 response).
+func MCPRawPOST(endpoint string) (int, http.Header, error) {
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"e2e-test","version":"1.0.0"},"capabilities":{}}}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return 0, nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := httpClientWithTimeout.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+	return resp.StatusCode, resp.Header, nil
+}
+
+// FetchOAuth2Token requests an access token from the Thunder IdP using
+// client_credentials grant with HTTP Basic auth (client_secret_basic).
+func FetchOAuth2Token(tokenURL, clientID, clientSecret string) (string, error) {
+	data := url.Values{
+		"grant_type": {"client_credentials"},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, clientSecret)
+
+	resp, err := httpClientWithTimeout.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("unmarshal token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("empty access_token in response: %s", string(body))
+	}
+	return tokenResp.AccessToken, nil
+}

--- a/test/e2e/suites/mcp/mcp_fixtures_test.go
+++ b/test/e2e/suites/mcp/mcp_fixtures_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+const (
+	clusterDataPlane = "e2e-shared"
+	openChoreoAPIVer = "openchoreo.dev/v1alpha1"
+)
+
+func mustYAMLDocs(objects ...any) string {
+	docs := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal yaml document: %v", err))
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return strings.Join(docs, "\n---\n")
+}
+
+func platformResourcesYAML(cpNamespace string, environments []string, projects []string) string {
+	promotionPaths := make([]openchoreov1alpha1.PromotionPath, 0)
+
+	if len(environments) == 0 {
+		promotionPaths = append(promotionPaths, openchoreov1alpha1.PromotionPath{
+			SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: "development"},
+			TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{{
+				Name: "development",
+			}},
+		})
+	} else if len(environments) == 1 {
+		promotionPaths = append(promotionPaths, openchoreov1alpha1.PromotionPath{
+			SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: environments[0]},
+			TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{{
+				Name: environments[0],
+			}},
+		})
+	} else {
+		for i := 0; i < len(environments)-1; i++ {
+			promotionPaths = append(promotionPaths, openchoreov1alpha1.PromotionPath{
+				SourceEnvironmentRef: openchoreov1alpha1.EnvironmentRef{Name: environments[i]},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{{
+					Name: environments[i+1],
+				}},
+			})
+		}
+	}
+
+	docs := []any{
+		&openchoreov1alpha1.DeploymentPipeline{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "DeploymentPipeline"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: cpNamespace,
+				Labels: map[string]string{
+					"openchoreo.dev/name": "default",
+				},
+			},
+			Spec: openchoreov1alpha1.DeploymentPipelineSpec{PromotionPaths: promotionPaths},
+		},
+	}
+
+	for _, env := range environments {
+		docs = append(docs, &openchoreov1alpha1.Environment{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Environment"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      env,
+				Namespace: cpNamespace,
+				Labels: map[string]string{
+					"openchoreo.dev/name": env,
+				},
+			},
+			Spec: openchoreov1alpha1.EnvironmentSpec{
+				DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+					Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+					Name: clusterDataPlane,
+				},
+				IsProduction: false,
+			},
+		})
+	}
+
+	for _, proj := range projects {
+		docs = append(docs, &openchoreov1alpha1.Project{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      proj,
+				Namespace: cpNamespace,
+				Labels: map[string]string{
+					"openchoreo.dev/name": proj,
+				},
+			},
+			Spec: openchoreov1alpha1.ProjectSpec{DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"}},
+		})
+	}
+
+	return mustYAMLDocs(docs...)
+}

--- a/test/e2e/suites/mcp/mcp_test.go
+++ b/test/e2e/suites/mcp/mcp_test.go
@@ -1,0 +1,317 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+const (
+	mcpEndpoint  = "http://api.e2e-cp.local:28080/mcp"
+	tokenURL     = "http://thunder.e2e-cp.local:28080/oauth2/token"
+	clientID     = "service_mcp_client"
+	clientSecret = "service_mcp_client_secret"
+)
+
+var (
+	mcpRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+	mcpNs    = fmt.Sprintf("e2e-mcp-%s", mcpRunID)
+	dpNs     string
+)
+
+var _ = Describe("MCP Server", Ordered, Label("tier2"), func() {
+	var token string
+
+	BeforeAll(func() {
+		By("fetching an OAuth2 access token from Thunder IdP")
+		var err error
+		token, err = framework.FetchOAuth2Token(tokenURL, clientID, clientSecret)
+		Expect(err).NotTo(HaveOccurred(), "failed to fetch OAuth2 token")
+		Expect(token).NotTo(BeEmpty(), "access token should not be empty")
+		fmt.Fprintf(GinkgoWriter, "OAuth2 token obtained successfully\n")
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+
+		By("cleaning up data plane namespace")
+		if dpNs != "" {
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs, "--ignore-not-found", "--wait=false")
+		}
+
+		By("cleaning up test namespace")
+		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", mcpNs, "--ignore-not-found", "--wait=false")
+	})
+
+	Context("authentication", func() {
+		It("rejects unauthenticated requests with 401", func() {
+			statusCode, headers, err := framework.MCPRawPOST(mcpEndpoint)
+			Expect(err).NotTo(HaveOccurred(), "raw POST should succeed at HTTP level")
+			Expect(statusCode).To(Equal(401), "unauthenticated request should return 401")
+			Expect(headers.Get("WWW-Authenticate")).To(ContainSubstring("Bearer"),
+				"401 response should include WWW-Authenticate header")
+		})
+
+		It("connects successfully with a valid token", func() {
+			session, err := framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint: mcpEndpoint,
+				Token:    token,
+			})
+			Expect(err).NotTo(HaveOccurred(), "MCP session should connect with valid token")
+			defer session.Close()
+
+			names, err := framework.ListMCPToolNames(session)
+			Expect(err).NotTo(HaveOccurred(), "tools/list should succeed")
+			Expect(names).NotTo(BeEmpty(), "tool list should not be empty")
+			fmt.Fprintf(GinkgoWriter, "Connected to MCP server, %d tools available\n", len(names))
+		})
+	})
+
+	Context("tool listing", func() {
+		It("returns expected core tools", func() {
+			noDeprecated := false
+			session, err := framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint:               mcpEndpoint,
+				Token:                  token,
+				IncludeDeprecatedTools: &noDeprecated,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			names, err := framework.ListMCPToolNames(session)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedTools := []string{
+				"list_namespaces",
+				"create_namespace",
+				"list_projects",
+				"create_project",
+				"create_component",
+				"list_components",
+				"create_workload",
+				"list_release_bindings",
+				"list_environments",
+			}
+			for _, expected := range expectedTools {
+				Expect(names).To(ContainElement(expected),
+					"tools/list should include %s", expected)
+			}
+		})
+
+		It("respects toolset narrowing via query parameter", func() {
+			noDeprecated := false
+			session, err := framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint:               mcpEndpoint,
+				Token:                  token,
+				Toolsets:               []string{"namespace"},
+				IncludeDeprecatedTools: &noDeprecated,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			names, err := framework.ListMCPToolNames(session)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(names).To(ContainElement("list_namespaces"),
+				"namespace toolset should include list_namespaces")
+			Expect(names).To(ContainElement("create_namespace"),
+				"namespace toolset should include create_namespace")
+
+			Expect(names).NotTo(ContainElement("create_project"),
+				"narrowed to namespace toolset should not include create_project")
+			Expect(names).NotTo(ContainElement("create_component"),
+				"narrowed to namespace toolset should not include create_component")
+		})
+	})
+
+	Context("namespace tool chain", func() {
+		It("creates a namespace via MCP and verifies it exists on the cluster", func() {
+			session, err := framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint: mcpEndpoint,
+				Token:    token,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			By("creating a namespace via MCP create_namespace tool")
+			_, err = framework.CallMCPTool(session, "create_namespace", map[string]any{
+				"name":         mcpNs,
+				"display_name": "MCP E2E Test",
+				"description":  "Created by MCP e2e test",
+			})
+			Expect(err).NotTo(HaveOccurred(), "create_namespace should succeed")
+
+			By("verifying the namespace exists on the cluster via kubectl")
+			Eventually(func(g Gomega) {
+				framework.AssertClusterResourceExists(g, kubeContext, "namespace", mcpNs)
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("listing namespaces via MCP and verifying the new namespace appears")
+			var listResult struct {
+				Namespaces []struct {
+					Name string `json:"name"`
+				} `json:"namespaces"`
+			}
+			err = framework.CallMCPToolJSON(session, "list_namespaces", nil, &listResult)
+			Expect(err).NotTo(HaveOccurred(), "list_namespaces should succeed")
+
+			found := false
+			for _, ns := range listResult.Namespaces {
+				if ns.Name == mcpNs {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "list_namespaces should include %s", mcpNs)
+		})
+	})
+
+	Context("component tool chain", func() {
+		const (
+			projectName   = "e2e-mcp-proj"
+			componentName = "e2e-mcp-echo"
+			workloadName  = componentName + "-workload"
+		)
+
+		var session *mcp.ClientSession
+
+		BeforeAll(func() {
+			var err error
+			session, err = framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint: mcpEndpoint,
+				Token:    token,
+			})
+			Expect(err).NotTo(HaveOccurred(), "MCP session should connect")
+
+			By("applying platform resources (DeploymentPipeline + Environments) for auto-deploy")
+			output, err := framework.KubectlApplyLiteral(kubeContext,
+				platformResourcesYAML(mcpNs, []string{"development", "staging"}, nil))
+			Expect(err).NotTo(HaveOccurred(), "failed to apply platform resources: %s", output)
+		})
+
+		AfterAll(func() {
+			if session != nil {
+				session.Close()
+			}
+		})
+
+		It("creates a project via MCP", func() {
+			_, err := framework.CallMCPTool(session, "create_project", map[string]any{
+				"namespace_name":      mcpNs,
+				"name":                projectName,
+				"description":         "MCP e2e test project",
+				"deployment_pipeline": "default",
+			})
+			Expect(err).NotTo(HaveOccurred(), "create_project should succeed")
+
+			By("verifying the project CR exists on the cluster")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, mcpNs, "project", projectName)
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+		})
+
+		It("creates a component via MCP", func() {
+			_, err := framework.CallMCPTool(session, "create_component", map[string]any{
+				"namespace_name": mcpNs,
+				"project_name":   projectName,
+				"name":           componentName,
+				"component_type": "deployment/service",
+				"auto_deploy":    true,
+			})
+			Expect(err).NotTo(HaveOccurred(), "create_component should succeed")
+
+			By("verifying the component CR exists on the cluster")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, mcpNs, "component", componentName)
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+		})
+
+		It("creates a workload via MCP", func() {
+			_, err := framework.CallMCPTool(session, "create_workload", map[string]any{
+				"namespace_name": mcpNs,
+				"component_name": componentName,
+				"workload_spec": map[string]any{
+					"container": map[string]any{
+						"image": "hashicorp/http-echo:0.2.3",
+						"args":  []string{"-text=mcp-e2e", "-listen=:8080"},
+					},
+					"endpoints": map[string]any{
+						"http": map[string]any{
+							"type":       "HTTP",
+							"port":       8080,
+							"visibility": []string{"project"},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "create_workload should succeed")
+
+			By("verifying the workload CR exists on the cluster")
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, mcpNs, "workload", workloadName)
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+		})
+
+		It("verifies the release chain is created", func() {
+			By("waiting for ComponentRelease to appear via component status")
+			Eventually(func(g Gomega) {
+				releaseName, err := framework.KubectlGetJsonpath(
+					kubeContext, mcpNs, "component", componentName,
+					"{.status.latestRelease.name}",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(releaseName).NotTo(BeEmpty(), "component should have a latestRelease")
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("waiting for ReleaseBinding to appear")
+			rbName := fmt.Sprintf("%s-development", componentName)
+			Eventually(func(g Gomega) {
+				framework.AssertResourceExists(g, kubeContext, mcpNs, "releasebinding", rbName)
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("discovering data plane namespace for cleanup")
+			Eventually(func() error {
+				var discoverErr error
+				dpNs, discoverErr = framework.GetDPNamespace(kubeContext, mcpNs, projectName, "development")
+				return discoverErr
+			}, framework.DefaultTimeout, 5*time.Second).Should(Succeed(), "dp namespace not found")
+			fmt.Fprintf(GinkgoWriter, "discovered dp namespace: %s\n", dpNs)
+		})
+
+		It("lists components and finds the created component", func() {
+			var listResult struct {
+				Components []struct {
+					Name string `json:"name"`
+				} `json:"components"`
+			}
+			err := framework.CallMCPToolJSON(session, "list_components", map[string]any{
+				"namespace_name": mcpNs,
+				"project_name":   projectName,
+			}, &listResult)
+			Expect(err).NotTo(HaveOccurred(), "list_components should succeed")
+
+			found := false
+			for _, c := range listResult.Components {
+				if c.Name == componentName {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "list_components should include %s", componentName)
+		})
+	})
+})

--- a/test/e2e/suites/mcp/suite_test.go
+++ b/test/e2e/suites/mcp/suite_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+var kubeContext string
+
+func init() {
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e tests (required)")
+}
+
+func TestE2EMCP(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo MCP e2e suite\n")
+	RunSpecs(t, "OpenChoreo E2E MCP Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(kubeContext).NotTo(BeEmpty(), "--e2e.kubecontext is required")
+	fmt.Fprintf(GinkgoWriter, "Using kube context: %s\n", kubeContext)
+
+	By("verifying cluster is accessible")
+	output, err := framework.Kubectl(kubeContext, "cluster-info")
+	Expect(err).NotTo(HaveOccurred(),
+		"cluster not accessible with context %s:\n%s", kubeContext, output)
+	fmt.Fprintf(GinkgoWriter, "Cluster accessible\n")
+})


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Adds tier2 e2e tests for the MCP server covering authentication, tool listing, toolset narrowing, and full namespace/component tool chains including release chain verification.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3616

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
