### PR TITLE
chore: pin builder, run, and lifecycle images by digest

### DIFF
--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -86,8 +86,10 @@ spec:
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
             export DOCKER_HOST=unix:///run/podman/podman.sock
 
-            BUILDER="docker.io/paketobuildpacks/builder-jammy-full:0.3.603"
-            RUN_IMG="docker.io/paketobuildpacks/run-jammy-full:0.1.130"
+            # docker.io/paketobuildpacks/builder-jammy-full:0.3.603
+            BUILDER="docker.io/paketobuildpacks/builder-jammy-full@sha256:9824e8d6e79f0b01f422dfd4062347a451956a1439cfe7874c42ca88418901dc"
+            # docker.io/paketobuildpacks/run-jammy-full:0.1.130
+            RUN_IMG="docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac"
 
             # Build --env flags
             ENV_ARGS=""
@@ -295,8 +297,10 @@ spec:
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
             export DOCKER_HOST=unix:///run/podman/podman.sock
 
-            BUILDER="ghcr.io/openchoreo/buildpack/ballerina:18"
-            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina:18-run"
+            # ghcr.io/openchoreo/buildpack/ballerina:18
+            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd"
+            # ghcr.io/openchoreo/buildpack/ballerina:18-run
+            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:cae91b6892095e0215f22208799f432646d74ad0b05f9a764a532dbeccb9f94c"
 
             # Build --env flags
             ENV_ARGS=""

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -72,8 +72,10 @@ spec:
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
             export DOCKER_HOST=unix:///run/podman/podman.sock
 
-            BUILDER="ghcr.io/openchoreo/buildpack/ballerina:18"
-            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina:18-run"
+            # ghcr.io/openchoreo/buildpack/ballerina:18
+            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd"
+            # ghcr.io/openchoreo/buildpack/ballerina:18-run
+            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:cae91b6892095e0215f22208799f432646d74ad0b05f9a764a532dbeccb9f94c"
 
             # Build --env flags
             ENV_ARGS=""

--- a/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
@@ -69,8 +69,10 @@ spec:
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
             export DOCKER_HOST=unix:///run/podman/podman.sock
 
-            BUILDER="docker.io/paketobuildpacks/builder-jammy-full:0.3.603"
-            RUN_IMG="docker.io/paketobuildpacks/run-jammy-full:0.1.130"
+            # docker.io/paketobuildpacks/builder-jammy-full:0.3.603
+            BUILDER="docker.io/paketobuildpacks/builder-jammy-full@sha256:9824e8d6e79f0b01f422dfd4062347a451956a1439cfe7874c42ca88418901dc"
+            # docker.io/paketobuildpacks/run-jammy-full:0.1.130
+            RUN_IMG="docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac"
 
             # Build --env flags
             ENV_ARGS=""


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Buildpack builder/run/lifecycle images directly determine the bytes of the produced application image, yet several were referenced by mutable tags. Combined with `--pull-policy always`, every build silently re-resolved those tags, leaving builds open to tag drift and tag-hijacking. Pin them to immutable `@sha256` digests for reproducible, tamper-resistant builds.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
