### PR TITLE
chore: add quick start test to e2e gate workflow

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -7,6 +7,8 @@
 #   tier1, tier2 — control plane + data plane only
 #   tier3       — multi-cluster (4 separate k3d clusters, one per plane)
 #   ui          — full stack + Backstage portal (Playwright)
+#   quick-start — published quick-start container, the documented Quick Start
+#                 Guide journey (all four planes + sample deploy)
 #
 # Callers: the scheduled e2e workflows (test-e2e, test-e2e-extended,
 # test-ui-e2e) and the release-orchestrator e2e gate. Also manually
@@ -47,6 +49,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_quick_start:
+        description: "Run the Quick Start smoke leg (published quick-start container, all four planes + sample deploy)"
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       ref:
@@ -76,6 +83,11 @@ on:
         default: true
       run_ui:
         description: "Run the Playwright UI leg (full stack + Backstage)"
+        required: false
+        type: boolean
+        default: true
+      run_quick_start:
+        description: "Run the Quick Start smoke leg (published quick-start container, all four planes + sample deploy)"
         required: false
         type: boolean
         default: true
@@ -457,3 +469,12 @@ jobs:
       - name: Delete e2e cluster
         if: always()
         run: make e2e.down || true
+
+  quick-start:
+    name: E2E (Quick Start Smoke)
+    if: ${{ inputs.run_quick_start }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test-quick-start.yml
+    with:
+      helm_chart_version: ${{ inputs.helm_chart_version }}

--- a/.github/workflows/test-e2e-extended.yml
+++ b/.github/workflows/test-e2e-extended.yml
@@ -31,3 +31,4 @@ jobs:
       run_tier2: false
       run_tier3: true
       run_ui: false
+      run_quick_start: false

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -29,3 +29,4 @@ jobs:
       run_tier2: true
       run_tier3: false
       run_ui: false
+      run_quick_start: false

--- a/.github/workflows/test-quick-start.yml
+++ b/.github/workflows/test-quick-start.yml
@@ -30,6 +30,13 @@ on:
         required: false
         type: string
         default: "latest-dev"
+  workflow_call:
+    inputs:
+      helm_chart_version:
+        description: "Helm chart version (e.g., 0.0.0-latest-dev or 0.0.0-<sha>); the quick-start image tag is the bare suffix"
+        required: false
+        type: string
+        default: "0.0.0-latest-dev"
   schedule:
     - cron: "0 2 * * *" # nightly at 02:00 UTC (07:30 IST)
   pull_request:
@@ -61,17 +68,45 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate Helm chart version
+        if: ${{ inputs.helm_chart_version != '' }}
+        env:
+          HELM_CHART_VERSION: ${{ inputs.helm_chart_version }}
+        run: |
+          if [ -z "${HELM_CHART_VERSION}" ]; then
+            echo "::error::HELM_CHART_VERSION is required"
+            exit 1
+          fi
+          case "${HELM_CHART_VERSION}" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::HELM_CHART_VERSION contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
       - name: Resolve test mode
         id: mode
+        # Inputs are read via env, never expanded directly into the shell body,
+        # so a crafted version string cannot inject commands.
+        env:
+          HELM_CHART_VERSION: ${{ inputs.helm_chart_version }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version || 'latest-dev' }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Build the quick-start image from the branch; component images and
             # Helm charts still come from published latest-dev.
             echo "build_from_branch=true" >> "$GITHUB_OUTPUT"
             echo "version=latest-dev" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${HELM_CHART_VERSION}" ]]; then
+            # Invoked by the e2e gate: it passes a Helm chart version
+            # (0.0.0-latest-dev, 0.0.0-<sha>), validated above. build-and-test
+            # publishes the quick-start image under the bare suffix, so strip
+            # the prefix.
+            echo "build_from_branch=false" >> "$GITHUB_OUTPUT"
+            echo "version=${HELM_CHART_VERSION#0.0.0-}" >> "$GITHUB_OUTPUT"
           else
             echo "build_from_branch=false" >> "$GITHUB_OUTPUT"
-            echo "version=${{ github.event.inputs.version || 'latest-dev' }}" >> "$GITHUB_OUTPUT"
+            echo "version=${DISPATCH_VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Go

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -34,3 +34,4 @@ jobs:
       run_tier2: false
       run_tier3: false
       run_ui: true
+      run_quick_start: false


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds quick start setup testing workflow as a job to the e2e gate. This will block release tagging based on quick start setup test pass status as well

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3588

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
