### PR TITLE
feat(api): resolve branch-head commit SHA for workflow runs triggered without an explicit commit

### DIFF
--- a/internal/openchoreo-api/services/git/bitbucket.go
+++ b/internal/openchoreo-api/services/git/bitbucket.go
@@ -4,17 +4,52 @@
 package git
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 )
 
 // BitbucketProvider implements the Provider interface for Bitbucket
 type BitbucketProvider struct {
+	apiBaseURL string
+	httpClient *http.Client
 }
 
 // NewBitbucketProvider creates a new Bitbucket provider
 func NewBitbucketProvider() *BitbucketProvider {
-	return &BitbucketProvider{}
+	return &BitbucketProvider{
+		apiBaseURL: bitbucketAPIBaseURL,
+		httpClient: newDefaultHTTPClient(),
+	}
+}
+
+// GetBranchHead returns the head commit SHA of the given branch via the Bitbucket API.
+func (p *BitbucketProvider) GetBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
+	_, segments, err := parseRepoPath(repoURL)
+	if err != nil {
+		return "", err
+	}
+	if len(segments) < 2 {
+		return "", fmt.Errorf("repository URL %q does not contain workspace and repository name", repoURL)
+	}
+
+	requestURL := fmt.Sprintf("%s/2.0/repositories/%s/%s/refs/branches/%s",
+		p.apiBaseURL, segments[0], segments[1], url.PathEscape(branch))
+
+	var result struct {
+		Target struct {
+			Hash string `json:"hash"`
+		} `json:"target"`
+	}
+	if err := getJSON(ctx, p.httpClient, requestURL, &result); err != nil {
+		return "", fmt.Errorf("failed to get branch %q of %s from Bitbucket: %w", branch, repoURL, err)
+	}
+	if result.Target.Hash == "" {
+		return "", fmt.Errorf("bitbucket response for branch %q of %s has no commit SHA", branch, repoURL)
+	}
+	return result.Target.Hash, nil
 }
 
 // ValidateWebhookPayload validates the Bitbucket webhook.

--- a/internal/openchoreo-api/services/git/bitbucket.go
+++ b/internal/openchoreo-api/services/git/bitbucket.go
@@ -32,7 +32,7 @@ func (p *BitbucketProvider) GetBranchHead(ctx context.Context, repoURL, branch s
 		return "", err
 	}
 	if len(segments) < 2 {
-		return "", fmt.Errorf("repository URL %q does not contain workspace and repository name", repoURL)
+		return "", fmt.Errorf("repository URL %q does not contain workspace and repository name", SanitizeRepoURL(repoURL))
 	}
 
 	requestURL := fmt.Sprintf("%s/2.0/repositories/%s/%s/refs/branches/%s",
@@ -44,10 +44,10 @@ func (p *BitbucketProvider) GetBranchHead(ctx context.Context, repoURL, branch s
 		} `json:"target"`
 	}
 	if err := getJSON(ctx, p.httpClient, requestURL, &result); err != nil {
-		return "", fmt.Errorf("failed to get branch %q of %s from Bitbucket: %w", branch, repoURL, err)
+		return "", fmt.Errorf("failed to get branch %q of %s from Bitbucket: %w", branch, SanitizeRepoURL(repoURL), err)
 	}
 	if result.Target.Hash == "" {
-		return "", fmt.Errorf("bitbucket response for branch %q of %s has no commit SHA", branch, repoURL)
+		return "", fmt.Errorf("bitbucket response for branch %q of %s has no commit SHA", branch, SanitizeRepoURL(repoURL))
 	}
 	return result.Target.Hash, nil
 }

