### PR TITLE
fix: add container args to openchoreo API e2e test fixtures

### DIFF
--- a/test/e2e/suites/openchoreoapi/fixtures_test.go
+++ b/test/e2e/suites/openchoreoapi/fixtures_test.go
@@ -65,6 +65,10 @@ spec:
               containers:
                 - name: main
                   image: "${workload.container.image}"
+                  command: |
+                    ${has(workload.container.command) ? workload.container.command : oc_omit()}
+                  args: |
+                    ${has(workload.container.args) ? workload.container.args : oc_omit()}
 `, namespace, name)
 }
 
@@ -117,6 +121,7 @@ func newWorkload(name, componentName, projectName string) gen.Workload {
 	port := 8080
 	epType := gen.WorkloadEndpointTypeHTTP
 	basePath := "/"
+	args := []string{"-listen=:8080", "-text=api-e2e"}
 	return gen.Workload{
 		Metadata: gen.ObjectMeta{
 			Name: name,
@@ -124,6 +129,7 @@ func newWorkload(name, componentName, projectName string) gen.Workload {
 		Spec: &gen.WorkloadSpec{
 			Container: &gen.WorkloadContainer{
 				Image: "hashicorp/http-echo:0.2.3",
+				Args:  &args,
 			},
 			Owner: &struct {
 				ComponentName string `json:"componentName"`


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The ComponentType template was missing command/args CEL mappings and the workload fixture omitted the required http-echo container arguments, causing CrashLoopBackOff and ReleaseBinding timeout failures.


## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
