### PR TITLE
chore: add end to end test readmes

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,38 @@
+# test/ — OpenChoreo test suites
+
+End-to-end and UI tests that run against a real OpenChoreo cluster (local k3d), plus shared Go test helpers. Note that the unit/integration tests live next to the code they test.
+
+## Structure
+
+```
+test/
+├── e2e/        Go (Ginkgo) end-to-end tests — `make e2e`
+│   ├── e2e_suite_test.go   Suite entry point; requires --e2e.kubecontext
+│   ├── e2e_test.go         Tier-1 platform health checks (all pods running)
+│   ├── suites/             One package per feature area (authz, build, gateway, gitops, mcp, observability, occ, secrets, …)
+│   ├── framework/          Test helpers: kubectl, occ, gitea, flux, gateway, port-forwarding, waits, MCP client, fixtures
+│   ├── fixtures/           Shared test data (alert rules, build sources)
+│   ├── cmd/tier3-fixtures/ One-shot setup binary that seeds tier-3 build sources before the suite runs
+│   └── k3d/                Cluster bring-up config: k3d config, Helm value overlays, plane registrations, CoreDNS and secret-store manifests
+├── ui/         Playwright tests for the Backstage portal (see ui/README.md)
+│   ├── specs/              Test suites (auth, catalog, lifecycle, dev-ops, pe-ops, abac-ui, config)
+│   ├── po/                 Page objects (semantic locators, intent-named methods)
+│   ├── fixtures/           Per-role auth state + kubectl wrapper fixtures
+│   ├── k3d/                Helm overlay that enables Backstage on the e2e cluster
+│   └── scripts/            IdP user seeding for already-installed clusters
+└── utils/      Shared Go helpers (run commands, install/uninstall cert-manager and prometheus-operator for tests)
+```
+
+- **`e2e/`** — spins up nothing itself; it asserts against an existing cluster identified by `--e2e.kubecontext`. Suites are labeled `tier1`, `tier2`, `tier3` on their top-level `Describe` so CI can shard them (`E2E_LABEL_FILTER`). `make e2e.setup` creates the local `openchoreo-e2e` k3d cluster from the configs in `e2e/k3d/`, then `make e2e.test` runs the suites.
+- **`ui/`** — drives the Backstage portal in Chromium against the same e2e cluster (`make e2e.setup E2E_WITH_UI=true`). Covers sign-in (Thunder OIDC), catalog sync, full component lifecycle, role-based access, and ABAC restrictions. Full details and prerequisites in [`ui/README.md`](ui/README.md).
+- **`utils/`** — small Go package used by tests to shell out (`Run`) and to install/uninstall external operators (cert-manager, prometheus-operator).
+
+## Running
+
+```sh
+make e2e                # full lifecycle: setup k3d cluster → test → teardown
+make e2e.test           # run tests against an existing cluster
+cd test/ui && npm test  # UI tests (after make e2e.setup E2E_WITH_UI=true)
+```
+
+See `make help` for the full list of e2e targets.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,264 @@
+# test/e2e — OpenChoreo end-to-end tests
+
+Go (Ginkgo) suites that exercise OpenChoreo features against a real Kubernetes cluster running all OpenChoreo planes — the same install path a user gets, on a local k3d cluster.
+
+## Structure
+
+```
+e2e/
+├── e2e_suite_test.go   Suite entry point; verifies the cluster is reachable (--e2e.kubecontext)
+├── e2e_test.go         Platform health checks: all control/data plane pods running
+├── suites/             One Go package per feature area (see table below)
+├── framework/          Shared helpers: kubectl/occ/helm wrappers, Eventually-style waits,
+│                       gateway invocation, port-forwarding, Gitea repos, MCP client
+├── fixtures/           Shared test data (alert rules, build source projects)
+├── cmd/tier3-fixtures/ One-shot binary that seeds Gitea build sources before tier-3 runs
+└── k3d/                Cluster bring-up: k3d config, Helm value overlays per plane,
+                        plane registration CRs, CoreDNS and secret-store manifests
+```
+
+## How to run
+
+```sh
+make e2e                                  # full lifecycle: setup → test → teardown (diagnostics on failure)
+make e2e.setup                            # create the openchoreo-e2e k3d cluster and install all planes
+make e2e.test                             # run suites against the existing cluster
+make e2e.test E2E_LABEL_FILTER='tier1'    # scope to a tier (Ginkgo label expression, e.g. 'tier1 || tier2')
+make e2e.down                             # delete the cluster
+```
+
+Useful knobs: `E2E_WITH_BUILD=true` / `E2E_WITH_OBSERVABILITY=true` add the workflow and observability planes (required for tier 3); `E2E_WITH_UI=true` enables Backstage for the UI suite (`test/ui/`); `E2E_KEEP_RESOURCES=true` skips per-suite cleanup for debugging. `make e2e.status` and `make e2e.diagnostics` help inspect a broken cluster.
+
+## Test suites
+
+Suites are labeled by tier on their top-level `Describe`, so CI can shard them and developers can run subsets.
+
+| Tier | Suite | What it covers |
+|---|---|---|
+| 1 | Platform Health | All control-plane and data-plane pods reach Running |
+| 1 | Workload Type Matrix | Service, web-app, and scheduled-task components deploy and respond |
+| 1 | Connection Resolution | Component-to-component connections resolve and route traffic |
+| 1 | NetworkPolicy Enforcement | Cross-project/namespace traffic is isolated as declared |
+| 1 | GCP Microservices Demo | A realistic multi-service application deploys end to end |
+| 2 | Authorization | Roles, bindings, namespace scoping, deny overrides, CEL conditions, propagation |
+| 2 | Gateway Routing | HTTP routing of deployed endpoints through the gateway |
+| 2 | OpenChoreo API | The control-plane REST API |
+| 2 | OCC CLI | `occ` commands against the control plane |
+| 2 | MCP Server | MCP tools served by the control plane |
+| 2 | Secrets and External Secrets | Secret references resolved via ESO/OpenBao into workloads |
+| 3 | Build From Source Matrix | Source-to-image builds via the workflow plane (sources seeded by `cmd/tier3-fixtures`) |
+| 3 | GitOps with Flux | Deploying OpenChoreo resources through a Flux-managed Git repo |
+| 3 | Observability Signals | Logs, metrics, and traces flow into the observability plane |
+| 3 | Observability Alerts | Alert rules fire and reach notification channels |
+
+Tiers 1–2 run on the default setup; tier 3 additionally needs the workflow and observability planes. Tier 5 is the Backstage UI suite, which lives separately in [`test/ui/`](../ui/README.md).
+
+## Test flow
+
+Each suite is an `Ordered` Ginkgo `Describe` that follows the same shape:
+
+1. `BeforeAll` applies fixtures with kubectl — namespaces, environments, projects, components — and polls (`Eventually`) until the controllers reconcile them (e.g. the data-plane namespace appears, pods become Ready).
+2. Specs assert the outcome: resource state via kubectl, and live behavior by invoking the deployed workload through the gateway (from an in-cluster tester pod or a port-forward).
+3. `AfterAll` deletes the suite's namespaces, which cascades cleanup to the data plane.
+
+Tests never create the cluster themselves — they target whatever `--e2e.kubecontext` points at, so a single setup is reused across suites and runs. New suites go under `suites/<area>/` as their own package, reuse `framework/` helpers, and pick the lowest tier whose plane requirements they fit.
+
+## Test walkthroughs
+
+The exact steps each suite performs, mirroring the `By(...)` steps in the code. Click a suite to expand; the source link points at its top-level `Describe`.
+
+<details>
+<summary><b>Platform Health</b> (tier 1) — control/data plane pods Running → CRDs registered → defaults present → agent connected</summary>
+
+Source: [`e2e_test.go:16`](e2e_test.go#L16)
+
+1. Assert all pods in the control-plane and data-plane namespaces reach Running
+2. Assert the OpenChoreo CRDs are registered (Project, Component, ComponentType, Trait, Environment, DeploymentPipeline, ComponentRelease, ReleaseBinding, Workload, Workflow, …)
+3. Assert the default namespace carries the out-of-box resources: Project `default`, DeploymentPipeline, the development/staging/production Environments, the built-in ClusterComponentTypes and builder ClusterWorkflows
+4. Assert the ClusterDataPlane `default` reports its agent as connected, and the cluster-agent pod logs confirm the connection
+
+</details>
+
+<details>
+<summary><b>Workload Type Matrix</b> (tier 1) — apply platform fixtures → deploy 3 component types → reconcile → invoke → delete → verify drain</summary>
+
+Source: [`suites/workloadtypes/workloadtypes_test.go:30`](suites/workloadtypes/workloadtypes_test.go#L30)
+
+1. Apply DeploymentPipeline, Environment, Project via kubectl
+2. Apply three Components with pre-built images: a service (greeter), a web application (http-echo), a scheduled task
+3. Wait for the controller to create the data-plane namespace and start a tester pod in it
+4. Per type, assert: ReleaseBinding `Ready` → pod Running → endpoint TCP-reachable from the tester pod (for the CronJob: `lastScheduleTime` populated instead)
+5. Invoke the service and web-app public URLs through the kgateway external listener (e.g. `/greeter/greet` returns 200)
+6. Delete one Component → its ReleaseBinding and Deployment drain while the sibling stays Ready; delete the Project → the whole DP namespace drains
+
+</details>
+
+<details>
+<summary><b>Connection Resolution</b> (tier 1) — deploy providers → deploy consumer with connections → resolve → env vars rendered → bad connection blocks Ready</summary>
+
+Source: [`suites/connections/connections_test.go:23`](suites/connections/connections_test.go#L23)
+
+1. Apply platform fixtures, then deploy two provider Components exposing HTTP endpoints with different visibilities
+2. Assert provider ReleaseBindings reach Ready with `ConnectionsResolved=True` (reason `NoConnections`)
+3. Deploy a consumer Component declaring connections to both providers; assert its ReleaseBinding reaches `ConnectionsResolved=True` (reason `AllConnectionsResolved`) and Ready
+4. Assert the rendered Deployment carries the connection env vars (`PROVIDER_A_URL`, `PROVIDER_B_URL`) with the correct service URLs, and the ReleaseBinding status lists both resolved connections
+5. Deploy a consumer pointing at a nonexistent component → `ConnectionsResolved=False` (reason `ConnectionsPending`) and Ready=False; remove the connections → status recovers and clears
+
+</details>
+
+<details>
+<summary><b>NetworkPolicy Enforcement</b> (tier 1) — deploy components across namespaces/projects/envs → NetworkPolicies rendered → probe 11 allow/block scenarios</summary>
+
+Source: [`suites/networkpolicy/networkpolicy_test.go:37`](suites/networkpolicy/networkpolicy_test.go#L37)
+
+1. Create two OpenChoreo namespaces with multiple Projects, and deploy Components with project / namespace / internal / external endpoint visibilities plus client pods in each project
+2. Promote one component to staging so a second environment's data-plane namespace exists
+3. Assert per-component NetworkPolicies are rendered in every data-plane namespace and enforcement is active
+4. Probe 11 connectivity scenarios from in-cluster client pods: intra-project allowed, cross-project to project-only blocked, cross-namespace blocked, cross-environment blocked, gateway → external-visible allowed, gateway → project-only blocked, and so on
+5. Assert cluster DNS still resolves while the egress policies are in place
+
+</details>
+
+<details>
+<summary><b>GCP Microservices Demo</b> (tier 1) — apply sample manifests → promote redis → all 11 services Ready → browse the shop through the gateway</summary>
+
+Source: [`suites/microservicesdemo/microservicesdemo_test.go:50`](suites/microservicesdemo/microservicesdemo_test.go#L50)
+
+1. `kubectl apply -R` the in-repo `samples/gcp-microservices-demo` (10 Components + a redis Resource)
+2. Promote the redis ResourceReleaseBinding to its latest release (the manual step the sample README asks of users)
+3. Wait for redis then all 10 component ReleaseBindings to reach Ready, and every pod to be Running
+4. Through the public gateway URL, GET `/` (proves frontend → productcatalog gRPC), `/product/<id>` (product + currency RPCs), and `/cart` (cart RPC) — all must return 200
+
+</details>
+
+<details>
+<summary><b>Authorization</b> (tier 2) — mint tokens per role → create roles/bindings → call the API → assert allow/deny</summary>
+
+Source: [`suites/authz/authz_test.go:34`](suites/authz/authz_test.go#L34)
+
+1. Mint an OIDC subject token and build authenticated + unauthenticated API clients
+2. Per scenario: apply AuthzRole / ClusterAuthzRole and bindings via kubectl, wait for policy propagation, call the API operation under test, assert the HTTP status matches the expected allow/deny
+3. Scenarios covered: unauthenticated (401), no binding (403), admin full access, developer partial access, namespace scoping, deny overriding an allow, binding create/delete propagation, cluster binding scoped to one namespace, role update propagation, server-side list filtering, who may manage authz resources themselves, CEL-conditioned allow, CEL-conditioned deny
+
+</details>
+
+<details>
+<summary><b>Gateway Routing</b> (tier 2) — deploy components with different endpoint visibilities → HTTPRoutes rendered per visibility → invoke external/internal URLs → env gateway override</summary>
+
+Source: [`suites/gateway/gateway_test.go:17`](suites/gateway/gateway_test.go#L17)
+
+1. Deploy five Components whose endpoints differ in visibility (external, project-only, internal, multi-endpoint, custom basePath); promote one to staging
+2. External visibility: HTTPRoute exists and is Accepted, the external URL returns 200
+3. Project-only visibility: no external HTTPRoute is rendered and the ReleaseBinding has no `externalURLs`
+4. Internal visibility: internal HTTPRoute only, reachable from the in-cluster tester pod
+5. Multi-endpoint component: one external HTTPRoute per endpoint, each with its own URL; basePath component: the route rewrites the prefix (`replacePrefixMatch`) and stays routable
+6. Staging: the rendered HTTPRoute parent switches to the environment's gateway override and hostname
+
+</details>
+
+<details>
+<summary><b>OpenChoreo API</b> (tier 2) — get OAuth2 token → CRUD namespaces/projects/components over REST → CRs appear on the cluster → delete cleans up</summary>
+
+Source: [`suites/openchoreoapi/openchoreoapi_test.go:20`](suites/openchoreoapi/openchoreoapi_test.go#L20)
+
+1. Reach the API through kgateway, obtain an OAuth2 token from the Thunder IdP; assert unauthenticated requests get 401 and `/health`, `/ready`, `/version` return 200
+2. Create a namespace via the API → the Kubernetes namespace exists with the control-plane label; list mixes API-created and kubectl-created namespaces
+3. Create a project via the API → the Project CR exists; list ComponentTypes with cursor-based pagination
+4. Create a component + workload via the API → Component CR, ComponentRelease, and ReleaseBinding appear, and the binding reaches Ready
+5. Delete the component then the project via the API → Component, Workload, ComponentRelease, ReleaseBinding, and Project CRs are all removed
+
+</details>
+
+<details>
+<summary><b>OCC CLI</b> (tier 2) — occ apply/get/create/delete against the control plane → resources reconcile → negative paths rejected</summary>
+
+Source: [`suites/occ/occ_test.go:32`](suites/occ/occ_test.go#L32)
+
+1. Smoke: `occ` connects and basic commands answer
+2. `occ apply` YAML fixtures create and configure resources
+3. Resource commands CRUD namespaces, projects, components, workloads, and release bindings
+4. Config, secret, and login command groups each get their own pass (context config, SecretReference management, auth flows)
+5. Negative scenarios: invalid input, missing fields, and authorization errors are rejected with useful errors
+6. Delete commands remove what was created; suite cleanup drains the data-plane namespaces
+
+</details>
+
+<details>
+<summary><b>MCP Server</b> (tier 2) — get token → connect MCP client → list/filter tools → create namespace/project/component/workload via tools → release chain appears</summary>
+
+Source: [`suites/mcp/mcp_test.go:33`](suites/mcp/mcp_test.go#L33)
+
+1. Fetch an OAuth2 token; assert an unauthenticated `POST /mcp` gets 401 with a `WWW-Authenticate: Bearer` challenge
+2. Connect an MCP client and `tools/list`: core tools are present, and filtering by toolset narrows the list (e.g. `namespace` toolset exposes only namespace tools)
+3. Call `create_namespace` → the namespace exists on the cluster and shows up in `list_namespaces`
+4. Call `create_project`, then `create_component` (auto-deploy) and `create_workload` with image + endpoint → the corresponding CRs exist
+5. The release chain follows: ComponentRelease appears in the component status, the ReleaseBinding is created, and `list_components` returns the new component
+
+</details>
+
+<details>
+<summary><b>Secrets and External Secrets</b> (tier 2) — create SecretReferences → deploy workload using them → ESO syncs → pod sees real values → update/delete propagate</summary>
+
+Source: [`suites/secrets/secrets_test.go:22`](suites/secrets/secrets_test.go#L22)
+
+1. Apply platform fixtures, two SecretReferences (one env var, one file mount) backed by a fake secret store, and a Component + Workload that consumes both
+2. Wait for ReleaseBinding Ready, then find the two ExternalSecrets the controller rendered in the DP namespace
+3. Assert each ExternalSecret reaches Ready and its target K8s Secret holds the expected decoded value
+4. `kubectl exec` into the workload pod: `printenv APP_USERNAME` and `cat password.txt` return the store values — the full chain from CR to process environment
+5. Update the env SecretReference to a different store key → a new ExternalSecret with an updated content hash rolls the pod, which now reads the new value (the file secret is untouched)
+6. Delete the Component → ExternalSecrets and their K8s Secrets cascade-delete from the DP namespace and no pods remain
+
+</details>
+
+<details>
+<summary><b>Build From Source Matrix</b> (tier 3) — trigger all builds concurrently → each workflow succeeds → release deploys → invoke</summary>
+
+Source: [`suites/build/build_test.go:90`](suites/build/build_test.go#L90)
+
+1. Seed Gitea with sample source repos (shared tier-3 fixture)
+2. Up front, apply a Component + WorkflowRun for each of the 5 builder cases — dockerfile (service + react web-app), GCP buildpacks, Paketo buildpacks, Ballerina buildpack — so the builds run concurrently on the workflow plane
+3. Per builder, wait up to 20 min for its WorkflowRun (Argo Workflow) to succeed; for the dockerfile case, also assert live build-pod logs are streamable
+4. Assert the build produced a ComponentRelease, the ReleaseBinding reaches Ready, and the workload pod runs the built image
+5. Probe the rendered Service for TCP reachability from a tester pod
+6. Solo specs: a build without `workload.yaml` auto-generates the Workload CR; SecretReference values resolve into the rendered Argo Workflow via CEL
+
+</details>
+
+<details>
+<summary><b>GitOps with Flux</b> (tier 3) — push manifests to Git → Flux reconciles → deployed → push image bump → rollout</summary>
+
+Source: [`suites/gitops/gitops_test.go:17`](suites/gitops/gitops_test.go#L17)
+
+1. Install Flux and an in-cluster Gitea, create a gitops repo, push the platform manifests (namespace, pipeline, environments, project)
+2. Point a Flux GitRepository + Kustomization at the repo and wait for it to reconcile
+3. Push a Component + Workload doc → Flux applies it → ReleaseBinding Ready, pod Running — no kubectl apply of app resources anywhere
+4. Push a commit bumping the image tag → the rendered Deployment rolls to the new image
+5. Push 3 components in one commit → all 3 reconcile and run (bulk promote)
+
+</details>
+
+<details>
+<summary><b>Observability Signals</b> (tier 3) — deploy workload → generate traffic → query observer API for logs and metrics</summary>
+
+Source: [`suites/observability/observability_test.go:44`](suites/observability/observability_test.go#L44)
+
+1. Deploy the greeter Component and wait for its ReleaseBinding Ready and pod Running; start a curl tester pod
+2. Generate ~45s of HTTP traffic at 5 RPS against the greeter's ClusterIP with a marker query string
+3. Query the observer's `POST /api/v1/logs/query` for the greeter's startup log line, scoped by component/project/environment
+4. Query `POST /api/v1/metrics/query` for CPU/memory series (kube-state-metrics + cadvisor) of the workload
+5. Probe the traces query endpoint best-effort (the sample app isn't OTel-instrumented, so empty results are acceptable)
+
+</details>
+
+<details>
+<summary><b>Observability Alerts</b> (tier 3) — register webhook channel → apply alert rules → trigger conditions → notifications arrive at the receiver</summary>
+
+Source: [`suites/alerts/alerts_test.go:40`](suites/alerts/alerts_test.go#L40)
+
+1. Deploy an in-cluster webhook receiver and register it as a NotificationChannel
+2. Apply the observability-alert-rule ClusterTrait and a Component carrying two alert rules: a metric rule (CPU threshold) and a log rule (pattern match)
+3. Wait for the rendered ObservabilityAlertRule to land on the observability plane
+4. Trigger the log rule by emitting the search phrase from inside the pod; poll the webhook receiver for the metric and log notifications (delivery asserted best-effort, rule presence strictly)
+5. Run a build, delete its WorkflowRun, then query the observer for the deleted run's logs — build logs stay queryable after CR cleanup
+
+</details>

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -1,125 +1,165 @@
 # test/ui — OpenChoreo Backstage UI tests
 
-Playwright tests that drive the Backstage portal end-to-end against a running
-OpenChoreo cluster.
+Playwright tests that drive the Backstage portal end-to-end in Chromium against a running OpenChoreo cluster — sign-in, catalog, component lifecycle, and role-based access, asserted through the real UI.
 
-## Quickstart against the local `openchoreo-e2e` k3d cluster
+## Structure
 
-The cleanest path is to let the Makefile do the bring-up:
+```
+ui/
+├── playwright.config.ts   Runner config; maps *.e2e-cp.local hostnames to 127.0.0.1
+│                          via Chromium host-resolver rules (no /etc/hosts edit needed)
+├── specs/                 One folder per suite (auth, catalog, config, lifecycle, dev-ops, pe-ops, abac-ui)
+├── po/                    Page objects — intent-named methods over semantic locators
+│                          (getByRole/getByLabel; no data-testid hooks needed)
+├── fixtures/              Playwright test.extend fixtures: per-role auth storage state,
+│                          a thin kubectl wrapper for cross-checking the cluster
+├── k3d/                   Helm value overlay that enables Backstage on the e2e cluster
+├── scripts/               seed-idp-users.sh — re-seeds Thunder IdP identities on an
+│                          already-installed cluster
+└── global-setup.ts        Pre-flight checks before the suite runs
+```
+
+## How to run
 
 ```sh
-make e2e.setup E2E_WITH_UI=true
+make e2e.setup E2E_WITH_UI=true   # e2e cluster with Backstage enabled (or `make e2e.setup-ui` to add UI to an existing cluster)
 cd test/ui
 npm ci
 npx playwright install --with-deps chromium
 UI_BASE_URL=http://openchoreo.e2e-cp.local:28080 npm test
 ```
 
-`make e2e.setup E2E_WITH_UI=true` extends the default e2e setup with the
-`test/ui/k3d/values-cp-ui.yaml` overlay (turns Backstage on) and waits for the
-Backstage deployment to become Ready. The PE and Dev identities come from
-Thunder's own bootstrap (`50-user-schema-and-users.sh`).
+For a fresh install the test identities (PE, Dev, ABAC-restricted) are seeded automatically by Thunder's bootstrap; on an already-installed cluster run `scripts/seed-idp-users.sh` (Thunder is briefly down while it re-runs the setup Job). To watch a run, use `PWSLOWMO=1000 npx playwright test --headed`.
 
-To bolt UI onto an existing cluster without re-running the full setup:
+## Test suites
 
-```sh
-make e2e.setup-ui
-```
+| Suite | What it covers |
+|---|---|
+| `auth/` | Thunder OIDC sign-in lands in the portal; `occ login` completes a PKCE round-trip driven through the browser consent form |
+| `catalog/` | A Component applied with kubectl appears in the Backstage catalog |
+| `lifecycle/` | Full UI-driven journey: create project + component → deploy → delete, verified against the cluster at each step |
+| `config/` | Component configuration edits through the UI: env vars, secret env vars, file mounts, and per-environment overrides, including form validation |
+| `dev-ops/` | Developer role: can create and view Components; platform-level actions (ComponentType create) are denied server-side |
+| `pe-ops/` | Platform-engineer role: CRUD of ComponentTypes and Traits via Scaffolder templates |
+| `abac-ui/` | Environment-conditioned access: deploy/promote allowed up to staging, the production Promote button renders permission-disabled, and the shape survives relogin |
 
-The Playwright config maps the `*.e2e-cp.local` hostnames to `127.0.0.1` via
-Chromium's `--host-resolver-rules`, so no `/etc/hosts` edit is needed.
+The `pkce-login` and `abac-ui` specs self-skip when their prerequisites are missing (host DNS entries for `occ`, the seeded ABAC identity), so the rest of the suite is unaffected.
 
-## Layout
+## Test flow
 
-- `playwright.config.ts` — runner config.
-- `specs/` — one folder per suite (`auth/`, `catalog/`, `lifecycle/`,
-  `dev-ops/`, `pe-ops/`, `abac-ui/`).
-- `po/` — page objects (intent-named methods, semantic locators). Every
-  affordance currently resolves via `getByRole` + accessible name or
-  `getByLabel`; no `data-testid` escape hatches are required against the
-  current Backstage UI surface.
-- `fixtures/` — Playwright `test.extend` fixtures (per-role storage state via
-  `mintAuthState` + `storageStateFor`, a thin `kubectl` wrapper).
-- `k3d/` — Helm value overlays that turn the e2e cluster into a UI-test target.
-- `scripts/` — `seed-idp-users.sh`, the Thunder setup-Job re-run for
-  already-installed clusters (see below).
+Specs sign in through the real Thunder OIDC redirect (the shared helper in `fixtures/auth.ts` mints per-role `storageState`, so each suite starts authenticated as the role it tests). They then interact with the portal exclusively through page objects in `po/`, and cross-check every UI action against the cluster with the `kubectl` fixture — a create in the UI must produce the right resource shape, and a delete must remove it. Role suites assert both sides: what the UI permits and what the server actually enforces.
 
-## Specs
+### pkce-login host prerequisites
 
-| Suite | Spec | What it asserts |
-|---|---|---|
-| `auth/` | sign-in | Thunder OIDC sign-in lands on the post-login Backstage layout |
-| `auth/` | pkce-login | `occ login` PKCE round-trip: Playwright drives the consent form, token persists, `occ get components` succeeds (self-skips unless the e2e hostnames resolve on the host — see below) |
-| `catalog/` | catalog-sync | kubectl-applied Component shows up in the Backstage catalog within polling timeout |
-| `lifecycle/` | full-lifecycle | UI-driven project + component create → deploy → delete, kubectl agreement on each step |
-| `dev-ops/` | dev-ops-component | Dev creates + views a Component; ComponentType create is denied server-side |
-| `pe-ops/` | pe-ops-pipeline | PE CRUD via the Scaffolder templates (ComponentType, Trait): create → kubectl shape → delete via the entity overflow menu |
-| `abac-ui/` | abac-env-restriction | Env-conditioned ClusterAuthzRoleBinding: deploy-to-dev + promote-to-staging allowed, promote-to-production renders the Promote button permission-disabled; relogin keeps the same permission shape (regression guard for backstage-plugins#549). Self-skips unless the ABAC identity is seeded — see below |
-
-## Sign-in spec
-
-`specs/auth/sign-in.spec.ts` signs in as `platform-engineer@openchoreo.dev`
-(seeded by Thunder's `50-user-schema-and-users.sh`).
-
-Sign-in is a same-page OIDC redirect: click the on-page `Sign In` button →
-fill the Thunder gate (`Enter your username` / `Enter your password`) → submit →
-wait for the post-login sidebar `Home` link. The shared helper in
-`fixtures/auth.ts` drives the same flow to mint per-role `storageState`.
-
-## Thunder bootstrap overlay (redirect URI + ABAC identity)
-
-`test/e2e/k3d/values-thunder.yaml` overlays two bootstrap scripts onto the
-Thunder chart:
-
-- `51-backstage-app.sh` — adds
-  `http://openchoreo.e2e-cp.local:28080/api/auth/openchoreo-auth/handler/frame`
-  alongside the single-cluster default redirect URI.
-- `52-abac-user.sh` — provisions the ABAC-restricted identity
-  (`abac-dev@openchoreo.dev` in group `abac-developers`) the `abac-ui` suite
-  signs in as. Thunder's admin API rejects every request (401) once the
-  server is up — even from loopback inside the pod — so identities can only
-  be seeded from the bootstrap setup Job, which runs against the SQLite
-  store directly.
-
-The Thunder helm chart only runs the bootstrap on `helm install`
-(`helm.sh/hook: pre-install`, `hook-delete-policy: hook-succeeded`), so
-fresh installs (`make e2e.setup E2E_WITH_UI=true`) get both automatically.
-For an already-installed cluster, re-run the setup Job with:
-
-```sh
-test/ui/scripts/seed-idp-users.sh
-```
-
-The script re-renders the bootstrap ConfigMap with the e2e overlay, scales
-Thunder to zero (the setup Job needs the RWO SQLite PVC), re-applies the
-setup Job (renamed, helm hooks stripped — the bootstrap scripts are
-idempotent), and scales Thunder back up. Sign-ins fail during the ~1–2
-minute window while Thunder is down. Requires `helm`, `kubectl`, `yq`.
-
-## pkce-login prerequisites
-
-The `auth/pkce-login` spec spawns `occ` as a host process — unlike the
-browser specs it cannot use Chromium's `--host-resolver-rules`, so the e2e
-hostnames must resolve via real DNS on the host:
+The `auth/pkce-login` spec spawns `occ` as a host process, so the e2e hostnames must resolve via real DNS (Chromium's resolver rules don't apply):
 
 ```sh
 sudo sh -c 'echo "127.0.0.1 openchoreo.e2e-cp.local api.e2e-cp.local thunder.e2e-cp.local" >> /etc/hosts'
 ```
 
-The spec self-skips when the control-plane hostname doesn't resolve, so the
-rest of the suite is unaffected by a missing entry. It also needs the `occ`
-binary — `make go.build.occ` places it under `bin/dist/<os>/<arch>/occ`,
-which the spec resolves automatically (override with `OCC_BIN`). The
-control-plane API URL defaults to `http://api.e2e-cp.local:28080`; override
-with `OCC_CONTROL_PLANE_URL` (deliberately not `UI_BASE_URL`, which is the
-Backstage portal, not the API).
+It also needs the `occ` binary (`make go.build.occ`, auto-resolved from `bin/dist/`, override with `OCC_BIN`) and uses `OCC_CONTROL_PLANE_URL` (default `http://api.e2e-cp.local:28080`) for the API — distinct from `UI_BASE_URL`, which is the portal.
 
-## Headed runs
+## Test walkthroughs
 
-`launchOptions.slowMo` is parked behind the `PWSLOWMO` env var (currently
-commented out in `playwright.config.ts`). Re-enable when you want to watch
-the click stream:
+The exact steps each spec performs. Click a spec to expand; the source link points at its `test.describe`.
 
-```sh
-PWSLOWMO=1000 npx playwright test --headed
-```
+<details>
+<summary><b>sign-in</b> — navigate home → OIDC redirect to Thunder → credentials → post-login sidebar</summary>
+
+Source: [`specs/auth/sign-in.spec.ts:14`](specs/auth/sign-in.spec.ts#L14)
+
+1. Navigate to `/` and click the on-page `Sign In` button (OpenChoreo OIDC provider)
+2. Fill the Thunder login gate with the platform-engineer credentials and submit
+3. Wait for the `Home` link in the Backstage sidebar — proof the OIDC redirect round-tripped and a session exists
+4. Assert the page title matches the portal
+
+</details>
+
+<details>
+<summary><b>pkce-login</b> — `occ login` emits auth URL → browser drives consent → token persisted → `occ` API call succeeds</summary>
+
+Source: [`specs/auth/pkce-login.spec.ts:70`](specs/auth/pkce-login.spec.ts#L70)
+
+1. Self-skips unless `api.e2e-cp.local` resolves on the host (see prerequisites above)
+2. Bootstrap an isolated `occ` home, add the e2e control-plane context, and spawn `occ login` with a noop browser shim
+3. Extract the OAuth2 authorization URL from `occ` stdout, navigate Playwright to it, and submit the PE credentials on Thunder's consent form
+4. Assert `occ login` exits 0 after the callback round-trips
+5. Cross-check the persisted token by running `occ component list` — exits 0
+
+</details>
+
+<details>
+<summary><b>catalog-sync</b> — kubectl apply a Component → catalog provider polls → entity appears in Backstage</summary>
+
+Source: [`specs/catalog/catalog-sync.spec.ts:45`](specs/catalog/catalog-sync.spec.ts#L45)
+
+1. As PE, apply a Project + Component to the cluster with kubectl — no UI interaction creates them
+2. Open the catalog filtered to the Component kind and poll (reloading) for up to 6 min until the applied Component shows up as a link
+3. Open the entity page and assert the Component heading renders
+
+</details>
+
+<details>
+<summary><b>full-lifecycle</b> — create project → create component → deploy to dev → kubectl agrees at each step → delete both via UI</summary>
+
+Source: [`specs/lifecycle/full-lifecycle.spec.ts:32`](specs/lifecycle/full-lifecycle.spec.ts#L32)
+
+1. Create a Project through the UI form; poll `kubectl get project` until the CR exists
+2. Create a Component (Web Application template, pre-built greeter image, port 9090); verify the Component CR and its `componentType` via kubectl
+3. Deploy to the `development` environment through the UI, setting workload args; wait for the release to show Active and cross-check the ReleaseBinding's Ready condition with kubectl
+4. Delete the Component via the entity overflow menu; poll kubectl until the CR is gone
+5. Delete the Project the same way; poll kubectl until it is gone
+
+</details>
+
+<details>
+<summary><b>config</b> — deploy a component → edit env vars, secrets, and file mounts → per-environment overrides → kubectl verifies every save</summary>
+
+Source: [`specs/config/component-config-edits.spec.ts:193`](specs/config/component-config-edits.spec.ts#L193)
+
+1. As PE, create a project + component and deploy to development; seed a SecretReference and ABAC bindings via kubectl (serial spec, ~14 tests)
+2. Component-level config: add a plain env var and a secret env var (from the SecretReference), then a plain and a secret file mount; edit values; each save creates a release and kubectl confirms the Workload carries the change
+3. Form validation: an empty env var name or file name disables Apply
+4. Per-environment overrides: add development-only env vars and file mounts, override inherited component values (name fields locked), edit and then delete all overrides — each step verified against `ReleaseBinding.spec.workloadOverrides` via kubectl
+5. Edit replicas on the component tab → `componentTypeEnvironmentConfigs.replicas` updates
+6. As the ABAC-restricted user, open the production overrides page → the UI signals denial and kubectl confirms the production binding never mutated
+7. Remove all config through the UI, then delete the component and project via their overflow menus; kubectl confirms everything is gone
+
+</details>
+
+<details>
+<summary><b>dev-ops</b> — sign in as Dev → create component succeeds → ComponentType create denied server-side</summary>
+
+Source: [`specs/dev-ops/dev-ops-component.spec.ts:36`](specs/dev-ops/dev-ops-component.spec.ts#L36)
+
+1. As the Dev identity, with a PE-seeded Project (kubectl), create a Component through the scaffolder (Web Application template, pre-built image)
+2. kubectl confirms both the Component CR and its generated Workload CR exist; the component overview page renders
+3. Navigate directly to the ComponentType scaffolder URL (bypassing the client-side disabled card) and submit the form
+4. Assert the server rejects it: the task page shows a permission-denied error and kubectl confirms no ComponentType CR was created — the deny is enforced server-side, not just hidden in the UI
+
+</details>
+
+<details>
+<summary><b>pe-ops</b> — sign in as PE → create ComponentType and Trait via Scaffolder → kubectl shape check → delete via catalog menu</summary>
+
+Source: [`specs/pe-ops/pe-ops-pipeline.spec.ts:59`](specs/pe-ops/pe-ops-pipeline.spec.ts#L59)
+
+1. For each of ComponentType and Trait (serial): open the Create page and fill the matching Scaffolder template (name + description), walking the wizard to Create
+2. Poll kubectl until the CR exists and assert its description field round-tripped into the spec
+3. Wait (up to 6 min) for the catalog provider to ingest the entity, then open it from the catalog table
+4. Delete it via the entity overflow menu and confirm in the modal; poll kubectl until the CR is not-found
+
+</details>
+
+<details>
+<summary><b>abac-ui</b> — env-conditioned bindings → deploy dev ✓ → promote staging ✓ → promote production denied → relogin keeps the deny</summary>
+
+Source: [`specs/abac-ui/abac-env-restriction.spec.ts:126`](specs/abac-ui/abac-env-restriction.spec.ts#L126)
+
+1. Self-skips unless the ABAC identity is seeded (see the Thunder bootstrap note above); seeds a ClusterAuthzRole + allow (dev/staging) and deny (production) bindings via kubectl
+2. As the ABAC identity, create a component and deploy to development; wait for the release to go Active
+3. Promote to staging — allowed; kubectl confirms exactly one staging ReleaseBinding exists
+4. Attempt promote to production — the Promote button renders permission-disabled with a tooltip, and kubectl confirms no production ReleaseBinding was created
+5. Sign out and re-authenticate interactively (forcing a Casbin cache eviction), then assert the production Promote button is still denied — regression guard for backstage-plugins#549
+
+</details>


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds readmes for the e2e tests (including UI e2e tests)
Adds each test walkthrough in detail

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)