### PR TITLE
test: add full CRUD e2e specs for all PE-ops CRDs

### DIFF
--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -40,7 +40,7 @@ For a fresh install the test identities (PE, Dev, ABAC-restricted) are seeded au
 | `lifecycle/` | Full UI-driven journey: create project + component → deploy → delete, verified against the cluster at each step |
 | `config/` | Component configuration edits through the UI: env vars, secret env vars, file mounts, and per-environment overrides, including form validation |
 | `dev-ops/` | Developer role: can create and view Components; platform-level actions (ComponentType create) are denied server-side |
-| `pe-ops/` | Platform-engineer role: CRUD of ComponentTypes and Traits via Scaffolder templates |
+| `pe-ops/` | Platform-engineer role: full CRUD (create, update, delete) of PE-managed CRDs via a representative subset — ComponentType and Trait (namespace-scoped) + ClusterComponentType and ClusterTrait (cluster-scoped) via the YAML editor scaffolder flow, and Environment + DeploymentPipeline via the FormWithYaml scaffolder flow. The remaining CRDs (Workflow, ResourceType, ClusterWorkflow, ClusterResourceType) follow the identical YAML editor UI path and are covered implicitly. Updates are tested via the Definition tab YAML editor; ComponentType and ClusterComponentType also test invalid-edit rejection. |
 | `abac-ui/` | Environment-conditioned access: deploy/promote allowed up to staging, the production Promote button renders permission-disabled, and the shape survives relogin |
 
 The `pkce-login` and `abac-ui` specs self-skip when their prerequisites are missing (host DNS entries for `occ`, the seeded ABAC identity), so the rest of the suite is unaffected.
