### PR TITLE
fix: handle existing releases in deployTo e2e page object

### DIFF
--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -267,6 +267,30 @@ export class ComponentPO {
       .click();
   }
 
+  // Deploy the latest existing release to `environment`. Use when releases
+  // have already been created (e.g. via saveAndCreateRelease) and the setup
+  // panel shows a release picker instead of the "Create release" button.
+  async deployLatestRelease(
+    componentName: string,
+    environment: string,
+  ): Promise<void> {
+    await this.gotoComponentRoute(componentName, '/environments');
+    await this.openSetupPanel();
+
+    const panelDeploy = this.page
+      .getByRole('button', { name: 'Deploy', exact: true })
+      .first();
+    await expect(panelDeploy).toBeEnabled({ timeout: 30_000 });
+    await panelDeploy.click();
+    await this.page.waitForURL(new RegExp(`overrides/${environment}`), {
+      timeout: 15_000,
+    });
+    await this.page
+      .getByRole('button', { name: 'Deploy', exact: true })
+      .first()
+      .click();
+  }
+
   // Open the "Set up" node's detail panel if it isn't already open. Clicking an
   // already-pressed node would toggle it closed, so guard on aria-pressed.
   private async openSetupPanel(): Promise<void> {

--- a/test/ui/specs/config/component-config-edits.spec.ts
+++ b/test/ui/specs/config/component-config-edits.spec.ts
@@ -392,7 +392,7 @@ test.describe('component config edits through Backstage UI', () => {
     const component = new ComponentPO(page);
     const release = new ReleasePO(page);
 
-    await component.deployTo(COMPONENT_NAME, 'development');
+    await component.deployLatestRelease(COMPONENT_NAME, 'development');
     await release.expectActive(COMPONENT_NAME, 'development', 120_000);
   });
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> The setup panel shows a release picker instead of Create release when releases already exist. Skip the create flow and deploy the latest release directly.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
