### PR TITLE
fix: correct opensearch pod selector in check-status.sh

### DIFF
--- a/install/quick-start/check-status.sh
+++ b/install/quick-start/check-status.sh
@@ -94,7 +94,7 @@ get_component_config() {
         # Observability Plane
         "obs_controller_manager") echo "$OBSERVABILITY_NS:app.kubernetes.io/name=openchoreo-observability-plane,app.kubernetes.io/component=controller-manager" ;;
         "cluster_agent_op") echo "$OBSERVABILITY_NS:app.kubernetes.io/name=openchoreo-observability-plane,app.kubernetes.io/component=cluster-agent" ;;
-        "opensearch") echo "$OBSERVABILITY_NS:opster.io/opensearch-cluster=opensearch" ;;
+        "opensearch") echo "$OBSERVABILITY_NS:app.kubernetes.io/name=opensearch" ;;
         "observer") echo "$OBSERVABILITY_NS:app.kubernetes.io/name=openchoreo-observability-plane,app.kubernetes.io/component=observer" ;;
         *) echo "unknown:unknown" ;;
     esac


### PR DESCRIPTION
Fixes #3283

The `opster.io/opensearch-cluster` label doesn't exist on the opensearch pod. Changed to `app.kubernetes.io/name=opensearch`.