### PR TITLE
test: add playwright ui e2e tests for backstage portal

### DIFF
--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -1,0 +1,139 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: UI E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      helm_chart_version:
+        description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<commit-sha>)"
+        required: false
+        default: "0.0.0-latest-dev"
+  schedule:
+    # Weekly: Monday 04:00 UTC (09:30 IST). The UI suite installs every plane,
+    # so keep it away from the regular nightly and extended e2e windows.
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HELM_CHART_VERSION: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
+  E2E_WITH_BUILD: "true"
+  E2E_WITH_OBSERVABILITY: "true"
+  E2E_WITH_UI: "true"
+  E2E_KUBECONTEXT: k3d-openchoreo-e2e
+  UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
+  K3D_VERSION: v5.8.3
+  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
+  YQ_VERSION: v4.45.4
+  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
+
+jobs:
+  ui-e2e:
+    name: UI E2E (Playwright)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: test/ui/package-lock.json
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Validate Helm chart version
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
+      - name: Install UI test dependencies
+        working-directory: test/ui
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: test/ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Install OpenChoreo e2e cluster
+        run: |
+          make e2e.setup \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_WITH_BUILD="${E2E_WITH_BUILD}" \
+            E2E_WITH_OBSERVABILITY="${E2E_WITH_OBSERVABILITY}" \
+            E2E_WITH_UI="${E2E_WITH_UI}" \
+            E2E_SETUP_TIMEOUT=10m
+
+      - name: Run UI e2e tests
+        working-directory: test/ui
+        run: npm test
+
+      - name: Collect e2e diagnostics
+        if: failure()
+        run: make e2e.diagnostics || true
+
+      - name: Upload e2e diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-diagnostics
+          path: test/e2e/_diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-playwright-report
+          path: test/ui/_report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-test-results
+          path: test/ui/_test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Delete e2e cluster
+        if: always()
+        run: make e2e.down || true

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -168,12 +168,15 @@ e2e.setup: ## All setup: cluster + prerequisites + install + configure (+ UI whe
 	@$(call log_success, E2E setup complete)
 
 .PHONY: e2e.setup-ui
-e2e.setup-ui: ## Enable Backstage and wait for the Backstage pod (idempotent)
+e2e.setup-ui: ## Enable Backstage on the control plane and wait for it to become Ready (idempotent)
+	@# When run standalone against a cluster installed without E2E_WITH_UI=true,
+	@# Backstage is not deployed yet — re-run the CP install with the UI overlay
+	@# (which also provisions backstage-secrets). When invoked from e2e.setup
+	@# the deployment already exists, so this branch is a no-op.
+	@if ! $(E2E_KUBECTL) -n $(E2E_CP_NS) get deploy backstage >/dev/null 2>&1; then \
+		$(MAKE) _e2e.install-cp E2E_WITH_UI=true; \
+	fi
 	@$(call log_info, Waiting for Backstage deployment to become Ready)
-	@for i in $$(seq 1 60); do \
-		$(E2E_KUBECTL) -n $(E2E_CP_NS) get deploy backstage >/dev/null 2>&1 && break; \
-		sleep 2; \
-	done
 	$(E2E_KUBECTL) wait -n $(E2E_CP_NS) \
 		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deploy/backstage
 	@$(call log_success, UI setup complete (Backstage Ready))

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -9,6 +9,10 @@ E2E_HELM_SOURCE        ?= local
 # Set to "true" to include workflow plane and observability plane in the e2e setup
 E2E_WITH_BUILD         ?= false
 E2E_WITH_OBSERVABILITY ?= false
+# Set to "true" to enable Backstage in the control plane and run the Tier 5 UI suite
+# (see test/ui/). Off by default so the existing e2e workflow keeps the lighter
+# Backstage-disabled install.
+E2E_WITH_UI            ?= false
 # Go duration for the test suite (go test -timeout)
 E2E_TEST_TIMEOUT       ?= 20m
 # Go duration for each individual helm install and kubectl wait (not the overall setup timeout)
@@ -31,6 +35,16 @@ endif
 E2E_DIR                := $(PROJECT_DIR)/test/e2e
 E2E_K3D_DIR            := $(E2E_DIR)/k3d
 E2E_DIAGNOSTICS_DIR    ?= $(E2E_DIR)/_diagnostics
+UI_DIR                 := $(PROJECT_DIR)/test/ui
+UI_K3D_DIR             := $(UI_DIR)/k3d
+
+# When the UI suite is enabled, layer the cp-ui overlay on top of the default
+# control-plane values so Backstage gets switched on.
+ifeq ($(E2E_WITH_UI),true)
+  E2E_CP_EXTRA_VALUES := --values $(UI_K3D_DIR)/values-cp-ui.yaml
+else
+  E2E_CP_EXTRA_VALUES :=
+endif
 
 # Namespaces
 E2E_CP_NS              := openchoreo-control-plane
@@ -145,12 +159,40 @@ e2e: ## Full e2e lifecycle: setup → test → down (collects diagnostics on fai
 # ---------------------------------------------------------------------------
 
 .PHONY: e2e.setup
-e2e.setup: ## All setup: cluster + prerequisites + install + configure
+e2e.setup: ## All setup: cluster + prerequisites + install + configure (+ UI when E2E_WITH_UI=true)
 	@$(MAKE) e2e.setup-cluster
 	@$(MAKE) e2e.setup-prerequisites
 	@$(MAKE) e2e.setup-install
 	@$(MAKE) e2e.setup-configure
+	@if [ "$(E2E_WITH_UI)" = "true" ]; then $(MAKE) e2e.setup-ui; fi
 	@$(call log_success, E2E setup complete)