@@ -140,7 +140,35 @@ Source: [`specs/dev-ops/dev-ops-component.spec.ts:36`](specs/dev-ops/dev-ops-com
 </details>
 
 <details>
-<summary><b>pe-ops</b> — sign in as PE → create ComponentType and Trait via Scaffolder → kubectl shape check → delete via catalog menu</summary>
+<summary><b>pe-ops (YAML editor)</b> — sign in as PE → create, update, and delete PE CRDs that use the YAML editor scaffolder flow</summary>
+
+Source: [`specs/pe-ops/pe-ops-yaml-editor-crud.spec.ts`](specs/pe-ops/pe-ops-yaml-editor-crud.spec.ts)
+
+For a representative subset — ComponentType and Trait (namespace-scoped), ClusterComponentType and ClusterTrait (cluster-scoped) — covering both scope variants and the invalid-edit branch:
+
+1. Open the Create page and fill the matching Scaffolder template (name + description), advance to the YAML editor step, then submit
+2. Poll kubectl until the CR exists and assert its description and kind round-tripped
+3. Wait (up to 6 min) for the catalog provider to ingest the entity, then open it from the catalog table
+4. Navigate to the Definition tab via the Edit icon, modify the description annotation in the YAML editor, save, and poll kubectl until the change is reflected
+5. Navigate back to the entity page and delete via the overflow menu; poll kubectl until the CR is not-found
+
+</details>
+
+<details>
+<summary><b>pe-ops (FormWithYaml)</b> — sign in as PE → create, update, and delete Environment and DeploymentPipeline via FormWithYaml scaffolder</summary>
+
+Source: [`specs/pe-ops/pe-ops-form-with-yaml-crud.spec.ts`](specs/pe-ops/pe-ops-form-with-yaml-crud.spec.ts)
+
+1. Create an Environment via the form (name, description, auto-selected namespace + dataplane), verify form→YAML→form round-trip preserves values, then submit
+2. Poll kubectl until the Environment CR exists; verify spec shape (isProduction, dataPlaneRef)
+3. Update the description via the Definition tab YAML editor; poll kubectl until reflected
+4. Delete via the overflow menu; poll kubectl until not-found
+5. Create a DeploymentPipeline via the form (name, description), submit, verify shape, update, and delete via the same flow
+
+</details>
+
+<details>
+<summary><b>pe-ops (legacy)</b> — sign in as PE → create ComponentType and Trait via Scaffolder → kubectl shape check → delete via catalog menu</summary>
 
 Source: [`specs/pe-ops/pe-ops-pipeline.spec.ts:59`](specs/pe-ops/pe-ops-pipeline.spec.ts#L59)
 

--- a/test/ui/fixtures/codemirror.ts
+++ b/test/ui/fixtures/codemirror.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Page } from '@playwright/test';
+
+// The YamlEditor component (plugins/openchoreo-react) wraps @uiw/react-codemirror
+// (CodeMirror 6) and sets aria-label="YAML editor" on the .cm-content element.
+// @uiw/react-codemirror attaches the CM6 EditorView to the .cm-content child
+// element as .cmView.view — a stable library-internal path.
+
+/**
+ * Replace the entire content of the CodeMirror 6 YAML editor on the page.
+ *
+ * Uses the CM6 view.dispatch API for reliability. Falls back to select-all +
+ * keyboard type if the view object is inaccessible (e.g. tree-shaken build).
+ */
+export async function cmSetContent(
+  page: Page,
+  yaml: string,
+): Promise<void> {
+  const editor = page.locator('.cm-editor');
+  await editor.first().waitFor({ state: 'visible', timeout: 15_000 });
+
+  const dispatched = await page.evaluate((content: string) => {
+    const el = document.querySelector('.cm-content') as HTMLElement & {
+      cmView?: { view: { state: { doc: { length: number } }; dispatch: (tr: unknown) => void } };
+    };
+    const view = el?.cmView?.view;
+    if (!view) return false;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: content },
+    });
+    return true;
+  }, yaml);
+
+  if (!dispatched) {
+    const content = page.locator('[aria-label="YAML editor"]');
+    await content.click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.type(yaml, { delay: 0 });
+  }
+}
+
+/**
+ * Read the current content of the CodeMirror 6 YAML editor.
+ *
+ * Waits for the editor to be visible and for the CM view to be attached
+ * before reading, so callers don't race a slow render.
+ */
+export async function cmGetContent(
+  page: Page,
+  timeoutMs = 15_000,
+): Promise<string> {
+  await page.locator('.cm-editor').first().waitFor({ state: 'visible', timeout: timeoutMs });
+
+  const content = await page.evaluate((deadline: number) => {
+    return new Promise<string>((resolve, reject) => {
+      const check = () => {
+        const el = document.querySelector('.cm-content') as HTMLElement & {
+          cmView?: { view: { state: { doc: { toString: () => string } } } };
+        };
+        const text = el?.cmView?.view?.state?.doc?.toString();
+        if (text !== undefined) return resolve(text);
+        if (Date.now() > deadline) return reject(new Error('CodeMirror view not ready'));
+        requestAnimationFrame(check);
+      };
+      check();
+    });
+  }, Date.now() + timeoutMs);
+
+  return content;
+}

--- a/test/ui/fixtures/kube.ts
+++ b/test/ui/fixtures/kube.ts
@@ -81,6 +81,47 @@ export function kNotFound(
   return r.stdout.trim() === '';
 }
 
