### PR TITLE
test: add e2e test for quick-start guide

### DIFF
--- a/.github/workflows/test-e2e-quickstart.yml
+++ b/.github/workflows/test-e2e-quickstart.yml
@@ -1,0 +1,76 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Quick Start E2E Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Quick-start container image'
+        required: false
+        default: 'ghcr.io/openchoreo/quick-start:latest-dev'
+      version:
+        description: 'OpenChoreo version to install'
+        required: false
+        default: 'latest-dev'
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  quickstart-e2e:
+    name: Quick Start Guide
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v6.0.2
+        with:
+          go-version-file: go.mod
+
+      - name: Run quick-start e2e test
+        run: |
+          go test ./test/e2e-quickstart/... \
+            -v \
+            -timeout 25m \
+            -args \
+            -qs.image="${{ inputs.image || 'ghcr.io/openchoreo/quick-start:latest-dev' }}" \
+            -qs.version="${{ inputs.version || 'latest-dev' }}"
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== Container status ==="
+          docker ps -a --filter name=openchoreo-qs-e2e-test || true
+
+          echo "=== Container logs ==="
+          docker logs openchoreo-qs-e2e-test 2>&1 | tail -100 || true
+
+          echo "=== k3d cluster list ==="
+          docker exec --user openchoreo -w /home/openchoreo openchoreo-qs-e2e-test \
+            bash -lc "k3d cluster list" 2>/dev/null || true
+
+          echo "=== Pod status (all namespaces) ==="
+          docker exec --user openchoreo -w /home/openchoreo openchoreo-qs-e2e-test \
+            bash -lc "kubectl get pods -A" 2>/dev/null || true
+
+          echo "=== Events ==="
+          docker exec --user openchoreo -w /home/openchoreo openchoreo-qs-e2e-test \
+            bash -lc "kubectl get events -A --sort-by=.lastTimestamp | tail -50" 2>/dev/null || true
+
+          echo "=== Components ==="
+          docker exec --user openchoreo -w /home/openchoreo openchoreo-qs-e2e-test \
+            bash -lc "kubectl get components,workloads,releasebindings -A -o wide" 2>/dev/null || true
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker exec --user openchoreo -w /home/openchoreo openchoreo-qs-e2e-test \
+            bash -lc "./uninstall.sh --force" 2>/dev/null || true
+          docker rm -f openchoreo-qs-e2e-test 2>/dev/null || true

