### PR TITLE
chore: improve extended e2e test suite to use a multi-cluster setup

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -5,7 +5,7 @@
 # runner + k3d cluster each, so callers pay the wall-clock of the slowest
 # leg instead of the serial sum:
 #   tier1, tier2 — control plane + data plane only
-#   tier3       — full stack (workflow + observability planes)
+#   tier3       — multi-cluster (4 separate k3d clusters, one per plane)
 #   ui          — full stack + Backstage portal (Playwright)
 #
 # Callers: the scheduled e2e workflows (test-e2e, test-e2e-extended,
@@ -230,7 +230,7 @@ jobs:
           if-no-files-found: ignore
 
   tier3:
-    name: E2E (Tier 3)
+    name: E2E (Tier 3 — Multi-cluster)
     if: ${{ inputs.run_tier3 }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -278,19 +278,18 @@ jobs:
               ;;
           esac
 
-      - name: Add e2e host entries
-        run: echo '127.0.0.1 api.e2e-cp.local thunder.e2e-cp.local openchoreo.e2e-cp.local' | sudo tee -a /etc/hosts
+      - name: Add e2e multi-cluster host entries
+        # CP cluster external domains only — DP/WP/OP clusters are reached
+        # via host.k3d.internal from within k3d nodes, not the CI runner.
+        run: echo '127.0.0.1 api.e2e-mc-cp.local thunder.e2e-mc-cp.local openchoreo.e2e-mc-cp.local cluster-gateway.e2e-mc-cp.local' | sudo tee -a /etc/hosts
 
-      - name: Run e2e tests (tier 3)
+      - name: Run multi-cluster e2e tests (tier 3)
         run: |
-          make e2e \
+          make e2e.multi \
             E2E_HELM_SOURCE=oci \
             HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
-            E2E_WITH_BUILD=true \
-            E2E_WITH_OBSERVABILITY=true \
-            E2E_SETUP_TIMEOUT=10m \
-            E2E_TEST_TIMEOUT=120m \
-            E2E_JOB_FIXTURE_SET=tier3 \
+            E2E_SETUP_TIMEOUT=20m \
+            E2E_TEST_TIMEOUT=60m \
             E2E_LABEL_FILTER='tier3'
 
       - name: Upload diagnostics

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -86,6 +86,32 @@ E2E_KUBECTL := kubectl --context $(E2E_KUBECONTEXT)
 E2E_HELM    := helm --kube-context $(E2E_KUBECONTEXT)
 
 # ---------------------------------------------------------------------------
+# Multi-cluster e2e — one k3d cluster per plane
+# ---------------------------------------------------------------------------
+E2E_MC_CP_CLUSTER_NAME ?= openchoreo-e2e-mc-cp
+E2E_MC_DP_CLUSTER_NAME ?= openchoreo-e2e-mc-dp
+E2E_MC_WP_CLUSTER_NAME ?= openchoreo-e2e-mc-wp
+E2E_MC_OP_CLUSTER_NAME ?= openchoreo-e2e-mc-op
+
+E2E_MC_CP_KUBECONTEXT  := k3d-$(E2E_MC_CP_CLUSTER_NAME)
+E2E_MC_DP_KUBECONTEXT  := k3d-$(E2E_MC_DP_CLUSTER_NAME)
+E2E_MC_WP_KUBECONTEXT  := k3d-$(E2E_MC_WP_CLUSTER_NAME)
+E2E_MC_OP_KUBECONTEXT  := k3d-$(E2E_MC_OP_CLUSTER_NAME)
+
+E2E_MC_CP_KUBECTL      := kubectl --context $(E2E_MC_CP_KUBECONTEXT)
+E2E_MC_DP_KUBECTL      := kubectl --context $(E2E_MC_DP_KUBECONTEXT)
+E2E_MC_WP_KUBECTL      := kubectl --context $(E2E_MC_WP_KUBECONTEXT)
+E2E_MC_OP_KUBECTL      := kubectl --context $(E2E_MC_OP_KUBECONTEXT)
+
+E2E_MC_CP_HELM         := helm --kube-context $(E2E_MC_CP_KUBECONTEXT)
+E2E_MC_DP_HELM         := helm --kube-context $(E2E_MC_DP_KUBECONTEXT)
+E2E_MC_WP_HELM         := helm --kube-context $(E2E_MC_WP_KUBECONTEXT)
+E2E_MC_OP_HELM         := helm --kube-context $(E2E_MC_OP_KUBECONTEXT)
+
+E2E_MC_K3D_DIR         := $(E2E_DIR)/k3d/multi-cluster
+E2E_MC_DIAGNOSTICS_DIR ?= $(E2E_DIAGNOSTICS_DIR)/multi-cluster
+
+# ---------------------------------------------------------------------------
 # Helper: copy cluster-gateway server CA from CP namespace to a target namespace.
 # The agent needs the server CA to verify the gateway's TLS certificate.
 # The CA is extracted from the cert-manager-issued secret during _e2e.install-cp
@@ -135,6 +161,58 @@ define e2e_register_plane
 		-n $(1) -o jsonpath='{.data.ca\.crt}' | base64 -d) && \
 	yq '.spec.clusterAgent.clientCA.value = strenv(AGENT_CA)' $(2) | \
 	$(E2E_KUBECTL) apply -f -
+endef
+
+# ---------------------------------------------------------------------------
+# Helper (multi-cluster): patch gateway-default in a specific cluster context.
+# Usage: $(call e2e_mc_patch_gateway,<kubecontext>,<namespace>)
+# ---------------------------------------------------------------------------
+define e2e_mc_patch_gateway
+	@$(call log_info, Waiting for gateway-default deployment in $(2))
+	@for i in $$(seq 1 30); do \
+		kubectl --context $(1) get deployment gateway-default -n $(2) >/dev/null 2>&1 && break; \
+		if [ $$i -eq 30 ]; then echo "gateway-default not found in $(2), skipping patch"; exit 0; fi; \
+		sleep 2; \
+	done
+	@$(call log_info, Patching gateway-default in $(2) with /tmp volume)
+	@kubectl --context $(1) patch deployment gateway-default -n $(2) \
+		--type='json' \
+		-p='[{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"tmp","emptyDir":{}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"tmp","mountPath":"/tmp"}}]'
+endef
+
+# ---------------------------------------------------------------------------
+# Helper (multi-cluster): copy cluster-gateway CA from the CP cluster into a
+# plane cluster's namespace. The CA lives in the CP cluster and each plane's
+# cluster-agent needs it to verify the cluster-gateway TLS certificate.
+# Usage: $(call e2e_copy_gateway_certs_cross_cluster,<cp-context>,<plane-context>,<plane-namespace>)
+# ---------------------------------------------------------------------------
+define e2e_copy_gateway_certs_cross_cluster
+	@$(call log_info, Copying cluster-gateway CA from CP to $(3))
+	@kubectl --context $(2) create namespace $(3) --dry-run=client -o yaml | \
+		kubectl --context $(2) apply -f -
+	@CA_CRT=$$(kubectl --context $(1) get configmap cluster-gateway-ca \
+		-n $(E2E_CP_NS) -o jsonpath='{.data.ca\.crt}') && \
+	kubectl --context $(2) create configmap cluster-gateway-ca \
+		--from-literal=ca.crt="$$CA_CRT" \
+		-n $(3) --dry-run=client -o yaml | kubectl --context $(2) apply -f -
+endef
+
+# ---------------------------------------------------------------------------
+# Helper (multi-cluster): register a plane CR by reading the cluster-agent TLS
+# cert from the plane cluster and applying the plane CR to the CP cluster.
+# Usage: $(call e2e_register_plane_cross_cluster,<plane-context>,<plane-namespace>,<cp-context>,<template-yaml>)
+# ---------------------------------------------------------------------------
+define e2e_register_plane_cross_cluster
+	@$(call log_info, Waiting for cluster-agent TLS cert in $(2))
+	@for i in $$(seq 1 60); do \
+		kubectl --context $(1) get secret cluster-agent-tls -n $(2) >/dev/null 2>&1 && break; \
+		if [ $$i -eq 60 ]; then echo "Timed out waiting for cluster-agent-tls in $(2)"; exit 1; fi; \
+		sleep 2; \
+	done
+	@export AGENT_CA=$$(kubectl --context $(1) get secret cluster-agent-tls \
+		-n $(2) -o jsonpath='{.data.ca\.crt}' | base64 -d) && \
+	yq '.spec.clusterAgent.clientCA.value = strenv(AGENT_CA)' $(4) | \
+	kubectl --context $(3) apply -f -
 endef
 
 ##@ E2E Testing
@@ -534,3 +612,590 @@ e2e.down: ## Delete k3d cluster
 	@$(call log_info, Deleting k3d cluster '$(E2E_CLUSTER_NAME)')
 	k3d cluster delete $(E2E_CLUSTER_NAME)
 	@$(call log_success, k3d cluster '$(E2E_CLUSTER_NAME)' deleted)
