### PR TITLE
fix: sanitize Authorization header before routing to k8s API in cluster-agent

### DIFF
--- a/internal/cluster-agent/router.go
+++ b/internal/cluster-agent/router.go
@@ -16,6 +16,12 @@ import (
 	"github.com/openchoreo/openchoreo/internal/cluster-agent/messaging"
 )
 
+// Backend types supported by the router.
+const (
+	backendKubernetes = "kubernetes"
+	backendHTTP       = "http"
+)
+
 // RouteConfig represents the configuration for a backend route
 type RouteConfig struct {
 	Name               string
@@ -122,6 +128,14 @@ func (r *Router) Route(req *messaging.HTTPTunnelRequest) *messaging.HTTPTunnelRe
 
 	httpReq.Header = req.Headers
 
+	// Strip any client-supplied Authorization header for k8s requests. The
+	// transport returned by rest.TransportFor only injects the agent's
+	// ServiceAccount token when no Authorization header is already set, so
+	// leaving a client token here would defeat the intended auth model.
+	if route.Backend == backendKubernetes {
+		httpReq.Header.Del("Authorization")
+	}
+
 	route.applyAuth(httpReq)
 
 	resp, err := route.Transport.RoundTrip(httpReq)
@@ -171,7 +185,7 @@ func createK8sRoute(config *rest.Config) (*Route, error) {
 
 	return &Route{
 		Name:      "k8s",
-		Backend:   "kubernetes",
+		Backend:   backendKubernetes,
 		Endpoint:  config.Host,
 		Transport: transport,
 	}, nil
@@ -187,7 +201,7 @@ func createRoute(cfg RouteConfig) *Route {
 
 	return &Route{
 		Name:      cfg.Name,
-		Backend:   "http",
+		Backend:   backendHTTP,
 		Endpoint:  cfg.Endpoint,
 		Auth:      cfg.Auth,
 		Transport: transport,

--- a/internal/cluster-agent/router_test.go
+++ b/internal/cluster-agent/router_test.go
@@ -467,6 +467,65 @@ func TestRoute_InvalidMethod(t *testing.T) {
 	assert.Contains(t, resp.Error.Message, "failed to create request")
 }
 
+func TestRoute_StripsAuthorizationForK8sBackend(t *testing.T) {
+	var capturedAuth string
+	route := newMockRoute("k8s", "https://kubernetes.svc", func(req *http.Request) (*http.Response, error) {
+		capturedAuth = req.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+	route.Backend = "kubernetes"
+
+	router := newTestRouter(t, map[string]*Route{"k8s": route})
+
+	req := &messaging.HTTPTunnelRequest{
+		RequestID: "req-k8s-auth",
+		Target:    "k8s",
+		Method:    "GET",
+		Path:      "/api/v1/pods",
+		Headers: map[string][]string{
+			"Authorization": {"Bearer client-supplied-token"},
+			"X-Custom":      {"keep-me"},
+		},
+	}
+
+	resp := router.Route(req)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, capturedAuth, "client-supplied Authorization header must be stripped for k8s backend")
+}
+
+func TestRoute_PreservesAuthorizationForHTTPBackend(t *testing.T) {
+	var capturedAuth string
+	route := newMockRoute("monitoring", "https://prometheus.svc", func(req *http.Request) (*http.Response, error) {
+		capturedAuth = req.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	router := newTestRouter(t, map[string]*Route{"monitoring": route})
+
+	req := &messaging.HTTPTunnelRequest{
+		RequestID: "req-http-auth",
+		Target:    "monitoring",
+		Method:    "GET",
+		Path:      "/api/v1/query",
+		Headers: map[string][]string{
+			"Authorization": {"Bearer client-supplied-token"},
+		},
+	}
+
+	resp := router.Route(req)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "Bearer client-supplied-token", capturedAuth,
+		"Authorization header must pass through for non-k8s backends")
+}
+
 // errReader is an io.Reader that always returns an error.
 type errReader struct{}
 


### PR DESCRIPTION
## Purpose

`router.go` in the cluster-agent was setting `httpReq.Header = req.Headers` verbatim. Client-go's `rest.TransportFor` bearer-token wrapper only injects the ServiceAccount token when no `Authorization` header is already set, so any client-supplied token silently took precedence and the k8s API server saw the client's identity instead of the agent's SA.

Identified during review of #2722 — see [discussion](https://github.com/openchoreo/openchoreo/pull/2722#discussion_r2936720942). Pre-existing issue, independent of the token refresh fix in that PR.

## Approach

- Delete client-supplied `Authorization` header on requests routed to the Kubernetes backend so `rest.TransportFor`'s bearer-token wrapper can inject the agent's ServiceAccount token.
- Non-k8s backends (`http` / `https` routes) continue to receive `Authorization` unchanged — the sanitization is scoped, not blanket.
- Replace the `"kubernetes"` / `"http"` magic strings in `router.go` with `backendKubernetes` / `backendHTTP` constants so the backend check is typo-proof.

## Related Issues

Fixes #2724

## Checklist

- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Tests added:
- `TestRoute_StripsAuthorizationForK8sBackend` — verifies client `Authorization` is removed for k8s backend.
- `TestRoute_PreservesAuthorizationForHTTPBackend` — verifies `Authorization` is preserved for non-k8s backends.