+
+.PHONY: e2e.setup-ui
+e2e.setup-ui: ## Enable Backstage and wait for the Backstage pod (idempotent)
+	@$(call log_info, Waiting for Backstage deployment to become Ready)
+	@for i in $$(seq 1 60); do \
+		$(E2E_KUBECTL) -n $(E2E_CP_NS) get deploy backstage >/dev/null 2>&1 && break; \
+		sleep 2; \
+	done
+	$(E2E_KUBECTL) wait -n $(E2E_CP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deploy/backstage
+	@$(call log_success, UI setup complete (Backstage Ready))
+
+.PHONY: _e2e.prepare-backstage-secret
+_e2e.prepare-backstage-secret:
+	@# The cp-ui overlay sets backstage.secretName=backstage-secrets. The
+	@# Helm chart references it via envFrom, so it must exist before install.
+	@$(call log_info, Provisioning backstage-secrets in $(E2E_CP_NS))
+	$(E2E_KUBECTL) create namespace $(E2E_CP_NS) --dry-run=client -o yaml | $(E2E_KUBECTL) apply -f -
+	@if ! $(E2E_KUBECTL) -n $(E2E_CP_NS) get secret backstage-secrets >/dev/null 2>&1; then \
+		BACKEND_SECRET=$$(head -c 32 /dev/urandom | base64 | tr -d '\n'); \
+		$(E2E_KUBECTL) -n $(E2E_CP_NS) create secret generic backstage-secrets \
+			--from-literal=backend-secret="$$BACKEND_SECRET" \
+			--from-literal=client-secret="backstage-portal-secret" \
+			--from-literal=jenkins-api-key="placeholder-not-in-use"; \
+	else \
+		echo "backstage-secrets already exists, leaving in place"; \
+	fi
 
 .PHONY: e2e.setup-cluster
 e2e.setup-cluster: ## Create k3d cluster
@@ -227,10 +269,12 @@ _e2e.install-thunder:
 .PHONY: _e2e.install-cp
 _e2e.install-cp:
 	@$(call log_info, Installing Control Plane)
+	@if [ "$(E2E_WITH_UI)" = "true" ]; then $(MAKE) _e2e.prepare-backstage-secret; fi
 	$(E2E_HELM) upgrade --install openchoreo-control-plane $(E2E_CP_CHART) \
 		$(E2E_HELM_DEP_UPDATE) \
 		--namespace $(E2E_CP_NS) --create-namespace \
 		--values $(E2E_K3D_DIR)/values-cp.yaml \
+		$(E2E_CP_EXTRA_VALUES) \
 		--timeout $(E2E_SETUP_TIMEOUT)
 	$(call e2e_patch_gateway,$(E2E_CP_NS))
 	$(E2E_KUBECTL) wait -n $(E2E_CP_NS) \

--- a/test/e2e/framework/mcp.go
+++ b/test/e2e/framework/mcp.go
@@ -24,7 +24,7 @@ var httpClientWithTimeout = &http.Client{Timeout: mcpCallTimeout}
 type MCPClientConfig struct {
 	Endpoint               string
 	Token                  string
-	Toolsets                []string
+	Toolsets               []string
 	FilterByAuthz          *bool
 	IncludeDeprecatedTools *bool
 }

--- a/test/e2e/k3d/values-thunder.yaml
+++ b/test/e2e/k3d/values-thunder.yaml
@@ -21,3 +21,111 @@ configuration:
   passkey:
     allowedOrigins:
       - "http://openchoreo.e2e-cp.local:28080"
+
+bootstrap:
+  scripts:
+    # Add the openchoreo.e2e-cp.local:28080 redirect URI alongside the
+    # single-cluster default so Thunder accepts the OIDC redirect-back from
+    # Backstage on this cluster. PUT path is idempotent.
+    51-backstage-app.sh: |
+      #!/bin/bash
+      set -e
+
+      THUNDER_URL="http://localhost:8090"
+
+      log_info "Checking if application 'Backstage' already exists..."
+      existing_apps=$(curl -s --max-time 10 "${THUNDER_URL}/applications")
+
+      app_id=$(echo "$existing_apps" | tr '\n' ' ' | sed 's/" *: *"/":"/g' | grep -o '"name":"Backstage"[^}]*"id":"[^"]*"\|"id":"[^"]*"[^}]*"name":"Backstage"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+      APP_PAYLOAD='{
+        "name": "Backstage",
+        "description": "OpenChoreo Backstage Portal",
+        "logo_url": "https://cdn.statically.io/gh/openchoreo/openchoreo.github.io@main/static/img/openchoreo-logo.png",
+        "allowed_user_types": ["openchoreo-user"],
+        "assertion": {
+          "validity_period": 3600
+        },
+        "inbound_auth_config": [
+          {
+            "type": "oauth2",
+            "config": {
+              "client_id": "openchoreo-backstage-client",
+              "client_secret": "backstage-portal-secret",
+              "redirect_uris": [
+                "http://openchoreo.localhost:8080/api/auth/openchoreo-auth/handler/frame",
+                "http://openchoreo.e2e-cp.local:28080/api/auth/openchoreo-auth/handler/frame"
+              ],
+              "grant_types": [
+                "authorization_code",
+                "client_credentials",
+                "refresh_token"
+              ],
+              "response_types": [
+                "code"
+              ],
+              "token_endpoint_auth_method": "client_secret_post",
+              "pkce_required": false,
+              "public_client": false,
+              "token": {
+                "access_token": {
+                  "validity_period": 86400,
+                  "user_attributes": [
+                    "given_name",
+                    "family_name",
+                    "username",
+                    "groups"
+                  ]
+                },
+                "id_token": {
+                  "validity_period": 86400,
+                  "user_attributes": [
+                    "given_name",
+                    "family_name",
+                    "username",
+                    "groups"
+                  ]
+                }
+              },
+              "scope_claims": {
+                "email": [
+                  "email"
+                ],
+                "groups": [
+                  "groups"
+                ],
+                "profile": [
+                  "username",
+                  "given_name",
+                  "family_name",
+                  "picture"
+                ]
+              }
+            }
+          }
+        ]
+      }'
+
+      if [ -n "$app_id" ]; then
+        log_info "Application 'Backstage' already exists (id: $app_id), updating..."
+        curl --location -X PUT "${THUNDER_URL}/applications/$app_id" \
+          --header 'Content-Type: application/json' \
+          --data "$APP_PAYLOAD" \
+          --fail-with-body \
+          --max-time 30 \
+          --retry 3 \
+          --retry-delay 5
+
+        log_info "Application updated successfully"
+      else
+        log_info "Application does not exist, creating default application..."
+        curl --location "${THUNDER_URL}/applications" \
+          --header 'Content-Type: application/json' \
+          --data "$APP_PAYLOAD" \
+          --fail-with-body \
+          --max-time 30 \
+          --retry 3 \
+          --retry-delay 5
+
+        log_info "Default application created successfully"
+      fi

--- a/test/e2e/k3d/values-thunder.yaml
+++ b/test/e2e/k3d/values-thunder.yaml
@@ -34,7 +34,22 @@ bootstrap:
       THUNDER_URL="http://localhost:8090"
 
       log_info "Checking if application 'Backstage' already exists..."
-      existing_apps=$(curl -s --max-time 10 "${THUNDER_URL}/applications")
+      # Fail on HTTP errors and retry: a transient Thunder error here would
+      # otherwise silently yield an empty app_id and divert into the create
+      # path instead of the idempotent PUT update.
+      existing_apps=""
+      for attempt in 1 2 3; do
+        if existing_apps=$(curl -s --fail --max-time 10 "${THUNDER_URL}/applications"); then
+          break
+        fi
+        existing_apps=""
+        log_info "Listing applications failed (attempt ${attempt}/3), retrying in 5s..."
+        sleep 5
+      done
+      if [ -z "$existing_apps" ]; then
+        log_error "Failed to list applications from ${THUNDER_URL} after 3 attempts"
+        exit 1
+      fi
 
       app_id=$(echo "$existing_apps" | tr '\n' ' ' | sed 's/" *: *"/":"/g' | grep -o '"name":"Backstage"[^}]*"id":"[^"]*"\|"id":"[^"]*"[^}]*"name":"Backstage"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 

--- a/test/e2e/suites/authz/fixtures_test.go
+++ b/test/e2e/suites/authz/fixtures_test.go
@@ -192,7 +192,7 @@ func newComponentWithType(name, project, typeName string, typeKind gen.Component
 			AutoDeploy: &autoDeploy,
 			ComponentType: struct {
 				Kind *gen.ComponentSpecComponentTypeKind `json:"kind,omitempty"`
-				Name string                             `json:"name"`
+				Name string                              `json:"name"`
 			}{
 				Kind: &typeKind,
 				Name: typeName,
@@ -272,7 +272,7 @@ func newEnvironment(name string) gen.Environment {
 		Spec: &gen.EnvironmentSpec{
 			DataPlaneRef: &struct {
 				Kind gen.EnvironmentSpecDataPlaneRefKind `json:"kind"`
-				Name string                             `json:"name"`
+				Name string                              `json:"name"`
 			}{
 				Kind: dpKind,
 				Name: "default",

--- a/test/e2e/suites/occ/suite_test.go
+++ b/test/e2e/suites/occ/suite_test.go
@@ -103,6 +103,5 @@ var _ = AfterSuite(func() {
 		occ.Cleanup()
 	}
 	framework.Kubectl(kubeContext, "delete", "clusterauthzrolebinding", clusterAuthzBindingName, "--ignore-not-found", "--wait=false") //nolint:errcheck
-	framework.Kubectl(kubeContext, "delete", "clusterauthzrole", clusterAuthzRoleName, "--ignore-not-found", "--wait=false")        //nolint:errcheck
+	framework.Kubectl(kubeContext, "delete", "clusterauthzrole", clusterAuthzRoleName, "--ignore-not-found", "--wait=false")           //nolint:errcheck
 })
-

--- a/test/e2e/suites/openchoreoapi/fixtures_test.go
+++ b/test/e2e/suites/openchoreoapi/fixtures_test.go
@@ -102,7 +102,7 @@ func newComponent(name, projectName, clusterComponentTypeName string) gen.Compon
 			AutoDeploy: &autoDeploy,
 			ComponentType: struct {
 				Kind *gen.ComponentSpecComponentTypeKind `json:"kind,omitempty"`
-				Name string                             `json:"name"`
+				Name string                              `json:"name"`
 			}{
 				Kind: &kind,
 				Name: clusterComponentTypeName,

--- a/test/e2e/suites/openchoreoapi/openchoreoapi_test.go
+++ b/test/e2e/suites/openchoreoapi/openchoreoapi_test.go
@@ -25,10 +25,10 @@ var _ = Describe("OpenChoreo API", Ordered, Label("tier2"), func() {
 		client *gen.ClientWithResponses
 		ctx    context.Context
 
-		nsName      string
-		kubectlNs   string
-		projectName string
-		compName    string
+		nsName       string
+		kubectlNs    string
+		projectName  string
+		compName     string
 		workloadName string
 
 		ct1Name string

--- a/test/ui/.gitignore
+++ b/test/ui/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+_report/
+_test-results/
+.auth/
+playwright-report/
+test-results/
+*.log

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -1,0 +1,99 @@
+# test/ui — OpenChoreo Backstage UI tests
+
+Playwright tests that drive the Backstage portal end-to-end against a running
+OpenChoreo cluster.
+
+## Quickstart against the local `openchoreo-e2e` k3d cluster
+
+1. Bring up the e2e cluster with Backstage turned on. The default
+   `test/e2e/k3d/values-cp.yaml` keeps Backstage off — apply the
+   `test/ui/k3d/values-cp-ui.yaml` overlay on top to flip it on:
+
+   ```sh
+   kubectl --context k3d-openchoreo-e2e -n openchoreo-control-plane \
+     create secret generic backstage-secrets \
+     --from-literal=backend-secret="$(head -c 32 /dev/urandom | base64)" \
+     --from-literal=client-secret="backstage-portal-secret" \
+     --from-literal=jenkins-api-key="placeholder-not-in-use"
+
+   helm --kube-context k3d-openchoreo-e2e upgrade openchoreo-control-plane \
+     install/helm/openchoreo-control-plane \
+     --namespace openchoreo-control-plane \
+     --values test/e2e/k3d/values-cp.yaml \
+     --values test/ui/k3d/values-cp-ui.yaml
+   ```
+
+2. Install dependencies and run the suite:
+
+   ```sh
+   cd test/ui
+   npm install
+   npx playwright install --with-deps chromium
+   npm test
+   ```
+
+The Playwright config maps the `*.e2e-cp.local` hostnames to `127.0.0.1` via
+Chromium's `--host-resolver-rules`, so no `/etc/hosts` edit is needed.
+
+## Layout
+
+- `playwright.config.ts` — runner config.
+- `specs/` — one folder per suite (`auth/`, `lifecycle/`, …).
+- `po/` — page objects (intent-named methods, semantic locators).
+- `fixtures/` — Playwright `test.extend` fixtures (auth state, kubectl helpers).
+- `k3d/` — Helm value overlays that turn the e2e cluster into a UI-test target.
+
+## Sign-in spec — pre-warmed popup pattern
+
+`specs/auth/sign-in.spec.ts` signs in as `platform-engineer@openchoreo.dev`
+(seeded by Thunder's `50-user-schema-and-users.sh`).
+
+Backstage's OpenChoreo-auth provider opens the consent popup during the
+initial `/api/auth/openchoreo-auth/refresh` probe — before the on-page
+`Sign In` button renders. The spec arms `context.waitForEvent('page')`
+*before* `page.goto('/')` and fills the form in that pre-warmed popup
+directly.
+
+**Do not click the on-page Sign In button.** It kicks off a second
+`/oauth2/authorize` call against the same `flowId` / `authId`, which races
+the warm popup for Thunder's SQLite store and fails non-deterministically
+with `SQLITE_BUSY → server_error: Failed to process authorization request`.
+
+## Thunder Backstage app must list the e2e redirect URI
+
+The chart's `bootstrap.scripts.51-backstage-app.sh` is overlaid in
+`test/e2e/k3d/values-thunder.yaml` to add
+`http://openchoreo.e2e-cp.local:28080/api/auth/openchoreo-auth/handler/frame`
+alongside the single-cluster default. The Thunder helm chart only runs the
+bootstrap on `helm install` (`helm.sh/hook: pre-install`,
+`hook-delete-policy: hook-succeeded`), so applying the overlay to an
+already-installed cluster needs three steps:
+
+```sh
+# Re-render with the e2e overlay and patch the bootstrap ConfigMap in place.
+helm --kube-context k3d-openchoreo-e2e template thunder \
+  oci://ghcr.io/asgardeo/helm-charts/thunder --namespace thunder --version 0.28.0 \
+  --values install/k3d/common/values-thunder.yaml \
+  --values test/e2e/k3d/values-thunder.yaml \
+  | awk '/^# Source: thunder\/templates\/bootstrap-configmap.yaml/,/^# Source:/' \
+  | sed '/^# Source: thunder\/templates\/[^b]/,$d' \
+  | kubectl --context k3d-openchoreo-e2e -n thunder apply -f -
+
+# Free the RWO sqlite PVC so the setup Job can mount it.
+kubectl --context k3d-openchoreo-e2e -n thunder scale deploy thunder-deployment --replicas=0
+kubectl --context k3d-openchoreo-e2e -n thunder wait --for=delete pod \
+  -l app.kubernetes.io/name=thunder --timeout=2m
+
+# Re-apply the setup Job manifest (renamed, helm hooks stripped) — bootstrap
+# scripts PUT-update each app idempotently against the existing PVC data.
+```
+
+## Headed runs
+
+`launchOptions.slowMo` is parked behind the `PWSLOWMO` env var (currently
+commented out in `playwright.config.ts`). Re-enable when you want to watch
+the click stream:
+
+```sh
+PWSLOWMO=1000 npx playwright test --headed
+```

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -10,7 +10,7 @@ The cleanest path is to let the Makefile do the bring-up:
 ```sh
 make e2e.setup E2E_WITH_UI=true
 cd test/ui
-npm install
+npm ci
 npx playwright install --with-deps chromium
 UI_BASE_URL=http://openchoreo.e2e-cp.local:28080 npm test
 ```
@@ -90,6 +90,19 @@ kubectl --context k3d-openchoreo-e2e -n thunder wait --for=delete pod \
 
 # Re-apply the setup Job manifest (renamed, helm hooks stripped) — bootstrap
 # scripts PUT-update each app idempotently against the existing PVC data.
+helm --kube-context k3d-openchoreo-e2e template thunder \
+  oci://ghcr.io/asgardeo/helm-charts/thunder --namespace thunder --version 0.28.0 \
+  --values install/k3d/common/values-thunder.yaml \
+  --values test/e2e/k3d/values-thunder.yaml \
+  --show-only templates/setup-job.yaml \
+  | yq '.metadata.name = "thunder-setup-rerun" | del(.metadata.annotations)' \
+  | kubectl --context k3d-openchoreo-e2e -n thunder apply -f -
+kubectl --context k3d-openchoreo-e2e -n thunder wait \
+  --for=condition=complete job/thunder-setup-rerun --timeout=5m
+kubectl --context k3d-openchoreo-e2e -n thunder delete job thunder-setup-rerun
+
+# Bring Thunder back up.
+kubectl --context k3d-openchoreo-e2e -n thunder scale deploy thunder-deployment --replicas=1
 ```
 
 ## Headed runs

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -5,32 +5,26 @@ OpenChoreo cluster.
 
 ## Quickstart against the local `openchoreo-e2e` k3d cluster
 
-1. Bring up the e2e cluster with Backstage turned on. The default
-   `test/e2e/k3d/values-cp.yaml` keeps Backstage off — apply the
-   `test/ui/k3d/values-cp-ui.yaml` overlay on top to flip it on:
+The cleanest path is to let the Makefile do the bring-up:
 
-   ```sh
-   kubectl --context k3d-openchoreo-e2e -n openchoreo-control-plane \
-     create secret generic backstage-secrets \
-     --from-literal=backend-secret="$(head -c 32 /dev/urandom | base64)" \
-     --from-literal=client-secret="backstage-portal-secret" \
-     --from-literal=jenkins-api-key="placeholder-not-in-use"
+```sh
+make e2e.setup E2E_WITH_UI=true
+cd test/ui
+npm install
+npx playwright install --with-deps chromium
+UI_BASE_URL=http://openchoreo.e2e-cp.local:28080 npm test
+```
 
-   helm --kube-context k3d-openchoreo-e2e upgrade openchoreo-control-plane \
-     install/helm/openchoreo-control-plane \
-     --namespace openchoreo-control-plane \
-     --values test/e2e/k3d/values-cp.yaml \
-     --values test/ui/k3d/values-cp-ui.yaml
-   ```
+`make e2e.setup E2E_WITH_UI=true` extends the default e2e setup with the
+`test/ui/k3d/values-cp-ui.yaml` overlay (turns Backstage on) and waits for the
+Backstage deployment to become Ready. The PE and Dev identities come from
+Thunder's own bootstrap (`50-user-schema-and-users.sh`).
 
-2. Install dependencies and run the suite:
+To bolt UI onto an existing cluster without re-running the full setup:
 
-   ```sh
-   cd test/ui
-   npm install
-   npx playwright install --with-deps chromium
-   npm test
-   ```
+```sh
+make e2e.setup-ui
+```
 
 The Playwright config maps the `*.e2e-cp.local` hostnames to `127.0.0.1` via
 Chromium's `--host-resolver-rules`, so no `/etc/hosts` edit is needed.
@@ -38,26 +32,36 @@ Chromium's `--host-resolver-rules`, so no `/etc/hosts` edit is needed.
 ## Layout
 
 - `playwright.config.ts` — runner config.
-- `specs/` — one folder per suite (`auth/`, `lifecycle/`, …).
-- `po/` — page objects (intent-named methods, semantic locators).
-- `fixtures/` — Playwright `test.extend` fixtures (auth state, kubectl helpers).
+- `specs/` — one folder per suite (`auth/`, `catalog/`, `lifecycle/`,
+  `dev-ops/`).
+- `po/` — page objects (intent-named methods, semantic locators). Every
+  affordance currently resolves via `getByRole` + accessible name or
+  `getByLabel`; no `data-testid` escape hatches are required against the
+  current Backstage UI surface.
+- `fixtures/` — Playwright `test.extend` fixtures (per-role storage state via
+  `mintAuthState` + `storageStateFor`, a thin `kubectl` wrapper).
 - `k3d/` — Helm value overlays that turn the e2e cluster into a UI-test target.
 
-## Sign-in spec — pre-warmed popup pattern
+## Specs
+
+| Suite | Spec | What it asserts |
+|---|---|---|
+| `auth/` | sign-in | Thunder OIDC sign-in lands on the post-login Backstage layout |
+| `catalog/` | catalog-sync | kubectl-applied Component shows up in the Backstage catalog within polling timeout |
+| `lifecycle/` | full-lifecycle | UI-driven project + component create → deploy → delete, kubectl agreement on each step |
+| `dev-ops/` | dev-ops-component | Dev creates + views a Component; ComponentType create is denied server-side |
+
+Further suites (`pe-ops`, `abac-ui`, `auth/pkce-login`) land in follow-up PRs.
+
+## Sign-in spec
 
 `specs/auth/sign-in.spec.ts` signs in as `platform-engineer@openchoreo.dev`
 (seeded by Thunder's `50-user-schema-and-users.sh`).
 
-Backstage's OpenChoreo-auth provider opens the consent popup during the
-initial `/api/auth/openchoreo-auth/refresh` probe — before the on-page
-`Sign In` button renders. The spec arms `context.waitForEvent('page')`
-*before* `page.goto('/')` and fills the form in that pre-warmed popup
-directly.
-
-**Do not click the on-page Sign In button.** It kicks off a second
-`/oauth2/authorize` call against the same `flowId` / `authId`, which races
-the warm popup for Thunder's SQLite store and fails non-deterministically
-with `SQLITE_BUSY → server_error: Failed to process authorization request`.
+Sign-in is a same-page OIDC redirect: click the on-page `Sign In` button →
+fill the Thunder gate (`Enter your username` / `Enter your password`) → submit →
+wait for the post-login sidebar `Home` link. The shared helper in
+`fixtures/auth.ts` drives the same flow to mint per-role `storageState`.
 
 ## Thunder Backstage app must list the e2e redirect URI
 

--- a/test/ui/fixtures/auth.ts
+++ b/test/ui/fixtures/auth.ts
@@ -1,0 +1,159 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test as base, type BrowserContext, type Page } from '@playwright/test';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+// Polyfill injected before any page script. Backstage uses
+// window.crypto.randomUUID(), which is gated by "secure context" (HTTPS or
+// localhost). The e2e portal serves over plain HTTP at openchoreo.e2e-cp.local
+// so the upstream code throws; we replace it with a v4-shaped stub built on
+// crypto.getRandomValues (always available). Not cryptographically meaningful
+// — Backstage only uses these as cache / DOM keys.
+export const cryptoUUIDPolyfill = `
+(() => {
+  if (typeof window === 'undefined' || !window.crypto) return;
+  if (typeof window.crypto.randomUUID === 'function') return;
+  window.crypto.randomUUID = function randomUUID() {
+    const buf = new Uint8Array(16);
+    window.crypto.getRandomValues(buf);
+    buf[6] = (buf[6] & 0x0f) | 0x40;
+    buf[8] = (buf[8] & 0x3f) | 0x80;
+    const hex = Array.from(buf, b => b.toString(16).padStart(2, '0'));
+    return (
+      hex.slice(0, 4).join('') + '-' +
+      hex.slice(4, 6).join('') + '-' +
+      hex.slice(6, 8).join('') + '-' +
+      hex.slice(8, 10).join('') + '-' +
+      hex.slice(10, 16).join('')
+    );
+  };
+})();
+`;
+
+// Identity catalogue. PE + Dev are seeded by Thunder's bootstrap script
+// (install/k3d/common/values-thunder.yaml → 50-user-schema-and-users.sh).
+// The ABAC identity is provisioned by test/ui/scripts/seed-idp-users.sh
+// because the bootstrap script does not know about it.
+export type Role = 'pe' | 'dev' | 'abac';
+
+export interface RoleCreds {
+  username: string;
+  password: string;
+  group: string;
+}
+
+export const ROLES: Record<Role, RoleCreds> = {
+  pe: {
+    username: 'platform-engineer@openchoreo.dev',
+    password: 'PE@123',
+    group: 'platform-engineers',
+  },
+  dev: {
+    username: 'developer@openchoreo.dev',
+    password: 'Dev@123',
+    group: 'developers',
+  },
+  abac: {
+    username: 'abac-dev@openchoreo.dev',
+    password: 'Abac@123',
+    group: 'abac-developers',
+  },
+};
+
+// Persisted Backstage auth state per role. Specs opt in with
+//   test.use({ storageState: storageStateFor('pe') })
+// after the suite has invoked signInAs(role) once to mint it.
+export function storageStateFor(role: Role): string {
+  const out = resolve(__dirname, '..', '.auth', `${role}.json`);
+  return out;
+}
+
+// Drive the Thunder OIDC consent page via the on-page Sign In button. The
+// current Backstage configuration uses a same-page redirect flow rather than
+// a popup, so the spec just clicks the Sign In affordance Backstage renders
+// pre-login and fills the form on the resulting Thunder consent page.
+export async function signIn(
+  page: Page,
+  _context: BrowserContext,
+  creds: RoleCreds,
+): Promise<void> {
+  await page.goto('/');
+
+  // Backstage's pre-login layout shows one or more Sign In buttons (one per
+  // provider). Click the first one — there is only the OpenChoreo provider
+  // configured in this install.
+  await page.getByRole('button', { name: 'Sign In', exact: true }).first().click();
+
+  // Wait for Thunder's gate to render. The placeholder strings are stable
+  // across the deployment because they come from the Thunder gate template.
+  const usernameField = page.getByPlaceholder('Enter your username');
+  await usernameField.waitFor({ state: 'visible', timeout: 30_000 });
+  await usernameField.fill(creds.username);
+  await page.getByPlaceholder('Enter your password').fill(creds.password);
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+
+  // Wait for the redirect back to Backstage. The post-login shell exposes
+  // the Home link in the sidebar — wait for that as the readiness signal.
+  // Match what specs/auth/sign-in.spec.ts does (no exact:true) so the same
+  // call site succeeds whether the Home affordance comes from the sidebar
+  // logo (<a aria-label="Home">) or the SidebarItem (text="Home").
+  await page.getByRole('link', { name: 'Home' }).first()
+    .waitFor({ state: 'visible', timeout: 60_000 });
+}
+
+// Mint a storageState file for a role by driving sign-in once and saving the
+// browser context. Cached on disk so subsequent specs in the run reuse it.
+async function mintStorageState(
+  context: BrowserContext,
+  role: Role,
+): Promise<string> {
+  const path = storageStateFor(role);
+  if (existsSync(path)) return path;
+
+  const page = await context.newPage();
+  await signIn(page, context, ROLES[role]);
+  mkdirSync(dirname(path), { recursive: true });
+  await context.storageState({ path });
+  await page.close();
+  return path;
+}
+
+export interface AuthFixtures {
+  signInAs: (role: Role) => Promise<{ page: Page }>;
+  mintAuthState: (role: Role) => Promise<string>;
+}
+
+export const test = base.extend<AuthFixtures>({
+  // Inject the crypto.randomUUID polyfill into every page created in this
+  // context before any spec code runs. Without it, the Backstage scaffolder
+  // pickers throw and the form stalls.
+  context: async ({ context }, use) => {
+    await context.addInitScript(cryptoUUIDPolyfill);
+    await use(context);
+  },
+
+  // Drive a fresh sign-in in the current browser context. Use this when a spec
+  // needs to assert sign-in behavior itself (the auth/sign-in spec).
+  signInAs: async ({ page, context }, use) => {
+    await use(async (role: Role) => {
+      await signIn(page, context, ROLES[role]);
+      return { page };
+    });
+  },
+
+  // Mint (or reuse) a persisted storageState file for a role. Specs that just
+  // want a logged-in session should call this in a beforeAll and then
+  // test.use({ storageState }) rather than signing in for every test.
+  mintAuthState: async ({ browser }, use) => {
+    await use(async (role: Role) => {
+      const ctx = await browser.newContext();
+      const path = await mintStorageState(ctx, role);
+      await ctx.close();
+      return path;
+    });
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/test/ui/fixtures/auth.ts
+++ b/test/ui/fixtures/auth.ts
@@ -146,9 +146,14 @@ export const test = base.extend<AuthFixtures>({
   // Mint (or reuse) a persisted storageState file for a role. Specs that just
   // want a logged-in session should call this in a beforeAll and then
   // test.use({ storageState }) rather than signing in for every test.
-  mintAuthState: async ({ browser }, use) => {
+  mintAuthState: async ({ browser, baseURL }, use) => {
     await use(async (role: Role) => {
-      const ctx = await browser.newContext();
+      // A context made via browser.newContext() inherits neither the config's
+      // baseURL nor the fixture context's init scripts, so wire both up
+      // explicitly — signIn navigates to '/' and Backstage needs the
+      // crypto.randomUUID polyfill before any page script runs.
+      const ctx = await browser.newContext({ baseURL });
+      await ctx.addInitScript(cryptoUUIDPolyfill);
       const path = await mintStorageState(ctx, role);
       await ctx.close();
       return path;

--- a/test/ui/fixtures/hosts.ts
+++ b/test/ui/fixtures/hosts.ts
@@ -1,0 +1,17 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Single source of truth for the e2e hostnames the suite resolves to
+// 127.0.0.1 (so no /etc/hosts edit is needed). Consumed by both the
+// Playwright config (test browser launch) and global-setup.ts (the
+// storage-state minting browser) — keep them resolving identical domains.
+export const E2E_HOSTS = [
+  'openchoreo.e2e-cp.local',
+  'thunder.e2e-cp.local',
+  'api.e2e-cp.local',
+];
+
+// Chromium --host-resolver-rules value mapping every e2e host to loopback.
+export const hostResolverRules = E2E_HOSTS.map(h => `MAP ${h} 127.0.0.1`).join(
+  ', ',
+);

--- a/test/ui/fixtures/kube.ts
+++ b/test/ui/fixtures/kube.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
+
+// Default to the e2e cluster context. Override with E2E_KUBECONTEXT in CI.
+export const KUBE_CONTEXT =
+  process.env.E2E_KUBECONTEXT ?? 'k3d-openchoreo-e2e';
+
+export interface KubectlResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface KubectlOptions {
+  context?: string;
+  input?: string;
+  // Throw on non-zero exit. Defaults to true.
+  check?: boolean;
+  // Optional override of the default 30s spawn timeout.
+  timeoutMs?: number;
+}
+
+// Thin synchronous wrapper around `kubectl`. Specs use this to cross-check
+// what the UI claims (e.g. "Active" status pill) against what the API has.
+//
+// Sync was deliberate: assertions are simple "kubectl get x -o json | jq ..."
+// snapshots, the suite runs serially (workers: 1), and async kubectl adds
+// no parallelism. expect.poll handles the few flows that need retrying.
+export function kubectl(args: string[], opts: KubectlOptions = {}): KubectlResult {
+  const ctx = opts.context ?? KUBE_CONTEXT;
+  const spawnOpts: SpawnSyncOptionsWithStringEncoding = {
+    encoding: 'utf8',
+    timeout: opts.timeoutMs ?? 30_000,
+    input: opts.input,
+  };
+  const result = spawnSync('kubectl', ['--context', ctx, ...args], spawnOpts);
+
+  if (result.error) {
+    throw new Error(`kubectl spawn failed: ${result.error.message}`);
+  }
+  const out: KubectlResult = {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+  if (opts.check !== false && out.status !== 0) {
+    throw new Error(
+      `kubectl ${args.join(' ')} exited ${out.status}: ${out.stderr || out.stdout}`,
+    );
+  }
+  return out;
+}
+
+// kubectl get <kind> <name> -n <ns> -o json, parsed.
+export function kGetJSON<T = unknown>(
+  kind: string,
+  name: string,
+  namespace = 'default',
+  opts: KubectlOptions = {},
+): T {
+  const { stdout } = kubectl(
+    ['get', kind, name, '-n', namespace, '-o', 'json'],
+    opts,
+  );
+  return JSON.parse(stdout) as T;
+}
+
+// True when `kubectl get` returns NotFound. Use to assert post-delete state.
+export function kNotFound(
+  kind: string,
+  name: string,
+  namespace = 'default',
+): boolean {
+  const r = kubectl(
+    ['get', kind, name, '-n', namespace, '--ignore-not-found', '-o', 'name'],
+    { check: false },
+  );
+  if (r.status !== 0) return /NotFound/i.test(r.stderr);
+  return r.stdout.trim() === '';
+}
+
+// kubectl apply -f - with the supplied YAML body. Idempotent.
+export function kApplyYAML(yaml: string): KubectlResult {
+  return kubectl(['apply', '-f', '-'], { input: yaml });
+}
+
+// kubectl delete with --ignore-not-found so teardown stays idempotent.
+// Pass namespace="" for cluster-scoped resources (Namespace,
+// ClusterAuthzRoleBinding, etc.) to omit the -n flag.
+export function kDelete(
+  kind: string,
+  name: string,
+  namespace = 'default',
+): KubectlResult {
+  const args = ['delete', kind, name, '--ignore-not-found', '--wait=false'];
+  if (namespace) args.splice(3, 0, '-n', namespace);
+  return kubectl(args, { check: false });
+}

--- a/test/ui/fixtures/kube.ts
+++ b/test/ui/fixtures/kube.ts
@@ -96,5 +96,15 @@ export function kDelete(
 ): KubectlResult {
   const args = ['delete', kind, name, '--ignore-not-found', '--wait=false'];
   if (namespace) args.splice(3, 0, '-n', namespace);
-  return kubectl(args, { check: false });
+  try {
+    return kubectl(args);
+  } catch (err) {
+    // --ignore-not-found only covers the resource itself; a missing namespace
+    // or CRD still exits non-zero. Treat those as already-deleted, but surface
+    // anything else (auth failures, timeouts, wrong context).
+    if (err instanceof Error && /not ?found/i.test(err.message)) {
+      return { status: 0, stdout: '', stderr: err.message };
+    }
+    throw err;
+  }
 }

--- a/test/ui/global-setup.ts
+++ b/test/ui/global-setup.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { chromium, type FullConfig } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { ROLES, cryptoUUIDPolyfill, signIn, storageStateFor, type Role } from './fixtures/auth';
+
+// Mint per-role storage-state files once, before any test workers spin up.
+// `test.use({ storageState })` is resolved when Playwright builds a browser
+// context for the test, which happens *before* beforeAll runs — so minting
+// inside beforeAll is too late. globalSetup is the right hook.
+//
+// Idempotent: if the file already exists from a previous run, we skip
+// re-signing in. Delete .auth/ to force a fresh run.
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL =
+    config.projects[0]?.use.baseURL ??
+    process.env.UI_BASE_URL ??
+    'http://openchoreo.e2e-cp.local:28080';
+
+  // Mirror playwright.config's host-resolver-rules so the *.e2e-cp.local
+  // hostnames map to 127.0.0.1 inside this Chromium too.
+  const E2E_HOSTS = [
+    'openchoreo.e2e-cp.local',
+    'thunder.e2e-cp.local',
+    'api.e2e-cp.local',
+  ];
+  const hostResolverRules = E2E_HOSTS.map(h => `MAP ${h} 127.0.0.1`).join(', ');
+
+  const roles: Role[] = ['pe', 'dev', 'abac'];
+
+  for (const role of roles) {
+    const path = storageStateFor(role);
+    try {
+      // Fast-path: don't re-sign-in if the file is already on disk.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { existsSync } = require('node:fs') as typeof import('node:fs');
+      if (existsSync(path)) continue;
+    } catch {
+      /* fall through */
+    }
+
+    const browser = await chromium.launch({
+      args: [`--host-resolver-rules=${hostResolverRules}`],
+    });
+    const ctx = await browser.newContext({ baseURL });
+    await ctx.addInitScript(cryptoUUIDPolyfill);
+    const page = await ctx.newPage();
+    try {
+      await signIn(page, ctx, ROLES[role]);
+      mkdirSync(dirname(path), { recursive: true });
+      await ctx.storageState({ path });
+    } catch (err) {
+      // Capture diagnostics so this is debuggable without re-running headed.
+      try {
+        mkdirSync(dirname(path), { recursive: true });
+        const dbgBase = `${dirname(path)}/${role}-failed`;
+        await page.screenshot({ path: `${dbgBase}.png`, fullPage: true });
+        const html = await page.content();
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { writeFileSync } = require('node:fs') as typeof import('node:fs');
+        writeFileSync(`${dbgBase}.html`, html);
+        writeFileSync(
+          `${dbgBase}.url.txt`,
+          `${page.url()}\n${(err as Error).message}\n`,
+        );
+        // eslint-disable-next-line no-console
+        console.log(`[global-setup] dumped diagnostics to ${dbgBase}.{png,html,url.txt}`);
+      } catch {
+        /* best-effort dump */
+      }
+      // ABAC role is provisioned by test/ui/scripts/seed-idp-users.sh, which
+      // can't talk to Thunder when admin gating is on. Don't fail the whole
+      // run when only that identity is missing — the abac-ui spec self-skips
+      // when its storage state file isn't on disk.
+      if (role === 'abac') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[global-setup] abac sign-in failed; abac-ui specs will self-skip',
+        );
+      } else {
+        throw err;
+      }
+    } finally {
+      await page.close().catch(() => undefined);
+      await ctx.close().catch(() => undefined);
+      await browser.close().catch(() => undefined);
+    }
+  }
+}

--- a/test/ui/global-setup.ts
+++ b/test/ui/global-setup.ts
@@ -5,6 +5,7 @@ import { chromium, type FullConfig } from '@playwright/test';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { ROLES, cryptoUUIDPolyfill, signIn, storageStateFor, type Role } from './fixtures/auth';
+import { hostResolverRules } from './fixtures/hosts';
 
 // Mint per-role storage-state files once, before any test workers spin up.
 // `test.use({ storageState })` is resolved when Playwright builds a browser
@@ -18,15 +19,6 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
     config.projects[0]?.use.baseURL ??
     process.env.UI_BASE_URL ??
     'http://openchoreo.e2e-cp.local:28080';
-
-  // Mirror playwright.config's host-resolver-rules so the *.e2e-cp.local
-  // hostnames map to 127.0.0.1 inside this Chromium too.
-  const E2E_HOSTS = [
-    'openchoreo.e2e-cp.local',
-    'thunder.e2e-cp.local',
-    'api.e2e-cp.local',
-  ];
-  const hostResolverRules = E2E_HOSTS.map(h => `MAP ${h} 127.0.0.1`).join(', ');
 
   const roles: Role[] = ['pe', 'dev', 'abac'];
 
@@ -70,10 +62,10 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
       } catch {
         /* best-effort dump */
       }
-      // ABAC role is provisioned by test/ui/scripts/seed-idp-users.sh, which
-      // can't talk to Thunder when admin gating is on. Don't fail the whole
-      // run when only that identity is missing — the abac-ui spec self-skips
-      // when its storage state file isn't on disk.
+      // The ABAC identity has no provisioning path yet — Thunder's admin API
+      // is auth-gated, so it isn't part of the bootstrap-seeded users. Don't
+      // fail the whole run when only that identity is missing — the abac-ui
+      // spec self-skips when its storage state file isn't on disk.
       if (role === 'abac') {
         // eslint-disable-next-line no-console
         console.warn(

--- a/test/ui/k3d/values-cp-ui.yaml
+++ b/test/ui/k3d/values-cp-ui.yaml
@@ -1,0 +1,10 @@
+# Overlay that turns Backstage on for the UI test suite. Layered on top of
+# test/e2e/k3d/values-cp.yaml so the default e2e install stays Backstage-off.
+
+backstage:
+  enabled: true
+  secretName: backstage-secrets
+  baseUrl: "http://openchoreo.e2e-cp.local:28080"
+  http:
+    hostnames:
+      - openchoreo.e2e-cp.local

--- a/test/ui/package-lock.json
+++ b/test/ui/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "@openchoreo/test-ui",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openchoreo/test-ui",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.1",
+        "@types/node": "^22.10.5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/test/ui/package.json
+++ b/test/ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openchoreo/test-ui",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Playwright UI tests (Tier 5) for OpenChoreo Backstage portal — runs against an e2e k3d cluster.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "PWDEBUG=1 playwright test",
+    "report": "playwright show-report _report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/node": "^22.10.5"
+  }
+}

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig, devices } from '@playwright/test';
+
+// Mapped into Chromium via --host-resolver-rules below so the suite runs
+// without /etc/hosts edits.
+const E2E_HOSTS = [
+  'openchoreo.e2e-cp.local',
+  'thunder.e2e-cp.local',
+  'api.e2e-cp.local',
+];
+
+const hostResolverRules = E2E_HOSTS.map(h => `MAP ${h} 127.0.0.1`).join(', ');
+
+export default defineConfig({
+  testDir: './specs',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: '_report' }],
+  ],
+
+  use: {
+    baseURL: process.env.UI_BASE_URL ?? 'http://openchoreo.e2e-cp.local:28080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [`--host-resolver-rules=${hostResolverRules}`],
+        },
+      },
+    },
+  ],
+
+  outputDir: '_test-results',
+});

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -15,6 +15,10 @@ const hostResolverRules = E2E_HOSTS.map(h => `MAP ${h} 127.0.0.1`).join(', ');
 
 export default defineConfig({
   testDir: './specs',
+  // globalSetup mints per-role storage-state files in .auth/ before any
+  // worker starts — test.use({ storageState }) only resolves after the
+  // files exist on disk, so this can't live in a beforeAll hook.
+  globalSetup: './global-setup.ts',
   timeout: 60_000,
   expect: { timeout: 10_000 },
 
@@ -36,6 +40,11 @@ export default defineConfig({
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
   },
+
+  // Backstage's frontend bundle calls window.crypto.randomUUID() which is
+  // only exposed in a "secure context". The e2e portal is plain HTTP, so a
+  // polyfill is injected via an init script — see fixtures/auth.ts (test
+  // contexts) and global-setup.ts (sign-in mint context).
 
   projects: [
     {

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -2,16 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { defineConfig, devices } from '@playwright/test';
-
 // Mapped into Chromium via --host-resolver-rules below so the suite runs
-// without /etc/hosts edits.
-const E2E_HOSTS = [
-  'openchoreo.e2e-cp.local',
-  'thunder.e2e-cp.local',
-  'api.e2e-cp.local',
-];
-
-const hostResolverRules = E2E_HOSTS.map(h => `MAP ${h} 127.0.0.1`).join(', ');
+// without /etc/hosts edits. Shared with global-setup.ts.
+import { hostResolverRules } from './fixtures/hosts';
 
 export default defineConfig({
   testDir: './specs',

--- a/test/ui/po/catalogTable.ts
+++ b/test/ui/po/catalogTable.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+// Backstage catalog table. The name column renders a Link, so the row is
+// uniquely identifiable by getByRole('link', { name }) — no testid needed.
+export class CatalogTablePO {
+  constructor(private readonly page: Page) {}
+
+  async openByName(name: string): Promise<void> {
+    await this.page.getByRole('link', { name, exact: true }).first().click();
+  }
+
+  async expectListed(name: string, timeoutMs = 60_000): Promise<void> {
+    await expect(
+      this.page.getByRole('link', { name, exact: true }).first(),
+    ).toBeVisible({ timeout: timeoutMs });
+  }
+
+  // Poll until the row appears (catalog sync is eventually consistent).
+  async waitForRow(name: string, timeoutMs = 60_000): Promise<void> {
+    await expect
+      .poll(
+        async () =>
+          this.page.getByRole('link', { name, exact: true }).count(),
+        { timeout: timeoutMs, intervals: [1_000, 2_000, 5_000] },
+      )
+      .toBeGreaterThan(0);
+  }
+
+  // The OpenChoreo catalog (CustomCatalogPage) has no manual refresh control —
+  // the processor backfills entities on its own poll cycle. To re-query, we
+  // reload the page; the ChoreoEntityKindPicker restores the kind from the
+  // URL query parameter, so the filter survives the reload.
+  async reload(): Promise<void> {
+    await this.page.reload({ waitUntil: 'domcontentloaded' });
+    // The catalog list fetches asynchronously after the DOM mounts. Wait for
+    // the Kind picker label to render so we don't count rows on a half-painted
+    // page (which would report 0 spuriously).
+    await this.page
+      .getByText('Kind', { exact: true })
+      .first()
+      .waitFor({ state: 'visible', timeout: 15_000 })
+      .catch(() => undefined);
+    await this.page.waitForLoadState('networkidle').catch(() => undefined);
+  }
+
+  // Navigate straight to the catalog filtered to a given entity kind. The
+  // kind picker reads the `kind` query parameter on mount
+  // (ChoreoEntityKindPicker.useEntityKindFilter), so this selects it without
+  // driving the MUI Select dropdown.
+  async gotoKind(kind: string): Promise<void> {
+    await this.page.goto(
+      `/catalog?filters%5Bkind%5D=${encodeURIComponent(kind.toLowerCase())}`,
+    );
+  }
+}

--- a/test/ui/po/catalogTable.ts
+++ b/test/ui/po/catalogTable.ts
@@ -66,12 +66,24 @@ export class CatalogTablePO {
     await this.page.waitForLoadState('networkidle').catch(() => undefined);
   }
 
+  // Navigate to the catalog pre-filtered to a kind via the URL query. The Kind
+  // picker only lists kinds that already have ≥1 entity in the catalog, so a
+  // kind cannot be selected through the dropdown until something of that kind
+  // has synced. Pre-filtering to a not-yet-populated kind (e.g. waiting for a
+  // kubectl-applied Component to appear) therefore has no click path — the
+  // query parameter is the only way. The picker reads `filters[kind]` on mount.
+  async gotoKind(kind: string): Promise<void> {
+    await this.page.goto(
+      `/catalog?filters%5Bkind%5D=${encodeURIComponent(kind.toLowerCase())}`,
+    );
+  }
+
   // Open the catalog (via the sidebar) filtered to a given entity kind by
   // driving the Kind picker dropdown — a MUI v4 Select rendered as a
   // role=button with aria-haspopup="listbox", whose menu items are role=option.
   // The catalog opens on the System (Project) kind, so for projects no dropdown
-  // interaction is needed. Changing the kind pushes it into the URL query, so a
-  // later reload() preserves the filter.
+  // interaction is needed. NOTE: only works for kinds that already have entities
+  // in the catalog (see gotoKind) — fine for the default System kind.
   async openKind(kind: string): Promise<void> {
     await new SidebarPO(this.page).goCatalog();
     if (kind.toLowerCase() === DEFAULT_KIND) return;
@@ -105,6 +117,12 @@ export class CatalogTablePO {
               .isVisible({ timeout: 6_000 })
               .catch(() => false);
             if (!notFound) return true;
+            // The click navigated to the entity route and 404'd — reload()
+            // would just re-render the not-found page, so re-enter the
+            // filtered catalog instead. The kind provably has ≥1 entity
+            // (the link was visible), so the click path is safe here.
+            await this.openKind(kind);
+            return false;
           }
           await this.reload();
           return false;

--- a/test/ui/po/catalogTable.ts
+++ b/test/ui/po/catalogTable.ts
@@ -2,6 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, type Page } from '@playwright/test';
+import { SidebarPO } from './sidebar';
+
+// Maps a kubectl/catalog kind to the label the Kind picker renders for it
+// (kindDisplayNames in the OpenChoreo Backstage app). Used to pick the matching
+// option when driving the picker dropdown.
+const KIND_DISPLAY: Record<string, string> = {
+  system: 'Project',
+  component: 'Component',
+  componenttype: 'Component Type',
+  trait: 'Trait',
+  api: 'API',
+  resource: 'Resource',
+  environment: 'Environment',
+  deploymentpipeline: 'Deployment Pipeline',
+  domain: 'Namespace',
+};
+
+// The catalog route (App.tsx) mounts CustomCatalogPage with initialKind="system",
+// so opening the catalog with no further interaction lands on the Project list.
+const DEFAULT_KIND = 'system';
 
 // Backstage catalog table. The name column renders a Link, so the row is
 // uniquely identifiable by getByRole('link', { name }) — no testid needed.
@@ -46,13 +66,51 @@ export class CatalogTablePO {
     await this.page.waitForLoadState('networkidle').catch(() => undefined);
   }
 
-  // Navigate straight to the catalog filtered to a given entity kind. The
-  // kind picker reads the `kind` query parameter on mount
-  // (ChoreoEntityKindPicker.useEntityKindFilter), so this selects it without
-  // driving the MUI Select dropdown.
-  async gotoKind(kind: string): Promise<void> {
-    await this.page.goto(
-      `/catalog?filters%5Bkind%5D=${encodeURIComponent(kind.toLowerCase())}`,
-    );
+  // Open the catalog (via the sidebar) filtered to a given entity kind by
+  // driving the Kind picker dropdown — a MUI v4 Select rendered as a
+  // role=button with aria-haspopup="listbox", whose menu items are role=option.
+  // The catalog opens on the System (Project) kind, so for projects no dropdown
+  // interaction is needed. Changing the kind pushes it into the URL query, so a
+  // later reload() preserves the filter.
+  async openKind(kind: string): Promise<void> {
+    await new SidebarPO(this.page).goCatalog();
+    if (kind.toLowerCase() === DEFAULT_KIND) return;
+    const display = KIND_DISPLAY[kind.toLowerCase()] ?? kind;
+    await this.page.locator('[aria-haspopup="listbox"]').first().click();
+    await this.page
+      .getByRole('option', { name: display, exact: true })
+      .click();
+  }
+
+  // Filter to `kind`, wait for the (eventually-consistent) row to sync in —
+  // reloading to re-query — then open the entity by clicking its catalog link.
+  // Tolerates the brief "Entity not found" window after a fresh create by
+  // re-clicking on the next iteration.
+  async openEntity(
+    kind: string,
+    name: string,
+    timeoutMs = 90_000,
+  ): Promise<void> {
+    await this.openKind(kind);
+    await expect
+      .poll(
+        async () => {
+          const link = this.page
+            .getByRole('link', { name, exact: true })
+            .first();
+          if (await link.isVisible({ timeout: 3_000 }).catch(() => false)) {
+            await link.click();
+            const notFound = await this.page
+              .getByText(/Entity not found/i)
+              .isVisible({ timeout: 6_000 })
+              .catch(() => false);
+            if (!notFound) return true;
+          }
+          await this.reload();
+          return false;
+        },
+        { timeout: timeoutMs, intervals: [3_000] },
+      )
+      .toBe(true);
   }
 }

--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, type Page } from '@playwright/test';
+import { CreatePO } from './create';
+import { CatalogTablePO } from './catalogTable';
 
 export interface CreateComponentInput {
   name: string;
@@ -37,24 +39,13 @@ export interface DeployOptions {
 // accessible name, so they are disambiguated by document order (namespace
 // first, project second).
 export class ComponentPO {
-  // Template form URL captured on open, so the Project picker can reload the
-  // form to re-fetch the project list while waiting for catalog sync.
-  private formUrl = '';
-
   constructor(private readonly page: Page) {}
 
   async openCreateForm(template = 'Web Application'): Promise<void> {
-    await this.page.goto('/create');
-    await this.page
-      .getByRole('button', { name: /Component Browse component templates/i })
-      .click();
-    await this.page
-      .getByRole('button', { name: `Use template ${template}`, exact: true })
-      .click();
+    await new CreatePO(this.page).chooseComponentTemplate(template);
     await this.page
       .getByRole('textbox', { name: 'Component Name' })
       .waitFor({ state: 'visible', timeout: 30_000 });
-    this.formUrl = this.page.url();
   }
 
   // Step 1: Component Metadata.
@@ -95,7 +86,7 @@ export class ComponentPO {
           }
           // Not synced yet — close the menu and reload the form to re-query.
           await this.page.keyboard.press('Escape').catch(() => undefined);
-          await this.page.goto(this.formUrl);
+          await this.page.reload();
           await this.page
             .getByRole('textbox', { name: 'Component Name' })
             .waitFor({ state: 'visible', timeout: 30_000 });
@@ -164,27 +155,19 @@ export class ComponentPO {
   }
 
   async openByName(name: string): Promise<void> {
-    await this.gotoComponentRoute(name);
+    await this.openComponentEntity(name);
   }
 
-  // Navigate to a component catalog route, tolerating the brief window after
-  // create where the Backstage catalog entity isn't resolvable yet (the page
-  // renders "Warning: Entity not found"). Reload-retry until it resolves —
-  // under full-suite load this race is otherwise intermittent.
-  private async gotoComponentRoute(name: string, suffix = ''): Promise<void> {
-    await expect
-      .poll(
-        async () => {
-          await this.page.goto(`/catalog/default/component/${name}${suffix}`);
-          const notFound = await this.page
-            .getByText(/Entity not found/i)
-            .isVisible({ timeout: 8_000 })
-            .catch(() => false);
-          return !notFound;
-        },
-        { timeout: 90_000, intervals: [3_000] },
-      )
-      .toBe(true);
+  // Open a component's catalog entity page by clicking through the Component
+  // catalog list (CatalogTablePO.openEntity handles the eventually-consistent
+  // row sync and the brief post-create "Entity not found" race). When a `tab`
+  // is requested, click the entity tab to reach that sub-route — e.g. the
+  // "Deploy" tab for the /environments graph.
+  private async openComponentEntity(name: string, tab = ''): Promise<void> {
+    await new CatalogTablePO(this.page).openEntity('component', name);
+    if (tab) {
+      await this.page.getByRole('tab', { name: tab, exact: true }).click();
+    }
   }
 
   // Deploy tab is a graph canvas, not a "Deploy" button. The flow is:
@@ -197,7 +180,7 @@ export class ComponentPO {
     opts: DeployOptions = {},
   ): Promise<void> {
     // Tolerate the post-create catalog-entity race before the graph renders.
-    await this.gotoComponentRoute(componentName, '/environments');
+    await this.openComponentEntity(componentName, 'Deploy');
     await this.openSetupPanel();
 
     // --- Create a release from the current workload ---

--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -3,14 +3,15 @@
 
 import { expect, type Page } from '@playwright/test';
 import { CreatePO } from './create';
-import { CatalogTablePO } from './catalogTable';
 
 export interface CreateComponentInput {
   name: string;
   project: string; // project metadata name to select in the form's Project picker
-  // Template card label on the "Browse component templates" page, e.g.
-  // "Web Application", "Service", "Worker". Defaults to "Web Application".
-  template?: string;
+  // Template card label on the "Browse component templates" page. Restricted
+  // to the endpoint-bearing templates: create() drives the endpoint sub-form
+  // ("Add Endpoint" / "Apply changes") unconditionally, which non-HTTP
+  // templates (e.g. "Worker") don't render. Defaults to "Web Application".
+  template?: 'Web Application' | 'Service';
   image: string; // container image reference (Container Image deployment source)
   // Web Application / Service component types require at least one HTTP
   // endpoint at render time, so creation adds one. Defaults to 8080.
@@ -155,19 +156,30 @@ export class ComponentPO {
   }
 
   async openByName(name: string): Promise<void> {
-    await this.openComponentEntity(name);
+    await this.gotoComponentRoute(name);
   }
 
-  // Open a component's catalog entity page by clicking through the Component
-  // catalog list (CatalogTablePO.openEntity handles the eventually-consistent
-  // row sync and the brief post-create "Entity not found" race). When a `tab`
-  // is requested, click the entity tab to reach that sub-route — e.g. the
-  // "Deploy" tab for the /environments graph.
-  private async openComponentEntity(name: string, tab = ''): Promise<void> {
-    await new CatalogTablePO(this.page).openEntity('component', name);
-    if (tab) {
-      await this.page.getByRole('tab', { name: tab, exact: true }).click();
-    }
+  // Navigate to a component's catalog entity route directly. This deliberately
+  // uses a URL rather than click-through the catalog: the Backstage entity
+  // route resolves as soon as the component is created, whereas the Kind picker
+  // only lists the "Component" kind once at least one component has synced into
+  // the catalog list — so the filtered-list click path can't reach a
+  // freshly-created component. Reload-retry rides out the brief post-create
+  // "Entity not found" window.
+  private async gotoComponentRoute(name: string, suffix = ''): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          await this.page.goto(`/catalog/default/component/${name}${suffix}`);
+          const notFound = await this.page
+            .getByText(/Entity not found/i)
+            .isVisible({ timeout: 8_000 })
+            .catch(() => false);
+          return !notFound;
+        },
+        { timeout: 90_000, intervals: [3_000] },
+      )
+      .toBe(true);
   }
 
   // Deploy tab is a graph canvas, not a "Deploy" button. The flow is:
@@ -180,7 +192,7 @@ export class ComponentPO {
     opts: DeployOptions = {},
   ): Promise<void> {
     // Tolerate the post-create catalog-entity race before the graph renders.
-    await this.openComponentEntity(componentName, 'Deploy');
+    await this.gotoComponentRoute(componentName, '/environments');
     await this.openSetupPanel();
 
     // --- Create a release from the current workload ---
@@ -213,10 +225,12 @@ export class ComponentPO {
       .getByRole('dialog')
       .getByRole('button', { name: 'Create release', exact: true })
       .click();
+    // A dialog stuck open means the release was not snapshotted — fail here
+    // with a precise error rather than letting the Deploy step time out.
+    // waitFor(hidden) also resolves when the dialog detaches entirely.
     await this.page
       .getByRole('dialog')
-      .waitFor({ state: 'hidden', timeout: 30_000 })
-      .catch(() => undefined);
+      .waitFor({ state: 'hidden', timeout: 30_000 });
 
     // --- Deploy the release to the environment ---
     await this.openSetupPanel();

--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -1,0 +1,285 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+export interface CreateComponentInput {
+  name: string;
+  project: string; // project metadata name to select in the form's Project picker
+  // Template card label on the "Browse component templates" page, e.g.
+  // "Web Application", "Service", "Worker". Defaults to "Web Application".
+  template?: string;
+  image: string; // container image reference (Container Image deployment source)
+  // Web Application / Service component types require at least one HTTP
+  // endpoint at render time, so creation adds one. Defaults to 8080.
+  endpointPort?: number;
+  displayName?: string;
+  description?: string;
+}
+
+export interface DeployOptions {
+  // Container args applied to the release workload before deploying, e.g.
+  // ['--port', '9090']. The create wizard has no args field — args can only
+  // be set when snapshotting a release in the Deploy tab.
+  args?: string[];
+}
+
+// Component creation is a 4-step Backstage Scaffolder wizard reached by
+// browsing /create -> "Component" card -> per-ComponentType template (there is
+// no fixed create-openchoreo-component template URL). The steps are:
+//   1. Component Metadata  (Namespace/Project pickers + name)
+//   2. Build & Deploy      (Deployment Source cards + image)
+//   3. Web Application Details (Endpoints / env / mounts)  -> "Review"
+//   4. Review              -> "Create"
+//
+// Namespace/Project are MUI v4 Selects (role=button, aria-haspopup=listbox),
+// not comboboxes — both render the current value ("default") as their
+// accessible name, so they are disambiguated by document order (namespace
+// first, project second).
+export class ComponentPO {
+  // Template form URL captured on open, so the Project picker can reload the
+  // form to re-fetch the project list while waiting for catalog sync.
+  private formUrl = '';
+
+  constructor(private readonly page: Page) {}
+
+  async openCreateForm(template = 'Web Application'): Promise<void> {
+    await this.page.goto('/create');
+    await this.page
+      .getByRole('button', { name: /Component Browse component templates/i })
+      .click();
+    await this.page
+      .getByRole('button', { name: `Use template ${template}`, exact: true })
+      .click();
+    await this.page
+      .getByRole('textbox', { name: 'Component Name' })
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    this.formUrl = this.page.url();
+  }
+
+  // Step 1: Component Metadata.
+  private async fillMetadata(input: CreateComponentInput): Promise<void> {
+    await this.selectProject(input.project);
+    await this.page
+      .getByRole('textbox', { name: 'Component Name' })
+      .fill(input.name);
+    if (input.displayName) {
+      await this.page
+        .getByRole('textbox', { name: 'Display Name' })
+        .fill(input.displayName);
+    }
+    if (input.description) {
+      await this.page
+        .getByRole('textbox', { name: 'Description' })
+        .fill(input.description);
+    }
+  }
+
+  // The Project picker (2nd MUI Select; namespace is the 1st — both read
+  // "default" pre-selection) is backed by the Backstage catalog, which syncs a
+  // freshly-created project on a delay. Reload the form to re-fetch until the
+  // project shows up, then select it. `default` is preselected so no-op.
+  private async selectProject(project: string): Promise<void> {
+    if (!project || project === 'default') return;
+    await expect
+      .poll(
+        async () => {
+          await this.page.getByRole('button', { name: 'default' }).nth(1).click();
+          const option = this.page.getByRole('option', {
+            name: project,
+            exact: true,
+          });
+          if (await option.isVisible({ timeout: 2_000 }).catch(() => false)) {
+            await option.click();
+            return true;
+          }
+          // Not synced yet — close the menu and reload the form to re-query.
+          await this.page.keyboard.press('Escape').catch(() => undefined);
+          await this.page.goto(this.formUrl);
+          await this.page
+            .getByRole('textbox', { name: 'Component Name' })
+            .waitFor({ state: 'visible', timeout: 30_000 });
+          return false;
+        },
+        { timeout: 150_000, intervals: [3_000] },
+      )
+      .toBe(true);
+  }
+
+  // Step 2: Build & Deploy — pick the Container Image source and fill the
+  // image. The source radios have no accessible name, so the card heading is
+  // the click target.
+  private async fillBuildAndDeploy(input: CreateComponentInput): Promise<void> {
+    await this.page
+      .getByRole('heading', { name: 'Container Image', level: 6 })
+      .click();
+    await this.page
+      .getByRole('textbox', { name: /ghcr\.io\/org\/app/i })
+      .fill(input.image);
+  }
+
+  // Step 3: Web Application Details — add one HTTP endpoint (required by the
+  // web-application / service component types).
+  private async fillDetails(input: CreateComponentInput): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Add Endpoint', exact: true })
+      .click();
+    // The endpoint sub-form defaults to name "endpoint-1", type HTTP, port
+    // 8080. Only the port needs overriding when the image listens elsewhere.
+    const port = input.endpointPort ?? 8080;
+    const portField = this.page.getByRole('spinbutton').first();
+    await portField.fill(String(port));
+    // Commit the endpoint item — the wizard refuses to advance to Review while
+    // an endpoint is still in edit mode ("Save or cancel the item you are
+    // currently editing before proceeding.").
+    await this.page
+      .getByRole('button', { name: 'Apply changes', exact: true })
+      .click();
+  }
+
+  async create(input: CreateComponentInput): Promise<void> {
+    await this.openCreateForm(input.template ?? 'Web Application');
+    await this.fillMetadata(input);
+    await this.clickStep('Next'); // -> Build & Deploy
+    await this.fillBuildAndDeploy(input);
+    await this.clickStep('Next'); // -> Web Application Details
+    await this.fillDetails(input);
+    await this.clickStep('Review'); // -> Review
+    await this.clickStep('Create'); // submit
+    // The scaffolder lands on a task page; the component is inserted into the
+    // catalog immediately (no provider-sync wait).
+    await this.page
+      .getByRole('button', { name: 'View Component', exact: true })
+      .waitFor({ state: 'visible', timeout: 60_000 });
+  }
+
+  // Click a wizard advance button and wait for it to disappear/re-render. Each
+  // step's button differs (Next / Review / Create); waitFor rides out the
+  // picker auto-select + re-render gap that isVisible() can't (its timeout arg
+  // is a no-op).
+  private async clickStep(label: string): Promise<void> {
+    const btn = this.page.getByRole('button', { name: label, exact: true });
+    await btn.waitFor({ state: 'visible', timeout: 15_000 });
+    await btn.click();
+  }
+
+  async openByName(name: string): Promise<void> {
+    await this.gotoComponentRoute(name);
+  }
+
+  // Navigate to a component catalog route, tolerating the brief window after
+  // create where the Backstage catalog entity isn't resolvable yet (the page
+  // renders "Warning: Entity not found"). Reload-retry until it resolves —
+  // under full-suite load this race is otherwise intermittent.
+  private async gotoComponentRoute(name: string, suffix = ''): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          await this.page.goto(`/catalog/default/component/${name}${suffix}`);
+          const notFound = await this.page
+            .getByText(/Entity not found/i)
+            .isVisible({ timeout: 8_000 })
+            .catch(() => false);
+          return !notFound;
+        },
+        { timeout: 90_000, intervals: [3_000] },
+      )
+      .toBe(true);
+  }
+
+  // Deploy tab is a graph canvas, not a "Deploy" button. The flow is:
+  //   Set up node -> Create release (opens workload-config) -> [set args] ->
+  //   Continue -> confirm "Create release" dialog -> Set up -> Deploy (panel)
+  //   -> overrides page -> Deploy (confirm).
+  async deployTo(
+    componentName: string,
+    environment: string,
+    opts: DeployOptions = {},
+  ): Promise<void> {
+    // Tolerate the post-create catalog-entity race before the graph renders.
+    await this.gotoComponentRoute(componentName, '/environments');
+    await this.openSetupPanel();
+
+    // --- Create a release from the current workload ---
+    await this.page
+      .getByRole('button', { name: 'Create release', exact: true })
+      .click();
+    if (opts.args?.length) {
+      // Container tab is selected by default in the workload-config panel.
+      await this.page
+        .getByRole('textbox', { name: 'Comma-separated arguments' })
+        .fill(opts.args.join(','));
+    }
+    // The advance button reads "Continue" when nothing changed and
+    // "Save & continue" once the workload was edited (e.g. args set above).
+    await this.page
+      .getByRole('button', { name: /continue/i })
+      .first()
+      .click();
+    // An edited workload first surfaces a "Confirm Save Changes" dialog whose
+    // primary action is "Save & Continue"; an unedited one goes straight to
+    // the release-name dialog.
+    const confirmSave = this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /save & continue/i });
+    if (await confirmSave.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await confirmSave.click();
+    }
+    // Release-name dialog (name optional) — confirm to snapshot the release.
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Create release', exact: true })
+      .click();
+    await this.page
+      .getByRole('dialog')
+      .waitFor({ state: 'hidden', timeout: 30_000 })
+      .catch(() => undefined);
+
+    // --- Deploy the release to the environment ---
+    await this.openSetupPanel();
+    const panelDeploy = this.page
+      .getByRole('button', { name: 'Deploy', exact: true })
+      .first();
+    await expect(panelDeploy).toBeEnabled({ timeout: 30_000 });
+    await panelDeploy.click();
+    await this.page.waitForURL(
+      new RegExp(`overrides/${environment}`),
+      { timeout: 15_000 },
+    );
+    // Confirm on the per-environment overrides page.
+    await this.page
+      .getByRole('button', { name: 'Deploy', exact: true })
+      .first()
+      .click();
+  }
+
+  // Open the "Set up" node's detail panel if it isn't already open. Clicking an
+  // already-pressed node would toggle it closed, so guard on aria-pressed.
+  private async openSetupPanel(): Promise<void> {
+    const setup = this.page.getByRole('button', { name: /Select setup/i });
+    await setup.waitFor({ state: 'visible', timeout: 30_000 });
+    if ((await setup.getAttribute('aria-pressed')) !== 'true') {
+      await setup.click();
+    }
+  }
+
+  async promoteTo(environment: string): Promise<void> {
+    await this.page.getByRole('tab', { name: /Deploy/i }).click();
+    await this.page
+      .getByRole('button', { name: `Actions for ${environment}`, exact: true })
+      .click();
+    await this.page.getByRole('menuitem', { name: /Promote/i }).click();
+  }
+
+  async expectListed(name: string): Promise<void> {
+    await expect(
+      this.page.getByRole('link', { name, exact: true }).first(),
+    ).toBeVisible();
+  }
+
+  async expectNotListed(name: string): Promise<void> {
+    await expect(
+      this.page.getByRole('link', { name, exact: true }),
+    ).toHaveCount(0);
+  }
+}

--- a/test/ui/po/create.ts
+++ b/test/ui/po/create.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Page } from '@playwright/test';
+import { SidebarPO } from './sidebar';
+
+// The OpenChoreo "Create" page (CustomTemplateListPage). The landing view shows
+// a card per scaffolder template (Project, ComponentType, Trait, …) plus two
+// navigation cards — "Component" and "Resource" — that drill into their own
+// per-type template lists. Each template card renders a
+// `<button aria-label="Use template <title>">`, and the navigation cards are
+// role=button elements whose accessible name is "<Title> <description>".
+//
+// Reaching a template form is therefore a pure click flow (sidebar → Create →
+// card), so specs never need to deep-link to `/create/templates/...`. The
+// NamespaceEntityPicker falls back to the `default` namespace on its own, so the
+// `?namespace=` query the old URLs carried is unnecessary.
+export class CreatePO {
+  constructor(private readonly page: Page) {}
+
+  // Open the Create landing page via the left-rail "Create…" item.
+  async open(): Promise<void> {
+    await new SidebarPO(this.page).goCreate();
+  }
+
+  // Choose a landing-view template card (e.g. "Project", "ComponentType",
+  // "Trait") and land on its scaffolder form.
+  async chooseTemplate(title: string): Promise<void> {
+    await this.open();
+    await this.useTemplate(title);
+  }
+
+  // Component templates live behind the "Component" navigation card, which opens
+  // the per-ComponentType template list; pick the template from there.
+  async chooseComponentTemplate(title: string): Promise<void> {
+    await this.open();
+    await this.page
+      .getByRole('button', { name: /Component Browse component templates/i })
+      .click();
+    await this.useTemplate(title);
+  }
+
+  private async useTemplate(title: string): Promise<void> {
+    await this.page
+      .getByRole('button', { name: `Use template ${title}`, exact: true })
+      .click();
+  }
+}

--- a/test/ui/po/delete.ts
+++ b/test/ui/po/delete.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Page } from '@playwright/test';
+
+// Entity-level deletion. Backstage's EntityContextMenu surfaces a kebab icon
+// button with aria-label="more" — semantic role+name is enough, no testid.
+// The menu item label is `Delete ${KindDisplayName}` (e.g. "Delete Component",
+// "Delete Project") so callers pass the kind they expect to see.
+//
+// The confirmation dialog has no "type the name to confirm" field — just a
+// single "Delete" button.
+export class DeletePO {
+  constructor(private readonly page: Page) {}
+
+  async openOverflowAndDelete(kindLabel: string): Promise<void> {
+    await this.page.getByRole('button', { name: 'more', exact: true }).click();
+    await this.page
+      .getByRole('menuitem', { name: `Delete ${kindLabel}`, exact: true })
+      .click();
+  }
+
+  async confirm(): Promise<void> {
+    // The destructive button is the second one in the dialog (after "Cancel").
+    // It reads "Delete" in idle state and "Deleting..." in flight.
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Delete', exact: true })
+      .click();
+  }
+}

--- a/test/ui/po/project.ts
+++ b/test/ui/po/project.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+export interface CreateProjectInput {
+  name: string;
+  namespace?: string; // defaults to "default"; preselected via ?namespace query.
+  displayName?: string;
+  description?: string;
+  pipeline?: string; // matches a Deployment Pipeline entity name.
+}
+
+// Project creation flows through the Backstage Scaffolder template
+// `create-openchoreo-project`. The action button on the namespace's
+// "Has Projects" card navigates to that template with `?namespace=` set so
+// the NamespaceEntityPicker preselects. We can do the same here.
+//
+// Field titles come from the template YAML: "Namespace Name", "Project Name",
+// "Display Name", "Description", "Deployment Pipeline". MUI labels are wired
+// through aria-labelledby, so getByLabel resolves each.
+export class ProjectPO {
+  constructor(private readonly page: Page) {}
+
+  async openCreateForm(namespace = 'default'): Promise<void> {
+    await this.page.goto(
+      `/create/templates/default/create-openchoreo-project?namespace=${namespace}`,
+    );
+  }
+
+  async fillCreateForm(input: CreateProjectInput): Promise<void> {
+    await this.page.getByLabel('Project Name', { exact: false }).fill(input.name);
+    if (input.displayName) {
+      await this.page
+        .getByLabel('Display Name', { exact: false })
+        .fill(input.displayName);
+    }
+    if (input.description) {
+      await this.page
+        .getByLabel('Description', { exact: false })
+        .fill(input.description);
+    }
+    // The DeploymentPipelinePicker (packages/app/src/scaffolder/
+    // DeploymentPipelinePicker/DeploymentPipelinePickerExtension.tsx)
+    // auto-selects the `default` pipeline when the namespace's pipelines
+    // load, so an explicit `pipeline` is informational only. The picker is
+    // a MUI v4 TextField with `select` — it does NOT expose a combobox role
+    // (that's MUI v5+) — so we deliberately do not drive it. If a non-default
+    // pipeline ever needs to be tested, swap in a `.locator()` query against
+    // the underlying <input> by its name attribute.
+    void input.pipeline;
+  }
+
+  async submitCreate(): Promise<void> {
+    // Scaffolder uses a multi-step layout. The Project template surfaces
+    // step 1 with a "Review" button (advances to step 2) and step 2 with a
+    // "Create" button (submits). Some templates also intersperse "Next" on
+    // wider steps. We walk the labels in order and *wait* for each before
+    // clicking — isVisible() doesn't accept a timeout argument, so we use
+    // waitFor with a tolerant timeout to ride out the picker auto-select +
+    // re-render gap.
+    for (const label of ['Next', 'Review', 'Create']) {
+      const btn = this.page.getByRole('button', { name: label, exact: true });
+      try {
+        await btn.waitFor({ state: 'visible', timeout: 10_000 });
+      } catch {
+        continue; // this label is not part of this template's flow
+      }
+      await btn.click();
+    }
+  }
+
+  async create(input: CreateProjectInput): Promise<void> {
+    await this.openCreateForm(input.namespace);
+    await this.fillCreateForm(input);
+    await this.submitCreate();
+  }
+
+  // Catalog row navigates to /catalog/<namespace>/system/<name>.
+  async openByName(name: string): Promise<void> {
+    await this.page.getByRole('link', { name, exact: true }).first().click();
+  }
+
+  async expectListed(name: string): Promise<void> {
+    await expect(
+      this.page.getByRole('link', { name, exact: true }).first(),
+    ).toBeVisible();
+  }
+
+  async expectNotListed(name: string): Promise<void> {
+    await expect(this.page.getByRole('link', { name, exact: true })).toHaveCount(0);
+  }
+}

--- a/test/ui/po/project.ts
+++ b/test/ui/po/project.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, type Page } from '@playwright/test';
+import { CreatePO } from './create';
 
 export interface CreateProjectInput {
   name: string;
@@ -12,9 +13,10 @@ export interface CreateProjectInput {
 }
 
 // Project creation flows through the Backstage Scaffolder template
-// `create-openchoreo-project`. The action button on the namespace's
-// "Has Projects" card navigates to that template with `?namespace=` set so
-// the NamespaceEntityPicker preselects. We can do the same here.
+// `create-openchoreo-project`, reached by clicking the "Project" card on the
+// Create page (CreatePO). The NamespaceEntityPicker auto-selects the `default`
+// namespace when no preselection is supplied, so the click flow needs no
+// `?namespace=` query.
 //
 // Field titles come from the template YAML: "Namespace Name", "Project Name",
 // "Display Name", "Description", "Deployment Pipeline". MUI labels are wired
@@ -22,10 +24,12 @@ export interface CreateProjectInput {
 export class ProjectPO {
   constructor(private readonly page: Page) {}
 
+  // `namespace` is accepted for API symmetry; only the auto-selected `default`
+  // namespace is exercised. A non-default namespace would need the
+  // NamespaceEntityPicker driven explicitly here.
   async openCreateForm(namespace = 'default'): Promise<void> {
-    await this.page.goto(
-      `/create/templates/default/create-openchoreo-project?namespace=${namespace}`,
-    );
+    void namespace;
+    await new CreatePO(this.page).chooseTemplate('Project');
   }
 
   async fillCreateForm(input: CreateProjectInput): Promise<void> {

--- a/test/ui/po/project.ts
+++ b/test/ui/po/project.ts
@@ -59,16 +59,21 @@ export class ProjectPO {
     // Scaffolder uses a multi-step layout. The Project template surfaces
     // step 1 with a "Review" button (advances to step 2) and step 2 with a
     // "Create" button (submits). Some templates also intersperse "Next" on
-    // wider steps. We walk the labels in order and *wait* for each before
-    // clicking — isVisible() doesn't accept a timeout argument, so we use
-    // waitFor with a tolerant timeout to ride out the picker auto-select +
-    // re-render gap.
-    for (const label of ['Next', 'Review', 'Create']) {
+    // wider steps, so that label is probed but optional. "Review" and
+    // "Create" are mandatory: a timeout there means a slow/broken render and
+    // must fail loudly — treating it as "absent" would skip the submit and
+    // surface as a confusing downstream failure.
+    for (const { label, required } of [
+      { label: 'Next', required: false },
+      { label: 'Review', required: true },
+      { label: 'Create', required: true },
+    ]) {
       const btn = this.page.getByRole('button', { name: label, exact: true });
       try {
-        await btn.waitFor({ state: 'visible', timeout: 10_000 });
-      } catch {
-        continue; // this label is not part of this template's flow
+        await btn.waitFor({ state: 'visible', timeout: required ? 30_000 : 10_000 });
+      } catch (err) {
+        if (required) throw err;
+        continue; // 'Next' is genuinely not part of this template's flow
       }
       await btn.click();
     }

--- a/test/ui/po/release.ts
+++ b/test/ui/po/release.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+// Deployment status on the component's Deploy tab (the "environments" graph).
+// Each environment node renders a status string as `status: <state>` plus a
+// `deployed: <time> ago` suffix once a release has been deployed. Observed
+// states: "Not Deployed", "Failed", and the healthy/active state.
+//
+// The graph nodes are custom SVG/div elements with hashed class names and no
+// per-environment ARIA scoping, so we match on the visible status text. The
+// lifecycle spec only deploys to `development`, leaving the other environments
+// "Not Deployed", which keeps the healthy-state match unambiguous.
+const ACTIVE = /status:\s*(Active|Ready|Healthy|Running|Succeeded)/i;
+
+export class ReleasePO {
+  constructor(private readonly page: Page) {}
+
+  // Ensure we're on the Deploy/environments graph for the component.
+  async openDeployTab(componentName: string): Promise<void> {
+    await this.page.goto(
+      `/catalog/default/component/${componentName}/environments`,
+    );
+  }
+
+  async expectActive(
+    componentName: string,
+    _environment: string,
+    timeoutMs = 120_000,
+  ): Promise<void> {
+    await this.openDeployTab(componentName);
+    await expect
+      .poll(
+        async () => {
+          await this.page
+            .getByRole('button', { name: /Select environment/i })
+            .first()
+            .waitFor({ state: 'visible', timeout: 15_000 })
+            .catch(() => undefined);
+          // The status string ("status: Active deployed: …") is split across
+          // CSS-uppercased spans, so innerText can't see it contiguously — the
+          // accessibility tree preserves the combined text node.
+          const aria = await this.page
+            .locator('article')
+            .first()
+            .ariaSnapshot()
+            .catch(() => '');
+          if (ACTIVE.test(aria)) return true;
+          // The graph has no in-page refresh; reload to re-poll the binding.
+          await this.page.reload();
+          return false;
+        },
+        { timeout: timeoutMs, intervals: [4_000] },
+      )
+      .toBe(true);
+  }
+}

--- a/test/ui/po/release.ts
+++ b/test/ui/po/release.ts
@@ -17,20 +17,22 @@ const ACTIVE = /status:\s*(Active|Ready|Healthy|Running|Succeeded)/i;
 export class ReleasePO {
   constructor(private readonly page: Page) {}
 
-  // Ensure we're on the Deploy/environments graph for the component. Callers
-  // reach this right after deploying, so the component entity (with its tab
-  // bar) is already open — click the "Deploy" tab to land on the graph. The
-  // `/environments` route maps to the "Deploy" entity tab (EntityPage.tsx).
-  async openDeployTab(_componentName: string): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Deploy', exact: true }).click();
+  // Ensure we're on the Deploy/environments graph for the component. Uses the
+  // entity route directly (see ComponentPO.gotoComponentRoute) — the filtered
+  // catalog list can't reach a component until it has synced.
+  async openDeployTab(componentName: string): Promise<void> {
+    await this.page.goto(
+      `/catalog/default/component/${encodeURIComponent(componentName)}/environments`,
+    );
   }
 
   async expectActive(
     componentName: string,
-    _environment: string,
+    environment: string,
     timeoutMs = 120_000,
   ): Promise<void> {
     await this.openDeployTab(componentName);
+    const envRe = new RegExp(environment, 'i');
     await expect
       .poll(
         async () => {
@@ -41,13 +43,16 @@ export class ReleasePO {
             .catch(() => undefined);
           // The status string ("status: Active deployed: …") is split across
           // CSS-uppercased spans, so innerText can't see it contiguously — the
-          // accessibility tree preserves the combined text node.
-          const aria = await this.page
-            .locator('article')
-            .first()
-            .ariaSnapshot()
-            .catch(() => '');
-          if (ACTIVE.test(aria)) return true;
+          // accessibility tree preserves the combined text node. Each
+          // environment renders its own article node, so scope the check to
+          // the article that names the requested environment rather than
+          // assuming it comes first in document order.
+          const articles = this.page.locator('article');
+          const count = await articles.count().catch(() => 0);
+          for (let i = 0; i < count; i++) {
+            const aria = await articles.nth(i).ariaSnapshot().catch(() => '');
+            if (envRe.test(aria) && ACTIVE.test(aria)) return true;
+          }
           // The graph has no in-page refresh; reload to re-poll the binding.
           await this.page.reload();
           return false;

--- a/test/ui/po/release.ts
+++ b/test/ui/po/release.ts
@@ -17,11 +17,12 @@ const ACTIVE = /status:\s*(Active|Ready|Healthy|Running|Succeeded)/i;
 export class ReleasePO {
   constructor(private readonly page: Page) {}
 
-  // Ensure we're on the Deploy/environments graph for the component.
-  async openDeployTab(componentName: string): Promise<void> {
-    await this.page.goto(
-      `/catalog/default/component/${componentName}/environments`,
-    );
+  // Ensure we're on the Deploy/environments graph for the component. Callers
+  // reach this right after deploying, so the component entity (with its tab
+  // bar) is already open — click the "Deploy" tab to land on the graph. The
+  // `/environments` route maps to the "Deploy" entity tab (EntityPage.tsx).
+  async openDeployTab(_componentName: string): Promise<void> {
+    await this.page.getByRole('tab', { name: 'Deploy', exact: true }).click();
   }
 
   async expectActive(

--- a/test/ui/po/sidebar.ts
+++ b/test/ui/po/sidebar.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Page } from '@playwright/test';
+
+// Backstage left-rail navigation. Items are rendered by core-components
+// SidebarItem as <a> / <button> with the visible text as the accessible name,
+// so getByRole resolves every entry without any data-testid escape hatch.
+//
+// The real sidebar only exposes Home / Catalog / Platform / APIs / Create…
+// at the top level — there is no "Projects" or "Components" item. Per-kind
+// views live under /catalog filtered by `kind`.
+export class SidebarPO {
+  constructor(private readonly page: Page) {}
+
+  async goHome(): Promise<void> {
+    await this.page.getByRole('link', { name: 'Home', exact: true }).first().click();
+  }
+
+  async goCatalog(): Promise<void> {
+    await this.page.getByRole('link', { name: 'Catalog', exact: true }).first().click();
+  }
+
+  async goPlatform(): Promise<void> {
+    await this.page
+      .getByRole('link', { name: 'Platform', exact: true })
+      .first()
+      .click();
+  }
+
+  async goCreate(): Promise<void> {
+    await this.page
+      .getByRole('link', { name: /^Create/i })
+      .first()
+      .click();
+  }
+
+  // Sign Out is a direct SidebarItem rendered as a button — no user-menu
+  // intermediate in the real Backstage shell.
+  async signOut(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Sign Out', exact: true }).click();
+  }
+}

--- a/test/ui/specs/auth/sign-in.spec.ts
+++ b/test/ui/specs/auth/sign-in.spec.ts
@@ -1,7 +1,11 @@
 // Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { test, expect } from '@playwright/test';
+// Importing from ../../fixtures/auth (not @playwright/test) gets us the
+// context override that injects the crypto.randomUUID polyfill before any
+// page script — required because Backstage's frontend uses
+// window.crypto.randomUUID() and the e2e portal isn't a secure context.
+import { test, expect } from '../../fixtures/auth';
 
 const PE_USERNAME = 'platform-engineer@openchoreo.dev';
 const PE_PASSWORD = 'PE@123';
@@ -9,29 +13,23 @@ const PE_PASSWORD = 'PE@123';
 test.describe('backstage sign-in', () => {
   test('signs in via Thunder OIDC and lands on the post-login layout', async ({
     page,
-    context,
   }) => {
-    // Backstage opens the consent popup during the initial /refresh probe,
-    // before the on-page Sign In button renders. Arm the listener before
-    // navigation so we don't miss it. Clicking Sign In afterwards races
-    // the warm popup for the same flowId in Thunder's SQLite and fails
-    // with SQLITE_BUSY → server_error.
-    const popupPromise = context.waitForEvent('page', { timeout: 30_000 });
     await page.goto('/');
-    const consent = await popupPromise;
-    await consent.waitForLoadState('domcontentloaded');
-    expect(consent.url()).toContain('/gate/signin');
 
-    // getByLabel('Password') also matches the toggle-visibility icon
-    // button, so pin to the visible placeholder copy.
-    await consent.getByPlaceholder('Enter your username').fill(PE_USERNAME);
-    await consent.getByPlaceholder('Enter your password').fill(PE_PASSWORD);
-    await consent.getByRole('button', { name: 'Sign In', exact: true }).click();
+    // Pre-login layout exposes one Sign In affordance per provider; this
+    // install only has the OpenChoreo provider, so .first() is safe.
+    await page.getByRole('button', { name: 'Sign In', exact: true }).first().click();
 
-    await consent.waitForEvent('close', { timeout: 30_000 });
+    // Thunder's gate page uses these placeholder strings — pinning to them
+    // keeps us off the toggle-visibility icon button that getByLabel matches.
+    await page.getByPlaceholder('Enter your username').fill(PE_USERNAME);
+    await page.getByPlaceholder('Enter your password').fill(PE_PASSWORD);
+    await page.getByRole('button', { name: 'Sign In', exact: true }).click();
 
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeHidden();
-    await expect(page.getByRole('link', { name: 'Home' }).first()).toBeVisible();
+    // Post-login: Home link appears in the Backstage sidebar.
+    await expect(page.getByRole('link', { name: 'Home' }).first()).toBeVisible({
+      timeout: 60_000,
+    });
     await expect(page).toHaveTitle(/openchoreo|backstage/i);
   });
 });

--- a/test/ui/specs/auth/sign-in.spec.ts
+++ b/test/ui/specs/auth/sign-in.spec.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect } from '@playwright/test';
+
+const PE_USERNAME = 'platform-engineer@openchoreo.dev';
+const PE_PASSWORD = 'PE@123';
+
+test.describe('backstage sign-in', () => {
+  test('signs in via Thunder OIDC and lands on the post-login layout', async ({
+    page,
+    context,
+  }) => {
+    // Backstage opens the consent popup during the initial /refresh probe,
+    // before the on-page Sign In button renders. Arm the listener before
+    // navigation so we don't miss it. Clicking Sign In afterwards races
+    // the warm popup for the same flowId in Thunder's SQLite and fails
+    // with SQLITE_BUSY → server_error.
+    const popupPromise = context.waitForEvent('page', { timeout: 30_000 });
+    await page.goto('/');
+    const consent = await popupPromise;
+    await consent.waitForLoadState('domcontentloaded');
+    expect(consent.url()).toContain('/gate/signin');
+
+    // getByLabel('Password') also matches the toggle-visibility icon
+    // button, so pin to the visible placeholder copy.
+    await consent.getByPlaceholder('Enter your username').fill(PE_USERNAME);
+    await consent.getByPlaceholder('Enter your password').fill(PE_PASSWORD);
+    await consent.getByRole('button', { name: 'Sign In', exact: true }).click();
+
+    await consent.waitForEvent('close', { timeout: 30_000 });
+
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeHidden();
+    await expect(page.getByRole('link', { name: 'Home' }).first()).toBeVisible();
+    await expect(page).toHaveTitle(/openchoreo|backstage/i);
+  });
+});

--- a/test/ui/specs/auth/sign-in.spec.ts
+++ b/test/ui/specs/auth/sign-in.spec.ts
@@ -5,10 +5,11 @@
 // context override that injects the crypto.randomUUID polyfill before any
 // page script — required because Backstage's frontend uses
 // window.crypto.randomUUID() and the e2e portal isn't a secure context.
-import { test, expect } from '../../fixtures/auth';
+import { test, expect, ROLES } from '../../fixtures/auth';
 
-const PE_USERNAME = 'platform-engineer@openchoreo.dev';
-const PE_PASSWORD = 'PE@123';
+// Pull the PE credentials from the shared role catalogue so credential
+// changes stay centralized in fixtures/auth.ts.
+const { username: PE_USERNAME, password: PE_PASSWORD } = ROLES.pe;
 
 test.describe('backstage sign-in', () => {
   test('signs in via Thunder OIDC and lands on the post-login layout', async ({

--- a/test/ui/specs/catalog/catalog-sync.spec.ts
+++ b/test/ui/specs/catalog/catalog-sync.spec.ts
@@ -67,8 +67,10 @@ test.describe('catalog-sync: kubectl-applied component appears in Backstage cata
 
     const catalog = new CatalogTablePO(page);
 
-    // Open the catalog and filter to Components via the Kind picker.
-    await catalog.openKind('component');
+    // Pre-filter to the Component kind. This must use the URL: the Kind picker
+    // doesn't list "Component" until a component has synced, which is exactly
+    // what this test is waiting for — so there is no click path here.
+    await catalog.gotoKind('component');
 
     // Reload on each attempt to re-query until the kubectl-created row appears
     // — give it longer than one provider cycle (300s) plus slack.

--- a/test/ui/specs/catalog/catalog-sync.spec.ts
+++ b/test/ui/specs/catalog/catalog-sync.spec.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import { kApplyYAML, kDelete } from '../../fixtures/kube';
+import { CatalogTablePO } from '../../po/catalogTable';
+
+const ts = Date.now().toString(36);
+const PROJECT_NAME = `ui-catsync-${ts}`;
+const COMPONENT_NAME = `kubectl-component-${ts}`;
+const PRE_BUILT_IMAGE = 'ghcr.io/openchoreo/sample-greeter:latest';
+
+// Both the Project and its Components live in the same OpenChoreo API
+// namespace (`default` here). The OpenChoreo catalog provider lists
+// components via GET /api/v1/namespaces/{projectNamespace}/components?project=
+// (catalog-backend-module-openchoreo OpenChoreoEntityProvider), so a
+// kubectl-seeded Component must sit in the project's namespace with
+// spec.owner.projectName — NOT in a separate per-project namespace, or the
+// provider's query never returns it.
+const seedYAML = `
+apiVersion: openchoreo.dev/v1alpha1
+kind: Project
+metadata:
+  name: ${PROJECT_NAME}
+  namespace: default
+spec:
+  deploymentPipelineRef:
+    name: default
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: ${COMPONENT_NAME}
+  namespace: default
+spec:
+  owner:
+    projectName: ${PROJECT_NAME}
+  componentType:
+    kind: ComponentType
+    name: deployment/web-app
+  parameters:
+    image: ${PRE_BUILT_IMAGE}
+`;
+
+test.describe('catalog-sync: kubectl-applied component appears in Backstage catalog', () => {
+  test.beforeAll(async ({ mintAuthState }) => {
+    await mintAuthState('pe');
+  });
+  test.use({ storageState: storageStateFor('pe') });
+
+  test.afterAll(async () => {
+    kDelete('component', COMPONENT_NAME, 'default');
+    kDelete('project', PROJECT_NAME, 'default');
+  });
+
+  test('component applied via kubectl shows up after catalog refresh', async ({
+    page,
+  }) => {
+    // The OpenChoreo catalog provider syncs on a scheduled poll whose default
+    // frequency is 300s (catalog-backend-module-openchoreo/src/module.ts:96).
+    // A kubectl-created component only appears after the next cycle, so the
+    // poll has to span a full interval plus slack — and the test timeout must
+    // exceed the poll. Lower `openchoreo.schedule.frequency` in app-config to
+    // make this faster in a dedicated UI-test install.
+    test.setTimeout(420_000);
+    kApplyYAML(seedYAML);
+
+    const catalog = new CatalogTablePO(page);
+
+    // Filter the catalog to Components via the URL query parameter.
+    await catalog.gotoKind('component');
+
+    // Reload on each attempt to re-query until the kubectl-created row appears
+    // — give it longer than one provider cycle (300s) plus slack.
+    await expect
+      .poll(
+        async () => {
+          await catalog.reload();
+          return page
+            .getByRole('link', { name: COMPONENT_NAME, exact: true })
+            .count();
+        },
+        { timeout: 360_000, intervals: [10_000, 15_000, 30_000] },
+      )
+      .toBeGreaterThan(0);
+
+    await catalog.openByName(COMPONENT_NAME);
+    await expect(
+      page.getByRole('heading', { name: COMPONENT_NAME, exact: false }).first(),
+    ).toBeVisible();
+  });
+});

--- a/test/ui/specs/catalog/catalog-sync.spec.ts
+++ b/test/ui/specs/catalog/catalog-sync.spec.ts
@@ -67,8 +67,8 @@ test.describe('catalog-sync: kubectl-applied component appears in Backstage cata
 
     const catalog = new CatalogTablePO(page);
 
-    // Filter the catalog to Components via the URL query parameter.
-    await catalog.gotoKind('component');
+    // Open the catalog and filter to Components via the Kind picker.
+    await catalog.openKind('component');
 
     // Reload on each attempt to re-query until the kubectl-created row appears
     // — give it longer than one provider cycle (300s) plus slack.

--- a/test/ui/specs/dev-ops/dev-ops-component.spec.ts
+++ b/test/ui/specs/dev-ops/dev-ops-component.spec.ts
@@ -4,7 +4,6 @@
 import { test, expect, storageStateFor } from '../../fixtures/auth';
 import { kApplyYAML, kDelete, kubectl } from '../../fixtures/kube';
 import { ComponentPO } from '../../po/component';
-import { CreatePO } from '../../po/create';
 
 const ts = Date.now().toString(36);
 const PROJECT_NAME = `ui-dev-${ts}`;
@@ -41,6 +40,12 @@ test.describe('dev-ops: Dev CRUD inside a PE-seeded project', () => {
   });
 
   test.use({ storageState: storageStateFor('dev') });
+
+  // Load the app shell before each test so sidebar click-navigation works
+  // (the storageState context starts on about:blank).
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
 
   test.afterAll(async () => {
     kDelete('component', COMPONENT_NAME, NS);
@@ -98,7 +103,13 @@ test.describe('dev-ops: Dev CRUD inside a PE-seeded project', () => {
     // gating is enforced server-side when the create action calls the API — so
     // the assertion drives the form to submit and expects the deny on the task
     // page, plus no ComponentType CR.
-    await new CreatePO(page).chooseTemplate('ComponentType');
+    // Navigate straight to the template form by URL — deliberately NOT via the
+    // Create page card. The Dev role lacks componenttype:create, so the card is
+    // disabled client-side ("Use template ComponentType" button is disabled).
+    // This test verifies the *server-side* denial: the form still renders, and
+    // the deny surfaces only when the create action calls the API. Reaching the
+    // form past the disabled card has no click path, so the URL is required.
+    await page.goto('/create/templates/default/create-openchoreo-componenttype');
     await page
       .getByRole('textbox', { name: /ComponentType Name/i })
       .waitFor({ state: 'visible', timeout: 30_000 });

--- a/test/ui/specs/dev-ops/dev-ops-component.spec.ts
+++ b/test/ui/specs/dev-ops/dev-ops-component.spec.ts
@@ -4,6 +4,7 @@
 import { test, expect, storageStateFor } from '../../fixtures/auth';
 import { kApplyYAML, kDelete, kubectl } from '../../fixtures/kube';
 import { ComponentPO } from '../../po/component';
+import { CreatePO } from '../../po/create';
 
 const ts = Date.now().toString(36);
 const PROJECT_NAME = `ui-dev-${ts}`;
@@ -97,7 +98,7 @@ test.describe('dev-ops: Dev CRUD inside a PE-seeded project', () => {
     // gating is enforced server-side when the create action calls the API — so
     // the assertion drives the form to submit and expects the deny on the task
     // page, plus no ComponentType CR.
-    await page.goto('/create/templates/default/create-openchoreo-componenttype');
+    await new CreatePO(page).chooseTemplate('ComponentType');
     await page
       .getByRole('textbox', { name: /ComponentType Name/i })
       .waitFor({ state: 'visible', timeout: 30_000 });

--- a/test/ui/specs/dev-ops/dev-ops-component.spec.ts
+++ b/test/ui/specs/dev-ops/dev-ops-component.spec.ts
@@ -1,0 +1,139 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import { kApplyYAML, kDelete, kubectl } from '../../fixtures/kube';
+import { ComponentPO } from '../../po/component';
+
+const ts = Date.now().toString(36);
+const PROJECT_NAME = `ui-dev-${ts}`;
+const COMPONENT_NAME = `dev-comp-${ts}`;
+// Name attempted (and expected to be denied) by the authz-gating test.
+const COMPONENT_TYPE_NAME = `zz-ct-dev-${ts}`;
+// Same pinned greeter sample the lifecycle spec + e2e Ginkgo suites use.
+const PRE_BUILT_IMAGE =
+  'ghcr.io/openchoreo/samples/greeter-service@sha256:5c67732c99ac3505dbab14c7ec92c33be57904420d62812694c64b56c5f92d40';
+// Components live in the project's namespace (`default`), linked by
+// spec.owner.projectName — not a namespace named after the project.
+const NS = 'default';
+
+// The Dev identity needs a project to operate against. PE-only resources are
+// pre-applied via kubectl; the spec then asserts that the Dev identity can
+// drive Component creation through the scaffolder.
+const seedProjectYAML = `
+apiVersion: openchoreo.dev/v1alpha1
+kind: Project
+metadata:
+  name: ${PROJECT_NAME}
+  namespace: default
+spec:
+  deploymentPipelineRef:
+    name: default
+`;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('dev-ops: Dev CRUD inside a PE-seeded project', () => {
+  test.beforeAll(async ({ mintAuthState }) => {
+    kApplyYAML(seedProjectYAML);
+    await mintAuthState('dev');
+  });
+
+  test.use({ storageState: storageStateFor('dev') });
+
+  test.afterAll(async () => {
+    kDelete('component', COMPONENT_NAME, NS);
+    kDelete('project', PROJECT_NAME, NS);
+    // Defensive: the authz test expects this to never exist, but clean up if
+    // the policy ever changes and the create unexpectedly succeeds.
+    kDelete('componenttype', COMPONENT_TYPE_NAME, NS);
+  });
+
+  test('creates and views Component + Workload as Dev', async ({ page }) => {
+    const component = new ComponentPO(page);
+
+    await component.create({
+      name: COMPONENT_NAME,
+      project: PROJECT_NAME,
+      template: 'Web Application',
+      image: PRE_BUILT_IMAGE,
+      endpointPort: 9090,
+    });
+
+    await expect
+      .poll(
+        () =>
+          kubectl(['get', 'component', COMPONENT_NAME, '-n', NS], {
+            check: false,
+          }).status,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+
+    // Creating a component also renders its Workload CR (`<name>-workload`).
+    await expect
+      .poll(
+        () =>
+          kubectl(
+            ['get', 'workload', `${COMPONENT_NAME}-workload`, '-n', NS],
+            { check: false },
+          ).status,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+
+    // The component overview opens for the Dev identity.
+    await component.openByName(COMPONENT_NAME);
+    await expect(
+      page.getByRole('heading', { name: COMPONENT_NAME, level: 1 }),
+    ).toBeVisible();
+  });
+
+  test('ComponentType create is denied for Dev (server-side authz)', async ({
+    page,
+  }) => {
+    // The developer role has `componenttype:view` but not
+    // `componenttype:create`. The scaffolder template renders fully for Dev —
+    // gating is enforced server-side when the create action calls the API — so
+    // the assertion drives the form to submit and expects the deny on the task
+    // page, plus no ComponentType CR.
+    await page.goto('/create/templates/default/create-openchoreo-componenttype');
+    await page
+      .getByRole('textbox', { name: /ComponentType Name/i })
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    await page
+      .getByRole('textbox', { name: /ComponentType Name/i })
+      .fill(COMPONENT_TYPE_NAME);
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await page.getByRole('button', { name: 'Review', exact: true }).click();
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+    // The scaffolder task surfaces the API's NotAllowedError.
+    await expect(
+      page
+        .getByText(/do not have permission|not ?allowed|forbidden/i)
+        .first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // The denied create must not have produced a ComponentType.
+    await expect
+      .poll(
+        () =>
+          kubectl(
+            [
+              'get',
+              'componenttype',
+              COMPONENT_TYPE_NAME,
+              '-n',
+              NS,
+              '--ignore-not-found',
+              '-o',
+              'name',
+            ],
+            { check: false },
+          ).stdout.trim(),
+        { timeout: 10_000 },
+      )
+      .toBe('');
+  });
+});

--- a/test/ui/specs/lifecycle/full-lifecycle.spec.ts
+++ b/test/ui/specs/lifecycle/full-lifecycle.spec.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import { kGetJSON, kNotFound, kDelete, kubectl } from '../../fixtures/kube';
+import { ProjectPO } from '../../po/project';
+import { ComponentPO } from '../../po/component';
+import { ReleasePO } from '../../po/release';
+import { DeletePO } from '../../po/delete';
+
+// Pre-built greeter sample. Pinned to the same digest the e2e Ginkgo suites
+// use (test/e2e/suites/observability) so the cluster can already pull it and
+// the readiness contract is known: it serves HTTP on 9090 when started with
+// `--port 9090`.
+const PRE_BUILT_IMAGE =
+  'ghcr.io/openchoreo/samples/greeter-service@sha256:5c67732c99ac3505dbab14c7ec92c33be57904420d62812694c64b56c5f92d40';
+const ENDPOINT_PORT = 9090;
+
+// Components and ReleaseBindings are namespaced resources that live in the
+// project's namespace (`default`) and link to their project via
+// spec.owner.projectName — there is no per-project namespace.
+const NS = 'default';
+
+// Suffix keeps reruns from colliding when a test container restarts.
+const ts = Date.now().toString(36);
+const PROJECT_NAME = `ui-lifecycle-${ts}`;
+const COMPONENT_NAME = `greeter-${ts}`;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('lifecycle: full kubectl-equivalent flow through Backstage UI', () => {
+  test.beforeAll(async ({ mintAuthState }) => {
+    await mintAuthState('pe');
+  });
+
+  test.use({ storageState: storageStateFor('pe') });
+
+  test.afterAll(async () => {
+    // Best-effort teardown in case a test bails mid-flight.
+    kDelete('component', COMPONENT_NAME, NS);
+    kDelete('project', PROJECT_NAME, NS);
+  });
+
+  test('creates project + component, deploys, deletes — UI and kubectl agree', async ({
+    page,
+  }) => {
+    // create + multi-step deploy + wait-for-Ready exceeds the global 60s.
+    test.setTimeout(360_000);
+    const project = new ProjectPO(page);
+    const component = new ComponentPO(page);
+    const release = new ReleasePO(page);
+    const del = new DeletePO(page);
+
+    await page.goto('/');
+
+    // ---- Create project ----
+    await project.create({
+      name: PROJECT_NAME,
+      namespace: NS,
+      displayName: PROJECT_NAME,
+      description: 'Tier 5 UI lifecycle spec',
+      pipeline: 'default',
+    });
+
+    await expect
+      .poll(
+        () =>
+          kubectl(['get', 'project', PROJECT_NAME, '-n', NS], {
+            check: false,
+          }).status,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+
+    // ---- Create component (Web Application, pre-built image, HTTP :9090) ----
+    await component.create({
+      name: COMPONENT_NAME,
+      project: PROJECT_NAME,
+      template: 'Web Application',
+      image: PRE_BUILT_IMAGE,
+      endpointPort: ENDPOINT_PORT,
+      description: 'pre-built greeter sample',
+    });
+
+    await expect
+      .poll(
+        () =>
+          kubectl(['get', 'component', COMPONENT_NAME, '-n', NS], {
+            check: false,
+          }).status,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+
+    // ---- Deploy to development ----
+    // The greeter needs `--port 9090` to listen on its endpoint port; the
+    // create wizard has no args field, so it's set on the release workload.
+    await component.deployTo(COMPONENT_NAME, 'development', {
+      args: ['--port', String(ENDPOINT_PORT)],
+    });
+    await release.expectActive(COMPONENT_NAME, 'development', 120_000);
+
+    // Cross-check kubectl: ReleaseBinding Ready, componentType matches.
+    await expect
+      .poll(
+        () => {
+          const bindings = kubectl(
+            [
+              'get',
+              'releasebinding',
+              '-n',
+              NS,
+              '-l',
+              `openchoreo.dev/component=${COMPONENT_NAME}`,
+              '-o',
+              'jsonpath={.items[*].status.conditions[?(@.type=="Ready")].status}',
+            ],
+            { check: false },
+          ).stdout;
+          return bindings.includes('True');
+        },
+        { timeout: 120_000 },
+      )
+      .toBe(true);
+
+    const componentJSON = kGetJSON<{
+      spec: { componentType: { name: string } };
+    }>('component', COMPONENT_NAME, NS);
+    expect(componentJSON.spec.componentType.name).toBe(
+      'deployment/web-application',
+    );
+
+    // ---- Delete component via UI ----
+    await component.openByName(COMPONENT_NAME);
+    await del.openOverflowAndDelete('Component');
+    await del.confirm();
+
+    await expect
+      .poll(() => kNotFound('component', COMPONENT_NAME, NS), {
+        timeout: 60_000,
+      })
+      .toBe(true);
+
+    // ---- Delete project via UI ----
+    await page.goto(`/catalog/${NS}/system/${PROJECT_NAME}`);
+    await del.openOverflowAndDelete('Project');
+    await del.confirm();
+
+    await expect
+      .poll(() => kNotFound('project', PROJECT_NAME, NS), {
+        timeout: 60_000,
+      })
+      .toBe(true);
+  });
+});

--- a/test/ui/specs/lifecycle/full-lifecycle.spec.ts
+++ b/test/ui/specs/lifecycle/full-lifecycle.spec.ts
@@ -7,6 +7,7 @@ import { ProjectPO } from '../../po/project';
 import { ComponentPO } from '../../po/component';
 import { ReleasePO } from '../../po/release';
 import { DeletePO } from '../../po/delete';
+import { CatalogTablePO } from '../../po/catalogTable';
 
 // Pre-built greeter sample. Pinned to the same digest the e2e Ginkgo suites
 // use (test/e2e/suites/observability) so the cluster can already pull it and
@@ -50,6 +51,7 @@ test.describe('lifecycle: full kubectl-equivalent flow through Backstage UI', ()
     const component = new ComponentPO(page);
     const release = new ReleasePO(page);
     const del = new DeletePO(page);
+    const catalog = new CatalogTablePO(page);
 
     await page.goto('/');
 
@@ -142,7 +144,7 @@ test.describe('lifecycle: full kubectl-equivalent flow through Backstage UI', ()
       .toBe(true);
 
     // ---- Delete project via UI ----
-    await page.goto(`/catalog/${NS}/system/${PROJECT_NAME}`);
+    await catalog.openEntity('system', PROJECT_NAME);
     await del.openOverflowAndDelete('Project');
     await del.confirm();
 

--- a/test/ui/tsconfig.json
+++ b/test/ui/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["specs/**/*", "po/**/*", "fixtures/**/*", "playwright.config.ts"]
+  "include": ["specs/**/*", "po/**/*", "fixtures/**/*", "playwright.config.ts", "global-setup.ts"]
 }

--- a/test/ui/tsconfig.json
+++ b/test/ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["specs/**/*", "po/**/*", "fixtures/**/*", "playwright.config.ts"]
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds a Playwright UI e2e test suite that drives the Backstage portal against the e2e k3d cluster.
It covers:
- sign-in
- catalog sync
- component lifecycle
- dev-ops flows.

The e2e setup gains an `E2E_WITH_UI` flag to enable Backstage, and a GitHub Actions workflow runs the suite.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
