### PR TITLE
docs: document Trait removes and toEndpointResources macro

### DIFF
--- a/docs/templating/configuration_helpers.md
+++ b/docs/templating/configuration_helpers.md
@@ -514,6 +514,81 @@ backendRefs:
 - Endpoints are processed in alphabetical order for deterministic output
 - Use with `includeWhen: ${size(workload.endpoints) > 0}` to conditionally create Services only when endpoints exist
 
+#### workload.toEndpointResources(endpointName)
+
+Opt-in helper that parses an endpoint's API schema (the OpenAPI document for HTTP endpoints, the protobuf definition
+for gRPC endpoints) and returns the flat list of routes it declares. This lets a ComponentType render **exact**
+per-route gateway matches (one match per OpenAPI path/method, or per gRPC service/method) instead of a single
+catch-all rule.
+
+The macro is **opt-in**: endpoint schemas are only parsed when a template actually calls
+`workload.toEndpointResources(...)`, so templates that don't use it pay no parsing cost.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `endpointName` | string | The endpoint map key (e.g. `"http"`, `"grpc"`) — the same key used under `workload.endpoints` |
+
+**Returns:** a CEL **optional** wrapping a list of route objects. Consume it with `.orValue([])`, or guard with
+`.hasValue()` / `.value()`. Each route object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kind` | string | Protocol of the route: `"HTTP"` or `"gRPC"` |
+| `service` | string | Fully-qualified gRPC service name (e.g. `greeter.Greeter`). Empty for HTTP routes |
+| `method` | string | HTTP verb (`GET`/`POST`/...) for HTTP routes, or the gRPC method name (e.g. `SayHello`) |
+| `path` | string | HTTP path template (e.g. `/v1/pets/{id}`). Empty for gRPC routes |
+
+Routes are returned in a deterministic (sorted) order so rendered output is stable.
+
+**Extraction is best-effort.** A missing, empty, or unparseable schema (or an endpoint protocol with no extractor,
+such as TCP/UDP) yields an empty list — never a render failure. Schema format is inferred from the endpoint type
+(`HTTP` → OpenAPI, `gRPC` → protobuf) unless `workload.endpoints.<name>.schema.type` overrides it.
+
+**Example — gRPC, one GRPCRoute match per (service, method):**
+
+```yaml
+rules:
+  # Render one match per (service, method) from the proto schema; fall back to a
+  # catch-all rule (no matches) when the endpoint has no parseable schema.
+  - matches: >-
+      ${workload.toEndpointResources(endpoint.key).hasValue()
+        ? workload.toEndpointResources(endpoint.key).value().map(r,
+            {"method": {"type": "Exact", "service": r.service, "method": r.method}})
+        : oc_omit()}
+    backendRefs:
+      - name: ${metadata.componentName}
+        port: ${endpoint.value.port}
+```
+
+**Example — HTTP, one HTTPRoute rule per (path, method) from OpenAPI:**
+
+```yaml
+# Parameterized paths (/books/{id}) become a RegularExpression match ({param} -> [^/]+);
+# static paths use an Exact match.
+rules: >-
+  ${workload.toEndpointResources(endpoint.key).orValue([]).map(r, {
+      "matches": [{
+        "path": {
+          "type": r.path.contains("{") ? "RegularExpression" : "Exact",
+          "value": r.path.contains("{")
+            ? r.path.split("/").map(s, s.startsWith("{") ? "[^/]+" : s).join("/")
+            : r.path
+        },
+        "method": r.method
+      }],
+      "backendRefs": [{"name": metadata.componentName, "port": endpoint.value.port}]
+    })}
+```
+
+**Notes:**
+- Returns a CEL optional, not a plain list — always unwrap with `.orValue([])` or `.hasValue()`/`.value()`.
+- Only OpenAPI (HTTP) and protobuf (gRPC) extractors are registered today; GraphQL and AsyncAPI are reserved and
+  currently degrade to an empty list.
+- Full, runnable examples ship in `samples/component-types/component-grpc-service/` and
+  `samples/component-types/component-http-openapi-service/`.
+
 ## See Also
 
 - [Context Reference](./context.md) - Main context documentation

--- a/docs/templating/context.md
+++ b/docs/templating/context.md
@@ -426,13 +426,18 @@ ports: |
   })}
 ```
 
-**Workload Endpoint Helper Method:**
+**Workload Endpoint Helper Methods:**
 
-The `workload` object provides a helper method to simplify Service port generation:
+The `workload` object provides helper methods for endpoint-driven resource generation:
 
