### PR TITLE
chore: bump Kubernetes Gateway API to v1.5

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-data-plane/templates/_helpers.tpl
@@ -150,5 +150,11 @@ Validate that placeholder .invalid hostnames have been replaced with real domain
     {{- fail "gateway.tls.hostname contains placeholder domain (.invalid). Set a real domain." -}}
   {{- end -}}
 {{- end -}}
+{{- if .Values.gateway.tlsPassthrough.enabled -}}
+  {{- $tpHostname := .Values.gateway.tlsPassthrough.hostname | default "" -}}
+  {{- if contains ".invalid" $tpHostname -}}
+    {{- fail "gateway.tlsPassthrough.hostname contains placeholder domain (.invalid). Set a real domain." -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}
 

--- a/install/helm/openchoreo-data-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-data-plane/templates/_helpers.tpl
@@ -144,6 +144,16 @@ Cluster Agent service account name
 Validate that placeholder .invalid hostnames have been replaced with real domains.
 */}}
 {{- define "openchoreo-data-plane.validateHostnames" -}}
+{{- $ports := list (int .Values.gateway.httpPort) -}}
+{{- if .Values.gateway.tls.enabled -}}
+  {{- $ports = append $ports (int .Values.gateway.httpsPort) -}}
+{{- end -}}
+{{- if .Values.gateway.tlsPassthrough.enabled -}}
+  {{- $ports = append $ports (int .Values.gateway.tlsPassthrough.port) -}}
+{{- end -}}
+{{- if ne (len $ports) (len (uniq $ports)) -}}
+  {{- fail "gateway listener ports (httpPort, httpsPort, tlsPassthrough.port) must be unique across all enabled listeners." -}}
+{{- end -}}
 {{- if .Values.gateway.tls.enabled -}}
   {{- $hostname := .Values.gateway.tls.hostname | default "" -}}
   {{- if contains ".invalid" $hostname -}}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -87,6 +87,7 @@ rules:
   - httproutes
   - tcproutes
   - grpcroutes
+  - tlsroutes
   - referencegrants
   verbs: ["*"]
 # External Secrets Operator

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -44,4 +44,17 @@ spec:
             {{- end }}
           {{- end }}
 {{- end }}