+// kubectl get <kind> <name> -o json, with scope-aware namespace handling.
+// Pass namespace="" for cluster-scoped resources to omit the -n flag.
+export function kGetJSONScoped<T = unknown>(
+  kind: string,
+  name: string,
+  namespace = 'default',
+  opts: KubectlOptions = {},
+): T {
+  const args = ['get', kind, name, '-o', 'json'];
+  if (namespace) args.splice(3, 0, '-n', namespace);
+  const { stdout } = kubectl(args, opts);
+  return JSON.parse(stdout) as T;
+}
+
+// True when `kubectl get` returns NotFound. Scope-aware variant of kNotFound.
+// Pass namespace="" for cluster-scoped resources to omit the -n flag.
+export function kNotFoundScoped(
+  kind: string,
+  name: string,
+  namespace = 'default',
+): boolean {
+  const args = ['get', kind, name, '--ignore-not-found', '-o', 'name'];
+  if (namespace) args.splice(3, 0, '-n', namespace);
+  const r = kubectl(args, { check: false });
+  if (r.status !== 0) return /NotFound/i.test(r.stderr);
+  return r.stdout.trim() === '';
+}
+
+// True when `kubectl get` succeeds. Counterpart to kNotFoundScoped.
+// Pass namespace="" for cluster-scoped resources to omit the -n flag.
+export function kExists(
+  kind: string,
+  name: string,
+  namespace = 'default',
+): boolean {
+  const args = ['get', kind, name, '--ignore-not-found', '-o', 'name'];
+  if (namespace) args.splice(3, 0, '-n', namespace);
+  const r = kubectl(args, { check: false });
+  return r.status === 0 && r.stdout.trim() !== '';
+}
+
 // kubectl apply -f - with the supplied YAML body. Idempotent.
 export function kApplyYAML(yaml: string): KubectlResult {
   return kubectl(['apply', '-f', '-'], { input: yaml });

--- a/test/ui/po/catalogTable.ts
+++ b/test/ui/po/catalogTable.ts
@@ -19,6 +19,13 @@ const KIND_DISPLAY: Record<string, string> = {
   environment: 'Environment',
   deploymentpipeline: 'Deployment Pipeline',
   domain: 'Namespace',
+  workflow: 'Workflow',
+  componentworkflow: 'Component Workflow',
+  resourcetype: 'Resource Type',
+  clustercomponenttype: 'Cluster Component Type',
+  clustertraittype: 'Cluster Trait Type',
+  clusterworkflow: 'Cluster Workflow',
+  clusterresourcetype: 'Cluster Resource Type',
 };
 
 // The catalog route (App.tsx) mounts CustomCatalogPage with initialKind="system",

--- a/test/ui/po/definitionTab.ts
+++ b/test/ui/po/definitionTab.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+// Drives the ResourceDefinitionTab for updating PE resource CRDs. Every PE
+// entity page has a "Definition" tab that renders a YAML editor (CodeMirror 6)
+// with the full CRD. The About card exposes an "Edit" icon button that links
+// to this tab.
+export class DefinitionTabPO {
+  constructor(private readonly page: Page) {}
+
+  async openViaEditIcon(timeoutMs = 60_000): Promise<void> {
+    // The entity page may briefly show "Entity not found" before the About
+    // card (which hosts the Edit icon) renders. Wait for the button.
+    const editBtn = this.page.getByRole('button', { name: 'Edit', exact: true });
+    await editBtn.waitFor({ state: 'visible', timeout: timeoutMs });
+    await editBtn.click();
+    await expect(
+      this.page.getByText(/Definition:/, { exact: false }),
+    ).toBeVisible({ timeout: 30_000 });
+  }
+
+  async openViaTab(): Promise<void> {
+    await this.page
+      .getByRole('tab', { name: /definition/i })
+      .click();
+    await expect(
+      this.page.getByText(/Definition:/, { exact: false }),
+    ).toBeVisible({ timeout: 30_000 });
+  }
+
+  async save(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Save changes', exact: true })
+      .click();
+  }
+
+  async expectSaveSuccess(timeoutMs = 30_000): Promise<void> {
+    await expect(
+      this.page.getByText('Resource saved successfully'),
+    ).toBeVisible({ timeout: timeoutMs });
+  }
+
+  async expectSaveError(timeoutMs = 30_000): Promise<void> {
+    await expect(
+      this.page.getByRole('alert').filter({ hasText: /./}),
+    ).toBeVisible({ timeout: timeoutMs });
+  }
+
+  async getSaveErrorText(timeoutMs = 30_000): Promise<string> {
+    const alert = this.page.getByRole('alert').filter({ hasText: /./ });
+    await expect(alert).toBeVisible({ timeout: timeoutMs });
+    return (await alert.textContent()) ?? '';
+  }
+
+  async dismissError(): Promise<void> {
+    await this.page
+      .getByRole('alert')
+      .getByRole('button', { name: 'Close' })
+      .click();
+  }
+
+  async discard(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: 'Discard changes', exact: true })
+      .click();
+  }
+}

