### PR TITLE
chore: hide deprecated cluster-prefixed tools by default

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -29,11 +29,12 @@ const (
 	QueryParamFilterByAuthz = "filterByAuthz"
 	// QueryParamIncludeDeprecatedTools controls whether tools/list includes the
 	// deprecated cluster-prefixed compatibility-alias tools (e.g.
-	// ?includeDeprecatedTools=false). Defaults to true in v1.1: the aliases are
-	// listed with a description-level deprecation banner and a structured _meta
-	// marker so existing clients see a migration signal before they disappear.
-	// Set this to false to preview the v1.2 surface, where the aliases are
-	// hidden from tools/list but remain callable; in v1.3 they are removed.
+	// ?includeDeprecatedTools=true). Defaults to false as of v1.2: the aliases
+	// are hidden from tools/list but remain callable and still return a runtime
+	// deprecation warning. Clients that have not yet migrated can set this to
+	// true to keep listing the aliases — each carrying a description-level
+	// deprecation banner and a structured _meta marker — until they are removed
+	// in v1.3.
 	QueryParamIncludeDeprecatedTools = "includeDeprecatedTools"
 )
 
@@ -43,9 +44,8 @@ const (
 // happens via query parameters parsed from the initialize request:
 //   - ?toolsets=ns1,ns2              — only show tools from those toolsets in tools/list
 //   - ?filterByAuthz=false           — disable MCP-layer authz filtering for the session
-//   - ?includeDeprecatedTools=false  — hide the deprecated cluster-prefixed alias tools
-//     (they are listed by default in v1.1 with a deprecation banner, hidden in v1.2,
-//     and removed in v1.3)
+//   - ?includeDeprecatedTools=true   — list the deprecated cluster-prefixed alias tools
+//     (hidden by default as of v1.2; they remain callable and are removed in v1.3)
 //
 // When pdp is non-nil the server installs a receiving middleware that filters
 // tools/list results and guards tools/call invocations based on the

--- a/pkg/mcp/tools/register.go
+++ b/pkg/mcp/tools/register.go
@@ -13,12 +13,13 @@ import (
 // with scope="cluster" (see scoped.go) and returns a deprecation warning.
 //
 // Visibility lifecycle:
-//   - v1.1 (current): listed in tools/list by default with a "[DEPRECATED ...]"
-//     description banner and a structured _meta marker so existing clients see a
-//     migration signal before the surface changes. Clients can opt out and
-//     preview the v1.2 surface with ?includeDeprecatedTools=false.
-//   - v1.2: hidden from the default tools/list response. Still callable; the
-//     description banner / _meta and the runtime deprecation_warning remain.
+//   - v1.1: listed in tools/list by default with a "[DEPRECATED ...]" description
+//     banner and a structured _meta marker so existing clients see a migration
+//     signal before the surface changes.
+//   - v1.2 (current): hidden from the default tools/list response. Still callable;
+//     the description banner / _meta and the runtime deprecation_warning remain.
+//     Clients that have not yet migrated can opt back in with
+//     ?includeDeprecatedTools=true to keep listing the aliases.
 //   - v1.3: removed entirely.
 var deprecatedToolNames = map[string]bool{
 	"list_cluster_component_types":               true,

--- a/pkg/mcp/tools/scoped_test.go
+++ b/pkg/mcp/tools/scoped_test.go
@@ -162,13 +162,35 @@ func TestScopedToolInvalidScope(t *testing.T) {
 	}
 }
 
-func TestDeprecatedAliasVisibleByDefault(t *testing.T) {
-	// Default session in v1.1: every deprecated alias appears in tools/list with
-	// a "[DEPRECATED ...]" description banner and the structured _meta marker,
-	// so existing pinned-name callers see a migration signal before the surface
-	// changes in v1.2/v1.3.
+func TestDeprecatedAliasHiddenByDefault(t *testing.T) {
+	// Default session as of v1.2: deprecated cluster-prefixed aliases are hidden
+	// from tools/list. They remain callable (see TestDeprecatedAliasRoutesAndWarns)
+	// and can be listed again with ?includeDeprecatedTools=true.
 	cs, _ := setupScopedTestServer(t, context.Background(), nil)
 	result, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	names := toolNameSet(result.Tools)
+	for alias := range deprecatedToolNames {
+		if names[alias] {
+			t.Errorf("deprecated alias %q should be hidden from the default tools/list", alias)
+		}
+	}
+	if !names["get_component_type"] || !names["list_component_types"] {
+		t.Errorf("expected canonical scope-collapsed tools to be present in tools/list")
+	}
+}
+
+func TestDeprecatedAliasVisibleWhenIncluded(t *testing.T) {
+	// includeDeprecatedTools=true keeps the deprecated aliases in tools/list for
+	// clients that have not yet migrated: every alias appears with a
+	// "[DEPRECATED ...]" description banner and the structured _meta marker, so
+	// pinned-name callers see a migration signal before the aliases are removed
+	// in v1.3.
+	ctx := WithIncludeDeprecatedTools(context.Background(), true)
+	cs, _ := setupScopedTestServer(t, ctx, nil)
+	result, err := cs.ListTools(ctx, nil)
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
@@ -179,7 +201,7 @@ func TestDeprecatedAliasVisibleByDefault(t *testing.T) {
 	}
 	for alias := range deprecatedToolNames {
 		if !names[alias] {
-			t.Errorf("deprecated alias %q should be visible in the default tools/list", alias)
+			t.Errorf("deprecated alias %q should be listed when includeDeprecatedTools=true", alias)
 			continue
 		}
 		tool := byName[alias]
@@ -212,8 +234,8 @@ func TestDeprecatedAliasVisibleByDefault(t *testing.T) {
 }
 
 func TestDeprecatedAliasHiddenWhenExcluded(t *testing.T) {
-	// includeDeprecatedTools=false previews the v1.2 surface: aliases drop out of
-	// tools/list, while canonical scope-collapsed tools remain.
+	// Explicitly setting includeDeprecatedTools=false matches the v1.2 default:
+	// aliases drop out of tools/list, while canonical scope-collapsed tools remain.
 	ctx := WithIncludeDeprecatedTools(context.Background(), false)
 	cs, _ := setupScopedTestServer(t, ctx, nil)
 	result, err := cs.ListTools(ctx, nil)

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -71,21 +71,23 @@ func FilterByAuthzFromContext(ctx context.Context) (bool, bool) {
 
 // WithIncludeDeprecatedTools returns a copy of ctx carrying the per-session
 // decision of whether tools/list should include deprecated compatibility-alias
-// tools. The default (no value in ctx) is true: deprecated aliases are listed
-// alongside the canonical tools, each carrying a description-level deprecation
-// banner and a structured _meta marker. Clients that want to preview the
-// post-deprecation surface can set this to false to hide the aliases.
+// tools. The default (no value in ctx) is false as of v1.2: deprecated aliases
+// are hidden from tools/list, though they remain callable and still return a
+// runtime deprecation warning. Clients that have not yet migrated can set this
+// to true to keep listing the aliases (each carrying a description-level
+// deprecation banner and a structured _meta marker) until they are removed in
+// v1.3.
 func WithIncludeDeprecatedTools(ctx context.Context, include bool) context.Context {
 	return context.WithValue(ctx, includeDeprecatedToolsCtxKey{}, include)
 }
 
 // IncludeDeprecatedToolsFromContext reports whether tools/list should include
-// the deprecated compatibility-alias tools for this session. Defaults to true
+// the deprecated compatibility-alias tools for this session. Defaults to false
 // when the client did not set the flag.
 func IncludeDeprecatedToolsFromContext(ctx context.Context) bool {
 	v, ok := ctx.Value(includeDeprecatedToolsCtxKey{}).(bool)
 	if !ok {
-		return true
+		return false
 	}
 	return v
 }


### PR DESCRIPTION
## Purpose
The deprecated `*_cluster_*` control-plane MCP tools were listed in `tools/list` by default. Per the v1.2.0 deprecation timeline they should now be hidden by default, so this PR flips the `includeDeprecatedTools` default to `false`. The aliases remain callable and can be listed again with `?includeDeprecatedTools=true`.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3483

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)