### PR TITLE
feat: expose data plane annotations to the render context

### DIFF
--- a/internal/controller/reference.go
+++ b/internal/controller/reference.go
@@ -67,6 +67,10 @@ func (r *DataPlaneResult) ToDataPlane() *openchoreov1alpha1.DataPlane {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: r.ClusterDataPlane.Name,
 				UID:  r.ClusterDataPlane.UID,
+				// Carry annotations so they reach the render context (dataplane.annotations)
+				// the same way whether the environment references a namespaced DataPlane or a
+				// cluster-scoped ClusterDataPlane.
+				Annotations: r.ClusterDataPlane.Annotations,
 			},
 			Spec: openchoreov1alpha1.DataPlaneSpec{
 				PlaneID:               r.ClusterDataPlane.Spec.PlaneID,

--- a/internal/controller/reference_test.go
+++ b/internal/controller/reference_test.go
@@ -760,8 +760,9 @@ func TestDataPlaneResult_ToDataPlane_WithDataPlane(t *testing.T) {
 func TestDataPlaneResult_ToDataPlane_WithClusterDataPlane(t *testing.T) {
 	cdp := &openchoreov1alpha1.ClusterDataPlane{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster-dp",
-			UID:  "cdp-uid-456",
+			Name:        "cluster-dp",
+			UID:         "cdp-uid-456",
+			Annotations: map[string]string{"example.com/team": "platform"},
 		},
 		Spec: openchoreov1alpha1.ClusterDataPlaneSpec{
 			PlaneID: "shared-plane",
@@ -800,6 +801,10 @@ func TestDataPlaneResult_ToDataPlane_WithClusterDataPlane(t *testing.T) {
 	require.NotNil(t, got.Spec.ObservabilityPlaneRef)
 	assert.Equal(t, openchoreov1alpha1.ObservabilityPlaneRefKindClusterObservabilityPlane, got.Spec.ObservabilityPlaneRef.Kind)
 	assert.Equal(t, "shared-obs", got.Spec.ObservabilityPlaneRef.Name)
+
+	// Annotations must carry onto the facade so they reach the render context
+	// (dataplane.annotations) for ClusterDataPlane-backed environments too.
+	assert.Equal(t, "platform", got.Annotations["example.com/team"])
 }
 
 func TestDataPlaneResult_ToDataPlane_WithClusterDataPlane_NoObsRef(t *testing.T) {

--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -1559,6 +1559,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.findConsumerReleaseBindingsForResourceReleaseBinding),
 			builder.WithPredicates(resourceReleaseBindingOutputsChangedPredicate()),
 		).
+		// A DataPlane's annotations and spec feed the render context (annotations are exposed
+		// to CEL as dataplane.annotations), so re-render the bindings that use it when it
+		// changes instead of waiting for the periodic resync.
+		Watches(
+			&openchoreov1alpha1.DataPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForDataPlane),
+			builder.WithPredicates(dataPlaneRenderInputsChangedPredicate()),
+		).
+		Watches(
+			&openchoreov1alpha1.ClusterDataPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForClusterDataPlane),
+			builder.WithPredicates(dataPlaneRenderInputsChangedPredicate()),
+		).
 		Named("releasebinding").
 		Complete(r)
 }

