### PR TITLE
feat(helm): add timeout policies to Backstage wirelogs streaming route

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/httproute.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/httproute.yaml
@@ -35,6 +35,16 @@ spec:
       backendRefs:
         - name: {{ include "openchoreo-control-plane.backstage.name" $ }}
           port: {{ .Values.backstage.service.port }}
+    - name: wirelogs
+      matches:
+        - path:
+            type: PathPrefix
+            value: /api/openchoreo/wirelogs/stream
+      timeouts:
+        backendRequest: "0s"
+      backendRefs:
+        - name: {{ include "openchoreo-control-plane.backstage.name" $ }}
+          port: {{ .Values.backstage.service.port }}
     - matches:
         - path:
             type: PathPrefix

--- a/install/helm/openchoreo-control-plane/templates/backstage/traffic-policy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/traffic-policy.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.backstage.enabled .Values.backstage.http.enabled .Values.gateway.enabled .Values.backstage.http.hostnames -}}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: {{ include "openchoreo-control-plane.backstage.name" . }}-wirelogs-timeout
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "openchoreo-control-plane.backstage.name" . }}
+      sectionName: wirelogs
+  timeouts:
+    request: "0s"
+    streamIdle: "24h"
+{{- end }}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Adds a new Backstage HTTPRoute for the wirelogs streaming endpoint (`/api/openchoreo/wirelogs/stream`) with proper timeout configuration via a Kubernetes TrafficPolicy resource. This enables long-lived streaming connections for wire-level logs without request timeouts.


## Approach
- **HTTPRoute Update**: Added a new route `wirelogs` in the Backstage gateway configuration that matches requests to `/api/openchoreo/wirelogs/stream` and sets backend request timeout to `0s` (disabled)
- **TrafficPolicy**: Created a new `TrafficPolicy` resource that applies to the wirelogs route section, setting:
  - `request: "0s"` — no request timeout for streaming connections
  - `streamIdle: "24h"` — idle timeout for long-lived streams


## Related Issues
https://github.com/openchoreo/openchoreo/issues/3294

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