--- a/internal/openchoreo-api/services/git/bitbucket.go
+++ b/internal/openchoreo-api/services/git/bitbucket.go
@@ -29,7 +29,7 @@ func NewBitbucketProvider() *BitbucketProvider {
 func (p *BitbucketProvider) GetBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
 	_, segments, err := parseRepoPath(repoURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse Bitbucket repository URL: %w", err)
 	}
 	if len(segments) < 2 {
 		return "", fmt.Errorf("repository URL %q does not contain workspace and repository name", SanitizeRepoURL(repoURL))

--- a/internal/openchoreo-api/services/git/branchhead.go
+++ b/internal/openchoreo-api/services/git/branchhead.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Default API base URLs for the hosted git providers.
+const (
+	githubAPIBaseURL    = "https://api.github.com"
+	gitlabAPIBaseURL    = "https://gitlab.com"
+	bitbucketAPIBaseURL = "https://api.bitbucket.org"
+)
+
+// branchHeadRequestTimeout bounds a single branch-head lookup against a git provider API.
+const branchHeadRequestTimeout = 10 * time.Second
+
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: branchHeadRequestTimeout}
+}
+
+// DetectProviderTypeFromURL determines the git provider type from the repository URL host.
+func DetectProviderTypeFromURL(repoURL string) (ProviderType, error) {
+	host, _, err := parseRepoPath(repoURL)
+	if err != nil {
+		return "", err
+	}
+	switch strings.TrimPrefix(strings.ToLower(host), "www.") {
+	case "github.com":
+		return ProviderGitHub, nil
+	case "gitlab.com":
+		return ProviderGitLab, nil
+	case "bitbucket.org":
+		return ProviderBitbucket, nil
+	default:
+		return "", fmt.Errorf("cannot determine git provider from repository host %q", host)
+	}
+}
+
+// ResolveBranchHead resolves the current head commit SHA of a branch by querying the
+// API of the git provider determined from the repository URL.
+func ResolveBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
+	providerType, err := DetectProviderTypeFromURL(repoURL)
+	if err != nil {
+		return "", err
+	}
+	provider, err := GetProvider(providerType)
+	if err != nil {
+		return "", err
+	}
+	return provider.GetBranchHead(ctx, repoURL, branch)
+}
+
+// parseRepoPath canonicalizes a repository URL (SSH form to HTTPS, trailing ".git"
+// removed, case preserved) and splits it into its host and non-empty path segments.
+func parseRepoPath(repoURL string) (string, []string, error) {
+	canonical := strings.TrimSpace(repoURL)
+	if strings.HasPrefix(canonical, "git@") {
+		canonical = strings.Replace(canonical, ":", "/", 1)
+		canonical = strings.Replace(canonical, "git@", "https://", 1)
+	}
+	canonical = strings.TrimSuffix(canonical, ".git")
+
+	u, err := url.Parse(canonical)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid repository URL %q: %w", repoURL, err)
+	}
+	if u.Host == "" {
+		return "", nil, fmt.Errorf("repository URL %q has no host", repoURL)
+	}
+
+	segments := make([]string, 0, 2)
+	for _, segment := range strings.Split(u.Path, "/") {
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return u.Host, segments, nil
+}
+
+// getJSON performs a GET request against a git provider API and decodes the JSON response.
+func getJSON(ctx context.Context, httpClient *http.Client, requestURL string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/openchoreo-api/services/git/branchhead.go
+++ b/internal/openchoreo-api/services/git/branchhead.go
@@ -32,7 +32,7 @@ func newDefaultHTTPClient() *http.Client {
 func DetectProviderTypeFromURL(repoURL string) (ProviderType, error) {
 	host, _, err := parseRepoPath(repoURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot detect git provider from repository URL: %w", err)
 	}
 	switch strings.TrimPrefix(strings.ToLower(host), "www.") {
 	case "github.com":
@@ -51,11 +51,11 @@ func DetectProviderTypeFromURL(repoURL string) (ProviderType, error) {
 func ResolveBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
 	providerType, err := DetectProviderTypeFromURL(repoURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to resolve head of branch %q: %w", branch, err)
 	}
 	provider, err := GetProvider(providerType)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to resolve head of branch %q for provider %q: %w", branch, providerType, err)
 	}
 	return provider.GetBranchHead(ctx, repoURL, branch)
 }
@@ -87,10 +87,10 @@ func parseRepoPath(repoURL string) (string, []string, error) {
 
 	u, err := url.Parse(canonical)
 	if err != nil {
-		return "", nil, fmt.Errorf("invalid repository URL %q: %w", repoURL, err)
+		return "", nil, fmt.Errorf("invalid repository URL %q: %w", SanitizeRepoURL(repoURL), err)
 	}
 	if u.Host == "" {
-		return "", nil, fmt.Errorf("repository URL %q has no host", repoURL)
+		return "", nil, fmt.Errorf("repository URL %q has no host", SanitizeRepoURL(repoURL))
 	}
 
 	segments := make([]string, 0, 2)

--- a/internal/openchoreo-api/services/git/branchhead.go
+++ b/internal/openchoreo-api/services/git/branchhead.go
@@ -60,6 +60,21 @@ func ResolveBranchHead(ctx context.Context, repoURL, branch string) (string, err
 	return provider.GetBranchHead(ctx, repoURL, branch)
 }
 
+// SanitizeRepoURL strips any userinfo (credentials) from a repository URL so it is
+// safe to include in logs and error messages.
+func SanitizeRepoURL(repoURL string) string {
+	u, err := url.Parse(strings.TrimSpace(repoURL))
+	if err != nil || u.Host == "" {
+		// Not a parseable absolute URL (e.g. SSH form); strip anything before '@' defensively.
+		if i := strings.LastIndex(repoURL, "@"); i >= 0 {
+			return repoURL[i+1:]
+		}
+		return repoURL
+	}
+	u.User = nil
+	return u.String()
+}
+
 // parseRepoPath canonicalizes a repository URL (SSH form to HTTPS, trailing ".git"
 // removed, case preserved) and splits it into its host and non-empty path segments.
 func parseRepoPath(repoURL string) (string, []string, error) {

--- a/internal/openchoreo-api/services/git/branchhead_test.go
+++ b/internal/openchoreo-api/services/git/branchhead_test.go
@@ -255,6 +255,48 @@ func TestBitbucketGetBranchHead(t *testing.T) {
 	})
 }
 
+func TestSanitizeRepoURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+		want    string
+	}{
+		{
+			name:    "https without credentials unchanged",
+			repoURL: "https://github.com/owner/repo.git",
+			want:    "https://github.com/owner/repo.git",
+		},
+		{
+			name:    "strips userinfo token",
+			repoURL: "https://user:secret-token@github.com/owner/repo.git",
+			want:    "https://github.com/owner/repo.git",
+		},
+		{
+			name:    "strips bare username",
+			repoURL: "https://token@gitlab.com/group/repo",
+			want:    "https://gitlab.com/group/repo",
+		},
+		{
+			name:    "ssh form strips user",
+			repoURL: "git@github.com:owner/repo.git",
+			want:    "github.com:owner/repo.git",
+		},
+		{
+			name:    "plain string unchanged",
+			repoURL: "not-a-url",
+			want:    "not-a-url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeRepoURL(tt.repoURL)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "secret-token")
+		})
+	}
+}
+
 func TestResolveBranchHeadUnknownProvider(t *testing.T) {
 	_, err := ResolveBranchHead(context.Background(), "https://git.example.com/owner/repo", "main")
 	require.Error(t, err)

--- a/internal/openchoreo-api/services/git/branchhead_test.go
+++ b/internal/openchoreo-api/services/git/branchhead_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testBranchHeadSHA = "9be21eb1421e23cd1cb02d877f8d62a06fab7a76"
+
+func TestDetectProviderTypeFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+		want    ProviderType
+		wantErr bool
+	}{
+		{name: "github https", repoURL: "https://github.com/owner/repo", want: ProviderGitHub},
+		{name: "github https with .git suffix", repoURL: "https://github.com/owner/repo.git", want: ProviderGitHub},
+		{name: "github ssh", repoURL: "git@github.com:owner/repo.git", want: ProviderGitHub},
+		{name: "github www prefix", repoURL: "https://www.github.com/owner/repo", want: ProviderGitHub},
+		{name: "gitlab https", repoURL: "https://gitlab.com/group/repo", want: ProviderGitLab},
+		{name: "gitlab nested group", repoURL: "https://gitlab.com/group/subgroup/repo", want: ProviderGitLab},
+		{name: "bitbucket https", repoURL: "https://bitbucket.org/workspace/repo", want: ProviderBitbucket},
+		{name: "unknown host", repoURL: "https://git.example.com/owner/repo", wantErr: true},
+		{name: "no host", repoURL: "not-a-url", wantErr: true},
+		{name: "empty", repoURL: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DetectProviderTypeFromURL(tt.repoURL)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGitHubGetBranchHead(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/repos/owner/repo/branches/main", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"main","commit":{"sha":"` + testBranchHeadSHA + `"}}`))
+		}))
+		defer server.Close()
+
+		p := NewGitHubProvider()
+		p.apiBaseURL = server.URL
+
+		sha, err := p.GetBranchHead(context.Background(), "https://github.com/owner/repo.git", "main")
+		require.NoError(t, err)
+		assert.Equal(t, testBranchHeadSHA, sha)
+	})
+
+	t.Run("escapes branch name with slash", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/repos/owner/repo/branches/feature%2Ffoo", r.URL.EscapedPath())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"` + testBranchHeadSHA + `"}}`))
+		}))
+		defer server.Close()
+
+		p := NewGitHubProvider()
+		p.apiBaseURL = server.URL
+
+		sha, err := p.GetBranchHead(context.Background(), "https://github.com/owner/repo", "feature/foo")
+		require.NoError(t, err)
+		assert.Equal(t, testBranchHeadSHA, sha)
+	})
+
+	t.Run("ssh repository URL", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/repos/owner/repo/branches/main", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"` + testBranchHeadSHA + `"}}`))
+		}))
+		defer server.Close()
+
+		p := NewGitHubProvider()
+		p.apiBaseURL = server.URL
+
+		sha, err := p.GetBranchHead(context.Background(), "git@github.com:owner/repo.git", "main")
+		require.NoError(t, err)
+		assert.Equal(t, testBranchHeadSHA, sha)
+	})
+
+	t.Run("branch not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"message":"Branch not found"}`, http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		p := NewGitHubProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://github.com/owner/repo", "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+
+	t.Run("response without commit SHA", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"main"}`))
+		}))
+		defer server.Close()
+
+		p := NewGitHubProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://github.com/owner/repo", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no commit SHA")
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{not-json`))
+		}))
+		defer server.Close()
+
+		p := NewGitHubProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://github.com/owner/repo", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
+	})
+
+	t.Run("repository URL without owner and repo", func(t *testing.T) {
+		p := NewGitHubProvider()
+		_, err := p.GetBranchHead(context.Background(), "https://github.com/owner", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner and repository name")
+	})
+}
+
+func TestGitLabGetBranchHead(t *testing.T) {
+	t.Run("success with nested group path", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v4/projects/group%2Fsubgroup%2Frepo/repository/branches/main", r.URL.EscapedPath())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"main","commit":{"id":"` + testBranchHeadSHA + `"}}`))
+		}))
+		defer server.Close()
+
+		p := NewGitLabProvider()
+		p.apiBaseURL = server.URL
+
+		sha, err := p.GetBranchHead(context.Background(), "https://gitlab.com/group/subgroup/repo.git", "main")
+		require.NoError(t, err)
+		assert.Equal(t, testBranchHeadSHA, sha)
+	})
+
+	t.Run("branch not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"message":"404 Branch Not Found"}`, http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		p := NewGitLabProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://gitlab.com/group/repo", "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+
+	t.Run("response without commit SHA", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"main"}`))
+		}))
+		defer server.Close()
+
+		p := NewGitLabProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://gitlab.com/group/repo", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no commit SHA")
+	})
+
+	t.Run("repository URL without project path", func(t *testing.T) {
+		p := NewGitLabProvider()
+		_, err := p.GetBranchHead(context.Background(), "https://gitlab.com/group", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project path")
+	})
+}
+
+func TestBitbucketGetBranchHead(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/2.0/repositories/workspace/repo/refs/branches/main", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"main","target":{"hash":"` + testBranchHeadSHA + `"}}`))
+		}))
+		defer server.Close()
+
+		p := NewBitbucketProvider()
+		p.apiBaseURL = server.URL
+
+		sha, err := p.GetBranchHead(context.Background(), "https://bitbucket.org/workspace/repo.git", "main")
+		require.NoError(t, err)
+		assert.Equal(t, testBranchHeadSHA, sha)
+	})
+
+	t.Run("branch not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"type":"error"}`, http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		p := NewBitbucketProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://bitbucket.org/workspace/repo", "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+
+	t.Run("response without commit SHA", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"main"}`))
+		}))
+		defer server.Close()
+
+		p := NewBitbucketProvider()
+		p.apiBaseURL = server.URL
+
+		_, err := p.GetBranchHead(context.Background(), "https://bitbucket.org/workspace/repo", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no commit SHA")
+	})
+
+	t.Run("repository URL without workspace and repo", func(t *testing.T) {
+		p := NewBitbucketProvider()
+		_, err := p.GetBranchHead(context.Background(), "https://bitbucket.org/workspace", "main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workspace and repository name")
+	})
+}
+
+func TestResolveBranchHeadUnknownProvider(t *testing.T) {
+	_, err := ResolveBranchHead(context.Background(), "https://git.example.com/owner/repo", "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot determine git provider")
+}

--- a/internal/openchoreo-api/services/git/github.go
+++ b/internal/openchoreo-api/services/git/github.go
@@ -33,7 +33,7 @@ func NewGitHubProvider() *GitHubProvider {
 func (p *GitHubProvider) GetBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
 	_, segments, err := parseRepoPath(repoURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse GitHub repository URL: %w", err)
 	}
 	if len(segments) < 2 {
 		return "", fmt.Errorf("repository URL %q does not contain owner and repository name", SanitizeRepoURL(repoURL))

--- a/internal/openchoreo-api/services/git/github.go
+++ b/internal/openchoreo-api/services/git/github.go
@@ -4,21 +4,56 @@
 package git
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 )
 
 // GitHubProvider implements the Provider interface for GitHub
 type GitHubProvider struct {
+	apiBaseURL string
+	httpClient *http.Client
 }
 
 // NewGitHubProvider creates a new GitHub provider
 func NewGitHubProvider() *GitHubProvider {
-	return &GitHubProvider{}
+	return &GitHubProvider{
+		apiBaseURL: githubAPIBaseURL,
+		httpClient: newDefaultHTTPClient(),
+	}
+}
+
+// GetBranchHead returns the head commit SHA of the given branch via the GitHub API.
+func (p *GitHubProvider) GetBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
+	_, segments, err := parseRepoPath(repoURL)
+	if err != nil {
+		return "", err
+	}
+	if len(segments) < 2 {
+		return "", fmt.Errorf("repository URL %q does not contain owner and repository name", repoURL)
+	}
+
+	requestURL := fmt.Sprintf("%s/repos/%s/%s/branches/%s",
+		p.apiBaseURL, segments[0], segments[1], url.PathEscape(branch))
+
+	var result struct {
+		Commit struct {
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	if err := getJSON(ctx, p.httpClient, requestURL, &result); err != nil {
+		return "", fmt.Errorf("failed to get branch %q of %s from GitHub: %w", branch, repoURL, err)
+	}
+	if result.Commit.SHA == "" {
+		return "", fmt.Errorf("GitHub response for branch %q of %s has no commit SHA", branch, repoURL)
+	}
+	return result.Commit.SHA, nil
 }
 
 // ValidateWebhookPayload validates the GitHub webhook signature

--- a/internal/openchoreo-api/services/git/github.go
+++ b/internal/openchoreo-api/services/git/github.go
@@ -36,7 +36,7 @@ func (p *GitHubProvider) GetBranchHead(ctx context.Context, repoURL, branch stri
 		return "", err
 	}
 	if len(segments) < 2 {
-		return "", fmt.Errorf("repository URL %q does not contain owner and repository name", repoURL)
+		return "", fmt.Errorf("repository URL %q does not contain owner and repository name", SanitizeRepoURL(repoURL))
 	}
 
 	requestURL := fmt.Sprintf("%s/repos/%s/%s/branches/%s",
@@ -48,10 +48,10 @@ func (p *GitHubProvider) GetBranchHead(ctx context.Context, repoURL, branch stri
 		} `json:"commit"`
 	}
 	if err := getJSON(ctx, p.httpClient, requestURL, &result); err != nil {
-		return "", fmt.Errorf("failed to get branch %q of %s from GitHub: %w", branch, repoURL, err)
+		return "", fmt.Errorf("failed to get branch %q of %s from GitHub: %w", branch, SanitizeRepoURL(repoURL), err)
 	}
 	if result.Commit.SHA == "" {
-		return "", fmt.Errorf("GitHub response for branch %q of %s has no commit SHA", branch, repoURL)
+		return "", fmt.Errorf("GitHub response for branch %q of %s has no commit SHA", branch, SanitizeRepoURL(repoURL))
 	}
 	return result.Commit.SHA, nil
 }

--- a/internal/openchoreo-api/services/git/gitlab.go
+++ b/internal/openchoreo-api/services/git/gitlab.go
@@ -33,7 +33,7 @@ func (p *GitLabProvider) GetBranchHead(ctx context.Context, repoURL, branch stri
 		return "", err
 	}
 	if len(segments) < 2 {
-		return "", fmt.Errorf("repository URL %q does not contain a project path", repoURL)
+		return "", fmt.Errorf("repository URL %q does not contain a project path", SanitizeRepoURL(repoURL))
 	}
 
 	// GitLab identifies projects by their full URL-encoded path (supports nested groups).
@@ -47,10 +47,10 @@ func (p *GitLabProvider) GetBranchHead(ctx context.Context, repoURL, branch stri
 		} `json:"commit"`
 	}
 	if err := getJSON(ctx, p.httpClient, requestURL, &result); err != nil {
-		return "", fmt.Errorf("failed to get branch %q of %s from GitLab: %w", branch, repoURL, err)
+		return "", fmt.Errorf("failed to get branch %q of %s from GitLab: %w", branch, SanitizeRepoURL(repoURL), err)
 	}
 	if result.Commit.ID == "" {
-		return "", fmt.Errorf("GitLab response for branch %q of %s has no commit SHA", branch, repoURL)
+		return "", fmt.Errorf("GitLab response for branch %q of %s has no commit SHA", branch, SanitizeRepoURL(repoURL))
 	}
 	return result.Commit.ID, nil
 }

--- a/internal/openchoreo-api/services/git/gitlab.go
+++ b/internal/openchoreo-api/services/git/gitlab.go
@@ -4,18 +4,55 @@
 package git
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 )
 
 // GitLabProvider implements the Provider interface for GitLab
 type GitLabProvider struct {
+	apiBaseURL string
+	httpClient *http.Client
 }
 
 // NewGitLabProvider creates a new GitLab provider
 func NewGitLabProvider() *GitLabProvider {
-	return &GitLabProvider{}
+	return &GitLabProvider{
+		apiBaseURL: gitlabAPIBaseURL,
+		httpClient: newDefaultHTTPClient(),
+	}
+}
+
+// GetBranchHead returns the head commit SHA of the given branch via the GitLab API.
+func (p *GitLabProvider) GetBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
+	_, segments, err := parseRepoPath(repoURL)
+	if err != nil {
+		return "", err
+	}
+	if len(segments) < 2 {
+		return "", fmt.Errorf("repository URL %q does not contain a project path", repoURL)
+	}
+
+	// GitLab identifies projects by their full URL-encoded path (supports nested groups).
+	projectPath := url.PathEscape(strings.Join(segments, "/"))
+	requestURL := fmt.Sprintf("%s/api/v4/projects/%s/repository/branches/%s",
+		p.apiBaseURL, projectPath, url.PathEscape(branch))
+
+	var result struct {
+		Commit struct {
+			ID string `json:"id"`
+		} `json:"commit"`
+	}
+	if err := getJSON(ctx, p.httpClient, requestURL, &result); err != nil {
+		return "", fmt.Errorf("failed to get branch %q of %s from GitLab: %w", branch, repoURL, err)
+	}
+	if result.Commit.ID == "" {
+		return "", fmt.Errorf("GitLab response for branch %q of %s has no commit SHA", branch, repoURL)
+	}
+	return result.Commit.ID, nil
 }
 
 // ValidateWebhookPayload validates the GitLab webhook token

--- a/internal/openchoreo-api/services/git/gitlab.go
+++ b/internal/openchoreo-api/services/git/gitlab.go
@@ -30,7 +30,7 @@ func NewGitLabProvider() *GitLabProvider {
 func (p *GitLabProvider) GetBranchHead(ctx context.Context, repoURL, branch string) (string, error) {
 	_, segments, err := parseRepoPath(repoURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse GitLab repository URL: %w", err)
 	}
 	if len(segments) < 2 {
 		return "", fmt.Errorf("repository URL %q does not contain a project path", SanitizeRepoURL(repoURL))

--- a/internal/openchoreo-api/services/git/provider.go
+++ b/internal/openchoreo-api/services/git/provider.go
@@ -4,6 +4,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -14,6 +15,9 @@ type Provider interface {
 
 	// ParseWebhookPayload parses the webhook payload and extracts relevant information
 	ParseWebhookPayload(payload []byte) (*WebhookEvent, error)
+
+	// GetBranchHead returns the head commit SHA of the given branch via the provider API
+	GetBranchHead(ctx context.Context, repoURL, branch string) (string, error)
 }
 
 // WebhookEvent represents a normalized webhook event

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -1006,20 +1006,21 @@ func (s *workflowRunService) resolveBranchHeadCommit(ctx context.Context, paramM
 		return ""
 	}
 
+	sanitizedRepo := git.SanitizeRepoURL(repoURL)
 	sha, err := s.resolveBranchHead(ctx, repoURL, branch)
 	if err != nil {
 		s.logger.Warn("Failed to resolve branch head commit; proceeding without commit pinning",
-			"component", componentName, "repository", repoURL, "branch", branch, "error", err)
+			"component", componentName, "repository", sanitizedRepo, "branch", branch, "error", err)
 		return ""
 	}
 	if !commitSHAPattern.MatchString(sha) {
 		s.logger.Warn("Resolved branch head commit has unexpected format; proceeding without commit pinning",
-			"component", componentName, "repository", repoURL, "branch", branch, "commit", sha)
+			"component", componentName, "repository", sanitizedRepo, "branch", branch, "commit", sha)
 		return ""
 	}
 
 	s.logger.Debug("Resolved branch head commit",
-		"component", componentName, "repository", repoURL, "branch", branch, "commit", sha)
+		"component", componentName, "repository", sanitizedRepo, "branch", branch, "commit", sha)
 	return sha
 }
 

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -33,6 +33,7 @@ import (
 	ocLabels "github.com/openchoreo/openchoreo/internal/labels"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/git"
 )
 
 // workflowRunService handles workflow run business logic without authorization checks.
@@ -41,6 +42,9 @@ type workflowRunService struct {
 	planeClientProvider kubernetesClient.WorkflowPlaneClientProvider
 	gwClient            *gatewayClient.Client
 	logger              *slog.Logger
+	// resolveBranchHead resolves the head commit SHA of a branch via the git
+	// provider API. Injectable for testing.
+	resolveBranchHead func(ctx context.Context, repoURL, branch string) (string, error)
 }
 
 var _ Service = (*workflowRunService)(nil)
@@ -50,6 +54,9 @@ var workflowRunTypeMeta = metav1.TypeMeta{
 	Kind:       "WorkflowRun",
 }
 
+// commitSHAPattern matches a full or abbreviated git commit SHA.
+var commitSHAPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
 // NewService creates a new workflow run service without authorization.
 func NewService(k8sClient client.Client, planeClientProvider kubernetesClient.WorkflowPlaneClientProvider, gwClient *gatewayClient.Client, logger *slog.Logger) Service {
 	return &workflowRunService{
@@ -57,6 +64,7 @@ func NewService(k8sClient client.Client, planeClientProvider kubernetesClient.Wo
 		planeClientProvider: planeClientProvider,
 		gwClient:            gwClient,
 		logger:              logger,
+		resolveBranchHead:   git.ResolveBranchHead,
 	}
 }
 
@@ -891,9 +899,17 @@ func (s *workflowRunService) TriggerWorkflow(ctx context.Context, namespaceName,
 
 	// Validate commit SHA format if provided
 	if commit != "" {
-		commitPattern := regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
-		if !commitPattern.MatchString(commit) {
+		if !commitSHAPattern.MatchString(commit) {
 			return nil, ErrInvalidCommitSHA
+		}
+	}
+
+	// When no explicit commit is given, resolve the current branch-head SHA so the
+	// run is pinned to the exact revision that will be built. Best-effort: if
+	// resolution fails, the run proceeds against the branch head as before.
+	if commit == "" {
+		if _, ok := paramMap["commit"]; ok {
+			commit = s.resolveBranchHeadCommit(ctx, paramMap, component.Spec.Workflow.Parameters, componentName)
 		}
 	}
 
@@ -965,6 +981,46 @@ func (s *workflowRunService) TriggerWorkflow(ctx context.Context, namespaceName,
 		Status:        workflowRunStatusPending,
 		CreatedAt:     workflowRun.CreationTimestamp.Time,
 	}, nil
+}
+
+// resolveBranchHeadCommit resolves the head commit SHA of the component's configured
+// branch via the git provider API. It returns an empty string when the repository
+// URL or branch is not mapped/configured or when resolution fails; failures are
+// logged but never block the trigger.
+func (s *workflowRunService) resolveBranchHeadCommit(ctx context.Context, paramMap map[string]string, params *runtime.RawExtension, componentName string) string {
+	urlPath, ok := paramMap["url"]
+	if !ok {
+		return ""
+	}
+	branchPath, ok := paramMap["branch"]
+	if !ok {
+		return ""
+	}
+
+	repoURL, err := getNestedStringInParams(params, urlPath)
+	if err != nil || repoURL == "" {
+		return ""
+	}
+	branch, err := getNestedStringInParams(params, branchPath)
+	if err != nil || branch == "" {
+		return ""
+	}
+
+	sha, err := s.resolveBranchHead(ctx, repoURL, branch)
+	if err != nil {
+		s.logger.Warn("Failed to resolve branch head commit; proceeding without commit pinning",
+			"component", componentName, "repository", repoURL, "branch", branch, "error", err)
+		return ""
+	}
+	if !commitSHAPattern.MatchString(sha) {
+		s.logger.Warn("Resolved branch head commit has unexpected format; proceeding without commit pinning",
+			"component", componentName, "repository", repoURL, "branch", branch, "commit", sha)
+		return ""
+	}
+
+	s.logger.Debug("Resolved branch head commit",
+		"component", componentName, "repository", repoURL, "branch", branch, "commit", sha)
+	return sha
 }
 
 // generateWorkflowRunName generates a unique name for the workflow run.

--- a/internal/openchoreo-api/services/workflowrun/service_test.go
+++ b/internal/openchoreo-api/services/workflowrun/service_test.go
@@ -1289,3 +1289,162 @@ func TestDeleteWorkflowRunVerifiesRemoval(t *testing.T) {
 		require.ErrorIs(t, err, ErrWorkflowRunNotFound)
 	})
 }
+
+func TestTriggerWorkflowBranchHeadResolution(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		testRepoURL     = "https://github.com/example/repo"
+		testBranch      = "main"
+		testResolvedSHA = "9be21eb1421e23cd1cb02d877f8d62a06fab7a76"
+	)
+
+	// buildSchema returns a workflow schema with url, branch and commit repository markers.
+	buildSchema := func() *runtime.RawExtension {
+		schema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"repoUrl": map[string]any{
+					"type": "string",
+					"x-openchoreo-component-parameter-repository-url": true,
+				},
+				"branch": map[string]any{
+					"type": "string",
+					"x-openchoreo-component-parameter-repository-branch": true,
+				},
+				"commit": map[string]any{
+					"type": "string",
+					"x-openchoreo-component-parameter-repository-commit": true,
+				},
+			},
+		}
+		b, _ := json.Marshal(schema)
+		return &runtime.RawExtension{Raw: b}
+	}
+
+	buildComponent := func() *openchoreov1alpha1.Component {
+		params, _ := json.Marshal(map[string]any{
+			"repoUrl": testRepoURL,
+			"branch":  testBranch,
+			"commit":  "",
+		})
+		comp := testutil.NewComponent(testNamespace, "proj", "my-comp")
+		comp.Spec.Workflow = &openchoreov1alpha1.ComponentWorkflowConfig{
+			Kind:       openchoreov1alpha1.WorkflowRefKindWorkflow,
+			Name:       testWorkflowName,
+			Parameters: &runtime.RawExtension{Raw: params},
+		}
+		return comp
+	}
+
+	newServiceWithResolver := func(t *testing.T, resolver func(ctx context.Context, repoURL, branch string) (string, error), objs ...client.Object) (*workflowRunService, client.Client) {
+		t.Helper()
+		fakeClient := testutil.NewFakeClient(objs...)
+		svc := NewService(fakeClient, nil, nil, testutil.TestLogger()).(*workflowRunService)
+		svc.resolveBranchHead = resolver
+		return svc, fakeClient
+	}
+
+	getCreatedRunCommit := func(t *testing.T, fakeClient client.Client) string {
+		t.Helper()
+		runs := &openchoreov1alpha1.WorkflowRunList{}
+		require.NoError(t, fakeClient.List(ctx, runs, client.InNamespace(testNamespace)))
+		require.Len(t, runs.Items, 1)
+		commit, err := getNestedStringInParams(runs.Items[0].Spec.Workflow.Parameters, "commit")
+		require.NoError(t, err)
+		return commit
+	}
+
+	t.Run("resolves branch head when commit is empty", func(t *testing.T) {
+		wf := testutil.NewWorkflow(testNamespace, testWorkflowName)
+		wf.Spec.Parameters = &openchoreov1alpha1.SchemaSection{OpenAPIV3Schema: buildSchema()}
+
+		var gotRepoURL, gotBranch string
+		svc, fakeClient := newServiceWithResolver(t, func(ctx context.Context, repoURL, branch string) (string, error) {
+			gotRepoURL, gotBranch = repoURL, branch
+			return testResolvedSHA, nil
+		}, wf, buildComponent())
+
+		result, err := svc.TriggerWorkflow(ctx, testNamespace, "proj", "my-comp", "")
+		require.NoError(t, err)
+		assert.Equal(t, testRepoURL, gotRepoURL)
+		assert.Equal(t, testBranch, gotBranch)
+		assert.Equal(t, testResolvedSHA, result.Commit)
+		assert.Equal(t, testResolvedSHA, getCreatedRunCommit(t, fakeClient))
+	})
+
+	t.Run("resolution failure does not block the trigger", func(t *testing.T) {
+		wf := testutil.NewWorkflow(testNamespace, testWorkflowName)
+		wf.Spec.Parameters = &openchoreov1alpha1.SchemaSection{OpenAPIV3Schema: buildSchema()}
+
+		svc, fakeClient := newServiceWithResolver(t, func(ctx context.Context, repoURL, branch string) (string, error) {
+			return "", assert.AnError
+		}, wf, buildComponent())
+
+		result, err := svc.TriggerWorkflow(ctx, testNamespace, "proj", "my-comp", "")
+		require.NoError(t, err)
+		assert.Empty(t, result.Commit)
+		assert.Empty(t, getCreatedRunCommit(t, fakeClient))
+	})
+
+	t.Run("explicit commit skips resolution", func(t *testing.T) {
+		wf := testutil.NewWorkflow(testNamespace, testWorkflowName)
+		wf.Spec.Parameters = &openchoreov1alpha1.SchemaSection{OpenAPIV3Schema: buildSchema()}
+
+		resolverCalled := false
+		svc, fakeClient := newServiceWithResolver(t, func(ctx context.Context, repoURL, branch string) (string, error) {
+			resolverCalled = true
+			return testResolvedSHA, nil
+		}, wf, buildComponent())
+
+		result, err := svc.TriggerWorkflow(ctx, testNamespace, "proj", "my-comp", "abc1234f")
+		require.NoError(t, err)
+		assert.False(t, resolverCalled)
+		assert.Equal(t, "abc1234f", result.Commit)
+		assert.Equal(t, "abc1234f", getCreatedRunCommit(t, fakeClient))
+	})
+
+	t.Run("missing branch marker skips resolution", func(t *testing.T) {
+		schema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"repoUrl": map[string]any{
+					"type": "string",
+					"x-openchoreo-component-parameter-repository-url": true,
+				},
+				"commit": map[string]any{
+					"type": "string",
+					"x-openchoreo-component-parameter-repository-commit": true,
+				},
+			},
+		}
+		b, _ := json.Marshal(schema)
+		wf := testutil.NewWorkflow(testNamespace, testWorkflowName)
+		wf.Spec.Parameters = &openchoreov1alpha1.SchemaSection{OpenAPIV3Schema: &runtime.RawExtension{Raw: b}}
+
+		resolverCalled := false
+		svc, _ := newServiceWithResolver(t, func(ctx context.Context, repoURL, branch string) (string, error) {
+			resolverCalled = true
+			return testResolvedSHA, nil
+		}, wf, buildComponent())
+
+		result, err := svc.TriggerWorkflow(ctx, testNamespace, "proj", "my-comp", "")
+		require.NoError(t, err)
+		assert.False(t, resolverCalled)
+		assert.Empty(t, result.Commit)
+	})
+
+	t.Run("resolved SHA with unexpected format is ignored", func(t *testing.T) {
+		wf := testutil.NewWorkflow(testNamespace, testWorkflowName)
+		wf.Spec.Parameters = &openchoreov1alpha1.SchemaSection{OpenAPIV3Schema: buildSchema()}
+
+		svc, fakeClient := newServiceWithResolver(t, func(ctx context.Context, repoURL, branch string) (string, error) {
+			return "not-a-sha!", nil
+		}, wf, buildComponent())
+
+		result, err := svc.TriggerWorkflow(ctx, testNamespace, "proj", "my-comp", "")
+		require.NoError(t, err)
+		assert.Empty(t, result.Commit)
+		assert.Empty(t, getCreatedRunCommit(t, fakeClient))
+	})
+}


### PR DESCRIPTION
## Purpose

Fixes #3799
Part of the Engineering Insights & DORA Metrics effort (#3346, proposal #3668).

When a workflow run is triggered without an explicit commit (e.g., a manual "build latest" from the UI/API), the workflow checks out the head of the configured branch, but the SHA that actually gets built is never recorded — only webhook-triggered runs carry full commit attribution. This breaks deployment→commit traceability (and therefore Lead Time for Changes) for the most common human-triggered path.

## Approach

At trigger time, when no explicit commit is provided and the workflow schema maps `url`, `branch` and `commit` repository parameters (via the existing `x-openchoreo-component-parameter-repository-*` extensions), the API resolves the current branch-head SHA through the git provider's REST API and injects it into the run parameters at the mapped commit path — exactly as the webhook path injects the pushed commit today.

- **New `GetBranchHead` capability on the git `Provider` interface**, implemented for GitHub (`GET /repos/{owner}/{repo}/branches/{branch}`), GitLab (`GET /api/v4/projects/{path}/repository/branches/{branch}`, supports nested groups) and Bitbucket (`GET /2.0/repositories/{ws}/{slug}/refs/branches/{branch}`), with the provider detected from the repository URL host. SSH-form URLs and `.git` suffixes are handled.
- **`TriggerWorkflow` resolves and injects the SHA** when the caller did not supply one. The trigger response now carries the resolved commit, so callers immediately see the exact revision being built.
- **Strictly best-effort**: if the provider cannot be detected, the repo/branch parameters are missing, the API call fails (rate limit, network, private repo), or the returned value doesn't look like a SHA, the trigger proceeds exactly as before (no commit pinning). Resolution failures can never block a build.

This also pins manual builds to the exact revision at trigger time, eliminating the race between triggering and checkout.

## Testing

- Unit tests for provider detection and `GetBranchHead` for all three providers (httptest-backed: success, branch-name escaping, nested GitLab groups, SSH URLs, 404/invalid JSON/missing SHA error paths).
- Unit tests for the trigger flow: resolved SHA injected into run parameters and returned in the response; resolution failure or malformed SHA falls back to no pinning without failing the trigger; explicit commit skips resolution; schemas without a branch marker skip resolution.
- `go test ./...` (189 packages) and `golangci-lint run` pass locally.
