### PR TITLE
test: reduce duplicate tier3 e2e fixtures

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -290,6 +290,7 @@ jobs:
             E2E_WITH_OBSERVABILITY=true \
             E2E_SETUP_TIMEOUT=10m \
             E2E_TEST_TIMEOUT=120m \
+            E2E_JOB_FIXTURE_SET=tier3 \
             E2E_LABEL_FILTER='tier3'
 
       - name: Upload diagnostics

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -21,6 +21,9 @@ E2E_SETUP_TIMEOUT      ?= 5m
 # Suites are labeled `tier1`, `tier2`, … on their top-level Describe; see proposal #3509.
 # Examples: `tier1`, `tier1 || tier2`, `tier1 && !tier2`.
 E2E_LABEL_FILTER       ?=
+# Optional job-local fixture set to run after e2e.setup and before the Go
+# suite package fan-out. Current supported value: tier3.
+E2E_JOB_FIXTURE_SET    ?=
 
 # Conditionally render the Ginkgo label-filter flag so the unfiltered command line stays clean.
 # Single-quote the value so shell metacharacters in the expression (e.g. `||`, `&&`) are not
@@ -146,7 +149,8 @@ e2e: ## Full e2e lifecycle: setup → test → down (collects diagnostics on fai
 	$(MAKE) e2e.setup && setup_ok=1; \
 	test_exit=0; \
 	if [ $$setup_ok -eq 1 ]; then \
-		$(MAKE) e2e.test || test_exit=$$?; \
+		$(MAKE) e2e.setup-tier-fixtures || test_exit=$$?; \
+		if [ $$test_exit -eq 0 ]; then $(MAKE) e2e.test || test_exit=$$?; fi; \
 		if [ $$test_exit -ne 0 ]; then $(MAKE) e2e.diagnostics || true; fi; \
 	else \
 		test_exit=1; \
@@ -167,6 +171,19 @@ e2e.setup: ## All setup: cluster + prerequisites + install + configure (+ UI whe
 	@$(MAKE) e2e.setup-configure
 	@if [ "$(E2E_WITH_UI)" = "true" ]; then $(MAKE) e2e.setup-ui; fi
 	@$(call log_success, E2E setup complete)
+
+.PHONY: e2e.setup-tier-fixtures
+e2e.setup-tier-fixtures: ## Run optional job-local shared fixture setup before tests
+	@if [ -z "$(strip $(E2E_JOB_FIXTURE_SET))" ]; then exit 0; fi; \
+	case "$(E2E_JOB_FIXTURE_SET)" in \
+		tier3) $(MAKE) _e2e.setup-tier3-fixtures ;; \
+		*) echo "Unsupported E2E_JOB_FIXTURE_SET='$(E2E_JOB_FIXTURE_SET)'"; exit 1 ;; \
+	esac
+
+.PHONY: _e2e.setup-tier3-fixtures
+_e2e.setup-tier3-fixtures:
+	@$(call log_info, Setting up Tier 3 shared e2e fixtures)
+	go run $(E2E_DIR)/cmd/tier3-fixtures --e2e.kubecontext=$(E2E_KUBECONTEXT)
 
 .PHONY: e2e.setup-ui
 e2e.setup-ui: ## Enable Backstage on the control plane and wait for it to become Ready (idempotent)

