### PR TITLE
test: add quick start guide smoke test e2e workflow

### DIFF
--- a/.github/workflows/test-quick-start.yml
+++ b/.github/workflows/test-quick-start.yml
@@ -1,0 +1,164 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Exercises the real Quick Start Guide user journey
+# (https://openchoreo.dev/docs/next/getting-started/quick-start-guide/) end to
+# end: run the `quick-start` container exactly as a user does, install the full
+# platform with `./install.sh --with-build --with-observability`, assert all
+# four planes are healthy, then deploy a sample web app.
+#
+# This is intentionally separate from the `make e2e` suite: that harness installs
+# via OCI Helm charts with bespoke values and never runs the quick-start scripts
+# or container. This workflow catches regressions a user would actually hit.
+#
+# Two modes, picked by trigger:
+#   schedule / workflow_dispatch -> pull the PUBLISHED quick-start image and run
+#       it as-is (true "what a user gets" smoke test of the latest-dev artifacts).
+#   pull_request (quick-start changes) -> the published image has stale scripts
+#       baked in, so build ONLY the quick-start image from the branch (just `occ`
+#       + the script layer, not the component-image matrix) and run it against
+#       published latest-dev component images and Helm charts. This exercises the
+#       PR's script/Dockerfile diff.
+
+name: Quick Start Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "OpenChoreo version / quick-start image tag to test"
+        required: false
+        type: string
+        default: "latest-dev"
+  schedule:
+    - cron: "0 2 * * *" # nightly at 02:00 UTC (07:30 IST)
+  pull_request:
+    paths:
+      - "install/quick-start/**"
+      - "install/k3d/**"
+      - "samples/from-image/react-starter-web-app/**"
+      - ".github/workflows/test-quick-start.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quick-start-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  QS_IMAGE: ghcr.io/openchoreo/quick-start
+  QS_CONTAINER: openchoreo-quick-start
+
+jobs:
+  quick-start:
+    name: Quick Start (build + observability)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Resolve test mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Build the quick-start image from the branch; component images and
+            # Helm charts still come from published latest-dev.
+            echo "build_from_branch=true" >> "$GITHUB_OUTPUT"
+            echo "version=latest-dev" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_from_branch=false" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.event.inputs.version || 'latest-dev' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Go
+        if: steps.mode.outputs.build_from_branch == 'true'
+        uses: ./.github/actions/setup-go
+
+      - name: Build quick-start image from branch
+        if: steps.mode.outputs.build_from_branch == 'true'
+        # Tags the image ghcr.io/openchoreo/quick-start:latest-dev locally so the
+        # run step below finds it without pulling.
+        run: make docker.build.quick-start TAG=latest-dev
+
+      - name: Pull published quick-start image
+        if: steps.mode.outputs.build_from_branch != 'true'
+        run: docker pull "${QS_IMAGE}:${{ steps.mode.outputs.version }}"
+
+      - name: Start quick-start container
+        # Mirrors the documented `docker run` invocation (host network + docker
+        # socket), detached with a TTY (-dit) so the image's own entrypoint runs:
+        # it configures docker-socket group access for the non-root `openchoreo`
+        # user and drops into a login shell that stays alive. The install/validate/
+        # deploy steps then drive it via `docker exec -u openchoreo`, exactly as a
+        # user typing commands inside the container would. OPENCHOREO_VERSION is
+        # surfaced to those login shells via the entrypoint.
+        run: |
+          docker run -dit \
+            --name "${QS_CONTAINER}" \
+            --network=host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e OPENCHOREO_VERSION="${{ steps.mode.outputs.version }}" \
+            "${QS_IMAGE}:${{ steps.mode.outputs.version }}"
+
+      - name: Wait for docker socket access
+        # Give the entrypoint a moment to wire up the openchoreo user's docker
+        # group before the install relies on it (k3d talks to the host daemon).
+        run: |
+          for _ in $(seq 1 15); do
+            if docker exec -u openchoreo "${QS_CONTAINER}" docker version >/dev/null 2>&1; then
+              echo "openchoreo user can reach the docker daemon"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::openchoreo user could not reach the docker daemon"
+          docker logs "${QS_CONTAINER}" || true
+          exit 1
+
+      - name: Install OpenChoreo (build + observability)
+        run: |
+          docker exec -u openchoreo "${QS_CONTAINER}" \
+            bash -lc './install.sh --with-build --with-observability --version "$OPENCHOREO_VERSION"'
+
+      - name: Validate all planes are healthy
+        # install.sh exports these flags in its own process; a fresh `docker exec`
+        # is a new shell, so pass them explicitly to validate the workflow +
+        # observability planes (not just control + data).
+        run: |
+          docker exec -u openchoreo \
+            -e ENABLE_WORKFLOW_PLANE=true \
+            -e ENABLE_OBSERVABILITY=true \
+            "${QS_CONTAINER}" bash -lc './validate-installation.sh'
+
+      - name: Deploy sample web application
+        # The script waits for ReleaseBinding sync -> Deployment available ->
+        # HTTPRoute accepted and exits non-zero on timeout.
+        run: docker exec -u openchoreo "${QS_CONTAINER}" bash -lc './deploy-react-starter.sh'
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          mkdir -p _diagnostics
+          docker exec -u openchoreo "${QS_CONTAINER}" bash -lc './check-status.sh' > _diagnostics/component-status.txt 2>&1 || true
+          docker exec -u openchoreo "${QS_CONTAINER}" bash -lc 'kubectl get pods -A -o wide' > _diagnostics/pods.txt 2>&1 || true
+          docker exec -u openchoreo "${QS_CONTAINER}" bash -lc 'kubectl get events -A --sort-by=.lastTimestamp' > _diagnostics/events.txt 2>&1 || true
+          for ns in openchoreo-control-plane openchoreo-data-plane openchoreo-workflow-plane openchoreo-observability-plane; do
+            docker exec -u openchoreo "${QS_CONTAINER}" bash -lc "kubectl describe pods -n ${ns}" > "_diagnostics/describe-${ns}.txt" 2>&1 || true
+          done
+          docker logs "${QS_CONTAINER}" > _diagnostics/container.log 2>&1 || true
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: quick-start-diagnostics
+          path: _diagnostics/
+          retention-days: 7
+
+      - name: Tear down quick-start container
+        if: always()
+        run: docker rm -f "${QS_CONTAINER}" 2>/dev/null || true

