### PR TITLE
fix: scope save-error alert locator to fix flaky pe-ops yaml editor test

### DIFF
--- a/test/ui/po/definitionTab.ts
+++ b/test/ui/po/definitionTab.ts
@@ -1,7 +1,12 @@
 // Copyright 2026 The OpenChoreo Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+// Copy shown by the Definition tab's success Snackbar after a valid save.
+// Referenced both to assert success and to exclude that Snackbar when
+// locating an error alert (see saveErrorAlert).
+const SAVE_SUCCESS_MESSAGE = 'Resource saved successfully';
 
 // Drives the ResourceDefinitionTab for updating PE resource CRDs. Every PE
 // entity page has a "Definition" tab that renders a YAML editor (CodeMirror 6)
@@ -38,25 +43,35 @@ export class DefinitionTabPO {
 
   async expectSaveSuccess(timeoutMs = 30_000): Promise<void> {
     await expect(
-      this.page.getByText('Resource saved successfully'),
+      this.page.getByText(SAVE_SUCCESS_MESSAGE),
     ).toBeVisible({ timeout: timeoutMs });
+  }
+
+  // The save error alert, scoped to exclude the success Snackbar. After a
+  // valid save the success Snackbar ("Resource saved successfully") auto-hides
+  // on a timer, so it can still be mounted as role="alert" when a subsequent
+  // save surfaces a validation error. Matching every non-empty alert would
+  // then resolve to two elements and trip Playwright's strict-mode check, so
+  // we target the error alert as "an alert that is not the success message".
+  private saveErrorAlert(): Locator {
+    return this.page
+      .getByRole('alert')
+      .filter({ hasText: /\S/ })
+      .filter({ hasNotText: SAVE_SUCCESS_MESSAGE });
   }
 
   async expectSaveError(timeoutMs = 30_000): Promise<void> {
-    await expect(
-      this.page.getByRole('alert').filter({ hasText: /./}),
-    ).toBeVisible({ timeout: timeoutMs });
+    await expect(this.saveErrorAlert()).toBeVisible({ timeout: timeoutMs });
   }
 
   async getSaveErrorText(timeoutMs = 30_000): Promise<string> {
-    const alert = this.page.getByRole('alert').filter({ hasText: /./ });
+    const alert = this.saveErrorAlert();
     await expect(alert).toBeVisible({ timeout: timeoutMs });
     return (await alert.textContent()) ?? '';
   }
 
   async dismissError(): Promise<void> {
-    await this.page
-      .getByRole('alert')
+    await this.saveErrorAlert()
       .getByRole('button', { name: 'Close' })
       .click();
   }


### PR DESCRIPTION
## Purpose
The pe-ops YAML editor CRUD UI e2e test (`pe-ops-yaml-editor-crud.spec.ts`) fails intermittently in the UI e2e gate. After a valid save the "Resource saved successfully" snackbar lingers as a `role="alert"` element while the subsequent validation-error alert appears, so the save-error locator matches two alerts and trips Playwright's strict-mode check. This PR scopes the save-error locator in `DefinitionTabPO` to exclude the success snackbar.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)