--- a/test/e2e/cmd/tier3-fixtures/main.go
+++ b/test/e2e/cmd/tier3-fixtures/main.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+func main() {
+	var kubeContext string
+	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
+		"Kubernetes context for e2e fixture setup (required)")
+	flag.Parse()
+
+	if kubeContext == "" {
+		fmt.Fprintln(os.Stderr, "--e2e.kubecontext is required")
+		os.Exit(2)
+	}
+	if err := framework.EnsureTier3BuildSources(kubeContext); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set up Tier 3 fixtures: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/test/e2e/framework/tier3_fixtures.go
+++ b/test/e2e/framework/tier3_fixtures.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+const (
+	Tier3GiteaNamespace          = "e2e-gitea"
+	Tier3UpstreamSampleWorkloads = "https://github.com/openchoreo/sample-workloads.git"
+	Tier3SampleWorkloadsRepo     = "sample-workloads"
+	Tier3NoWorkloadRepo          = "no-workload-sample"
+	Tier3PaketoNodeRepo          = "paketo-node-sample"
+
+	tier3SampleWorkloadsMarker = "tier3-sample-workloads-ready"
+	tier3BuildSourcesMarker    = "tier3-build-sources-ready"
+)
+
+// EnsureTier3SampleWorkloads ensures the shared Tier 3 Gitea install and
+// sample-workloads mirror exist in the current e2e cluster. The fixture is
+// intentionally scoped to one k3d cluster/job; it never crosses CI tiers.
+func EnsureTier3SampleWorkloads(kubeContext string) error {
+	if tier3FixtureMarkerExists(kubeContext, tier3SampleWorkloadsMarker) {
+		return nil
+	}
+	if err := InstallGitea(kubeContext, Tier3GiteaNamespace); err != nil {
+		return err
+	}
+	if err := MigrateRepo(kubeContext, Tier3GiteaNamespace,
+		Tier3SampleWorkloadsRepo, Tier3UpstreamSampleWorkloads); err != nil {
+		return err
+	}
+	return applyTier3FixtureMarker(kubeContext, tier3SampleWorkloadsMarker)
+}
+
+// EnsureTier3BuildSources extends EnsureTier3SampleWorkloads with the local
+// build fixture repositories used by the Tier 3 build matrix.
+func EnsureTier3BuildSources(kubeContext string) error {
+	if tier3FixtureMarkerExists(kubeContext, tier3BuildSourcesMarker) {
+		return nil
+	}
+	if err := EnsureTier3SampleWorkloads(kubeContext); err != nil {
+		return err
+	}
+	repoRoot, err := RepoRoot()
+	if err != nil {
+		return err
+	}
+	if err := EnsureGiteaRepo(kubeContext, Tier3GiteaNamespace, Tier3NoWorkloadRepo); err != nil {
+		return err
+	}
+	if err := PushTree(kubeContext, Tier3GiteaNamespace, Tier3NoWorkloadRepo, "main",
+		filepath.Join(repoRoot, "test/e2e/fixtures/build/no-workload")); err != nil {
+		return err
+	}
+	if err := EnsureGiteaRepo(kubeContext, Tier3GiteaNamespace, Tier3PaketoNodeRepo); err != nil {
+		return err
+	}
+	if err := PushTree(kubeContext, Tier3GiteaNamespace, Tier3PaketoNodeRepo, "main",
+		filepath.Join(repoRoot, "test/e2e/fixtures/build/paketo-node")); err != nil {
+		return err
+	}
+	return applyTier3FixtureMarker(kubeContext, tier3BuildSourcesMarker)
+}
+
+func tier3FixtureMarkerExists(kubeContext, name string) bool {
+	_, err := Kubectl(kubeContext, "get", "configmap", name, "-n", Tier3GiteaNamespace)
+	return err == nil
+}
+
+func applyTier3FixtureMarker(kubeContext, name string) error {
+	_, err := KubectlApplyLiteral(kubeContext, fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    openchoreo.dev/e2e-managed: "true"
+data:
+  readyAt: "%s"
+`, name, Tier3GiteaNamespace, time.Now().UTC().Format(time.RFC3339)))
+	return err
+}

--- a/test/e2e/suites/alerts/alerts_fixtures_test.go
+++ b/test/e2e/suites/alerts/alerts_fixtures_test.go
@@ -26,8 +26,7 @@ const (
 	envDev      = "development"
 	envStaging  = "staging"
 
-	componentMetric        = "alert-metric-svc"
-	componentLog           = "alert-log-svc"
+	componentAlerts        = "alert-greeter-svc"
 	componentBuildLogs     = "alert-build-svc"
 	releaseBindingSuffix   = "-" + envDev
 	servicePort            = 9090
@@ -157,7 +156,30 @@ func notificationChannelYAML() string {
 // not surface). Setting
 // `releaseBinding.spec.traitEnvironmentConfigs.<ruleName>.actions.notifications.channels`
 // pins the channel deterministically.
-func alertComponentYAML(componentName, ruleName string, params map[string]any) string {
+type alertRuleFixture struct {
+	name   string
+	params map[string]any
+}
+
+func alertComponentYAML(componentName string, rules ...alertRuleFixture) string {
+	traits := make([]any, 0, len(rules))
+	traitEnvConfigs := make(map[string]any, len(rules))
+	for _, rule := range rules {
+		traits = append(traits, map[string]any{
+			"name":         "observability-alert-rule",
+			"kind":         "ClusterTrait",
+			"instanceName": rule.name,
+			"parameters":   rule.params,
+		})
+		traitEnvConfigs[rule.name] = map[string]any{
+			"enabled": true,
+			"actions": map[string]any{
+				"notifications": map[string]any{
+					"channels": []string{notificationChannel},
+				},
+			},
+		}
+	}
 	comp := map[string]any{
 		"apiVersion": openChoreoAPIVer,
 		"kind":       "Component",
@@ -173,12 +195,7 @@ func alertComponentYAML(componentName, ruleName string, params map[string]any) s
 				"name": "deployment/service",
 			},
 			"autoDeploy": true,
-			"traits": []any{map[string]any{
-				"name":         "observability-alert-rule",
-				"kind":         "ClusterTrait",
-				"instanceName": ruleName,
-				"parameters":   params,
-			}},
+			"traits":     traits,
 		},
 	}
 	wl := map[string]any{
@@ -219,17 +236,8 @@ func alertComponentYAML(componentName, ruleName string, params map[string]any) s
 				"projectName":   projectName,
 				"componentName": componentName,
 			},
-			"environment": envDev,
-			"traitEnvironmentConfigs": map[string]any{
-				ruleName: map[string]any{
-					"enabled": true,
-					"actions": map[string]any{
-						"notifications": map[string]any{
-							"channels": []string{notificationChannel},
-						},
-					},
-				},
-			},
+			"environment":             envDev,
+			"traitEnvironmentConfigs": traitEnvConfigs,
 		},
 	}
 	return mustYAMLDocs(comp, wl, rb)

--- a/test/e2e/suites/alerts/alerts_test.go
+++ b/test/e2e/suites/alerts/alerts_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	dpNs      string
-	observerQ framework.ObserverQueryFrom
+	dpNs            string
+	observerQ       framework.ObserverQueryFrom
+	logSearchPhrase string
 )
 
 const (
@@ -32,16 +33,8 @@ const (
 	// same node as the test, so generous bounds avoid CI flakiness.
 	buildTimeout = 20 * time.Minute
 
-	// giteaNamespace is the in-cluster Gitea fixture's namespace. The WP
-	// plan installs it via framework.InstallGitea; the alerts suite re-
-	// uses the same namespace so a parallel run of build + alerts shares
-	// one Gitea install.
-	giteaNamespace = "e2e-gitea"
-
-	// upstreamSampleWorkloads mirrors the constant in the build suite so
-	// the build-logs-after-deletion spec can find the same source.
-	upstreamSampleWorkloads = "https://github.com/openchoreo/sample-workloads.git"
-	sampleWorkloadsRepo     = "sample-workloads"
+	giteaNamespace      = framework.Tier3GiteaNamespace
+	sampleWorkloadsRepo = framework.Tier3SampleWorkloadsRepo
 )
 
 var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
@@ -67,6 +60,29 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		By("applying the webhook notification channel")
 		out, err = framework.KubectlApplyLiteral(kubeContext, notificationChannelYAML())
 		Expect(err).NotTo(HaveOccurred(), "apply notification channel: %s", out)
+
+		logSearchPhrase = "e2e-log-alert-trigger-" + framework.RandSuffix(6)
+
+		By("applying shared alert component")
+		out, err = framework.KubectlApplyLiteral(kubeContext, alertComponentYAML(
+			componentAlerts,
+			alertRuleFixture{name: alertRuleMetric, params: metricAlertParams()},
+			alertRuleFixture{name: alertRuleLog, params: logAlertParams(logSearchPhrase)},
+		))
+		Expect(err).NotTo(HaveOccurred(), "apply shared alert component: %s", out)
+
+		By("discovering data plane namespace")
+		Eventually(func() error {
+			var derr error
+			dpNs, derr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+			return derr
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for shared alert component pod to be Running")
+		Eventually(func(g Gomega) {
+			framework.AssertPodsRunning(g, kubeContext, dpNs,
+				"openchoreo.dev/component="+componentAlerts)
+		}, 5*time.Minute, 5*time.Second).Should(Succeed())
 	})
 
 	AfterAll(func() {
@@ -86,25 +102,6 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 	})
 
 	It("metric-alert-fires: webhook receiver records a notification when CPU rule trips", func() {
-		By("applying metric-alert component (low CPU threshold → trips quickly)")
-		out, err := framework.KubectlApplyLiteral(kubeContext, alertComponentYAML(
-			componentMetric, alertRuleMetric, metricAlertParams(),
-		))
-		Expect(err).NotTo(HaveOccurred(), "apply metric-alert component: %s", out)
-
-		By("discovering data plane namespace")
-		Eventually(func() error {
-			var derr error
-			dpNs, derr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
-			return derr
-		}, 3*time.Minute, 5*time.Second).Should(Succeed())
-
-		By("waiting for metric-alert component pod to be Running")
-		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, kubeContext, dpNs,
-				"openchoreo.dev/component="+componentMetric)
-		}, 5*time.Minute, 5*time.Second).Should(Succeed())
-
 		By("rendered ObservabilityAlertRule reaches Ready or Pending phase")
 		Eventually(func(g Gomega) {
 			out, err := framework.Kubectl(kubeContext,
@@ -139,32 +136,11 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 	})
 
 	It("log-alert-fires: webhook receiver records a notification on a log-pattern match", func() {
+		By("emitting the matching log phrase from the component pod")
 		// Use a distinctive phrase the greeter never emits naturally so
 		// the trigger is deterministic. We "emit" it by directly writing
 		// to the greeter pod's stdout via `kubectl exec`. This avoids
 		// having to wedge a misconfiguration into the sample image.
-		searchPhrase := "e2e-log-alert-trigger-" + framework.RandSuffix(6)
-
-		By("applying log-alert component")
-		out, err := framework.KubectlApplyLiteral(kubeContext, alertComponentYAML(
-			componentLog, alertRuleLog, logAlertParams(searchPhrase),
-		))
-		Expect(err).NotTo(HaveOccurred(), "apply log-alert component: %s", out)
-
-		By("discovering data plane namespace (idempotent)")
-		Eventually(func() error {
-			var derr error
-			dpNs, derr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
-			return derr
-		}, 3*time.Minute, 5*time.Second).Should(Succeed())
-
-		By("waiting for log-alert component pod to be Running")
-		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, kubeContext, dpNs,
-				"openchoreo.dev/component="+componentLog)
-		}, 5*time.Minute, 5*time.Second).Should(Succeed())
-
-		By("emitting the matching log phrase from the component pod")
 		// Repeat enough times to clear the rule's threshold and to let
 		// the logs-adapter flush. The greeter image runs `/usr/bin/env`
 		// then `./greeter-service`, both of which write to stdout — we
@@ -175,15 +151,15 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		for i := 0; i < 5; i++ {
 			out, err := framework.KubectlExecByLabel(
 				kubeContext, dpNs,
-				"openchoreo.dev/component="+componentLog, "",
-				"sh", "-c", fmt.Sprintf("echo %s; echo %s 1>&2", searchPhrase, searchPhrase),
+				"openchoreo.dev/component="+componentAlerts, "",
+				"sh", "-c", fmt.Sprintf("echo %s; echo %s 1>&2", logSearchPhrase, logSearchPhrase),
 			)
 			lastExecOut = out
 			lastExecErr = err
 			if err != nil {
 				fmt.Fprintf(GinkgoWriter, "log-alert exec (attempt %d) failed: %v\n%s\n",
 					i, err, out)
-			} else if strings.Contains(out, searchPhrase) {
+			} else if strings.Contains(out, logSearchPhrase) {
 				logEmitted = true
 				break
 			} else {
@@ -195,7 +171,7 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		}
 		Expect(logEmitted).To(BeTrue(),
 			"failed to emit log phrase %q via kubectl exec; last error=%v; last output=%s",
-			searchPhrase, lastExecErr, lastExecOut)
+			logSearchPhrase, lastExecErr, lastExecOut)
 
 		By("rendered ObservabilityAlertRule for the log rule reaches the OP")
 		Eventually(func(g Gomega) {
@@ -227,13 +203,11 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 
 	It("build-logs-after-deletion: deleted WorkflowRun's logs remain queryable via observer", func() {
 		// This spec composes the WP build flow with the OP query path —
-		// the only Tier 3 spec that needs both planes. It re-uses the WP
-		// suite's Gitea install (idempotent) so this PR's framework doesn't
-		// duplicate the Gitea helper.
-		By("ensuring Gitea + sample-workloads mirror are present")
-		Expect(framework.InstallGitea(kubeContext, giteaNamespace)).To(Succeed())
-		Expect(framework.MigrateRepo(kubeContext, giteaNamespace,
-			sampleWorkloadsRepo, upstreamSampleWorkloads)).To(Succeed())
+		// the only Tier 3 spec that needs both planes. It uses the shared
+		// Tier 3 source fixture but keeps its WorkflowRun dedicated because
+		// the test deletes that run before querying observer logs.
+		By("ensuring shared Tier 3 sample-workloads source is present")
+		Expect(framework.EnsureTier3SampleWorkloads(kubeContext)).To(Succeed())
 
 		runName := componentBuildLogs + "-run-01"
 		gitURL := framework.GiteaRepoCloneURL(giteaNamespace, sampleWorkloadsRepo)

--- a/test/e2e/suites/build/build_fixtures_test.go
+++ b/test/e2e/suites/build/build_fixtures_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
 const (
@@ -26,16 +27,10 @@ const (
 	envDev      = "development"
 	envStaging  = "staging"
 
-	// In-cluster Gitea sits in its own namespace so it survives across builds
-	// in the same e2e session and so the WP namespace stays uncluttered.
-	giteaNamespace = "e2e-gitea"
-	// Public sample-workloads repo we mirror into Gitea. Pinned by branch so
-	// the build matrix is reproducible.
-	upstreamSampleWorkloads = "https://github.com/openchoreo/sample-workloads.git"
-	sampleWorkloadsRepo     = "sample-workloads"
-	noWorkloadRepo          = "no-workload-sample"
-	paketoNodeRepo          = "paketo-node-sample"
-	externalRefsRepo        = "externalrefs-sample"
+	giteaNamespace      = framework.Tier3GiteaNamespace
+	sampleWorkloadsRepo = framework.Tier3SampleWorkloadsRepo
+	noWorkloadRepo      = framework.Tier3NoWorkloadRepo
+	paketoNodeRepo      = framework.Tier3PaketoNodeRepo
 
 	// Component / workflow names. Kept short so the rendered Argo Workflow's
 	// generated names don't blow past Kubernetes' 63-char DNS label limit.
@@ -46,7 +41,6 @@ const (
 	componentBallerina       = "bal-svc"
 	componentNoWorkload      = "auto-wl"
 	componentExternalRefs    = "extref-svc"
-	componentLogs            = "logs-svc"
 
 	releaseBindingSuffix = "-" + envDev
 

--- a/test/e2e/suites/build/build_test.go
+++ b/test/e2e/suites/build/build_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,24 +29,8 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 
 	BeforeAll(func() {
-		By("installing in-cluster Gitea")
-		Expect(framework.InstallGitea(kubeContext, giteaNamespace)).To(Succeed())
-
-		By("mirroring openchoreo/sample-workloads into Gitea")
-		Expect(framework.MigrateRepo(kubeContext, giteaNamespace,
-			sampleWorkloadsRepo, upstreamSampleWorkloads)).To(Succeed())
-
-		By("seeding the no-workload fixture into Gitea")
-		Expect(framework.EnsureGiteaRepo(kubeContext, giteaNamespace, noWorkloadRepo)).To(Succeed())
-		repoRoot, err := framework.RepoRoot()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(framework.PushTree(kubeContext, giteaNamespace, noWorkloadRepo, "main",
-			filepath.Join(repoRoot, "test/e2e/fixtures/build/no-workload"))).To(Succeed())
-
-		By("seeding the paketo-node fixture into Gitea")
-		Expect(framework.EnsureGiteaRepo(kubeContext, giteaNamespace, paketoNodeRepo)).To(Succeed())
-		Expect(framework.PushTree(kubeContext, giteaNamespace, paketoNodeRepo, "main",
-			filepath.Join(repoRoot, "test/e2e/fixtures/build/paketo-node"))).To(Succeed())
+		By("ensuring shared Tier 3 Gitea build sources are present")
+		Expect(framework.EnsureTier3BuildSources(kubeContext)).To(Succeed())
 
 		By("creating control plane namespace")
 		output, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
@@ -70,8 +53,6 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
 				"--ignore-not-found", "--wait=false")
 		}
-		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", giteaNamespace,
-			"--ignore-not-found", "--wait=false")
 	})
 
 	Context("builder matrix", func() {
@@ -85,6 +66,7 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 				dockerfile:   "/service-go-greeter/Dockerfile",
 				endpoint:     "greeter-api",
 				assertReach:  true,
+				assertLogs:   true,
 			})
 		})
 
@@ -198,44 +180,6 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("build-logs-via-k8s: live logs reachable from a running WorkflowRun pod", func() {
-			component := componentLogs
-			runName := component + "-run-01"
-
-			By("applying component + workflowrun")
-			gitURL := framework.GiteaRepoCloneURL(giteaNamespace, sampleWorkloadsRepo)
-			output, err := framework.KubectlApplyLiteral(kubeContext, buildComponentYAML(
-				component, "deployment/service", "dockerfile-builder",
-				gitURL, "/service-go-greeter", "/service-go-greeter/Dockerfile",
-			))
-			Expect(err).NotTo(HaveOccurred(), "failed to apply component: %s", output)
-			output, err = framework.KubectlApplyLiteral(kubeContext, workflowRunYAML(
-				component, runName, "dockerfile-builder",
-				gitURL, "/service-go-greeter", "/service-go-greeter/Dockerfile",
-			))
-			Expect(err).NotTo(HaveOccurred(), "failed to apply workflow run: %s", output)
-
-			By("waiting for the build Argo Workflow pod to appear")
-			wfNs := "workflows-" + cpNs
-			Eventually(func(g Gomega) {
-				out, err := framework.Kubectl(kubeContext,
-					"get", "pods", "-n", wfNs,
-					"-l", "workflows.argoproj.io/workflow="+runName,
-					"-o", "jsonpath={.items[*].metadata.name}")
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
-					"no pod found yet for WorkflowRun %s in %s", runName, wfNs)
-			}, 5*time.Minute, 5*time.Second).Should(Succeed())
-
-			By("kubectl logs against the build pod returns non-empty content")
-			Eventually(func(g Gomega) {
-				out, err := framework.KubectlLogs(kubeContext, wfNs,
-					"workflows.argoproj.io/workflow="+runName, 50)
-				g.Expect(err).NotTo(HaveOccurred(), "kubectl logs failed: %s", out)
-				g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
-					"expected non-empty build pod logs while WorkflowRun is running")
-			}, 5*time.Minute, 5*time.Second).Should(Succeed())
-		})
 	})
 })
 
@@ -248,6 +192,7 @@ type buildSpec struct {
 	dockerfile   string // optional — leave empty for buildpacks
 	endpoint     string // endpoint name as declared in the workload.yaml the build checks out
 	assertReach  bool   // whether to assert in-cluster HTTP reachability of the rendered Service
+	assertLogs   bool   // whether to assert the live build pod exposes non-empty logs
 }
 
 // runDeployableBuildSpec drives a Component + WorkflowRun through the build
@@ -269,6 +214,10 @@ func runDeployableBuildSpec(spec buildSpec) {
 		spec.component, runName, spec.workflow, gitURL, spec.appPath, spec.dockerfile,
 	))
 	Expect(err).NotTo(HaveOccurred(), "failed to apply workflow run: %s", output)
+
+	if spec.assertLogs {
+		assertWorkflowRunLogs(runName)
+	}
 
 	By("waiting for WorkflowRun to succeed")
 	Eventually(func(g Gomega) {
@@ -318,6 +267,29 @@ func runDeployableBuildSpec(spec buildSpec) {
 		return err
 	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 		"%s:%s should be TCP-reachable for component %s", host, port, spec.component)
+}
+
+func assertWorkflowRunLogs(runName string) {
+	By("waiting for the build Argo Workflow pod to appear")
+	wfNs := "workflows-" + cpNs
+	Eventually(func(g Gomega) {
+		out, err := framework.Kubectl(kubeContext,
+			"get", "pods", "-n", wfNs,
+			"-l", "workflows.argoproj.io/workflow="+runName,
+			"-o", "jsonpath={.items[*].metadata.name}")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
+			"no pod found yet for WorkflowRun %s in %s", runName, wfNs)
+	}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+	By("kubectl logs against the build pod returns non-empty content")
+	Eventually(func(g Gomega) {
+		out, err := framework.KubectlLogs(kubeContext, wfNs,
+			"workflows.argoproj.io/workflow="+runName, 50)
+		g.Expect(err).NotTo(HaveOccurred(), "kubectl logs failed: %s", out)
+		g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
+			"expected non-empty build pod logs while WorkflowRun is running")
+	}, 5*time.Minute, 5*time.Second).Should(Succeed())
 }
 
 // endpointHostPort reads the rendered Service URL host+port for a named endpoint


### PR DESCRIPTION
## Purpose
Tier 3 e2e suites duplicate Gitea setup, source builds, and greeter alert resources inside one CI job. This PR reduces that duplicate work without sharing runtime resources across e2e jobs.

## Approach
Adds a job-local Tier 3 fixture set that runs before Go suite package fan-out, while suite-level idempotent guards keep direct package runs working.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g. `backport/release-v1.0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Added Tier 3 E2E test fixture setup for managing shared test resources (Gitea installations and sample repositories).
  * Introduced idempotent fixture initialization with timestamp markers to improve test reliability and reduce setup overhead.

* **Refactor**
  * Consolidated fixture setup logic across build and alert test suites to reduce duplication.
  * Improved test infrastructure organization with centralized framework helpers for tier 3 fixture management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->