### PR TITLE
test: fix ClusterTrait catalog wait and pkce-login diagnostics

### DIFF
--- a/test/ui/specs/auth/pkce-login.spec.ts
+++ b/test/ui/specs/auth/pkce-login.spec.ts
@@ -127,24 +127,33 @@ test.describe('pkce-login: occ login drives PKCE through the Backstage browser',
 
     const child = spawn(occ, ['login', '--credential', 'ui-pkce'], { env });
 
+    // Capture occ's output so a non-zero exit surfaces the cause (the token
+    // exchange is host-side and never appears in the browser trace).
+    let loginStdout = '';
+    let loginStderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      loginStdout += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      loginStderr += chunk.toString('utf8');
+    });
+
     const authURL = await new Promise<string>((resolve, reject) => {
-      let stdout = '';
-      let stderr = '';
       const timer = setTimeout(
-        () => reject(new Error(`timed out waiting for auth URL on stdout\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`)),
+        () => reject(new Error(`timed out waiting for auth URL on stdout\n--- stdout ---\n${loginStdout}\n--- stderr ---\n${loginStderr}`)),
         30_000,
       );
-      child.stdout.on('data', (chunk: Buffer) => {
-        stdout += chunk.toString('utf8');
-        const m = stdout.match(/https?:\/\/[^\s]+\/oauth2\/authorize\S*/);
+      const onData = () => {
+        const m = loginStdout.match(/https?:\/\/[^\s]+\/oauth2\/authorize\S*/);
         if (m) {
           clearTimeout(timer);
+          child.stdout.off('data', onData);
           resolve(m[0]);
         }
-      });
-      child.stderr.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString('utf8');
-      });
+      };
+      child.stdout.on('data', onData);
+      // The URL may have been buffered before this listener attached.
+      onData();
       child.on('error', err => {
         clearTimeout(timer);
         reject(err);
@@ -153,7 +162,7 @@ test.describe('pkce-login: occ login drives PKCE through the Backstage browser',
         clearTimeout(timer);
         reject(
           new Error(
-            `occ login exited ${code} before printing auth URL\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+            `occ login exited ${code} before printing auth URL\n--- stdout ---\n${loginStdout}\n--- stderr ---\n${loginStderr}`,
           ),
         );
       });
@@ -183,7 +192,10 @@ test.describe('pkce-login: occ login drives PKCE through the Backstage browser',
     // success page rendered by occ's local server; the CLI process should
     // then exit 0.
     const exitCode = await exitPromise;
-    expect(exitCode).toBe(0);
+    expect(
+      exitCode,
+      `occ login exited ${exitCode}\n--- stdout ---\n${loginStdout}\n--- stderr ---\n${loginStderr}`,
+    ).toBe(0);
 
     // Verify a token round-trip via a follow-on occ call (occ has no
     // kubectl-style `get` verb — listing is noun-first and project-scoped;

--- a/test/ui/specs/pe-ops/pe-ops-clustertrait.spec.ts
+++ b/test/ui/specs/pe-ops/pe-ops-clustertrait.spec.ts
@@ -86,7 +86,9 @@ test.describe('pe-ops: ClusterTrait lifecycle via scaffolder', () => {
     // The scaffolder action registers ClusterTraits as kind=ClusterTraitType in
     // the "openchoreo-cluster" namespace (entityRef format:
     // clustertraittype:openchoreo-cluster/{name}).
-    // Poll until the catalog provider syncs the new entity.
+    // Poll until the catalog provider syncs the entity: reload, then waitFor
+    // (auto-waiting) the heading — a one-shot isVisible() right after goto fires
+    // before the SPA paints the <h1>.
     await expect
       .poll(
         async () => {
@@ -96,10 +98,11 @@ test.describe('pe-ops: ClusterTrait lifecycle via scaffolder', () => {
           return page
             .getByRole('heading', { name: CLUSTER_TRAIT_NAME })
             .first()
-            .isVisible({ timeout: 5_000 })
+            .waitFor({ state: 'visible', timeout: 10_000 })
+            .then(() => true)
             .catch(() => false);
         },
-        { timeout: 120_000, intervals: [5_000] },
+        { timeout: 120_000, intervals: [2_000] },
       )
       .toBe(true);
   });


### PR DESCRIPTION
## Purpose

The E2E gate's UI (Playwright) leg fails on two pe-ops specs:

- `pe-ops-clustertrait`: the catalog-visibility check used a one-shot `isVisible()` that fired before the Backstage SPA rendered the heading — a deterministic 120s timeout. It now auto-waits with `waitFor()`.
- `pkce-login`: a non-zero `occ login` exit reported only a bare exit code. It now captures occ's stdout/stderr so the host-side cause is surfaced (the token exchange is invisible to the browser trace).

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

The gate's third UI failure, trait attach/detach (`workloadConfig.ts`), is already fixed with #3783.