### PR TITLE
test: record ui e2e failure videos and screenshots at higher resolution

### DIFF
--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -29,7 +29,12 @@ export default defineConfig({
     baseURL: process.env.UI_BASE_URL ?? 'http://openchoreo.e2e-cp.local:28080',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // Playwright downscales videos to fit 800x800 unless a size is given —
+    // record at the full viewport resolution instead.
+    video: {
+      mode: 'retain-on-failure',
+      size: { width: 1920, height: 1080 },
+    },
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
   },
@@ -44,6 +49,8 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        viewport: { width: 1920, height: 1080 },
+        deviceScaleFactor: 2,
         launchOptions: {
           args: [`--host-resolver-rules=${hostResolverRules}`],
           ...(process.env.PWSLOWMO && { slowMo: Number(process.env.PWSLOWMO) }),


### PR DESCRIPTION
## Purpose
UI e2e failure screenshots are captured at the Desktop Chrome preset's 1280x720 viewport, and Playwright silently downscales failure videos to fit 800x800, making them hard to read during triage. This PR bumps the viewport to 1920x1080, records videos at the full viewport size, and renders screenshots at 2x DPI.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
Failure artifacts grow roughly 4-5x in size; they are already capped at 7-day retention in `e2e-gate.yml` and artifact storage is free on public repos.