--- a/test/ui/po/scaffolderWizard.ts
+++ b/test/ui/po/scaffolderWizard.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+// Walks the Backstage multi-step scaffolder wizard. The wizard steps are
+// advanced by clicking whichever button is currently visible among
+// "Next", "Review", and "Create". A slow step-render can race a fixed label
+// sequence, so we re-resolve on each iteration.
+export class ScaffolderWizardPO {
+  constructor(private readonly page: Page) {}
+
+  async fillField(label: string, value: string): Promise<void> {
+    await this.page.getByLabel(label, { exact: false }).fill(value);
+  }
+
+  // Fill a MUI v4 text field where the label lacks a `for` attribute and the
+  // input has no `id`. Locates the input via a CSS sibling selector relative
+  // to the label element. Use this for custom form components (e.g.
+  // FormWithYaml templates) that don't wire up standard accessibility attrs.
+  async fillMuiField(label: string, value: string): Promise<void> {
+    const input = this.muiFieldLocator(label);
+    await input.waitFor({ state: 'visible', timeout: 15_000 });
+    await input.fill(value);
+  }
+
+  muiFieldLocator(label: string) {
+    return this.page
+      .locator('label', { hasText: label })
+      .locator('+ div input')
+      .first();
+  }
+
+  async selectMuiOption(label: string, option: string): Promise<void> {
+    const dropdown = this.page
+      .locator('label', { hasText: label })
+      .locator('+ div [role="button"]')
+      .first();
+    await dropdown.waitFor({ state: 'visible', timeout: 15_000 });
+    await dropdown.click();
+    await this.page
+      .getByRole('option', { name: option, exact: true })
+      .click();
+  }
+
+  async waitForMuiSelectValue(label: string, timeoutMs = 15_000): Promise<void> {
+    const input = this.muiFieldLocator(label);
+    await expect(input).not.toHaveValue('', { timeout: timeoutMs });
+  }
+
+  async advanceTo(targetLabel = 'Create'): Promise<void> {
+    for (let i = 0; ; i++) {
+      expect(i, `wizard did not reach ${targetLabel}`).toBeLessThan(10);
+      const btn = this.page
+        .getByRole('button', { name: /^(Next|Review|Create)$/ })
+        .first();
+      await btn.waitFor({ state: 'visible', timeout: 15_000 });
+      const label = (await btn.textContent())?.trim();
+      await expect(btn).toBeEnabled({ timeout: 15_000 });
+      await btn.click();
+      if (label === targetLabel) break;
+    }
+  }
+
+  async next(): Promise<void> {
+    const btn = this.page
+      .getByRole('button', { name: 'Next' })
+      .first();
+    await expect(btn).toBeEnabled({ timeout: 15_000 });
+    await btn.click();
+  }
+
+  async submit(): Promise<void> {
+    await this.advanceTo('Create');
+  }
+
+  async switchToYaml(): Promise<void> {
+    await this.page.getByRole('button', { name: 'YAML', exact: true }).click();
+    await this.expectMode('yaml');
+  }
+
+  async switchToForm(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Form', exact: true }).click();
+    await this.expectMode('form');
+  }
+
+  async expectMode(mode: 'form' | 'yaml'): Promise<void> {
+    const label = mode === 'form' ? 'Form' : 'YAML';
+    await expect(
+      this.page.getByRole('button', { name: label, exact: true }),
+    ).toHaveAttribute('aria-pressed', 'true');
+  }
+}