--- a/internal/controller/releasebinding/controller_watch.go
+++ b/internal/controller/releasebinding/controller_watch.go
@@ -5,6 +5,7 @@ package releasebinding
 
 import (
 	"context"
+	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
@@ -346,10 +347,18 @@ func (r *Reconciler) findReleaseBindingsForComponent(ctx context.Context, obj cl
 	return requests
 }
 
-// dataPlaneRenderInputsChangedPredicate passes when a (Cluster)DataPlane's annotations or
-// spec change. Render reads inputs from both: the spec (gateway, secretStore) and the
-// annotations (surfaced to CEL as dataplane.annotations). A change to either must re-render
-// the bindings that use this data plane rather than waiting for the periodic resync.
+// dataPlaneRenderInputsChangedPredicate passes when a (Cluster)DataPlane's spec or its
+// openchoreo.dev/-prefixed annotations change. Render reads inputs from both: the spec
+// (gateway, secretStore) and the annotations (surfaced to CEL as dataplane.annotations).
+// A change to either must re-render the bindings that use this data plane rather than
+// waiting for the periodic resync.
+//
+// Only platform-owned (openchoreo.dev/) annotations trigger a re-render. Render still
+// exposes every annotation to CEL, but matching on the whole map would fan out a wasted
+// re-render to every dependent binding on any third-party churn (GitOps sync stamps,
+// kubectl.kubernetes.io/last-applied-configuration). A non-prefixed annotation that a
+// template happens to read is still picked up by the periodic resync.
+//
 // Status-only updates are ignored to avoid needless reconciles.
 func dataPlaneRenderInputsChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
@@ -363,9 +372,27 @@ func dataPlaneRenderInputsChangedPredicate() predicate.Predicate {
 			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
 				return true // spec changed
 			}
-			return !apiequality.Semantic.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
+			return openchoreoAnnotationsChanged(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
 		},
 	}
+}
+
+// openchoreoAnnotationPrefix scopes the annotation-change trigger to platform-owned keys.
+const openchoreoAnnotationPrefix = "openchoreo.dev/"
+
+// openchoreoAnnotationsChanged reports whether the openchoreo.dev/-prefixed subset of two
+// annotation maps differs, ignoring annotations set by other tooling.
+func openchoreoAnnotationsChanged(oldAnn, newAnn map[string]string) bool {
+	pick := func(m map[string]string) map[string]string {
+		out := make(map[string]string, len(m))
+		for k, v := range m {
+			if strings.HasPrefix(k, openchoreoAnnotationPrefix) {
+				out[k] = v
+			}
+		}
+		return out
+	}
+	return !apiequality.Semantic.DeepEqual(pick(oldAnn), pick(newAnn))
 }
 
 // findReleaseBindingsForDataPlane enqueues every ReleaseBinding whose target Environment

--- a/internal/controller/releasebinding/controller_watch.go
+++ b/internal/controller/releasebinding/controller_watch.go
@@ -346,6 +346,106 @@ func (r *Reconciler) findReleaseBindingsForComponent(ctx context.Context, obj cl
 	return requests
 }
 
