### PR TITLE
test: add e2e coverage for MCP authorization and observer MCP

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -300,9 +300,12 @@ jobs:
           esac
 
       - name: Add e2e multi-cluster host entries
-        # CP cluster external domains only — DP/WP/OP clusters are reached
-        # via host.k3d.internal from within k3d nodes, not the CI runner.
-        run: echo '127.0.0.1 api.e2e-mc-cp.local thunder.e2e-mc-cp.local openchoreo.e2e-mc-cp.local cluster-gateway.e2e-mc-cp.local' | sudo tee -a /etc/hosts
+        # CP cluster external domains plus the OP observer hostname. The observer
+        # is reachable from the runner via the OP cluster's loadbalancer port
+        # mapping (31080:11080), so the observer MCP specs drive host-side MCP
+        # sessions against observer.e2e-mc-op.local. Other DP/WP/OP services are
+        # still reached only via host.k3d.internal from within k3d nodes.
+        run: echo '127.0.0.1 api.e2e-mc-cp.local thunder.e2e-mc-cp.local openchoreo.e2e-mc-cp.local cluster-gateway.e2e-mc-cp.local observer.e2e-mc-op.local' | sudo tee -a /etc/hosts
 
       - name: Run multi-cluster e2e tests (tier 3)
         run: |

--- a/install/k3d/common/values-thunder.yaml
+++ b/install/k3d/common/values-thunder.yaml
@@ -950,3 +950,55 @@ bootstrap:
 
         log_info "FinOps Agent application created successfully"
       fi
+
+    61-mcp-e2e-subject-app.sh: |
+      #!/bin/bash
+      set -e
+
+      THUNDER_URL="http://localhost:8090"
+
+      log_info "Checking if application 'MCP E2E Subject' already exists..."
+      existing_apps=$(curl -s --max-time 10 "${THUNDER_URL}/applications")
+
+      app_id=$(echo "$existing_apps" | tr '\n' ' ' | sed 's/" *: *"/":"/g' | grep -o '"client_id":"mcp-e2e-subject-client"[^}]*"id":"[^"]*"\|"id":"[^"]*"[^}]*"client_id":"mcp-e2e-subject-client"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+      APP_PAYLOAD='{
+        "name": "MCP E2E Subject",
+        "description": "Permission-less client_credentials subject for MCP e2e authorization tests. Intentionally has NO ClusterAuthzRoleBinding.",
+        "inbound_auth_config": [
+          {
+            "type": "oauth2",
+            "config": {
+              "client_id": "mcp-e2e-subject-client",
+              "client_secret": "mcp-e2e-subject-secret",
+              "grant_types": [
+                "client_credentials"
+              ],
+              "token_endpoint_auth_method": "client_secret_post",
+              "pkce_required": false,
+              "public_client": false,
+              "token": {
+                "access_token": {
+                  "validity_period": 3600
+                }
+              }
+            }
+          }
+        ]
+      }'
+
+      if [ -n "$app_id" ]; then
+        log_info "Application 'MCP E2E Subject' already exists (id: $app_id), updating..."
+        curl --location -X PUT "${THUNDER_URL}/applications/$app_id" \
+          --header 'Content-Type: application/json' \
+          --data "$APP_PAYLOAD" \
+          --fail-with-body --max-time 30 --retry 3 --retry-delay 5
+        log_info "Application updated successfully"
+      else
+        log_info "Application 'MCP E2E Subject' does not exist, creating..."
+        curl --location "${THUNDER_URL}/applications" \
+          --header 'Content-Type: application/json' \
+          --data "$APP_PAYLOAD" \
+          --fail-with-body --max-time 30 --retry 3 --retry-delay 5
+        log_info "Application created successfully"
+      fi

--- a/test/e2e/framework/authzfixtures.go
+++ b/test/e2e/framework/authzfixtures.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+// Parameterized ClusterAuthzRole / ClusterAuthzRoleBinding builders shared by e2e
+// suites that need a custom subject and cleanup label. The subject and label
+// key/value are parameters so suites running concurrently don't collide on a
+// single subject.
+
+// ClusterAuthzRoleYAML renders a ClusterAuthzRole with the given actions and an
+// arbitrary label (key/value) for cleanup selectors.
+func ClusterAuthzRoleYAML(name, labelKey, labelValue string, actions []string) string {
+	actionsYAML := ""
+	for _, a := range actions {
+		actionsYAML += fmt.Sprintf("    - %q\n", a)
+	}
+	return fmt.Sprintf(`apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRole
+metadata:
+  name: %s
+  labels:
+    %s: %q
+spec:
+  actions:
+%s`, name, labelKey, labelValue, actionsYAML)
+}
+
+// ClusterAuthzRoleBindingYAML renders a ClusterAuthzRoleBinding mapping the
+// entitlement claim `sub` == subject to the named ClusterAuthzRole.
+// effect is "allow" or "deny".
+func ClusterAuthzRoleBindingYAML(name, labelKey, labelValue, roleName, subject, effect string) string {
+	return fmt.Sprintf(`apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: %s
+  labels:
+    %s: %q
+spec:
+  roleMappings:
+    - roleRef:
+        name: %s
+        kind: ClusterAuthzRole
+  entitlement:
+    claim: sub
+    value: %s
+  effect: %s
+`, name, labelKey, labelValue, roleName, subject, effect)
+}
+
+// ScopedClusterAuthzRoleBindingYAML is ClusterAuthzRoleBindingYAML with a
+// `scope.namespace` restriction on the role mapping.
+func ScopedClusterAuthzRoleBindingYAML(name, labelKey, labelValue, roleName, subject, effect, scopeNamespace string) string {
+	return fmt.Sprintf(`apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: %s
+  labels:
+    %s: %q
+spec:
+  roleMappings:
+    - roleRef:
+        name: %s
+        kind: ClusterAuthzRole
+      scope:
+        namespace: %s
+  entitlement:
+    claim: sub
+    value: %s
+  effect: %s
+`, name, labelKey, labelValue, roleName, scopeNamespace, subject, effect)
+}
+
+// DeleteClusterAuthzRoleBindingAndWaitForRevocation deletes the binding and
+// polls probe() (which must return true once the subject is denied again)
+// until the Casbin PDP has observed the revocation.
+// Mirrors test/e2e/suites/authz/authz_test.go:23-32.
+func DeleteClusterAuthzRoleBindingAndWaitForRevocation(kubeContext, name string, probe func() bool) {
+	output, err := Kubectl(kubeContext, "delete", "clusterauthzrolebinding", name, "--ignore-not-found", "--wait=false")
+	// Fail fast: a failed delete leaves the binding in place, so the probe below
+	// would never observe revocation and would mask the real cause behind a timeout.
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(),
+		"failed to delete clusterauthzrolebinding %s: %s", name, output)
+	gomega.EventuallyWithOffset(1, probe, DefaultTimeout, 2*time.Second).Should(gomega.BeTrue(),
+		"binding %s revocation did not propagate in time", name)
+}

--- a/test/e2e/framework/mcp.go
+++ b/test/e2e/framework/mcp.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/onsi/gomega"
 )
 
 const mcpCallTimeout = 30 * time.Second
@@ -143,6 +144,41 @@ func CallMCPToolJSON(session *mcp.ClientSession, toolName string, args map[strin
 		}
 	}
 	return nil
