### PR TITLE
docs: fix events-collector OpenSearch export in multi-cluster k3d guide

### DIFF
--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -700,6 +700,7 @@ exporters:
       endpoint: "https://host.k3d.internal:11085"
       tls:
         insecure_skip_verify: true
+        server_name_override: "opensearch.observability.openchoreo.localhost"
       headers:
         Host: "opensearch.observability.openchoreo.localhost"
       auth:
@@ -744,6 +745,7 @@ exporters:
       endpoint: "https://host.k3d.internal:11085"
       tls:
         insecure_skip_verify: true
+        server_name_override: "opensearch.observability.openchoreo.localhost"
       headers:
         Host: "opensearch.observability.openchoreo.localhost"
       auth:


### PR DESCRIPTION
## Problem

Following the multi-cluster k3d guide, the `observability-events-otel-collector` on the data/workflow planes never publishes events. Every flush fails with:

```
Exporting failed. Rejecting data. ... Permanent error: flush: EOF
```

The OP gateway exposes OpenSearch on 11085 via a **TLS passthrough listener routed by SNI** (`TLSRoute` for `opensearch.observability.openchoreo.localhost`). The guide's collector values only set an HTTP `Host:` header, so the handshake presents SNI `host.k3d.internal`, matches no route, and the gateway closes the connection before any HTTP is exchanged. (Fluent Bit is unaffected — its `openSearchVHost` sets the real SNI.)

## Fix

Add `server_name_override` to the exporter TLS config in both the data-plane and workflow-plane snippets so the SNI matches the TLSRoute.

## Verified

On a fresh multi-cluster install from `main` (v1.2.0-m1): before the change no `k8s-events-*` index is ever created; after upgrading both collectors with the override, the index appears and fills, with no collector errors.