### PR TITLE
test: add pe-ops, abac-ui, and pkce-login ui specs

### DIFF
--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -29,6 +29,9 @@ env:
   E2E_WITH_UI: "true"
   E2E_KUBECONTEXT: k3d-openchoreo-e2e
   UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
+  # OpenChoreo API URL the pkce-login spec points occ at (NOT the Backstage
+  # portal URL above).
+  OCC_CONTROL_PLANE_URL: http://api.e2e-cp.local:28080
   K3D_VERSION: v5.8.3
   K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
   YQ_VERSION: v4.45.4
@@ -80,6 +83,17 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Map e2e hostnames for host processes
+        # The browsers resolve *.e2e-cp.local via Chromium host-resolver-rules,
+        # but occ (driven by the pkce-login spec) is a host process and needs
+        # real DNS — without this entry the spec self-skips.
+        run: |
+          echo "127.0.0.1 openchoreo.e2e-cp.local api.e2e-cp.local thunder.e2e-cp.local" | sudo tee -a /etc/hosts
+
+      - name: Build occ CLI
+        # The pkce-login spec spawns bin/occ for the browser-assisted PKCE leg.
+        run: make go.build.occ
 
       - name: Install UI test dependencies
         working-directory: test/ui

--- a/test/e2e/k3d/values-thunder.yaml
+++ b/test/e2e/k3d/values-thunder.yaml
@@ -144,3 +144,77 @@ bootstrap:
 
         log_info "Default application created successfully"
       fi