+// dataPlaneRenderInputsChangedPredicate passes when a (Cluster)DataPlane's annotations or
+// spec change. Render reads inputs from both: the spec (gateway, secretStore) and the
+// annotations (surfaced to CEL as dataplane.annotations). A change to either must re-render
+// the bindings that use this data plane rather than waiting for the periodic resync.
+// Status-only updates are ignored to avoid needless reconciles.
+func dataPlaneRenderInputsChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(_ event.CreateEvent) bool { return true },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true // spec changed
+			}
+			return !apiequality.Semantic.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
+		},
+	}
+}
+
+// findReleaseBindingsForDataPlane enqueues every ReleaseBinding whose target Environment
+// references the changed namespace-scoped DataPlane.
+func (r *Reconciler) findReleaseBindingsForDataPlane(ctx context.Context, obj client.Object) []reconcile.Request {
+	dp, ok := obj.(*openchoreov1alpha1.DataPlane)
+	if !ok {
+		return nil
+	}
+	return r.releaseBindingsForDataPlaneRef(ctx, dp.Namespace, openchoreov1alpha1.DataPlaneRefKindDataPlane, dp.Name)
+}
+
+// findReleaseBindingsForClusterDataPlane enqueues every ReleaseBinding whose target
+// Environment references the changed cluster-scoped ClusterDataPlane. ClusterDataPlanes can be
+// referenced from any namespace, so the scan is cluster-wide.
+func (r *Reconciler) findReleaseBindingsForClusterDataPlane(ctx context.Context, obj client.Object) []reconcile.Request {
+	cdp, ok := obj.(*openchoreov1alpha1.ClusterDataPlane)
+	if !ok {
+		return nil
+	}
+	return r.releaseBindingsForDataPlaneRef(ctx, "", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, cdp.Name)
+}
+
+// releaseBindingsForDataPlaneRef returns reconcile requests for the ReleaseBindings whose target
+// Environment references the given data plane (kind+name). When namespace is empty the
+// Environment scan is cluster-wide (used for ClusterDataPlane). Environments that resolve to a
+// data plane only via the ClusterDataPlane "default" fallback are not matched here; the periodic
+// resync remains the backstop for that edge.
+func (r *Reconciler) releaseBindingsForDataPlaneRef(
+	ctx context.Context, namespace string, kind openchoreov1alpha1.DataPlaneRefKind, name string,
+) []reconcile.Request {
+	logger := log.FromContext(ctx)
+
+	var envs openchoreov1alpha1.EnvironmentList
+	var listOpts []client.ListOption
+	if namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+	if err := r.List(ctx, &envs, listOpts...); err != nil {
+		logger.Error(err, "Failed to list Environments for data plane change", "kind", kind, "dataPlane", name)
+		return nil
+	}
+
+	// Group the matching environment names by namespace so each namespace is listed once.
+	envsByNamespace := make(map[string]map[string]struct{})
+	for i := range envs.Items {
+		env := &envs.Items[i]
+		ref := env.Spec.DataPlaneRef
+		if ref == nil || ref.Kind != kind || ref.Name != name {
+			continue
+		}
+		if envsByNamespace[env.Namespace] == nil {
+			envsByNamespace[env.Namespace] = make(map[string]struct{})
+		}
+		envsByNamespace[env.Namespace][env.Name] = struct{}{}
+	}
+	if len(envsByNamespace) == 0 {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for ns, envNames := range envsByNamespace {
+		var bindings openchoreov1alpha1.ReleaseBindingList
+		if err := r.List(ctx, &bindings, client.InNamespace(ns)); err != nil {
+			logger.Error(err, "Failed to list ReleaseBindings for data plane change", "namespace", ns, "dataPlane", name)
+			continue
+		}
+		for i := range bindings.Items {
+			rb := &bindings.Items[i]
+			if _, match := envNames[rb.Spec.Environment]; !match {
+				continue
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace},
+			})
+		}
+	}
+	return requests
+}
+
 // collectSecretReferenceNames extracts SecretReference names from a merged workload.
 // This is used to populate status.secretReferenceNames for the field index.
 func collectSecretReferenceNames(workload *openchoreov1alpha1.Workload, releaseBinding *openchoreov1alpha1.ReleaseBinding) []string {

--- a/internal/controller/releasebinding/controller_watch_dataplane_test.go
+++ b/internal/controller/releasebinding/controller_watch_dataplane_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+func dataPlaneObj(generation int64, annotations map[string]string) *openchoreov1alpha1.DataPlane {
+	return &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Generation: generation, Annotations: annotations},
+	}
+}
+
+// TestDataPlaneRenderInputsChangedPredicate locks the contract that a data plane re-renders
+// dependent bindings on an annotation or spec change, but not on status-only churn.
+func TestDataPlaneRenderInputsChangedPredicate(t *testing.T) {
+	p := dataPlaneRenderInputsChangedPredicate()
+
+	assert.True(t, p.Create(event.CreateEvent{Object: dataPlaneObj(1, nil)}), "create should pass")
+	assert.False(t, p.Delete(event.DeleteEvent{Object: dataPlaneObj(1, nil)}), "delete should be ignored")
+	assert.False(t, p.Generic(event.GenericEvent{Object: dataPlaneObj(1, nil)}), "generic should be ignored")
+
+	cases := []struct {
+		name         string
+		oldDP, newDP *openchoreov1alpha1.DataPlane
+		want         bool
+	}{
+		{"annotation_added", dataPlaneObj(1, nil), dataPlaneObj(1, map[string]string{"k": "v"}), true},
+		{"annotation_value_changed", dataPlaneObj(1, map[string]string{"k": "v1"}), dataPlaneObj(1, map[string]string{"k": "v2"}), true},
+		{"annotation_removed", dataPlaneObj(1, map[string]string{"k": "v"}), dataPlaneObj(1, nil), true},
+		{"spec_generation_changed", dataPlaneObj(1, map[string]string{"k": "v"}), dataPlaneObj(2, map[string]string{"k": "v"}), true},
+		{"no_op_same_gen_and_annotations", dataPlaneObj(1, map[string]string{"k": "v"}), dataPlaneObj(1, map[string]string{"k": "v"}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.Update(event.UpdateEvent{ObjectOld: tc.oldDP, ObjectNew: tc.newDP})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func watchTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(s))
+	return s
+}
+
+func envRef(ns, name string, kind openchoreov1alpha1.DataPlaneRefKind, dpName string) *openchoreov1alpha1.Environment {
+	return &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{Kind: kind, Name: dpName},
+		},
+	}
+}
+
+func bindingFor(ns, name, environment string) *openchoreov1alpha1.ReleaseBinding {
+	return &openchoreov1alpha1.ReleaseBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       openchoreov1alpha1.ReleaseBindingSpec{Environment: environment},
+	}
+}
+
+func requestNames(reqs []reconcile.Request) []string {
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func newReconcilerWith(t *testing.T, objs ...client.Object) *Reconciler {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(watchTestScheme(t)).WithObjects(objs...).Build()
+	return &Reconciler{Client: c}
+}
+
+// TestFindReleaseBindingsForDataPlane: a namespaced DataPlane change enqueues only the bindings
+// whose target environment references that DataPlane by matching kind+name, within its namespace.
+func TestFindReleaseBindingsForDataPlane(t *testing.T) {
+	ctx := context.Background()
+	r := newReconcilerWith(t,
+		envRef("org", "env-a", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-a"),
+		envRef("org", "env-b", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-b"),
+		envRef("org", "env-cdp", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, "dp-a"), // kind mismatch
+		bindingFor("org", "rb-a", "env-a"),
+		bindingFor("org", "rb-b", "env-b"),
+		bindingFor("org", "rb-cdp", "env-cdp"),
+	)
+
+	t.Run("matches_only_bindings_for_that_dataplane", func(t *testing.T) {
+		reqs := r.findReleaseBindingsForDataPlane(ctx,
+			&openchoreov1alpha1.DataPlane{ObjectMeta: metav1.ObjectMeta{Namespace: "org", Name: "dp-a"}})
+		assert.ElementsMatch(t, []string{"rb-a"}, requestNames(reqs))
+	})
+
+	t.Run("no_referencing_environment_yields_nothing", func(t *testing.T) {
+		reqs := r.findReleaseBindingsForDataPlane(ctx,
+			&openchoreov1alpha1.DataPlane{ObjectMeta: metav1.ObjectMeta{Namespace: "org", Name: "dp-none"}})
+		assert.Empty(t, reqs)
+	})
+
+	t.Run("environment_without_binding_yields_nothing", func(t *testing.T) {
+		r2 := newReconcilerWith(t,
+			envRef("org", "env-only", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-x"),
+		)
+		reqs := r2.findReleaseBindingsForDataPlane(ctx,
+			&openchoreov1alpha1.DataPlane{ObjectMeta: metav1.ObjectMeta{Namespace: "org", Name: "dp-x"}})
+		assert.Empty(t, reqs)
+	})
+}
+
+// TestFindReleaseBindingsForClusterDataPlane: a cluster-scoped DataPlane change scans every
+// namespace and enqueues the bindings of environments that reference it (kind ClusterDataPlane),
+// while a namespaced DataPlane of the same name must not match.
+func TestFindReleaseBindingsForClusterDataPlane(t *testing.T) {
+	ctx := context.Background()
+	r := newReconcilerWith(t,
+		envRef("org1", "env-1", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, "cdp"),
+		envRef("org2", "env-2", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, "cdp"),
+		envRef("org1", "env-ns", openchoreov1alpha1.DataPlaneRefKindDataPlane, "cdp"), // kind mismatch
+		bindingFor("org1", "rb-1", "env-1"),
+		bindingFor("org2", "rb-2", "env-2"),
+		bindingFor("org1", "rb-ns", "env-ns"),
+	)
+
+	reqs := r.findReleaseBindingsForClusterDataPlane(ctx,
+		&openchoreov1alpha1.ClusterDataPlane{ObjectMeta: metav1.ObjectMeta{Name: "cdp"}})
+	assert.ElementsMatch(t, []string{"rb-1", "rb-2"}, requestNames(reqs))
+}

--- a/internal/controller/releasebinding/controller_watch_dataplane_test.go
+++ b/internal/controller/releasebinding/controller_watch_dataplane_test.go
@@ -26,7 +26,8 @@ func dataPlaneObj(generation int64, annotations map[string]string) *openchoreov1
 }
 
 // TestDataPlaneRenderInputsChangedPredicate locks the contract that a data plane re-renders
-// dependent bindings on an annotation or spec change, but not on status-only churn.
+// dependent bindings on a spec change or an openchoreo.dev/-prefixed annotation change, but
+// not on status-only churn or third-party annotations (GitOps stamps, kubectl metadata).
 func TestDataPlaneRenderInputsChangedPredicate(t *testing.T) {
 	p := dataPlaneRenderInputsChangedPredicate()
 
@@ -34,16 +35,20 @@ func TestDataPlaneRenderInputsChangedPredicate(t *testing.T) {
 	assert.False(t, p.Delete(event.DeleteEvent{Object: dataPlaneObj(1, nil)}), "delete should be ignored")
 	assert.False(t, p.Generic(event.GenericEvent{Object: dataPlaneObj(1, nil)}), "generic should be ignored")
 
+	const oc = "openchoreo.dev/scaling"
 	cases := []struct {
 		name         string
 		oldDP, newDP *openchoreov1alpha1.DataPlane
 		want         bool
 	}{
-		{"annotation_added", dataPlaneObj(1, nil), dataPlaneObj(1, map[string]string{"k": "v"}), true},
-		{"annotation_value_changed", dataPlaneObj(1, map[string]string{"k": "v1"}), dataPlaneObj(1, map[string]string{"k": "v2"}), true},
-		{"annotation_removed", dataPlaneObj(1, map[string]string{"k": "v"}), dataPlaneObj(1, nil), true},
-		{"spec_generation_changed", dataPlaneObj(1, map[string]string{"k": "v"}), dataPlaneObj(2, map[string]string{"k": "v"}), true},
-		{"no_op_same_gen_and_annotations", dataPlaneObj(1, map[string]string{"k": "v"}), dataPlaneObj(1, map[string]string{"k": "v"}), false},
+		{"openchoreo_annotation_added", dataPlaneObj(1, nil), dataPlaneObj(1, map[string]string{oc: "knative"}), true},
+		{"openchoreo_annotation_value_changed", dataPlaneObj(1, map[string]string{oc: "knative"}), dataPlaneObj(1, map[string]string{oc: "keda"}), true},
+		{"openchoreo_annotation_removed", dataPlaneObj(1, map[string]string{oc: "knative"}), dataPlaneObj(1, nil), true},
+		{"spec_generation_changed", dataPlaneObj(1, map[string]string{oc: "knative"}), dataPlaneObj(2, map[string]string{oc: "knative"}), true},
+		{"third_party_annotation_added", dataPlaneObj(1, nil), dataPlaneObj(1, map[string]string{"fluxcd.io/sync": "ts"}), false},
+		{"last_applied_config_added", dataPlaneObj(1, nil), dataPlaneObj(1, map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"}), false},
+		{"third_party_changes_openchoreo_stable", dataPlaneObj(1, map[string]string{oc: "knative", "fluxcd.io/sync": "a"}), dataPlaneObj(1, map[string]string{oc: "knative", "fluxcd.io/sync": "b"}), false},
+		{"no_op_same_gen_and_annotations", dataPlaneObj(1, map[string]string{oc: "knative"}), dataPlaneObj(1, map[string]string{oc: "knative"}), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -169,6 +169,7 @@ func extractParameters(raw *runtime.RawExtension) (map[string]any, error) {
 // extractDataPlaneData extracts DataPlaneData from a DataPlane resource.
 func extractDataPlaneData(dp *v1alpha1.DataPlane) DataPlaneData {
 	data := DataPlaneData{}
+	data.Annotations = dp.GetAnnotations()
 	if dp.Spec.SecretStoreRef != nil {
 		data.SecretStore = dp.Spec.SecretStoreRef.Name
 	}

--- a/internal/pipeline/component/context/dataplane_test.go
+++ b/internal/pipeline/component/context/dataplane_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/template"
+)
+
+// readAnnotationExpr is the defensive read pattern templates use to pull a DataPlane
+// annotation from the render context, defaulting when the key (or the whole annotations
+// map) is absent. The generic feature is "any template can read any DataPlane annotation
+// from CEL"; this expression exercises exactly that contract.
+func readAnnotationExpr(key, def string) string {
+	return fmt.Sprintf(`${has(dataplane.annotations) && %q in dataplane.annotations ? dataplane.annotations[%q] : %q}`, key, key, def)
+}
+
+// dataPlaneCELMap builds the CEL "dataplane" input the way the pipeline does: extract the
+// DataPlaneData from the resource, then convert it to the map[string]any CEL evaluates against.
+func dataPlaneCELMap(t *testing.T, dp *v1alpha1.DataPlane) map[string]any {
+	t.Helper()
+	m, err := structToMap(extractDataPlaneData(dp))
+	require.NoError(t, err)
+	return m
+}
+
+func TestExtractDataPlaneData_Annotations(t *testing.T) {
+	t.Run("surfaces_all_annotations_verbatim", func(t *testing.T) {
+		dp := &v1alpha1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"example.com/team":         "platform",
+					"example.com/tier":         "gold",
+					"plain-key":                "v",
+					"example.com/empty":        "", // empty value must still be present
+					"sub.domain.example.com/x": "dotted-and-slashed",
+				},
+			},
+		}
+
+		data := extractDataPlaneData(dp)
+		require.NotNil(t, data.Annotations)
+		assert.Len(t, data.Annotations, 5)
+		assert.Equal(t, "platform", data.Annotations["example.com/team"])
+		assert.Equal(t, "dotted-and-slashed", data.Annotations["sub.domain.example.com/x"])
+
+		// All keys survive the struct->map conversion CEL evaluates against.
+		m := dataPlaneCELMap(t, dp)
+		ann, ok := m["annotations"].(map[string]any)
+		require.True(t, ok, "annotations should be present in the CEL map")
+		assert.Equal(t, "platform", ann["example.com/team"])
+		assert.Equal(t, "gold", ann["example.com/tier"])
+		assert.Equal(t, "", ann["example.com/empty"])
+		assert.Equal(t, "dotted-and-slashed", ann["sub.domain.example.com/x"])
+	})
+
+	t.Run("omitted_when_no_annotations", func(t *testing.T) {
+		data := extractDataPlaneData(&v1alpha1.DataPlane{})
+		assert.Nil(t, data.Annotations)
+
+		// omitempty drops the nil map, so the CEL "dataplane" object stays {} (no fixture
+		// churn) and guarded reads still resolve without a missing-key error.
+		m := dataPlaneCELMap(t, &v1alpha1.DataPlane{})
+		_, present := m["annotations"]
+		assert.False(t, present, "nil annotations should be omitted from the CEL map")
+	})
+}
+
+// TestDataPlaneAnnotations_CELRead proves arbitrary annotations are readable from CEL through
+// the real template engine, across the edge cases: present key, domain-prefixed key, empty
+// value, absent key (map present), and entirely-absent annotations. None of these error.
+func TestDataPlaneAnnotations_CELRead(t *testing.T) {
+	engine := template.NewEngine()
+
+	withAnnotations := &v1alpha1.DataPlane{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		"example.com/team":  "platform",
+		"example.com/empty": "",
+	}}}
+	noAnnotations := &v1alpha1.DataPlane{}
+
+	cases := []struct {
+		name string
+		dp   *v1alpha1.DataPlane
+		key  string
+		want string
+	}{
+		{name: "present_key", dp: withAnnotations, key: "example.com/team", want: "platform"},
+		{name: "empty_value_is_present", dp: withAnnotations, key: "example.com/empty", want: ""},
+		{name: "absent_key_with_map_present", dp: withAnnotations, key: "example.com/missing", want: "<default>"},
+		{name: "absent_annotations_map", dp: noAnnotations, key: "example.com/team", want: "<default>"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := map[string]any{"dataplane": dataPlaneCELMap(t, tc.dp)}
+			got, err := engine.Render(readAnnotationExpr(tc.key, "<default>"), inputs)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("direct_index_of_present_key", func(t *testing.T) {
+		inputs := map[string]any{"dataplane": dataPlaneCELMap(t, withAnnotations)}
+		got, err := engine.Render(`${dataplane.annotations["example.com/team"]}`, inputs)
+		require.NoError(t, err)
+		assert.Equal(t, "platform", got)
+	})
+}

--- a/internal/pipeline/component/context/types.go
+++ b/internal/pipeline/component/context/types.go
@@ -261,6 +261,12 @@ type DataPlaneData struct {
 	SecretStore           string                     `json:"secretStore,omitempty"`
 	Gateway               *GatewayData               `json:"gateway,omitempty"`
 	ObservabilityPlaneRef *ObservabilityPlaneRefData `json:"observabilityPlaneRef,omitempty"`
+
+	// Annotations are the DataPlane's metadata.annotations, surfaced verbatim so templates
+	// can read platform-set hints from the data plane. Read defensively, e.g.
+	// has(dataplane.annotations) && "key" in dataplane.annotations, since the map is absent
+	// when the DataPlane has no annotations.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // GatewayData provides gateway configuration in templates.


### PR DESCRIPTION
## Purpose

Part of the scale-to-zero (Elastic) module epic #3104, and the core change from the proposal in #3744. It is the first implementation slice tracked by #3753.

The proposal keeps core generic. Rather than teaching core about scaling, a data plane advertises what it supports and traits render against it. Today the render context exposes a DataPlane's spec, like its gateway and secret store, but not its annotations. So a data plane has no way to pass a platform-set hint, such as which scaling backend it runs, to a template. This adds that.

## Approach

Annotations are surfaced as `dataplane.annotations` in the CEL render context, so any component or trait template can read them. A typed capabilities field was the other option, but that means a core change for every new hint, so annotations keep the set open.

- `extractDataPlaneData` copies `metadata.annotations` into the render context. It is omitted when empty, so guarded reads like `has(dataplane.annotations) && "k" in dataplane.annotations` still resolve and existing fixtures don't change.
- The ClusterDataPlane facade in `ToDataPlane` carries annotations too, so a cluster-scoped data plane renders the same as a namespaced one.
- The ReleaseBinding controller now watches DataPlane and ClusterDataPlane. When a data plane's annotations or spec change, the bindings that use it re-render rather than waiting for the periodic resync. A predicate ignores status-only updates.

## Related Issues

Closes #3753
Part of #3104
Design: #3752
Proposal: #3744

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

The watch matches environments that name a data plane through an explicit `dataPlaneRef`. Environments that fall back to the default plane are not matched, so a change to the default plane's annotations reaches them on the next periodic resync rather than straight away. That is fine for the current use, and it is noted on #3753 to revisit alongside the trait work.
