### PR TITLE
fix: preserve oneOf/anyOf/allOf values in component & trait rendering

### DIFF
--- a/internal/pipeline/component/context/builder_test.go
+++ b/internal/pipeline/component/context/builder_test.go
@@ -158,6 +158,10 @@ spec:
 			want: map[string]any{
 				"parameters": map[string]any{
 					"cpu": "100m", // From Component.Spec.Parameters
+					// "replicas" is not declared in the parameters schema (it belongs to
+					// environmentConfigs), but rendering no longer prunes unknown values, so the
+					// extra parameter flows through inertly.
+					"replicas": float64(3),
 				},
 				"environmentConfigs": map[string]any{
 					"replicas": float64(5), // From ReleaseBinding.Spec.ComponentTypeEnvironmentConfigs
@@ -551,6 +555,10 @@ spec:
 			want: map[string]any{
 				"parameters": map[string]any{
 					"database": "mydb",
+					// "size" is not declared in the parameters schema (it belongs to
+					// environmentConfigs), but rendering no longer prunes unknown values, so the
+					// extra parameter flows through inertly.
+					"size": "small",
 				},
 				"environmentConfigs": map[string]any{
 					"size": "large", // From ReleaseBinding.Spec.TraitEnvironmentConfigs

--- a/internal/pipeline/component/context/component.go
+++ b/internal/pipeline/component/context/component.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
-	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -25,8 +24,8 @@ var validate = validator.New(validator.WithRequiredStructEnabled())
 // BuildComponentContext builds a CEL evaluation context for rendering component resources.
 //
 // The context includes:
-//   - parameters: From Component.Spec.Parameters (pruned to schema.parameters) - access via ${parameters.*}
-//   - environmentConfigs: From ReleaseBinding.Spec.ComponentTypeEnvironmentConfigs (pruned to schema.environmentConfigs) - access via ${environmentConfigs.*}
+//   - parameters: From Component.Spec.Parameters (validated against schema.parameters) - access via ${parameters.*}
+//   - environmentConfigs: From ReleaseBinding.Spec.ComponentTypeEnvironmentConfigs (validated against schema.environmentConfigs) - access via ${environmentConfigs.*}
 //   - workload: Workload specification (image, resources, etc.) - access via ${workload.*}
 //   - metadata: Structured naming and labeling information - access via ${metadata.*}
 //   - dataplane: Data plane configuration - access via ${dataplane.*}
@@ -114,16 +113,19 @@ func processComponentParameters(input *ComponentContextInput) (map[string]any, m
 	return parameters, envConfigs, nil
 }
 
-// applySchemaSection prunes, applies defaults, and validates a raw map of values against a
+// applySchemaSection applies defaults to and validates a raw map of values against a
 // schema bundle. Returns an empty map if bundle is nil (no schema defined).
 // Used by component and trait context builders to process both parameters and environmentConfigs.
+//
+// Note: values are intentionally not pruned. Structural-schema pruning does not descend into
+// oneOf/anyOf/allOf branches, so it corrupts values whose shape is declared only inside such a
+// branch; JSON-schema validation stays authoritative for developer-supplied values instead.
 func applySchemaSection(raw map[string]any, bundle *SchemaBundle, section string) (map[string]any, error) {
 	if bundle == nil {
 		return make(map[string]any), nil
 	}
 	out := make(map[string]any, len(raw))
 	maps.Copy(out, raw)
-	pruning.Prune(out, bundle.Structural, false)
 	out = schema.ApplyDefaults(out, bundle.Structural)
 	if err := schema.ValidateWithJSONSchema(out, bundle.JSONSchema); err != nil {
 		return nil, fmt.Errorf("%s validation failed: %w", section, err)
@@ -418,7 +420,7 @@ func structToMap(v any) (map[string]any, error) {
 }
 
 // SchemaBundle holds both structural and JSON schemas for validation workflows.
-// The structural schema is used for pruning and defaulting, while the JSON schema
+// The structural schema is used for defaulting, while the JSON schema
 // is used for validation.
 type SchemaBundle struct {
 	Structural *apiextschema.Structural

--- a/internal/pipeline/component/context/component_test.go
+++ b/internal/pipeline/component/context/component_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -280,15 +281,17 @@ func TestProcessComponentParameters_NoSchema(t *testing.T) {
 	assert.Empty(t, ctx.EnvironmentConfigs)
 }
 
-func TestProcessComponentParameters_PruneAndDefault(t *testing.T) {
+func TestProcessComponentParameters_DefaultAndExtra(t *testing.T) {
 	// Schema defines "replicas" (integer, default=1), "image" (string), and "protocol" (string, default="TCP").
 	// Component provides "image" and "extra" but omits "replicas" and "protocol" — those should get defaults.
+	// The schema does not forbid additional properties, so the "extra" key flows through inertly
+	// (rendering no longer prunes unknown developer-supplied values).
 	input := &ComponentContextInput{
 		Component: &v1alpha1.Component{
 			Spec: v1alpha1.ComponentSpec{
 				Parameters: rawParams(map[string]any{
 					"image": "myapp:v1",
-					"extra": "should-be-pruned",
+					"extra": "kept-not-pruned",
 				}),
 			},
 		},
@@ -308,14 +311,76 @@ func TestProcessComponentParameters_PruneAndDefault(t *testing.T) {
 
 	ctx, err := BuildComponentContext(input)
 	require.NoError(t, err)
-	// extra key should be pruned
-	_, hasExtra := ctx.Parameters["extra"]
-	assert.False(t, hasExtra, "extra key should be pruned")
+	// extra key is no longer pruned; it flows through since the schema allows additional properties
+	assert.Equal(t, "kept-not-pruned", ctx.Parameters["extra"])
 	// provided values should remain
 	assert.Equal(t, "myapp:v1", ctx.Parameters["image"])
 	// omitted fields should get schema defaults
 	assert.Equal(t, int64(1), ctx.Parameters["replicas"])
 	assert.Equal(t, "TCP", ctx.Parameters["protocol"])
+}
+
+// TestProcessComponentParameters_OneOfObjectVariantPreserved is a regression test for the
+// pruning bug where a field whose shape is declared only inside a oneOf/anyOf/allOf branch
+// (e.g. a CORS allowed-origin that is either a plain string OR an object {regex: ...}) was
+// stripped to {} by structural-schema pruning and then rejected by JSON-schema validation.
+// Structural-schema pruning never descends into oneOf/anyOf/allOf branches, so the object
+// variant's inner fields must survive untouched once pruning is removed from the pipeline.
+func TestProcessComponentParameters_OneOfObjectVariantPreserved(t *testing.T) {
+	oneOfItemSchema := objectSchema(map[string]any{
+		"corsAllowedOrigins": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"oneOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"regex": map[string]any{"type": "string"},
+						},
+						"required": []any{"regex"},
+					},
+				},
+			},
+		},
+	})
+
+	input := &ComponentContextInput{
+		Component: &v1alpha1.Component{
+			Spec: v1alpha1.ComponentSpec{
+				Parameters: rawParams(map[string]any{
+					"corsAllowedOrigins": []any{
+						"https://example.com",                       // string variant -> survives
+						map[string]any{"regex": `.*\.example\.com`}, // object variant -> must be preserved
+					},
+				}),
+			},
+		},
+		ComponentType: &v1alpha1.ComponentType{
+			Spec: v1alpha1.ComponentTypeSpec{
+				Parameters: openAPIV3Schema(oneOfItemSchema),
+			},
+		},
+		DataPlane:   minimalDataPlane(),
+		Environment: minimalEnvironment(),
+		Metadata:    validMetadata(),
+	}
+
+	ctx, err := BuildComponentContext(input)
+	require.NoError(t, err)
+
+	// The schema has no defaults, so the parameters must pass through untouched: the string
+	// variant survives and the object variant's regex (declared only inside the oneOf branch)
+	// is preserved rather than pruned to {}.
+	want := map[string]any{
+		"corsAllowedOrigins": []any{
+			"https://example.com",
+			map[string]any{"regex": `.*\.example\.com`},
+		},
+	}
+	if diff := cmp.Diff(want, ctx.Parameters); diff != "" {
+		t.Errorf("parameters mismatch (-want +got):\n%s", diff)
+	}
 }
 
 // --- extractDataPlaneData tests ---

--- a/internal/pipeline/component/context/trait_unit_test.go
+++ b/internal/pipeline/component/context/trait_unit_test.go
@@ -186,7 +186,7 @@ func TestBuildTraitContext_EmptyResolvedParamsAppliesDefaults(t *testing.T) {
 	assert.Equal(t, int64(3), ctx.Parameters["retries"])
 }
 
-func TestBuildTraitContext_PrunesAndDefaults(t *testing.T) {
+func TestBuildTraitContext_DefaultsAndExtra(t *testing.T) {
 	input := validTraitContextInput()
 	input.Trait.Spec.Parameters = openAPIV3Schema(objectSchema(map[string]any{
 		"name":    stringPropSchema(),
@@ -196,10 +196,11 @@ func TestBuildTraitContext_PrunesAndDefaults(t *testing.T) {
 		"replicas": integerPropSchema(1),
 	}))
 
-	// One valid key, one extra key to be pruned, timeout omitted so defaults apply
+	// One valid key, one extra key; timeout omitted so defaults apply. The schema allows
+	// additional properties, so the extra key flows through inertly (no longer pruned).
 	input.ResolvedParameters = map[string]any{
 		"name":     "my-app",
-		"extraKey": "should-be-pruned",
+		"extraKey": "kept-not-pruned",
 	}
 	// Empty so defaults are applied
 	input.ResolvedEnvironmentConfigs = map[string]any{}
@@ -208,8 +209,8 @@ func TestBuildTraitContext_PrunesAndDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ctx)
 
-	_, hasExtra := ctx.Parameters["extraKey"]
-	assert.False(t, hasExtra, "extraKey should have been pruned")
+	assert.Equal(t, "kept-not-pruned", ctx.Parameters["extraKey"],
+		"extra key is no longer pruned; it flows through since the schema allows additional properties")
 	assert.Equal(t, "my-app", ctx.Parameters["name"])
 	assert.Equal(t, "30s", ctx.Parameters["timeout"])
 	assert.Equal(t, int64(1), ctx.EnvironmentConfigs["replicas"])


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
A Component or Trait parameters/environmentConfigs field whose shape is declared only inside a oneOf/anyOf/allOf branch of the ComponentType/Trait schema (e.g. a CORS allowed-origin that is either a string or {regex: ...}) was corrupted during rendering. Structural-schema pruning never descends into oneOf/anyOf/allOf branches, so the value was stripped to {} and then rejected by JSON-schema validation, failing the render.

Remove the pruning.Prune call from applySchemaSection (the helper shared by the component and trait context builders, for both parameters and environmentConfigs). The protections pruning once provided are now covered by strict admission-time CEL expression validation and JSON-schema validation, which stays authoritative for developer-supplied values. The pipeline is now copy -> ApplyDefaults -> ValidateWithJSONSchema.

Unknown developer-supplied values are no longer silently dropped: they flow through inertly (no template can reference them) or surface as a validation error if the schema forbids additional properties. Existing context tests are updated to reflect this; adds a regression test asserting a oneOf object variant in Component parameters survives end-to-end.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> closes https://github.com/openchoreo/openchoreo/issues/3812

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
