### PR TITLE
fix: add validation to restrict replica count for 1 in cluster gateway

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -162,6 +162,27 @@ Cluster Gateway resource name
 {{- end }}
 
 {{/*
+Cluster Gateway must run as a singleton.
+
+The gateway keeps every cluster agent's live WebSocket connection (and the
+authorization state derived from its client certificate) in process memory via
+the in-memory ConnectionManager. That state is not shared between pods, so
+running more than one replica would split agent connections across pods: a
+request routed to a pod that does not hold the target agent's connection
+fails. Until the gateway supports shared/sticky connection state it must be
+deployed with exactly one replica.
+
+Include this from any template that consumes clusterGateway.replicas to
+fail-fast (at `helm template`/`helm install` time) on an invalid value.
+*/}}
+{{- define "openchoreo-control-plane.clusterGateway.validateReplicas" -}}
+{{- $replicas := int .Values.clusterGateway.replicas -}}
+{{- if ne $replicas 1 -}}
+{{- fail (printf "\n\nINVALID VALUE: clusterGateway.replicas=%d\n\nThe cluster gateway must run as a singleton (clusterGateway.replicas=1).\nIt holds cluster-agent WebSocket connections in process memory, so multiple\nreplicas would split that connection state across pods and break agent\nconnectivity. Set clusterGateway.replicas=1 (the default).\n" $replicas) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Cluster Gateway service account name
 */}}
 {{- define "openchoreo-control-plane.clusterGateway.serviceAccountName" -}}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "openchoreo-control-plane.clusterGateway.validateReplicas" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1228,7 +1228,8 @@
         },
         "replicas": {
           "default": 1,
-          "description": "Number of cluster gateway replicas",
+          "description": "Number of cluster gateway replicas. Must be 1 - the gateway holds cluster-agent WebSocket connections in process memory and cannot be horizontally scaled. Provide support in upcoming release.",
+          "maximum": 1,
           "minimum": 1,
           "title": "replicas",
           "type": "integer"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3167,13 +3167,15 @@ clusterGateway:
   name: cluster-gateway
 
   # type: integer
-  # description: Number of cluster gateway replicas
+  # description: Number of cluster gateway replicas. Must be 1 - the gateway holds cluster-agent WebSocket connections in process memory and cannot be horizontally scaled. Provide support in upcoming release.
   # minimum: 1
+  # maximum: 1
   # default: 1
   # @schema
   # type: integer
-  # description: Number of cluster gateway replicas
+  # description: Number of cluster gateway replicas. Must be 1 - the gateway holds cluster-agent WebSocket connections in process memory and cannot be horizontally scaled. Provide support in upcoming release.
   # minimum: 1
+  # maximum: 1
   # default: 1
   # @schema
   replicas: 1


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Currently, we allow users to edit replica count in Clustergateway, but we have not designed it to work with multiple replicas. We have a plan to fix this [issue](https://github.com/openchoreo/openchoreo/issues/3232) in the long term. Until then, we send a message if the replica count is greater than 1.

## Approach
Add a validation to reject any value other than 1.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3232

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