--- a/test/e2e-quickstart/docker.go
+++ b/test/e2e-quickstart/docker.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package quickstart
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+)
+
+const (
+	containerName = "openchoreo-qs-e2e-test"
+	containerUser = "openchoreo"
+	containerHome = "/home/openchoreo"
+)
+
+func startContainer(image string) error {
+	cleanupContainer()
+
+	// The entrypoint normally sets up docker socket permissions and starts an
+	// interactive shell.  We override it to run the permission setup inline
+	// and keep the container alive with "sleep infinity".
+	initScript := `
+if [ -S /var/run/docker.sock ]; then
+  GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null || echo 0)
+  if [ "$GID" = "0" ]; then
+    addgroup openchoreo root 2>/dev/null || true
+    chmod g+rw /var/run/docker.sock 2>/dev/null || true
+  else
+    getent group "$GID" >/dev/null 2>&1 || addgroup -g "$GID" docker 2>/dev/null || true
+    GN=$(getent group "$GID" | cut -d: -f1)
+    addgroup openchoreo "${GN:-docker}" 2>/dev/null || true
+  fi
+fi
+exec sleep infinity`
+
+	cmd := exec.Command("docker", "run", "-d",
+		"--name", containerName,
+		"-v", "/var/run/docker.sock:/var/run/docker.sock",
+		"--network=host",
+		"--entrypoint", "",
+		image,
+		"sh", "-c", initScript,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker run failed: %w\n%s", err, string(out))
+	}
+	return nil
+}
+
+func cleanupContainer() {
+	exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
+}
+
+// dockerExec runs a command inside the container as the openchoreo user.
+func dockerExec(script string) (string, error) {
+	cmd := exec.Command("docker", "exec",
+		"--user", containerUser,
+		"--workdir", containerHome,
+		containerName,
+		"bash", "-lc", script,
+	)
+	fmt.Fprintf(GinkgoWriter, "docker exec: %s\n", truncate(script, 120))
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return output, fmt.Errorf("docker exec failed: %w\n%s", err, output)
+	}
+	return output, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/test/e2e-quickstart/quickstart_test.go
+++ b/test/e2e-quickstart/quickstart_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package quickstart
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+var _ = Describe("Quick Start Guide", Ordered, func() {
+	const (
+		installTimeout = 10 * time.Minute
+		deployTimeout  = 5 * time.Minute
+		httpTimeout    = 2 * time.Minute
+	)
+
+	BeforeAll(func() {
+		By("starting the quick-start container")
+		Expect(startContainer(image)).To(Succeed())
+
+		By("verifying Docker is accessible inside the container")
+		_, err := dockerExec("docker info >/dev/null 2>&1")
+		Expect(err).NotTo(HaveOccurred(), "docker should be accessible inside the container")
+
+		By(fmt.Sprintf("running install.sh --version %s", version))
+		output, err := dockerExec(fmt.Sprintf("./install.sh --version %s --skip-resource-check", version))
+		fmt.Fprintf(GinkgoWriter, "install output (last 500 chars):\n%s\n", lastN(output, 500))
+		Expect(err).NotTo(HaveOccurred(), "install.sh should succeed")
+	})
+
+	AfterAll(func() {
+		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+			By("skipping cleanup because E2E_KEEP_RESOURCES=true")
+			return
+		}
+
+		By("running uninstall.sh")
+		dockerExec("./uninstall.sh --force") //nolint:errcheck
+
+		By("removing container")
+		cleanupContainer()
+	})
+
+	// ─── Installation validation ───────────────────────────────────────
+
+	Context("Installation validation", func() {
+		It("should pass check-status.sh with all core components READY", func() {
+			Eventually(func(g Gomega) {
+				output, err := dockerExec("./check-status.sh")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(ContainSubstring("[NOT STARTED]"))
+				g.Expect(output).NotTo(ContainSubstring("[PENDING]"))
+			}, 2*time.Minute, 10*time.Second).Should(Succeed())
+		})
+
+		It("should pass validate-installation.sh", func() {
+			_, err := dockerExec("./validate-installation.sh")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	// ─── CRDs ──────────────────────────────────────────────────────────
+
+	Context("CRDs", func() {
+		crds := []string{
+			"projects.openchoreo.dev",
+			"components.openchoreo.dev",
+			"componenttypes.openchoreo.dev",
+			"environments.openchoreo.dev",
+			"releasebindings.openchoreo.dev",
+			"workloads.openchoreo.dev",
+		}
+
+		for _, crd := range crds {
+			It(fmt.Sprintf("should have CRD %s", crd), func() {
+				_, err := dockerExec(fmt.Sprintf("kubectl get crd %s", crd))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+	})
+
+	// ─── Default resources ─────────────────────────────────────────────
+
+	Context("Default resources", func() {
+		It("should have Project 'default'", func() {
+			_, err := dockerExec("kubectl get project default -o name")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		environments := []string{"development", "staging", "production"}
+		for _, env := range environments {
+			It(fmt.Sprintf("should have Environment '%s'", env), func() {
+				_, err := dockerExec(fmt.Sprintf("kubectl get environment %s -o name", env))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+
+		clusterComponentTypes := []string{"worker", "service", "web-application", "scheduled-task"}
+		for _, cct := range clusterComponentTypes {
+			It(fmt.Sprintf("should have ClusterComponentType '%s'", cct), func() {
+				_, err := dockerExec(fmt.Sprintf("kubectl get clustercomponenttype %s -o name", cct))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+
+		It("should have ClusterDataPlane 'default'", func() {
+			_, err := dockerExec("kubectl get clusterdataplane default -o name")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	// ─── Pod health ────────────────────────────────────────────────────
+
+	Context("Pod health", func() {
+		namespaces := []string{"openchoreo-control-plane", "openchoreo-data-plane"}
+		for _, ns := range namespaces {
+			It(fmt.Sprintf("should have all pods running in %s", ns), func() {
+				Eventually(func(g Gomega) {
+					output, err := dockerExec(fmt.Sprintf(
+						"kubectl get pods -n %s --no-headers --field-selector=status.phase!=Succeeded,status.phase!=Failed | grep -cv Running || true", ns))
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(strings.TrimSpace(output)).To(Equal("0"),
+						"all non-completed pods in %s should be Running", ns)
+				}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			})
+		}
+	})
+
+	// ─── Deploy react-starter ──────────────────────────────────────────
+
+	Context("React starter deployment", Ordered, func() {
+		It("should deploy successfully via deploy-react-starter.sh", func() {
+			output, err := dockerExec("./deploy-react-starter.sh")
+			fmt.Fprintf(GinkgoWriter, "deploy output:\n%s\n", output)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have Component 'react-starter'", func() {
+			_, err := dockerExec("kubectl get component react-starter -o name")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have Workload 'react-starter'", func() {
+			_, err := dockerExec("kubectl get workload react-starter -o name")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have ReleaseBinding 'react-starter-development' Ready", func() {
+			Eventually(func(g Gomega) {
+				output, err := dockerExec(
+					`kubectl get releasebinding react-starter-development -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+			}, deployTimeout, 5*time.Second).Should(Succeed())
+		})
+
+		It("should list react-starter in 'kubectl get components'", func() {
+			output, err := dockerExec("kubectl get components")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("react-starter"))
+		})
+	})
+
+	// ─── HTTP access ───────────────────────────────────────────────────
+
+	Context("HTTP access", func() {
+		It("should serve the react-starter app via external gateway", func() {
+			By("discovering the external URL from ReleaseBinding status")
+			var reactURL string
+			Eventually(func(g Gomega) {
+				host, err := dockerExec(
+					`kubectl get releasebinding react-starter-development -o jsonpath='{.status.endpoints[0].externalURLs.http.host}'`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(host).NotTo(BeEmpty())
+
+				port, err := dockerExec(
+					`kubectl get releasebinding react-starter-development -o jsonpath='{.status.endpoints[0].externalURLs.http.port}'`)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(port).NotTo(BeEmpty())
+
+				reactURL = fmt.Sprintf("http://%s:%s", host, port)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By(fmt.Sprintf("polling %s for HTTP 200", reactURL))
+			Eventually(func(g Gomega) {
+				output, err := dockerExec(fmt.Sprintf(
+					"curl -s -o /dev/null -w '%%{http_code}' --connect-timeout 5 -4 '%s'", reactURL))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("200"), "react-starter should return HTTP 200")
+			}, httpTimeout, 5*time.Second).Should(Succeed())
+		})
+
+		It("should serve the Backstage UI", func() {
+			Eventually(func(g Gomega) {
+				output, err := dockerExec(
+					"curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 -4 http://openchoreo.localhost:8080/")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("200"), "Backstage UI should return HTTP 200")
+			}, httpTimeout, 5*time.Second).Should(Succeed())
+		})
+
+		It("should have the OpenChoreo API reachable", func() {
+			Eventually(func(g Gomega) {
+				output, err := dockerExec(
+					"curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 -4 http://api.openchoreo.localhost:8080/")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(Equal("000"), "API should be reachable (any HTTP status)")
+			}, httpTimeout, 5*time.Second).Should(Succeed())
+		})
+	})
+
+	// ─── Guide kubectl commands ────────────────────────────────────────
+
+	Context("Guide kubectl commands", func() {
+		It("should list control plane namespaces", func() {
+			output, err := dockerExec("kubectl get namespaces -l openchoreo.dev/control-plane=true --no-headers")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+		})
+
+		It("should show environments", func() {
+			output, err := dockerExec("kubectl get environments")
+			Expect(err).NotTo(HaveOccurred())
+			for _, env := range []string{"development", "staging", "production"} {
+				Expect(output).To(ContainSubstring(env))
+			}
+		})
+
+		It("should show clustercomponenttypes", func() {
+			output, err := dockerExec("kubectl get clustercomponenttypes")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+		})
+	})
+
+	// ─── Cleanup ───────────────────────────────────────────────────────
+
+	Context("Sample app cleanup", Ordered, func() {
+		It("should clean up react-starter via --clean flag", func() {
+			_, err := dockerExec("./deploy-react-starter.sh --clean")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should delete the component", func() {
+			Eventually(func(g Gomega) {
+				output, err := dockerExec("kubectl get component react-starter -o name 2>&1")
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("NotFound"))
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+		})
+	})
+})
+
+// lastN returns the last n characters of s.
+func lastN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "..." + s[len(s)-n:]
+}
+

--- a/test/e2e-quickstart/suite_test.go
+++ b/test/e2e-quickstart/suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package quickstart
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+var (
+	image   string
+	version string
+)
+
+func init() {
+	flag.StringVar(&image, "qs.image", "ghcr.io/openchoreo/quick-start:latest-dev",
+		"Quick-start container image to test")
+	flag.StringVar(&version, "qs.version", "latest-dev",
+		"OpenChoreo version to pass to install.sh")
+}
+
+func TestQuickStart(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting OpenChoreo Quick Start e2e suite\n")
+	RunSpecs(t, "Quick Start E2E Suite")
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
$subject

## Approach

- Adds a Go (Ginkgo v2) e2e test that exercises the quick-start container image end-to-end
- Starts the `ghcr.io/openchoreo/quick-start:latest-dev` container, runs `install.sh`, validates CRDs, default resources, pod health, deploys the react-starter sample app, verifies HTTP access via dynamically-discovered URLs, runs guide kubectl commands, and cleans up
- Adds a CI workflow (`.github/workflows/test-e2e-quickstart.yml`) that runs daily at 06:00 UTC and supports manual dispatch with configurable image/version inputs

## What it tests
The test mirrors every step from the [Quick Start Guide](https://openchoreo.dev/docs/next/getting-started/quick-start-guide/):
1. Container startup with Docker socket access
2. `install.sh` / `check-status.sh` / `validate-installation.sh`
3. All 6 core CRDs exist
4. Default resources (project, environments, ClusterComponentTypes, ClusterDataPlane)
5. Pod health in control-plane and data-plane namespaces
6. `deploy-react-starter.sh` — Component, Workload, ReleaseBinding created and Ready
7. HTTP 200 from react-starter app (URL dynamically discovered from ReleaseBinding status)
8. Backstage UI and OpenChoreo API reachable
9. Guide kubectl commands (namespaces, environments, clustercomponenttypes)
10. Cleanup via `--clean` flag

## Run locally
```bash
GOWORK=off go test ./test/e2e-quickstart/... -v -timeout 20m
```

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.