--- a/install/quick-start/validate-installation.sh
+++ b/install/quick-start/validate-installation.sh
@@ -7,6 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source helper functions
 source "${SCRIPT_DIR}/.helpers.sh"
 
+# Optional planes are validated only when enabled. install.sh exports these
+# flags; when running this script standalone (e.g. via docker exec), pass them
+# explicitly, e.g.:
+#   ENABLE_WORKFLOW_PLANE=true ENABLE_OBSERVABILITY=true ./validate-installation.sh
+ENABLE_WORKFLOW_PLANE="${ENABLE_WORKFLOW_PLANE:-false}"
+ENABLE_OBSERVABILITY="${ENABLE_OBSERVABILITY:-false}"
+
 # Validation functions
 validate_cluster() {
     log_info "Validating k3d cluster..."
@@ -31,9 +38,24 @@ validate_helm_releases() {
     local expected_releases=(
         "openchoreo-data-plane:$DATA_PLANE_NS"
         "openchoreo-control-plane:$CONTROL_PLANE_NS"
-
     )
-    
+
+    if [[ "$ENABLE_WORKFLOW_PLANE" == "true" ]]; then
+        expected_releases+=(
+            "openchoreo-workflow-plane:$WORKFLOW_PLANE_NS"
+            "registry:$WORKFLOW_PLANE_NS"
+        )
+    fi
+
+    if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
+        expected_releases+=(
+            "openchoreo-observability-plane:$OBSERVABILITY_NS"
+            "observability-logs-opensearch:$OBSERVABILITY_NS"
+            "observability-traces-opensearch:$OBSERVABILITY_NS"
+            "observability-metrics-prometheus:$OBSERVABILITY_NS"
+        )
+    fi
+
     local failed_releases=()
     
     for release_info in "${expected_releases[@]}"; do
@@ -60,7 +82,15 @@ validate_namespaces() {
         "$CONTROL_PLANE_NS"
         "$DATA_PLANE_NS"
     )
-    
+
+    if [[ "$ENABLE_WORKFLOW_PLANE" == "true" ]]; then
+        expected_namespaces+=("$WORKFLOW_PLANE_NS")
+    fi
+
+    if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
+        expected_namespaces+=("$OBSERVABILITY_NS")
+    fi
+
     local missing_namespaces=()
     
     for ns in "${expected_namespaces[@]}"; do
@@ -84,7 +114,15 @@ validate_pods() {
         "$CONTROL_PLANE_NS"
         "$DATA_PLANE_NS"
     )
-    
+
+    if [[ "$ENABLE_WORKFLOW_PLANE" == "true" ]]; then
+        namespaces+=("$WORKFLOW_PLANE_NS")
+    fi
+
+    if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
+        namespaces+=("$OBSERVABILITY_NS")
+    fi
+
     local failed_namespaces=()
     
     for ns in "${namespaces[@]}"; do


### PR DESCRIPTION
## Purpose
There is currently no automated check that the [Quick Start Guide](https://openchoreo.dev/docs/next/getting-started/quick-start-guide/) actually works for a user installing OpenChoreo with the **build** and **observability** planes. The existing `make e2e` suite installs OpenChoreo via OCI Helm charts with bespoke `test/e2e/k3d/values-*.yaml` and the `e2e-cp.local` domains — it never runs the quick-start scripts or the `ghcr.io/openchoreo/quick-start` container, so regressions in the actual QSG path go uncaught.

This PR adds an e2e smoke test that runs the real QSG user journey end to end.

## Approach
New workflow `.github/workflows/test-quick-start.yml` runs the `quick-start` container exactly as the docs instruct (host network + mounted docker socket), then drives it via `docker exec`:

1. `./install.sh --with-build --with-observability`
2. `./validate-installation.sh` (all four planes)
3. `./deploy-react-starter.sh` (waits for ReleaseBinding sync → Deployment available → HTTPRoute accepted)

Two modes, by trigger:
- **schedule (nightly) / workflow_dispatch** — pulls the **published** `quick-start` image and runs it as-is (true "what a user gets" smoke test of the `latest-dev` artifacts).
- **pull_request** touching `install/quick-start/**`, `install/k3d/**`, the sample, or the workflow — builds **only** the quick-start image from the branch (`make docker.build.quick-start` — `occ` + the script layer, not the component-image matrix) and runs it against published `latest-dev` component images and Helm charts, so a PR's script/Dockerfile diff is exercised.

`install/quick-start/validate-installation.sh` is made **flag-aware**: when `ENABLE_WORKFLOW_PLANE` / `ENABLE_OBSERVABILITY` are set it additionally validates those namespaces, Helm releases, and pod readiness (previously it asserted only the control and data planes). The workflow passes those flags so the build + observability planes are actually gated.

Diagnostics (component status, pods, events, descriptions, container log) are collected and uploaded on failure; the container is always torn down.

## Related Issues
> N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
- Cadence is **nightly**; since `latest-dev` advances on every merge to `main`, this gives tight signal. Easy to dial back to weekly if it proves heavy.
- The published container runs as the non-root `openchoreo` user; the workflow grants docker-socket access via `--group-add` of the host docker GID. If the first scheduled run shows socket-permission failures on the CI runner, the fix is to switch the `docker run` to `--user root`.