+{{- if .Values.gateway.tlsPassthrough.enabled }}
+    - name: tls-passthrough
+      protocol: TLS
+      port: {{ .Values.gateway.tlsPassthrough.port | default 8443 }}
+      {{- if .Values.gateway.tlsPassthrough.hostname }}
+      hostname: {{ .Values.gateway.tlsPassthrough.hostname | quote }}
+      {{- end }}
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Passthrough
+{{- end }}
 {{- end }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -796,6 +796,35 @@
           "required": [],
           "title": "tls",
           "type": "object"
+        },
+        "tlsPassthrough": {
+          "additionalProperties": false,
+          "description": "TLS passthrough (SNI) configuration. Adds a Gateway listener (protocol TLS, mode Passthrough)\nthat routes encrypted traffic by SNI without terminating TLS; the workload terminates TLS itself.\nRequired by TLSRoute-based ComponentTypes such as the component-tls-service sample.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable the TLS passthrough listener. When false, no passthrough listener is created.",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "hostname": {
+              "default": "*.openchoreoapis.invalid",
+              "description": "Hostname pattern for the TLS passthrough listener (SNI matching). When empty, the listener\nmatches all SNIs. Must encompass the TLSRoute hostnames (e.g. \"*.openchoreoapis.invalid\").\n",
+              "title": "hostname",
+              "type": "string"
+            },
+            "port": {
+              "default": 8443,
+              "description": "Port for the TLS passthrough listener. Must differ from httpsPort when the HTTPS (Terminate) listener is also enabled.",
+              "maximum": 65535,
+              "minimum": 1,
+              "title": "port",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "tlsPassthrough",
+          "type": "object"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -132,6 +132,39 @@ gateway:
 
   # @schema
   # type: object
+  # description: |
+  #   TLS passthrough (SNI) configuration. Adds a Gateway listener (protocol TLS, mode Passthrough)
+  #   that routes encrypted traffic by SNI without terminating TLS; the workload terminates TLS itself.
+  #   Required by TLSRoute-based ComponentTypes such as the component-tls-service sample.
+  # @schema
+  tlsPassthrough:
+    # @schema
+    # type: boolean
+    # description: Enable the TLS passthrough listener. When false, no passthrough listener is created.
+    # default: false
+    # @schema
+    enabled: false
+
+    # @schema
+    # type: string
+    # description: |
+    #   Hostname pattern for the TLS passthrough listener (SNI matching). When empty, the listener
+    #   matches all SNIs. Must encompass the TLSRoute hostnames (e.g. "*.openchoreoapis.invalid").
+    # default: "*.openchoreoapis.invalid"
+    # @schema
+    hostname: "*.openchoreoapis.invalid"
+
+    # @schema
+    # type: integer
+    # description: Port for the TLS passthrough listener. Must differ from httpsPort when the HTTPS (Terminate) listener is also enabled.
+    # default: 8443
+    # minimum: 1
+    # maximum: 65535
+    # @schema
+    port: 8443
+
+  # @schema
+  # type: object
   # additionalProperties: true
   # description: KGateway controller configuration for managing Gateway API resources
   # @schema

--- a/install/k3d/k3d-prerequisites.sh
+++ b/install/k3d/k3d-prerequisites.sh
@@ -13,10 +13,10 @@ set -euo pipefail
 
 # -- versions (update these on release branches) --
 OPENCHOREO_REF="${OPENCHOREO_REF:-main}"   # overridable via env; defaults to main
-GATEWAY_API_VERSION="v1.4.1"
+GATEWAY_API_VERSION="v1.5.1"
 CERT_MANAGER_VERSION="v1.19.4"
 ESO_VERSION="2.0.1"
-KGATEWAY_VERSION="v2.2.1"
+KGATEWAY_VERSION="v2.3.1"
 OPENBAO_CHART_VERSION="0.25.6"
 
 # -- derived constants --

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -43,7 +43,7 @@ k3d cluster create --config install/k3d/multi-cluster/config-cp.yaml
 ```bash
 # Gateway API CRDs
 kubectl apply --context k3d-openchoreo-cp --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 
 # cert-manager
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
@@ -59,11 +59,11 @@ kubectl --context k3d-openchoreo-cp wait --for=condition=Available deployment/ce
 # kgateway
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-control-plane --kube-context k3d-openchoreo-cp \
-  --version v2.2.1
+  --version v2.3.1
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace --kube-context k3d-openchoreo-cp \
-  --version v2.2.1 \
+  --version v2.3.1 \
   --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
 ```
 
@@ -135,7 +135,7 @@ docker exec k3d-openchoreo-dp-server-0 sh -c \
 ```bash
 # Gateway API CRDs
 kubectl apply --context k3d-openchoreo-dp --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 
 # cert-manager
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
@@ -162,11 +162,11 @@ kubectl --context k3d-openchoreo-dp wait --for=condition=Available deployment/ex
 # kgateway
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-data-plane --kube-context k3d-openchoreo-dp \
-  --version v2.2.1
+  --version v2.3.1
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-data-plane --create-namespace --kube-context k3d-openchoreo-dp \
-  --version v2.2.1 \
+  --version v2.3.1 \
   --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
 ```
 
@@ -406,16 +406,16 @@ docker exec k3d-openchoreo-op-server-0 sh -c \
 ```bash
 # Gateway API CRDs
 kubectl apply --context k3d-openchoreo-op --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 
 # kgateway
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-observability-plane --kube-context k3d-openchoreo-op \
-  --version v2.2.1
+  --version v2.3.1
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-observability-plane --create-namespace --kube-context k3d-openchoreo-op \
-  --version v2.2.1 \
+  --version v2.3.1 \
   --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
 
 # cert-manager

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -29,7 +29,7 @@ docker exec k3d-openchoreo-server-0 sh -c \
 
 ```bash
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 ```
 
 ### cert-manager
@@ -69,11 +69,11 @@ Single install, watches Gateway resources across all namespaces.
 ```bash
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-control-plane \
-  --version v2.2.1
+  --version v2.3.1
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace \
-  --version v2.2.1 \
+  --version v2.3.1 \
   --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
 ```
 

--- a/install/quick-start/.config.sh
+++ b/install/quick-start/.config.sh
@@ -26,7 +26,7 @@ ESO_VERSION="v2.0.1"
 ESO_REPO="oci://ghcr.io/external-secrets/charts"
 
 # kgateway configuration
-KGATEWAY_VERSION="v2.2.1"
+KGATEWAY_VERSION="v2.3.1"
 
 # Thunder configuration
 THUNDER_VERSION="0.28.0"

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -567,7 +567,7 @@ install_eso() {
 install_gateway_crds() {
     log_info "Installing Gateway API CRDs..."
     kubectl apply --server-side \
-        -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml >/dev/null
+        -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml >/dev/null
     log_success "Gateway API CRDs installed"
 }
 


### PR DESCRIPTION
## Purpose
This PR updates the Kubernetes Gateway API version to v1.5.1 along with kgateway v2.3.1. Also as the Kubernetes Gateway API v1.5 graduated the TLSRoute, we can provide support for TLS passthrough via a gateway listener.

## Approach
Upgrade the dependency versions of the helm charts.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3836

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
API gateway modules will be updated separately depending on the availability of the Gateway API version.