+}
+
+// CallMCPToolExpectDenied calls the tool and asserts the call fails with an
+// error containing wantSubstring. It returns the error for further inspection.
+// Covers both denial surfaces: the JSON-RPC method error from the CP tool-filter
+// middleware (pkg/mcp/tools/filter.go:174), and the IsError tool result when the
+// service layer denies — CallMCPTool surfaces both as a non-nil error whose
+// message contains the denial text.
+func CallMCPToolExpectDenied(session *mcp.ClientSession, toolName string, args map[string]any, wantSubstring string) error {
+	_, err := CallMCPTool(session, toolName, args)
+	// Offset(1) so a failure is reported at the calling spec, not in this helper.
+	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(),
+		"expected tool %s to be denied, but the call succeeded", toolName)
+	gomega.ExpectWithOffset(1, err.Error()).To(gomega.ContainSubstring(wantSubstring),
+		"tool %s denial error %q does not contain %q", toolName, err.Error(), wantSubstring)
+	return err
+}
+
+// DeniedProbe builds a probe for DeleteClusterAuthzRoleBindingAndWaitForRevocation: it calls
+// toolName and returns true once the resulting error contains wantSubstring (i.e. the subject is
+// denied again). If the call unexpectedly succeeds (still authorized), it runs onUnexpectedSuccess
+// — pass nil for read-only tools that create nothing — and returns false to keep waiting.
+// Centralizing the cleanup-on-success branch keeps a stray probe resource from colliding on the
+// next poll.
+func DeniedProbe(session *mcp.ClientSession, toolName string, args map[string]any, wantSubstring string, onUnexpectedSuccess func()) func() bool {
+	return func() bool {
+		_, err := CallMCPTool(session, toolName, args)
+		if err == nil {
+			if onUnexpectedSuccess != nil {
+				onUnexpectedSuccess()
+			}
+			return false
+		}
+		return strings.Contains(err.Error(), wantSubstring)
+	}
 }
 
 func extractTextContent(result *mcp.CallToolResult) string {

--- a/test/e2e/suites/mcp/mcp_fixtures_test.go
+++ b/test/e2e/suites/mcp/mcp_fixtures_test.go
@@ -30,6 +30,19 @@ func mustYAMLDocs(objects ...any) string {
 	return strings.Join(docs, "\n---\n")
 }
 
+// cpNamespaceYAML renders a control-plane namespace (labelled so the
+// openchoreo-api recognises it as a CP namespace). Used by the authorization
+// cases that need additional namespaces beyond the suite's primary mcpNs.
+func cpNamespaceYAML(ns string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels:
+    openchoreo.dev/control-plane: "true"
+`, ns)
+}
+
 func platformResourcesYAML(cpNamespace string, environments []string, projects []string) string {
 	promotionPaths := make([]openchoreov1alpha1.PromotionPath, 0)
 

--- a/test/e2e/suites/mcp/mcp_test.go
+++ b/test/e2e/suites/mcp/mcp_test.go
@@ -22,6 +22,21 @@ const (
 	tokenURL     = "http://thunder.e2e-cp.local:28080/oauth2/token"
 	clientID     = "service_mcp_client"
 	clientSecret = "service_mcp_client_secret"
+
+	// subjectClientID is a dedicated, permission-less client_credentials subject
+	// seeded unbound by the Thunder bootstrap (install/k3d/common/values-thunder.yaml
+	// `61-mcp-e2e-subject-app.sh`). It is OWNED EXCLUSIVELY by this MCP suite's
+	// authorization context: the authz suite already binds/unbinds roles on
+	// `customer-portal-client`, and `make e2e.test` runs the authz and mcp suite
+	// packages concurrently (no `-p 1`), so sharing a subject would flake both.
+	// Never create bindings for this client from any other suite, and never bind
+	// `customer-portal-client` / `service_mcp_client` from this context.
+	subjectClientID     = "mcp-e2e-subject-client"
+	subjectClientSecret = "mcp-e2e-subject-secret" //nolint:gosec
+
+	// mcpAuthzLabelKey labels every ClusterAuthzRole(Binding) this context creates
+	// so the AfterAll can sweep leftovers by selector.
+	mcpAuthzLabelKey = "e2e-mcp-authz/run"
 )
 
 var (
@@ -312,6 +327,307 @@ var _ = Describe("MCP Server", Ordered, Label("tier2"), func() {
 				}
 			}
 			Expect(found).To(BeTrue(), "list_components should include %s", componentName)
+		})
+	})
+
+	// authorization exercises the control-plane MCP tool-filter middleware
+	// (pkg/mcp/tools/filter.go) end to end against a real OAuth subject and the
+	// live PDP. It uses the dedicated permission-less subjectClientID so it never
+	// collides with the concurrently-running authz suite's subject. All
+	// ClusterAuthzRole(Binding) CRs are labelled mcpAuthzLabelKey=<mcpRunID> and
+	// swept in this context's AfterAll.
+	Context("authorization", Ordered, func() {
+		var subjectToken string
+		labelValue := mcpRunID
+
+		// subjectSession is the default-config session (filterByAuthz=on) used by
+		// every case that needs the visibility filter active.
+		var subjectSession *mcp.ClientSession
+
+		BeforeAll(func() {
+			By("fetching a token for the permission-less MCP subject")
+			Eventually(func() error {
+				var tokenErr error
+				subjectToken, tokenErr = framework.FetchClientCredentialsToken(
+					tokenURL, subjectClientID, subjectClientSecret)
+				return tokenErr
+			}, 60*time.Second, 5*time.Second).Should(Succeed(),
+				"failed to obtain token for %s", subjectClientID)
+			Expect(subjectToken).NotTo(BeEmpty())
+
+			var err error
+			subjectSession, err = framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint: mcpEndpoint,
+				Token:    subjectToken,
+			})
+			Expect(err).NotTo(HaveOccurred(), "subject MCP session should connect")
+		})
+
+		AfterAll(func() {
+			if subjectSession != nil {
+				subjectSession.Close()
+			}
+			// Always sweep authz CRs even when keeping namespaces: a lingering
+			// grant would poison later deny-by-default cases and reruns.
+			By("sweeping leftover authz CRs by selector")
+			selector := fmt.Sprintf("%s=%s", mcpAuthzLabelKey, labelValue)
+			_, _ = framework.Kubectl(kubeContext, "delete", "clusterauthzrolebinding", "-l", selector, "--ignore-not-found", "--wait=false")
+			_, _ = framework.Kubectl(kubeContext, "delete", "clusterauthzrole", "-l", selector, "--ignore-not-found", "--wait=false")
+		})
+
+		It("T1: deny-by-default visibility — unbound subject's tools/list excludes write tools", func() {
+			// T1: the unbound subject's tools/list must HIDE write tools (create_namespace/project/component).
+			// Verifies the MCP visibility filter (filter.go:113) over the real request path:
+			// OAuth token -> MCP filter -> PDP. The PDP's allow/deny decisions are unit-tested in
+			// internal/authz/casbin/pdp_test.go; what this adds is that the MCP layer actually consults
+			// the PDP for a real subject. Meaningful only paired with T2 (an empty list passes vacuously).
+			names, err := framework.ListMCPToolNames(subjectSession)
+			Expect(err).NotTo(HaveOccurred(), "tools/list should succeed")
+			Expect(names).NotTo(ContainElement("create_namespace"))
+			Expect(names).NotTo(ContainElement("create_project"))
+			Expect(names).NotTo(ContainElement("create_component"))
+		})
+
+		It("T2: deny-by-default enforcement — create_namespace rejected", func() {
+			// T2: an unbound subject's create_namespace call must be REJECTED with the explicit
+			// "missing permission \"namespace:create\"" error (filter.go:174). This is the real deny-by-default
+			// proof and what makes T1's absence meaningful. Exercises the real OAuth -> MCP filter -> PDP
+			// path (the PDP decision itself is unit-tested in pdp_test.go); this proves the live PDP is
+			// wired into the MCP layer and denying.
+			deniedNs := fmt.Sprintf("e2e-mcp-denied-%s", mcpRunID)
+			framework.CallMCPToolExpectDenied(subjectSession, "create_namespace",
+				map[string]any{"name": deniedNs},
+				`not authorized to call tool "create_namespace": missing permission "namespace:create"`)
+
+			By("verifying the namespace was not created")
+			_, err := framework.Kubectl(kubeContext, "get", "namespace", deniedNs)
+			Expect(err).To(HaveOccurred(), "denied create_namespace must not create %s", deniedNs)
+		})
+
+		It("T3: allow-after-grant round-trip — grant, call succeeds, tool visible, revoke, denied", func() {
+			// T3: grant role -> call succeeds + tool becomes visible -> revoke -> denied again.
+			// Verifies the full grant/propagate/revoke lifecycle through the MCP layer, not just denial.
+			// Exercises real binding-propagation timing (eventual consistency) end to end; the PDP decision
+			// logic is unit-tested in pdp_test.go.
+			roleName := "e2e-mcp-authz-nscreate-" + mcpRunID
+			bindingName := "e2e-mcp-authz-nscreate-bind-" + mcpRunID
+			grantedNs := "e2e-mcp-granted-" + mcpRunID
+
+			By("granting a ClusterAuthzRole + binding with namespace:create")
+			out, err := framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleYAML(roleName, mcpAuthzLabelKey, labelValue,
+					[]string{"namespace:create", "namespace:view"}))
+			Expect(err).NotTo(HaveOccurred(), "create role: %s", out)
+			out, err = framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleBindingYAML(bindingName, mcpAuthzLabelKey, labelValue,
+					roleName, subjectClientID, "allow"))
+			Expect(err).NotTo(HaveOccurred(), "create binding: %s", out)
+
+			By("waiting for the grant to propagate, then create_namespace succeeds")
+			Eventually(func(g Gomega) {
+				_, callErr := framework.CallMCPTool(subjectSession, "create_namespace",
+					map[string]any{"name": grantedNs})
+				g.Expect(callErr).NotTo(HaveOccurred())
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("verifying create_namespace is now visible in tools/list")
+			Eventually(func(g Gomega) {
+				names, listErr := framework.ListMCPToolNames(subjectSession)
+				g.Expect(listErr).NotTo(HaveOccurred())
+				g.Expect(names).To(ContainElement("create_namespace"))
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("verifying the namespace exists on the cluster")
+			Eventually(func(g Gomega) {
+				framework.AssertClusterResourceExists(g, kubeContext, "namespace", grantedNs)
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("cleaning up the granted namespace and revoking the binding")
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", grantedNs, "--ignore-not-found", "--wait=false")
+			probeNs := "e2e-mcp-revoke-probe-" + mcpRunID
+			framework.DeleteClusterAuthzRoleBindingAndWaitForRevocation(kubeContext, bindingName,
+				framework.DeniedProbe(subjectSession, "create_namespace", map[string]any{"name": probeNs},
+					`missing permission "namespace:create"`,
+					func() {
+						_, _ = framework.Kubectl(kubeContext, "delete", "namespace", probeNs, "--ignore-not-found", "--wait=false")
+					}))
+			_, _ = framework.Kubectl(kubeContext, "delete", "clusterauthzrole", roleName, "--ignore-not-found", "--wait=false")
+		})
+
+		It("T4: scoped isolation — namespace-scoped grant allows ns-A, denies ns-B", func() {
+			// T4: a namespace-scoped grant must allow create_project in ns-A and DENY it in ns-B.
+			// Verifies per-call scope extraction (filter.go:299) -> multi-tenant isolation, flowing
+			// OAuth -> MCP -> PDP for a real scoped binding. The scoped-decision logic itself is unit-tested
+			// in pdp_test.go; this proves the MCP filter extracts and passes the scope per call.
+			nsA := "e2e-mcp-scope-a-" + mcpRunID
+			nsB := "e2e-mcp-scope-b-" + mcpRunID
+			roleName := "e2e-mcp-authz-projcreate-" + mcpRunID
+			bindingName := "e2e-mcp-authz-projcreate-bind-" + mcpRunID
+
+			By("creating two control-plane namespaces with platform resources")
+			for _, ns := range []string{nsA, nsB} {
+				out, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML(ns))
+				Expect(err).NotTo(HaveOccurred(), "create namespace %s: %s", ns, out)
+				out, err = framework.KubectlApplyLiteral(kubeContext,
+					platformResourcesYAML(ns, []string{"development"}, nil))
+				Expect(err).NotTo(HaveOccurred(), "apply platform resources %s: %s", ns, out)
+			}
+
+			By("granting project:create scoped to ns-A only")
+			out, err := framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleYAML(roleName, mcpAuthzLabelKey, labelValue,
+					[]string{"project:create", "project:view", "namespace:view"}))
+			Expect(err).NotTo(HaveOccurred(), "create role: %s", out)
+			out, err = framework.KubectlApplyLiteral(kubeContext,
+				framework.ScopedClusterAuthzRoleBindingYAML(bindingName, mcpAuthzLabelKey, labelValue,
+					roleName, subjectClientID, "allow", nsA))
+			Expect(err).NotTo(HaveOccurred(), "create scoped binding: %s", out)
+
+			By("create_project in ns-A succeeds once the scoped grant propagates")
+			Eventually(func(g Gomega) {
+				_, callErr := framework.CallMCPTool(subjectSession, "create_project", map[string]any{
+					"namespace_name":      nsA,
+					"name":                "scoped-proj",
+					"deployment_pipeline": "default",
+				})
+				g.Expect(callErr).NotTo(HaveOccurred())
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("create_project in ns-B is denied (out of scope)")
+			framework.CallMCPToolExpectDenied(subjectSession, "create_project", map[string]any{
+				"namespace_name":      nsB,
+				"name":                "scoped-proj-b",
+				"deployment_pipeline": "default",
+			}, `missing permission "project:create"`)
+
+			By("revoking the binding and cleaning up")
+			framework.DeleteClusterAuthzRoleBindingAndWaitForRevocation(kubeContext, bindingName,
+				framework.DeniedProbe(subjectSession, "create_project", map[string]any{
+					"namespace_name":      nsA,
+					"name":                "scoped-proj-probe",
+					"deployment_pipeline": "default",
+				}, `missing permission "project:create"`, func() {
+					// grant still active; drop the probe project so a later poll doesn't hit a conflict
+					_, _ = framework.Kubectl(kubeContext, "delete", "project", "scoped-proj-probe", "-n", nsA, "--ignore-not-found", "--wait=false")
+				}))
+			_, _ = framework.Kubectl(kubeContext, "delete", "clusterauthzrole", roleName, "--ignore-not-found", "--wait=false")
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", nsA, "--ignore-not-found", "--wait=false")
+			_, _ = framework.Kubectl(kubeContext, "delete", "namespace", nsB, "--ignore-not-found", "--wait=false")
+		})
+
+		It("T5: deny effect overrides allow", func() {
+			// T5: a deny binding must OVERRIDE an allow binding (deny-precedence).
+			// Security-critical PDP semantic: without it, access can't be revoked by adding a deny.
+			// The deny-precedence decision is unit-tested in pdp_test.go; this proves it holds end to end
+			// through the MCP path with real allow+deny bindings applied as CRs.
+			allowRoleName := "e2e-mcp-authz-allowrole-" + mcpRunID
+			allowBindingName := "e2e-mcp-authz-allow-" + mcpRunID
+			denyRoleName := "e2e-mcp-authz-denyrole-" + mcpRunID
+			denyBindingName := "e2e-mcp-authz-deny-" + mcpRunID
+
+			By("granting an allow role (namespace:create + namespace:view)")
+			out, err := framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleYAML(allowRoleName, mcpAuthzLabelKey, labelValue,
+					[]string{"namespace:create", "namespace:view"}))
+			Expect(err).NotTo(HaveOccurred(), "create allow role: %s", out)
+			out, err = framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleBindingYAML(allowBindingName, mcpAuthzLabelKey, labelValue,
+					allowRoleName, subjectClientID, "allow"))
+			Expect(err).NotTo(HaveOccurred(), "create allow binding: %s", out)
+
+			By("adding a deny role+binding covering namespace:create")
+			out, err = framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleYAML(denyRoleName, mcpAuthzLabelKey, labelValue,
+					[]string{"namespace:create"}))
+			Expect(err).NotTo(HaveOccurred(), "create deny role: %s", out)
+			out, err = framework.KubectlApplyLiteral(kubeContext,
+				framework.ClusterAuthzRoleBindingYAML(denyBindingName, mcpAuthzLabelKey, labelValue,
+					denyRoleName, subjectClientID, "deny"))
+			Expect(err).NotTo(HaveOccurred(), "create deny binding: %s", out)
+
+			// Denial surface for deny-override: because the allow binding is
+			// present, the MCP filter middleware sees namespace:create as permitted and lets the call
+			// THROUGH; the deny is then enforced at the SERVICE layer, which returns
+			// "insufficient permissions to perform this action" (services/errors.go:8) — the same
+			// backstop T6 exercises. It does NOT surface as the middleware's `missing permission`
+			// message (that is the deny-by-default path, T2). The deny still wins; it just lands one
+			// layer deeper than a no-binding denial.
+			denyOverrideMsg := "insufficient permissions to perform this action"
+
+			By("waiting until list_namespaces succeeds (allow landed) AND create_namespace is denied (deny landed)")
+			Eventually(func(g Gomega) {
+				_, listErr := framework.CallMCPTool(subjectSession, "list_namespaces", nil)
+				g.Expect(listErr).NotTo(HaveOccurred(), "namespace:view should be allowed")
+				denyWaitNs := "e2e-mcp-deny-wait-" + mcpRunID
+				_, createErr := framework.CallMCPTool(subjectSession, "create_namespace",
+					map[string]any{"name": denyWaitNs})
+				if createErr == nil {
+					// allow landed before the deny did; drop the namespace and keep waiting
+					_, _ = framework.Kubectl(kubeContext, "delete", "namespace", denyWaitNs, "--ignore-not-found", "--wait=false")
+				}
+				g.Expect(createErr).To(HaveOccurred(), "deny binding should block namespace:create")
+				g.Expect(createErr.Error()).To(ContainSubstring(denyOverrideMsg))
+			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("list_namespaces succeeds (not covered by the deny)")
+			_, err = framework.CallMCPTool(subjectSession, "list_namespaces", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("create_namespace is denied despite the allow binding (service-layer deny-override)")
+			framework.CallMCPToolExpectDenied(subjectSession, "create_namespace",
+				map[string]any{"name": "e2e-mcp-deny-final-" + mcpRunID},
+				denyOverrideMsg)
+
+			By("revoking the deny binding first, then the allow binding")
+			framework.DeleteClusterAuthzRoleBindingAndWaitForRevocation(kubeContext, denyBindingName, func() bool {
+				probeNs := "e2e-mcp-deny-revoke-probe-" + mcpRunID
+				_, probeErr := framework.CallMCPTool(subjectSession, "create_namespace",
+					map[string]any{"name": probeNs})
+				if probeErr == nil {
+					_, _ = framework.Kubectl(kubeContext, "delete", "namespace", probeNs, "--ignore-not-found", "--wait=false")
+					return true
+				}
+				return false
+			})
+			allowProbeNs := "e2e-mcp-allow-revoke-probe-" + mcpRunID
+			framework.DeleteClusterAuthzRoleBindingAndWaitForRevocation(kubeContext, allowBindingName,
+				framework.DeniedProbe(subjectSession, "create_namespace", map[string]any{"name": allowProbeNs},
+					`missing permission "namespace:create"`,
+					func() {
+						_, _ = framework.Kubectl(kubeContext, "delete", "namespace", allowProbeNs, "--ignore-not-found", "--wait=false")
+					}))
+			_, _ = framework.Kubectl(kubeContext, "delete", "clusterauthzrole", allowRoleName, denyRoleName, "--ignore-not-found", "--wait=false")
+		})
+
+		It("T6: filterByAuthz=false — tool visible but the call is still denied by the service layer", func() {
+			// T6: with ?filterByAuthz=false the tool is visible and passes the middleware, but the
+			// SERVICE LAYER still denies ("insufficient permissions to perform this action").
+			// Verifies defense-in-depth (filter.go:36-39): disabling the MCP filter does NOT bypass authz.
+			// A real request through both layers proves the service layer still enforces when the filter is
+			// off — exercised only when the MCP server, PDP, and service layer run together.
+			off := false
+			session, err := framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+				Endpoint:      mcpEndpoint,
+				Token:         subjectToken,
+				FilterByAuthz: &off,
+			})
+			Expect(err).NotTo(HaveOccurred(), "filterByAuthz=false session should connect")
+			defer session.Close()
+
+			By("create_namespace is visible because the MCP filter is disabled")
+			names, err := framework.ListMCPToolNames(session)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(ContainElement("create_namespace"))
+
+			By("but the call is still denied by the service layer")
+			t6Ns := "e2e-mcp-t6-" + mcpRunID
+			framework.CallMCPToolExpectDenied(session, "create_namespace",
+				map[string]any{"name": t6Ns},
+				"insufficient permissions to perform this action")
+
+			By("verifying the namespace was not created")
+			_, err = framework.Kubectl(kubeContext, "get", "namespace", t6Ns)
+			Expect(err).To(HaveOccurred(), "service-layer-denied create_namespace must not create %s", t6Ns)
 		})
 	})
 })

--- a/test/e2e/suites/observability/observability_fixtures_test.go
+++ b/test/e2e/suites/observability/observability_fixtures_test.go
@@ -9,11 +9,14 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
 )
 
 const (
@@ -199,4 +202,90 @@ func curlPodYAML(dpNamespace string) string {
 		}}},
 	}
 	return mustYAMLDocs(pod)
+}
+
+// obsFixturesReady guards ensureObservabilityFixtures so the shared greeter +
+// tester pod plumbing is provisioned at most once even though two top-level
+// Ordered Describes (Observability Signals and Observer MCP) both call it from
+// their BeforeAll, and Ginkgo v2 randomizes top-level container ordering. The
+// underlying applies are idempotent kubectl applies and the waits are
+// Eventually-based, so this is an optimization; correctness comes from
+// idempotence. It is set only AFTER successful provisioning: a transient failure
+// panics out via a failed assertion and leaves it false, so the other Describe's
+// BeforeAll retries the setup. (sync.Once would latch even on panic, dooming the
+// second Describe.)
+var obsFixturesReady bool
+
+// ensureObservabilityFixtures provisions the shared observability fixtures
+// (CP namespace, platform resources, greeter component, DP tester pod) and
+// resolves the package-level dpNs / observerQ / greeterHost / greeterPort used
+// by both the REST and MCP observability Describes. Safe to call from multiple
+// BeforeAll blocks.
+func ensureObservabilityFixtures() {
+	if obsFixturesReady {
+		return
+	}
+
+	By("creating control plane namespace")
+	out, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
+	Expect(err).NotTo(HaveOccurred(), "create cp namespace: %s", out)
+
+	By("applying platform resources (pipeline, environments, project)")
+	out, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML())
+	Expect(err).NotTo(HaveOccurred(), "apply platform resources: %s", out)
+
+	By("deploying greeter component")
+	out, err = framework.KubectlApplyLiteral(kubeContext, greeterComponentYAML())
+	Expect(err).NotTo(HaveOccurred(), "create greeter: %s", out)
+
+	By("discovering data plane namespace")
+	Eventually(func() error {
+		var derr error
+		dpNs, derr = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
+		return derr
+	}, 3*time.Minute, 5*time.Second).Should(Succeed())
+	fmt.Fprintf(GinkgoWriter, "discovered dp namespace: %s\n", dpNs)
+
+	By("deploying tester pod")
+	out, err = framework.KubectlApplyLiteral(dpCtx(), curlPodYAML(dpNs))
+	Expect(err).NotTo(HaveOccurred(), "create tester pod: %s", out)
+
+	By("waiting for tester pod to be Running")
+	Eventually(func(g Gomega) {
+		framework.AssertPodsRunning(g, dpCtx(), dpNs, curlPodLabel)
+	}, 4*time.Minute, 3*time.Second).Should(Succeed())
+
+	By("waiting for greeter ReleaseBinding Ready")
+	Eventually(func(g Gomega) {
+		framework.AssertReleaseBindingReady(g, kubeContext, cpNs,
+			componentGreeter+releaseBindingSuffix)
+	}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+	By("waiting for greeter pod Running")
+	Eventually(func(g Gomega) {
+		framework.AssertPodsRunning(g, dpCtx(), dpNs,
+			"openchoreo.dev/component="+componentGreeter)
+	}, 3*time.Minute, 3*time.Second).Should(Succeed())
+
+	By("resolving greeter Service host:port")
+	Eventually(func(g Gomega) {
+		h, p := serviceURLHostPort(g, componentGreeter+releaseBindingSuffix)
+		greeterHost, greeterPort = h, p
+	}, 3*time.Minute, 3*time.Second).Should(Succeed())
+	fmt.Fprintf(GinkgoWriter, "greeter resolved at %s:%s\n", greeterHost, greeterPort)
+
+	// In multi-cluster mode the tester pod sits in the DP cluster and needs
+	// to reach Thunder (CP) and the observer (OP) via external hostnames
+	// resolved through the DP cluster's CoreDNS rewrites. In single-cluster
+	// mode the empty fields fall back to the in-cluster defaults.
+	observerQ = framework.ObserverQueryFrom{
+		KubeContext:     dpCtx(),
+		Namespace:       dpNs,
+		PodLabel:        curlPodLabel,
+		Container:       curlContainer,
+		ThunderTokenURL: mcThunderURL(),
+		ObserverURL:     mcObserverURL(),
+	}
+
+	obsFixturesReady = true
 }

--- a/test/e2e/suites/observability/observability_test.go
+++ b/test/e2e/suites/observability/observability_test.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -46,80 +45,11 @@ var _ = Describe("Observability Signals", Ordered, Label("tier3"), func() {
 	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
 
 	BeforeAll(func() {
-		By("creating control plane namespace")
-		out, err := framework.KubectlApplyLiteral(kubeContext, cpNamespaceYAML())
-		Expect(err).NotTo(HaveOccurred(), "create cp namespace: %s", out)
-
-		By("applying platform resources (pipeline, environments, project)")
-		out, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML())
-		Expect(err).NotTo(HaveOccurred(), "apply platform resources: %s", out)
-
-		By("deploying greeter component")
-		out, err = framework.KubectlApplyLiteral(kubeContext, greeterComponentYAML())
-		Expect(err).NotTo(HaveOccurred(), "create greeter: %s", out)
-
-		By("discovering data plane namespace")
-		Eventually(func() error {
-			var derr error
-			dpNs, derr = framework.GetDPNamespace(dpCtx(), cpNs, projectName, envDev)
-			return derr
-		}, 3*time.Minute, 5*time.Second).Should(Succeed())
-		fmt.Fprintf(GinkgoWriter, "discovered dp namespace: %s\n", dpNs)
-
-		By("deploying tester pod")
-		out, err = framework.KubectlApplyLiteral(dpCtx(), curlPodYAML(dpNs))
-		Expect(err).NotTo(HaveOccurred(), "create tester pod: %s", out)
-
-		By("waiting for tester pod to be Running")
-		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, dpCtx(), dpNs, curlPodLabel)
-		}, 4*time.Minute, 3*time.Second).Should(Succeed())
-
-		By("waiting for greeter ReleaseBinding Ready")
-		Eventually(func(g Gomega) {
-			framework.AssertReleaseBindingReady(g, kubeContext, cpNs,
-				componentGreeter+releaseBindingSuffix)
-		}, 5*time.Minute, 5*time.Second).Should(Succeed())
-
-		By("waiting for greeter pod Running")
-		Eventually(func(g Gomega) {
-			framework.AssertPodsRunning(g, dpCtx(), dpNs,
-				"openchoreo.dev/component="+componentGreeter)
-		}, 3*time.Minute, 3*time.Second).Should(Succeed())
-
-		By("resolving greeter Service host:port")
-		Eventually(func(g Gomega) {
-			h, p := serviceURLHostPort(g, componentGreeter+releaseBindingSuffix)
-			greeterHost, greeterPort = h, p
-		}, 3*time.Minute, 3*time.Second).Should(Succeed())
-		fmt.Fprintf(GinkgoWriter, "greeter resolved at %s:%s\n", greeterHost, greeterPort)
-
-		// In multi-cluster mode the tester pod sits in the DP cluster and needs
-		// to reach Thunder (CP) and the observer (OP) via external hostnames
-		// resolved through the DP cluster's CoreDNS rewrites. In single-cluster
-		// mode the empty fields fall back to the in-cluster defaults.
-		observerQ = framework.ObserverQueryFrom{
-			KubeContext:     dpCtx(),
-			Namespace:       dpNs,
-			PodLabel:        curlPodLabel,
-			Container:       curlContainer,
-			ThunderTokenURL: mcThunderURL(),
-			ObserverURL:     mcObserverURL(),
-		}
-	})
-
-	AfterAll(func() {
-		if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
-			By("E2E_KEEP_RESOURCES=true — skipping cleanup")
-			return
-		}
-		By("deleting control plane namespace (cascades to DP)")
-		_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
-			"--ignore-not-found", "--wait=false")
-		if dpNs != "" {
-			_, _ = framework.Kubectl(dpCtx(), "delete", "namespace", dpNs,
-				"--ignore-not-found", "--wait=false")
-		}
+		// Shared with the Observer MCP Describe; provisioned once. Cleanup is in
+		// the suite-level AfterSuite (suite_test.go) so neither Describe tears
+		// down the namespace the other still needs under Ginkgo's randomized
+		// top-level container ordering.
+		ensureObservabilityFixtures()
 	})
 
 	It("logs-queryable: POST /api/v1/logs/query returns greeter log lines", func() {

--- a/test/e2e/suites/observability/observer_mcp_test.go
+++ b/test/e2e/suites/observability/observer_mcp_test.go
@@ -1,0 +1,429 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/openchoreo/openchoreo/test/e2e/framework"
+)
+
+// Multi-cluster (tier3) external endpoints. An empty opKubeContext means
+// single-cluster, where these specs are skipped (see the BeforeAll gating
+// below): the MCP specs depend on the external observer hostname which only the
+// multi-cluster setup exposes.
+const (
+	mcObserverMCPEndpoint = "http://observer.e2e-mc-op.local:31080/mcp"
+	mcThunderTokenURL     = "http://thunder.e2e-mc-cp.local:38080/oauth2/token"
+
+	// Admin identity (service_mcp_client) carries the bootstrap admin
+	// ClusterAuthzRoleBinding (admin = "*"), so it can call every observer
+	// query tool. Uses client_secret_basic.
+	obsAdminClientID     = "service_mcp_client"
+	obsAdminClientSecret = "service_mcp_client_secret" //nolint:gosec
+
+	// Subject identity (mcp-e2e-subject-client) is seeded unbound by the Thunder
+	// bootstrap (install/k3d/common/values-thunder.yaml `61-mcp-e2e-subject-app.sh`)
+	// and uses client_secret_post. It is the same permission-less subject the
+	// control-plane MCP suite owns; the observer's PDP is the same CP authz API,
+	// so grants/denials on it are controlled by ClusterAuthzRole(Binding) CRs on
+	// the CP cluster.
+	obsSubjectClientID     = "mcp-e2e-subject-client"
+	obsSubjectClientSecret = "mcp-e2e-subject-secret" //nolint:gosec
+
+	// obsMCPAuthzLabelKey labels the ClusterAuthzRoleBinding created by O6 so it
+	// is swept on cleanup.
+	obsMCPAuthzLabelKey = "e2e-obsmcp/run"
+)
+
+// allObserverTools is the exact set of 11 tools the observer MCP server
+// registers (internal/observer/mcp/server.go). Pinned here so O3 catches an
+// accidental add/remove.
+var allObserverTools = []string{
+	"query_component_logs",
+	"query_workflow_logs",
+	"query_component_events",
+	"query_workflow_events",
+	"query_resource_metrics",
+	"query_http_metrics",
+	"query_traces",
+	"query_trace_spans",
+	"get_span_details",
+	"query_alerts",
+	"query_incidents",
+}
+
+var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
+	SetDefaultEventuallyTimeout(framework.DefaultTimeout)
+	SetDefaultEventuallyPollingInterval(framework.DefaultPolling)
+
+	var (
+		adminToken     string
+		subjectToken   string
+		adminSession   *mcp.ClientSession
+		subjectSession *mcp.ClientSession
+	)
+
+	BeforeAll(func() {
+		if opKubeContext == "" {
+			Skip("observer MCP specs require the multi-cluster setup (--e2e.op-kubecontext)")
+		}
+
+		// These specs (and only these) drive host-side MCP sessions against the OP
+		// cluster's external observer hostname, which must resolve to 127.0.0.1 (the
+		// OP loadbalancer publishes 31080:11080). Checked here rather than in the
+		// suite's BeforeSuite so REST-only observability runs aren't blocked by it.
+		By("verifying observer.e2e-mc-op.local resolves to 127.0.0.1")
+		addrs, lookupErr := net.LookupHost("observer.e2e-mc-op.local")
+		Expect(lookupErr).NotTo(HaveOccurred(),
+			"observer.e2e-mc-op.local does not resolve — add '127.0.0.1 observer.e2e-mc-op.local' to /etc/hosts")
+		Expect(addrs).To(ContainElement("127.0.0.1"),
+			"observer.e2e-mc-op.local resolves to %v instead of 127.0.0.1 — check /etc/hosts", addrs)
+
+		By("provisioning the shared observability fixtures (greeter + tester pod)")
+		ensureObservabilityFixtures()
+
+		By("minting an admin token (service_mcp_client, client_secret_basic)")
+		Eventually(func() error {
+			var err error
+			adminToken, err = framework.FetchOAuth2Token(mcThunderTokenURL, obsAdminClientID, obsAdminClientSecret)
+			return err
+		}, 60*time.Second, 5*time.Second).Should(Succeed(), "failed to mint admin token")
+		Expect(adminToken).NotTo(BeEmpty())
+
+		By("minting a subject token (mcp-e2e-subject-client, client_secret_post)")
+		Eventually(func() error {
+			var err error
+			subjectToken, err = framework.FetchClientCredentialsToken(mcThunderTokenURL, obsSubjectClientID, obsSubjectClientSecret)
+			return err
+		}, 60*time.Second, 5*time.Second).Should(Succeed(), "failed to mint subject token")
+		Expect(subjectToken).NotTo(BeEmpty())
+
+		var err error
+		adminSession, err = framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+			Endpoint: mcObserverMCPEndpoint,
+			Token:    adminToken,
+		})
+		Expect(err).NotTo(HaveOccurred(), "admin observer MCP session should connect")
+
+		subjectSession, err = framework.NewMCPSession(context.Background(), framework.MCPClientConfig{
+			Endpoint: mcObserverMCPEndpoint,
+			Token:    subjectToken,
+		})
+		Expect(err).NotTo(HaveOccurred(), "subject observer MCP session should connect")
+
+		By("generating a traffic burst so the pipeline has fresh signal")
+		generateTrafficAndQuery(framework.LoadGenMarker("observer-mcp"))
+	})
+
+	AfterAll(func() {
+		if adminSession != nil {
+			adminSession.Close()
+		}
+		if subjectSession != nil {
+			subjectSession.Close()
+		}
+		// Always sweep any leftover authz bindings created by O6.
+		selector := obsMCPAuthzLabelKey + "=" + obsRunID
+		_, _ = framework.Kubectl(kubeContext, "delete", "clusterauthzrolebinding", "-l", selector, "--ignore-not-found", "--wait=false")
+	})
+
+	// observerTimeWindow returns the start/end RFC3339 strings for a query,
+	// recomputed on each call so Eventually loops keep the window fresh (end has
+	// a small forward skew tolerance).
+	observerTimeWindow := func() (string, string) {
+		start := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
+		end := time.Now().Add(5 * time.Minute).UTC().Format(time.RFC3339)
+		return start, end
+	}
+
+	It("O1: unauthenticated POST to /mcp returns 401 + WWW-Authenticate", func() {
+		// O1: an unauthenticated POST to /mcp must return 401 + WWW-Authenticate: Bearer (main.go:472-484).
+		// Baseline auth gate. Proves the auth interceptor is actually wired on the live /mcp route
+		// (middleware wiring, not authz decision logic).
+		status, headers, err := framework.MCPRawPOST(mcObserverMCPEndpoint)
+		Expect(err).NotTo(HaveOccurred(), "raw POST should succeed at HTTP level")
+		Expect(status).To(Equal(401), "unauthenticated /mcp request should return 401")
+		Expect(headers.Get("WWW-Authenticate")).To(ContainSubstring("Bearer"),
+			"401 response should include a WWW-Authenticate: Bearer challenge")
+	})
+
+	It("O2: connects with a valid token and lists tools", func() {
+		// O2: a valid client_credentials token must connect and list tools.
+		// Smoke for the jwt path + MCP session against the real observer: exercises real JWKS validation
+		// end to end (token issuance -> jwt middleware -> session).
+		names, err := framework.ListMCPToolNames(adminSession)
+		Expect(err).NotTo(HaveOccurred(), "tools/list should succeed with a valid token")
+		Expect(names).NotTo(BeEmpty(), "observer tool list should not be empty")
+	})
+
+	It("O3: all 11 observer tools are registered/visible (no visibility filter)", func() {
+		// O3: all 11 observer tools must be registered/visible; observer has NO visibility filter,
+		// so an unbound subject still sees all 11 (unlike the control-plane MCP). Pins the live registered
+		// inventory and the no-filter behavior end to end.
+		//
+		// Toolset narrowing / filterByAuthz / deprecated-tool specs are N/A here:
+		// the observer's NewHTTPServer (internal/observer/mcp/server.go:15-26)
+		// registers no filter middleware, so there is no per-tool authz visibility
+		// filter and the unbound subject sees the same 11 tools (pinned in O6).
+		adminNames, err := framework.ListMCPToolNames(adminSession)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(adminNames).To(ConsistOf(allObserverTools),
+			"admin tools/list should be exactly the %d observer tools", len(allObserverTools))
+
+		subjectNames, err := framework.ListMCPToolNames(subjectSession)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(subjectNames).To(ConsistOf(allObserverTools),
+			"unbound subject should see exactly the same %d tools (no visibility filter)", len(allObserverTools))
+	})
+
+	// O4 — tool chain: exactly one tool per distinct signal/service path
+	// (logs / metrics / events / traces).
+	//
+	// Selection rationale (4 of the 11 tools, not 7):
+	//
+	// The 11 observer MCP tools share one integration path — jwt → MCP handler → authz-wrapped
+	// service → CP PDP → JSON-marshalled `TextContent` (internal/observer/mcp/server.go:29-42).
+	// What actually differs per tool, and therefore needs a *live cluster* to verify, is the
+	// distinct signal/service path each tool drives — its own service + adapter + authz wrapper,
+	// and (for most) a distinct external dependency:
+	//   - logs   → logs service → OpenSearch
+	//   - metrics → metrics service → Prometheus
+	//   - events → events service + `events_adapter.go` (forwards to the logs adapter →
+	//     OpenSearch); NOT a separate backend, but a separate service/adapter AND the only observer
+	//     authz wrapper with zero unit coverage (`events_authz.go`, see O5b) — so it earns an e2e
+	//   - traces → traces service → tracing receiver (make/e2e.mk:984-993)
+	// e2e earns its (expensive, ingestion-lag-prone, CPU-starved tier3) keep by exercising one
+	// representative tool per signal/service path — query_component_logs, query_resource_metrics,
+	// query_component_events, query_traces — which proves the wiring to each external system end
+	// to end. The remaining 7 tools add no new signal path: they are the same service behind a
+	// different query (query_workflow_logs/query_http_metrics/query_workflow_events/
+	// query_incidents), a follow-up read off a trace_id (query_trace_spans, get_span_details),
+	// or owned by another suite's fixtures (query_alerts/query_incidents ← alerts suite). Their
+	// per-tool logic (arg validation, validateComponentScope, query construction, response
+	// decoding, defaults) is pure and is covered by unit/integration tests. Testing all 7 here
+	// would re-prove the same integration path 7× at full e2e cost for zero new signal-path coverage.
+	//
+	// (O3 already asserts all 11 tools are registered/visible; O4 deliberately exercises only the
+	// 4 backend-representatives. Distinguishing "listed" from "exercised" is intentional.)
+	//
+	// Tools deliberately NOT exercised in e2e, and where their coverage lives instead:
+	//
+	//   | Cut tool            | Why no e2e                                                       | Coverage home                          |
+	//   |---------------------|-----------------------------------------------------------------|----------------------------------------|
+	//   | query_workflow_logs | same OpenSearch backend as query_component_logs, different query;| unit/integration: logs adapter +       |
+	//   |                     | no WorkflowRun fixture here (build suite owns it)               | query builder                          |
+	//   | query_workflow_events| same events service path as query_component_events; no WorkflowRun| unit/integration: events adapter      |
+	//   | query_http_metrics  | same Prometheus backend as query_resource_metrics; no envoy/    | unit/integration: metrics adapter      |
+	//   |                     | instrumentation in e2e (observability_test.go:174-179)         |                                        |
+	//   | query_trace_spans   | follow-up read off a trace_id on the SAME tracing receiver as   | unit/integration: trace service        |
+	//   |                     | query_traces; no reliable trace_id in e2e                      |                                        |
+	//   | get_span_details    | intentionally has NO authz check — trace_id+span_id carry no    | already covered — pass-through is       |
+	//   |                     | scope, so the authz wrapper deliberately passes through        | unit-tested (authz_test.go:297). Do    |
+	//   |                     | (traces_authz.go:67-71), already unit-tested                   | NOT add e2e or claim an authz gap.     |
+	//   | query_alerts,       | alert/incident firing is owned by the alerts suite's fixtures;  | alerts suite (firing) +                |
+	//   | query_incidents     | same authz/PDP path as O5/O6 proves the wiring                 | unit/integration (query/decode)        |
+
+	It("O4a: query_component_logs returns the greeter's logs (logs → OpenSearch)", func() {
+		// O4a: query_component_logs must return the greeter's logs. Verifies the logs -> OpenSearch
+		// signal path end to end. Genuinely needs e2e: real log ingestion (pod stdout -> adapter ->
+		// OpenSearch -> query) is the actual value here and can't be reproduced at integration level.
+		Eventually(func(g Gomega) {
+			start, end := observerTimeWindow()
+			var out struct {
+				Logs  []map[string]any `json:"logs"`
+				Total int              `json:"total"`
+			}
+			err := framework.CallMCPToolJSON(adminSession, "query_component_logs", map[string]any{
+				"namespace":     cpNs,
+				"project":       projectName,
+				"component":     componentGreeter,
+				"environment":   envDev,
+				"start_time":    start,
+				"end_time":      end,
+				"search_phrase": "Starting HTTP Greeter",
+				"limit":         50,
+			}, &out)
+			g.Expect(err).NotTo(HaveOccurred(), "query_component_logs should succeed")
+			g.Expect(out.Logs).NotTo(BeEmpty(), "observer MCP returned no logs for the greeter")
+		}, framework.IngestionBudget, pollPoll).Should(Succeed())
+	})
+
+	It("O4b: query_resource_metrics returns data (metrics → Prometheus)", func() {
+		// O4b: query_resource_metrics must return data. Verifies the metrics -> Prometheus path.
+		// Genuinely needs e2e: real metric scraping/ingestion is the value and can't be mocked at
+		// integration level.
+		Eventually(func(g Gomega) {
+			start, end := observerTimeWindow()
+			var m map[string]any
+			err := framework.CallMCPToolJSON(adminSession, "query_resource_metrics", map[string]any{
+				"namespace":   cpNs,
+				"project":     projectName,
+				"component":   componentGreeter,
+				"environment": envDev,
+				"start_time":  start,
+				"end_time":    end,
+				"step":        "1m",
+			}, &m)
+			g.Expect(err).NotTo(HaveOccurred(), "query_resource_metrics should succeed")
+			g.Expect(m).NotTo(BeEmpty(), "observer MCP returned an empty metrics object")
+		}, framework.IngestionBudget, pollPoll).Should(Succeed())
+	})
+
+	It("O4c: query_component_events succeeds + decodes (events service + events_adapter.go)", func() {
+		// O4c: query_component_events must succeed and decode — this exercises the events service +
+		// events_adapter.go path (distinct service code, though it reuses the logs/OpenSearch backend).
+		// Assert succeeds+decodes, NOT non-empty events: greeter events come from deployment-time
+		// activity (pod scheduling/image pull), not the traffic burst, and may not be queryable within
+		// the e2e window. Keeping it non-fatal also avoids blocking the later specs in this Ordered
+		// container.
+		Eventually(func(g Gomega) {
+			start, end := observerTimeWindow()
+			var ev struct {
+				Events []map[string]any `json:"events"`
+				Total  int              `json:"total"`
+			}
+			err := framework.CallMCPToolJSON(adminSession, "query_component_events", map[string]any{
+				"namespace":   cpNs,
+				"project":     projectName,
+				"component":   componentGreeter,
+				"environment": envDev,
+				"start_time":  start,
+				"end_time":    end,
+				"limit":       100,
+			}, &ev)
+			g.Expect(err).NotTo(HaveOccurred(), "query_component_events should succeed and decode")
+			// Contract check (not a data check): the observer always returns a non-nil events
+			// array (service builds it with make([]…,0,…), internal/observer/service/events.go),
+			// so a nil slice means the response was `{}`/`null` — a real contract regression —
+			// rather than just "no events yet". This catches that without requiring non-empty.
+			g.Expect(ev.Events).NotTo(BeNil(), "response must include the events array, got %+v", ev)
+		}, framework.IngestionBudget, pollPoll).Should(Succeed())
+	})
+
+	It("O4d: query_traces (best-effort, traces → tracing receiver)", func() {
+		// O4d (best-effort): query_traces. Verifies the traces -> tracing-receiver path; accepts zero
+		// traces / OBS-V1-T-05 since the greeter isn't OTel-instrumented. Genuinely needs e2e: real
+		// tracing-receiver wiring.
+		start, end := observerTimeWindow()
+		_, err := framework.CallMCPTool(adminSession, "query_traces", map[string]any{
+			"namespace":   cpNs,
+			"project":     projectName,
+			"component":   componentGreeter,
+			"environment": envDev,
+			"start_time":  start,
+			"end_time":    end,
+			"limit":       10,
+		})
+		if err != nil {
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("Failed to retrieve traces"),
+				ContainSubstring(tracesRetrievalFailedCode),
+			), "unexpected query_traces error: %v", err)
+		}
+	})
+
+	It("O5: unbound subject is DENIED on query_component_logs", func() {
+		// O5: an unbound subject must be DENIED on query_component_logs with "insufficient permissions".
+		// Observer has no protocol-layer filter, so the denial necessarily traverses the authz chain:
+		// jwt -> handler -> authz-wrapped service -> CP PDP. The PDP decision itself is unit-tested in
+		// internal/authz/casbin/pdp_test.go; what e2e adds is that this genuinely spans the observer (OP)
+		// and CP clusters over the real authz-API call.
+		start, end := observerTimeWindow()
+		framework.CallMCPToolExpectDenied(subjectSession, "query_component_logs", map[string]any{
+			"namespace":     cpNs,
+			"project":       projectName,
+			"component":     componentGreeter,
+			"environment":   envDev,
+			"start_time":    start,
+			"end_time":      end,
+			"search_phrase": "Starting HTTP Greeter",
+			"limit":         50,
+		}, "insufficient permissions to perform this action")
+	})
+
+	It("O5b: unbound subject is DENIED on query_component_events (events authz wrapper)", func() {
+		// O5b: an unbound subject must be DENIED on query_component_events. Covers events_authz.go --
+		// the ONLY observer authz wrapper with zero unit tests, yet wired in prod (main.go:207).
+		// Exercises that wrapper end to end through the MCP path; its branch logic still needs a
+		// dedicated unit test.
+		start, end := observerTimeWindow()
+		framework.CallMCPToolExpectDenied(subjectSession, "query_component_events", map[string]any{
+			"namespace":   cpNs,
+			"project":     projectName,
+			"component":   componentGreeter,
+			"environment": envDev,
+			"start_time":  start,
+			"end_time":    end,
+			"limit":       100,
+		}, "insufficient permissions to perform this action")
+	})
+
+	It("O6: grant developer role → query succeeds → revoke → denied (and tool count stays 11)", func() {
+		// O6: grant developer role -> query succeeds -> revoke -> denied (allow-after-grant +
+		// revocation propagation) on the observer path. Also pins tool count stays 11 before/after grant
+		// (no visibility filtering). The PDP decision is unit-tested in pdp_test.go; e2e adds real binding
+		// propagation across the OP and CP clusters over the live authz-API call.
+		bindingName := "e2e-obsmcp-dev-" + obsRunID
+
+		By("pinning the subject sees exactly all observer tools before the grant (no visibility filter)")
+		before, err := framework.ListMCPToolNames(subjectSession)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(before).To(ConsistOf(allObserverTools))
+
+		By("granting the bundled developer role (includes logs:view) on the CP cluster")
+		out, err := framework.KubectlApplyLiteral(kubeContext,
+			framework.ClusterAuthzRoleBindingYAML(bindingName, obsMCPAuthzLabelKey, obsRunID,
+				"developer", obsSubjectClientID, "allow"))
+		Expect(err).NotTo(HaveOccurred(), "create developer binding: %s", out)
+
+		By("waiting until the subject's query_component_logs is no longer denied")
+		Eventually(func(g Gomega) {
+			start, end := observerTimeWindow()
+			_, callErr := framework.CallMCPTool(subjectSession, "query_component_logs", map[string]any{
+				"namespace":     cpNs,
+				"project":       projectName,
+				"component":     componentGreeter,
+				"environment":   envDev,
+				"start_time":    start,
+				"end_time":      end,
+				"search_phrase": "Starting HTTP Greeter",
+				"limit":         50,
+			})
+			// A successful query returns {"logs":[...],"total":N} even with zero logs, so the call
+			// must SUCCEED outright once the grant propagates — not merely "not be an authz error",
+			// which would false-green on a 500 / backend / decode error.
+			g.Expect(callErr).NotTo(HaveOccurred(),
+				"developer grant should let query_component_logs succeed")
+		}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+		By("pinning the subject still sees exactly all observer tools after the grant")
+		after, err := framework.ListMCPToolNames(subjectSession)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after).To(ConsistOf(allObserverTools))
+
+		By("revoking the binding and confirming the denial returns")
+		// The denial fires at the authz layer before the time window matters, so a window
+		// captured once here is fine for the probe.
+		probeStart, probeEnd := observerTimeWindow()
+		framework.DeleteClusterAuthzRoleBindingAndWaitForRevocation(kubeContext, bindingName,
+			framework.DeniedProbe(subjectSession, "query_component_logs", map[string]any{
+				"namespace":     cpNs,
+				"project":       projectName,
+				"component":     componentGreeter,
+				"environment":   envDev,
+				"start_time":    probeStart,
+				"end_time":      probeEnd,
+				"search_phrase": "Starting HTTP Greeter",
+				"limit":         50,
+			}, "insufficient permissions", nil))
+	})
+})

--- a/test/e2e/suites/observability/suite_test.go
+++ b/test/e2e/suites/observability/suite_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"flag"
 	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -73,4 +74,21 @@ var _ = BeforeSuite(func() {
 		"get", "svc", framework.ObserverService, "-n", framework.ObserverNamespace)
 	Expect(err).NotTo(HaveOccurred(),
 		"observability plane is not installed; run make e2e.setup with E2E_WITH_OBSERVABILITY=true or make e2e.multi")
+})
+
+var _ = AfterSuite(func() {
+	if kubeContext == "" {
+		return
+	}
+	if os.Getenv("E2E_KEEP_RESOURCES") == "true" {
+		By("E2E_KEEP_RESOURCES=true — skipping cleanup")
+		return
+	}
+	By("deleting control plane namespace (cascades to DP)")
+	_, _ = framework.Kubectl(kubeContext, "delete", "namespace", cpNs,
+		"--ignore-not-found", "--wait=false")
+	if dpNs != "" {
+		_, _ = framework.Kubectl(dpCtx(), "delete", "namespace", dpNs,
+			"--ignore-not-found", "--wait=false")
+	}
 })


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

Adds end-to-end test coverage for OpenChoreo's two MCP servers, both previously
under-covered at the e2e layer:

- **Control-plane MCP (tier2)** — authorization-denial coverage. The filter
  middleware in `pkg/mcp/tools/filter.go` had only happy-path e2e tests.
- **Observer MCP (tier3)** — the server had zero e2e coverage.

## Tests added

### Control-plane MCP — `test/e2e/suites/mcp` (T1–T6, tier2)

| Case | Verifies |
|---|---|
| T1 | deny-by-default visibility — unbound subject's `tools/list` hides write tools |
| T2 | deny-by-default enforcement — `create_namespace` rejected (`missing permission`) |
| T3 | allow-after-grant round-trip — grant → call succeeds + tool visible → revoke → denied |
| T4 | namespace-scoped grant allows ns-A, denies ns-B (multi-tenant isolation) |
| T5 | deny-precedence — a deny binding overrides an allow (enforced at the service layer) |
| T6 | `?filterByAuthz=false` — tool visible but the service layer still denies |

All run under a new permission-less OAuth subject (`mcp-e2e-subject-client`),
kept exclusive to this suite so the concurrently-scheduled authz suite never
shares a subject.

### Observer MCP — `test/e2e/suites/observability/observer_mcp_test.go` (O1–O6 + O5b, tier3)

| Case | Verifies |
|---|---|
| O1 | 401 + `WWW-Authenticate` on unauthenticated `/mcp` |
| O2 | connects with a valid token, lists tools |
| O3 | exactly the 11 registered tools; observer has no visibility filter |
| O4a–d | one representative tool per signal path: logs, metrics, events, traces |
| O5 | unbound subject denied on `query_component_logs` |
| O5b | unbound subject denied on `query_component_events` (covers `events_authz.go`, the only observer authz wrapper with no unit tests) |
| O6 | allow-after-grant + revocation on the observer path |

O4 deliberately exercises only 4 of the 11 observer tools — one per distinct signal/service path — because the other 7 add no new  signal/service path to verify end to end; their per-tool logic belongs in unit tests. The rationale is documented in the code.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
