### PR TITLE
feat: route agent LLM calls through an OpenAI-compatible gateway

### DIFF
--- a/agents/finops-agent/src/clients/llm.py
+++ b/agents/finops-agent/src/clients/llm.py
@@ -20,8 +20,8 @@ def get_model(
     # module) when configured; the real provider key then lives at the gateway
     # so api_key may be a placeholder. Forward base_url only when set to leave
     # the direct-to-provider path unchanged.
-    if settings.llm_base_url and "base_url" not in kwargs:
-        kwargs["base_url"] = settings.llm_base_url
+    if settings.finops_agent_llm_base_url and "base_url" not in kwargs:
+        kwargs["base_url"] = settings.finops_agent_llm_base_url
     return init_chat_model(
         model=model_name,
         api_key=api_key,

--- a/agents/finops-agent/src/clients/llm.py
+++ b/agents/finops-agent/src/clients/llm.py
@@ -16,6 +16,12 @@ def get_model(
     api_key: str = settings.llm_api_key,
     **kwargs: Any,
 ) -> BaseChatModel:
+    # Route through an OpenAI-compatible proxy (the ai-gateway-agentgateway
+    # module) when configured; the real provider key then lives at the gateway
+    # so api_key may be a placeholder. Forward base_url only when set to leave
+    # the direct-to-provider path unchanged.
+    if settings.llm_base_url and "base_url" not in kwargs:
+        kwargs["base_url"] = settings.llm_base_url
     return init_chat_model(
         model=model_name,
         api_key=api_key,

--- a/agents/finops-agent/src/config.py
+++ b/agents/finops-agent/src/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
 
     llm_name: str = ""
     llm_api_key: str = ""
-    llm_base_url: str = ""
+    finops_agent_llm_base_url: str = ""
 
     observability_mcp_server_url: str = "http://observer:8080/mcp"
     opencost_mcp_server_url: str = (

--- a/agents/finops-agent/src/config.py
+++ b/agents/finops-agent/src/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
 
     llm_name: str = ""
     llm_api_key: str = ""
+    llm_base_url: str = ""
 
     observability_mcp_server_url: str = "http://observer:8080/mcp"
     opencost_mcp_server_url: str = (

--- a/agents/portal-assistant/src/clients/llm.py
+++ b/agents/portal-assistant/src/clients/llm.py
@@ -26,6 +26,12 @@ def get_model(
 ) -> BaseChatModel:
     model_name = model_name or settings.portal_assistant_model_name
     api_key = api_key or settings.portal_assistant_llm_api_key
+    # Route through an OpenAI-compatible proxy (the ai-gateway-agentgateway
+    # module) when configured; the real provider key then lives at the gateway
+    # so api_key may be a placeholder. Forward base_url only when set to leave
+    # the direct-to-provider path unchanged.
+    if settings.portal_assistant_llm_base_url and "base_url" not in kwargs:
+        kwargs["base_url"] = settings.portal_assistant_llm_base_url
     # OpenAI gpt-5 / o-series reasoning_effort. ``init_chat_model`` forwards
     # unknown kwargs to the provider class (langchain-openai's ChatOpenAI),
     # which accepts ``reasoning_effort`` as a first-class field. Only pass

--- a/agents/portal-assistant/src/config.py
+++ b/agents/portal-assistant/src/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     # LLM — independent of rca-agent so ops can pick a cheaper model for chat.
     portal_assistant_model_name: str = ""
     portal_assistant_llm_api_key: str = ""
+    portal_assistant_llm_base_url: str = ""
     # OpenAI gpt-5 / o-series reasoning effort. One of "minimal" /
     # "low" / "medium" / "high"; empty string leaves the model on its
     # default (medium for gpt-5-mini). Reasoning tokens are generated

--- a/agents/sre-agent/src/clients/llm.py
+++ b/agents/sre-agent/src/clients/llm.py
@@ -16,4 +16,10 @@ def get_model(
     api_key: str = settings.rca_llm_api_key,
     **kwargs: Any,
 ) -> BaseChatModel:
+    # Route through an OpenAI-compatible proxy (the ai-gateway-agentgateway
+    # module) when configured; the real provider key then lives at the gateway
+    # so api_key may be a placeholder. Forward base_url only when set to leave
+    # the direct-to-provider path unchanged.
+    if settings.rca_llm_base_url and "base_url" not in kwargs:
+        kwargs["base_url"] = settings.rca_llm_base_url
     return init_chat_model(model=model_name, api_key=api_key, **kwargs)

--- a/agents/sre-agent/src/config.py
+++ b/agents/sre-agent/src/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
 
     rca_model_name: str = ""
     rca_llm_api_key: str = ""
+    rca_llm_base_url: str = ""
 
     observer_api_url: str = "http://observer:8080"
     openchoreo_api_url: str = "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"

--- a/install/helm/openchoreo-control-plane/templates/portal-assistant/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/portal-assistant/configmap.yaml
@@ -12,6 +12,9 @@ data:
   OBSERVER_API_URL: {{ .Values.portalAssistant.config.observerApiUrl | quote }}
   RCA_AGENT_API_URL: {{ default "" .Values.portalAssistant.config.rcaAgentApiUrl | quote }}
   PORTAL_ASSISTANT_MODEL_NAME: {{ .Values.portalAssistant.llm.modelName | quote }}
+  {{- if .Values.portalAssistant.llm.baseUrl }}
+  PORTAL_ASSISTANT_LLM_BASE_URL: {{ .Values.portalAssistant.llm.baseUrl | quote }}
+  {{- end }}
   MAX_CONCURRENT_CHATS: {{ .Values.portalAssistant.config.maxConcurrentChats | quote }}
   AUTHZ_TIMEOUT_SECONDS: {{ .Values.portalAssistant.config.authzTimeoutSeconds | quote }}
   JWKS_URL_TLS_INSECURE_SKIP_VERIFY: {{ .Values.security.oidc.jwksUrlTlsInsecureSkipVerify | default "false" | quote }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -4215,6 +4215,12 @@
         "llm": {
           "additionalProperties": false,
           "properties": {
+            "baseUrl": {
+              "default": "",
+              "description": "Optional OpenAI-compatible base URL. Set to route LLM calls through the\nai-gateway-agentgateway module (e.g. http://agentgateway-proxy.openchoreo-data-plane)\ninstead of the provider directly; the provider key is then managed at the\ngateway and the secret's PORTAL_ASSISTANT_LLM_API_KEY may be a placeholder.",
+              "title": "baseUrl",
+              "type": "string"
+            },
             "modelName": {
               "default": "",
               "title": "modelName",
@@ -4228,7 +4234,8 @@
           },
           "required": [
             "secretName",
-            "modelName"
+            "modelName",
+            "baseUrl"
           ],
           "title": "llm",
           "type": "object"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3886,6 +3886,11 @@ portalAssistant:
   llm:
     secretName: ""
     modelName: ""
+    # Optional OpenAI-compatible base URL. Set to route LLM calls through the
+    # ai-gateway-agentgateway module (e.g. http://agentgateway-proxy.openchoreo-data-plane)
+    # instead of the provider directly; the provider key is then managed at the
+    # gateway and the secret's PORTAL_ASSISTANT_LLM_API_KEY may be a placeholder.
+    baseUrl: ""
 
   config:
     openchoreoApiUrl: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"

--- a/install/helm/openchoreo-observability-plane/templates/finops-agent/config-map.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/finops-agent/config-map.yaml
@@ -14,6 +14,9 @@ data:
   CORS_ALLOWED_ORIGINS: {{ join "," .Values.finOpsAgent.cors.allowedOrigins | quote }}
   {{- end }}
   LLM_NAME: {{ .Values.finOpsAgent.llmName | quote }}
+  {{- if .Values.finOpsAgent.llmBaseUrl }}
+  LLM_BASE_URL: {{ .Values.finOpsAgent.llmBaseUrl | quote }}
+  {{- end }}
   JWT_AUDIENCE: {{ .Values.security.jwt.audience | quote }}
   JWT_ISSUER: {{ .Values.security.oidc.issuer | quote }}
   JWT_JWKS_URL: {{ .Values.security.oidc.jwksUrl | quote }}

--- a/install/helm/openchoreo-observability-plane/templates/finops-agent/config-map.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/finops-agent/config-map.yaml
@@ -15,7 +15,7 @@ data:
   {{- end }}
   LLM_NAME: {{ .Values.finOpsAgent.llmName | quote }}
   {{- if .Values.finOpsAgent.llmBaseUrl }}
-  LLM_BASE_URL: {{ .Values.finOpsAgent.llmBaseUrl | quote }}
+  FINOPS_AGENT_LLM_BASE_URL: {{ .Values.finOpsAgent.llmBaseUrl | quote }}
   {{- end }}
   JWT_AUDIENCE: {{ .Values.security.jwt.audience | quote }}
   JWT_ISSUER: {{ .Values.security.oidc.issuer | quote }}

--- a/install/helm/openchoreo-observability-plane/templates/sre-agent/rca-agent-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/sre-agent/rca-agent-config.yaml
@@ -11,6 +11,9 @@ data:
   OPENCHOREO_API_URL: {{ .Values.rca.openchoreoApiUrl | quote }}
   AUTHZ_TIMEOUT_SECONDS: {{ .Values.rca.authz.timeoutSeconds | quote }}
   RCA_MODEL_NAME: {{ .Values.rca.llm.modelName | quote }}
+  {{- if .Values.rca.llm.baseUrl }}
+  RCA_LLM_BASE_URL: {{ .Values.rca.llm.baseUrl | quote }}
+  {{- end }}
   REPORT_BACKEND: {{ .Values.rca.reportBackend | quote }}
   OAUTH_TOKEN_URL: {{ .Values.security.oidc.tokenUrl | quote }}
   OAUTH_CLIENT_ID: {{ .Values.rca.oauth.clientId | quote }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -949,6 +949,12 @@
           "title": "image",
           "type": "object"
         },
+        "llmBaseUrl": {
+          "default": "",
+          "description": "Optional OpenAI-compatible base URL for LLM calls. Set this to route through the ai-gateway-agentgateway module (e.g., http://agentgateway-proxy.openchoreo-data-plane) instead of calling the provider directly. When set, the provider API key is managed at the gateway and LLM_API_KEY may be a placeholder.",
+          "title": "llmBaseUrl",
+          "type": "string"
+        },
         "llmName": {
           "default": "",
           "description": "LLM model name (e.g., gpt-5.2)",
@@ -1763,6 +1769,12 @@
           "additionalProperties": false,
           "description": "LLM configuration for AI-powered analysis",
           "properties": {
+            "baseUrl": {
+              "default": "",
+              "description": "Optional OpenAI-compatible base URL for LLM calls. Set this to route through the ai-gateway-agentgateway module (e.g., http://agentgateway-proxy.openchoreo-data-plane) instead of calling the provider directly. When set, the provider API key is managed at the gateway and RCA_LLM_API_KEY may be a placeholder.",
+              "title": "baseUrl",
+              "type": "string"
+            },
             "modelName": {
               "default": "",
               "description": "LLM model name (e.g., gpt-5.2)",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1435,6 +1435,13 @@ rca:
     # @schema
     modelName: ""
 
+    # @schema
+    # type: string
+    # description: Optional OpenAI-compatible base URL for LLM calls. Set this to route through the ai-gateway-agentgateway module (e.g., http://agentgateway-proxy.openchoreo-data-plane) instead of calling the provider directly. When set, the provider API key is managed at the gateway and RCA_LLM_API_KEY may be a placeholder.
+    # default: ""
+    # @schema
+    baseUrl: ""
+
 
   # @schema
   # description: Report storage backend type
@@ -1670,6 +1677,13 @@ finOpsAgent:
   # default: ""
   # @schema
   llmName: ""
+
+  # @schema
+  # type: string
+  # description: Optional OpenAI-compatible base URL for LLM calls. Set this to route through the ai-gateway-agentgateway module (e.g., http://agentgateway-proxy.openchoreo-data-plane) instead of calling the provider directly. When set, the provider API key is managed at the gateway and LLM_API_KEY may be a placeholder.
+  # default: ""
+  # @schema
+  llmBaseUrl: ""
 
   # @schema
   # description: Report storage backend type


### PR DESCRIPTION
## Purpose

The FinOps, Portal Assistant, and SRE agents currently call their LLM provider (OpenAI) directly with a baked-in API key. This means each agent has to manage provider credentials itself, and switching providers, adding PII guardrails, or applying rate limits requires code/config changes per agent.

This PR lets these agents route their LLM traffic through an **OpenAI-compatible gateway** — specifically the [`ai-gateway-agentgateway`](https://github.com/openchoreo/community-modules/tree/main/ai-gateway-agentgateway) community module — so that provider key management, provider switching, PII guardrails, and rate limiting become a platform/gateway concern instead of an application concern. This is an opt-in change that "dogfoods" OpenChoreo's own AI gateway capability for the internal agents.

## Approach

The agents already build their LLM via LangChain's `init_chat_model`, which accepts a `base_url`. The change is therefore minimal and additive:

- **Agents** (`agents/finops-agent`, `agents/portal-assistant`, `agents/sre-agent`): add an optional base URL setting (`llm_base_url` / `portal_assistant_llm_base_url` / `rca_llm_base_url`) and forward it as `base_url` to `init_chat_model` **only when set**, leaving the direct-to-provider path byte-for-byte unchanged when it is empty. When routed through the gateway, the provider key lives at the gateway, so the agent's own LLM API key may be a placeholder.
- **Helm**: add opt-in values `finOpsAgent.llmBaseUrl`, `rca.llm.baseUrl`, and `portalAssistant.llm.baseUrl`, rendered into the agent ConfigMaps as `LLM_BASE_URL` / `RCA_LLM_BASE_URL` / `PORTAL_ASSISTANT_LLM_BASE_URL`. The env var is **omitted entirely when the value is empty**, so existing deployments are unaffected.
- Regenerated `values.schema.json` for the control-plane and observability-plane charts via `make helm-generate`.

Behavior is fully backward compatible: with the new values unset (the default), nothing changes.

### Usage example

```bash
helm upgrade ... \
  --set finOpsAgent.llmBaseUrl=http://agentgateway-proxy.openchoreo-data-plane \
  --set finOpsAgent.llmName=openai:gpt-5
```

## Related Issues

> None. Happy to link an issue if maintainers would prefer one tracked first.

## Checklist

- [ ] Tests added or updated (unit, integration, etc.) — _no behavioral change to existing paths; the new path is a thin pass-through of `base_url` to `init_chat_model`. Guidance welcome on whether a unit test per agent is desired._
- [x] Samples updated (if applicable) — _not applicable._
- [ ] Added `backport/<release-branch>` label if this should be backported — _not needed unless maintainers want it in a release branch._

## Remarks

- **Cross-plane reachability**: the FinOps/SRE agents run in the observability plane and the portal-assistant in the control plane, while `agentgateway-proxy` lives in `openchoreo-data-plane`. The value accepts any URL, so operators can point it at whatever address is routable from those planes. The default is empty, so this is opt-in and does not assume any topology.
- Verified locally: `make lint` clean, `make code.gen-check` passes with no diff, and `helm lint` passes for both regenerated charts. `helm template` confirms the `*_LLM_BASE_URL` env var renders when the value is set and is omitted when unset.