--- a/test/ui/specs/pe-ops/pe-ops-form-with-yaml-crud.spec.ts
+++ b/test/ui/specs/pe-ops/pe-ops-form-with-yaml-crud.spec.ts
@@ -1,0 +1,225 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import {
+  kGetJSONScoped,
+  kNotFoundScoped,
+  kExists,
+  kDelete,
+} from '../../fixtures/kube';
+import { cmGetContent, cmSetContent } from '../../fixtures/codemirror';
+import { DeletePO } from '../../po/delete';
+import { CreatePO } from '../../po/create';
+import { CatalogTablePO } from '../../po/catalogTable';
+import { ScaffolderWizardPO } from '../../po/scaffolderWizard';
+import { DefinitionTabPO } from '../../po/definitionTab';
+
+// PE CRUD for CRDs that use the FormWithYaml scaffolder pattern:
+//   - A single step with Form/YAML toggle
+//   - Form fields map to specific CRD spec fields
+//   - Switching between form and YAML preserves state
+//
+// Environment is tested first because DeploymentPipeline references
+// environments in its promotion paths.
+
+const ts = Date.now().toString(36);
+
+const ENV_NAME = `peops-env-${ts}`;
+const ENV_DESC = 'e2e form-with-yaml environment';
+const DP_NAME = `peops-dp-${ts}`;
+const DP_DESC = 'e2e form-with-yaml deployment pipeline';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('pe-ops: FormWithYaml CRUD', () => {
+  test.beforeAll(async ({ mintAuthState }) => {
+    await mintAuthState('pe');
+  });
+  test.use({ storageState: storageStateFor('pe') });
+
+  test.afterAll(async () => {
+    kDelete('deploymentpipeline', DP_NAME, 'default');
+    kDelete('environment', ENV_NAME, 'default');
+  });
+
+  test('environment: create via form → form↔yaml round-trip → update → delete', async ({
+    page,
+  }) => {
+    test.setTimeout(300_000);
+    const catalog = new CatalogTablePO(page);
+    const del = new DeletePO(page);
+    const wizard = new ScaffolderWizardPO(page);
+
+    // ── CREATE ──
+    await page.goto('/');
+    await new CreatePO(page).chooseTemplate('Environment');
+
+    // Verify starts in Form mode
+    await wizard.expectMode('form');
+    // Namespace must be explicitly selected; auto-selection is racy
+    await wizard.selectMuiOption('Namespace', 'default');
+    // Wait for Data Plane to auto-populate after namespace selection
+    await wizard.waitForMuiSelectValue('Data Plane');
+    await wizard.fillMuiField('Environment Name', ENV_NAME);
+    await wizard.fillMuiField('Description', ENV_DESC);
+
+    // ── Form → YAML round-trip verification ──
+    await wizard.switchToYaml();
+
+    // Verify form values appear in YAML
+    const yamlContent = await cmGetContent(page);
+    expect(yamlContent).toContain(ENV_NAME);
+    expect(yamlContent).toContain(ENV_DESC);
+
+    // Switch back to Form — verify fields preserved
+    await wizard.switchToForm();
+    await expect(wizard.muiFieldLocator('Environment Name')).toHaveValue(ENV_NAME);
+
+    // Submit via the wizard
+    await wizard.submit();
+
+    // Poll kubectl until the Environment CR exists
+    await expect
+      .poll(
+        () => kExists('environment', ENV_NAME, 'default'),
+        { timeout: 60_000 },
+      )
+      .toBe(true);
+
+    // Verify shape
+    const created = kGetJSONScoped<{
+      kind: string;
+      spec: { isProduction: boolean; dataPlaneRef?: unknown };
+      metadata: { annotations?: Record<string, string> };
+    }>('environment', ENV_NAME, 'default');
+    expect(created.kind).toBe('Environment');
+    // isProduction is omitted (omitempty) when false, so check it's falsy
+    expect(created.spec.isProduction).toBeFalsy();
+    expect(created.spec.dataPlaneRef).toBeTruthy();
+
+    // ── UPDATE via Definition Tab ──
+    await catalog.openEntity('environment', ENV_NAME, 90_000);
+
+    const defTab = new DefinitionTabPO(page);
+    await defTab.openViaEditIcon();
+
+    // Modify the description annotation
+    const updatedDesc = `${ENV_DESC} updated`;
+    const currentYaml = await cmGetContent(page);
+    const newYaml = currentYaml.replace(ENV_DESC, updatedDesc);
+    await cmSetContent(page, newYaml);
+
+    await defTab.save();
+    await defTab.expectSaveSuccess();
+
+    await expect
+      .poll(
+        () => {
+          const obj = kGetJSONScoped<{
+            metadata: { annotations?: Record<string, string> };
+          }>('environment', ENV_NAME, 'default');
+          return obj.metadata.annotations?.['openchoreo.dev/description'];
+        },
+        { timeout: 60_000 },
+      )
+      .toBe(updatedDesc);
+
+    // ── DELETE ──
+    await catalog.openEntity('environment', ENV_NAME, 60_000);
+    await del.openOverflowAndDelete('Environment');
+    await del.confirm();
+
+    await expect
+      .poll(
+        () => kNotFoundScoped('environment', ENV_NAME, 'default'),
+        { timeout: 60_000 },
+      )
+      .toBe(true);
+  });
+
+  test('deploymentpipeline: create via form → update → delete', async ({
+    page,
+  }) => {
+    test.setTimeout(300_000);
+    const catalog = new CatalogTablePO(page);
+    const del = new DeletePO(page);
+    const wizard = new ScaffolderWizardPO(page);
+
+    // ── CREATE ──
+    await page.goto('/');
+    await new CreatePO(page).chooseTemplate('Deployment Pipeline');
+
+    await wizard.expectMode('form');
+    // Namespace must be explicitly selected; auto-selection is racy
+    await wizard.selectMuiOption('Namespace', 'default');
+    await wizard.fillMuiField('Pipeline Name', DP_NAME);
+    await wizard.fillMuiField('Description', DP_DESC);
+
+    // ── Form → YAML round-trip verification ──
+    await wizard.switchToYaml();
+    const yamlContent = await cmGetContent(page);
+    expect(yamlContent).toContain(DP_NAME);
+    expect(yamlContent).toContain(DP_DESC);
+
+    // Switch back to Form — verify fields preserved
+    await wizard.switchToForm();
+    await expect(wizard.muiFieldLocator('Pipeline Name')).toHaveValue(DP_NAME);
+
+    // Submit
+    await wizard.submit();
+
+    // Poll kubectl until the DeploymentPipeline CR exists
+    await expect
+      .poll(
+        () => kExists('deploymentpipeline', DP_NAME, 'default'),
+        { timeout: 60_000 },
+      )
+      .toBe(true);
+
+    // Verify shape
+    const created = kGetJSONScoped<{
+      kind: string;
+      metadata: { annotations?: Record<string, string> };
+    }>('deploymentpipeline', DP_NAME, 'default');
+    expect(created.kind).toBe('DeploymentPipeline');
+
+    // ── UPDATE via Definition Tab ──
+    await catalog.openEntity('deploymentpipeline', DP_NAME, 90_000);
+
+    const defTab = new DefinitionTabPO(page);
+    await defTab.openViaEditIcon();
+
+    const updatedDesc = `${DP_DESC} updated`;
+    const currentYaml = await cmGetContent(page);
+    const newYaml = currentYaml.replace(DP_DESC, updatedDesc);
+    await cmSetContent(page, newYaml);
+
+    await defTab.save();
+    await defTab.expectSaveSuccess();
+
+    await expect
+      .poll(
+        () => {
+          const obj = kGetJSONScoped<{
+            metadata: { annotations?: Record<string, string> };
+          }>('deploymentpipeline', DP_NAME, 'default');
+          return obj.metadata.annotations?.['openchoreo.dev/description'];
+        },
+        { timeout: 60_000 },
+      )
+      .toBe(updatedDesc);
+
+    // ── DELETE ──
+    await catalog.openEntity('deploymentpipeline', DP_NAME, 60_000);
+    await del.openOverflowAndDelete('Deployment Pipeline');
+    await del.confirm();
+
+    await expect
+      .poll(
+        () => kNotFoundScoped('deploymentpipeline', DP_NAME, 'default'),
+        { timeout: 60_000 },
+      )
+      .toBe(true);
+  });
+});

