### PR TITLE
fix(controller): validate component name against DNS-1035 at admission time

### DIFF
--- a/internal/webhook/component/webhook.go
+++ b/internal/webhook/component/webhook.go
@@ -6,6 +6,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,6 +83,10 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	// Note: Required field validations (componentType, owner.projectName, traits.name, traits.instanceName) are enforced by the CRD schema
 	// Note: Cross-resource validation (ComponentType, Trait, schema validation) is handled by the controller
 
+	// Validate component name against DNS-1035 constraints.
+	// The component name is used directly as a Kubernetes Service name, which must satisfy DNS-1035.
+	allErrs = append(allErrs, validateComponentName(component)...)
+
 	// Validate unique trait instance names
 	allErrs = append(allErrs, validateUniqueTraitInstanceNames(component)...)
 
@@ -112,6 +117,10 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	// Note: spec.componentType immutability is enforced by CEL rules in the CRD schema
 	// Note: Cross-resource validation (ComponentType, Trait, schema validation) is handled by the controller
 
+	// Validate component name against DNS-1035 constraints.
+	// The component name is used directly as a Kubernetes Service name, which must satisfy DNS-1035.
+	allErrs = append(allErrs, validateComponentName(newComponent)...)
+
 	// Validate unique trait instance names
 	allErrs = append(allErrs, validateUniqueTraitInstanceNames(newComponent)...)
 
@@ -132,6 +141,28 @@ func (v *Validator) ValidateDelete(ctx context.Context, obj runtime.Object) (adm
 
 	// No special validation needed for deletion
 	return nil, nil
+}
+
+// dns1035LabelFmt is the regex for a valid Kubernetes DNS-1035 label.
+// A DNS-1035 label must start with a lowercase letter, consist of lowercase alphanumeric characters
+// or '-', and end with an alphanumeric character.
+var dns1035LabelRegex = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
+
+// validateComponentName validates that the Component metadata.name satisfies the Kubernetes
+// DNS-1035 label format required by downstream resource names (e.g. Service names).
+func validateComponentName(component *openchoreodevv1alpha1.Component) field.ErrorList {
+	allErrs := field.ErrorList{}
+	name := component.GetName()
+	if name != "" && !dns1035LabelRegex.MatchString(name) {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("metadata").Child("name"),
+			name,
+			"a DNS-1035 label must consist of lower case alphanumeric characters or '-', "+
+				"start with an alphabetic character, and end with an alphanumeric character "+
+				"(e.g. 'my-component', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')",
+		))
+	}
+	return allErrs
 }
 
 // validateUniqueTraitInstanceNames validates that trait instance names are unique within a component

--- a/internal/webhook/component/webhook_test.go
+++ b/internal/webhook/component/webhook_test.go
@@ -45,6 +45,46 @@ var _ = Describe("Component Webhook", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("should admit a Component with a valid DNS-1035 name", func() {
+			obj.Name = "my-valid-component"
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should admit a Component with a single-character lowercase name", func() {
+			obj.Name = "a"
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject a Component whose name contains dots (e.g. wso2-is-7.1.0)", func() {
+			obj.Name = "wso2-is-7.1.0"
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DNS-1035"))
+		})
+
+		It("should reject a Component whose name starts with a digit", func() {
+			obj.Name = "1invalid"
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DNS-1035"))
+		})
+
+		It("should reject a Component whose name contains uppercase letters", func() {
+			obj.Name = "MyComponent"
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DNS-1035"))
+		})
+
+		It("should reject a Component whose name ends with a hyphen", func() {
+			obj.Name = "invalid-"
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DNS-1035"))
+		})
+
 		It("should admit a Component with unique trait instance names", func() {
 			obj = componentWithTraits([]openchoreodevv1alpha1.ComponentTrait{
 				{Name: "sidecar", InstanceName: "sidecar-a"},
@@ -76,6 +116,21 @@ var _ = Describe("Component Webhook", func() {
 		It("should admit a valid update with no traits", func() {
 			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should admit an update with a valid DNS-1035 name", func() {
+			newObj := &openchoreodevv1alpha1.Component{}
+			newObj.Name = "valid-name-123"
+			_, err := validator.ValidateUpdate(ctx, oldObj, newObj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject an update whose name contains dots (e.g. wso2-is-7.1.0)", func() {
+			newObj := &openchoreodevv1alpha1.Component{}
+			newObj.Name = "wso2-is-7.1.0"
+			_, err := validator.ValidateUpdate(ctx, oldObj, newObj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DNS-1035"))
 		})
 
 		It("should admit an update with unique trait instance names in the new object", func() {


### PR DESCRIPTION
Fixes #3562

Component names are used directly as Kubernetes Service names, which must satisfy DNS-1035 format. Before this fix, names like wso2-is-7.1.0 were silently accepted but failed later with ResourceApplyFailed.

This change adds DNS-1035 validation to the component admission webhook, rejecting invalid names at creation time with a clear error pointing to metadata.name.