+
+##@ E2E Multi-cluster Testing
+
+# ---------------------------------------------------------------------------
+# Lifecycle target
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e.multi
+e2e.multi: ## Full multi-cluster e2e lifecycle: setup → test → down (collects diagnostics on failure)
+	@setup_ok=0; \
+	$(MAKE) e2e.multi.setup && setup_ok=1; \
+	if [ $$setup_ok -eq 1 ]; then \
+		$(MAKE) e2e.multi.test; test_exit=$$?; \
+		if [ $$test_exit -ne 0 ]; then $(MAKE) e2e.multi.diagnostics || true; fi; \
+	else \
+		test_exit=1; \
+		$(MAKE) e2e.multi.diagnostics || true; \
+	fi; \
+	$(MAKE) e2e.multi.down || true; \
+	exit $$test_exit
+
+# ---------------------------------------------------------------------------
+# Setup targets
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e.multi.setup
+e2e.multi.setup: ## All setup: clusters + prerequisites + install + configure
+	@$(MAKE) e2e.multi.setup-clusters
+	@$(MAKE) e2e.multi.setup-prerequisites
+	@$(MAKE) e2e.multi.setup-install
+	@$(MAKE) e2e.multi.setup-configure
+	@$(call log_success, Multi-cluster e2e setup complete)
+
+.PHONY: e2e.multi.setup-clusters
+e2e.multi.setup-clusters: ## Create all four k3d clusters (CP, DP, WP, OP)
+	@$(call log_info, Creating CP cluster '$(E2E_MC_CP_CLUSTER_NAME)')
+	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-cp.yaml
+	$(E2E_MC_CP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	@$(call log_info, Creating DP cluster '$(E2E_MC_DP_CLUSTER_NAME)')
+	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-dp.yaml
+	$(E2E_MC_DP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	@$(call log_info, Creating WP cluster '$(E2E_MC_WP_CLUSTER_NAME)')
+	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-wp.yaml
+	$(E2E_MC_WP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	@$(call log_info, Creating OP cluster '$(E2E_MC_OP_CLUSTER_NAME)')
+	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-op.yaml
+	$(E2E_MC_OP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	@$(call log_info, Applying CoreDNS rewrites)
+	$(E2E_MC_CP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-cp.yaml
+	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-dp.yaml
+	$(E2E_MC_OP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-op.yaml
+	@# Restart CoreDNS in each cluster that received a custom rewrite so the
+	@# new ConfigMap keys are loaded immediately rather than waiting for the
+	@# volume-sync propagation delay (up to 120s).
+	$(E2E_MC_CP_KUBECTL) -n kube-system rollout restart deployment/coredns
+	$(E2E_MC_DP_KUBECTL) -n kube-system rollout restart deployment/coredns
+	$(E2E_MC_OP_KUBECTL) -n kube-system rollout restart deployment/coredns
+	$(E2E_MC_CP_KUBECTL) -n kube-system rollout status deployment/coredns --timeout=60s
+	$(E2E_MC_DP_KUBECTL) -n kube-system rollout status deployment/coredns --timeout=60s
+	$(E2E_MC_OP_KUBECTL) -n kube-system rollout status deployment/coredns --timeout=60s
+	@$(call log_success, All four k3d clusters created)
+
+.PHONY: e2e.multi.setup-prerequisites
+e2e.multi.setup-prerequisites: ## Install prerequisites into each cluster
+	@$(call log_info, === CP cluster prerequisites ===)
+	$(E2E_MC_CP_KUBECTL) apply --server-side \
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+	$(E2E_MC_CP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+		--namespace cert-manager --create-namespace \
+		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_CP_HELM) upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets \
+		--namespace external-secrets --create-namespace \
+		--version $(ESO_VERSION) --set installCRDs=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_CP_HELM) upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+		--version $(KGATEWAY_VERSION)
+	$(E2E_MC_CP_HELM) upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+		--namespace $(E2E_CP_NS) --create-namespace \
+		--version $(KGATEWAY_VERSION) \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_CP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/secretstore.yaml
+	@$(call log_info, === DP cluster prerequisites ===)
+	$(E2E_MC_DP_KUBECTL) apply --server-side \
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+	$(E2E_MC_DP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+		--namespace cert-manager --create-namespace \
+		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_DP_HELM) upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets \
+		--namespace external-secrets --create-namespace \
+		--version $(ESO_VERSION) --set installCRDs=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_DP_HELM) upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+		--version $(KGATEWAY_VERSION)
+	$(E2E_MC_DP_HELM) upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+		--namespace $(E2E_DP_NS) --create-namespace \
+		--version $(KGATEWAY_VERSION) \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/secretstore.yaml
+	@$(call log_info, === WP cluster prerequisites ===)
+	$(E2E_MC_WP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+		--namespace cert-manager --create-namespace \
+		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@# ESO CRDs are required in WP cluster so the WorkflowRun controller can create
+	@# ExternalSecret resources in the workflows-<cpNs> namespace before build jobs run.
+	$(E2E_MC_WP_HELM) upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets \
+		--namespace external-secrets --create-namespace \
+		--version $(ESO_VERSION) --set installCRDs=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_WP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/secretstore.yaml
+	@$(call log_info, === OP cluster prerequisites ===)
+	$(E2E_MC_OP_KUBECTL) apply --server-side \
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+	$(E2E_MC_OP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+		--namespace cert-manager --create-namespace \
+		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_OP_HELM) upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+		--version $(KGATEWAY_VERSION)
+	$(E2E_MC_OP_HELM) upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+		--namespace $(E2E_OP_NS) --create-namespace \
+		--version $(KGATEWAY_VERSION) \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_OP_HELM) upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets \
+		--namespace external-secrets --create-namespace \
+		--version $(ESO_VERSION) --set installCRDs=true \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_success, Prerequisites installed in all clusters)
+
+.PHONY: e2e.multi.setup-install
+e2e.multi.setup-install: ## Install all planes into their respective clusters via Helm
+	@$(MAKE) _e2e.mc.install-thunder
+	@$(MAKE) _e2e.mc.install-cp
+	@$(MAKE) _e2e.mc.install-dp
+	@$(MAKE) _e2e.mc.install-openbao
+	@$(MAKE) _e2e.mc.install-wp
+	@$(MAKE) _e2e.mc.install-op
+	@$(MAKE) _e2e.mc.install-fluent-bit
+	@$(call log_success, All planes installed)
+
+.PHONY: e2e.multi.setup-configure
+e2e.multi.setup-configure: ## Apply default resources, register planes, link observability
+	@$(call log_info, Applying default resources)
+	$(E2E_MC_CP_KUBECTL) label namespace default openchoreo.dev/control-plane=true --overwrite
+	$(E2E_MC_CP_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/all.yaml
+	@$(MAKE) _e2e.mc.configure-dp
+	@$(MAKE) _e2e.mc.configure-wp
+	@$(MAKE) _e2e.mc.configure-op
+	@$(MAKE) _e2e.mc.link-observability
+	@$(call log_info, Waiting for CP controller-manager webhook to be ready)
+	@until $(E2E_MC_CP_KUBECTL) get endpoints controller-manager-webhook-service \
+		-n $(E2E_CP_NS) -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .; \
+		do sleep 3; done
+	@$(call log_success, Multi-cluster e2e configuration complete)
+
+# ---------------------------------------------------------------------------
+# Internal install targets
+# ---------------------------------------------------------------------------
+
+.PHONY: _e2e.mc.install-thunder
+_e2e.mc.install-thunder:
+	@# Thunder requires a valid /etc/machine-id on the node
+	docker exec k3d-$(E2E_MC_CP_CLUSTER_NAME)-server-0 sh -c \
+		"cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+	@$(call log_info, Installing Thunder $(THUNDER_VERSION))
+	$(E2E_MC_CP_HELM) upgrade --install thunder oci://ghcr.io/asgardeo/helm-charts/thunder \
+		--namespace thunder --create-namespace \
+		--version $(THUNDER_VERSION) \
+		--values $(PROJECT_DIR)/install/k3d/common/values-thunder.yaml \
+		--values $(E2E_MC_K3D_DIR)/values-thunder.yaml \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+
+.PHONY: _e2e.mc.install-cp
+_e2e.mc.install-cp:
+	@$(call log_info, Installing Control Plane)
+	$(E2E_MC_CP_HELM) upgrade --install openchoreo-control-plane $(E2E_CP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_CP_NS) --create-namespace \
+		--values $(E2E_MC_K3D_DIR)/values-cp.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(call e2e_mc_patch_gateway,$(E2E_MC_CP_KUBECONTEXT),$(E2E_CP_NS))
+	$(E2E_MC_CP_KUBECTL) wait -n $(E2E_CP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+	@$(call log_info, Waiting for cluster-gateway CA)
+	$(E2E_MC_CP_KUBECTL) wait -n $(E2E_CP_NS) \
+		--for=condition=Ready certificate/cluster-gateway-ca --timeout=$(E2E_SETUP_TIMEOUT)
+	@$(E2E_MC_CP_KUBECTL) get secret cluster-gateway-ca -n $(E2E_CP_NS) \
+		-o jsonpath='{.data.ca\.crt}' | base64 -d | \
+	$(E2E_MC_CP_KUBECTL) create configmap cluster-gateway-ca \
+		--from-file=ca.crt=/dev/stdin \
+		-n $(E2E_CP_NS) \
+		--dry-run=client -o yaml | $(E2E_MC_CP_KUBECTL) apply -f -
+
+.PHONY: _e2e.mc.install-dp
+_e2e.mc.install-dp:
+	$(call e2e_copy_gateway_certs_cross_cluster,$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_DP_KUBECONTEXT),$(E2E_DP_NS))
+	@# Fluent Bit (installed later in the DP cluster) mounts /etc/machine-id as
+	@# a hostPath volume — seed it on the node so the init container doesn't block.
+	docker exec k3d-$(E2E_MC_DP_CLUSTER_NAME)-server-0 sh -c \
+		"[ -f /etc/machine-id ] || cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+	@$(call log_info, Installing Data Plane)
+	$(E2E_MC_DP_HELM) upgrade --install openchoreo-data-plane $(E2E_DP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_DP_NS) --create-namespace \
+		--values $(E2E_MC_K3D_DIR)/values-dp.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(call e2e_mc_patch_gateway,$(E2E_MC_DP_KUBECONTEXT),$(E2E_DP_NS))
+	$(E2E_MC_DP_KUBECTL) wait -n $(E2E_DP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+.PHONY: _e2e.mc.install-openbao
+_e2e.mc.install-openbao:
+	@# Install OpenBao in CP, DP, and OP clusters (per install/k3d/multi-cluster/README.md).
+	@# WP does not need OpenBao — secrets are created directly (README §4 note).
+	@$(call log_info, Installing OpenBao in CP cluster)
+	$(E2E_MC_CP_HELM) upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
+		--namespace openbao --create-namespace \
+		--version $(OPENBAO_CHART_VERSION) \
+		--values $(PROJECT_DIR)/install/k3d/common/values-openbao.yaml \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Replacing fake ClusterSecretStore with openbao-backed default in CP)
+	$(E2E_MC_CP_KUBECTL) delete clustersecretstore default --ignore-not-found
+	$(E2E_MC_CP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/openbao-secretstore.yaml
+	@$(call log_info, Installing OpenBao in DP cluster \(required for ClusterSecretStore\))
+	$(E2E_MC_DP_HELM) upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
+		--namespace openbao --create-namespace \
+		--version $(OPENBAO_CHART_VERSION) \
+		--values $(PROJECT_DIR)/install/k3d/common/values-openbao.yaml \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Replacing fake ClusterSecretStore with openbao-backed default in DP)
+	$(E2E_MC_DP_KUBECTL) delete clustersecretstore default --ignore-not-found
+	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/openbao-secretstore.yaml
+
+.PHONY: _e2e.mc.install-wp
+_e2e.mc.install-wp:
+	$(call e2e_copy_gateway_certs_cross_cluster,$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_WP_KUBECONTEXT),$(E2E_WP_NS))
+	@# Seed /etc/machine-id on the WP node for Fluent Bit (installed later).
+	docker exec k3d-$(E2E_MC_WP_CLUSTER_NAME)-server-0 sh -c \
+		"[ -f /etc/machine-id ] || cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+	@$(call log_info, Installing container registry)
+	helm repo add twuni https://twuni.github.io/docker-registry.helm 2>/dev/null || true
+	helm repo update twuni
+	$(E2E_MC_WP_HELM) upgrade --install registry twuni/docker-registry \
+		--namespace $(E2E_WP_NS) --create-namespace \
+		--values $(PROJECT_DIR)/install/k3d/single-cluster/values-registry.yaml
+	@$(call log_info, Installing Workflow Plane)
+	$(E2E_MC_WP_HELM) upgrade --install openchoreo-workflow-plane $(E2E_WP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_WP_NS) --create-namespace \
+		--values $(E2E_MC_K3D_DIR)/values-wp.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_WP_KUBECTL) wait -n $(E2E_WP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+.PHONY: _e2e.mc.install-op
+_e2e.mc.install-op:
+	$(call e2e_copy_gateway_certs_cross_cluster,$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_OP_KUBECONTEXT),$(E2E_OP_NS))
+	@# Fluent Bit mounts /etc/machine-id as a hostPath volume to tag log entries.
+	@# k3d node containers don't have this file — seed it before the observability
+	@# modules install so the Fluent Bit DaemonSet init container doesn't block.
+	docker exec k3d-$(E2E_MC_OP_CLUSTER_NAME)-server-0 sh -c \
+		"[ -f /etc/machine-id ] || cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+	@$(call log_info, Creating OP cluster namespace and base secrets)
+	@$(E2E_MC_OP_KUBECTL) create namespace $(E2E_OP_NS) --dry-run=client -o yaml | $(E2E_MC_OP_KUBECTL) apply -f -
+	@$(E2E_MC_OP_KUBECTL) create secret generic observer-opensearch-credentials \
+		-n $(E2E_OP_NS) \
+		--from-literal=username="admin" \
+		--from-literal=password="ThisIsTheOpenSearchPassword1" \
+		--dry-run=client -o yaml | $(E2E_MC_OP_KUBECTL) apply -f -
+	@$(E2E_MC_OP_KUBECTL) create secret generic observer-secret \
+		-n $(E2E_OP_NS) \
+		--from-literal=OPENSEARCH_USERNAME="admin" \
+		--from-literal=OPENSEARCH_PASSWORD="ThisIsTheOpenSearchPassword1" \
+		--from-literal=UID_RESOLVER_OAUTH_CLIENT_SECRET="openchoreo-observer-resource-reader-client-secret" \
+		--dry-run=client -o yaml | $(E2E_MC_OP_KUBECTL) apply -f -
+	@$(call log_info, Installing OpenBao in OP cluster \(required for ExternalSecret → opensearch-admin-credentials\))
+	$(E2E_MC_OP_HELM) upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
+		--namespace openbao --create-namespace \
+		--version $(OPENBAO_CHART_VERSION) \
+		--values $(PROJECT_DIR)/install/k3d/common/values-openbao.yaml \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Creating ClusterSecretStore and ExternalSecret for opensearch-admin-credentials)
+	$(E2E_MC_OP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/openbao-secretstore.yaml
+	$(E2E_MC_OP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/opensearch-admin-externalsecret.yaml
+	@$(call log_info, Waiting for opensearch-admin-credentials secret to be ready)
+	$(E2E_MC_OP_KUBECTL) wait -n $(E2E_OP_NS) \
+		--for=condition=Ready externalsecret/opensearch-admin-credentials --timeout=60s
+	@$(call log_info, Installing Observability Plane)
+	$(E2E_MC_OP_HELM) upgrade --install openchoreo-observability-plane $(E2E_OP_CHART) \
+		$(E2E_HELM_DEP_UPDATE) \
+		--namespace $(E2E_OP_NS) --create-namespace \
+		--values $(E2E_MC_K3D_DIR)/values-op.yaml \
+		--timeout $(E2E_SETUP_TIMEOUT)
+	$(call e2e_mc_patch_gateway,$(E2E_MC_OP_KUBECONTEXT),$(E2E_OP_NS))
+	@$(call log_info, Installing OpenSearch operator \(v2.8.0 per module README\))
+	helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/ 2>/dev/null || true
+	helm repo update opensearch-operator 2>/dev/null || true
+	$(E2E_MC_OP_HELM) upgrade --install opensearch-operator opensearch-operator/opensearch-operator \
+		--namespace $(E2E_OP_NS) --create-namespace \
+		--version 2.8.0 \
+		--set kubeRbacProxy.image.repository=quay.io/brancz/kube-rbac-proxy \
+		--set kubeRbacProxy.image.tag=v0.15.0 \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@# Install per module README — operator mode with ExternalSecret-backed credentials.
+	@# https://github.com/openchoreo/community-modules/blob/main/observability-logs-opensearch/README.md
+	@$(call log_info, Installing logs module without Fluent Bit \(operator mode per README\))
+	$(E2E_MC_OP_HELM) upgrade --install observability-logs-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
+		--version $(OBSERVABILITY_LOGS_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--values $(E2E_MC_K3D_DIR)/values-op-modules.yaml \
+		--set openSearch.enabled=false \
+		--set openSearchCluster.enabled=true \
+		--set openSearchCluster.credentialsSecretName="opensearch-admin-credentials" \
+		--set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
+		--set adapter.openSearchSecretName="opensearch-admin-credentials" \
+		--set fluent-bit.enabled=false \
+		--wait --wait-for-jobs --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Enabling Fluent Bit after logs module setup)
+	$(E2E_MC_OP_HELM) upgrade --install observability-logs-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
+		--version $(OBSERVABILITY_LOGS_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--values $(E2E_MC_K3D_DIR)/values-op-modules.yaml \
+		--set openSearch.enabled=false \
+		--set openSearchCluster.enabled=true \
+		--set openSearchCluster.credentialsSecretName="opensearch-admin-credentials" \
+		--set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
+		--set adapter.openSearchSecretName="opensearch-admin-credentials" \
+		--set fluent-bit.enabled=true \
+		--wait --wait-for-jobs --timeout $(E2E_SETUP_TIMEOUT)
+	@# Multi-cluster receiver mode — per observability-tracing-opensearch README
+	$(E2E_MC_OP_HELM) upgrade --install observability-traces-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
+		--version $(OBSERVABILITY_TRACES_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set global.installationMode="multiClusterReceiver" \
+		--set openSearch.enabled=false \
+		--set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
+		--set-json 'opentelemetryCollectorCustomizations.http.hostnames=["host.k3d.internal"]' \
+		--wait --wait-for-jobs --timeout $(E2E_SETUP_TIMEOUT)
+	@# Multi-cluster receiver mode — per observability-metrics-prometheus README
+	$(E2E_MC_OP_HELM) upgrade --install observability-metrics-prometheus \
+		oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
+		--version $(OBSERVABILITY_METRICS_PROMETHEUS_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--values $(E2E_MC_K3D_DIR)/values-op-modules.yaml \
+		--set global.installationMode="multiClusterReceiver" \
+		--set-json 'prometheusCustomizations.http.hostnames=["host.k3d.internal"]' \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	$(E2E_MC_OP_KUBECTL) wait -n $(E2E_OP_NS) \
+		--for=condition=available --timeout=$(E2E_SETUP_TIMEOUT) deployment --all
+
+.PHONY: _e2e.mc.install-fluent-bit
+_e2e.mc.install-fluent-bit:
+	@# Install Fluent Bit in the DP and WP clusters so workload and build logs are
+	@# shipped to OpenSearch in the OP cluster. Each cluster only enables Fluent Bit;
+	@# the OpenSearch stack (setup, operator, adapter) runs only in OP.
+	@# Follows install/k3d/multi-cluster/README.md §5 "Enable Fluent Bit in DP/WP".
+	@$(call log_info, Preparing observability namespaces and credentials in DP/WP clusters)
+	$(E2E_MC_DP_KUBECTL) create namespace $(E2E_OP_NS) --dry-run=client -o yaml | $(E2E_MC_DP_KUBECTL) apply -f -
+	$(E2E_MC_WP_KUBECTL) create namespace $(E2E_OP_NS) --dry-run=client -o yaml | $(E2E_MC_WP_KUBECTL) apply -f -
+	@# DP cluster has OpenBao — create opensearch-admin-credentials via ExternalSecret (per README §5)
+	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/opensearch-admin-externalsecret.yaml
+	$(E2E_MC_DP_KUBECTL) wait -n $(E2E_OP_NS) \
+		--for=condition=Ready externalsecret/opensearch-admin-credentials --timeout=60s
+	@# WP cluster has no ClusterSecretStore — create secret directly (per README §5 note)
+	@$(E2E_MC_WP_KUBECTL) create secret generic opensearch-admin-credentials \
+		-n $(E2E_OP_NS) \
+		--from-literal=username="admin" \
+		--from-literal=password="ThisIsTheOpenSearchPassword1" \
+		--dry-run=client -o yaml | $(E2E_MC_WP_KUBECTL) apply -f -
+	@# Fluent Bit routes logs through the OP cluster's kgateway TLS passthrough
+	@# (port 31085 → 11085 → kgateway SNI routing → OpenSearch 9200 with TLS).
+	@# This mirrors install/k3d/multi-cluster/README.md §5 "Enable Fluent Bit in DP/WP".
+	@$(call log_info, Installing Fluent Bit in DP cluster)
+	$(E2E_MC_DP_HELM) upgrade --install observability-logs-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
+		--version $(OBSERVABILITY_LOGS_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set openSearch.enabled=false \
+		--set openSearchCluster.enabled=false \
+		--set openSearchSetup.enabled=false \
+		--set adapter.enabled=false \
+		--set fluent-bit.enabled=true \
+		--set fluent-bit.openSearchHost=host.k3d.internal \
+		--set fluent-bit.openSearchPort=31085 \
+		--set fluent-bit.openSearchVHost=opensearch.observability.openchoreo.localhost \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Installing Fluent Bit in WP cluster)
+	$(E2E_MC_WP_HELM) upgrade --install observability-logs-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
+		--version $(OBSERVABILITY_LOGS_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set openSearch.enabled=false \
+		--set openSearchCluster.enabled=false \
+		--set openSearchSetup.enabled=false \
+		--set adapter.enabled=false \
+		--set fluent-bit.enabled=true \
+		--set fluent-bit.openSearchHost=host.k3d.internal \
+		--set fluent-bit.openSearchPort=31085 \
+		--set fluent-bit.openSearchVHost=opensearch.observability.openchoreo.localhost \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@# Install metrics exporter in DP and WP clusters — per observability-metrics-prometheus README.
+	@# Deploys PrometheusAgent to scrape local metrics and forward to OP cluster's receiver
+	@# via remote write on host.k3d.internal:31080 (OP kgateway HTTP port).
+	@$(call log_info, Installing metrics exporter in DP cluster)
+	$(E2E_MC_DP_HELM) upgrade --install observability-metrics-prometheus \
+		oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
+		--version $(OBSERVABILITY_METRICS_PROMETHEUS_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set global.installationMode="multiClusterExporter" \
+		--set prometheusCustomizations.http.observabilityPlaneUrl="http://host.k3d.internal:31080/api/v1/write" \
+		--set kube-prometheus-stack.prometheus.enabled=false \
+		--set kube-prometheus-stack.alertmanager.enabled=false \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Installing metrics exporter in WP cluster)
+	$(E2E_MC_WP_HELM) upgrade --install observability-metrics-prometheus \
+		oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
+		--version $(OBSERVABILITY_METRICS_PROMETHEUS_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set global.installationMode="multiClusterExporter" \
+		--set prometheusCustomizations.http.observabilityPlaneUrl="http://host.k3d.internal:31080/api/v1/write" \
+		--set kube-prometheus-stack.prometheus.enabled=false \
+		--set kube-prometheus-stack.alertmanager.enabled=false \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@# Install tracing exporter in DP and WP clusters — per observability-tracing-opensearch README.
+	@# Deploys OTel collector in exporter mode forwarding traces to OP cluster's receiver
+	@# via host.k3d.internal:31080 (OP kgateway HTTP port in e2e).
+	@$(call log_info, Installing tracing exporter in DP cluster)
+	$(E2E_MC_DP_HELM) upgrade --install observability-traces-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
+		--version $(OBSERVABILITY_TRACES_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set global.installationMode="multiClusterExporter" \
+		--set openSearch.enabled=false \
+		--set openSearchCluster.enabled=false \
+		--set openSearchSetup.enabled=false \
+		--set adapter.enabled=false \
+		--set-json 'opentelemetry-collector.extraEnvs=[]' \
+		--set opentelemetryCollectorCustomizations.http.observabilityPlaneUrl="http://host.k3d.internal:31080" \
+		--set opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost="opentelemetry.observability.openchoreo.localhost" \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+	@$(call log_info, Installing tracing exporter in WP cluster)
+	$(E2E_MC_WP_HELM) upgrade --install observability-traces-opensearch \
+		oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
+		--version $(OBSERVABILITY_TRACES_OPENSEARCH_VERSION) \
+		--namespace $(E2E_OP_NS) \
+		--set global.installationMode="multiClusterExporter" \
+		--set openSearch.enabled=false \
+		--set openSearchCluster.enabled=false \
+		--set openSearchSetup.enabled=false \
+		--set adapter.enabled=false \
+		--set-json 'opentelemetry-collector.extraEnvs=[]' \
+		--set opentelemetryCollectorCustomizations.http.observabilityPlaneUrl="http://host.k3d.internal:31080" \
+		--set opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost="opentelemetry.observability.openchoreo.localhost" \
+		--wait --timeout $(E2E_SETUP_TIMEOUT)
+
+# ---------------------------------------------------------------------------
+# Internal configure targets
+# ---------------------------------------------------------------------------
+
+.PHONY: _e2e.mc.configure-dp
+_e2e.mc.configure-dp:
+	@$(call log_info, Registering DataPlane)
+	$(call e2e_register_plane_cross_cluster,$(E2E_MC_DP_KUBECONTEXT),$(E2E_DP_NS),$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_K3D_DIR)/dataplane.yaml)
+	@$(call log_info, Registering ClusterDataPlane)
+	$(call e2e_register_plane_cross_cluster,$(E2E_MC_DP_KUBECONTEXT),$(E2E_DP_NS),$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_K3D_DIR)/clusterdataplane.yaml)
+	@$(call log_info, Creating internal gateway)
+	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/internal-gateway.yaml
+
+.PHONY: _e2e.mc.configure-wp
+_e2e.mc.configure-wp:
+	@$(call log_info, Registering WorkflowPlane)
+	$(call e2e_register_plane_cross_cluster,$(E2E_MC_WP_KUBECONTEXT),$(E2E_WP_NS),$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_K3D_DIR)/workflowplane.yaml)
+	@$(call log_info, Registering ClusterWorkflowPlane)
+	$(call e2e_register_plane_cross_cluster,$(E2E_MC_WP_KUBECONTEXT),$(E2E_WP_NS),$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_K3D_DIR)/clusterworkflowplane.yaml)
+	@$(call log_info, Applying ClusterWorkflowTemplates used by the builder workflows)
+	@# ClusterWorkflowTemplates are Argo Workflows resources — apply to the WP cluster
+	@# where the Argo Workflows controller and its CRDs actually live.
+	$(E2E_MC_WP_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates/checkout-source.yaml
+	$(E2E_MC_WP_KUBECTL) apply -f $(PROJECT_DIR)/samples/getting-started/workflow-templates.yaml
+	@# e2e-mc-specific templates override the shared samples: registry port 30082 (WP cluster)
+	@# and CP gateway port 38080 instead of the single-cluster e2e ports.
+	$(E2E_MC_WP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/workflow-templates/publish-image-e2e-mc.yaml
+	$(E2E_MC_WP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/workflow-templates/generate-workload-e2e-mc.yaml
+
+.PHONY: _e2e.mc.configure-op
+_e2e.mc.configure-op:
+	@$(call log_info, Registering ObservabilityPlane)
+	$(call e2e_register_plane_cross_cluster,$(E2E_MC_OP_KUBECONTEXT),$(E2E_OP_NS),$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_K3D_DIR)/observabilityplane.yaml)
+	@$(call log_info, Registering ClusterObservabilityPlane)
+	$(call e2e_register_plane_cross_cluster,$(E2E_MC_OP_KUBECONTEXT),$(E2E_OP_NS),$(E2E_MC_CP_KUBECONTEXT),$(E2E_MC_K3D_DIR)/clusterobservabilityplane.yaml)
+
+.PHONY: _e2e.mc.link-observability
+_e2e.mc.link-observability:
+	@$(call log_info, Linking ObservabilityPlane to other planes)
+	$(E2E_MC_CP_KUBECTL) patch clusterdataplane default --type merge \
+		-p '{"spec":{"observabilityPlaneRef":{"kind":"ClusterObservabilityPlane","name":"default"}}}'
+	$(E2E_MC_CP_KUBECTL) patch clusterdataplane e2e-shared --type merge \
+		-p '{"spec":{"observabilityPlaneRef":{"kind":"ClusterObservabilityPlane","name":"default"}}}'
+	$(E2E_MC_CP_KUBECTL) patch workflowplane default -n default --type merge \
+		-p '{"spec":{"observabilityPlaneRef":{"kind":"ObservabilityPlane","name":"default"}}}'
+
+# ---------------------------------------------------------------------------
+# Test target
+# ---------------------------------------------------------------------------
+
+# Tier-4 suites that accept the multi-cluster kubecontext flags.
+# Scoped explicitly rather than using suites/... to avoid passing unknown flags
+# to tier1/tier2 suite binaries that don't define --e2e.{dp,wp,op}-kubecontext.
+E2E_MC_SUITES := \
+	$(E2E_DIR)/suites/observability \
+	$(E2E_DIR)/suites/alerts \
+	$(E2E_DIR)/suites/build \
+	$(E2E_DIR)/suites/gitops
+
+.PHONY: e2e.multi.test
+e2e.multi.test: ## Run tier3 multi-cluster e2e suites (set E2E_LABEL_FILTER to scope further)
+	@$(call log_info, Running multi-cluster e2e tests$(if $(E2E_GINKGO_LABEL_FLAG), with label filter '$(E2E_LABEL_FILTER)'))
+	go test $(E2E_MC_SUITES) -v -ginkgo.v -timeout $(E2E_TEST_TIMEOUT) \
+		--e2e.kubecontext=$(E2E_MC_CP_KUBECONTEXT) \
+		--e2e.dp-kubecontext=$(E2E_MC_DP_KUBECONTEXT) \
+		--e2e.wp-kubecontext=$(E2E_MC_WP_KUBECONTEXT) \
+		--e2e.op-kubecontext=$(E2E_MC_OP_KUBECONTEXT) \
+		$(E2E_GINKGO_LABEL_FLAG)
+
+# ---------------------------------------------------------------------------
+# Utility targets
+# ---------------------------------------------------------------------------
+
+.PHONY: e2e.multi.status
+e2e.multi.status: ## Check status of all planes and agent connections across all clusters
+	@for ctx in $(E2E_MC_CP_KUBECONTEXT) $(E2E_MC_DP_KUBECONTEXT) $(E2E_MC_WP_KUBECONTEXT) $(E2E_MC_OP_KUBECONTEXT); do \
+		echo ""; \
+		echo "=== Pods in $$ctx ==="; \
+		kubectl --context $$ctx get pods -A; \
+	done
+	@echo ""
+	@echo "=== Plane Resources (CP cluster) ==="
+	$(E2E_MC_CP_KUBECTL) get clusterdataplane,clusterworkflowplane,clusterobservabilityplane 2>/dev/null || true
+	@echo ""
+	@echo "=== Agent Connections ==="
+	@echo "--- DP ---"; \
+	$(E2E_MC_DP_KUBECTL) logs -n $(E2E_DP_NS) -l app=cluster-agent --tail=3 2>/dev/null || echo "(no agent)"
+	@echo "--- WP ---"; \
+	$(E2E_MC_WP_KUBECTL) logs -n $(E2E_WP_NS) -l app=cluster-agent --tail=3 2>/dev/null || echo "(no agent)"
+	@echo "--- OP ---"; \
+	$(E2E_MC_OP_KUBECTL) logs -n $(E2E_OP_NS) -l app=cluster-agent --tail=3 2>/dev/null || echo "(no agent)"
+
+.PHONY: e2e.multi.diagnostics
+e2e.multi.diagnostics: ## Collect logs, events, and resource dumps from all four clusters
+	@$(call log_info, Collecting multi-cluster diagnostics to $(E2E_MC_DIAGNOSTICS_DIR))
+	@mkdir -p $(E2E_MC_DIAGNOSTICS_DIR)
+	@for ns in $(E2E_CP_NS) default; do \
+		$(E2E_MC_CP_KUBECTL) get pods -n $$ns -o wide > $(E2E_MC_DIAGNOSTICS_DIR)/cp-pods-$$ns.txt 2>&1 || true; \
+		$(E2E_MC_CP_KUBECTL) get events -n $$ns --sort-by=.lastTimestamp > $(E2E_MC_DIAGNOSTICS_DIR)/cp-events-$$ns.txt 2>&1 || true; \
+		for pod in $$($(E2E_MC_CP_KUBECTL) get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
+			$(E2E_MC_CP_KUBECTL) logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_MC_DIAGNOSTICS_DIR)/cp-logs-$$ns-$$pod.txt 2>&1 || true; \
+		done; \
+	done
+	@for plane_ctx in $(E2E_MC_DP_KUBECONTEXT):dp:$(E2E_DP_NS) \
+	                  $(E2E_MC_WP_KUBECONTEXT):wp:$(E2E_WP_NS) \
+	                  $(E2E_MC_OP_KUBECONTEXT):op:$(E2E_OP_NS); do \
+		ctx=$$(echo $$plane_ctx | cut -d: -f1); \
+		prefix=$$(echo $$plane_ctx | cut -d: -f2); \
+		ns=$$(echo $$plane_ctx | cut -d: -f3); \
+		kubectl --context $$ctx get pods -n $$ns -o wide > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-pods.txt 2>&1 || true; \
+		kubectl --context $$ctx get events -n $$ns --sort-by=.lastTimestamp > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-events.txt 2>&1 || true; \
+		for pod in $$(kubectl --context $$ctx get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
+			kubectl --context $$ctx logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-logs-$$pod.txt 2>&1 || true; \
+		done; \
+	done
+	@$(E2E_MC_CP_KUBECTL) get clusterdataplane,clusterworkflowplane,clusterobservabilityplane -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/plane-resources.yaml 2>&1 || true
+	@$(E2E_MC_CP_KUBECTL) get component,componentrelease,releasebinding,renderedrelease -A -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/release-chain.yaml 2>&1 || true
+	@$(call log_success, Diagnostics collected to $(E2E_MC_DIAGNOSTICS_DIR))
+
+.PHONY: e2e.multi.down
+e2e.multi.down: ## Delete all four k3d clusters
+	@$(call log_info, Deleting all multi-cluster e2e k3d clusters)
+	k3d cluster delete $(E2E_MC_CP_CLUSTER_NAME) || true
+	k3d cluster delete $(E2E_MC_DP_CLUSTER_NAME) || true
+	k3d cluster delete $(E2E_MC_WP_CLUSTER_NAME) || true
+	k3d cluster delete $(E2E_MC_OP_CLUSTER_NAME) || true
+	@$(call log_success, All multi-cluster e2e clusters deleted)

--- a/test/e2e/framework/gitea.go
+++ b/test/e2e/framework/gitea.go
@@ -63,7 +63,7 @@ func InstallGitea(kubeContext, namespace string) error {
 				GiteaAdminUser, GiteaAdminPassword, GiteaAdminEmail,
 			),
 		)
-		if adminCreateErr != nil {
+		if adminCreateErr != nil && !strings.Contains(adminCreateOutput, "already exists") {
 			return fmt.Errorf("failed to create missing gitea admin user %q: %w (output: %s; admin users: %s)",
 				GiteaAdminUser, adminCreateErr, adminCreateOutput, adminListOutput)
 		}

--- a/test/e2e/framework/observer.go
+++ b/test/e2e/framework/observer.go
@@ -42,16 +42,32 @@ const (
 )
 
 // ObserverQueryFrom resolves a Running pod that has curl available and runs
-// observer queries through it. The pod must live in the cluster so it can
-// reach `observer.openchoreo-observability-plane.svc:8080` and acquire a
-// token from `thunder-service.thunder.svc:8090`. The Gitea pod used by the
-// build/gitops suites is a natural fit (it ships curl); suites that don't
-// install Gitea should call `framework.DeployCurlPod` to get one.
+// observer queries through it. The Gitea pod used by the build/gitops suites
+// is a natural fit (it ships curl); suites that don't install Gitea should
+// call `framework.DeployCurlPod` to get one.
+//
+// In a single-cluster setup the pod reaches Thunder and the observer via
+// in-cluster DNS. In a multi-cluster setup set ThunderTokenURL and ObserverURL
+// to the externally reachable URLs so the pod can cross cluster boundaries.
 type ObserverQueryFrom struct {
 	KubeContext string
 	Namespace   string
 	PodLabel    string // selector, e.g. "app=gitea"
 	Container   string // container name; "" picks the first
+
+	// ThunderTokenURL overrides the in-cluster Thunder token endpoint.
+	// Set this when the exec pod cannot reach thunder-service.thunder.svc
+	// via cluster DNS (e.g. multi-cluster e2e where Thunder is in a different
+	// k3d cluster). Empty falls back to the default in-cluster URL.
+	ThunderTokenURL string
+
+	// ObserverURL overrides the in-cluster observer service base URL.
+	// Set this when the exec pod cannot reach
+	// observer.openchoreo-observability-plane.svc via cluster DNS (e.g.
+	// multi-cluster e2e where the observer is in a different k3d cluster).
+	// Must not include a trailing slash. Empty falls back to the default
+	// in-cluster URL.
+	ObserverURL string
 }
 
 // LogsQueryRequest mirrors the observer's OpenAPI request body for
@@ -129,6 +145,10 @@ type MetricsQueryResponse map[string]any
 // each hammer the IdP. Tokens have a 1h validity in the e2e bootstrap, which
 // dwarfs a Ginkgo It-block.
 func AcquireObserverToken(q ObserverQueryFrom) (string, error) {
+	tokenURL := thunderTokenURLInCluster
+	if q.ThunderTokenURL != "" {
+		tokenURL = q.ThunderTokenURL
+	}
 	// service_mcp_client uses token_endpoint_auth_method=client_secret_basic
 	// so credentials go in the Authorization header, not the form body.
 	out, err := KubectlExecByLabel(q.KubeContext, q.Namespace, q.PodLabel, q.Container,
@@ -138,7 +158,7 @@ func AcquireObserverToken(q ObserverQueryFrom) (string, error) {
 		"-H", "Content-Type: application/x-www-form-urlencoded",
 		"-X", "POST",
 		"--data", "grant_type=client_credentials",
-		thunderTokenURLInCluster,
+		tokenURL,
 	)
 	if err != nil {
 		return "", fmt.Errorf("thunder token request failed: %w (body: %s)", err, out)
@@ -208,8 +228,12 @@ func observerPost(q ObserverQueryFrom, token, path string, payload any) (string,
 	if err != nil {
 		return "", fmt.Errorf("marshal payload: %w", err)
 	}
-	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s",
-		ObserverService, ObserverNamespace, ObserverPort, path)
+	baseURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
+		ObserverService, ObserverNamespace, ObserverPort)
+	if q.ObserverURL != "" {
+		baseURL = q.ObserverURL
+	}
+	url := baseURL + path
 	args := []string{
 		"-sS", "--fail-with-body",
 		"-m", fmt.Sprintf("%d", observerQueryHTTPTimeoutSc),

--- a/test/e2e/k3d/multi-cluster/clusterdataplane.yaml
+++ b/test/e2e/k3d/multi-cluster/clusterdataplane.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ClusterDataPlane CR for the multi-cluster e2e setup.
+# Cluster-scoped; referenced by all per-suite Environment fixtures via
+# `clusterDataPlane: e2e-shared`. Applied to the CP cluster. The
+# clusterAgent.clientCA.value is injected at apply time by
+# e2e_register_plane_cross_cluster in make/e2e.mk.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterDataPlane
+metadata:
+  name: e2e-shared
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: default
+  gateway:
+    ingress:
+      external:
+        name: gateway-default
+        namespace: openchoreo-data-plane
+        http:
+          port: 39080
+          host: e2e-mc-dp.local
+        https:
+          port: 39443
+          host: e2e-mc-dp.local
+      internal:
+        name: gateway-internal
+        namespace: openchoreo-data-plane
+        http:
+          port: 18080
+          host: e2e-mc-dp-internal.local

--- a/test/e2e/k3d/multi-cluster/clusterobservabilityplane.yaml
+++ b/test/e2e/k3d/multi-cluster/clusterobservabilityplane.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ClusterObservabilityPlane CR for the multi-cluster e2e setup.
+# Cluster-scoped; referenced by _e2e.mc.link-observability which patches
+# clusterdataplane.spec.observabilityPlaneRef to point at this CR.
+# Applied to the CP cluster. The clusterAgent.clientCA.value is injected at
+# apply time by e2e_register_plane_cross_cluster in make/e2e.mk.
+#
+# observerURL points to the OP cluster's external observer gateway. Tests that
+# query the observer directly use the OP kubecontext and exec into a pod in
+# the OP cluster, where the in-cluster service DNS resolves correctly.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterObservabilityPlane
+metadata:
+  name: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  observerURL: http://observer.e2e-mc-op.local:31080

--- a/test/e2e/k3d/multi-cluster/clusterworkflowplane.yaml
+++ b/test/e2e/k3d/multi-cluster/clusterworkflowplane.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ClusterWorkflowPlane CR for the multi-cluster e2e setup.
+# Cluster-scoped; required because the built-in ClusterWorkflow builders
+# (dockerfile-builder, paketo-buildpacks-builder, …) carry
+# workflowPlaneRef.kind: ClusterWorkflowPlane. Applied to the CP cluster.
+# The clusterAgent.clientCA.value is injected at apply time by
+# e2e_register_plane_cross_cluster in make/e2e.mk.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterWorkflowPlane
+metadata:
+  name: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: default

--- a/test/e2e/k3d/multi-cluster/config-cp.yaml
+++ b/test/e2e/k3d/multi-cluster/config-cp.yaml
@@ -1,0 +1,34 @@
+# k3d cluster config for the Control Plane in the multi-cluster e2e setup.
+# Port prefix 38xxx / kubeAPI 36550 avoids collision with:
+#   single-cluster e2e  (28xxx / 26550)
+#   dev multi-cluster   (8xxx  / 6550)
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: openchoreo-e2e-mc-cp
+image: rancher/k3s:v1.36.1-k3s1
+servers: 1
+agents: 0
+kubeAPI:
+  hostPort: "36550"
+ports:
+  # HTTP — OpenChoreo API + Thunder via kgateway
+  - port: 38080:8080
+    nodeFilters:
+      - loadbalancer
+  # HTTPS — kgateway HTTPS + cluster-gateway TLS (SNI-routed)
+  - port: 38443:8443
+    nodeFilters:
+      - loadbalancer
+options:
+  k3s:
+    extraArgs:
+      - arg: "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%"
+        nodeFilters:
+          - server:*
+      - arg: "--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%"
+        nodeFilters:
+          - server:*
+      - arg: "--disable=traefik"
+        nodeFilters:
+          - server:*

--- a/test/e2e/k3d/multi-cluster/config-dp.yaml
+++ b/test/e2e/k3d/multi-cluster/config-dp.yaml
@@ -1,0 +1,44 @@
+# k3d cluster config for the Data Plane in the multi-cluster e2e setup.
+# Port prefix 39xxx / kubeAPI 36551 avoids collision with:
+#   single-cluster e2e  (29xxx / 26550)
+#   dev multi-cluster   (19xxx / 6551)
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: openchoreo-e2e-mc-dp
+image: rancher/k3s:v1.36.1-k3s1
+servers: 1
+agents: 0
+kubeAPI:
+  hostPort: "36551"
+ports:
+  # HTTP — workload traffic via kgateway
+  - port: 39080:19080
+    nodeFilters:
+      - loadbalancer
+  # HTTPS — workload traffic via kgateway
+  - port: 39443:19443
+    nodeFilters:
+      - loadbalancer
+options:
+  k3s:
+    extraArgs:
+      - arg: "--tls-san=host.k3d.internal"
+        nodeFilters:
+          - server:*
+      - arg: "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%"
+        nodeFilters:
+          - server:*
+      - arg: "--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%"
+        nodeFilters:
+          - server:*
+      - arg: "--disable=traefik"
+        nodeFilters:
+          - server:*
+# Kubelet pulls built images from the WP registry exposed on host port 30082
+registries:
+  config: |
+    mirrors:
+      "host.k3d.internal:30082":
+        endpoint:
+          - http://host.k3d.internal:30082

--- a/test/e2e/k3d/multi-cluster/config-op.yaml
+++ b/test/e2e/k3d/multi-cluster/config-op.yaml
@@ -1,0 +1,50 @@
+# k3d cluster config for the Observability Plane in the multi-cluster e2e setup.
+# Port prefix 31xxx / kubeAPI 36553 avoids collision with:
+#   single-cluster e2e  (21xxx / 26550)
+#   dev multi-cluster   (11xxx / 6553)
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: openchoreo-e2e-mc-op
+image: rancher/k3s:v1.36.1-k3s1
+servers: 1
+agents: 0
+kubeAPI:
+  hostPort: "36553"
+ports:
+  # Observer API via kgateway HTTP
+  - port: 31080:11080
+    nodeFilters:
+      - loadbalancer
+  # kgateway HTTPS / OpenSearch TLS passthrough
+  - port: 31085:11085
+    nodeFilters:
+      - loadbalancer
+  # OpenSearch Dashboard
+  - port: 31081:5601
+    nodeFilters:
+      - loadbalancer
+  # OpenSearch API (Fluent Bit data ingestion from DP/WP)
+  - port: 31082:9200
+    nodeFilters:
+      - loadbalancer
+  # Prometheus remote-write from DP/WP
+  - port: 31084:9091
+    nodeFilters:
+      - loadbalancer
+  # OpenTelemetry Collector for traces from DP/WP
+  - port: 31086:4317
+    nodeFilters:
+      - loadbalancer
+options:
+  k3s:
+    extraArgs:
+      - arg: "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%"
+        nodeFilters:
+          - server:*
+      - arg: "--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%"
+        nodeFilters:
+          - server:*
+      - arg: "--disable=traefik"
+        nodeFilters:
+          - server:*

--- a/test/e2e/k3d/multi-cluster/config-wp.yaml
+++ b/test/e2e/k3d/multi-cluster/config-wp.yaml
@@ -1,0 +1,30 @@
+# k3d cluster config for the Workflow Plane in the multi-cluster e2e setup.
+# Port prefix 30xxx / kubeAPI 36552 avoids collision with:
+#   single-cluster e2e  (20xxx / 26550)
+#   dev multi-cluster   (10xxx / 6552)
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: openchoreo-e2e-mc-wp
+image: rancher/k3s:v1.36.1-k3s1
+servers: 1
+agents: 0
+kubeAPI:
+  hostPort: "36552"
+ports:
+  # Container registry for storing built images
+  - port: 30082:10082
+    nodeFilters:
+      - loadbalancer
+options:
+  k3s:
+    extraArgs:
+      - arg: "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%"
+        nodeFilters:
+          - server:*
+      - arg: "--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%"
+        nodeFilters:
+          - server:*
+      - arg: "--disable=traefik"
+        nodeFilters:
+          - server:*

--- a/test/e2e/k3d/multi-cluster/coredns-custom-cp.yaml
+++ b/test/e2e/k3d/multi-cluster/coredns-custom-cp.yaml
@@ -1,0 +1,28 @@
+# CoreDNS custom config for the CP cluster in the multi-cluster e2e setup.
+# Rewrites all e2e-mc plane domains to host.k3d.internal so pods in the CP
+# cluster can reach services exposed via k3d load balancers on the host.
+# The dp-internal rewrite is needed when CP-side tests resolve workload
+# endpoints that use the internal gateway hostname.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  e2e-mc.override: |
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-cp\.local host.k3d.internal
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-dp\.local host.k3d.internal
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-dp-internal\.local gateway-internal.openchoreo-data-plane.svc.cluster.local
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-op\.local host.k3d.internal
+      answer auto
+    }

--- a/test/e2e/k3d/multi-cluster/coredns-custom-dp.yaml
+++ b/test/e2e/k3d/multi-cluster/coredns-custom-dp.yaml
@@ -1,0 +1,22 @@
+# CoreDNS custom config for the DP cluster in the multi-cluster e2e setup.
+# DP cluster pods (e.g., the obs-tester curl pod used for observer queries)
+# need to reach services in other clusters:
+#   - Thunder (CP cluster) to acquire observer bearer tokens
+#   - Observer API (OP cluster) to query logs/metrics/traces
+# Both are rewritten to host.k3d.internal so pods reach the correct
+# k3d load-balancer ports (38080 for CP, 31080 for OP).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  e2e-mc.override: |
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-cp\.local host.k3d.internal
+      answer auto
+    }
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-op\.local host.k3d.internal
+      answer auto
+    }

--- a/test/e2e/k3d/multi-cluster/coredns-custom-op.yaml
+++ b/test/e2e/k3d/multi-cluster/coredns-custom-op.yaml
@@ -1,0 +1,16 @@
+# CoreDNS custom config for the OP cluster in the multi-cluster e2e setup.
+# The observer needs to reach Thunder (JWKS/token) and the CP API (authz/UID
+# resolver), both of which are exposed via the CP cluster's kgateway on
+# host.k3d.internal:38080. Rewriting *.e2e-mc-cp.local lets the observer use
+# fully qualified hostnames that match the CP kgateway HTTPRoutes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  e2e-mc.override: |
+    rewrite stop {
+      name regex (.+\.)?e2e-mc-cp\.local host.k3d.internal
+      answer auto
+    }

--- a/test/e2e/k3d/multi-cluster/dataplane.yaml
+++ b/test/e2e/k3d/multi-cluster/dataplane.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# DataPlane CR for the multi-cluster e2e setup.
+# Applied to the CP cluster. The clusterAgent.clientCA.value is injected at
+# apply time by e2e_register_plane_cross_cluster in make/e2e.mk.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterDataPlane
+metadata:
+  name: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: default
+  gateway:
+    ingress:
+      external:
+        name: gateway-default
+        namespace: openchoreo-data-plane
+        http:
+          port: 39080
+          host: e2e-mc-dp.local
+        https:
+          port: 39443
+          host: e2e-mc-dp.local
+      internal:
+        name: gateway-internal
+        namespace: openchoreo-data-plane
+        http:
+          port: 18080
+          host: e2e-mc-dp-internal.local

--- a/test/e2e/k3d/multi-cluster/internal-gateway.yaml
+++ b/test/e2e/k3d/multi-cluster/internal-gateway.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Internal Gateway for the Data Plane cluster in the multi-cluster e2e setup.
+# Applied to the DP cluster (E2E_MC_DP_KUBECTL). Provides an internal ingress
+# gateway for internal-visibility endpoints running in the DP cluster.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-internal
+  namespace: openchoreo-data-plane
+spec:
+  gatewayClassName: kgateway
+  infrastructure:
+    labels:
+      openchoreo.dev/system-component: gateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 18080
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/test/e2e/k3d/multi-cluster/observabilityplane.yaml
+++ b/test/e2e/k3d/multi-cluster/observabilityplane.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ObservabilityPlane CR for the multi-cluster e2e setup.
+# Applied to the CP cluster. The clusterAgent.clientCA.value is injected at
+# apply time by e2e_register_plane_cross_cluster in make/e2e.mk.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ObservabilityPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  observerURL: http://observer.e2e-mc-op.local:31080

--- a/test/e2e/k3d/multi-cluster/openbao-secretstore.yaml
+++ b/test/e2e/k3d/multi-cluster/openbao-secretstore.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# OpenBao-backed ClusterSecretStore for multi-cluster e2e tests.
+# Replaces the fake ClusterSecretStore in the CP cluster after OpenBao is
+# installed (see _e2e.mc.install-openbao in make/e2e.mk).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-openbao
+  namespace: openbao
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: default
+spec:
+  provider:
+    vault:
+      server: "http://openbao.openbao.svc:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "openchoreo-secret-writer-role"
+          serviceAccountRef:
+            name: "external-secrets-openbao"
+            namespace: "openbao"

--- a/test/e2e/k3d/multi-cluster/opensearch-admin-externalsecret.yaml
+++ b/test/e2e/k3d/multi-cluster/opensearch-admin-externalsecret.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ExternalSecret that creates opensearch-admin-credentials from OpenBao.
+# Applied to any cluster that has OpenBao installed (CP, DP, OP).
+# WP cluster creates the secret directly (no ClusterSecretStore per README §4 note).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opensearch-admin-credentials
+  namespace: openchoreo-observability-plane
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: default
+  target:
+    name: opensearch-admin-credentials
+  data:
+  - secretKey: username
+    remoteRef:
+      key: opensearch-username
+      property: value
+  - secretKey: password
+    remoteRef:
+      key: opensearch-password
+      property: value

--- a/test/e2e/k3d/multi-cluster/opensearch-tls-route.yaml
+++ b/test/e2e/k3d/multi-cluster/opensearch-tls-route.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TLSRoute connecting kgateway's TLS passthrough listener to the standalone
+# OpenSearch service. The observability-logs-opensearch chart generates this
+# automatically when openSearchCluster.enabled=true (operator mode), but in
+# e2e we use standalone OpenSearch (openSearch.enabled=true, operator 2.8.0
+# does not support OPENSEARCH_INITIAL_ADMIN_PASSWORD injection for 3.x), so
+# we apply it manually. The template mirrors the chart's
+# opensearch-cluster/tls-route.yaml exactly.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: opensearch
+  namespace: openchoreo-observability-plane
+spec:
+  parentRefs:
+    - name: gateway-default
+      namespace: openchoreo-observability-plane
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: opensearch
+          port: 9200

--- a/test/e2e/k3d/multi-cluster/secretstore.yaml
+++ b/test/e2e/k3d/multi-cluster/secretstore.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fake ClusterSecretStore for multi-cluster e2e testing.
+# Applied to both the CP and DP clusters. Replaced in the CP cluster by the
+# OpenBao-backed store after _e2e.mc.install-openbao runs.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: default
+spec:
+  provider:
+    fake:
+      data:
+      - key: npm-token
+        value: "fake-npm-token"
+      - key: docker-username
+        value: "e2e-user"
+      - key: docker-password
+        value: "e2e-password"
+      - key: github-pat
+        value: "fake-github-token"
+      - key: username
+        value: "e2e-user"
+      - key: password
+        value: "e2e-password"

--- a/test/e2e/k3d/multi-cluster/values-cp.yaml
+++ b/test/e2e/k3d/multi-cluster/values-cp.yaml
@@ -1,0 +1,54 @@
+# Helm values for OpenChoreo Control Plane in the multi-cluster e2e setup.
+# Domains use *.e2e-mc-cp.local; port 38080 (HTTP) / 38443 (HTTPS).
+# Backstage UI is disabled — e2e tests use kubectl/Go client only.
+
+openchoreoApi:
+  http:
+    hostnames:
+    - api.e2e-mc-cp.local
+  config:
+    server:
+      publicUrl: "http://api.e2e-mc-cp.local:38080"
+
+backstage:
+  enabled: false
+  baseUrl: "http://openchoreo.e2e-mc-cp.local:38080"
+  http:
+    hostnames:
+      - openchoreo.e2e-mc-cp.local
+
+security:
+  oidc:
+    issuer: "http://thunder.e2e-mc-cp.local:38080"
+    jwksUrl: "http://thunder.e2e-mc-cp.local:38080/oauth2/jwks"
+    authorizationUrl: "http://thunder.e2e-mc-cp.local:38080/oauth2/authorize"
+    tokenUrl: "http://thunder.e2e-mc-cp.local:38080/oauth2/token"
+
+# Expose cluster-gateway via TLS route on port 38443 so DP/WP/OP agents can
+# connect cross-cluster. Agents use wss://host.k3d.internal:38443/ws; the SNI
+# matches the TLSRoute host below and the certificate SAN includes host.k3d.internal.
+clusterGateway:
+  tlsRoute:
+    enabled: true
+    hosts:
+      - host: host.k3d.internal
+        paths:
+          - path: /
+            pathType: Prefix
+  tls:
+    issuerRef:
+      name: cluster-gateway-server-issuer
+    dnsNames:
+      - cluster-gateway.openchoreo-control-plane.svc
+      - cluster-gateway.openchoreo-control-plane.svc.cluster.local
+      - host.k3d.internal
+
+gateway:
+  httpPort: 8080
+  httpsPort: 8443
+  tls:
+    enabled: false
+
+features:
+  secretManagement:
+    enabled: true

--- a/test/e2e/k3d/multi-cluster/values-dp.yaml
+++ b/test/e2e/k3d/multi-cluster/values-dp.yaml
@@ -1,0 +1,11 @@
+# Helm values for OpenChoreo Data Plane in the multi-cluster e2e setup.
+# Agent connects to the CP cluster-gateway via host.k3d.internal:38443.
+
+clusterAgent:
+  serverUrl: "wss://host.k3d.internal:38443/ws"
+
+gateway:
+  httpPort: 19080
+  httpsPort: 19443
+  tls:
+    enabled: false

--- a/test/e2e/k3d/multi-cluster/values-op-modules.yaml
+++ b/test/e2e/k3d/multi-cluster/values-op-modules.yaml
@@ -1,0 +1,26 @@
+# Resource config for the observability module charts installed by _e2e.mc.install-op.
+# Passed via -f to observability-logs-opensearch and observability-metrics-prometheus.
+
+# ---- observability-logs-opensearch (OP cluster — standalone mode) ----
+# Caps standalone OpenSearch JVM heap and memory to fit the shared 10 GB Lima VM.
+openSearch:
+  extraEnvs:
+    - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+      value: ThisIsTheOpenSearchPassword1
+    - name: OPENSEARCH_JAVA_OPTS
+      value: "-Xms512m -Xmx768m"
+  resources:
+    requests:
+      memory: "1Gi"
+    limits:
+      memory: "1.5Gi"
+
+# ---- observability-metrics-prometheus ----
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      resources:
+        requests:
+          memory: "256Mi"
+        limits:
+          memory: "512Mi"

--- a/test/e2e/k3d/multi-cluster/values-op.yaml
+++ b/test/e2e/k3d/multi-cluster/values-op.yaml
@@ -1,0 +1,57 @@
+# Helm values for OpenChoreo Observability Plane in the multi-cluster e2e setup.
+# Agent connects to the CP cluster-gateway via host.k3d.internal:38443.
+# Thunder and CP API are reached via *.e2e-mc-cp.local (resolved by the OP
+# cluster's CoreDNS rewrite → host.k3d.internal:38080).
+
+observer:
+  openSearchSecretName: observer-opensearch-credentials
+  secretName: observer-secret
+  http:
+    hostnames:
+    - observer.e2e-mc-op.local
+  # CP API URL for the observer's authz client and UID resolver.
+  # CoreDNS in the OP cluster rewrites api.e2e-mc-cp.local → host.k3d.internal,
+  # so this reaches the CP kgateway on host port 38080.
+  controlPlaneApiUrl: "http://api.e2e-mc-cp.local:38080"
+  logsAdapter:
+    url: "http://logs-adapter:9098"
+  tracingAdapter:
+    url: "http://tracing-adapter:9100"
+  extraEnvs:
+    - name: OBSERVER_BASE_URL
+      value: "http://observer.e2e-mc-op.local:31080"
+    - name: OPENSEARCH_ADDRESS
+      value: "https://opensearch:9200"
+    - name: PROMETHEUS_ADDRESS
+      value: "http://openchoreo-observability-prometheus:9091"
+    - name: PROMETHEUS_TIMEOUT
+      value: "30s"
+    - name: AUTHZ_TIMEOUT
+      value: "30s"
+
+security:
+  oidc:
+    # Thunder is in the CP cluster; CoreDNS rewrites *.e2e-mc-cp.local → host.k3d.internal
+    jwksUrl: "http://thunder.e2e-mc-cp.local:38080/oauth2/jwks"
+    tokenUrl: "http://thunder.e2e-mc-cp.local:38080/oauth2/token"
+
+gateway:
+  httpPort: 11080
+  httpsPort: 11085
+  tls:
+    enabled: false
+  tlsPassthrough:
+    enabled: true
+    hostname: "opensearch.observability.openchoreo.localhost"
+    port: 11085
+
+# tls.enabled=true creates the openchoreo-observability-plane-ca-issuer that the
+# OpenSearch operator uses to issue transport and HTTP certificates.
+tls:
+  enabled: true
+  dnsNames:
+    - "observability.openchoreo.localhost"
+    - "*.observability.openchoreo.localhost"
+
+clusterAgent:
+  serverUrl: "wss://host.k3d.internal:38443/ws"

--- a/test/e2e/k3d/multi-cluster/values-thunder.yaml
+++ b/test/e2e/k3d/multi-cluster/values-thunder.yaml
@@ -1,0 +1,22 @@
+# Thunder IdP overrides for the multi-cluster e2e setup.
+# Applied on top of install/k3d/common/values-thunder.yaml.
+
+httproute:
+  hostnames:
+    - thunder.e2e-mc-cp.local
+
+configuration:
+  server:
+    publicUrl: "http://thunder.e2e-mc-cp.local:38080"
+
+  gateClient:
+    hostname: "thunder.e2e-mc-cp.local"
+    port: 38080
+
+  cors:
+    allowedOrigins:
+      - "http://openchoreo.e2e-mc-cp.local:38080"
+
+  passkey:
+    allowedOrigins:
+      - "http://openchoreo.e2e-mc-cp.local:38080"

--- a/test/e2e/k3d/multi-cluster/values-wp.yaml
+++ b/test/e2e/k3d/multi-cluster/values-wp.yaml
@@ -1,0 +1,10 @@
+# Helm values for OpenChoreo Workflow Plane in the multi-cluster e2e setup.
+# Agent connects to the CP cluster-gateway via host.k3d.internal:38443.
+# Argo Workflows server UI is disabled — e2e tests do not use it directly.
+
+clusterAgent:
+  serverUrl: "wss://host.k3d.internal:38443/ws"
+
+argo-workflows:
+  server:
+    enabled: false

--- a/test/e2e/k3d/multi-cluster/workflow-templates/generate-workload-e2e-mc.yaml
+++ b/test/e2e/k3d/multi-cluster/workflow-templates/generate-workload-e2e-mc.yaml
@@ -1,0 +1,286 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-cluster e2e variant of generate-workload-e2e.yaml.
+#
+# The single-cluster e2e template uses host.k3d.internal:28080 for the CP
+# gateway (OAuth + openchoreo-api). The multi-cluster e2e setup exposes the
+# CP cluster's kgateway on host port 38080 (see config-cp.yaml), so this
+# variant points OAuth and API endpoints at host.k3d.internal:38080 with the
+# appropriate Host headers for e2e-mc-cp.local routing.
+#
+# Keep in sync with test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml.
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: generate-workload
+spec:
+  templates:
+    - name: generate-workload-cr
+      inputs:
+        parameters:
+          - name: image
+          - name: run-name
+          - name: oauth-token-url
+            default: "http://host.k3d.internal:38080/oauth2/token"
+          - name: oauth-host-header
+            default: "thunder.e2e-mc-cp.local"
+          - name: oauth-client-id
+            default: "openchoreo-workload-publisher-client"
+          - name: oauth-client-secret
+            default: "openchoreo-workload-publisher-secret"
+          - name: oauth-scope
+            default: ""
+          - name: api-server-url
+            default: "http://host.k3d.internal:38080"
+          - name: api-server-host-header
+            default: "api.e2e-mc-cp.local"
+      container:
+        image: ghcr.io/openchoreo/podman-runner:v1.1
+        command:
+          - sh
+          - -c
+        args:
+          - |-
+            set -e
+
+            IMAGE={{inputs.parameters.image}}
+            RUN_NAME={{inputs.parameters.run-name}}
+            PROJECT_NAME={{workflow.parameters.project-name}}
+            COMPONENT_NAME={{workflow.parameters.component-name}}
+            NAMESPACE_NAME={{workflow.parameters.namespace-name}}
+            APP_PATH="{{workflow.parameters.app-path}}"
+
+            DESCRIPTOR_PATH="/mnt/vol/source${APP_PATH:+/${APP_PATH#/}}"
+            OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+
+            echo ">> Image: ${IMAGE}"
+            echo ">> Descriptor path: ${DESCRIPTOR_PATH}"
+            echo ">> Namespace: ${NAMESPACE_NAME}, Project: ${PROJECT_NAME}, Component: ${COMPONENT_NAME}"
+            if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
+              echo ">> Workload descriptor: found (${DESCRIPTOR_PATH}/workload.yaml)"
+            else
+              echo ">> Workload descriptor: not found (will generate default workload)"
+            fi
+
+            if [ ! -d "$DESCRIPTOR_PATH" ]; then
+              echo ">> Error: The specified application path '$APP_PATH' does not exist in the repository"
+              ls -la /mnt/vol/source/
+              exit 1
+            fi
+
+            mkdir -p /etc/containers
+            cat <<EOF > /etc/containers/storage.conf
+            [storage]
+            driver = "overlay"
+            runroot = "/run/containers/storage"
+            graphroot = "/var/lib/containers/storage"
+            [storage.options.overlay]
+            mount_program = "/usr/bin/fuse-overlayfs"
+            EOF
+
+            WORKLOAD_FROM_SOURCE="false"
+            if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
+              WORKLOAD_FROM_SOURCE="true"
+              echo ">> Generating workload CR from workload descriptor"
+              podman run --rm --network=none \
+              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
+                workload create \
+                --namespace "${NAMESPACE_NAME}" \
+                --project "${PROJECT_NAME}" \
+                --component "${COMPONENT_NAME}" \
+                --image "${IMAGE}" \
+                --descriptor "workload.yaml" \
+                -o "workload-cr.yaml"
+            else
+              echo ">> Generating default workload CR"
+              podman run --rm --network=none \
+              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
+                workload create \
+                --namespace "${NAMESPACE_NAME}" \
+                --project "${PROJECT_NAME}" \
+                --component "${COMPONENT_NAME}" \
+                --image "${IMAGE}" \
+                -o "workload-cr.yaml"
+            fi
+
+            cp -f "${DESCRIPTOR_PATH}/workload-cr.yaml" "${OUTPUT_PATH}"
+
+            podman run --rm \
+              -v /mnt/vol:/data:rw \
+              mikefarah/yq:4.45.4 -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
+              > /mnt/vol/workload-cr-raw.json
+            podman run --rm \
+              -v /mnt/vol:/data:rw \
+              ghcr.io/jqlang/jq:1.7.1 -c '.' /data/workload-cr-raw.json \
+              > /mnt/vol/workload-cr.json
+            echo ">> Generated workload JSON payload:"
+            cat /mnt/vol/workload-cr.json
+
+            OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
+            OAUTH_HOST="{{inputs.parameters.oauth-host-header}}"
+            CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
+            CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
+            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
+
+            echo ">> Requesting OAuth token from ${OAUTH_URL}"
+            if [ -n "${OAUTH_SCOPE}" ]; then
+              TOKEN_RESPONSE=$(curl -s --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                -H "Host: ${OAUTH_HOST}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}" \
+                --data-urlencode "scope=${OAUTH_SCOPE}")
+            else
+              TOKEN_RESPONSE=$(curl -s --fail-with-body \
+                -X POST "${OAUTH_URL}" \
+                -H "Host: ${OAUTH_HOST}" \
+                --data-urlencode "grant_type=client_credentials" \
+                --data-urlencode "client_id=${CLIENT_ID}" \
+                --data-urlencode "client_secret=${CLIENT_SECRET}")
+            fi
+
+            ACCESS_TOKEN=$(printf '%s' "${TOKEN_RESPONSE}" | podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.access_token')
+
+            if [ -z "${ACCESS_TOKEN}" ]; then
+              echo ">> Failed to get access token: ${TOKEN_RESPONSE}"
+              exit 1
+            fi
+
+            echo ">> Successfully obtained access token"
+
+            API_URL="{{inputs.parameters.api-server-url}}"
+            API_HOST="{{inputs.parameters.api-server-host-header}}"
+
+            WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq:4.45.4 -r '.metadata.name' /data/workload-cr.json)
+
+            echo ">> Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads"
+            RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X POST "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads" \
+              -H "Host: ${API_HOST}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -d @/mnt/vol/workload-cr.json)
+
+            HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+            BODY=$(echo "${RESPONSE}" | sed '$d')
+
+            if [ "${HTTP_CODE}" -ge 200 ] && [ "${HTTP_CODE}" -lt 300 ]; then
+              echo ">> Workload created successfully (HTTP ${HTTP_CODE}): ${BODY}"
+            elif [ "${HTTP_CODE}" -eq 409 ]; then
+              if [ "${WORKLOAD_FROM_SOURCE}" = "true" ]; then
+                echo ">> Workload already exists, updating via PUT"
+                RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d @/mnt/vol/workload-cr.json)
+              else
+                echo ">> Workload already exists, updating only container image"
+                GET_RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X GET "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}")
+
+                GET_HTTP_CODE=$(echo "${GET_RESPONSE}" | tail -1)
+                GET_BODY=$(echo "${GET_RESPONSE}" | sed '$d')
+
+                if [ "${GET_HTTP_CODE}" -lt 200 ] || [ "${GET_HTTP_CODE}" -ge 300 ]; then
+                  echo ">> Failed to get existing workload (HTTP ${GET_HTTP_CODE}): ${GET_BODY}"
+                  exit 1
+                fi
+
+                echo "${GET_BODY}" > /mnt/vol/workload-existing.json
+                NEW_IMAGE=$(podman run --rm \
+                  -v /mnt/vol:/data:ro \
+                  ghcr.io/jqlang/jq:1.7.1 -r '.spec.container.image' /data/workload-cr.json)
+
+                podman run --rm \
+                  -v /mnt/vol:/data:rw \
+                  ghcr.io/jqlang/jq:1.7.1 \
+                  --arg img "${NEW_IMAGE}" \
+                  '.spec.container.image = $img' \
+                  /data/workload-existing.json \
+                  > /mnt/vol/workload-merged.json
+
+                RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d @/mnt/vol/workload-merged.json)
+              fi
+
+              HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+              BODY=$(echo "${RESPONSE}" | sed '$d')
+
+              if [ "${HTTP_CODE}" -ge 200 ] && [ "${HTTP_CODE}" -lt 300 ]; then
+                echo ">> Workload updated successfully (HTTP ${HTTP_CODE}): ${BODY}"
+              else
+                echo ">> Failed to update workload (HTTP ${HTTP_CODE}): ${BODY}"
+                exit 1
+              fi
+            else
+              echo ">> Failed to create workload (HTTP ${HTTP_CODE}): ${BODY}"
+              exit 1
+            fi
+
+            echo ">> Getting WorkflowRun ${RUN_NAME}"
+            WF_RUN_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X GET "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workflowruns/${RUN_NAME}" \
+              -H "Host: ${API_HOST}" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}")
+
+            WF_RUN_HTTP_CODE=$(echo "${WF_RUN_RESPONSE}" | tail -1)
+            WF_RUN_BODY=$(echo "${WF_RUN_RESPONSE}" | sed '$d')
+
+            if [ "${WF_RUN_HTTP_CODE}" -lt 200 ] || [ "${WF_RUN_HTTP_CODE}" -ge 300 ]; then
+              echo ">> Failed to get WorkflowRun (HTTP ${WF_RUN_HTTP_CODE}): ${WF_RUN_BODY}"
+              exit 1
+            fi
+
+            echo "${WF_RUN_BODY}" > /mnt/vol/workflowrun-get.json
+            if [ "${WORKLOAD_FROM_SOURCE}" = "true" ]; then
+              podman run --rm \
+                -v /mnt/vol:/data:rw \
+                ghcr.io/jqlang/jq:1.7.1 \
+                --rawfile wl /data/workload-cr.json \
+                '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "true"' \
+                /data/workflowrun-get.json \
+                > /mnt/vol/workflowrun-updated.json
+            else
+              podman run --rm \
+                -v /mnt/vol:/data:rw \
+                ghcr.io/jqlang/jq:1.7.1 \
+                --rawfile wl /data/workload-cr.json \
+                '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "false"' \
+                /data/workflowrun-get.json \
+                > /mnt/vol/workflowrun-updated.json
+            fi
+
+            echo ">> Updating WorkflowRun with workload annotation"
+            UPDATE_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workflowruns/${RUN_NAME}" \
+              -H "Host: ${API_HOST}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -d @/mnt/vol/workflowrun-updated.json)
+
+            UPDATE_HTTP_CODE=$(echo "${UPDATE_RESPONSE}" | tail -1)
+            UPDATE_BODY=$(echo "${UPDATE_RESPONSE}" | sed '$d')
+
+            if [ "${UPDATE_HTTP_CODE}" -ge 200 ] && [ "${UPDATE_HTTP_CODE}" -lt 300 ]; then
+              echo ">> WorkflowRun annotated successfully (HTTP ${UPDATE_HTTP_CODE})"
+            else
+              echo ">> Failed to update WorkflowRun (HTTP ${UPDATE_HTTP_CODE}): ${UPDATE_BODY}"
+              exit 1
+            fi
+        volumeMounts:
+          - name: workspace
+            mountPath: /mnt/vol
+        securityContext:
+          privileged: true

--- a/test/e2e/k3d/multi-cluster/workflow-templates/publish-image-e2e-mc.yaml
+++ b/test/e2e/k3d/multi-cluster/workflow-templates/publish-image-e2e-mc.yaml
@@ -1,0 +1,89 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-cluster e2e variant of publish-image-e2e.yaml.
+#
+# The single-cluster e2e template uses host.k3d.internal:20082 (WP registry).
+# The multi-cluster e2e setup exposes the WP registry on host port 30082
+# (see test/e2e/k3d/multi-cluster/config-wp.yaml), so this variant pushes to
+# host.k3d.internal:30082. The DP cluster's kubelet mirror config also points
+# to :30082 for image pulls (see config-dp.yaml).
+#
+# Keep in sync with test/e2e/k3d/workflow-templates/publish-image-e2e.yaml.
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: publish-image
+spec:
+  templates:
+    - name: publish-image
+      inputs:
+        parameters:
+          - name: git-revision
+      outputs:
+        parameters:
+          - name: image
+            valueFrom:
+              path: /tmp/image.txt
+      volumes:
+        - name: registry-push-secret
+          secret:
+            optional: true
+            secretName: '{{workflow.parameters.registry-push-secret}}'
+      container:
+        image: ghcr.io/openchoreo/podman-runner@sha256:2165f0d5ca5c8286c234388d542f50ede8f38108fc25a57ce141fcdf5cc87b00
+        command:
+          - sh
+          - -c
+        args:
+          - |-
+            set -e
+
+            GIT_REVISION={{inputs.parameters.git-revision}}
+            IMAGE_NAME={{workflow.parameters.image-name}}
+            IMAGE_TAG={{workflow.parameters.image-tag}}
+            SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
+
+            REGISTRY_ENDPOINT="host.k3d.internal:30082"
+            AUTH_FILE="/etc/secrets/registry-push-secret/.dockerconfigjson"
+
+            echo ">> Source image: $SRC_IMAGE"
+            echo ">> Registry: $REGISTRY_ENDPOINT"
+            echo ">> Authentication: $([ -f "$AUTH_FILE" ] && echo "registry secret found" || echo "no registry secret (anonymous push)")"
+
+            if [ ! -f "/mnt/vol/app-image.tar" ]; then
+              echo ">> Error: Built image tar not found at /mnt/vol/app-image.tar"
+              exit 1
+            fi
+
+            mkdir -p /etc/containers
+            cat <<EOF > /etc/containers/storage.conf
+            [storage]
+            driver = "overlay"
+            runroot = "/run/containers/storage"
+            graphroot = "/var/lib/containers/storage"
+            [storage.options.overlay]
+            mount_program = "/usr/bin/fuse-overlayfs"
+            EOF
+
+            podman load -i /mnt/vol/app-image.tar
+
+            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+
+            echo ">> Pushing image to registry"
+            if [ -f "$AUTH_FILE" ]; then
+              podman push --tls-verify=false --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+            else
+              podman push --tls-verify=false $REGISTRY_ENDPOINT/$SRC_IMAGE
+            fi
+
+            echo ">> Image published successfully: $REGISTRY_ENDPOINT/$SRC_IMAGE"
+            echo -n "$REGISTRY_ENDPOINT/$SRC_IMAGE" > /tmp/image.txt
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /mnt/vol
+            name: workspace
+          - mountPath: /etc/secrets/registry-push-secret
+            name: registry-push-secret
+            readOnly: true

--- a/test/e2e/k3d/multi-cluster/workflowplane.yaml
+++ b/test/e2e/k3d/multi-cluster/workflowplane.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# WorkflowPlane CR for the multi-cluster e2e setup.
+# Applied to the CP cluster. The clusterAgent.clientCA.value is injected at
+# apply time by e2e_register_plane_cross_cluster in make/e2e.mk.
+apiVersion: openchoreo.dev/v1alpha1
+kind: WorkflowPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  planeID: default
+  clusterAgent:
+    clientCA:
+      value: ""
+  secretStoreRef:
+    name: default

--- a/test/e2e/suites/alerts/alerts_test.go
+++ b/test/e2e/suites/alerts/alerts_test.go
@@ -33,8 +33,9 @@ const (
 	// same node as the test, so generous bounds avoid CI flakiness.
 	buildTimeout = 20 * time.Minute
 
-	giteaNamespace      = framework.Tier3GiteaNamespace
-	sampleWorkloadsRepo = framework.Tier3SampleWorkloadsRepo
+	giteaNamespace          = framework.Tier3GiteaNamespace
+	sampleWorkloadsRepo     = framework.Tier3SampleWorkloadsRepo
+	upstreamSampleWorkloads = framework.Tier3UpstreamSampleWorkloads
 )
 
 var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
@@ -42,8 +43,10 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 
 	BeforeAll(func() {
-		By("deploying the in-cluster webhook receiver")
-		Expect(framework.DeployWebhookReceiver(kubeContext, alertReceiverNamespace)).To(Succeed())
+		By("deploying the webhook receiver")
+		// In multi-cluster mode the receiver must be in the same cluster as
+		// alertmanager (OP cluster) so notifications are deliverable in-cluster.
+		Expect(framework.DeployWebhookReceiver(opCtx(), alertReceiverNamespace)).To(Succeed())
 
 		By("creating control plane namespace")
 		out, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
@@ -74,13 +77,13 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		By("discovering data plane namespace")
 		Eventually(func() error {
 			var derr error
-			dpNs, derr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+			dpNs, derr = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
 			return derr
 		}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 		By("waiting for shared alert component pod to be Running")
 		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, kubeContext, dpNs,
+			framework.AssertPodsRunning(g, dpCtx(), dpNs,
 				"openchoreo.dev/component="+componentAlerts)
 		}, 5*time.Minute, 5*time.Second).Should(Succeed())
 	})
@@ -94,17 +97,17 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
 			"--ignore-not-found", "--wait=false")
 		if dpNs != "" {
-			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+			_, _ = framework.Kubectl(dpCtx(), "delete", "namespace", dpNs,
 				"--ignore-not-found", "--wait=false")
 		}
-		_, _ = framework.Kubectl(kubeContext, "delete", "namespace",
+		_, _ = framework.Kubectl(opCtx(), "delete", "namespace",
 			alertReceiverNamespace, "--ignore-not-found", "--wait=false")
 	})
 
 	It("metric-alert-fires: webhook receiver records a notification when CPU rule trips", func() {
 		By("rendered ObservabilityAlertRule reaches Ready or Pending phase")
 		Eventually(func(g Gomega) {
-			out, err := framework.Kubectl(kubeContext,
+			out, err := framework.Kubectl(opCtx(),
 				"get", "observabilityalertrule", "-A",
 				"-l", "openchoreo.dev/component-uid",
 				"-o", `jsonpath={.items[*].spec.name}`,
@@ -124,7 +127,7 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		// the reasoning behind the looser delivery check.
 		var metricDelivered bool
 		Eventually(func(g Gomega) {
-			bodies, rerr := framework.ReceivedNotifications(kubeContext, alertReceiverNamespace)
+			bodies, rerr := framework.ReceivedNotifications(opCtx(), alertReceiverNamespace)
 			g.Expect(rerr).NotTo(HaveOccurred())
 			if containsAlert(bodies, alertRuleMetric) {
 				metricDelivered = true
@@ -150,7 +153,7 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		var lastExecErr error
 		for i := 0; i < 5; i++ {
 			out, err := framework.KubectlExecByLabel(
-				kubeContext, dpNs,
+				dpCtx(), dpNs,
 				"openchoreo.dev/component="+componentAlerts, "",
 				"sh", "-c", fmt.Sprintf("echo %s; echo %s 1>&2", logSearchPhrase, logSearchPhrase),
 			)
@@ -175,7 +178,7 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 
 		By("rendered ObservabilityAlertRule for the log rule reaches the OP")
 		Eventually(func(g Gomega) {
-			out, err := framework.Kubectl(kubeContext,
+			out, err := framework.Kubectl(opCtx(),
 				"get", "observabilityalertrule", "-A",
 				"-l", "openchoreo.dev/component-uid",
 				"-o", `jsonpath={.items[*].spec.name}`,
@@ -190,7 +193,7 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		// and TIER3-OP-PLAN.md "What shifted during implementation".
 		var logDelivered bool
 		Eventually(func(g Gomega) {
-			bodies, rerr := framework.ReceivedNotifications(kubeContext, alertReceiverNamespace)
+			bodies, rerr := framework.ReceivedNotifications(opCtx(), alertReceiverNamespace)
 			g.Expect(rerr).NotTo(HaveOccurred())
 			if containsAlert(bodies, alertRuleLog) {
 				logDelivered = true
@@ -206,8 +209,12 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		// the only Tier 3 spec that needs both planes. It uses the shared
 		// Tier 3 source fixture but keeps its WorkflowRun dedicated because
 		// the test deletes that run before querying observer logs.
-		By("ensuring shared Tier 3 sample-workloads source is present")
-		Expect(framework.EnsureTier3SampleWorkloads(kubeContext)).To(Succeed())
+		// Gitea must be in the WP cluster so Argo Workflow pods can clone via
+		// in-cluster DNS. In single-cluster mode wpCtx() == kubeContext.
+		By("ensuring Gitea + sample-workloads mirror are present in the WP cluster")
+		Expect(framework.InstallGitea(wpCtx(), giteaNamespace)).To(Succeed())
+		Expect(framework.MigrateRepo(wpCtx(), giteaNamespace,
+			sampleWorkloadsRepo, upstreamSampleWorkloads)).To(Succeed())
 
 		runName := componentBuildLogs + "-run-01"
 		gitURL := framework.GiteaRepoCloneURL(giteaNamespace, sampleWorkloadsRepo)
@@ -235,20 +242,22 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		By("setting up an observer-query tester pod in the DP namespace")
 		Eventually(func() error {
 			var derr error
-			dpNs, derr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+			dpNs, derr = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
 			return derr
 		}, 3*time.Minute, 5*time.Second).Should(Succeed())
-		out, err = framework.KubectlApplyLiteral(kubeContext, curlPodYAML(dpNs))
+		out, err = framework.KubectlApplyLiteral(dpCtx(), curlPodYAML(dpNs))
 		Expect(err).NotTo(HaveOccurred(), "create tester pod: %s", out)
 		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, kubeContext, dpNs, curlPodLabel)
+			framework.AssertPodsRunning(g, dpCtx(), dpNs, curlPodLabel)
 		}, 4*time.Minute, 3*time.Second).Should(Succeed())
 
 		observerQ = framework.ObserverQueryFrom{
-			KubeContext: kubeContext,
-			Namespace:   dpNs,
-			PodLabel:    curlPodLabel,
-			Container:   curlContainer,
+			KubeContext:     dpCtx(),
+			Namespace:       dpNs,
+			PodLabel:        curlPodLabel,
+			Container:       curlContainer,
+			ThunderTokenURL: mcThunderURL(),
+			ObserverURL:     mcObserverURL(),
 		}
 		token, err := framework.AcquireObserverToken(observerQ)
 		Expect(err).NotTo(HaveOccurred(), "acquire observer token")
@@ -278,6 +287,20 @@ var _ = Describe("Observability Alerts", Ordered, Label("tier3"), func() {
 		}, framework.IngestionBudget, alertPoll).Should(Succeed())
 	})
 })
+
+func mcThunderURL() string {
+	if opKubeContext != "" {
+		return "http://thunder.e2e-mc-cp.local:38080/oauth2/token"
+	}
+	return ""
+}
+
+func mcObserverURL() string {
+	if opKubeContext != "" {
+		return "http://observer.e2e-mc-op.local:31080"
+	}
+	return ""
+}
 
 // containsAlert returns true if any of the JSON bodies references the named
 // alert rule. The exact payload shape is observer-defined; we look for the

--- a/test/e2e/suites/alerts/suite_test.go
+++ b/test/e2e/suites/alerts/suite_test.go
@@ -14,11 +14,43 @@ import (
 	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
-var kubeContext string
+var (
+	kubeContext   string
+	dpKubeContext string
+	wpKubeContext string
+	opKubeContext string
+)
 
 func init() {
 	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
-		"Kubernetes context for e2e tests (required)")
+		"Kubernetes context for the control plane cluster (required)")
+	flag.StringVar(&dpKubeContext, "e2e.dp-kubecontext", "",
+		"Kubernetes context for the data plane cluster (multi-cluster only)")
+	flag.StringVar(&wpKubeContext, "e2e.wp-kubecontext", "",
+		"Kubernetes context for the workflow plane cluster (multi-cluster only)")
+	flag.StringVar(&opKubeContext, "e2e.op-kubecontext", "",
+		"Kubernetes context for the observability plane cluster (multi-cluster only)")
+}
+
+func dpCtx() string {
+	if dpKubeContext != "" {
+		return dpKubeContext
+	}
+	return kubeContext
+}
+
+func wpCtx() string {
+	if wpKubeContext != "" {
+		return wpKubeContext
+	}
+	return kubeContext
+}
+
+func opCtx() string {
+	if opKubeContext != "" {
+		return opKubeContext
+	}
+	return kubeContext
 }
 
 func TestE2EAlerts(t *testing.T) {
@@ -36,9 +68,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred(),
 		"cluster not accessible with context %s:\n%s", kubeContext, output)
 
-	By("verifying observability plane is installed")
-	_, err = framework.Kubectl(kubeContext,
+	By("verifying the observer service is present")
+	_, err = framework.Kubectl(opCtx(),
 		"get", "svc", framework.ObserverService, "-n", framework.ObserverNamespace)
 	Expect(err).NotTo(HaveOccurred(),
-		"observability plane is not installed; set E2E_WITH_OBSERVABILITY=true on make e2e.setup")
+		"observability plane is not installed; run make e2e.setup with E2E_WITH_OBSERVABILITY=true or make e2e.multi")
 })

--- a/test/e2e/suites/build/build_fixtures_test.go
+++ b/test/e2e/suites/build/build_fixtures_test.go
@@ -27,10 +27,11 @@ const (
 	envDev      = "development"
 	envStaging  = "staging"
 
-	giteaNamespace      = framework.Tier3GiteaNamespace
-	sampleWorkloadsRepo = framework.Tier3SampleWorkloadsRepo
-	noWorkloadRepo      = framework.Tier3NoWorkloadRepo
-	paketoNodeRepo      = framework.Tier3PaketoNodeRepo
+	giteaNamespace          = framework.Tier3GiteaNamespace
+	sampleWorkloadsRepo     = framework.Tier3SampleWorkloadsRepo
+	noWorkloadRepo          = framework.Tier3NoWorkloadRepo
+	paketoNodeRepo          = framework.Tier3PaketoNodeRepo
+	upstreamSampleWorkloads = framework.Tier3UpstreamSampleWorkloads
 
 	// Component / workflow names. Kept short so the rendered Argo Workflow's
 	// generated names don't blow past Kubernetes' 63-char DNS label limit.
@@ -41,6 +42,7 @@ const (
 	componentBallerina       = "bal-svc"
 	componentNoWorkload      = "auto-wl"
 	componentExternalRefs    = "extref-svc"
+	componentLogs            = "logs-svc"
 
 	releaseBindingSuffix = "-" + envDev
 

--- a/test/e2e/suites/build/build_test.go
+++ b/test/e2e/suites/build/build_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -92,8 +93,26 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 
 	BeforeAll(func() {
-		By("ensuring shared Tier 3 Gitea build sources are present")
-		Expect(framework.EnsureTier3BuildSources(kubeContext)).To(Succeed())
+		By("installing in-cluster Gitea")
+		// Gitea must be in the WP cluster so Argo Workflow pods can clone via
+		// in-cluster DNS. In single-cluster mode wpCtx() == kubeContext.
+		Expect(framework.InstallGitea(wpCtx(), giteaNamespace)).To(Succeed())
+
+		By("mirroring openchoreo/sample-workloads into Gitea")
+		Expect(framework.MigrateRepo(wpCtx(), giteaNamespace,
+			sampleWorkloadsRepo, upstreamSampleWorkloads)).To(Succeed())
+
+		By("seeding the no-workload fixture into Gitea")
+		Expect(framework.EnsureGiteaRepo(wpCtx(), giteaNamespace, noWorkloadRepo)).To(Succeed())
+		repoRoot, err := framework.RepoRoot()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.PushTree(wpCtx(), giteaNamespace, noWorkloadRepo, "main",
+			filepath.Join(repoRoot, "test/e2e/fixtures/build/no-workload"))).To(Succeed())
+
+		By("seeding the paketo-node fixture into Gitea")
+		Expect(framework.EnsureGiteaRepo(wpCtx(), giteaNamespace, paketoNodeRepo)).To(Succeed())
+		Expect(framework.PushTree(wpCtx(), giteaNamespace, paketoNodeRepo, "main",
+			filepath.Join(repoRoot, "test/e2e/fixtures/build/paketo-node"))).To(Succeed())
 
 		By("creating control plane namespace")
 		output, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
@@ -118,9 +137,11 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
 			"--ignore-not-found", "--wait=false")
 		if dpNs != "" {
-			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+			_, _ = framework.Kubectl(dpCtx(), "delete", "namespace", dpNs,
 				"--ignore-not-found", "--wait=false")
 		}
+		_, _ = framework.Kubectl(wpCtx(), "delete", "namespace", giteaNamespace,
+			"--ignore-not-found", "--wait=false")
 	})
 
 	Context("builder matrix", func() {
@@ -196,8 +217,9 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 			fmt.Fprintf(GinkgoWriter, "rendered workflow ref: %s %s/%s\n", kind, refNs, refName)
 
 			By("rendered Argo Workflow carries the resolved externalRef value as a label")
+			// The Argo Workflow lives in the WP cluster in multi-cluster mode.
 			Eventually(func(g Gomega) {
-				out, err := framework.KubectlGetJsonpath(kubeContext, refNs,
+				out, err := framework.KubectlGetJsonpath(wpCtx(), refNs,
 					"workflow.argoproj.io", refName,
 					`{.metadata.labels['openchoreo\.dev/e2e-cel-probe']}`,
 				)
@@ -207,6 +229,58 @@ var _ = Describe("Build From Source Matrix", Ordered, Label("tier3"), func() {
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
+		It("build-logs-via-k8s: live logs reachable from a running WorkflowRun pod", func() {
+			component := componentLogs
+			runName := component + "-run-01"
+
+			By("waiting for controller-manager webhook to be ready")
+			Eventually(func() error {
+				out, err := framework.KubectlGetJsonpath(kubeContext, "openchoreo-control-plane",
+					"endpoints", "controller-manager-webhook-service",
+					`{.subsets[0].addresses[0].ip}`)
+				if err != nil || strings.TrimSpace(out) == "" {
+					return fmt.Errorf("webhook endpoint not ready yet")
+				}
+				return nil
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"controller-manager webhook endpoint never became ready")
+
+			By("applying component + workflowrun")
+			gitURL := framework.GiteaRepoCloneURL(giteaNamespace, sampleWorkloadsRepo)
+			output, err := framework.KubectlApplyLiteral(kubeContext, buildComponentYAML(
+				component, "deployment/service", "dockerfile-builder",
+				gitURL, "/service-go-greeter", "/service-go-greeter/Dockerfile",
+			))
+			Expect(err).NotTo(HaveOccurred(), "failed to apply component: %s", output)
+			output, err = framework.KubectlApplyLiteral(kubeContext, workflowRunYAML(
+				component, runName, "dockerfile-builder",
+				gitURL, "/service-go-greeter", "/service-go-greeter/Dockerfile",
+			))
+			Expect(err).NotTo(HaveOccurred(), "failed to apply workflow run: %s", output)
+
+			By("waiting for the build Argo Workflow pod to appear")
+			// Argo Workflow pods run in the WP cluster; wpCtx() is the WP
+			// kubecontext in multi-cluster mode and falls back to kubeContext.
+			wfNs := "workflows-" + cpNs
+			Eventually(func(g Gomega) {
+				out, err := framework.Kubectl(wpCtx(),
+					"get", "pods", "-n", wfNs,
+					"-l", "workflows.argoproj.io/workflow="+runName,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
+					"no pod found yet for WorkflowRun %s in %s", runName, wfNs)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("kubectl logs against the build pod returns non-empty content")
+			Eventually(func(g Gomega) {
+				out, err := framework.KubectlLogs(wpCtx(), wfNs,
+					"workflows.argoproj.io/workflow="+runName, 50)
+				g.Expect(err).NotTo(HaveOccurred(), "kubectl logs failed: %s", out)
+				g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),
+					"expected non-empty build pod logs while WorkflowRun is running")
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+		})
 	})
 })
 
@@ -237,6 +311,21 @@ func triggerDeployableBuildSpec(spec buildSpec) {
 	runName := spec.component + "-run-01"
 	gitURL := framework.GiteaRepoCloneURL(giteaNamespace, spec.repoName)
 
+	// The CP controller-manager webhook may be temporarily unavailable if the
+	// controller restarted due to leader election loss during a long test run.
+	// Wait for the webhook endpoint to be ready before applying any resources.
+	By("waiting for controller-manager webhook to be ready")
+	Eventually(func() error {
+		out, err := framework.KubectlGetJsonpath(kubeContext, "openchoreo-control-plane",
+			"endpoints", "controller-manager-webhook-service",
+			`{.subsets[0].addresses[0].ip}`)
+		if err != nil || strings.TrimSpace(out) == "" {
+			return fmt.Errorf("webhook endpoint not ready yet")
+		}
+		return nil
+	}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+		"controller-manager webhook endpoint never became ready")
+
 	By(fmt.Sprintf("applying Component %s with workflow %s", spec.component, spec.workflow))
 	output, err := framework.KubectlApplyLiteral(kubeContext, buildComponentYAML(
 		spec.component, spec.componentTyp, spec.workflow, gitURL, spec.appPath, spec.dockerfile,
@@ -263,6 +352,11 @@ func assertDeployableBuildSpec(spec buildSpec) {
 
 	By("waiting for WorkflowRun to succeed")
 	Eventually(func(g Gomega) {
+		// Emit runReference on each poll so CI logs show whether the CP
+		// controller ever created the Argo Workflow in the WP cluster.
+		kind, name, ns, _ := framework.WorkflowRunReference(kubeContext, cpNs, runName)
+		fmt.Fprintf(GinkgoWriter, "WorkflowRun %s runReference: kind=%s name=%s ns=%s\n",
+			runName, kind, name, ns)
 		framework.AssertWorkflowRunSucceeded(g, kubeContext, cpNs, runName)
 	}, buildTimeout, 10*time.Second).Should(Succeed())
 
@@ -279,13 +373,13 @@ func assertDeployableBuildSpec(spec buildSpec) {
 	By("discovering the data plane namespace")
 	Eventually(func() error {
 		var discoverErr error
-		dpNs, discoverErr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+		dpNs, discoverErr = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
 		return discoverErr
 	}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 	By("workload pod is Running")
 	Eventually(func(g Gomega) {
-		framework.AssertPodsRunning(g, kubeContext, dpNs,
+		framework.AssertPodsRunning(g, dpCtx(), dpNs,
 			"openchoreo.dev/component="+spec.component)
 	}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
@@ -294,17 +388,17 @@ func assertDeployableBuildSpec(spec buildSpec) {
 	}
 
 	By("ensuring a tester pod is available in the DP namespace")
-	output, err := framework.KubectlApplyLiteral(kubeContext, testerPodYAML(dpNs))
+	output, err := framework.KubectlApplyLiteral(dpCtx(), testerPodYAML(dpNs))
 	Expect(err).NotTo(HaveOccurred(), "failed to apply tester pod: %s", output)
 	Eventually(func(g Gomega) {
-		framework.AssertPodsRunning(g, kubeContext, dpNs, testerLabel)
+		framework.AssertPodsRunning(g, dpCtx(), dpNs, testerLabel)
 	}, 3*time.Minute, 3*time.Second).Should(Succeed())
 
 	By("rendered Service is TCP-reachable from the tester pod")
 	host, port := endpointHostPort(spec.component, spec.endpoint)
 	Eventually(func() error {
 		_, err := framework.CheckTCPReachableFromPodByLabel(
-			kubeContext, dpNs, testerLabel, testerContainer, host, port, 5,
+			dpCtx(), dpNs, testerLabel, testerContainer, host, port, 5,
 		)
 		return err
 	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
@@ -315,7 +409,7 @@ func assertWorkflowRunLogs(runName string) {
 	By("waiting for the build Argo Workflow pod to appear")
 	wfNs := "workflows-" + cpNs
 	Eventually(func(g Gomega) {
-		out, err := framework.Kubectl(kubeContext,
+		out, err := framework.Kubectl(wpCtx(),
 			"get", "pods", "-n", wfNs,
 			"-l", "workflows.argoproj.io/workflow="+runName,
 			"-o", "jsonpath={.items[*].metadata.name}")
@@ -326,7 +420,7 @@ func assertWorkflowRunLogs(runName string) {
 
 	By("kubectl logs against the build pod returns non-empty content")
 	Eventually(func(g Gomega) {
-		out, err := framework.KubectlLogs(kubeContext, wfNs,
+		out, err := framework.KubectlLogs(wpCtx(), wfNs,
 			"workflows.argoproj.io/workflow="+runName, 50)
 		g.Expect(err).NotTo(HaveOccurred(), "kubectl logs failed: %s", out)
 		g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(),

--- a/test/e2e/suites/build/suite_test.go
+++ b/test/e2e/suites/build/suite_test.go
@@ -14,11 +14,43 @@ import (
 	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
-var kubeContext string
+var (
+	kubeContext   string
+	dpKubeContext string
+	wpKubeContext string
+	opKubeContext string
+)
 
 func init() {
 	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
-		"Kubernetes context for e2e tests (required)")
+		"Kubernetes context for the control plane cluster (required)")
+	flag.StringVar(&dpKubeContext, "e2e.dp-kubecontext", "",
+		"Kubernetes context for the data plane cluster (multi-cluster only)")
+	flag.StringVar(&wpKubeContext, "e2e.wp-kubecontext", "",
+		"Kubernetes context for the workflow plane cluster (multi-cluster only)")
+	flag.StringVar(&opKubeContext, "e2e.op-kubecontext", "",
+		"Kubernetes context for the observability plane cluster (multi-cluster only)")
+}
+
+func dpCtx() string {
+	if dpKubeContext != "" {
+		return dpKubeContext
+	}
+	return kubeContext
+}
+
+func wpCtx() string {
+	if wpKubeContext != "" {
+		return wpKubeContext
+	}
+	return kubeContext
+}
+
+func opCtx() string {
+	if opKubeContext != "" {
+		return opKubeContext
+	}
+	return kubeContext
 }
 
 func TestE2EBuild(t *testing.T) {
@@ -36,10 +68,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred(),
 		"cluster not accessible with context %s:\n%s", kubeContext, output)
 
-	By("verifying workflow plane is present (E2E_WITH_BUILD=true)")
-	_, err = framework.Kubectl(kubeContext, "get", "namespace", "openchoreo-workflow-plane")
+	By("verifying workflow plane is present")
+	_, err = framework.Kubectl(wpCtx(), "get", "namespace", "openchoreo-workflow-plane")
 	Expect(err).NotTo(HaveOccurred(),
-		"workflow plane not installed; build suite requires E2E_WITH_BUILD=true")
+		"workflow plane not installed; run make e2e.setup with E2E_WITH_BUILD=true or make e2e.multi")
 
 	_, err = framework.Kubectl(kubeContext, "get", "clusterworkflow", "dockerfile-builder")
 	Expect(err).NotTo(HaveOccurred(),

--- a/test/e2e/suites/gitops/gitops_test.go
+++ b/test/e2e/suites/gitops/gitops_test.go
@@ -60,7 +60,7 @@ var _ = Describe("GitOps with Flux", Ordered, Label("tier3"), func() {
 		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
 			"--ignore-not-found", "--wait=false")
 		if dpNs != "" {
-			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+			_, _ = framework.Kubectl(dpCtx(), "delete", "namespace", dpNs,
 				"--ignore-not-found", "--wait=false")
 		}
 		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", giteaNamespace,
@@ -94,13 +94,13 @@ var _ = Describe("GitOps with Flux", Ordered, Label("tier3"), func() {
 			By("discovering the data plane namespace")
 			Eventually(func() error {
 				var err error
-				dpNs, err = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+				dpNs, err = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
 				return err
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("pod is Running with the initial image")
 			Eventually(func(g Gomega) {
-				framework.AssertPodsRunning(g, kubeContext, dpNs,
+				framework.AssertPodsRunning(g, dpCtx(), dpNs,
 					"openchoreo.dev/component="+componentSingle)
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		})
@@ -117,7 +117,7 @@ var _ = Describe("GitOps with Flux", Ordered, Label("tier3"), func() {
 
 			By("rendered Deployment image updates to the new tag")
 			Eventually(func(g Gomega) {
-				out, err := framework.Kubectl(kubeContext,
+				out, err := framework.Kubectl(dpCtx(),
 					"get", "deployment",
 					"-n", dpNs,
 					"-l", "openchoreo.dev/component="+componentSingle,
@@ -130,7 +130,7 @@ var _ = Describe("GitOps with Flux", Ordered, Label("tier3"), func() {
 
 			By("pod is Running on the new image")
 			Eventually(func(g Gomega) {
-				framework.AssertPodsRunning(g, kubeContext, dpNs,
+				framework.AssertPodsRunning(g, dpCtx(), dpNs,
 					"openchoreo.dev/component="+componentSingle)
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		})
@@ -165,7 +165,7 @@ var _ = Describe("GitOps with Flux", Ordered, Label("tier3"), func() {
 			By("all 3 component pods are Running")
 			for _, c := range components {
 				Eventually(func(g Gomega) {
-					framework.AssertPodsRunning(g, kubeContext, dpNs,
+					framework.AssertPodsRunning(g, dpCtx(), dpNs,
 						"openchoreo.dev/component="+c)
 				}, 5*time.Minute, 5*time.Second).Should(Succeed(),
 					"pods for component %s never reached Running", c)

--- a/test/e2e/suites/gitops/suite_test.go
+++ b/test/e2e/suites/gitops/suite_test.go
@@ -14,11 +14,29 @@ import (
 	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
-var kubeContext string
+var (
+	kubeContext   string
+	dpKubeContext string
+	wpKubeContext string
+	opKubeContext string
+)
 
 func init() {
 	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
-		"Kubernetes context for e2e tests (required)")
+		"Kubernetes context for the control plane cluster (required)")
+	flag.StringVar(&dpKubeContext, "e2e.dp-kubecontext", "",
+		"Kubernetes context for the data plane cluster (multi-cluster only)")
+	flag.StringVar(&wpKubeContext, "e2e.wp-kubecontext", "",
+		"Kubernetes context for the workflow plane cluster (multi-cluster only)")
+	flag.StringVar(&opKubeContext, "e2e.op-kubecontext", "",
+		"Kubernetes context for the observability plane cluster (multi-cluster only)")
+}
+
+func dpCtx() string {
+	if dpKubeContext != "" {
+		return dpKubeContext
+	}
+	return kubeContext
 }
 
 func TestE2EGitOps(t *testing.T) {

--- a/test/e2e/suites/observability/observability_test.go
+++ b/test/e2e/suites/observability/observability_test.go
@@ -61,18 +61,18 @@ var _ = Describe("Observability Signals", Ordered, Label("tier3"), func() {
 		By("discovering data plane namespace")
 		Eventually(func() error {
 			var derr error
-			dpNs, derr = framework.GetDPNamespace(kubeContext, cpNs, projectName, envDev)
+			dpNs, derr = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
 			return derr
 		}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		fmt.Fprintf(GinkgoWriter, "discovered dp namespace: %s\n", dpNs)
 
 		By("deploying tester pod")
-		out, err = framework.KubectlApplyLiteral(kubeContext, curlPodYAML(dpNs))
+		out, err = framework.KubectlApplyLiteral(dpCtx(), curlPodYAML(dpNs))
 		Expect(err).NotTo(HaveOccurred(), "create tester pod: %s", out)
 
 		By("waiting for tester pod to be Running")
 		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, kubeContext, dpNs, curlPodLabel)
+			framework.AssertPodsRunning(g, dpCtx(), dpNs, curlPodLabel)
 		}, 4*time.Minute, 3*time.Second).Should(Succeed())
 
 		By("waiting for greeter ReleaseBinding Ready")
@@ -83,7 +83,7 @@ var _ = Describe("Observability Signals", Ordered, Label("tier3"), func() {
 
 		By("waiting for greeter pod Running")
 		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, kubeContext, dpNs,
+			framework.AssertPodsRunning(g, dpCtx(), dpNs,
 				"openchoreo.dev/component="+componentGreeter)
 		}, 3*time.Minute, 3*time.Second).Should(Succeed())
 
@@ -94,14 +94,17 @@ var _ = Describe("Observability Signals", Ordered, Label("tier3"), func() {
 		}, 3*time.Minute, 3*time.Second).Should(Succeed())
 		fmt.Fprintf(GinkgoWriter, "greeter resolved at %s:%s\n", greeterHost, greeterPort)
 
-		// Pin the observer query helper to the tester pod. AcquireObserverToken
-		// runs inside this pod so the curl already has the right egress path
-		// to the in-cluster Thunder service.
+		// In multi-cluster mode the tester pod sits in the DP cluster and needs
+		// to reach Thunder (CP) and the observer (OP) via external hostnames
+		// resolved through the DP cluster's CoreDNS rewrites. In single-cluster
+		// mode the empty fields fall back to the in-cluster defaults.
 		observerQ = framework.ObserverQueryFrom{
-			KubeContext: kubeContext,
-			Namespace:   dpNs,
-			PodLabel:    curlPodLabel,
-			Container:   curlContainer,
+			KubeContext:     dpCtx(),
+			Namespace:       dpNs,
+			PodLabel:        curlPodLabel,
+			Container:       curlContainer,
+			ThunderTokenURL: mcThunderURL(),
+			ObserverURL:     mcObserverURL(),
 		}
 	})
 
@@ -114,7 +117,7 @@ var _ = Describe("Observability Signals", Ordered, Label("tier3"), func() {
 		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
 			"--ignore-not-found", "--wait=false")
 		if dpNs != "" {
-			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", dpNs,
+			_, _ = framework.Kubectl(dpCtx(), "delete", "namespace", dpNs,
 				"--ignore-not-found", "--wait=false")
 		}
 	})
@@ -246,12 +249,30 @@ var _ = Describe("Observability Signals", Ordered, Label("tier3"), func() {
 // tester pod into the greeter's project-visibility ClusterIP, so the
 // observability pipeline has something to ingest. The marker is folded
 // into the request URL's query string so it's searchable in logs.
+// mcThunderURL returns the external Thunder token URL for multi-cluster mode,
+// or empty string to fall back to the in-cluster default.
+func mcThunderURL() string {
+	if opKubeContext != "" {
+		return "http://thunder.e2e-mc-cp.local:38080/oauth2/token"
+	}
+	return ""
+}
+
+// mcObserverURL returns the external observer base URL for multi-cluster mode,
+// or empty string to fall back to the in-cluster default.
+func mcObserverURL() string {
+	if opKubeContext != "" {
+		return "http://observer.e2e-mc-op.local:31080"
+	}
+	return ""
+}
+
 func generateTrafficAndQuery(marker string) {
 	url := fmt.Sprintf("http://%s:%s/greeter/greet?marker=%s",
 		greeterHost, greeterPort, marker)
 	By(fmt.Sprintf("generating %ds of traffic at %d rps against %s", trafficDuration, trafficRPS, url))
 	out, err := framework.GenerateHTTPTraffic(
-		kubeContext, dpNs, curlPodLabel, curlContainer,
+		dpCtx(), dpNs, curlPodLabel, curlContainer,
 		url, marker, trafficRPS, trafficDuration,
 	)
 	if err != nil {

--- a/test/e2e/suites/observability/suite_test.go
+++ b/test/e2e/suites/observability/suite_test.go
@@ -14,11 +14,43 @@ import (
 	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
-var kubeContext string
+var (
+	kubeContext   string
+	dpKubeContext string
+	wpKubeContext string
+	opKubeContext string
+)
 
 func init() {
 	flag.StringVar(&kubeContext, "e2e.kubecontext", "",
-		"Kubernetes context for e2e tests (required)")
+		"Kubernetes context for the control plane cluster (required)")
+	flag.StringVar(&dpKubeContext, "e2e.dp-kubecontext", "",
+		"Kubernetes context for the data plane cluster (multi-cluster only)")
+	flag.StringVar(&wpKubeContext, "e2e.wp-kubecontext", "",
+		"Kubernetes context for the workflow plane cluster (multi-cluster only)")
+	flag.StringVar(&opKubeContext, "e2e.op-kubecontext", "",
+		"Kubernetes context for the observability plane cluster (multi-cluster only)")
+}
+
+func dpCtx() string {
+	if dpKubeContext != "" {
+		return dpKubeContext
+	}
+	return kubeContext
+}
+
+func wpCtx() string {
+	if wpKubeContext != "" {
+		return wpKubeContext
+	}
+	return kubeContext
+}
+
+func opCtx() string {
+	if opKubeContext != "" {
+		return opKubeContext
+	}
+	return kubeContext
 }
 
 func TestE2EObservability(t *testing.T) {
@@ -36,9 +68,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred(),
 		"cluster not accessible with context %s:\n%s", kubeContext, output)
 
-	By("verifying the observer service is present (E2E_WITH_OBSERVABILITY=true must be set at setup time)")
-	_, err = framework.Kubectl(kubeContext,
+	By("verifying the observer service is present")
+	_, err = framework.Kubectl(opCtx(),
 		"get", "svc", framework.ObserverService, "-n", framework.ObserverNamespace)
 	Expect(err).NotTo(HaveOccurred(),
-		"observability plane is not installed; set E2E_WITH_OBSERVABILITY=true on make e2e.setup")
+		"observability plane is not installed; run make e2e.setup with E2E_WITH_OBSERVABILITY=true or make e2e.multi")
 })


### PR DESCRIPTION
The Tier 3 e2e suite used to run the entire OpenChoreo stack in a single k3d cluster with E2E_WITH_BUILD=true and E2E_WITH_OBSERVABILITY=true. That worked well enough as a smoke test, but it doesn't reflect how OpenChoreo actually runs in production, where each plane lives in its own cluster. Cross-cluster communication, CA propagation, and agent TLS handshakes were never exercised.
  
This PR replaces that single-cluster full-stack setup with a proper multi-cluster topology: four separate k3d clusters, one per plane.

What changed:

- Added make e2e.multi.* targets covering the full lifecycle: cluster creation, prerequisites, plane installs, configuration, testing, diagnostics, and teardown
- Added cross-cluster Make helpers (e2e_copy_gateway_certs_cross_cluster, e2e_register_plane_cross_cluster, e2e_mc_patch_gateway) that wire up CA propagation and agent registration across cluster boundaries
- Added test/e2e/k3d/multi-cluster/ with k3d configs, per-plane Helm values, CoreDNS rewrites, plane CRs, OpenBao secret stores, OpenSearch ExternalSecrets, and workflow
  templates for build and gitops flows
- Updated the alerts, build, gitops, and observability suites to accept per-plane kubecontext flags (--e2e.dp-kubecontext, --e2e.wp-kubecontext, --e2e.op-kubecontext)
- Observability runs in operator mode: OpenSearch in the OP cluster, with Fluent Bit and OTel collectors in the DP and WP clusters shipping to it in exporter mode
- Updated the Tier 3 CI job in e2e-gate.yml to use make e2e.multi. Setup timeout went up to 20m (four clusters take longer to provision), test timeout dropped to 60m (was 120m)

Fixes - https://github.com/openchoreo/openchoreo/issues/3731