### PR TITLE
fix: prevent webhook downtime during controller-manager rolling upgrades

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	// +kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
@@ -247,6 +248,16 @@ func setupObservabilityPlaneControllers(mgr ctrl.Manager) error {
 
 // nolint:gocyclo
 func main() {
+	if len(os.Args) == 3 && os.Args[1] == "sleep" {
+		d, err := strconv.Atoi(os.Args[2])
+		if err != nil || d < 0 {
+			fmt.Fprintf(os.Stderr, "usage: manager sleep <seconds>\n")
+			os.Exit(1)
+		}
+		time.Sleep(time.Duration(d) * time.Second)
+		os.Exit(0)
+	}
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
     {{- include "openchoreo-control-plane.componentLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.controllerManager.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.controllerManager.strategy.rollingUpdate.maxSurge }}
   selector:
     matchLabels:
       {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 6 }}
@@ -41,7 +46,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.controllerManager.terminationGracePeriodSeconds }}
       {{- /* No init container needed - Secret is created directly by cert-manager */}}
       containers:
       - name: manager
@@ -91,6 +96,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.controllerManager.resources | nindent 10 }}
+        {{- if and (eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true") (gt (int .Values.controllerManager.preStopSleepSeconds) 0) }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/manager", "sleep", "{{ .Values.controllerManager.preStopSleepSeconds }}"]
+        {{- end }}
         {{- with .Values.controllerManager.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2066,6 +2066,13 @@
           "title": "podSecurityContext",
           "type": "object"
         },
+        "preStopSleepSeconds": {
+          "default": 10,
+          "description": "Seconds to sleep before SIGTERM during pod shutdown, giving kube-apiserver time to de-register the webhook endpoint; set 0 to disable",
+          "minimum": 0,
+          "title": "preStopSleepSeconds",
+          "type": "integer"
+        },
         "priorityClass": {
           "additionalProperties": false,
           "description": "Priority class configuration for pod scheduling priority",
@@ -2211,6 +2218,46 @@
           "required": [],
           "title": "serviceAccount",
           "type": "object"
+        },
+        "strategy": {
+          "additionalProperties": false,
+          "description": "Rolling update strategy; maxUnavailable 0 ensures zero-downtime upgrades for the webhook server",
+          "properties": {
+            "rollingUpdate": {
+              "additionalProperties": false,
+              "properties": {
+                "maxSurge": {
+                  "default": 1,
+                  "description": "Maximum extra pods allowed during a rolling update",
+                  "minimum": 0,
+                  "title": "maxSurge",
+                  "type": "integer"
+                },
+                "maxUnavailable": {
+                  "default": 0,
+                  "description": "Maximum pods that can be unavailable during a rolling update",
+                  "minimum": 0,
+                  "title": "maxUnavailable",
+                  "type": "integer"
+                }
+              },
+              "required": [],
+              "title": "rollingUpdate",
+              "type": "object"
+            }
+          },
+          "required": [
+            "rollingUpdate"
+          ],
+          "title": "strategy",
+          "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+          "default": 30,
+          "description": "Seconds Kubernetes waits before force-killing the pod; must exceed preStopSleepSeconds plus webhook drain time",
+          "minimum": 10,
+          "title": "terminationGracePeriodSeconds",
+          "type": "integer"
         },
         "tolerations": {
           "default": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -166,6 +166,43 @@ controllerManager:
   replicas: 1
 
   # @schema
+  # type: integer
+  # description: Seconds to sleep before SIGTERM during pod shutdown, giving kube-apiserver time to de-register the webhook endpoint; set 0 to disable
+  # minimum: 0
+  # default: 10
+  # @schema
+  preStopSleepSeconds: 10
+
+  # @schema
+  # type: object
+  # description: Rolling update strategy; maxUnavailable 0 ensures zero-downtime upgrades for the webhook server
+  # @schema
+  strategy:
+    rollingUpdate:
+      # @schema
+      # type: integer
+      # description: Maximum pods that can be unavailable during a rolling update
+      # minimum: 0
+      # default: 0
+      # @schema
+      maxUnavailable: 0
+      # @schema
+      # type: integer
+      # description: Maximum extra pods allowed during a rolling update
+      # minimum: 0
+      # default: 1
+      # @schema
+      maxSurge: 1
+
+  # @schema
+  # type: integer
+  # description: Seconds Kubernetes waits before force-killing the pod; must exceed preStopSleepSeconds plus webhook drain time
+  # minimum: 10
+  # default: 30
+  # @schema
+  terminationGracePeriodSeconds: 30
+
+  # @schema
   # type: object
   # description: Container image configuration
   # @schema


### PR DESCRIPTION
Fixes #3723

## What

During a `helm upgrade` that rolls the controller-manager pod, the default rolling strategy (`maxUnavailable: 25%`) terminates the old pod before the new one is ready. With a single replica this leaves the webhook service with zero endpoints, causing any concurrent admission call to fail with `no endpoints available`.

## Changes

**`cmd/main.go`** — adds a `sleep <N>` subcommand so the preStop hook works in the distroless image without requiring shell utilities.

**`install/helm/openchoreo-control-plane`**
- `strategy.rollingUpdate`: `maxUnavailable: 0`, `maxSurge: 1` — new pod must be Ready before old pod is terminated
- `preStopSleepSeconds: 10` — delays SIGTERM via `/manager sleep 10`, giving the kube-apiserver time to de-register the endpoint before the TLS listener closes
- `terminationGracePeriodSeconds: 30` — budget for preStop (10s) + webhook drain

Both `preStopSleepSeconds` and the rolling strategy values are configurable. Set `preStopSleepSeconds: 0` to disable the preStop hook.

## Test

Reproduced and verified on a local k3d cluster:

| Scenario | Webhook calls | Failures |
|---|---|---|
| Broken strategy (`maxUnavailable=1`) | 788 | **181** |
| Rolling strategy fix only | 855 | 0 |
| Rolling strategy + preStop sleep | 1243 | 0 |