-| Helper Method               | Description                                                                                     |
-|-----------------------------|-------------------------------------------------------------------------------------------------|
-| `workload.toServicePorts()` | Converts endpoints map to Service ports list with proper protocol mapping and name sanitization |
+| Helper Method                                | Description                                                                                                                                          |
+|----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `workload.toServicePorts()`                  | Converts endpoints map to Service ports list with proper protocol mapping and name sanitization                                                     |
+| `workload.toEndpointResources(endpointName)` | Opt-in: parses the named endpoint's API schema (`schema` field) into a list of routes for rendering exact per-route gateway matches. Returns a CEL optional |
+
+`toEndpointResources` reads `workload.endpoints.<name>.schema` (OpenAPI for HTTP, protobuf for gRPC) and returns a CEL
+optional wrapping a list of `{kind, service, method, path}` route objects — consume it with `.orValue([])` or
+`.hasValue()`/`.value()`. Schemas are only parsed when a template calls this macro.
 
 For detailed documentation and examples,
 see [Configuration Helpers - Workload Endpoint Helpers](./configuration_helpers.md#workload-endpoint-helpers).

--- a/docs/templating/patching.md
+++ b/docs/templating/patching.md
@@ -10,6 +10,9 @@ Traits can modify existing resources using patches, which are JSON Patch operati
 - CEL-based resource targeting
 - forEach iteration support
 
+A Trait can also **delete** whole resources produced by the ComponentType or earlier traits using the `spec.removes`
+section. See [Removing Resources](#removing-resources).
+
 ## Basic Patch Structure
 
 Patches are defined in the Trait's `spec.patches` section:
@@ -381,6 +384,97 @@ patches:
         value:
           containerPort: ${port.number}
           name: ${port.name}
+```
+
+## Removing Resources
+
+Patches modify resources in place. When a Trait needs to **delete** a whole resource produced by the ComponentType
+or by an earlier trait, use the `spec.removes` section instead. Each entry matches resources by GVK (and optional
+`where` filter) and removes the matched resources entirely from the rendered output.
+
+```yaml
+apiVersion: v1alpha1
+kind: Trait
+metadata:
+  name: drop-default-route
+spec:
+  removes:
+    - target:
+        kind: HTTPRoute
+        group: gateway.networking.k8s.io
+        version: v1
+      targetPlane: dataplane
+```
+
+### Remove Structure
+
+A remove entry uses the same `target` shape as a patch, but has no `operations` — the whole matched resource is
+deleted:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `target.kind` | Yes | Resource kind to remove (e.g. `HTTPRoute`, `ConfigMap`) |
+| `target.group` | Yes | API group; use `""` for core API resources |
+| `target.version` | Yes | API version (e.g. `v1`) |
+| `target.where` | No | CEL expression to filter which matching resources are removed (e.g. `${resource.metadata.name.endsWith("-default")}`) |
+| `targetPlane` | No | Plane whose resources are targeted; defaults to `"dataplane"` |
+| `forEach` / `var` | No | Iterate over a CEL list, binding each item to `var` for use in `where` |
+
+### Execution Order
+
+Within a single trait, removes run **after** its `creates` and `patches`. This lets one trait fully express a
+substitution — create a replacement resource and then remove the original:
+
+```yaml
+spec:
+  creates:
+    - template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${metadata.name}-tuned-config
+        data:
+          mode: optimized
+  removes:
+    # Drop the ConfigMap the ComponentType emitted, now that the tuned one exists
+    - target:
+        kind: ConfigMap
+        group: ""
+        version: v1
+        where: ${resource.metadata.name == metadata.name + "-default-config"}
+```
+
+### Workload Resources Cannot Be Removed
+
+The primary workload is defined by the ComponentType, so traits **must not** delete it. The admission webhook
+rejects removes that target a built-in workload GVK — kinds `Deployment`, `StatefulSet`, `DaemonSet`, `CronJob`, or
+`Job` in the `apps` or `batch` groups:
+
+```yaml
+# REJECTED by the webhook - cannot remove the workload
+removes:
+  - target:
+      kind: Deployment
+      group: apps
+      version: v1
+```
+
+The match is on the full GVK, so a custom CRD that merely shares one of these kind names in a different group
+(e.g. `group: example.com`, `kind: Deployment`) is **not** rejected.
+
+### ForEach Removal
+
+Like patches, removes support `forEach` to delete a set of resources derived from a CEL list:
+
+```yaml
+removes:
+  - target:
+      kind: HTTPRoute
+      group: gateway.networking.k8s.io
+      version: v1
+      where: ${resource.metadata.labels["openchoreo.dev/endpoint-name"] == route}
+    forEach: ${parameters.routesToDrop}
+    var: route
 ```
 
 ## RFC 6901 Escaping


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Bring docs/templating up to date with two features that landed after the last docs refresh:

- Add a "Removing Resources" section to patching.md covering the Trait spec.removes section (#3573): target shape, execution order (removes run after creates/patches), the webhook rule blocking built-in workload kinds, and forEach removal.
- Document the opt-in workload.toEndpointResources() CEL macro (#3671) in configuration_helpers.md, with the route field shape and gRPC/HTTP examples, and reference it from the workload section of context.md.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
