### PR TITLE
test: add playwright ui e2e tests for component config edits

### DIFF
--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         launchOptions: {
           args: [`--host-resolver-rules=${hostResolverRules}`],
+          ...(process.env.PWSLOWMO && { slowMo: Number(process.env.PWSLOWMO) }),
         },
       },
     },

--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -183,6 +183,12 @@ export class ComponentPO {
               .getByRole('heading', { name })
               .first()
               .waitFor({ state: 'visible', timeout: 8_000 });
+            // The heading renders even on the "Entity not found" page —
+            // reject that state so the poll retries until the entity syncs.
+            const notFound = this.page.getByText('Entity not found');
+            if (await notFound.isVisible({ timeout: 1_000 }).catch(() => false)) {
+              return false;
+            }
             return true;
           } catch {
             return false;

--- a/test/ui/po/overrides.ts
+++ b/test/ui/po/overrides.ts
@@ -1,0 +1,340 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export interface EnvVarInput {
+  name: string;
+  value?: string;
+  secretRef?: { name: string; key: string };
+}
+
+export interface FileMountInput {
+  fileName: string;
+  mountPath: string;
+  content?: string;
+  secretRef?: { name: string; key: string };
+}
+
+// Page object for the EnvironmentOverridesPage.
+// Depends on aria-label attributes added in Phase 0 selector readiness.
+export class OverridesPO {
+  constructor(private readonly page: Page) {}
+
+  async open(
+    componentName: string,
+    environment = 'development',
+  ): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          await this.page.goto(
+            `/catalog/default/component/${componentName}/environments/overrides/${environment}`,
+          );
+          try {
+            await this.page
+              .getByText(/overrides|configure/i)
+              .first()
+              .waitFor({ state: 'visible', timeout: 10_000 });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 60_000, intervals: [3_000] },
+      )
+      .toBe(true);
+  }
+
+  async openWorkloadTab(): Promise<void> {
+    const tab = this.page.getByRole('tab', { name: /workload/i });
+    if (await tab.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await tab.click();
+    }
+  }
+
+  async openComponentTab(): Promise<void> {
+    const tab = this.page.getByRole('tab', { name: /component/i });
+    await tab.click();
+  }
+
+  // ── Override inherited entries ──────────────────────────────────────
+
+  async overrideInheritedEnv(
+    name: string,
+    newValue: string,
+  ): Promise<void> {
+    const card = this.envCard(name);
+    await card
+      .getByRole('button', { name: 'Override', exact: true })
+      .click();
+    const valueField = this.page.getByLabel('Value', { exact: true }).last();
+    await valueField.clear();
+    await valueField.fill(newValue);
+    await this.clickApply();
+  }
+
+  async overrideInheritedFile(
+    fileName: string,
+    newContent: string,
+  ): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    const card = this.fileCard(fileName);
+    await card
+      .getByRole('button', { name: 'Override', exact: true })
+      .click();
+    const content = this.page.getByLabel(/^(Edit )?Content$/).last();
+    await content.scrollIntoViewIfNeeded();
+    await content.clear();
+    await content.fill(newContent);
+    await this.clickApply();
+  }
+
+  // ── Add new override entries ───────────────────────────────────────
+
+  async addPlainEnv(input: EnvVarInput): Promise<void> {
+    await this.clickAddEnvVar();
+    await this.page.getByLabel('Name', { exact: true }).last().fill(input.name);
+    await this.page
+      .getByLabel('Value', { exact: true })
+      .last()
+      .fill(input.value ?? '');
+    await this.clickApply();
+  }
+
+  async addSecretEnv(input: EnvVarInput): Promise<void> {
+    await this.clickAddEnvVar();
+    await this.page.getByLabel('Name', { exact: true }).last().fill(input.name);
+    await this.page
+      .getByRole('button', { name: /switch to secret/i })
+      .last()
+      .click();
+    await this.fillSecretRef(input.secretRef!);
+    await this.clickApply();
+  }
+
+  async addPlainFile(input: FileMountInput): Promise<void> {
+    await this.clickAddFileMount();
+    await this.page
+      .getByLabel('File Name', { exact: true })
+      .last()
+      .fill(input.fileName);
+    await this.page
+      .getByLabel('Mount Path', { exact: true })
+      .last()
+      .fill(input.mountPath);
+    if (input.content) {
+      const content = this.page.getByLabel(/^(Edit )?Content$/).last();
+      await content.scrollIntoViewIfNeeded();
+      await content.fill(input.content);
+    }
+    await this.clickApply();
+  }
+
+  async addSecretFile(input: FileMountInput): Promise<void> {
+    await this.clickAddFileMount();
+    await this.page
+      .getByLabel('File Name', { exact: true })
+      .last()
+      .fill(input.fileName);
+    await this.page
+      .getByLabel('Mount Path', { exact: true })
+      .last()
+      .fill(input.mountPath);
+    await this.page
+      .getByRole('button', { name: /switch to secret/i })
+      .last()
+      .click();
+    await this.fillSecretRef(input.secretRef!);
+    await this.clickApply();
+  }
+
+  // ── Edit existing override entries ─────────────────────────────────
+
+  async editOverrideEnv(name: string, newValue: string): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    const card = this.envCard(name);
+    await card
+      .getByRole('button', { name: 'Edit', exact: true })
+      .first()
+      .click();
+    const valueField = this.page.getByLabel('Value', { exact: true }).last();
+    await valueField.clear();
+    await valueField.fill(newValue);
+    await this.clickApply();
+  }
+
+  async editOverrideFile(
+    fileName: string,
+    newContent: string,
+  ): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    const card = this.fileCard(fileName);
+    await card.scrollIntoViewIfNeeded();
+    await card
+      .getByRole('button', { name: 'Edit', exact: true })
+      .first()
+      .click();
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .waitFor({ state: 'visible', timeout: 5_000 });
+    const expandBtn = this.page.getByRole('button', {
+      name: /expand content/i,
+    });
+    if (await expandBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await expandBtn.click();
+    }
+    const content = this.page.getByLabel(/^(Edit )?Content$/).last();
+    await content.waitFor({ state: 'visible', timeout: 5_000 });
+    await content.scrollIntoViewIfNeeded();
+    await content.clear();
+    await content.fill(newContent);
+    await this.clickApply();
+  }
+
+  // ── Delete override entries ────────────────────────────────────────
+
+  async deleteOverrideEnv(name: string): Promise<void> {
+    const card = this.envCard(name);
+    await card
+      .getByRole('button', { name: 'Remove environment variable' })
+      .click();
+  }
+
+  async deleteOverrideFile(fileName: string): Promise<void> {
+    const card = this.fileCard(fileName);
+    await card
+      .getByRole('button', { name: 'Remove file mount' })
+      .click();
+  }
+
+  // ── Save flow ──────────────────────────────────────────────────────
+
+  async saveOverrides(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Save Overrides', exact: true })
+      .click();
+    await this.confirmIfShown();
+  }
+
+  async saveAndDeploy(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: /save & deploy/i })
+      .first()
+      .click();
+    await this.confirmIfShown();
+  }
+
+  // ── Assertions ─────────────────────────────────────────────────────
+
+  async expectApplyDisabled(): Promise<void> {
+    await expect(
+      this.page.getByRole('button', { name: 'Apply changes' }),
+    ).toBeDisabled();
+  }
+
+  async cancelEditing(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Cancel editing' })
+      .click();
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────
+
+  private envCard(name: string): Locator {
+    return this.page
+      .getByText(name, { exact: true })
+      .locator('xpath=ancestor::div[.//button]')
+      .filter({
+        has: this.page.getByRole('button', {
+          name: /^(edit|override|remove environment variable)$/i,
+        }),
+      })
+      .last();
+  }
+
+  private fileCard(fileName: string): Locator {
+    return this.page
+      .getByText(fileName, { exact: true })
+      .locator('xpath=ancestor::div[.//button]')
+      .filter({
+        has: this.page.getByRole('button', {
+          name: /^(edit|override|remove file mount)$/i,
+        }),
+      })
+      .last();
+  }
+
+  private async cancelAnyOpenEditor(): Promise<void> {
+    const cancelBtn = this.page.getByRole('button', { name: 'Cancel editing' });
+    if (await cancelBtn.count() > 0) {
+      await cancelBtn.first().scrollIntoViewIfNeeded();
+      await cancelBtn.first().click();
+      await cancelBtn.first().waitFor({ state: 'hidden', timeout: 5_000 });
+    }
+  }
+
+  private async clickAddEnvVar(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Add Environment Variable', exact: true })
+      .click();
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .first()
+      .waitFor({ state: 'visible', timeout: 10_000 });
+  }
+
+  private async clickAddFileMount(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Add File Mount', exact: true })
+      .click();
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .last()
+      .waitFor({ state: 'visible', timeout: 10_000 });
+  }
+
+  private async clickApply(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .click();
+  }
+
+  private async fillSecretRef(ref: {
+    name: string;
+    key: string;
+  }): Promise<void> {
+    const nameControl = this.page
+      .getByText('Secret Reference Name', { exact: true })
+      .last()
+      .locator('xpath=ancestor::div[contains(@class,"MuiFormControl")]');
+    await nameControl.locator('[role="button"]').click();
+    await this.page
+      .getByRole('option', { name: ref.name, exact: true })
+      .click();
+
+    const keyControl = this.page
+      .getByText('Secret Reference Key', { exact: true })
+      .last()
+      .locator('xpath=ancestor::div[contains(@class,"MuiFormControl")]');
+    const keyTrigger = keyControl.locator('[role="button"]');
+    await expect(keyTrigger).toBeEnabled({ timeout: 5_000 });
+    await keyTrigger.click();
+    await this.page
+      .getByRole('option', { name: ref.key, exact: true })
+      .click();
+  }
+
+  private async confirmIfShown(): Promise<void> {
+    const dialog = this.page.getByRole('dialog');
+    if (await dialog.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      const confirm = dialog.getByRole('button', {
+        name: /save|confirm|deploy|promote/i,
+      });
+      if (await confirm.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await confirm.click();
+        await dialog.waitFor({ state: 'hidden', timeout: 30_000 });
+      }
+    }
+  }
+}

