### PR TITLE
ci: gate releases on parallel e2e tiers

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -1,0 +1,459 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable e2e workflow that shards the suite into independent legs, one
+# runner + k3d cluster each, so callers pay the wall-clock of the slowest
+# leg instead of the serial sum:
+#   tier1, tier2 — control plane + data plane only
+#   tier3       — full stack (workflow + observability planes)
+#   ui          — full stack + Backstage portal (Playwright)
+#
+# Callers: the scheduled e2e workflows (test-e2e, test-e2e-extended,
+# test-ui-e2e) and the release-orchestrator e2e gate. Also manually
+# dispatchable to pre-flight a branch (e.g. before starting a release).
+
+name: E2E Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (commit SHA or branch) to check out and test; defaults to the dispatched branch"
+        required: false
+        type: string
+        default: ""
+      helm_chart_version:
+        description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<commit-sha>)"
+        required: false
+        type: string
+        default: "0.0.0-latest-dev"
+      run_tier1:
+        description: "Run the tier1 leg"
+        required: false
+        type: boolean
+        default: true
+      run_tier2:
+        description: "Run the tier2 leg"
+        required: false
+        type: boolean
+        default: true
+      run_tier3:
+        description: "Run the tier3 leg (workflow + observability planes)"
+        required: false
+        type: boolean
+        default: true
+      run_ui:
+        description: "Run the Playwright UI leg (full stack + Backstage)"
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (commit SHA or branch) to check out and test; defaults to the caller's ref"
+        required: false
+        type: string
+        default: ""
+      helm_chart_version:
+        description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<commit-sha>)"
+        required: false
+        type: string
+        default: "0.0.0-latest-dev"
+      run_tier1:
+        description: "Run the tier1 leg"
+        required: false
+        type: boolean
+        default: true
+      run_tier2:
+        description: "Run the tier2 leg"
+        required: false
+        type: boolean
+        default: true
+      run_tier3:
+        description: "Run the tier3 leg (workflow + observability planes)"
+        required: false
+        type: boolean
+        default: true
+      run_ui:
+        description: "Run the Playwright UI leg (full stack + Backstage)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  HELM_CHART_VERSION: ${{ inputs.helm_chart_version }}
+  K3D_VERSION: v5.8.3
+  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
+  YQ_VERSION: v4.45.4
+  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
+
+jobs:
+  tier1:
+    name: E2E (Tier 1)
+    if: ${{ inputs.run_tier1 }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Clone workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: _workflow
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: ./_workflow/.github/actions/setup-go
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Validate Helm chart version
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
+      - name: Add e2e host entries
+        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
+
+      - name: Run e2e tests (tier 1)
+        run: |
+          make e2e \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_SETUP_TIMEOUT=10m \
+            E2E_LABEL_FILTER='tier1'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-diagnostics-tier1
+          path: test/e2e/_diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  tier2:
+    name: E2E (Tier 2)
+    if: ${{ inputs.run_tier2 }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Clone workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: _workflow
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: ./_workflow/.github/actions/setup-go
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Validate Helm chart version
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
+      - name: Add e2e host entries
+        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
+
+      - name: Run e2e tests (tier 2)
+        run: |
+          make e2e \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_SETUP_TIMEOUT=10m \
+            E2E_LABEL_FILTER='tier2'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-diagnostics-tier2
+          path: test/e2e/_diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  tier3:
+    name: E2E (Tier 3)
+    if: ${{ inputs.run_tier3 }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Clone workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: _workflow
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: ./_workflow/.github/actions/setup-go
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Validate Helm chart version
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
+      - name: Add e2e host entries
+        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
+
+      - name: Run e2e tests (tier 3)
+        run: |
+          make e2e \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_WITH_BUILD=true \
+            E2E_WITH_OBSERVABILITY=true \
+            E2E_SETUP_TIMEOUT=10m \
+            E2E_TEST_TIMEOUT=120m \
+            E2E_LABEL_FILTER='tier3'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-diagnostics-tier3
+          path: test/e2e/_diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  ui:
+    name: E2E (UI / Playwright)
+    if: ${{ inputs.run_ui }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      E2E_WITH_BUILD: "true"
+      E2E_WITH_OBSERVABILITY: "true"
+      E2E_WITH_UI: "true"
+      E2E_KUBECONTEXT: k3d-openchoreo-e2e
+      UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
+      # OpenChoreo API URL the pkce-login spec points occ at (NOT the Backstage
+      # portal URL above).
+      OCC_CONTROL_PLANE_URL: http://api.e2e-cp.local:28080
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Check UI suite presence
+        # Older release branches predate the Playwright suite; skip the leg
+        # gracefully instead of failing the gate for refs without test/ui.
+        id: ui-suite
+        run: |
+          if [ -f test/ui/package-lock.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::test/ui is not present at this ref; skipping the UI e2e leg"
+          fi
+
+      - name: Clone workflow actions
+        if: steps.ui-suite.outputs.present == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: _workflow
+          persist-credentials: false
+
+      - name: Setup Go
+        if: steps.ui-suite.outputs.present == 'true'
+        uses: ./_workflow/.github/actions/setup-go
+
+      - name: Setup Node
+        if: steps.ui-suite.outputs.present == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: test/ui/package-lock.json
+
+      - name: Install k3d
+        if: steps.ui-suite.outputs.present == 'true'
+        run: |
+          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
+          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        if: steps.ui-suite.outputs.present == 'true'
+        run: |
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Validate Helm chart version
+        if: steps.ui-suite.outputs.present == 'true'
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
+      - name: Map e2e hostnames for host processes
+        # The browsers resolve *.e2e-cp.local via Chromium host-resolver-rules,
+        # but occ (driven by the pkce-login spec) is a host process and needs
+        # real DNS — without this entry the spec self-skips.
+        if: steps.ui-suite.outputs.present == 'true'
+        run: |
+          echo "127.0.0.1 openchoreo.e2e-cp.local api.e2e-cp.local thunder.e2e-cp.local" | sudo tee -a /etc/hosts
+
+      - name: Build occ CLI
+        # The pkce-login spec spawns bin/occ for the browser-assisted PKCE leg.
+        if: steps.ui-suite.outputs.present == 'true'
+        run: make go.build.occ
+
+      - name: Install UI test dependencies
+        if: steps.ui-suite.outputs.present == 'true'
+        working-directory: test/ui
+        run: npm ci
+
+      - name: Install Playwright browsers
+        if: steps.ui-suite.outputs.present == 'true'
+        working-directory: test/ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Install OpenChoreo e2e cluster
+        if: steps.ui-suite.outputs.present == 'true'
+        run: |
+          make e2e.setup \
+            E2E_HELM_SOURCE=oci \
+            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_WITH_BUILD="${E2E_WITH_BUILD}" \
+            E2E_WITH_OBSERVABILITY="${E2E_WITH_OBSERVABILITY}" \
+            E2E_WITH_UI="${E2E_WITH_UI}" \
+            E2E_SETUP_TIMEOUT=10m
+
+      - name: Run UI e2e tests
+        if: steps.ui-suite.outputs.present == 'true'
+        working-directory: test/ui
+        run: npm test
+
+      - name: Collect e2e diagnostics
+        if: failure()
+        run: make e2e.diagnostics || true
+
+      - name: Upload e2e diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-diagnostics
+          path: test/e2e/_diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-playwright-report
+          path: test/ui/_report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-test-results
+          path: test/ui/_test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Delete e2e cluster
+        if: always()
+        run: make e2e.down || true

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -31,6 +31,11 @@ on:
         description: 'Explicit commit SHA to tag (overrides automatic resolution)'
         required: false
         type: string
+      skip_e2e:
+        description: 'Skip the e2e gate (emergency releases only)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-orchestrator-${{ github.event.inputs.major }}-${{ github.event.inputs.minor }}
@@ -297,30 +302,26 @@ jobs:
           echo "Pushed branch: ${BRANCH}"
 
   # ----------------------------------------------------------------
-  # Tag: create and push the annotated release tag at the release branch tip.
+  # Resolve target: pin the exact commit to gate and tag, then wait for
+  # build-and-test at that commit so the e2e gate can consume the
+  # sha-tagged images and Helm charts its publish job pushes.
   # always() allows this to run even when branch is skipped (action=tag
-  # or branch already exists). !failure() prevents tagging after errors.
+  # or branch already exists). !failure() prevents running after errors.
   # ----------------------------------------------------------------
-  tag:
+  resolve-target:
     needs: [validate, branch]
     if: ${{ always() && !failure() && !cancelled() && (github.event.inputs.action == 'full' || github.event.inputs.action == 'tag') }}
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
       actions: read
+    outputs:
+      target: ${{ steps.resolve-target.outputs.target }}
+      helm-chart-version: ${{ steps.resolve-target.outputs.helm-chart-version }}
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.OC_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.OC_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ needs.validate.outputs.checkout-sha }}
           fetch-depth: 0
 
@@ -336,8 +337,8 @@ jobs:
             TARGET="$VALIDATE_TARGET"
             echo "Target: explicit commit_sha (${TARGET})"
           else
-            # Always resolve the release branch tip so the tag points to the actual released
-            # state, including any URL-update commit added by the branch job.
+            # Always resolve the release branch tip so the gate and tag point to the actual
+            # released state, including any URL-update commit added by the branch job.
             git fetch origin "refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}" 2>/dev/null || true
             BRANCH_TIP=$(git rev-parse "origin/${RELEASE_BRANCH}" 2>/dev/null || echo "")
             if [ -n "$BRANCH_TIP" ]; then
@@ -348,7 +349,9 @@ jobs:
               echo "Target: validate fallback — ${RELEASE_BRANCH} not found (${TARGET})"
             fi
           fi
+          SHORT_SHA=$(git rev-parse --short=8 "${TARGET}")
           echo "target=${TARGET}" >> $GITHUB_OUTPUT
+          echo "helm-chart-version=0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Wait for build-and-test workflow
         env:
@@ -389,6 +392,50 @@ jobs:
           echo "::error::build-and-test for ${SHORT_SHA} not completed after 30 minutes."
           exit 1
 
+  # ----------------------------------------------------------------
+  # E2E gate: All e2e suits plus the Playwright UI suite must pass
+  # at the exact commit being released before the tag is created. Legs run
+  # in parallel, one k3d cluster each. skip_e2e bypasses the gate for
+  # declared emergencies only.
+  # ----------------------------------------------------------------
+  e2e:
+    needs: [validate, resolve-target]
+    if: ${{ always() && !failure() && !cancelled() && (github.event.inputs.action == 'full' || github.event.inputs.action == 'tag') && !inputs.skip_e2e }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-gate.yml
+    with:
+      ref: ${{ needs.resolve-target.outputs.target }}
+      helm_chart_version: ${{ needs.resolve-target.outputs.helm-chart-version }}
+
+  # ----------------------------------------------------------------
+  # Tag: create and push the annotated release tag at the gated commit.
+  # always() allows this to run even when branch is skipped (action=tag
+  # or branch already exists) or e2e is skipped (skip_e2e). !failure()
+  # prevents tagging after errors, including any failed e2e leg.
+  # ----------------------------------------------------------------
+  tag:
+    needs: [validate, branch, resolve-target, e2e]
+    if: ${{ always() && !failure() && !cancelled() && (github.event.inputs.action == 'full' || github.event.inputs.action == 'tag') }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.OC_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OC_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ needs.validate.outputs.checkout-sha }}
+          fetch-depth: 0
+
       - name: Set git identity
         run: |
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
@@ -397,7 +444,7 @@ jobs:
       - name: Create and push tag
         run: |
           TAG="${{ needs.validate.outputs.release-tag }}"
-          TARGET="${{ steps.resolve-target.outputs.target }}"
+          TARGET="${{ needs.resolve-target.outputs.target }}"
           VERSION="${{ needs.validate.outputs.release-version }}"
           git tag -a "${TAG}" -m "Release ${VERSION}" "${TARGET}"
           git push origin "${TAG}"

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -138,6 +138,12 @@ jobs:
           echo "::error::action=tag requires an existing release branch (${{ steps.resolve-version.outputs.release-branch }}), but it does not exist."
           exit 1
 
+      - name: Fail if full mode uses an explicit commit
+        if: ${{ github.event.inputs.action == 'full' && github.event.inputs.commit_sha != '' }}
+        run: |
+          echo "::error::commit_sha cannot be used with action=full because branch creation and tagging would resolve different histories. Use action=tag with commit_sha after preparing the release branch, or omit commit_sha for action=full."
+          exit 1
+
       - name: Validate VERSION file
         env:
           ACTION: ${{ github.event.inputs.action }}
@@ -339,15 +345,16 @@ jobs:
           else
             # Always resolve the release branch tip so the gate and tag point to the actual
             # released state, including any URL-update commit added by the branch job.
-            git fetch origin "refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}" 2>/dev/null || true
-            BRANCH_TIP=$(git rev-parse "origin/${RELEASE_BRANCH}" 2>/dev/null || echo "")
-            if [ -n "$BRANCH_TIP" ]; then
-              TARGET="$BRANCH_TIP"
-              echo "Target: HEAD of ${RELEASE_BRANCH} (${TARGET})"
-            else
-              TARGET="$VALIDATE_TARGET"
-              echo "Target: validate fallback — ${RELEASE_BRANCH} not found (${TARGET})"
+            if ! git fetch origin "refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"; then
+              echo "::error::Failed to fetch release branch ${RELEASE_BRANCH}"
+              exit 1
             fi
+            if ! BRANCH_TIP=$(git rev-parse --verify "origin/${RELEASE_BRANCH}^{commit}"); then
+              echo "::error::Failed to resolve release branch ${RELEASE_BRANCH}"
+              exit 1
+            fi
+            TARGET="$BRANCH_TIP"
+            echo "Target: HEAD of ${RELEASE_BRANCH} (${TARGET})"
           fi
           SHORT_SHA=$(git rev-parse --short=8 "${TARGET}")
           echo "target=${TARGET}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -435,6 +435,7 @@ jobs:
           client-id: ${{ secrets.OC_RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.OC_RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-e2e-extended.yml
+++ b/.github/workflows/test-e2e-extended.yml
@@ -9,8 +9,7 @@ on:
         default: "0.0.0-latest-dev"
   schedule:
     # Weekly: Sunday 03:00 UTC (08:30 IST). Stays off the nightly path so the
-    # extended suite's wall-clock budget (~90-120 min) does not encroach on the
-    # nightly's ~45 min slot.
+    # extended suite (~20-25 min, all planes) does not encroach on the nightly's slot.
     - cron: "0 3 * * 0"
 
 permissions:
@@ -20,72 +19,15 @@ concurrency:
   group: e2e-extended-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  HELM_CHART_VERSION: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
-  E2E_WITH_BUILD: "true"
-  E2E_WITH_OBSERVABILITY: "true"
-  K3D_VERSION: v5.8.3
-  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
-  YQ_VERSION: v4.45.4
-  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
-
 jobs:
   e2e-extended:
     name: E2E Extended (Tier 3)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 150
-    steps:
-      - name: Clone the code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Install k3d
-        run: |
-          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
-          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
-          sudo install /tmp/k3d /usr/local/bin/k3d
-          k3d version
-
-      - name: Install yq
-        run: |
-          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
-          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
-          sudo install /tmp/yq /usr/local/bin/yq
-
-      - name: Validate Helm chart version
-        run: |
-          if [ -z "${HELM_CHART_VERSION}" ]; then
-            echo "::error::HELM_CHART_VERSION is required"
-            exit 1
-          fi
-          case "${HELM_CHART_VERSION}" in
-            *[!A-Za-z0-9._-]*)
-              echo "::error::HELM_CHART_VERSION contains unsupported characters"
-              exit 1
-              ;;
-          esac
-
-      - name: Add e2e host entries
-        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
-
-      - name: Run extended e2e tests (tier 3)
-        run: |
-          make e2e \
-            E2E_HELM_SOURCE=oci \
-            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
-            E2E_WITH_BUILD="${E2E_WITH_BUILD}" \
-            E2E_WITH_OBSERVABILITY="${E2E_WITH_OBSERVABILITY}" \
-            E2E_TEST_TIMEOUT=120m \
-            E2E_LABEL_FILTER='tier3'
-
-      - name: Upload diagnostics
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: e2e-extended-diagnostics
-          path: test/e2e/_diagnostics/
-          retention-days: 7
+    uses: ./.github/workflows/e2e-gate.yml
+    permissions:
+      contents: read
+    with:
+      helm_chart_version: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
+      run_tier1: false
+      run_tier2: false
+      run_tier3: true
+      run_ui: false

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,14 +7,6 @@ on:
         description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<commit-sha>)"
         required: false
         default: "0.0.0-latest-dev"
-      with_build:
-        description: "Include workflow plane"
-        type: boolean
-        default: false
-      with_observability:
-        description: "Include observability plane"
-        type: boolean
-        default: false
   schedule:
     - cron: "0 1 * * *" # nightly at 01:00 UTC (06:30 IST)
 
@@ -25,56 +17,15 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  HELM_CHART_VERSION: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
-  E2E_WITH_BUILD: ${{ github.event.inputs.with_build || 'false' }}
-  E2E_WITH_OBSERVABILITY: ${{ github.event.inputs.with_observability || 'false' }}
-  K3D_VERSION: v5.8.3
-  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
-  YQ_VERSION: v4.45.4
-  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
-
 jobs:
   e2e:
-    name: E2E
-    runs-on: ubuntu-24.04
-    timeout-minutes: 45
-    steps:
-      - name: Clone the code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Install k3d
-        run: |
-          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
-          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
-          sudo install /tmp/k3d /usr/local/bin/k3d
-          k3d version
-
-      - name: Install yq
-        run: |
-          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
-          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
-          sudo install /tmp/yq /usr/local/bin/yq
-
-      - name: Add e2e host entries
-        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
-
-      - name: Run e2e tests
-        run: |
-          make e2e \
-            E2E_HELM_SOURCE=oci \
-            HELM_CHART_VERSION=${{ env.HELM_CHART_VERSION }} \
-            E2E_WITH_BUILD=${{ env.E2E_WITH_BUILD }} \
-            E2E_WITH_OBSERVABILITY=${{ env.E2E_WITH_OBSERVABILITY }} \
-            E2E_LABEL_FILTER='tier1 || tier2'
-
-      - name: Upload diagnostics
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: e2e-diagnostics
-          path: test/e2e/_diagnostics/
-          retention-days: 7
+    name: E2E (Tier 1 + 2)
+    uses: ./.github/workflows/e2e-gate.yml
+    permissions:
+      contents: read
+    with:
+      helm_chart_version: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
+      run_tier1: true
+      run_tier2: true
+      run_tier3: false
+      run_ui: false

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -22,132 +22,15 @@ concurrency:
   group: ui-e2e-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  HELM_CHART_VERSION: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
-  E2E_WITH_BUILD: "true"
-  E2E_WITH_OBSERVABILITY: "true"
-  E2E_WITH_UI: "true"
-  E2E_KUBECONTEXT: k3d-openchoreo-e2e
-  UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
-  # OpenChoreo API URL the pkce-login spec points occ at (NOT the Backstage
-  # portal URL above).
-  OCC_CONTROL_PLANE_URL: http://api.e2e-cp.local:28080
-  K3D_VERSION: v5.8.3
-  K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
-  YQ_VERSION: v4.45.4
-  YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
-
 jobs:
   ui-e2e:
     name: UI E2E (Playwright)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 150
-    steps:
-      - name: Clone the code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: test/ui/package-lock.json
-
-      - name: Install k3d
-        run: |
-          curl -fsSL -o /tmp/k3d https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-amd64
-          echo "${{ env.K3D_SHA256 }}  /tmp/k3d" | sha256sum -c -
-          sudo install /tmp/k3d /usr/local/bin/k3d
-          k3d version
-
-      - name: Install yq
-        run: |
-          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
-          echo "${{ env.YQ_SHA256 }}  /tmp/yq" | sha256sum -c -
-          sudo install /tmp/yq /usr/local/bin/yq
-
-      - name: Validate Helm chart version
-        run: |
-          if [ -z "${HELM_CHART_VERSION}" ]; then
-            echo "::error::HELM_CHART_VERSION is required"
-            exit 1
-          fi
-          case "${HELM_CHART_VERSION}" in
-            *[!A-Za-z0-9._-]*)
-              echo "::error::HELM_CHART_VERSION contains unsupported characters"
-              exit 1
-              ;;
-          esac
-
-      - name: Map e2e hostnames for host processes
-        # The browsers resolve *.e2e-cp.local via Chromium host-resolver-rules,
-        # but occ (driven by the pkce-login spec) is a host process and needs
-        # real DNS — without this entry the spec self-skips.
-        run: |
-          echo "127.0.0.1 openchoreo.e2e-cp.local api.e2e-cp.local thunder.e2e-cp.local" | sudo tee -a /etc/hosts
-
-      - name: Build occ CLI
-        # The pkce-login spec spawns bin/occ for the browser-assisted PKCE leg.
-        run: make go.build.occ
-
-      - name: Install UI test dependencies
-        working-directory: test/ui
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: test/ui
-        run: npx playwright install --with-deps chromium
-
-      - name: Install OpenChoreo e2e cluster
-        run: |
-          make e2e.setup \
-            E2E_HELM_SOURCE=oci \
-            HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
-            E2E_WITH_BUILD="${E2E_WITH_BUILD}" \
-            E2E_WITH_OBSERVABILITY="${E2E_WITH_OBSERVABILITY}" \
-            E2E_WITH_UI="${E2E_WITH_UI}" \
-            E2E_SETUP_TIMEOUT=10m
-
-      - name: Run UI e2e tests
-        working-directory: test/ui
-        run: npm test
-
-      - name: Collect e2e diagnostics
-        if: failure()
-        run: make e2e.diagnostics || true
-
-      - name: Upload e2e diagnostics
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ui-e2e-diagnostics
-          path: test/e2e/_diagnostics/
-          retention-days: 7
-          if-no-files-found: ignore
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ui-e2e-playwright-report
-          path: test/ui/_report/
-          retention-days: 7
-          if-no-files-found: ignore
-
-      - name: Upload Playwright test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ui-e2e-test-results
-          path: test/ui/_test-results/
-          retention-days: 7
-          if-no-files-found: ignore
-
-      - name: Delete e2e cluster
-        if: always()
-        run: make e2e.down || true
+    uses: ./.github/workflows/e2e-gate.yml
+    permissions:
+      contents: read
+    with:
+      helm_chart_version: ${{ github.event.inputs.helm_chart_version || '0.0.0-latest-dev' }}
+      run_tier1: false
+      run_tier2: false
+      run_tier3: false
+      run_ui: true

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -12,3 +12,45 @@ issue and complete the release process.
 4. Complete the prerequisites listed in the issue before triggering any
    workflows
 5. Follow the checklist in the issue to complete the release process
+
+## E2E release gate
+
+Every release — a minor release cut from `main` or a patch release cut from a
+`release-vX.Y` branch (e.g. after merging backported fixes) — is gated on the
+full e2e suite. The `Release Orchestrator` workflow runs the reusable
+[`e2e-gate.yml`](../../.github/workflows/e2e-gate.yml) workflow against the
+exact commit being tagged, after `build-and-test` has published the
+sha-tagged images and Helm charts for that commit. The release tag is only
+created when every leg passes.
+
+The gate shards the suite into four parallel legs, each on its own runner
+and k3d cluster:
+
+| Leg   | Scope                                   | Typical | Timeout |
+|-------|-----------------------------------------|---------|---------|
+| tier1 | Core platform (CP + DP)                 | ~10 min | 45 min  |
+| tier2 | API, CLI, authz, gateway (CP + DP)      | ~10 min | 45 min  |
+| tier3 | Build + observability (all planes)      | ~25 min | 90 min  |
+| ui    | Playwright Backstage suite (all planes) | ~15 min | 90 min  |
+
+Because the legs run in parallel, the gate costs the wall-clock of the
+slowest leg (~25 minutes), not the sum. Expect the orchestrator run to take
+roughly 45–60 minutes end to end: ~15–30 minutes waiting for
+`build-and-test` at the release commit, then the slowest e2e leg, then
+tagging.
+
+If a leg fails:
+
+1. On gate failure, the gate blocks the release tag and tag-keyed
+   publications, but SHA-scoped artifacts published earlier remain available.
+   This includes images and Helm charts produced by `build-and-test` for the
+   candidate commit. Inspect the failing leg's diagnostics artifacts on the
+   workflow run.
+2. Fix (or backport the fix to the release branch), wait for
+   `build-and-test` on the new commit, and re-run the `Release Orchestrator`
+   workflow.
+
+The orchestrator exposes a `skip_e2e` input that bypasses the gate. It is
+reserved for declared emergencies (e.g. a critical security hotfix where the
+fix has been validated out of band) and should be noted on the release issue
+when used.

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -144,8 +144,9 @@ endef
 e2e: ## Full e2e lifecycle: setup → test → down (collects diagnostics on failure)
 	@setup_ok=0; \
 	$(MAKE) e2e.setup && setup_ok=1; \
+	test_exit=0; \
 	if [ $$setup_ok -eq 1 ]; then \
-		$(MAKE) e2e.test; test_exit=$$?; \
+		$(MAKE) e2e.test || test_exit=$$?; \
 		if [ $$test_exit -ne 0 ]; then $(MAKE) e2e.diagnostics || true; fi; \
 	else \
 		test_exit=1; \

--- a/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
+++ b/test/e2e/suites/microservicesdemo/microservicesdemo_test.go
@@ -36,10 +36,13 @@ const (
 )
 
 // All components shipped by the demo. Used to wait for each RB to reach Ready.
+// redis is not listed: it ships as a Resource (backed by the valkey
+// ClusterResourceType), so it has a ResourceReleaseBinding instead of a
+// ReleaseBinding and is waited on separately.
 var demoComponents = []string{
 	"ad", "cart", "checkout", "currency", "email",
 	"frontend", "payment", "productcatalog",
-	"recommendation", "redis", "shipping",
+	"recommendation", "shipping",
 }
 
 var demoDPNs string
@@ -59,6 +62,24 @@ var _ = Describe("GCP Microservices Demo", Ordered, Label("tier1"), func() {
 		By("applying gcp-microservices-demo sample manifests")
 		output, err := framework.Kubectl(kubeContext, "apply", "-f", sampleDir, "-R")
 		Expect(err).NotTo(HaveOccurred(), "kubectl apply failed: %s", output)
+
+		// The redis ResourceReleaseBinding ships with spec.resourceRelease
+		// unset (see samples/gcp-microservices-demo/resources/redis.yaml);
+		// the README has the user promote it manually. Do that promote here,
+		// otherwise the cart component's resource dependency never resolves.
+		By("promoting the redis ResourceReleaseBinding to the latest ResourceRelease")
+		var redisRelease string
+		Eventually(func(g Gomega) {
+			name, jpErr := framework.KubectlGetJsonpath(kubeContext, demoCPNamespace,
+				"resource", "redis", `{.status.latestRelease.name}`)
+			g.Expect(jpErr).NotTo(HaveOccurred())
+			g.Expect(name).NotTo(BeEmpty(), "Resource redis has no latestRelease yet")
+			redisRelease = name
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+		output, err = framework.Kubectl(kubeContext, "patch", "resourcereleasebinding",
+			"redis-development", "-n", demoCPNamespace, "--type=merge",
+			"-p", fmt.Sprintf(`{"spec":{"resourceRelease":%q}}`, redisRelease))
+		Expect(err).NotTo(HaveOccurred(), "failed to promote redis binding: %s", output)
 
 		By("waiting for project DP namespace discovery")
 		Eventually(func() error {
@@ -100,6 +121,16 @@ var _ = Describe("GCP Microservices Demo", Ordered, Label("tier1"), func() {
 
 	Context("multi-service deployment", func() {
 		It("all ReleaseBindings reach Ready", func() {
+			// redis is a Resource, not a Component — its readiness gates the
+			// cart component below, so wait on its ResourceReleaseBinding first.
+			By("waiting on ResourceReleaseBinding redis-" + demoEnvironment)
+			Eventually(func(g Gomega) {
+				framework.AssertJsonpathEquals(g, kubeContext, demoCPNamespace,
+					"resourcereleasebinding", "redis-"+demoEnvironment,
+					`{.status.conditions[?(@.type=="Ready")].status}`, "True")
+			}, 8*time.Minute, 5*time.Second).Should(Succeed(),
+				"ResourceReleaseBinding redis-%s should be Ready", demoEnvironment)
+
 			for _, comp := range demoComponents {
 				rbName := comp + "-" + demoEnvironment
 				By("waiting on ReleaseBinding " + rbName)

--- a/test/e2e/suites/occ/occ_fixtures_test.go
+++ b/test/e2e/suites/occ/occ_fixtures_test.go
@@ -231,7 +231,7 @@ func authzRoleWithBindingYAML() string {
 		Spec: openchoreov1alpha1.AuthzRoleBindingSpec{
 			Entitlement: openchoreov1alpha1.EntitlementClaim{
 				Claim: "sub",
-				Value: "customer-portal-client",
+				Value: clientID,
 			},
 			RoleMappings: []openchoreov1alpha1.RoleMapping{{
 				RoleRef: openchoreov1alpha1.RoleRef{

--- a/test/e2e/suites/occ/suite_test.go
+++ b/test/e2e/suites/occ/suite_test.go
@@ -27,8 +27,13 @@ const (
 	apiURL   = "http://api.e2e-cp.local:28080"
 	tokenURL = "http://thunder.e2e-cp.local:28080/oauth2/token"
 
-	clientID     = "customer-portal-client"
-	clientSecret = "supersecret"
+	// openchoreo-system-app, NOT customer-portal-client: the authz suite owns
+	// customer-portal-client and asserts exact grants/revocations for it, and
+	// suite packages run in parallel within a tier — the cluster-wide admin
+	// binding this suite creates for its subject would leak into those
+	// assertions (seen as a tier2 flake in CI).
+	clientID     = "openchoreo-system-app"
+	clientSecret = "openchoreo-system-app-secret"
 )
 
 func init() {
@@ -72,8 +77,8 @@ spec:
         kind: ClusterAuthzRole
   entitlement:
     claim: sub
-    value: customer-portal-client
-  effect: allow`, clusterAuthzBindingName)
+    value: %s
+  effect: allow`, clusterAuthzBindingName, clientID)
 	out, err = framework.KubectlApplyLiteral(kubeContext, abacBinding)
 	Expect(err).NotTo(HaveOccurred(), "failed to create ABAC binding: %s", out)
 


### PR DESCRIPTION
## Purpose
Release tags are currently created without an e2e pass at the exact release commit. This PR adds a reusable e2e-gate workflow that shards the suite into parallel legs (tier1, tier2, tier3, Playwright UI) and runs it in the release orchestrator before tagging, so no tag is cut until every leg passes.

## Related issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
The nightly, extended, and UI e2e workflows are now thin wrappers over the shared gate. The orchestrator's `skip_e2e` input is reserved for emergency releases, and the gate is also exposed via `workflow_dispatch` to pre-flight any branch.