### PR TITLE
docs: add Azure tracing adapter proposal and tracing architecture explainer

### DIFF
--- a/docs/proposals/azure-observability-tracing-adapter-implementation.md
+++ b/docs/proposals/azure-observability-tracing-adapter-implementation.md
@@ -1,0 +1,465 @@
+# Azure Observability Tracing Adapter — Implementation Plan
+
+Status: IMPLEMENTED and verified E2E on `oc-obs-dev-aks` (2026-06-12).
+Module lives in `community-modules/observability-tracing-azure-appinsights`;
+adapter image published as
+`janakasandaruwan/observability-tracing-azure-appinsights-adapter:0.1.1`
+(move to ghcr.io/openchoreo via module CI on upstreaming). All three
+endpoints verified against live App Insights data, including cross-tenant
+isolation and injection rejection. Two implementation findings beyond the
+Phase 0 results: (1) `totimespan(strcat(ms, "ms"))` returns null for
+fractional milliseconds — use `TimeGenerated + (todouble(DurationMs) * 1ms)`;
+(2) the collector subchart names a cluster-scoped ClusterRole after its
+fullname, so `fullnameOverride` must be unique per tracing module
+(`otel-collector-azure`) to coexist with the OpenSearch module.
+Author: janakas@wso2.com
+Sibling docs:
+- `azure-observability-logs-module-setup.md` (Azure infra + AKS bring-up)
+- `azure-observability-logs-adapter-implementation.md` (logs adapter; this
+  plan reuses its Azure client, auth, and Helm identity patterns)
+- `azure-observability-metrics-adapter-implementation.md` (metrics adapter)
+
+## Goal
+
+Build a new OpenChoreo tracing adapter that satisfies the published
+Observability Tracing Adapter API (the contract implemented by
+`observability-tracing-opensearch`) and queries distributed-trace data stored
+in workspace-based Application Insights tables (`AppRequests`,
+`AppDependencies`) inside the same Log Analytics workspace the logs and
+metrics adapters already query.
+
+Ingestion uses the OpenTelemetry Collector (contrib distribution) with the
+`azuremonitor` exporter; the existing `k8sattributes` enrichment and
+`tail_sampling` pipeline from the OSS tracing modules is kept unchanged.
+
+The module lives in `community-modules/observability-tracing-azure-appinsights`
+as a sibling to the existing OpenSearch, OpenObserve, and AWS X-Ray tracing
+adapters.
+
+## Non-goals
+
+- Custom Log Analytics table for spans (`OTelTraces_CL` via Logs Ingestion
+  API). Rejected: no off-the-shelf collector exporter exists for
+  traces → Logs Ingestion, so it requires a custom OTLP→rows bridge service
+  we would own forever. Revisit only if a hard requirement (span-kind
+  fidelity, ns precision, no-App-Insights-resource policy) emerges.
+- Azure native OTLP ingestion. Still in preview (as of June 2026) and uses
+  Entra ID + DCR auth instead of the connection string. Tracked as future
+  simplification; the query layer is unaffected because it targets the same
+  `App*` tables.
+- AMA-based trace collection. AMA cannot create spans (traces originate in
+  app SDKs) and its preview OTLP receiver does not enrich spans with pod
+  labels, which breaks the `openchoreo.dev/*-uid` tenancy filters.
+- Jaeger/Zipkin receivers. All tracing modules are OTLP-only; adding legacy
+  receivers would be a deliberate cross-module change, not an Azure quirk.
+- Alert endpoints. Tracing adapter API has none.
+
+## Reference architecture
+
+```
+            ┌────────────────────────────────────────────────────────────┐
+            │ AKS cluster (data plane / observability plane)             │
+            │                                                            │
+            │  app pods (OTel SDK)                                       │
+            │     │ OTLP gRPC :4317 / HTTP :4318                         │
+            │     ▼                                                      │
+            │  OTel Collector (CONTRIB image)                            │
+            │    processors:                                             │
+            │      k8sattributes  ← copies ALL pod labels onto spans,    │
+            │                       incl. openchoreo.dev/*-uid           │
+            │      tail_sampling  ← rate limiting                        │
+            │    exporters:                                              │
+            │      azuremonitor   ← connection string from Secret        │
+            │     │                                                      │
+            │  ┌──────────────────────────────────────────────────────┐  │
+            │  │ adapter Deployment (this module) :9100               │  │
+            │  │   ServiceAccount: tracing-adapter                    │  │
+            │  │     azure.workload.identity/client-id → UAMI         │  │
+            │  │   Pod label: azure.workload.identity/use=true        │  │
+            │  └──────────────┬───────────────────────────────────────┘  │
+            │                 │ azlogs.Client.QueryWorkspace (KQL)        │
+            │                 │ Bearer via azidentity.DefaultAzureCred    │
+            └─────────────────┼──────────────────────────────────────────┘
+                              ▼
+            ┌────────────────────────────────────────────────────────────┐
+            │ Application Insights resource (workspace-based, free)      │
+            │   connection string = ingestion endpoint only              │
+            │           │ rows stored in ▼                               │
+            │ Log Analytics workspace (same one as logs/metrics)         │
+            │   AppRequests      ← SERVER / CONSUMER spans               │
+            │   AppDependencies  ← CLIENT / PRODUCER / INTERNAL spans    │
+            │   Properties["openchoreo.dev/*"] = tenancy filters         │
+            └────────────────────────────────────────────────────────────┘
+
+            Observer ─POST /api/v1alpha1/traces/query─▶ adapter ─KQL─▶ workspace
+```
+
+Column mapping (verified against learn.microsoft.com and the
+azuremonitorexporter source — see References):
+
+| Adapter API concept | App Insights column |
+|---|---|
+| traceId | `OperationId` |
+| spanId | `Id` |
+| parentSpanId | `ParentId` (empty ⇒ root span) |
+| span name | `Name` |
+| durationNs | `DurationMs` × 1e6 (precision loss: ms → ns) |
+| status error | `Success == false` (+ `ResultCode`) |
+| service name | `AppRoleName` (from `service.name`) |
+| attributes / resource attributes | `Properties` (strings/bools), `Measurements` (numbers) |
+| span kind | implied by table; CLIENT/PRODUCER/INTERNAL collapse into AppDependencies — Phase 0 decides the mapping |
+
+Caution: `AppTraces` is the LOG table (legacy .NET "trace" naming). The
+tracing adapter never reads it.
+
+## Phase 0 — de-risking spike (blocking)
+
+The design rests on one assumption: spans exported via `azuremonitor` carry
+the `openchoreo.dev/*-uid` resource attributes in the `Properties` column.
+The exporter source (`applyResourcesToDataProperties` in
+`contracts_utils.go`) says yes; prove it on a real cluster before writing
+module code.
+
+1. Create a workspace-based Application Insights resource against the
+   existing workspace; capture the connection string into a Secret.
+2. Hand-deploy an OTel Collector contrib with the OpenSearch module's
+   receiver/processor config plus the `azuremonitor` exporter, and one
+   OTLP-instrumented sample app on an OpenChoreo-labeled pod.
+3. Verify in the workspace:
+   - spans land in `AppRequests` / `AppDependencies`;
+   - `Properties["openchoreo.dev/component-uid"]` etc. present and
+     filterable in `where` clauses;
+   - where (if anywhere) span kind survives → decide the SpanKind mapping;
+   - App Insights ingestion sampling/throttling does not interact badly
+     with `tail_sampling` (expectation: adaptive sampling is SDK-side only);
+   - measure ingestion latency (expected: minutes) for the README.
+4. Prototype the trace-list KQL and confirm root span, duration, span count,
+   and error count come back correct for a known trace.
+
+Exit criteria: a saved KQL query returning correct trace summaries, plus
+captured result rows checked in later as mapping-test fixtures.
+
+### Phase 0 results (run 2026-06-11 on oc-obs-dev-aks)
+
+Setup used: App Insights `oc-obs-dev-appinsights` (workspace-based →
+`oc-obs-dev-law-v2`), collector contrib v0.153.0 via the upstream Helm chart
+(release `otel-spike`, namespace `otel-spike`), telemetrygen sending
+10 traces x 4 spans from a pod labeled with the four `openchoreo.dev/*`
+test values.
+
+1. PASSED (load-bearing): all four `openchoreo.dev/*` pod labels arrive in
+   `Properties` on every row and are filterable with
+   `tostring(Properties["openchoreo.dev/..."]) == ...`.
+2. PASSED: trace-list `summarize by OperationId` returns correct SpanCount,
+   root span, and error count. Cross-tenant negative test returns 0 rows.
+3. FINDING — root detection: the azuremonitor exporter sets
+   `ParentId = OperationId` for root spans, NOT empty. Root predicate must
+   be `ParentId == OperationId or isempty(ParentId)`. (KQL snippets in this
+   doc still show the isempty-only form; fix when implementing.)
+4. FINDING — kind mapping confirmed: SERVER spans → `AppRequests`, CLIENT
+   spans → `AppDependencies` with `DependencyType == "Other"` for non-HTTP
+   spans. Kind is not preserved beyond the table split (open decision #1
+   stands: AppDependencies rows can't distinguish CLIENT/PRODUCER/INTERNAL).
+5. FINDING — ingestion latency: rows queryable in under ~2 minutes,
+   better than the expected 2-5 min.
+6. FINDING — collector rename: `k8sattributes` is a deprecated alias as of
+   contrib v0.153.0; the module's collector config should use
+   `k8s_attributes`.
+7. `DurationMs` confirmed as float milliseconds (e.g. 0.123).
+
+## Repository layout
+
+```
+observability-tracing-azure-appinsights/
+├── main.go                          # boot: config, credential, ping, serve
+├── Dockerfile                       # multi-stage, distroless/alpine, non-root
+├── Makefile                         # gen, build, test, lint
+├── module.yaml                      # CI image manifest (adapter image only —
+│                                    #   no setup image; schema is Azure-managed)
+├── README.md
+├── go.mod                           # azcore, azidentity, azlogs, oapi runtime
+├── helm/
+│   ├── Chart.yaml
+│   ├── values.yaml
+│   └── templates/
+│       ├── adapter/                 # deployment, service(:9100), configmap,
+│       │                            #   serviceaccount (WI annotations),
+│       │                            #   networkpolicy, validate.yaml
+│       └── opentelemetry-collector/ # configMap (contrib), deployment,
+│                                    #   httproute (multiClusterReceiver)
+└── internal/
+    ├── config.go                    # env vars, fail-fast validation
+    ├── server.go                    # OpenAPI router (stdlib net/http)
+    ├── handlers.go                  # 3 endpoints + /healthz
+    ├── api/                         # cfg-server/models/client.yaml + gen/
+    │                                #   (copied from tracing-opensearch,
+    │                                #    regenerated with oapi-codegen)
+    └── appinsights/
+        ├── client.go                # azlogs wrapper: timeout, error mapping
+        ├── kql.go                   # 3 query builders (parameterized)
+        ├── mapping.go               # rows → TraceInfo / SpanInfo
+        ├── labels.go                # openchoreo.dev/* Properties keys,
+        │                            #   scope → where-clause builder
+        └── *_test.go                # golden KQL + fixture mapping tests
+```
+
+Donors: API/server/handler skeleton and collector Helm templates from
+`observability-tracing-opensearch`; Azure client wrapper, auth, ServiceAccount
+identity pattern, validate.yaml, and config conventions from
+`observability-logs-azure-loganalytics`.
+
+## Module naming and CI
+
+`module.yaml`:
+
+```yaml
+images:
+  - name: observability-tracing-azure-appinsights-adapter
+    context: .
+    dockerfile: Dockerfile
+```
+
+No `setup` image. The OpenSearch module needs an init job for index templates
+and ISM policies; here the table schema and retention are managed by Azure.
+
+## OpenAPI contract
+
+Identical to `observability-tracing-opensearch` — the Observer's generated
+client is the consumer, so the spec is copied verbatim and only the server
+implementation differs:
+
+- `POST /api/v1alpha1/traces/query` — list traces (searchScope.namespace
+  required; project/component/environment optional UIDs)
+- `POST /api/v1alpha1/traces/{traceId}/spans/query` — spans of one trace
+- `GET  /api/v1alpha1/traces/{traceId}/spans/{spanId}` — span detail
+- `GET  /healthz`
+
+## Configuration (environment variables)
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `LOG_ANALYTICS_WORKSPACE_ID` | yes | — | workspace customerId (GUID) for azlogs queries |
+| `SERVER_PORT` | no | `9100` | adapter listen port (Observer default) |
+| `QUERY_TIMEOUT_SECONDS` | no | `30` | per-query KQL timeout |
+| `MAX_QUERY_LIMIT` | no | `10000` | hard cap on `limit` (matches OpenSearch module) |
+| `LOG_LEVEL` | no | `INFO` | |
+
+The App Insights connection string is collector-side only (exporter Secret);
+the adapter never sees it. Credentials come from
+`azidentity.NewDefaultAzureCredential` — Workload Identity in-cluster, az CLI
+locally. The UAMI needs `Log Analytics Reader` on the workspace (already
+granted for the logs adapter; same workspace covers `App*` tables).
+
+## Implementation phases
+
+### Phase 1 — adapter (query path)
+
+- Skeleton per the layout above; regenerate `internal/api/gen`.
+- `internal/appinsights` query layer (detail below).
+- Boot sequence mirrors the logs adapter: load config →
+  `DefaultAzureCredential` → one near-zero-cost reachability ping
+  (`union AppRequests, AppDependencies | take 1`) → serve.
+- Unit tests green; `golangci-lint` clean.
+
+### Phase 2 — Helm chart and collector wiring
+
+- Collector templates from the OpenSearch module with these deltas:
+  - contrib image (configurable; pinned tag in values);
+  - `azuremonitor` exporter with `connection_string` from
+    `${env:APPINSIGHTS_CONNECTION_STRING}` (Secret-mounted);
+  - receivers (`otlp` 4317/4318), `k8sattributes` (all-labels regex
+    extract), `tail_sampling`, and all three `installationMode`s kept
+    verbatim. In `multiClusterReceiver`, the central collector runs the
+    azuremonitor exporter; HTTPRoute unchanged.
+- Adapter templates from the logs module: deployment, service, configmap,
+  ServiceAccount with `azure.workload.identity/client-id` annotation +
+  `azure.workload.identity/use: "true"` pod label, networkpolicy,
+  validate.yaml (fail install on missing workspaceId).
+- `values.yaml` keys: `azure.{subscriptionId,resourceGroup,region}`,
+  `logAnalytics.workspaceId`, `appInsights.connectionStringSecretRef`,
+  `adapter.*` (image, serviceAccount.annotations, queryTimeoutSeconds,
+  logLevel), `opentelemetryCollectorCustomizations.*` (image, tailSampling,
+  queue), `global.installationMode`.
+- Azure prerequisites added to the install skill / Terraform: App Insights
+  resource (workspace-based), federated identity credential for the
+  `tracing-adapter` ServiceAccount on the existing UAMI.
+
+### Phase 3 — Observer integration and end-to-end validation
+
+- Wire Observer: `TRACING_ADAPTER_ENABLED=true`,
+  `TRACING_ADAPTER_URL=http://tracing-adapter.<ns>.svc:9100`.
+- E2E: instrumented sample component → traces visible via Observer
+  `POST /api/v1alpha1/traces/query` with name-based scope (exercises
+  name→UID resolution + authz + adapter + KQL).
+- Negative tests: cross-namespace scope returns empty; unknown traceId;
+  empty window; limit overflow.
+
+## Query layer detail
+
+### KQL — traces list
+
+Equivalent of the OpenSearch terms aggregation. All user inputs are bound,
+never interpolated:
+
+```kusto
+union AppRequests, AppDependencies
+| where TimeGenerated between (datetime({start}) .. datetime({end}))
+| where tostring(Properties["openchoreo.dev/namespace"]) == {namespace}
+| where tostring(Properties["openchoreo.dev/component-uid"]) == {componentUid}   // optional
+| where tostring(Properties["openchoreo.dev/environment-uid"]) == {environmentUid} // optional
+| where tostring(Properties["openchoreo.dev/project-uid"]) == {projectUid}       // optional
+| summarize
+    SpanCount  = count(),
+    StartTime  = min(TimeGenerated),
+    EndTime    = max(TimeGenerated + totimespan(strcat(tostring(DurationMs), "ms"))),
+    ErrorCount = countif(Success == false),
+    RootName   = take_anyif(Name, isempty(ParentId)),
+    RootId     = take_anyif(Id, isempty(ParentId))
+  by OperationId
+| order by StartTime {sortOrder}
+| take {limit}
+```
+
+`traceName`/`rootSpanName` come from the root-span fields; `hasErrors` is
+`ErrorCount > 0`; `durationNs` is `(EndTime - StartTime)` in ns. Traces whose
+root span fell outside the window (or was sampled away) have empty Root*
+fields — same degraded behavior as the OpenSearch module; fall back to the
+earliest span's name.
+
+### KQL — spans of a trace
+
+```kusto
+union AppRequests, AppDependencies
+| where TimeGenerated between (datetime({start}) .. datetime({end}))
+| where OperationId == {traceId}
+| <same scope filters>
+| project TimeGenerated, Id, ParentId, Name, DurationMs, Success, ResultCode,
+          AppRoleName, Type, Target, Properties, Measurements, itemType = $table
+| order by TimeGenerated asc
+```
+
+`Properties`/`Measurements` are projected only when `includeAttributes=true`.
+`$table`/itemType drives the kind mapping (AppRequests → SERVER;
+AppDependencies → per Phase 0 decision).
+
+### KQL — span detail
+
+Same union filtered by `OperationId == {traceId} and Id == {spanId}`, full
+attribute projection, `take 1`.
+
+### Error mapping
+
+azlogs errors map to the contract's error responses: 401/403 from Entra →
+502 with auth detail (misconfigured identity is an operator error, not a
+client error); workspace throttling (429) → 429 passthrough; KQL timeout →
+504; partial-result flag from azlogs → log warning + serve partial (matches
+logs adapter behavior).
+
+## Test strategy
+
+- `kql.go`: golden-string tests per builder × scope permutations (namespace
+  only; +component; +environment; +project; all), sort orders, limits.
+  Injection attempts (quotes, pipes in traceId) must fail validation, not
+  reach KQL.
+- `mapping.go`: fixtures captured from the Phase 0 spike rows; assert
+  ms→ns conversion, root detection, error flag, kind mapping.
+- `handlers.go`: httptest against a mocked client (pattern from the X-Ray
+  module's `client_test.go`).
+- E2E on the Azure cluster as Phase 3 above.
+
+## Deployment story
+
+### Local dev
+
+```
+az login
+export LOG_ANALYTICS_WORKSPACE_ID=<customerId>
+go run .   # DefaultAzureCredential falls through to AzureCLICredential
+# in another terminal:
+curl -s localhost:9100/healthz
+curl -s -X POST localhost:9100/api/v1alpha1/traces/query -d @sample-query.json
+```
+
+### In-cluster
+
+```
+helm install tracing-azure ./helm \
+  --set logAnalytics.workspaceId=<customerId> \
+  --set appInsights.connectionStringSecretRef=appinsights-conn \
+  --set adapter.serviceAccount.annotations."azure\.workload\.identity/client-id"=<uami-client-id>
+# wire Observer:
+#   TRACING_ADAPTER_ENABLED=true
+#   TRACING_ADAPTER_URL=http://tracing-adapter.<ns>.svc.cluster.local:9100
+```
+
+## Open decisions, deferred until the spike
+
+1. SpanKind mapping for AppDependencies rows (table-only signal vs a
+   Properties key, if the exporter preserves one).
+2. Whether the spans-of-trace query needs a wider time window than the
+   request's (a trace's spans can straddle the window edges; OpenSearch
+   module behavior is the reference).
+3. Pagination beyond `take {limit}` for very large traces (BatchGetTraces in
+   the X-Ray module paginates; KQL `take` truncates silently — may need a
+   `serializedLength`-style guard).
+4. Whether `multiClusterExporter` data planes are AKS-only or any-K8s (the
+   collector side has no Azure dependency; only docs are affected).
+
+## Cost
+
+- Application Insights resource: free; billing is per-GB into the existing
+  workspace (Analytics plan), same meter as logs.
+- Span volume is bounded by `tail_sampling` (default 10 spans/sec per
+  collector) — at that ceiling, worst case is in the low single-digit
+  GB/month range per cluster.
+- Adapter pod: same footprint as siblings (64–128 Mi, 20–100m CPU).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Resource attrs not filterable in `Properties` | Phase 0 spike is blocking; exporter source already confirms the mechanism |
+| Span kind lost in the two-table split | spike decides mapping; document the fidelity loss vs OpenSearch |
+| `summarize by OperationId` slow over long windows | enforce limit/time-range caps (max 10000, default 20) like the OpenSearch module |
+| App Insights ingestion latency (minutes) surprises users | measure in spike; document expected freshness in README and Observer-facing docs |
+| Contrib collector image drift / exporter breaking change | pin image tag in values; bump deliberately |
+| Azure native OTLP ingestion GAs and obsoletes the exporter hop | query layer targets the same `App*` tables either way; keep ingestion and query concerns separated in the chart |
+
+## Acceptance criteria
+
+- [ ] Phase 0 spike passed; KQL prototype + fixture rows captured.
+- [ ] All three endpoints return contract-correct responses against live
+      App Insights data.
+- [ ] Tenancy: a query scoped to namespace A never returns namespace B spans
+      (verified with two labeled workloads).
+- [ ] Observer E2E with name-based scope works (`TRACING_ADAPTER_URL` wired).
+- [ ] Helm install from a clean cluster succeeds with only documented values;
+      validate.yaml rejects missing workspaceId.
+- [ ] Unit tests + lint green; README documents env vars, prerequisites,
+      ingestion latency, and the AppTraces naming trap.
+
+## Effort estimate
+
+- Phase 0 spike: ~1 day (dominated by ingestion-latency round trips).
+- Phase 1 adapter: 2–3 days with both donor modules to crib from.
+- Phase 2 Helm/collector: 1–2 days.
+- Phase 3 integration + validation: 2–3 days.
+
+## References
+
+- Tracing adapter contract + reference implementation:
+  `community-modules/observability-tracing-opensearch`
+- Azure client/auth/Helm donor:
+  `community-modules/observability-logs-azure-loganalytics`
+- App Insights workspace tables (AppRequests/AppDependencies mapping):
+  https://learn.microsoft.com/en-us/azure/azure-monitor/app/convert-classic-resource
+- Telemetry correlation (OperationId/Id/ParentId):
+  https://learn.microsoft.com/en-us/azure/azure-monitor/app/correlation
+- azuremonitorexporter (contrib; resource attrs → properties):
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/azuremonitorexporter/README.md
+- AKS Workload Identity:
+  https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
+- azlogs query SDK:
+  https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azlogs
+- Azure Monitor OTLP ingestion (preview; future simplification):
+  https://learn.microsoft.com/en-us/azure/azure-monitor/containers/opentelemetry-protocol-ingestion

--- a/docs/tracing-architecture-explained.md
+++ b/docs/tracing-architecture-explained.md
@@ -1,0 +1,635 @@
+# Distributed Tracing in OpenChoreo — From Zero
+
+This document explains how distributed tracing is implemented across the OpenChoreo
+codebases: the tracing community modules (`community-modules/observability-tracing-*`)
+and the Observer in the main repo (`cmd/observer/`). It assumes no prior knowledge
+of tracing.
+
+---
+
+## Part 0: What is tracing, and why does it exist?
+
+Imagine a user clicks "Checkout" in an online store. Behind the scenes, that one
+click might touch five different services:
+
+```
+Browser → API Gateway → Order Service → Payment Service → Database
+                              ↓
+                        Inventory Service
+```
+
+Now the user reports "checkout is slow." Where is it slow? Logs alone can't easily
+tell you, because each service writes its own logs independently and there's no
+thread connecting them.
+
+**Distributed tracing** solves this by giving each request a unique ID and recording
+how long it spent in each service. The vocabulary:
+
+- **Trace** — the complete journey of one request through the whole system.
+  Identified by a `traceId` (a random hex string like `4bf92f3577b34da6a3ce929d0e0e4736`).
+- **Span** — one unit of work inside that journey (e.g., "Order Service handled
+  POST /orders", or "DB query ran"). Each span has a `spanId`, a start time, an end
+  time, and a status (ok/error).
+- **Parent-child relationship** — spans nest. The Order Service span is the *parent*
+  of the Payment Service span it triggered. Each span records its `parentSpanId`.
+  The span with **no parent** is the **root span** — the entry point of the request.
+
+A trace is therefore a tree of spans:
+
+```
+TRACE 4bf92f35...  (total: 850ms)
+│
+└── SPAN A: "POST /checkout"  [API Gateway]          0ms ──────────────── 850ms   ← root span (parentSpanId = "")
+    │
+    └── SPAN B: "create order"  [Order Service]        20ms ───────────── 830ms   (parent = A)
+        │
+        ├── SPAN C: "charge card"  [Payment Service]     50ms ──── 700ms          (parent = B)
+        │   └── SPAN D: "SQL INSERT"  [Database]           60ms ─ 120ms           (parent = C)
+        │
+        └── SPAN E: "reserve stock"  [Inventory]          55ms ── 200ms           (parent = B)
+```
+
+Looking at this you instantly see: the 850ms is mostly inside "charge card."
+That's the value of tracing.
+
+**How does the traceId travel between services?** When Service A calls Service B
+over HTTP, it adds a header (`traceparent: 00-<traceId>-<spanId>-01`). Service B
+reads it and tags its own spans with the same traceId. This is called *context
+propagation* and it's handled by the OpenTelemetry SDK inside each app — not by
+the platform.
+
+**OpenTelemetry (OTel)** is the industry-standard toolkit for all of this: SDKs
+that apps use to create spans, a wire protocol (**OTLP**) for shipping them, and
+a **Collector** for receiving/processing/forwarding them.
+
+---
+
+## Part 1: The big picture in OpenChoreo
+
+OpenChoreo's tracing system is split across two codebases with a clean dividing line:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                                                             │
+│   DATA PLANE (where user workloads run)                                    │
+│   ┌──────────────┐                                                         │
+│   │  Your app    │  Layer 1: instrumentation (OTel SDK in the app)         │
+│   │  (OTel SDK)  │                                                         │
+│   └──────┬───────┘                                                         │
+│          │ OTLP (spans)                                                    │
+│          ▼                                                                 │
+│   ┌──────────────────────┐                                                 │
+│   │ OpenTelemetry        │  Layer 2: collection                            │
+│   │ Collector            │  (receive, enrich, sample, export)              │
+│   └──────┬───────────────┘                                                 │
+│          │                                                                 │
+├──────────┼──────────────────────────────────────────────────────────────────┤
+│          ▼                                                                 │
+│   OBSERVABILITY PLANE                                                      │
+│   ┌──────────────────────┐                                                 │
+│   │ Storage backend      │  Layer 3: storage                               │
+│   │ (OpenSearch / X-Ray  │  (indices, retention)                           │
+│   │  / OpenObserve)      │                                                 │
+│   └──────▲───────────────┘                                                 │
+│          │ backend-specific queries                                        │
+│   ┌──────┴───────────────┐                                                 │
+│   │ Tracing Adapter      │  Layer 4: query adapter      ← community-modules│
+│   │ :9100                │  (uniform REST API over any backend)            │
+│   └──────▲───────────────┘                                                 │
+│          │ HTTP (uniform API)                                              │
+│   ┌──────┴───────────────┐                                                 │
+│   │ Observer :9097       │  Layer 5: platform API       ← choreov3 repo    │
+│   │ (JWT, authz,         │  (security + abstraction)                       │
+│   │  name→UID)           │                                                 │
+│   └──────▲───────────────┘                                                 │
+│          │                                                                 │
+├──────────┼──────────────────────────────────────────────────────────────────┤
+│          │ HTTPS + JWT                                                     │
+│   ┌──────┴───────────────┐                                                 │
+│   │ UI / Backstage /     │  Layer 6: consumers                             │
+│   │ control plane        │                                                 │
+│   └──────────────────────┘                                                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Layers 2–4 live in `community-modules` (one module per storage backend:
+`observability-tracing-opensearch`, `observability-tracing-openobserve`,
+`observability-tracing-aws-xray`). Layer 5 lives in the main repo (`cmd/observer/`).
+The contract between layers 4 and 5 is a shared OpenAPI spec, which is what makes
+backends swappable.
+
+---
+
+## Part 2: Layer 1 — Instrumentation (inside the app)
+
+This layer is the developer's responsibility, not the platform's. The app embeds
+an OpenTelemetry SDK (available for Go, Java, Node, Python, etc.), which:
+
+1. Creates a span when a request arrives, ends it when the response is sent.
+2. Propagates the `traceparent` header on outgoing calls.
+3. Batches finished spans and pushes them over **OTLP** to a collector endpoint,
+   typically configured by one env var:
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://opentelemetry-collector:4318
+```
+
+The platform's only job here is to make sure a collector endpoint exists for the
+app to send to. Everything from here down is platform-owned.
+
+---
+
+## Part 3: Layer 2 — The OpenTelemetry Collector (collection & enrichment)
+
+**Where:** Helm templates in each community module, e.g.
+`observability-tracing-opensearch/helm/templates/opentelemetry-collector/configMap.yaml`.
+Uses the upstream `opentelemetry-collector` chart (v0.146.1).
+
+The Collector is a pipeline with three stages — think of it as a mail sorting facility:
+
+```
+                 ┌────────────────── OTel Collector ──────────────────┐
+                 │                                                    │
+  apps ───OTLP──▶│  RECEIVERS          PROCESSORS         EXPORTERS   │───▶ storage
+                 │  ┌───────────┐     ┌──────────────┐   ┌─────────┐  │
+                 │  │ otlp/grpc │     │ k8sattributes│   │opensearch│ │
+                 │  │  :4317    │ ──▶ │              │──▶│   or     │ │
+                 │  │ otlp/http │     │ tail_sampling│   │ awsxray  │ │
+                 │  │  :4318    │     └──────────────┘   │   or     │ │
+                 │  └───────────┘                        │openobserve│ │
+                 │                                       └─────────┘  │
+                 └────────────────────────────────────────────────────┘
+```
+
+**Receivers** open the OTLP ports (gRPC 4317, HTTP 4318) that apps send spans to.
+
+**Processors** modify spans in flight:
+
+- **`k8sattributes`** — when a span arrives, the collector asks the Kubernetes API
+  "which pod sent this?" (matching the span's source IP to a pod IP) and copies that
+  pod's labels onto the span. OpenChoreo puts identity labels on every workload pod
+  it deploys, so every span gets stamped with:
+
+  ```
+  openchoreo.dev/namespace          ← which tenant namespace
+  openchoreo.dev/project-uid        ← which project
+  openchoreo.dev/component-uid      ← which component
+  openchoreo.dev/environment-uid    ← which environment (dev/staging/prod)
+  ```
+
+  This is how a span from "some pod" becomes a span from "component X of project Y
+  in prod." The app developer never has to set these. Every query later in the
+  stack filters on these fields. (See Part 10 for exactly where this is configured
+  and where the pod labels come from.)
+
+- **`tail_sampling`** — rate limiting (default 10 spans/sec, configurable) so a
+  chatty app can't flood storage.
+
+**Exporters** write the processed spans to the backend. This is the only part that
+differs between the three modules (OpenSearch exporter / X-Ray exporter /
+OpenObserve HTTP exporter).
+
+### Multi-cluster topologies
+
+OpenChoreo separates the data plane (where apps run) from the observability plane
+(where storage runs), possibly in different clusters. The chart supports three
+modes via `global.installationMode`:
+
+```
+singleCluster:                    multiCluster:
+
+┌─ one cluster ─────────┐         ┌─ data plane cluster ──┐   ┌─ observability cluster ─┐
+│ apps → collector →    │         │ apps → collector      │   │  collector (receiver)   │
+│        storage        │         │        (exporter) ────┼──▶│  exposed via HTTPRoute  │
+└───────────────────────┘         │        forwards OTLP  │   │     │                   │
+                                  └───────────────────────┘   │     ▼                   │
+                                                              │  storage                │
+                                                              └─────────────────────────┘
+```
+
+In multi-cluster mode, each data plane runs a lightweight collector
+(`multiClusterExporter`) that just forwards OTLP to a central collector
+(`multiClusterReceiver`) exposed through a Gateway API `HTTPRoute` in the
+observability plane.
+
+---
+
+## Part 4: Layer 3 — Storage (OpenSearch as the reference)
+
+**Where:** `observability-tracing-opensearch/init/setup-opensearch.sh` (index
+template + retention policy), provisioned by a Helm setup job.
+
+OpenSearch is a search/analytics database (an Elasticsearch fork). Spans land in
+**daily indices** — one per calendar day:
+
+```
+otel-traces-2026-06-08
+otel-traces-2026-06-09
+otel-traces-2026-06-10   ← today's spans go here
+```
+
+Daily indices make time-range queries fast (only relevant days are touched) and
+make retention trivial: an **ISM policy** (Index State Management) deletes whole
+indices after 30 days (configurable via `OTEL_TRACES_MIN_INDEX_AGE`). No
+per-record cleanup needed.
+
+Each document in an index is **one span**, with a fixed schema (`dynamic: false`
+means unknown fields aren't indexed — protects against schema explosion):
+
+```json
+{
+  "traceId":       "4bf92f3577b34da6...",
+  "spanId":        "00f067aa0ba902b7",
+  "parentSpanId":  "",
+  "name":          "POST /checkout",
+  "kind":          "SERVER",
+  "startTime":     "2026-06-10T10:00:00.000000001Z",
+  "endTime":       "2026-06-10T10:00:00.850000000Z",
+  "status":        { "code": "ok" },
+  "resource": {
+    "k8s.pod.name":                    "checkout-7d9f...",
+    "service.name":                    "checkout",
+    "openchoreo.dev/namespace":        "acme-corp-ns",
+    "openchoreo.dev/project-uid":      "f47ac10b-...",
+    "openchoreo.dev/component-uid":    "d4e5f6a7-...",
+    "openchoreo.dev/environment-uid":  "7a8b9c0d-..."
+  },
+  "attributes": { "http.method": "POST", "http.status_code": 200 }
+}
+```
+
+Field notes:
+
+- `traceId`, `spanId`, `parentSpanId`, `kind`, `status.code`, and the
+  `resource.openchoreo.dev/*` fields are `keyword` (exact-match) fields.
+- `startTime`/`endTime` are `date_nanos` (nanosecond precision).
+- `parentSpanId == ""` marks the root span.
+- Span `kind` is one of `SERVER`, `CLIENT`, `INTERNAL`, `PRODUCER`, `CONSUMER`.
+
+Important: storage knows nothing about "traces" as objects. **It only stores
+spans.** A "trace" is reconstructed at query time by grouping spans that share a
+`traceId` — that's the next layer's job.
+
+---
+
+## Part 5: Layer 4 — The query adapter (community module)
+
+**Where:** `observability-tracing-opensearch/internal/` — `handlers.go:45-174`,
+`opensearch/queries.go`, `opensearch/process.go:17-104`. A small Go service,
+port 9100. The OpenObserve and X-Ray modules implement the identical API against
+their own backends.
+
+This is the **translation layer**: it speaks a simple, uniform REST API upward,
+and the backend's native query language downward.
+
+```
+            uniform REST API (same for all 3 backends)
+                          │
+            ┌─────────────▼──────────────┐
+            │   tracing-adapter :9100    │
+            │                            │
+            │  POST /api/v1alpha1/traces/query                 → list traces
+            │  POST /api/v1alpha1/traces/{traceId}/spans/query → spans of one trace
+            │  GET  /api/v1alpha1/traces/{traceId}/spans/{spanId} → one span's detail
+            │  GET  /healthz                                   │
+            └─────────────┬──────────────┘
+                          │ backend-native queries
+                          ▼
+              OpenSearch DSL / X-Ray SDK / OpenObserve API
+```
+
+The API is defined as an OpenAPI spec, and both server stubs and the client are
+**code-generated** (oapi-codegen) — so the adapter and its callers can never drift
+apart on request/response shapes.
+
+### Endpoint 1: "list traces"
+
+A request looks like:
+
+```json
+POST /api/v1alpha1/traces/query
+{
+  "startTime": "2026-06-10T00:00:00Z",
+  "endTime":   "2026-06-10T23:59:59Z",
+  "limit": 20,
+  "sortOrder": "desc",
+  "searchScope": {
+    "namespace":   "acme-corp-ns",
+    "project":     "f47ac10b-...",
+    "component":   "d4e5f6a7-...",
+    "environment": "7a8b9c0d-..."
+  }
+}
+```
+
+`namespace` is required (tenant isolation); the UID filters are optional.
+
+Remember: storage only has individual spans. To return a list of *traces*, the
+adapter uses an OpenSearch **terms aggregation** (`queries.go:111-260`) — "group
+all matching spans by traceId, and for each group compute summaries":
+
+```
+   spans matching filters (time range + searchScope terms)
+        │
+        ▼  GROUP BY traceId
+   ┌─────────────────────────────────────────────────┐
+   │ for each traceId bucket, compute:               │
+   │   • earliest_span   (min startTime → trace start)│
+   │   • latest_span     (max endTime  → trace end)   │
+   │   • root_span       (the span where              │
+   │                      parentSpanId == "")         │
+   │   • error_span_count (spans with status=error)   │
+   │   • span count                                   │
+   └─────────────────────────────────────────────────┘
+        │
+        ▼
+   one summary row per trace:
+   { traceId, traceName, spanCount, rootSpanName,
+     startTime, endTime, durationNs, hasErrors }
+```
+
+So one OpenSearch query reconstructs trace summaries from raw spans, entirely
+server-side. The `hasErrors` flag is what lets a UI paint failed traces red.
+
+### Endpoint 2: "spans of a trace"
+
+Once a user clicks a trace, the UI calls `POST /traces/{traceId}/spans/query`.
+This is a plain filter query (`queries.go:21-107`): `traceId == X` plus the same
+scope filters, returning every span document. The caller rebuilds the tree using
+each span's `parentSpanId` to draw the waterfall view from Part 0.
+
+### Endpoint 3: "span detail"
+
+`GET /traces/{traceId}/spans/{spanId}` fetches a single span *with* full
+`attributes` and `resourceAttributes`. (The list endpoints omit attributes by
+default — `includeAttributes: false` — to keep payloads small.)
+
+### Tenant safety at this layer
+
+Every query the adapter builds includes a `term` filter on
+`resource.openchoreo.dev/namespace` — `namespace` is a required field in
+`searchScope`. The adapter physically cannot produce a query that spans tenants.
+But note what it does **not** do: it doesn't check *who is asking*. It trusts its
+caller. That's deliberate, and it's why the next layer exists.
+
+---
+
+## Part 6: Layer 5 — The Observer (main repo)
+
+**Where:** `cmd/observer/main.go` (entry, trace routes at lines 281-283),
+`internal/observer/api/handlers/traces.go`, `internal/observer/service/traces.go`,
+`internal/observer/service/tracing_adapter.go`,
+`internal/observer/adaptor/traces_default.go`, interface in
+`pkg/observability/traces.go:12-19`.
+
+The Observer is the **front door of the observability plane** — one API server
+(port 9097) for logs, metrics, traces, and alerts. For tracing it exposes the
+*same three endpoints* as the adapter, but adds everything a multi-tenant platform
+needs that the adapter deliberately skipped:
+
+```
+        UI / control plane
+              │  POST /api/v1alpha1/traces/query
+              │  Authorization: Bearer <JWT>
+              │  searchScope: { project: "my-project", component: "checkout", ... }  ← NAMES
+              ▼
+   ┌────────────────────────── Observer :9097 ──────────────────────────┐
+   │                                                                    │
+   │  ① JWT middleware      — is this token valid? who is the caller?   │
+   │                                                                    │
+   │  ② Authz wrapper       — may THIS caller see THIS scope?           │
+   │     (NewTracesServiceWithAuthz, main.go:226-232 →                  │
+   │      calls authz service /api/v1/authz/evaluates)                  │
+   │                                                                    │
+   │  ③ Name → UID resolution (resolveSearchScope, traces.go:109-140)   │
+   │     "my-project" ──▶ openchoreo-api (OAuth2) ──▶ "f47ac10b-..."    │
+   │     because storage indexes UIDs, not names                        │
+   │                                                                    │
+   │  ④ Route to a backend, via the TracingAdapter interface:           │
+   │       GetTraces / GetSpans / GetSpanDetails                        │
+   │            │                                                       │
+   │            ├── TRACING_ADAPTER_ENABLED=true (default)              │
+   │            │     → HTTP client to http://tracing-adapter:9100      │
+   │            │       (the Layer-4 community module)                  │
+   │            │                                                       │
+   │            └── TRACING_ADAPTER_ENABLED=false                       │
+   │                  → DefaultTracesAdaptor: query OpenSearch          │
+   │                    otel-traces-* directly (built-in fallback,      │
+   │                    same aggregation logic, queries.go:665-914)     │
+   └────────────────────────────────────────────────────────────────────┘
+```
+
+Each step exists for a reason:
+
+**① Authentication (JWT).** The adapter trusts anyone who can reach it; the
+Observer doesn't. Every request must carry a valid JWT.
+
+**② Authorization.** Being authenticated isn't enough — a developer in project A
+must not read project B's traces. The traces service is wrapped in an authz
+decorator that asks a central authorization service "may subject S query scope X?"
+*before* any backend call happens.
+
+**③ Name→UID resolution.** Humans and UIs use names ("checkout"); the spans in
+storage are stamped with stable UIDs (names can change, UIDs can't). The Observer's
+`ResourceUIDResolver` calls openchoreo-api (authenticating with OAuth2 client
+credentials) to translate, then forwards UIDs downstream.
+
+**④ Pluggability.** Both backends implement one Go interface:
+
+```go
+// pkg/observability/traces.go:12-19
+type TracingAdapter interface {
+    GetTraces(ctx, params)           (*TracesQueryResult, error)
+    GetSpans(ctx, traceID, params)   (*SpansResult, error)
+    GetSpanDetails(ctx, traceID, spanID) (*SpanDetail, error)
+}
+```
+
+The handler and service code never know which one is behind it. The same pattern
+is used for logs (`LOGS_ADAPTER_ENABLED`, adapter on :9098) and metrics (always an
+external adapter on :9099) — tracing just follows the house convention.
+
+Configuration is all env vars:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TRACING_ADAPTER_ENABLED` | `true` | use external adapter vs built-in OpenSearch fallback |
+| `TRACING_ADAPTER_URL` | `http://tracing-adapter:9100` | where the Layer-4 module lives |
+| `OPENSEARCH_ADDRESS` | `http://localhost:9200` | used by the fallback path |
+| `AUTHZ_SERVICE_URL` | — | authorization service |
+| `UID_RESOLVER_OPENCHOREO_API_URL` | — | name→UID resolution |
+
+---
+
+## Part 7: Layer 6 — Consumers
+
+The control plane discovers an Observer through a CRD: `ObservabilityPlane`
+(namespaced) or `ClusterObservabilityPlane` (cluster-scoped), whose spec carries
+an `observerURL` (`api/v1alpha1/observabilityplane_types.go`). An `Environment`
+is tied to planes, so when a UI asks "show traces for component X in prod," the
+control plane knows *which* Observer instance to call and does so over HTTPS with
+a JWT.
+
+---
+
+## Part 8: One request, end to end
+
+**Write path** (happens continuously, milliseconds per span):
+
+```
+1. User hits POST /checkout on the "checkout" component in prod.
+2. The app's OTel SDK creates spans (root + children), propagates the
+   traceparent header to downstream services it calls.
+3. SDK batches spans → OTLP → OTel Collector :4318.
+4. Collector's k8sattributes processor looks up the sending pod and stamps:
+   openchoreo.dev/namespace, project-uid, component-uid, environment-uid.
+5. tail_sampling rate-limits; the OpenSearch exporter writes each span
+   as a document into otel-traces-2026-06-10.
+6. 30 days later, the ISM policy deletes that whole index.
+```
+
+**Read path** (when a developer opens the tracing UI):
+
+```
+1. UI → Observer:9097  POST /api/v1alpha1/traces/query
+        JWT + { searchScope: { namespace, project: "shop", component: "checkout" } }
+2. Observer validates the JWT, asks authz "may this user query this scope?" → yes
+3. Observer resolves "shop"/"checkout" names → UIDs via openchoreo-api
+4. Observer → tracing-adapter:9100 with UIDs
+5. Adapter builds a terms-aggregation query (group spans by traceId,
+   compute root span / duration / error count) → OpenSearch
+6. Trace summaries flow back up; UI shows a sortable list, errors flagged
+7. Developer clicks a trace → /traces/{traceId}/spans/query → all spans
+   → UI rebuilds the parent/child tree → waterfall diagram → "ah, the
+   slowness is in 'charge card'"
+```
+
+---
+
+## Part 9: Why it's layered this way
+
+The architecture comes down to three separations:
+
+1. **Collection vs. query** — the Collector and the adapter share nothing at
+   runtime; their only contract is the storage schema (the index template). You
+   can scale or replace either independently.
+2. **Backend-specific vs. backend-agnostic** — everything that knows "OpenSearch"
+   (or X-Ray, or OpenObserve) lives in one community module. The Observer, authz,
+   UID resolution, and UI are written once against the OpenAPI contract.
+   **Adding a new backend = writing one new community module** (collector exporter
+   config + the three query endpoints); zero changes in the main repo.
+3. **Trust boundary** — the adapter enforces *what* can be queried (namespace
+   filter is structurally required), the Observer enforces *who* may query it
+   (JWT + authz). Keeping the security layer in the platform core means a
+   community-contributed adapter can't weaken tenant isolation.
+
+---
+
+## Part 10: Where the k8sattributes enrichment comes from
+
+Two separate places work together: the **processor configuration** lives in the
+community module's Helm chart, and the **pod labels it extracts** are stamped by
+the OpenChoreo control plane at deploy time.
+
+### 10.1 The processor configuration
+
+`observability-tracing-opensearch/helm/templates/opentelemetry-collector/configMap.yaml`:
+
+```yaml
+processors:
+  k8sattributes:
+    auth_type: "serviceAccount"   # use the collector pod's own SA to call the k8s API
+    passthrough: false            # actually resolve metadata here (don't defer)
+    extract:
+      labels:
+        - tag_name: $$1           # Helm-escaped $1 → the regex capture group
+          key_regex: (.*)         # match EVERY pod label
+          from: pod
+      metadata:
+        - k8s.pod.name
+        - k8s.pod.uid
+        - k8s.deployment.name
+        - k8s.namespace.name
+        - k8s.node.name
+```
+
+Two things to notice:
+
+- **It copies all pod labels, not just OpenChoreo's.** `key_regex: (.*)` with
+  `tag_name: $$1` means "take every label on the pod and attach it to the span as
+  a resource attribute, with the same name." So `openchoreo.dev/component-uid: d4e5...`
+  on the pod becomes `resource.openchoreo.dev/component-uid` on the span. There is
+  no OpenChoreo-specific list in the collector config — the filtering happens
+  later, because the OpenSearch index template (`dynamic: false`) only indexes the
+  specific `resource.openchoreo.dev/*` fields it has mappings for. Everything else
+  is carried but not searchable.
+
+- **It's only enabled where pods are local.** The Helm template gates the
+  processor on installation mode: it runs in `singleCluster` and
+  `multiClusterExporter` modes, but **not** in `multiClusterReceiver`. Enrichment
+  must happen in the cluster where the workload pods actually live, because the
+  processor identifies the sender by matching the span's **source IP to a pod IP**
+  via the local Kubernetes API (hence `auth_type: serviceAccount` — the collector's
+  service account needs RBAC to list/watch pods, provided by the upstream chart).
+  The central receiver in another cluster cannot resolve a foreign pod IP, so
+  spans arrive there already enriched.
+
+```
+multiClusterExporter (data plane)              multiClusterReceiver (obs plane)
+┌────────────────────────────────┐             ┌─────────────────────────────┐
+│ app pod ──OTLP──▶ collector    │             │ collector                   │
+│   ▲              [k8sattributes│──OTLP──────▶│ [NO k8sattributes]          │
+│   │               + sampling]  │  (already   │ ──▶ opensearch exporter     │
+│   └─ "which pod has this IP?"  │   enriched) │                             │
+│      via local k8s API         │             │                             │
+└────────────────────────────────┘             └─────────────────────────────┘
+```
+
+### 10.2 Where the pod labels themselves come from
+
+The labels exist on the pod because the **ReleaseBinding controller** puts them
+there when it renders the workload. In
+`internal/controller/releasebinding/controller.go:289-309`, it builds the standard
+label set from the actual Kubernetes object UIDs:
+
+```go
+standardLabels := map[string]string{
+    labels.LabelKeyComponentUID:   componentUID,    // string(component.UID)
+    labels.LabelKeyEnvironmentUID: environmentUID,  // string(environment.UID)
+    labels.LabelKeyProjectUID:     projectUID,      // string(project.UID)
+    // plus the human-readable *-name labels
+}
+```
+
+The constants are defined in `internal/labels/labels.go:23-25`
+(`openchoreo.dev/project-uid`, `openchoreo.dev/component-uid`,
+`openchoreo.dev/environment-uid`). These go into the `MetadataContext`
+(`controller.go:311-326`) — both as `Labels` and `PodSelectors` — which feeds the
+ComponentType rendering pipeline, so the generated Deployment's pod template
+carries them. The RenderedRelease then ships those manifests to the data plane.
+
+### 10.3 Full provenance of one field
+
+```
+Component CR created → k8s assigns metadata.uid
+        │
+ReleaseBinding controller: standardLabels[openchoreo.dev/component-uid] = component.UID
+        │  (releasebinding/controller.go:295)
+        ▼
+rendering pipeline → Deployment podTemplate.metadata.labels → pod gets the label
+        │
+        ▼
+app sends span → collector matches source IP → pod → k8sattributes copies
+all pod labels onto the span as resource attributes
+        │
+        ▼
+OpenSearch doc: resource."openchoreo.dev/component-uid" (indexed as keyword)
+        │
+        ▼
+adapter query: term filter on that field
+```
+
+The nice property: the app, the OTel SDK, and the collector config all have zero
+knowledge of OpenChoreo identity. The control plane stamps identity onto pods
+once, and the generic "copy all labels" rule carries it through to every span
+automatically.


### PR DESCRIPTION
## Purpose

Adds the design/implementation proposal for an Azure Application Insights tracing adapter and a from-zero explainer of how distributed tracing works across OpenChoreo. These sit alongside the existing Azure logs and metrics adapter proposals and give contributors the context needed to build and review the new tracing module.

## Approach

- `docs/proposals/azure-observability-tracing-adapter-implementation.md`: implementation plan for a tracing adapter that queries workspace-based Application Insights (`AppRequests`/`AppDependencies`) via KQL, with OTel Collector (contrib) + `azuremonitor` exporter for ingestion. Includes the passed Phase 0 spike results and two implementation findings:
  - `totimespan(strcat(ms, "ms"))` returns null for fractional milliseconds; use `TimeGenerated + (todouble(DurationMs) * 1ms)` instead.
  - the collector subchart names a cluster-scoped ClusterRole after its fullname, so `fullnameOverride` must be unique per tracing module to coexist with the OpenSearch module.
- `docs/tracing-architecture-explained.md`: layer-by-layer walkthrough of the tracing stack, from OTel instrumentation through the collector, storage, the query adapter, and the Observer, including the `k8sattributes` enrichment that carries `openchoreo.dev/*` tenancy labels onto spans.

Docs only; no code changes. The adapter module itself lives in the community-modules repo.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)