--- a/test/ui/specs/pe-ops/pe-ops-yaml-editor-crud.spec.ts
+++ b/test/ui/specs/pe-ops/pe-ops-yaml-editor-crud.spec.ts
@@ -1,0 +1,232 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect, storageStateFor } from '../../fixtures/auth';
+import {
+  kGetJSONScoped,
+  kNotFoundScoped,
+  kExists,
+  kDelete,
+} from '../../fixtures/kube';
+import { cmSetContent, cmGetContent } from '../../fixtures/codemirror';
+import { DeletePO } from '../../po/delete';
+import { CreatePO } from '../../po/create';
+import { CatalogTablePO } from '../../po/catalogTable';
+import { ScaffolderWizardPO } from '../../po/scaffolderWizard';
+import { DefinitionTabPO } from '../../po/definitionTab';
+
+// PE CRUD for CRDs that use the two-step scaffolder flow:
+//   Step 1: name + description (+ namespace for namespace-scoped)
+//   Step 2: CodeMirror YAML editor (pre-populated from Step 1)
+//
+// Each row exercises: Create via scaffolder → Update via Definition tab → Delete
+// via catalog overflow menu. kubectl cross-checks every mutation.
+
+interface YamlEditorRow {
+  kind: string;
+  crdKind: string;
+  catalogKind: string;
+  templateTitle: string;
+  nameFieldLabel: string;
+  kindDisplayName: string;
+  namespace: string;
+  name: string;
+  description: string;
+  // Returns YAML that should fail server-side validation when saved.
+  // When present, the test verifies that saving shows an error alert
+  // and the invalid change does NOT persist to the cluster.
+  invalidEdit?: (yaml: string) => string;
+}
+
+const ts = Date.now().toString(36);
+
+// One namespace-scoped and one cluster-scoped representative per variation axis:
+//   - with invalidEdit (ComponentType, ClusterComponentType)
+//   - without invalidEdit (Trait, ClusterTrait)
+// The remaining CRDs (Workflow, ResourceType, ClusterWorkflow, ClusterResourceType)
+// follow the identical UI path and are covered implicitly.
+const rows: YamlEditorRow[] = [
+  {
+    kind: 'componenttype',
+    crdKind: 'ComponentType',
+    catalogKind: 'componenttype',
+    templateTitle: 'ComponentType',
+    nameFieldLabel: 'ComponentType Name',
+    kindDisplayName: 'Component Type',
+    namespace: 'default',
+    name: `yaml-ct-${ts}`,
+    description: 'e2e yaml editor component type',
+    invalidEdit: (yaml) => {
+      if (/targetPlane:/.test(yaml))
+        return yaml.replace(/targetPlane:\s*\S+/, 'targetPlane: workflowplane');
+      return yaml.replace(/(resources:)/m, 'targetPlane: workflowplane\n    $1');
+    },
+  },
+  {
+    kind: 'trait',
+    crdKind: 'Trait',
+    catalogKind: 'traittype',
+    templateTitle: 'Trait',
+    nameFieldLabel: 'Trait Name',
+    kindDisplayName: 'Trait Type',
+    namespace: 'default',
+    name: `yaml-trait-${ts}`,
+    description: 'e2e yaml editor trait',
+  },
+  {
+    kind: 'clustercomponenttype',
+    crdKind: 'ClusterComponentType',
+    catalogKind: 'clustercomponenttype',
+    templateTitle: 'ClusterComponentType',
+    nameFieldLabel: 'ClusterComponentType Name',
+    kindDisplayName: 'Cluster Component Type',
+    namespace: '',
+    name: `yaml-cct-${ts}`,
+    description: 'e2e yaml editor cluster component type',
+    invalidEdit: (yaml) => {
+      if (/targetPlane:/.test(yaml))
+        return yaml.replace(/targetPlane:\s*\S+/, 'targetPlane: workflowplane');
+      return yaml.replace(/(resources:)/m, 'targetPlane: workflowplane\n    $1');
+    },
+  },
+  {
+    kind: 'clustertrait',
+    crdKind: 'ClusterTrait',
+    catalogKind: 'clustertraittype',
+    templateTitle: 'ClusterTrait',
+    nameFieldLabel: 'ClusterTrait Name',
+    kindDisplayName: 'Cluster Trait Type',
+    namespace: '',
+    name: `yaml-ctrait-${ts}`,
+    description: 'e2e yaml editor cluster trait',
+  },
+];
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('pe-ops: YAML editor CRUD for PE CRDs', () => {
+  test.beforeAll(async ({ mintAuthState }) => {
+    await mintAuthState('pe');
+  });
+  test.use({ storageState: storageStateFor('pe') });
+
+  test.afterAll(async () => {
+    for (const row of rows) kDelete(row.kind, row.name, row.namespace);
+  });
+
+  for (const row of rows) {
+    test(`${row.kind}: create → update → delete`, async ({ page }) => {
+      test.setTimeout(300_000);
+      const catalog = new CatalogTablePO(page);
+      const del = new DeletePO(page);
+
+      // ── CREATE ──
+      await page.goto('/');
+      await new CreatePO(page).chooseTemplate(row.templateTitle);
+      const wizard = new ScaffolderWizardPO(page);
+
+      await wizard.fillField(row.nameFieldLabel, row.name);
+      await wizard.fillField('Description', row.description);
+
+      // Advance to YAML editor step
+      await wizard.next();
+
+      // Wait for the CodeMirror editor to render and verify it has content
+      // from Step 1 (name + description seeded into the YAML template).
+      const prePopulated = await cmGetContent(page);
+      expect(prePopulated).toContain(row.name);
+
+      // Edit the YAML to prove that create-time changes are wired to
+      // scaffolder state — replace the description in the editor.
+      const createDesc = `${row.description} via yaml`;
+      const editedYaml = prePopulated.replace(row.description, createDesc);
+      await cmSetContent(page, editedYaml);
+
+      // Submit the wizard (Review → Create)
+      await wizard.submit();
+
+      // Poll kubectl until the CR exists
+      await expect
+        .poll(
+          () => kExists(row.kind, row.name, row.namespace),
+          { timeout: 60_000 },
+        )
+        .toBe(true);
+
+      // Verify the YAML-edited description round-tripped into the CRD
+      const created = kGetJSONScoped<{
+        kind: string;
+        metadata: { annotations?: Record<string, string> };
+      }>(row.kind, row.name, row.namespace);
+      expect(created.kind).toBe(row.crdKind);
+      expect(
+        created.metadata.annotations?.['openchoreo.dev/description'],
+      ).toBe(createDesc);
+
+      // ── UPDATE via Definition Tab ──
+      // Wait for catalog provider to ingest the entity, then open it
+      await catalog.openEntity(row.catalogKind, row.name, 90_000);
+
+      const defTab = new DefinitionTabPO(page);
+      await defTab.openViaEditIcon();
+
+      // Modify the description annotation in the YAML
+      const updatedDesc = `${createDesc} updated`;
+      const currentYaml = await cmGetContent(page);
+      const newYaml = currentYaml.replace(createDesc, updatedDesc);
+      await cmSetContent(page, newYaml);
+
+      // Save and verify success
+      await defTab.save();
+      await defTab.expectSaveSuccess();
+
+      // Poll kubectl until the change is reflected
+      await expect
+        .poll(
+          () => {
+            const obj = kGetJSONScoped<{
+              metadata: { annotations?: Record<string, string> };
+            }>(row.kind, row.name, row.namespace);
+            return obj.metadata.annotations?.['openchoreo.dev/description'];
+          },
+          { timeout: 60_000 },
+        )
+        .toBe(updatedDesc);
+
+      // ── INVALID EDIT — verify server rejects bad schema ──
+      if (row.invalidEdit) {
+        const validYaml = await cmGetContent(page);
+        const badYaml = row.invalidEdit(validYaml);
+        expect(badYaml, 'invalidEdit must mutate the YAML').not.toBe(validYaml);
+
+        await cmSetContent(page, badYaml);
+        await defTab.save();
+        await defTab.expectSaveError();
+
+        // Verify the invalid change did NOT persist to the cluster
+        const afterReject = kGetJSONScoped<{
+          spec: { targetPlane?: string };
+        }>(row.kind, row.name, row.namespace);
+        expect(afterReject.spec.targetPlane).not.toBe('workflowplane');
+
+        // Discard the invalid change so the editor is clean for delete
+        await defTab.discard();
+      }
+
+      // ── DELETE ──
+      // Navigate back to the entity page via catalog
+      await catalog.openEntity(row.catalogKind, row.name, 60_000);
+
+      await del.openOverflowAndDelete(row.kindDisplayName);
+      await del.confirm();
+
+      // Poll kubectl until the CR is gone
+      await expect
+        .poll(
+          () => kNotFoundScoped(row.kind, row.name, row.namespace),
+          { timeout: 60_000 },
+        )
+        .toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Cover create, update, invalid-edit, and delete flows for CRD types across two scaffolder patterns: YAML-editor (ComponentType + cluster-scoped variants) and FormWithYaml (Environment, DeploymentPipeline). Includes CodeMirror 6 interaction helpers, Definition Tab page object, form↔YAML toggle verification, and scope-aware kubectl fixtures for cluster-scoped resources.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