+
+    # Provision the ABAC-restricted identity the abac-ui Playwright suite
+    # signs in as. Thunder's admin API rejects all requests (401) once the
+    # server is up — even from loopback — so users can only be seeded from
+    # inside the setup Job, where these bootstrap scripts run. Runs after the
+    # stock 50-user-schema-and-users.sh (which creates the org unit, the
+    # openchoreo-user schema, and the PE/Dev identities) and reuses the same
+    # idempotent ensure-user / ensure-group shape.
+    52-abac-user.sh: |
+      #!/bin/bash
+      set -e
+
+      THUNDER_URL="http://localhost:8090"
+
+      ORG_UNIT_ID=$(curl -s --max-time 10 "${THUNDER_URL}/organization-units/tree/default" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+      if [ -z "$ORG_UNIT_ID" ]; then
+        log_error "Failed to resolve default organization unit ID from ${THUNDER_URL}"
+        exit 1
+      fi
+      log_info "Using organization unit ID: $ORG_UNIT_ID"
+
+      ABAC_USERNAME="abac-dev@openchoreo.dev"
+      ABAC_GROUP="abac-developers"
+
+      existing_users=$(curl -s --max-time 10 "${THUNDER_URL}/users")
+      if echo "$existing_users" | grep -q "\"username\" *: *\"${ABAC_USERNAME}\""; then
+        log_info "User '${ABAC_USERNAME}' already exists, getting ID..."
+        abac_user_id=$(echo "$existing_users" | tr '\n' ' ' | sed 's/" *: *"/":"/g' \
+          | grep -o "\"username\":\"${ABAC_USERNAME}\"[^}]*\"id\":\"[^\"]*\"\|\"id\":\"[^\"]*\"[^}]*\"username\":\"${ABAC_USERNAME}\"" \
+          | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+      else
+        log_info "Creating user '${ABAC_USERNAME}'..."
+        response=$(curl --location "${THUNDER_URL}/users" \
+          --header 'accept: application/json' \
+          --header 'Content-Type: application/json' \
+          --data "{
+            \"type\": \"openchoreo-user\",
+            \"organizationUnit\": \"$ORG_UNIT_ID\",
+            \"attributes\": {
+              \"username\": \"${ABAC_USERNAME}\",
+              \"email\": \"${ABAC_USERNAME}\",
+              \"password\": \"Abac@123\",
+              \"given_name\": \"ABAC\",
+              \"family_name\": \"Developer\"
+            }
+          }" \
+          --fail-with-body \
+          --max-time 30 \
+          --retry 3 \
+          --retry-delay 5)
+        log_info "User '${ABAC_USERNAME}' created successfully"
+        abac_user_id=$(echo "$response" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+      fi
+
+      existing_groups=$(curl -s --max-time 10 "${THUNDER_URL}/groups")
+      if echo "$existing_groups" | grep -q "\"name\" *: *\"${ABAC_GROUP}\""; then
+        log_info "Group '${ABAC_GROUP}' already exists, skipping creation"
+      else
+        log_info "Creating group '${ABAC_GROUP}'..."
+        curl --location "${THUNDER_URL}/groups" \
+          --header 'accept: application/json' \
+          --header 'Content-Type: application/json' \
+          --data "{
+            \"name\": \"${ABAC_GROUP}\",
+            \"organizationUnitId\": \"$ORG_UNIT_ID\",
+            \"description\": \"ABAC-restricted developers (environment-scoped access, used by the abac-ui Playwright suite)\",
+            \"members\": [{\"type\":\"user\",\"id\":\"${abac_user_id}\"}]
+          }" \
+          --fail-with-body \
+          --max-time 30 \
+          --retry 3 \
+          --retry-delay 5
+        log_info "Group '${ABAC_GROUP}' created successfully"
+      fi

--- a/test/e2e/k3d/values-thunder.yaml
+++ b/test/e2e/k3d/values-thunder.yaml
@@ -168,7 +168,23 @@ bootstrap:
       ABAC_USERNAME="abac-dev@openchoreo.dev"
       ABAC_GROUP="abac-developers"
 
-      existing_users=$(curl -s --max-time 10 "${THUNDER_URL}/users")
+      # Fail on HTTP errors and retry: a transient Thunder error here would
+      # otherwise yield an empty list and divert into the create path
+      # (which then fails on the already-existing user). Mirrors the retry
+      # in 51-backstage-app.sh.
+      existing_users=""
+      for attempt in 1 2 3; do
+        if existing_users=$(curl -s --fail --max-time 10 "${THUNDER_URL}/users"); then
+          break
+        fi
+        existing_users=""
+        log_info "Listing users failed (attempt ${attempt}/3), retrying in 5s..."
+        sleep 5
+      done
+      if [ -z "$existing_users" ]; then
+        log_error "Failed to list users from ${THUNDER_URL} after 3 attempts"
+        exit 1
+      fi
       if echo "$existing_users" | grep -q "\"username\" *: *\"${ABAC_USERNAME}\""; then
         log_info "User '${ABAC_USERNAME}' already exists, getting ID..."
         abac_user_id=$(echo "$existing_users" | tr '\n' ' ' | sed 's/" *: *"/":"/g' \
@@ -198,7 +214,20 @@ bootstrap:
         abac_user_id=$(echo "$response" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
       fi
 
-      existing_groups=$(curl -s --max-time 10 "${THUNDER_URL}/groups")
+      # Same fail-and-retry rationale as the user listing above.
+      existing_groups=""
+      for attempt in 1 2 3; do
+        if existing_groups=$(curl -s --fail --max-time 10 "${THUNDER_URL}/groups"); then
+          break
+        fi
+        existing_groups=""
+        log_info "Listing groups failed (attempt ${attempt}/3), retrying in 5s..."
+        sleep 5
+      done
+      if [ -z "$existing_groups" ]; then
+        log_error "Failed to list groups from ${THUNDER_URL} after 3 attempts"
+        exit 1
+      fi
       if echo "$existing_groups" | grep -q "\"name\" *: *\"${ABAC_GROUP}\""; then
         log_info "Group '${ABAC_GROUP}' already exists, skipping creation"
       else

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -33,7 +33,7 @@ Chromium's `--host-resolver-rules`, so no `/etc/hosts` edit is needed.
 
 - `playwright.config.ts` — runner config.
 - `specs/` — one folder per suite (`auth/`, `catalog/`, `lifecycle/`,
-  `dev-ops/`).
+  `dev-ops/`, `pe-ops/`, `abac-ui/`).
 - `po/` — page objects (intent-named methods, semantic locators). Every
   affordance currently resolves via `getByRole` + accessible name or
   `getByLabel`; no `data-testid` escape hatches are required against the
@@ -41,17 +41,20 @@ Chromium's `--host-resolver-rules`, so no `/etc/hosts` edit is needed.
 - `fixtures/` — Playwright `test.extend` fixtures (per-role storage state via
   `mintAuthState` + `storageStateFor`, a thin `kubectl` wrapper).
 - `k3d/` — Helm value overlays that turn the e2e cluster into a UI-test target.
+- `scripts/` — `seed-idp-users.sh`, the Thunder setup-Job re-run for
+  already-installed clusters (see below).
 
 ## Specs
 
 | Suite | Spec | What it asserts |
 |---|---|---|
 | `auth/` | sign-in | Thunder OIDC sign-in lands on the post-login Backstage layout |
+| `auth/` | pkce-login | `occ login` PKCE round-trip: Playwright drives the consent form, token persists, `occ get components` succeeds (self-skips unless the e2e hostnames resolve on the host — see below) |
 | `catalog/` | catalog-sync | kubectl-applied Component shows up in the Backstage catalog within polling timeout |
 | `lifecycle/` | full-lifecycle | UI-driven project + component create → deploy → delete, kubectl agreement on each step |
 | `dev-ops/` | dev-ops-component | Dev creates + views a Component; ComponentType create is denied server-side |
-
-Further suites (`pe-ops`, `abac-ui`, `auth/pkce-login`) land in follow-up PRs.
+| `pe-ops/` | pe-ops-pipeline | PE CRUD via the Scaffolder templates (ComponentType, Trait): create → kubectl shape → delete via the entity overflow menu |
+| `abac-ui/` | abac-env-restriction | Env-conditioned ClusterAuthzRoleBinding: deploy-to-dev + promote-to-staging allowed, promote-to-production renders the Promote button permission-disabled; relogin keeps the same permission shape (regression guard for backstage-plugins#549). Self-skips unless the ABAC identity is seeded — see below |
 
 ## Sign-in spec
 
@@ -63,47 +66,53 @@ fill the Thunder gate (`Enter your username` / `Enter your password`) → submit
 wait for the post-login sidebar `Home` link. The shared helper in
 `fixtures/auth.ts` drives the same flow to mint per-role `storageState`.
 
-## Thunder Backstage app must list the e2e redirect URI
+## Thunder bootstrap overlay (redirect URI + ABAC identity)
 
-The chart's `bootstrap.scripts.51-backstage-app.sh` is overlaid in
-`test/e2e/k3d/values-thunder.yaml` to add
-`http://openchoreo.e2e-cp.local:28080/api/auth/openchoreo-auth/handler/frame`
-alongside the single-cluster default. The Thunder helm chart only runs the
-bootstrap on `helm install` (`helm.sh/hook: pre-install`,
-`hook-delete-policy: hook-succeeded`), so applying the overlay to an
-already-installed cluster needs three steps:
+`test/e2e/k3d/values-thunder.yaml` overlays two bootstrap scripts onto the
+Thunder chart:
+
+- `51-backstage-app.sh` — adds
+  `http://openchoreo.e2e-cp.local:28080/api/auth/openchoreo-auth/handler/frame`
+  alongside the single-cluster default redirect URI.
+- `52-abac-user.sh` — provisions the ABAC-restricted identity
+  (`abac-dev@openchoreo.dev` in group `abac-developers`) the `abac-ui` suite
+  signs in as. Thunder's admin API rejects every request (401) once the
+  server is up — even from loopback inside the pod — so identities can only
+  be seeded from the bootstrap setup Job, which runs against the SQLite
+  store directly.
+
+The Thunder helm chart only runs the bootstrap on `helm install`
+(`helm.sh/hook: pre-install`, `hook-delete-policy: hook-succeeded`), so
+fresh installs (`make e2e.setup E2E_WITH_UI=true`) get both automatically.
+For an already-installed cluster, re-run the setup Job with:
 
 ```sh
-# Re-render with the e2e overlay and patch the bootstrap ConfigMap in place.
-helm --kube-context k3d-openchoreo-e2e template thunder \
-  oci://ghcr.io/asgardeo/helm-charts/thunder --namespace thunder --version 0.28.0 \
-  --values install/k3d/common/values-thunder.yaml \
-  --values test/e2e/k3d/values-thunder.yaml \
-  | awk '/^# Source: thunder\/templates\/bootstrap-configmap.yaml/,/^# Source:/' \
-  | sed '/^# Source: thunder\/templates\/[^b]/,$d' \
-  | kubectl --context k3d-openchoreo-e2e -n thunder apply -f -
-
-# Free the RWO sqlite PVC so the setup Job can mount it.
-kubectl --context k3d-openchoreo-e2e -n thunder scale deploy thunder-deployment --replicas=0
-kubectl --context k3d-openchoreo-e2e -n thunder wait --for=delete pod \
-  -l app.kubernetes.io/name=thunder --timeout=2m
-
-# Re-apply the setup Job manifest (renamed, helm hooks stripped) — bootstrap
-# scripts PUT-update each app idempotently against the existing PVC data.
-helm --kube-context k3d-openchoreo-e2e template thunder \
-  oci://ghcr.io/asgardeo/helm-charts/thunder --namespace thunder --version 0.28.0 \
-  --values install/k3d/common/values-thunder.yaml \
-  --values test/e2e/k3d/values-thunder.yaml \
-  --show-only templates/setup-job.yaml \
-  | yq '.metadata.name = "thunder-setup-rerun" | del(.metadata.annotations)' \
-  | kubectl --context k3d-openchoreo-e2e -n thunder apply -f -
-kubectl --context k3d-openchoreo-e2e -n thunder wait \
-  --for=condition=complete job/thunder-setup-rerun --timeout=5m
-kubectl --context k3d-openchoreo-e2e -n thunder delete job thunder-setup-rerun
-
-# Bring Thunder back up.
-kubectl --context k3d-openchoreo-e2e -n thunder scale deploy thunder-deployment --replicas=1
+test/ui/scripts/seed-idp-users.sh
 ```
+
+The script re-renders the bootstrap ConfigMap with the e2e overlay, scales
+Thunder to zero (the setup Job needs the RWO SQLite PVC), re-applies the
+setup Job (renamed, helm hooks stripped — the bootstrap scripts are
+idempotent), and scales Thunder back up. Sign-ins fail during the ~1–2
+minute window while Thunder is down. Requires `helm`, `kubectl`, `yq`.
+
+## pkce-login prerequisites
+
+The `auth/pkce-login` spec spawns `occ` as a host process — unlike the
+browser specs it cannot use Chromium's `--host-resolver-rules`, so the e2e
+hostnames must resolve via real DNS on the host:
+
+```sh
+sudo sh -c 'echo "127.0.0.1 openchoreo.e2e-cp.local api.e2e-cp.local thunder.e2e-cp.local" >> /etc/hosts'
+```
+
+The spec self-skips when the control-plane hostname doesn't resolve, so the
+rest of the suite is unaffected by a missing entry. It also needs the `occ`
+binary — `make go.build.occ` places it under `bin/dist/<os>/<arch>/occ`,
+which the spec resolves automatically (override with `OCC_BIN`). The
+control-plane API URL defaults to `http://api.e2e-cp.local:28080`; override
+with `OCC_CONTROL_PLANE_URL` (deliberately not `UI_BASE_URL`, which is the
+Backstage portal, not the API).
 
 ## Headed runs
 

--- a/test/ui/k3d/values-cp-ui.yaml
+++ b/test/ui/k3d/values-cp-ui.yaml
@@ -8,3 +8,9 @@ backstage:
   http:
     hostnames:
       - openchoreo.e2e-cp.local
+  # The default 300s full-sync cycle makes catalog-dependent flows (the
+  # catalog-sync spec, the component form's project picker) ride a 5-minute
+  # wait for freshly-created resources. 60s keeps the suite snappy without
+  # meaningfully loading the test cluster.
+  catalogSync:
+    frequency: 60

--- a/test/ui/po/catalogTable.ts
+++ b/test/ui/po/catalogTable.ts
@@ -11,7 +11,9 @@ const KIND_DISPLAY: Record<string, string> = {
   system: 'Project',
   component: 'Component',
   componenttype: 'Component Type',
-  trait: 'Trait',
+  // Trait CRs surface in the catalog as kind "traittype" — there is no
+  // catalog kind named "trait".
+  traittype: 'Trait Type',
   api: 'API',
   resource: 'Resource',
   environment: 'Environment',
@@ -98,12 +100,19 @@ export class CatalogTablePO {
   // reloading to re-query — then open the entity by clicking its catalog link.
   // Tolerates the brief "Entity not found" window after a fresh create by
   // re-clicking on the next iteration.
+  //
+  // Navigates via gotoKind (URL query) rather than the openKind click path,
+  // for two reasons: (1) the Kind picker only lists kinds that already have a
+  // synced entity, so the dropdown cannot reach a kind whose *first* entity
+  // is the one still syncing in (the pe-ops trait case); (2) a dropdown
+  // selection is not reflected in the URL, so the reload-to-repoll loop
+  // would reset the filter back to the initialKind on every iteration.
   async openEntity(
     kind: string,
     name: string,
     timeoutMs = 90_000,
   ): Promise<void> {
-    await this.openKind(kind);
+    await this.gotoKind(kind);
     await expect
       .poll(
         async () => {
@@ -119,9 +128,8 @@ export class CatalogTablePO {
             if (!notFound) return true;
             // The click navigated to the entity route and 404'd — reload()
             // would just re-render the not-found page, so re-enter the
-            // filtered catalog instead. The kind provably has ≥1 entity
-            // (the link was visible), so the click path is safe here.
-            await this.openKind(kind);
+            // filtered catalog instead.
+            await this.gotoKind(kind);
             return false;
           }
           await this.reload();

--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -164,20 +164,31 @@ export class ComponentPO {
   // route resolves as soon as the component is created, whereas the Kind picker
   // only lists the "Component" kind once at least one component has synced into
   // the catalog list — so the filtered-list click path can't reach a
-  // freshly-created component. Reload-retry rides out the brief post-create
+  // freshly-created component. Reload-retry rides out the post-create
   // "Entity not found" window.
+  //
+  // Polls for a POSITIVE readiness signal (the entity page heading carries
+  // the component name) rather than the absence of "Entity not found" — on
+  // a slow load neither state is painted yet, so an absence check passes
+  // spuriously and the caller then times out on a half-rendered page. The
+  // budget covers a full catalog-provider sync cycle (default 300s) for
+  // installs without the UI-test values overlay.
   private async gotoComponentRoute(name: string, suffix = ''): Promise<void> {
     await expect
       .poll(
         async () => {
           await this.page.goto(`/catalog/default/component/${name}${suffix}`);
-          const notFound = await this.page
-            .getByText(/Entity not found/i)
-            .isVisible({ timeout: 8_000 })
-            .catch(() => false);
-          return !notFound;
+          try {
+            await this.page
+              .getByRole('heading', { name })
+              .first()
+              .waitFor({ state: 'visible', timeout: 8_000 });
+            return true;
+          } catch {
+            return false;
+          }
         },
-        { timeout: 90_000, intervals: [3_000] },
+        { timeout: 360_000, intervals: [3_000] },
       )
       .toBe(true);
   }
@@ -260,12 +271,65 @@ export class ComponentPO {
     }
   }
 
-  async promoteTo(environment: string): Promise<void> {
-    await this.page.getByRole('tab', { name: /Deploy/i }).click();
+  // The canvas's Promote affordance. The Deploy graph renders every
+  // environment node inside a single <article>, so per-environment scoping
+  // is not possible via roles — but it isn't needed: the Promote button only
+  // renders on an environment with a deployed binding, and once its target
+  // is promoted the button reads "Promoted" instead. At most one button
+  // named exactly "Promote" therefore exists at any time, and it always
+  // belongs to the most-recently-deployed pipeline stage.
+  private promoteButton() {
+    return this.page.getByRole('button', { name: 'Promote', exact: true });
+  }
+
+  // Promote the deployed release to `targetEnvironment` (its single
+  // promotion source is whichever stage currently shows the Promote
+  // button). Clicking it opens the target's overrides page, where "Promote"
+  // (or "Save & Promote" when overrides changed) confirms.
+  async promoteToNext(targetEnvironment: string): Promise<void> {
+    const promote = this.promoteButton();
+    await expect(promote).toBeEnabled({ timeout: 60_000 });
+    await promote.click();
+    await this.page.waitForURL(new RegExp(`overrides/${targetEnvironment}`), {
+      timeout: 15_000,
+    });
     await this.page
-      .getByRole('button', { name: `Actions for ${environment}`, exact: true })
+      .getByRole('button', { name: /^(Save & )?Promote$/ })
+      .first()
       .click();
-    await this.page.getByRole('menuitem', { name: /Promote/i }).click();
+  }
+
+  // Assert the canvas's Promote affordance is permission-denied for
+  // `targetEnvironment`. The UI gates Promote client-side per TARGET
+  // environment (usePromoteToEnvPermission: releasebinding:create + update),
+  // so an ABAC deny renders a DISABLED button wrapped in a tooltip naming
+  // the missing permission — there is no click → server-deny → toast path.
+  async expectPromoteDenied(
+    targetEnvironment: string,
+    timeoutMs = 60_000,
+  ): Promise<void> {
+    const promote = this.promoteButton();
+    // Auto-retries through the window where the previous stage's button is
+    // still enabled: once the target stage deploys, the previous button
+    // renames to "Promoted" and this locator re-resolves to the new stage.
+    await expect(promote).toBeDisabled({ timeout: timeoutMs });
+    // Disabled is also the transient state while the permission check loads;
+    // the deny tooltip naming the target is what distinguishes "denied"
+    // from "still loading". The tooltip's hover listener is only armed once
+    // the deny resolves, and MUI won't show it for a pointer already resting
+    // on the element — so re-hover (leave + enter) on every retry instead of
+    // hovering once and polling visibility.
+    const tooltip = this.page.getByText(
+      new RegExp(
+        `do not have permission to (promote|deploy)( to)? .*${targetEnvironment}`,
+        'i',
+      ),
+    );
+    await expect(async () => {
+      await this.page.mouse.move(0, 0);
+      await promote.hover({ force: true });
+      await expect(tooltip).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 30_000 });
   }
 
   async expectListed(name: string): Promise<void> {

--- a/test/ui/scripts/seed-idp-users.sh
+++ b/test/ui/scripts/seed-idp-users.sh
@@ -54,10 +54,12 @@ helm_template --show-only templates/bootstrap-configmap.yaml \
   | "${KUBECTL[@]}" apply -f -
 
 log_info "Scaling thunder-deployment to 0 to free the RWO SQLite PVC"
+# Install the restore trap before touching the replica count so any early
+# exit (including a failed wait below) scales Thunder back up.
+trap restore_thunder EXIT
 "${KUBECTL[@]}" scale deploy thunder-deployment --replicas=0
 "${KUBECTL[@]}" wait --for=delete pod \
   -l app.kubernetes.io/name=thunder --timeout=2m
-trap restore_thunder EXIT
 
 log_info "Re-running the setup Job (renamed, helm hooks stripped)"
 "${KUBECTL[@]}" delete job "${RERUN_JOB}" --ignore-not-found

--- a/test/ui/scripts/seed-idp-users.sh
+++ b/test/ui/scripts/seed-idp-users.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Re-runs Thunder's bootstrap setup Job against an already-installed cluster
+# so the e2e overlay's bootstrap scripts take effect — in particular
+# 52-abac-user.sh (test/e2e/k3d/values-thunder.yaml), which provisions the
+# ABAC-restricted identity the abac-ui Playwright suite signs in as.
+#
+# Why a Job re-run instead of calling the admin API directly: Thunder rejects
+# every admin API request (401) once the server is up — even from loopback
+# inside the pod — so users can only be seeded from the setup Job, where the
+# bootstrap scripts run against the SQLite store before the server enforces
+# auth. Fresh installs (make e2e.setup) run the Job automatically as a helm
+# pre-install hook; this script exists for clusters installed before the
+# overlay changed.
+#
+# Usage:
+#   test/ui/scripts/seed-idp-users.sh
+#   E2E_KUBECONTEXT=k3d-openchoreo-e2e THUNDER_VERSION=0.28.0 test/ui/scripts/seed-idp-users.sh
+#
+# Requires: helm, kubectl, yq. Thunder is briefly scaled to zero while the
+# Job holds the RWO SQLite PVC — sign-ins fail during that window.
+
+set -euo pipefail
+
+KCTX="${E2E_KUBECONTEXT:-k3d-openchoreo-e2e}"
+THUNDER_NS="${THUNDER_NS:-thunder}"
+# Keep in sync with THUNDER_VERSION in make/e2e.mk.
+THUNDER_VERSION="${THUNDER_VERSION:-0.28.0}"
+THUNDER_CHART="oci://ghcr.io/asgardeo/helm-charts/thunder"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RERUN_JOB="thunder-setup-rerun"
+
+log_info()  { printf '[seed-idp-users] %s\n' "$*"; }
+log_error() { printf '[seed-idp-users] ERROR: %s\n' "$*" >&2; }
+
+KUBECTL=(kubectl --context "${KCTX}" -n "${THUNDER_NS}")
+helm_template() {
+  helm --kube-context "${KCTX}" template thunder "${THUNDER_CHART}" \
+    --namespace "${THUNDER_NS}" --version "${THUNDER_VERSION}" \
+    --values "${REPO_ROOT}/install/k3d/common/values-thunder.yaml" \
+    --values "${REPO_ROOT}/test/e2e/k3d/values-thunder.yaml" \
+    "$@"
+}
+
+restore_thunder() {
+  log_info "Scaling thunder-deployment back to 1"
+  "${KUBECTL[@]}" scale deploy thunder-deployment --replicas=1 || true
+}
+
+log_info "Patching the bootstrap ConfigMap with the e2e overlay scripts"
+helm_template --show-only templates/bootstrap-configmap.yaml \
+  | "${KUBECTL[@]}" apply -f -
+
+log_info "Scaling thunder-deployment to 0 to free the RWO SQLite PVC"
+"${KUBECTL[@]}" scale deploy thunder-deployment --replicas=0
+"${KUBECTL[@]}" wait --for=delete pod \
+  -l app.kubernetes.io/name=thunder --timeout=2m
+trap restore_thunder EXIT
+
+log_info "Re-running the setup Job (renamed, helm hooks stripped)"
+"${KUBECTL[@]}" delete job "${RERUN_JOB}" --ignore-not-found
+helm_template --show-only templates/setup-job.yaml \
+  | yq ".metadata.name = \"${RERUN_JOB}\" | del(.metadata.annotations)" \
+  | "${KUBECTL[@]}" apply -f -
+if ! "${KUBECTL[@]}" wait --for=condition=complete "job/${RERUN_JOB}" --timeout=5m; then
+  log_error "setup Job did not complete; logs follow"
+  "${KUBECTL[@]}" logs "job/${RERUN_JOB}" --tail=100 || true
+  exit 1
+fi
+"${KUBECTL[@]}" logs "job/${RERUN_JOB}" --tail=20 || true
+"${KUBECTL[@]}" delete job "${RERUN_JOB}"
+
+restore_thunder
+trap - EXIT
+"${KUBECTL[@]}" wait --for=condition=available deploy/thunder-deployment --timeout=2m
+
+log_info "done — abac-dev@openchoreo.dev / abac-developers seeded"

--- a/test/ui/specs/abac-ui/abac-env-restriction.spec.ts
+++ b/test/ui/specs/abac-ui/abac-env-restriction.spec.ts
@@ -1,0 +1,268 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor, ROLES } from '../../fixtures/auth';
+import { kApplyYAML, kDelete, kubectl } from '../../fixtures/kube';
+import { SidebarPO } from '../../po/sidebar';
+import { ComponentPO } from '../../po/component';
+import { ReleasePO } from '../../po/release';
+
+const ts = Date.now().toString(36);
+const PROJECT_NAME = `ui-abac-${ts}`;
+const COMPONENT_NAME = `abac-comp-${ts}`;
+const BINDING_NAME = `abac-env-${ts}`;
+// Pinned digest, same as full-lifecycle: serves HTTP on 9090 when started
+// with `--port 9090` (ghcr.io/openchoreo/sample-greeter:latest does not
+// exist).
+const PRE_BUILT_IMAGE =
+  'ghcr.io/openchoreo/samples/greeter-service@sha256:5c67732c99ac3505dbab14c7ec92c33be57904420d62812694c64b56c5f92d40';
+
+// PE-seeded scaffolding: project + roles/bindings exercising the
+// resource.environment ABAC predicate for the abac-developers group:
+//
+//   - allow: developer role, releasebinding actions conditioned on
+//     environment in [development, staging]
+//   - deny: explicit deny on environment == production, bound through a
+//     NARROW role carrying only the releasebinding actions
+//
+// staging is in the allow set because the default DeploymentPipeline's
+// promotion paths are development → staging → production — there is no
+// direct dev → production path in the UI, so reaching the production deny
+// requires the staging promotion to be permitted.
+//
+// The deny needs its own narrow role because conditions only constrain the
+// actions they name — every OTHER action granted by the bound role gets the
+// binding's effect unconditionally (ConditionMatcher in
+// internal/authz/casbin/helpers.go: "if the condition entries don't target
+// the considered action then the RBAC decision stands as-is"). A deny
+// binding over the full developer role would therefore deny component:create
+// etc. outright, and deny overrides allow.
+//
+// CEL `resource.environment` values are NAMESPACE-PREFIXED ("default/development",
+// not "development") — see the AuthzContext schema ("Namespace-prefixed target
+// deployment Environment name (e.g. acme/dev)") and formatDualScopedName in
+// the Backstage permission policy module. Bare names never match.
+//
+// The allow binding scopes to the namespace (not the project) so the
+// developer role's view actions keep working across the scaffolder pickers;
+// the environment conditions are the thing under test.
+const seedYAML = `
+apiVersion: openchoreo.dev/v1alpha1
+kind: Project
+metadata:
+  name: ${PROJECT_NAME}
+  namespace: default
+spec:
+  deploymentPipelineRef:
+    name: default
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRole
+metadata:
+  name: ${BINDING_NAME}-rb-role
+spec:
+  description: releasebinding-only role so the deny below stays scoped
+  actions:
+    - releasebinding:create
+    - releasebinding:update
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: ${BINDING_NAME}
+spec:
+  entitlement:
+    claim: groups
+    value: abac-developers
+  effect: allow
+  roleMappings:
+    - roleRef:
+        kind: ClusterAuthzRole
+        name: developer
+      scope:
+        namespace: default
+      conditions:
+        - actions:
+            - releasebinding:create
+            - releasebinding:update
+          expression: resource.environment in ["default/development", "default/staging"]
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: ${BINDING_NAME}-deny
+spec:
+  entitlement:
+    claim: groups
+    value: abac-developers
+  effect: deny
+  roleMappings:
+    - roleRef:
+        kind: ClusterAuthzRole
+        name: ${BINDING_NAME}-rb-role
+      scope:
+        namespace: default
+      conditions:
+        - actions:
+            - releasebinding:create
+            - releasebinding:update
+          expression: resource.environment == "default/production"
+`;
+
+// Skip the entire suite when the ABAC identity isn't seeded. Fresh installs
+// provision it via the Thunder bootstrap overlay (52-abac-user.sh in
+// test/e2e/k3d/values-thunder.yaml); clusters installed before that overlay
+// need test/ui/scripts/seed-idp-users.sh (re-runs the Thunder setup Job —
+// the admin API is auth-gated once the server is up, even from loopback).
+// The other Phase 1 specs run regardless.
+import { existsSync as _existsSync } from 'node:fs';
+const ABAC_STATE = storageStateFor('abac');
+test.describe.configure({ mode: 'serial' });
+test.skip(
+  !_existsSync(ABAC_STATE),
+  'abac storage state not minted (abac user not seeded in this Thunder install — see test/ui/scripts/seed-idp-users.sh)',
+);
+
+test.describe('abac-ui: env-restricted bindings, promote deny, cache eviction on relogin', () => {
+  test.beforeAll(async () => {
+    kApplyYAML(seedYAML);
+  });
+
+  test.afterAll(async () => {
+    // Components live in the project's namespace (default), not a
+    // namespace named after the project; ClusterAuthzRoleBindings are
+    // cluster-scoped (namespace "" omits -n).
+    kDelete('component', COMPONENT_NAME, 'default');
+    kDelete('project', PROJECT_NAME, 'default');
+    kDelete('clusterauthzrolebinding', BINDING_NAME, '');
+    kDelete('clusterauthzrolebinding', `${BINDING_NAME}-deny`, '');
+    kDelete('clusterauthzrole', `${BINDING_NAME}-rb-role`, '');
+  });
+
+  test.use({ storageState: ABAC_STATE });
+
+  test('deploy to development succeeds, promote to production denied', async ({
+    page,
+  }) => {
+    // Deploy + a promotion + an Active wait per hop, with room for a full
+    // catalog-provider sync cycle inside the entity-route wait.
+    test.setTimeout(900_000);
+    const component = new ComponentPO(page);
+    const release = new ReleasePO(page);
+
+    await page.goto('/');
+    await component.create({
+      name: COMPONENT_NAME,
+      project: PROJECT_NAME,
+      template: 'Web Application',
+      image: PRE_BUILT_IMAGE,
+      endpointPort: 9090,
+    });
+
+    // Development: allowed by the binding's condition.
+    await component.deployTo(COMPONENT_NAME, 'development', {
+      args: ['--port', '9090'],
+    });
+    await release.expectActive(COMPONENT_NAME, 'development', 120_000);
+
+    // Staging: in the allow set — the promotion path to production runs
+    // dev → staging → production, so this hop must succeed first. Assert
+    // the staging ReleaseBinding lands via kubectl (the Deploy graph is a
+    // single article, so a UI text match can't be scoped per environment).
+    await component.promoteToNext('staging');
+    await expect
+      .poll(
+        () =>
+          kubectl(
+            [
+              'get',
+              'releasebinding',
+              '-n',
+              'default',
+              '-l',
+              `openchoreo.dev/component=${COMPONENT_NAME}`,
+              '-o',
+              'jsonpath={range .items[*]}{.spec.environment}{"\\n"}{end}',
+            ],
+            { check: false },
+          )
+            .stdout.split('\n')
+            .filter(e => e.trim() === 'staging').length,
+        { timeout: 120_000 },
+      )
+      .toBe(1);
+
+    // Production: explicit deny. The UI gates Promote client-side per
+    // target environment, so the deny renders staging's Promote button
+    // disabled with a permission tooltip (no click → server-deny path).
+    await component.expectPromoteDenied('production');
+
+    // Assert via .spec.environment rather than an environment label — the
+    // label set on the ReleaseBinding CR itself is not part of the API
+    // contract, but spec.environment is.
+    await expect
+      .poll(
+        () =>
+          kubectl(
+            [
+              'get',
+              'releasebinding',
+              '-n',
+              'default',
+              '-l',
+              `openchoreo.dev/component=${COMPONENT_NAME}`,
+              '-o',
+              'jsonpath={range .items[*]}{.spec.environment}{"\\n"}{end}',
+            ],
+            { check: false },
+          )
+            .stdout.split('\n')
+            .filter(e => e.trim() === 'production').length,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+  });
+
+  test('relogin clears Casbin evaluation cache (regression for backstage-plugins#549)', async ({
+    page,
+  }) => {
+    test.setTimeout(300_000);
+    const sidebar = new SidebarPO(page);
+    const component = new ComponentPO(page);
+    const release = new ReleasePO(page);
+
+    // Sign out, then sign back in. Even though we already have a stored
+    // session, sign-out → sign-in is what reproduces the cache-eviction bug.
+    await page.goto('/');
+    await sidebar.signOut();
+    await page
+      .getByRole('button', { name: 'Sign In', exact: true })
+      .first()
+      .waitFor({ state: 'visible', timeout: 30_000 });
+
+    // Drive the same redirect-based consent flow used in fixtures/auth.ts.
+    // We intentionally do NOT reuse the persisted state — the whole point of
+    // this test is to walk through the full re-auth path so the Casbin
+    // evaluation cache gets cleared.
+    await page
+      .getByRole('button', { name: 'Sign In', exact: true })
+      .first()
+      .click();
+    await page
+      .getByPlaceholder('Enter your username')
+      .fill(ROLES.abac.username);
+    await page
+      .getByPlaceholder('Enter your password')
+      .fill(ROLES.abac.password);
+    await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+    await page
+      .getByRole('link', { name: 'Home' })
+      .first()
+      .waitFor({ state: 'visible', timeout: 60_000 });
+
+    // Same permission shape must apply post-relogin: staging's Promote
+    // (whose target is production) must still render denied.
+    await release.openDeployTab(COMPONENT_NAME);
+    await component.expectPromoteDenied('production');
+  });
+});

--- a/test/ui/specs/auth/pkce-login.spec.ts
+++ b/test/ui/specs/auth/pkce-login.spec.ts
@@ -159,6 +159,14 @@ test.describe('pkce-login: occ login drives PKCE through the Backstage browser',
       });
     });
 
+    // Arm the exit listener before driving the consent form — occ exits as
+    // soon as the callback round-trips, which can race a listener attached
+    // only after the form interactions (a 'close' event that fired earlier
+    // would never reach it, hanging the test).
+    const exitPromise = new Promise<number>(resolve => {
+      child.on('close', code => resolve(code ?? 1));
+    });
+
     // Drive the consent form via Playwright. Reuse the PE identity — the
     // pkce flow only validates the browser leg, not RBAC.
     await page.goto(authURL);
@@ -174,9 +182,7 @@ test.describe('pkce-login: occ login drives PKCE through the Backstage browser',
     // callback (http://127.0.0.1:<port>/callback). The browser shows the
     // success page rendered by occ's local server; the CLI process should
     // then exit 0.
-    const exitCode = await new Promise<number>(resolve => {
-      child.on('close', code => resolve(code ?? 1));
-    });
+    const exitCode = await exitPromise;
     expect(exitCode).toBe(0);
 
     // Verify a token round-trip via a follow-on occ call (occ has no

--- a/test/ui/specs/auth/pkce-login.spec.ts
+++ b/test/ui/specs/auth/pkce-login.spec.ts
@@ -1,0 +1,192 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, ROLES } from '../../fixtures/auth';
+import { spawn, spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { lookup } from 'node:dns/promises';
+
+// occ runs as a host process — unlike the browser specs, it can't use
+// Chromium's --host-resolver-rules, so it needs the e2e control-plane
+// hostname to resolve via real DNS (an /etc/hosts entry mapping
+// openchoreo.e2e-cp.local / api.e2e-cp.local → 127.0.0.1). When that's
+// absent (the suite's default, since the browser specs don't need it), this
+// spec self-skips rather than failing — same pattern as abac-ui.
+// NOTE: deliberately not falling back to UI_BASE_URL — that is the Backstage
+// portal URL, not the OpenChoreo API; occ must talk to the API hostname.
+function controlPlaneURL(): string {
+  return (
+    process.env.OCC_CONTROL_PLANE_URL ?? 'http://api.e2e-cp.local:28080'
+  );
+}
+
+function controlPlaneHost(): string {
+  return new URL(controlPlaneURL()).hostname;
+}
+
+async function hostResolvable(host: string): Promise<boolean> {
+  try {
+    await lookup(host);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// occ does not have a --no-browser flag today; the authorization URL is
+// always printed to stdout alongside the (best-effort) browser launch. We
+// suppress the real browser launch by prepending a tmp dir to PATH that
+// contains no-op `open`/`xdg-open`/`cmd` shims. Playwright drives the URL
+// captured from stdout instead.
+function noopBrowserPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'occ-no-browser-'));
+  for (const name of ['open', 'xdg-open', 'cmd']) {
+    const path = join(dir, name);
+    writeFileSync(path, '#!/usr/bin/env bash\nexit 0\n');
+    chmodSync(path, 0o755);
+  }
+  return dir;
+}
+
+function resolveOccBinary(): string {
+  // Prefer an explicit override, then the `make go.build.occ` output
+  // (bin/dist/<os>/<arch>/occ), then a manually-placed bin/occ.
+  if (process.env.OCC_BIN) return process.env.OCC_BIN;
+  const repoRoot = join(__dirname, '..', '..', '..', '..');
+  const os =
+    process.platform === 'darwin'
+      ? 'darwin'
+      : process.platform === 'win32'
+        ? 'windows'
+        : 'linux';
+  const arch = process.arch === 'x64' ? 'amd64' : process.arch;
+  const dist = join(repoRoot, 'bin', 'dist', os, arch, 'occ');
+  if (existsSync(dist)) return dist;
+  return join(repoRoot, 'bin', 'occ');
+}
+
+test.describe('pkce-login: occ login drives PKCE through the Backstage browser', () => {
+  test('occ login → consent → token persisted → occ get components succeeds', async ({
+    page,
+  }) => {
+    const cpHost = controlPlaneHost();
+    test.skip(
+      !(await hostResolvable(cpHost)),
+      `occ needs ${cpHost} to resolve on the host — add an /etc/hosts entry ` +
+        `(${cpHost} 127.0.0.1) to run this spec. The browser specs don't need it.`,
+    );
+
+    const occ = resolveOccBinary();
+    const noopDir = noopBrowserPath();
+
+    // Isolated HOME so the spec doesn't trample the user's ~/.occ. occ
+    // resolves the control-plane URL from its config file (~/.occ), not from
+    // env vars, so we bootstrap a context inside this isolated HOME before
+    // running `occ login`.
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${noopDir}:${process.env.PATH ?? ''}`,
+      HOME: mkdtempSync(join(tmpdir(), 'occ-home-')),
+    };
+
+    const cpURL = controlPlaneURL();
+
+    const must = (r: SpawnSyncReturns<string>, label: string) => {
+      if (r.status !== 0) {
+        throw new Error(
+          `${label} exited ${r.status}: ${r.stderr || r.stdout}`,
+        );
+      }
+    };
+
+    must(
+      spawnSync(occ, ['config', 'controlplane', 'add', 'e2e', '--url', cpURL], {
+        env,
+        encoding: 'utf8',
+      }),
+      'controlplane add',
+    );
+    must(
+      spawnSync(occ, ['config', 'context', 'add', 'e2e', '--controlplane', 'e2e', '--credentials', 'ui-pkce'], {
+        env,
+        encoding: 'utf8',
+      }),
+      'context add',
+    );
+    // Activate the e2e context — otherwise occ falls back to the seeded
+    // `default` context whose URL points at localhost:8080.
+    must(
+      spawnSync(occ, ['config', 'context', 'use', 'e2e'], {
+        env,
+        encoding: 'utf8',
+      }),
+      'context use',
+    );
+
+    const child = spawn(occ, ['login', '--credential', 'ui-pkce'], { env });
+
+    const authURL = await new Promise<string>((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      const timer = setTimeout(
+        () => reject(new Error(`timed out waiting for auth URL on stdout\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`)),
+        30_000,
+      );
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+        const m = stdout.match(/https?:\/\/[^\s]+\/oauth2\/authorize\S*/);
+        if (m) {
+          clearTimeout(timer);
+          resolve(m[0]);
+        }
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      child.on('error', err => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      child.on('close', code => {
+        clearTimeout(timer);
+        reject(
+          new Error(
+            `occ login exited ${code} before printing auth URL\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+          ),
+        );
+      });
+    });
+
+    // Drive the consent form via Playwright. Reuse the PE identity — the
+    // pkce flow only validates the browser leg, not RBAC.
+    await page.goto(authURL);
+    await page
+      .getByPlaceholder('Enter your username')
+      .fill(ROLES.pe.username);
+    await page
+      .getByPlaceholder('Enter your password')
+      .fill(ROLES.pe.password);
+    await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+
+    // After the consent submission, Thunder redirects to occ's local
+    // callback (http://127.0.0.1:<port>/callback). The browser shows the
+    // success page rendered by occ's local server; the CLI process should
+    // then exit 0.
+    const exitCode = await new Promise<number>(resolve => {
+      child.on('close', code => resolve(code ?? 1));
+    });
+    expect(exitCode).toBe(0);
+
+    // Verify a token round-trip via a follow-on occ call (occ has no
+    // kubectl-style `get` verb — listing is noun-first and project-scoped;
+    // the `default` namespace + project ship with the e2e seed resources).
+    const r = spawnSync(
+      occ,
+      ['component', 'list', '--namespace', 'default', '--project', 'default'],
+      { env, encoding: 'utf8' },
+    );
+    expect(r.status, r.stderr || r.stdout).toBe(0);
+  });
+});

--- a/test/ui/specs/dev-ops/dev-ops-component.spec.ts
+++ b/test/ui/specs/dev-ops/dev-ops-component.spec.ts
@@ -56,6 +56,9 @@ test.describe('dev-ops: Dev CRUD inside a PE-seeded project', () => {
   });
 
   test('creates and views Component + Workload as Dev', async ({ page }) => {
+    // The entity-route wait inside openByName can ride a full
+    // catalog-provider sync cycle (default 300s) on stock installs.
+    test.setTimeout(600_000);
     const component = new ComponentPO(page);
 
     await component.create({

--- a/test/ui/specs/lifecycle/full-lifecycle.spec.ts
+++ b/test/ui/specs/lifecycle/full-lifecycle.spec.ts
@@ -46,7 +46,9 @@ test.describe('lifecycle: full kubectl-equivalent flow through Backstage UI', ()
     page,
   }) => {
     // create + multi-step deploy + wait-for-Ready exceeds the global 60s.
-    test.setTimeout(360_000);
+    // Sized to absorb a full catalog-provider sync cycle (default 300s)
+    // inside the entity-route wait on installs without the UI values overlay.
+    test.setTimeout(900_000);
     const project = new ProjectPO(page);
     const component = new ComponentPO(page);
     const release = new ReleasePO(page);

--- a/test/ui/specs/pe-ops/pe-ops-pipeline.spec.ts
+++ b/test/ui/specs/pe-ops/pe-ops-pipeline.spec.ts
@@ -1,0 +1,136 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import { kGetJSON, kNotFound, kDelete, kubectl } from '../../fixtures/kube';
+import { DeletePO } from '../../po/delete';
+import { CreatePO } from '../../po/create';
+import { CatalogTablePO } from '../../po/catalogTable';
+
+// PE CRUD across the Phase 1 CRD families. The plan called for five kinds
+// (ComponentType, Trait, Workflow, DeploymentPipeline, Environment) but the
+// real Backstage UI gates each behind a Scaffolder template with a bespoke
+// form shape:
+//
+//   - ComponentType / Trait / Workflow → name + description + YAML editor
+//   - DeploymentPipeline / Environment → single FormWithYaml field
+//
+// Driving the YAML editor (Monaco) reliably from Playwright is out of Phase 1
+// scope. The spec therefore exercises the two families that have plain name +
+// description fields and leaves a YAML default — full CRUD across all five
+// kinds lands in Phase 2 alongside the YAML-editor selector contract.
+interface CrdRow {
+  kind: string; // kubectl Kind
+  catalogKind: string; // Backstage catalog kind (for the Kind picker)
+  cardTitle: string; // Create-page template card title ("Use template <this>")
+  formNameLabel: string; // accessible label for the name field
+  kindDisplayName: string; // "Delete ${this}" menu item label
+  name: string; // generated resource name
+  description: string;
+}
+
+const ts = Date.now().toString(36);
+
+const rows: CrdRow[] = [
+  {
+    kind: 'componenttype',
+    catalogKind: 'componenttype',
+    cardTitle: 'ComponentType',
+    formNameLabel: 'ComponentType Name',
+    kindDisplayName: 'Component Type',
+    name: `peops-ct-${ts}`,
+    description: 'tier5 ui spec component type',
+  },
+  {
+    kind: 'trait',
+    // The catalog ingests Trait CRs as kind "TraitType" (kubectl kind and
+    // catalog kind diverge for traits only).
+    catalogKind: 'traittype',
+    cardTitle: 'Trait',
+    formNameLabel: 'Trait Name',
+    kindDisplayName: 'Trait Type',
+    name: `peops-trait-${ts}`,
+    description: 'tier5 ui spec trait',
+  },
+];
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('pe-ops: PE CRUD through the Scaffolder templates', () => {
+  test.beforeAll(async ({ mintAuthState }) => {
+    await mintAuthState('pe');
+  });
+  test.use({ storageState: storageStateFor('pe') });
+
+  test.afterAll(async () => {
+    for (const row of rows) kDelete(row.kind, row.name, 'default');
+  });
+
+  for (const row of rows) {
+    test(`${row.kind}: create via scaffolder → kubectl shape → delete`, async ({
+      page,
+    }) => {
+      // Budget for a full default catalog-sync cycle (300s) plus the create
+      // and delete flows around it — same pattern as full-lifecycle.
+      test.setTimeout(600_000);
+      const del = new DeletePO(page);
+      const catalog = new CatalogTablePO(page);
+
+      await page.goto('/');
+      await new CreatePO(page).chooseTemplate(row.cardTitle);
+
+      await page
+        .getByLabel(row.formNameLabel, { exact: false })
+        .fill(row.name);
+      await page
+        .getByLabel('Description', { exact: false })
+        .fill(row.description);
+
+      // Walk the wizard to submission. The advance label differs per step
+      // (Next → … → Review → Create), a slow step-render can race a
+      // fixed label sequence, and a click can be swallowed while the step
+      // is still validating — so re-resolve whatever advance affordance is
+      // present and re-click until Create has been pressed. (isVisible's
+      // timeout arg is a no-op, so a fixed label walk silently skips steps.)
+      for (let i = 0; ; i++) {
+        expect(i, 'wizard did not reach Create').toBeLessThan(8);
+        const advance = page
+          .getByRole('button', { name: /^(Next|Review|Create)$/ })
+          .first();
+        await advance.waitFor({ state: 'visible', timeout: 15_000 });
+        const label = (await advance.textContent())?.trim();
+        await expect(advance).toBeEnabled({ timeout: 15_000 });
+        await advance.click();
+        if (label === 'Create') break;
+      }
+
+      await expect
+        .poll(
+          () =>
+            kubectl(['get', row.kind, row.name, '-n', 'default'], {
+              check: false,
+            }).status,
+          { timeout: 60_000 },
+        )
+        .toBe(0);
+
+      const created = kGetJSON<unknown>(row.kind, row.name, 'default');
+      expect(JSON.stringify(created)).toContain(row.description);
+
+      // Delete via the catalog entity overflow menu. The freshly-created
+      // entity reaches the catalog on the provider's periodic full sync
+      // (default 300s; the UI-test install lowers it via
+      // backstage.catalogSync.frequency) — size the timeout to survive a
+      // full default cycle so the spec also passes against a stock install.
+      await catalog.openEntity(row.catalogKind, row.name, 360_000);
+      await del.openOverflowAndDelete(row.kindDisplayName);
+      await del.confirm();
+
+      await expect
+        .poll(() => kNotFound(row.kind, row.name, 'default'), {
+          timeout: 60_000,
+        })
+        .toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Purpose
The Phase 1 UI e2e suite (#3667) deferred three specs behind environment blockers. This PR resolves the blockers and lands them:

- `pe-ops`: PE CRUD for ComponentType and Trait via the scaffolder templates
- `abac-ui`: environment-conditioned allow/deny bindings; deploy and staging promotion allowed, production promotion denied, with a relogin regression guard for backstage-plugins#549
- `pkce-login`: `occ login` PKCE round-trip with Playwright driving the consent form

## Related issues
https://github.com/openchoreo/openchoreo/issues/3588

## Approach
Thunder's admin API rejects requests once the server is up, so the ABAC identity is seeded from the bootstrap setup Job: fresh installs get it via a bootstrap-script overlay, and `test/ui/scripts/seed-idp-users.sh` re-runs the Job for already-installed clusters.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
`abac-ui` self-skips when the ABAC identity is not seeded, and `pkce-login` self-skips unless the e2e hostnames resolve on the host (the UI e2e workflow now maps them and builds `occ`). The full suite runs 10/10 green against a fresh k3d cluster.