--- a/test/ui/po/workloadConfig.ts
+++ b/test/ui/po/workloadConfig.ts
@@ -1,0 +1,303 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export interface EnvVarInput {
+  name: string;
+  value?: string;
+  secretRef?: { name: string; key: string };
+}
+
+export interface FileMountInput {
+  fileName: string;
+  mountPath: string;
+  content?: string;
+  secretRef?: { name: string; key: string };
+}
+
+// Page object for the WorkloadConfigPage.
+//
+// Depends on aria-label attributes added to MUI TextFields in
+// EnvVarEditor, FileVarEditor, and ContainerContent (Phase 0 selector
+// readiness). With those labels, fields are addressed via getByLabel.
+export class WorkloadConfigPO {
+  constructor(private readonly page: Page) {}
+
+  async open(componentName: string): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          await this.page.goto(
+            `/catalog/default/component/${componentName}/environments/workload-config`,
+          );
+          try {
+            await this.page
+              .getByRole('heading', { name: 'Environment Variables' })
+              .first()
+              .waitFor({ state: 'visible', timeout: 10_000 });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 60_000, intervals: [3_000] },
+      )
+      .toBe(true);
+  }
+
+  // ── Env var operations ──────────────────────────────────────────────
+
+  async addPlainEnv(input: EnvVarInput): Promise<void> {
+    await this.clickAddEnvVar();
+    await this.page.getByLabel('Name', { exact: true }).last().fill(input.name);
+    await this.page.getByLabel('Value', { exact: true }).last().fill(input.value ?? '');
+    await this.clickApply();
+  }
+
+  async addSecretEnv(input: EnvVarInput): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    await this.clickAddEnvVar();
+    await this.page.getByLabel('Name', { exact: true }).last().fill(input.name);
+    await this.page
+      .getByRole('button', { name: /switch to secret/i })
+      .last()
+      .click();
+    await this.fillSecretRef(input.secretRef!);
+    await this.clickApply();
+  }
+
+  async editPlainEnv(currentName: string, next: EnvVarInput): Promise<void> {
+    await this.clickEditOnEnvRow(currentName);
+    if (next.name !== currentName) {
+      const nameField = this.page.getByLabel('Name', { exact: true }).last();
+      await nameField.clear();
+      await nameField.fill(next.name);
+    }
+    const valueField = this.page.getByLabel('Value', { exact: true }).last();
+    await valueField.clear();
+    await valueField.fill(next.value ?? '');
+    await this.clickApply();
+  }
+
+  async deleteEnv(name: string): Promise<void> {
+    const card = this.envCard(name);
+    await card
+      .getByRole('button', { name: 'Remove environment variable' })
+      .click();
+  }
+
+  // ── File mount operations ───────────────────────────────────────────
+
+  async addPlainFile(input: FileMountInput): Promise<void> {
+    await this.page.reload();
+    await this.page
+      .getByRole('heading', { name: 'Environment Variables' })
+      .first()
+      .waitFor({ state: 'visible', timeout: 10_000 });
+    await this.cancelAnyOpenEditor();
+    await this.clickAddFileMount();
+    await this.page.getByLabel('File Name', { exact: true }).last().fill(input.fileName);
+    await this.page.getByLabel('Mount Path', { exact: true }).last().fill(input.mountPath);
+    if (input.content) {
+      const content = this.page.getByLabel(/^(Edit )?Content$/).last();
+      await content.scrollIntoViewIfNeeded();
+      await content.fill(input.content);
+    }
+    await this.clickApply();
+  }
+
+  async addSecretFile(input: FileMountInput): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    await this.clickAddFileMount();
+    await this.page.getByLabel('File Name', { exact: true }).last().fill(input.fileName);
+    await this.page.getByLabel('Mount Path', { exact: true }).last().fill(input.mountPath);
+    await this.page
+      .getByRole('button', { name: /switch to secret/i })
+      .last()
+      .click();
+    await this.fillSecretRef(input.secretRef!);
+    await this.clickApply();
+  }
+
+  async editPlainFile(fileName: string, next: FileMountInput): Promise<void> {
+    await this.clickEditOnFileRow(fileName);
+    // Truthy check, not `!== undefined`: empty string means "skip" (clear would fail MUI validation).
+    if (next.mountPath) {
+      const mountField = this.page.getByLabel('Mount Path', { exact: true }).last();
+      await mountField.clear();
+      await mountField.fill(next.mountPath);
+    }
+    if (next.content !== undefined) {
+      const expandBtn = this.page.getByRole('button', {
+        name: /expand content/i,
+      });
+      if (await expandBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        await expandBtn.click();
+      }
+      const content = this.page.getByLabel(/content/i).last();
+      await content.waitFor({ state: 'visible', timeout: 5_000 });
+      await content.clear();
+      await content.fill(next.content);
+    }
+    await this.clickApply();
+  }
+
+  async deleteFile(fileName: string): Promise<void> {
+    const card = this.fileCard(fileName);
+    await card
+      .getByRole('button', { name: 'Remove file mount' })
+      .click();
+  }
+
+  // ── Assertions ──────────────────────────────────────────────────────
+
+  async expectEnvVisible(name: string): Promise<void> {
+    await expect(this.page.getByText(name, { exact: true }).first()).toBeVisible();
+  }
+
+  async expectFileVisible(fileName: string): Promise<void> {
+    await expect(this.page.getByText(fileName, { exact: true }).first()).toBeVisible();
+  }
+
+  async expectApplyDisabled(): Promise<void> {
+    await expect(
+      this.page.getByRole('button', { name: 'Apply changes' }),
+    ).toBeDisabled();
+  }
+
+  async cancelEditing(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Cancel editing' })
+      .click();
+  }
+
+  // ── Save flow ───────────────────────────────────────────────────────
+
+  async saveAndCreateRelease(): Promise<void> {
+    const saveBtn = this.page
+      .getByRole('button', { name: /continue/i })
+      .first();
+    await saveBtn.click();
+
+    const confirmSave = this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /save & continue/i });
+    if (await confirmSave.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await confirmSave.click();
+    }
+
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Create release', exact: true })
+      .click();
+    await this.page
+      .getByRole('dialog')
+      .waitFor({ state: 'hidden', timeout: 30_000 });
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────
+
+  private envCard(name: string): Locator {
+    return this.page
+      .getByText(name, { exact: true })
+      .locator('xpath=ancestor::div[.//button]')
+      .filter({
+        has: this.page.getByRole('button', {
+          name: /^(edit|remove environment variable)$/i,
+        }),
+      })
+      .last();
+  }
+
+  private fileCard(fileName: string): Locator {
+    return this.page
+      .getByText(fileName, { exact: true })
+      .locator('xpath=ancestor::div[.//button]')
+      .filter({
+        has: this.page.getByRole('button', {
+          name: /^(edit|remove file mount)$/i,
+        }),
+      })
+      .last();
+  }
+
+  private async clickEditOnEnvRow(name: string): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    const card = this.envCard(name);
+    await card.getByRole('button', { name: 'Edit', exact: true }).first().click();
+  }
+
+  private async clickEditOnFileRow(fileName: string): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    const card = this.fileCard(fileName);
+    await card.scrollIntoViewIfNeeded();
+    await card.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .waitFor({ state: 'visible', timeout: 5_000 });
+  }
+
+  private async cancelAnyOpenEditor(): Promise<void> {
+    const cancelBtn = this.page.getByRole('button', { name: 'Cancel editing' });
+    if (await cancelBtn.count() > 0) {
+      await cancelBtn.first().scrollIntoViewIfNeeded();
+      await cancelBtn.first().click();
+      await cancelBtn.first().waitFor({ state: 'hidden', timeout: 5_000 });
+    }
+  }
+
+  private async clickAddEnvVar(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Add Environment Variable', exact: true })
+      .click();
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .first()
+      .waitFor({ state: 'visible', timeout: 10_000 });
+  }
+
+  private async clickAddFileMount(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Add File Mount', exact: true })
+      .click();
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .last()
+      .waitFor({ state: 'visible', timeout: 10_000 });
+  }
+
+  private async clickApply(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Apply changes' })
+      .click();
+  }
+
+  private async fillSecretRef(ref: {
+    name: string;
+    key: string;
+  }): Promise<void> {
+    // MUI v4 Select without id props doesn't get an accessible name from
+    // InputLabel. Locate the FormControl containing the label text, then
+    // find the [role=button] Select trigger inside it.
+    const nameControl = this.page
+      .getByText('Secret Reference Name', { exact: true })
+      .last()
+      .locator('xpath=ancestor::div[contains(@class,"MuiFormControl")]');
+    await nameControl.locator('[role="button"]').click();
+    await this.page
+      .getByRole('option', { name: ref.name, exact: true })
+      .click();
+
+    const keyControl = this.page
+      .getByText('Secret Reference Key', { exact: true })
+      .last()
+      .locator('xpath=ancestor::div[contains(@class,"MuiFormControl")]');
+    const keyTrigger = keyControl.locator('[role="button"]');
+    await expect(keyTrigger).toBeEnabled({ timeout: 5_000 });
+    await keyTrigger.click();
+    await this.page
+      .getByRole('option', { name: ref.key, exact: true })
+      .click();
+  }
+}

