### PR TITLE
docs: fix MCP tool deprecation notice link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Changes since [v1.1.0-alpha-1](https://github.com/openchoreo/openchoreo/releases
 ### Deprecation Notice
 
 - Git secret management APIs are deprecated and removed in v1.2
-- Deprecated cluster-prefixed mcp tools. Hidden in v1.2 and removed in v1.3 (https://openchoreo.dev/docs/v1.1.0/reference/mcp-servers/#deprecated-cluster-prefixed-tools)
+- Deprecated cluster-prefixed mcp tools. Hidden in v1.2 and removed in v1.3 (https://openchoreo.dev/docs/v1.1.x/reference/mcp-servers/#deprecated-cluster-prefixed-tools)
 
 ## v1.1.0-alpha-1
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR fixes the doc link for the MCP tool deprecation notice

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