--- a/test/ui/specs/config/component-config-edits.spec.ts
+++ b/test/ui/specs/config/component-config-edits.spec.ts
@@ -1,0 +1,716 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import {
+  kApplyYAML,
+  kDelete,
+  kGetJSON,
+  kNotFound,
+  kubectl,
+} from '../../fixtures/kube';
+import { ProjectPO } from '../../po/project';
+import { ComponentPO } from '../../po/component';
+import { ReleasePO } from '../../po/release';
+import { DeletePO } from '../../po/delete';
+import { CatalogTablePO } from '../../po/catalogTable';
+import { WorkloadConfigPO } from '../../po/workloadConfig';
+import { OverridesPO } from '../../po/overrides';
+
+const PRE_BUILT_IMAGE =
+  'ghcr.io/openchoreo/samples/greeter-service@sha256:5c67732c99ac3505dbab14c7ec92c33be57904420d62812694c64b56c5f92d40';
+const ENDPOINT_PORT = 9090;
+const NS = 'default';
+
+const ts = Date.now().toString(36);
+const PROJECT_NAME = `ui-config-${ts}`;
+const COMPONENT_NAME = `greeter-cfg-${ts}`;
+const SECRET_REF_NAME = `ui-cfg-secret-${ts}`;
+const ABAC_BINDING_NAME = `ui-cfg-abac-${ts}`;
+
+// ── CRD type helpers ────────────────────────────────────────────────────
+
+type WorkloadJSON = {
+  spec?: {
+    container?: {
+      image?: string;
+      args?: string[];
+      env?: Array<{
+        key: string;
+        value?: string;
+        valueFrom?: { secretKeyRef?: { name: string; key: string } };
+      }>;
+      files?: Array<{
+        key: string;
+        mountPath?: string;
+        value?: string;
+        valueFrom?: { secretKeyRef?: { name: string; key: string } };
+      }>;
+    };
+  };
+};
+
+type ReleaseBindingJSON = {
+  metadata: { name: string };
+  spec?: {
+    environment?: string;
+    componentTypeEnvironmentConfigs?: Record<string, unknown>;
+    workloadOverrides?: {
+      container?: WorkloadJSON['spec']['container'];
+    };
+  };
+};
+
+function getWorkload(): WorkloadJSON {
+  return kGetJSON<WorkloadJSON>('workload', `${COMPONENT_NAME}-workload`, NS);
+}
+
+function getWorkloadEnvByKey(envKey: string) {
+  return getWorkload().spec?.container?.env?.find(e => e.key === envKey);
+}
+
+function getWorkloadFileByKey(fileKey: string) {
+  return getWorkload().spec?.container?.files?.find(f => f.key === fileKey);
+}
+
+function getDevelopmentReleaseBinding(): ReleaseBindingJSON {
+  const list = JSON.parse(
+    kubectl(
+      [
+        'get',
+        'releasebinding',
+        '-n',
+        NS,
+        '-l',
+        `openchoreo.dev/component=${COMPONENT_NAME}`,
+        '-o',
+        'json',
+      ],
+      { check: false },
+    ).stdout,
+  );
+  const binding = list.items?.find(
+    (item: ReleaseBindingJSON) => item.spec?.environment === 'development',
+  );
+  if (!binding) throw new Error('No development ReleaseBinding found');
+  return binding;
+}
+
+function getOverrideEnvByKey(envKey: string) {
+  const rb = getDevelopmentReleaseBinding();
+  return rb.spec?.workloadOverrides?.container?.env?.find(
+    (e: { key: string }) => e.key === envKey,
+  );
+}
+
+function getOverrideFileByKey(fileKey: string) {
+  const rb = getDevelopmentReleaseBinding();
+  return rb.spec?.workloadOverrides?.container?.files?.find(
+    (f: { key: string }) => f.key === fileKey,
+  );
+}
+
+// ── Seed fixtures ───────────────────────────────────────────────────────
+
+const secretRefYAML = `
+apiVersion: openchoreo.dev/v1alpha1
+kind: SecretReference
+metadata:
+  name: ${SECRET_REF_NAME}
+  namespace: ${NS}
+spec:
+  template:
+    type: Opaque
+  data:
+    - secretKey: token
+      remoteRef:
+        key: ui/config/${SECRET_REF_NAME}
+        property: token
+    - secretKey: config-data
+      remoteRef:
+        key: ui/config/${SECRET_REF_NAME}
+        property: config-data
+`;
+
+// ABAC: narrow role + deny binding for production releasebinding actions.
+// This mirrors the pattern in abac-env-restriction.spec.ts — the deny must
+// use its own scoped role so only releasebinding actions are denied, not
+// all developer actions.
+const abacSeedYAML = `
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRole
+metadata:
+  name: ${ABAC_BINDING_NAME}-rb-role
+spec:
+  description: releasebinding-only role for config-edit ABAC test
+  actions:
+    - releasebinding:create
+    - releasebinding:update
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: ${ABAC_BINDING_NAME}
+spec:
+  entitlement:
+    claim: groups
+    value: abac-developers
+  effect: allow
+  roleMappings:
+    - roleRef:
+        kind: ClusterAuthzRole
+        name: developer
+      scope:
+        namespace: ${NS}
+      conditions:
+        - actions:
+            - releasebinding:create
+            - releasebinding:update
+          expression: resource.environment in ["${NS}/development", "${NS}/staging"]
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: ${ABAC_BINDING_NAME}-deny
+spec:
+  entitlement:
+    claim: groups
+    value: abac-developers
+  effect: deny
+  roleMappings:
+    - roleRef:
+        kind: ClusterAuthzRole
+        name: ${ABAC_BINDING_NAME}-rb-role
+      scope:
+        namespace: ${NS}
+      conditions:
+        - actions:
+            - releasebinding:create
+            - releasebinding:update
+          expression: resource.environment == "${NS}/production"
+`;
+
+// ── Test suite ──────────────────────────────────────────────────────────
+
+test.describe('component config edits through Backstage UI', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.beforeAll(async ({ mintAuthState }) => {
+    await mintAuthState('pe');
+    await mintAuthState('abac');
+    kApplyYAML(secretRefYAML);
+    kApplyYAML(abacSeedYAML);
+  });
+
+  test.afterAll(async () => {
+    kDelete('component', COMPONENT_NAME, NS);
+    kDelete('project', PROJECT_NAME, NS);
+    kDelete('secretreference', SECRET_REF_NAME, NS);
+    kDelete('clusterauthzrolebinding', ABAC_BINDING_NAME, '');
+    kDelete('clusterauthzrolebinding', `${ABAC_BINDING_NAME}-deny`, '');
+    kDelete('clusterauthzrole', `${ABAC_BINDING_NAME}-rb-role`, '');
+  });
+
+  test.use({ storageState: storageStateFor('pe') });
+
+  // ─── 1. Setup ─────────────────────────────────────────────────────────
+  test('creates project, component, and initial deployment', async ({
+    page,
+  }) => {
+    test.setTimeout(360_000);
+    const project = new ProjectPO(page);
+    const component = new ComponentPO(page);
+    const release = new ReleasePO(page);
+
+    await page.goto('/');
+
+    await project.create({
+      name: PROJECT_NAME,
+      namespace: NS,
+      displayName: PROJECT_NAME,
+      description: 'UI config edit e2e',
+      pipeline: 'default',
+    });
+    await expect
+      .poll(
+        () =>
+          kubectl(['get', 'project', PROJECT_NAME, '-n', NS], {
+            check: false,
+          }).status,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+
+    await component.create({
+      name: COMPONENT_NAME,
+      project: PROJECT_NAME,
+      template: 'Web Application',
+      image: PRE_BUILT_IMAGE,
+      endpointPort: ENDPOINT_PORT,
+      description: 'greeter config edit e2e',
+    });
+    await expect
+      .poll(
+        () =>
+          kubectl(['get', 'component', COMPONENT_NAME, '-n', NS], {
+            check: false,
+          }).status,
+        { timeout: 30_000 },
+      )
+      .toBe(0);
+
+    await component.deployTo(COMPONENT_NAME, 'development', {
+      args: ['--port', String(ENDPOINT_PORT)],
+    });
+    await release.expectActive(COMPONENT_NAME, 'development', 120_000);
+
+    await expect
+      .poll(
+        () => {
+          const bindings = kubectl(
+            [
+              'get',
+              'releasebinding',
+              '-n',
+              NS,
+              '-l',
+              `openchoreo.dev/component=${COMPONENT_NAME}`,
+              '-o',
+              'jsonpath={.items[*].status.conditions[?(@.type=="Ready")].status}',
+            ],
+            { check: false },
+          ).stdout;
+          return bindings.includes('True');
+        },
+        { timeout: 120_000 },
+      )
+      .toBe(true);
+  });
+
+  // ─── 2. Validation: empty env var name ────────────────────────────────
+  test('validates that empty env var name disables apply', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const wc = new WorkloadConfigPO(page);
+    await wc.open(COMPONENT_NAME);
+
+    await page
+      .getByRole('button', { name: 'Add Environment Variable', exact: true })
+      .click();
+    await page
+      .getByRole('button', { name: 'Apply changes' })
+      .waitFor({ state: 'visible', timeout: 10_000 });
+    // Fill only the Value field, leave Name empty.
+    await page.getByLabel('Value', { exact: true }).last().fill('some-value');
+
+    await wc.expectApplyDisabled();
+    await wc.cancelEditing();
+  });
+
+  // ─── 3. Add + edit component-level plain and secret env vars ──────────
+  test('adds and edits component-level plain and secret env vars', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const wc = new WorkloadConfigPO(page);
+    await wc.open(COMPONENT_NAME);
+
+    await wc.addPlainEnv({ name: 'GREETING_PREFIX', value: 'hello' });
+    await wc.expectEnvVisible('GREETING_PREFIX');
+
+    await wc.addSecretEnv({
+      name: 'GREETER_TOKEN',
+      secretRef: { name: SECRET_REF_NAME, key: 'token' },
+    });
+    await wc.expectEnvVisible('GREETER_TOKEN');
+
+    await wc.editPlainEnv('GREETING_PREFIX', {
+      name: 'GREETING_PREFIX',
+      value: 'hola',
+    });
+
+    await wc.saveAndCreateRelease();
+
+    await expect
+      .poll(() => getWorkloadEnvByKey('GREETING_PREFIX')?.value, {
+        timeout: 30_000,
+      })
+      .toBe('hola');
+
+    const secretEnv = getWorkloadEnvByKey('GREETER_TOKEN');
+    expect(secretEnv?.valueFrom?.secretKeyRef?.name).toBe(SECRET_REF_NAME);
+    expect(secretEnv?.valueFrom?.secretKeyRef?.key).toBe('token');
+  });
+
+  // ─── 4. Add + edit component-level plain and secret file mounts ───────
+  test('adds and edits component-level plain and secret file mounts', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const wc = new WorkloadConfigPO(page);
+    await wc.open(COMPONENT_NAME);
+
+    await wc.addPlainFile({
+      fileName: 'app.properties',
+      mountPath: '/etc/greeter/app.properties',
+      content: 'message=hello',
+    });
+    await wc.expectFileVisible('app.properties');
+
+    await wc.addSecretFile({
+      fileName: 'token.txt',
+      mountPath: '/etc/greeter/token.txt',
+      secretRef: { name: SECRET_REF_NAME, key: 'config-data' },
+    });
+    await wc.expectFileVisible('token.txt');
+
+    await wc.editPlainFile('app.properties', {
+      fileName: 'app.properties',
+      mountPath: '',
+      content: 'message=hola',
+    });
+
+    await wc.saveAndCreateRelease();
+
+    await expect
+      .poll(() => getWorkloadFileByKey('app.properties')?.value, {
+        timeout: 30_000,
+      })
+      .toBe('message=hola');
+
+    const secretFile = getWorkloadFileByKey('token.txt');
+    expect(secretFile?.mountPath).toBe('/etc/greeter/token.txt');
+    expect(secretFile?.valueFrom?.secretKeyRef?.name).toBe(SECRET_REF_NAME);
+    expect(secretFile?.valueFrom?.secretKeyRef?.key).toBe('config-data');
+  });
+
+  // ─── 5. Delete all component-level entries ──────────────────────────
+  // Delete all added entries so the next deploy (test 6) uses a clean
+  // workload without secret-backed mounts that would require an external
+  // secret store to resolve.
+  test('deletes component-level env var and file mount entries', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const wc = new WorkloadConfigPO(page);
+    await wc.open(COMPONENT_NAME);
+
+    await wc.deleteEnv('GREETING_PREFIX');
+    await wc.deleteEnv('GREETER_TOKEN');
+    await wc.deleteFile('app.properties');
+    await wc.deleteFile('token.txt');
+
+    await wc.saveAndCreateRelease();
+
+    await expect
+      .poll(() => getWorkloadEnvByKey('GREETING_PREFIX'), { timeout: 30_000 })
+      .toBeUndefined();
+    await expect
+      .poll(() => getWorkloadEnvByKey('GREETER_TOKEN'), { timeout: 30_000 })
+      .toBeUndefined();
+    await expect
+      .poll(() => getWorkloadFileByKey('app.properties'), { timeout: 30_000 })
+      .toBeUndefined();
+    await expect
+      .poll(() => getWorkloadFileByKey('token.txt'), { timeout: 30_000 })
+      .toBeUndefined();
+  });
+
+  // ─── 6. Deploy the updated release so overrides tests have current state
+  test('deploys updated release so override tests see current workload', async ({
+    page,
+  }) => {
+    test.setTimeout(240_000);
+    const component = new ComponentPO(page);
+    const release = new ReleasePO(page);
+
+    await component.deployTo(COMPONENT_NAME, 'development');
+    await release.expectActive(COMPONENT_NAME, 'development', 120_000);
+  });
+
+  // ─── 7. Per-environment env var overrides ─────────────────────────────
+  test('adds per-environment env var overrides', async ({ page }) => {
+    test.setTimeout(180_000);
+    const overrides = new OverridesPO(page);
+    await overrides.open(COMPONENT_NAME, 'development');
+    await overrides.openWorkloadTab();
+
+    await overrides.addPlainEnv({
+      name: 'ENV_ONLY_GREETING',
+      value: 'development',
+    });
+
+    await overrides.saveOverrides();
+
+    await expect
+      .poll(() => getOverrideEnvByKey('ENV_ONLY_GREETING')?.value, {
+        timeout: 30_000,
+      })
+      .toBe('development');
+  });
+
+  // ─── 8. Per-environment file mount overrides ──────────────────────────
+  test('adds per-environment file mount overrides', async ({ page }) => {
+    test.setTimeout(180_000);
+    const overrides = new OverridesPO(page);
+    await overrides.open(COMPONENT_NAME, 'development');
+    await overrides.openWorkloadTab();
+
+    await overrides.addPlainFile({
+      fileName: 'env-only.properties',
+      mountPath: '/etc/greeter/env-only.properties',
+      content: 'env=development',
+    });
+
+    await overrides.saveOverrides();
+
+    await expect
+      .poll(() => getOverrideFileByKey('env-only.properties')?.value, {
+        timeout: 30_000,
+      })
+      .toBe('env=development');
+  });
+
+  // ─── 9. Override validation: empty name ───────────────────────────────
+  test('validates per-environment env var editor rejects empty name', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const overrides = new OverridesPO(page);
+    await overrides.open(COMPONENT_NAME, 'development');
+    await overrides.openWorkloadTab();
+
+    await page
+      .getByRole('button', { name: 'Add Environment Variable', exact: true })
+      .click();
+    await page
+      .getByRole('button', { name: 'Apply changes' })
+      .waitFor({ state: 'visible', timeout: 10_000 });
+    await page.getByLabel('Value', { exact: true }).last().fill('orphan-val');
+
+    await overrides.expectApplyDisabled();
+    await overrides.cancelEditing();
+  });
+
+  // ─── 10. Edit + delete per-environment overrides ──────────────────────
+  test('edits and then deletes per-environment overrides', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const overrides = new OverridesPO(page);
+    await overrides.open(COMPONENT_NAME, 'development');
+    await overrides.openWorkloadTab();
+
+    // Edit existing overrides.
+    await overrides.editOverrideEnv(
+      'ENV_ONLY_GREETING',
+      'development-updated',
+    );
+    await overrides.editOverrideFile(
+      'env-only.properties',
+      'env=development-updated',
+    );
+
+    await overrides.saveOverrides();
+
+    await expect
+      .poll(() => getOverrideEnvByKey('ENV_ONLY_GREETING')?.value, {
+        timeout: 30_000,
+      })
+      .toBe('development-updated');
+
+    await expect
+      .poll(() => getOverrideFileByKey('env-only.properties')?.value, {
+        timeout: 30_000,
+      })
+      .toBe('env=development-updated');
+
+    // Re-open and delete the overrides.
+    await overrides.open(COMPONENT_NAME, 'development');
+    await overrides.openWorkloadTab();
+
+    await overrides.deleteOverrideEnv('ENV_ONLY_GREETING');
+    await overrides.deleteOverrideFile('env-only.properties');
+
+    await overrides.saveOverrides();
+
+    await expect
+      .poll(() => getOverrideEnvByKey('ENV_ONLY_GREETING'), {
+        timeout: 30_000,
+      })
+      .toBeUndefined();
+
+    await expect
+      .poll(() => getOverrideFileByKey('env-only.properties'), {
+        timeout: 30_000,
+      })
+      .toBeUndefined();
+  });
+
+  // ─── 11. Per-environment component overrides (environmentConfigs) ─────
+  test('edits per-environment component overrides', async ({ page }) => {
+    test.setTimeout(180_000);
+    const overrides = new OverridesPO(page);
+    await overrides.open(COMPONENT_NAME, 'development');
+    await overrides.openComponentTab();
+
+    const replicasField = page.getByRole('spinbutton', {
+      name: /replicas/i,
+    });
+    await expect(replicasField).toBeVisible({ timeout: 10_000 });
+    await replicasField.clear();
+    await replicasField.fill('3');
+
+    await overrides.saveOverrides();
+
+    await expect
+      .poll(
+        () => {
+          const rb = getDevelopmentReleaseBinding();
+          return rb.spec?.componentTypeEnvironmentConfigs?.replicas;
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(3);
+  });
+
+  // ─── 12. ABAC: production override denied ─────────────────────────────
+  // The ABAC deny binding scoped to production releasebinding actions
+  // prevents the abac-developers group from mutating production overrides.
+  // The UI gates this client-side via permission hooks (useEnvScopedPermission).
+  test('denies configure-overrides to ABAC-restricted user on production', async ({
+    browser,
+    baseURL,
+  }) => {
+    test.setTimeout(120_000);
+    const abacState = storageStateFor('abac');
+    const { existsSync } = await import('node:fs');
+    if (!existsSync(abacState)) {
+      test.skip(true, 'abac storage state not minted');
+      return;
+    }
+
+    const context = await browser.newContext({
+      baseURL,
+      storageState: abacState,
+    });
+    const { cryptoUUIDPolyfill } = await import('../../fixtures/auth');
+    await context.addInitScript(cryptoUUIDPolyfill);
+    const page = await context.newPage();
+
+    try {
+      // Snapshot production ReleaseBinding state before the test to prove
+      // no mutation occurs. Production may not have a binding at all.
+      const beforeList = JSON.parse(
+        kubectl(
+          [
+            'get',
+            'releasebinding',
+            '-n',
+            NS,
+            '-l',
+            `openchoreo.dev/component=${COMPONENT_NAME}`,
+            '-o',
+            'json',
+          ],
+          { check: false },
+        ).stdout,
+      );
+      const productionBefore = beforeList.items?.find(
+        (item: ReleaseBindingJSON) => item.spec?.environment === 'production',
+      );
+
+      // Navigate to production overrides page as the ABAC user.
+      await page.goto(
+        `/catalog/default/component/${COMPONENT_NAME}/environments/overrides/production`,
+      );
+
+      // Wait for the overrides page to finish loading — the component
+      // entity header proves Backstage resolved the entity and rendered
+      // the route, so absence of controls is a real denial signal, not
+      // a loading/redirect artifact.
+      await page
+        .getByText(COMPONENT_NAME)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 });
+
+      // Assert the page signals denial. The UI renders one of:
+      //   (a) explicit permission error text,
+      //   (b) a disabled/absent "Save Overrides" button, or
+      //   (c) all mutating affordances (Add, Override) are disabled/absent.
+      // We check all three and require at least one to be true.
+      const permissionText = page.getByText(
+        /permission|forbidden|not authorized|not allowed/i,
+      );
+      const addEnvBtn = page.getByRole('button', {
+        name: 'Add Environment Variable',
+        exact: true,
+      });
+      const saveBtn = page.getByRole('button', {
+        name: /save overrides/i,
+      });
+
+      await expect(async () => {
+        const hasPermissionText = await permissionText
+          .isVisible({ timeout: 2_000 })
+          .catch(() => false);
+        const addEnvVisible = (await addEnvBtn.count()) > 0 &&
+          (await addEnvBtn.isEnabled().catch(() => false));
+        const saveVisible = (await saveBtn.count()) > 0 &&
+          (await saveBtn.isEnabled().catch(() => false));
+        expect(hasPermissionText || (!addEnvVisible && !saveVisible)).toBe(true);
+      }).toPass({ timeout: 30_000 });
+
+      // Verify no production ReleaseBinding was created or mutated.
+      const afterList = JSON.parse(
+        kubectl(
+          [
+            'get',
+            'releasebinding',
+            '-n',
+            NS,
+            '-l',
+            `openchoreo.dev/component=${COMPONENT_NAME}`,
+            '-o',
+            'json',
+          ],
+          { check: false },
+        ).stdout,
+      );
+      const productionAfter = afterList.items?.find(
+        (item: ReleaseBindingJSON) => item.spec?.environment === 'production',
+      );
+      expect(JSON.stringify(productionAfter)).toBe(
+        JSON.stringify(productionBefore),
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
+  // ─── 13. Cleanup ──────────────────────────────────────────────────────
+  test('cleans up component and project via UI', async ({ page }) => {
+    test.setTimeout(180_000);
+    const component = new ComponentPO(page);
+    const del = new DeletePO(page);
+    const catalog = new CatalogTablePO(page);
+
+    await component.openByName(COMPONENT_NAME);
+    await del.openOverflowAndDelete('Component');
+    await del.confirm();
+    await expect
+      .poll(() => kNotFound('component', COMPONENT_NAME, NS), {
+        timeout: 60_000,
+      })
+      .toBe(true);
+
+    await catalog.openEntity('system', PROJECT_NAME);
+    await del.openOverflowAndDelete('Project');
+    await del.confirm();
+    await expect
+      .poll(() => kNotFound('project', PROJECT_NAME, NS), {
+        timeout: 60_000,
+      })
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Add a serial Playwright suite covering workload config and per-environment override editing through the Backstage portal: env vars (plain + secret), file mounts (plain + secret), component parameters, delete, validation, and ABAC denial.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
