### PR TITLE
ci: pin Backstage image to backstage-plugins branch SHA in e2e gate

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: "0.0.0-latest-dev"
+      backstage_image_tag:
+        description: "Backstage (openchoreo-ui) image tag for the UI leg; empty uses the chart's AppVersion default"
+        required: false
+        type: string
+        default: ""
       run_tier1:
         description: "Run the tier1 leg"
         required: false
@@ -72,6 +77,11 @@ on:
         required: false
         type: string
         default: "0.0.0-latest-dev"
+      backstage_image_tag:
+        description: "Backstage (openchoreo-ui) image tag for the UI leg; empty uses the chart's AppVersion default"
+        required: false
+        type: string
+        default: ""
       run_tier1:
         description: "Run the tier1 leg"
         required: false
@@ -334,6 +344,12 @@ jobs:
       E2E_WITH_BUILD: "true"
       E2E_WITH_OBSERVABILITY: "true"
       E2E_WITH_UI: "true"
+      # Backstage image tag for the UI install. openchoreo-ui is built by the
+      # backstage-plugins repo (tagged with its commit short SHA), so the chart's
+      # AppVersion default has no matching image at the release ref; the caller
+      # passes the backstage-plugins release-branch tip SHA here. Empty on the
+      # schedule/dispatch paths, where the latest-dev chart's AppVersion resolves.
+      E2E_BACKSTAGE_IMAGE_TAG: ${{ inputs.backstage_image_tag }}
       E2E_KUBECONTEXT: k3d-openchoreo-e2e
       UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
       # OpenChoreo API URL the pkce-login spec points occ at (NOT the Backstage
@@ -440,6 +456,7 @@ jobs:
             E2E_WITH_BUILD="${E2E_WITH_BUILD}" \
             E2E_WITH_OBSERVABILITY="${E2E_WITH_OBSERVABILITY}" \
             E2E_WITH_UI="${E2E_WITH_UI}" \
+            E2E_BACKSTAGE_IMAGE_TAG="${E2E_BACKSTAGE_IMAGE_TAG}" \
             E2E_SETUP_TIMEOUT=10m
 
       - name: Run UI e2e tests

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -319,6 +319,7 @@ jobs:
     outputs:
       target: ${{ steps.resolve-target.outputs.target }}
       helm-chart-version: ${{ steps.resolve-target.outputs.helm-chart-version }}
+      backstage-image-tag: ${{ steps.backstage-tag.outputs.backstage-image-tag }}
       e2e-already-passed: ${{ steps.e2e-status.outputs.e2e-already-passed }}
     steps:
       - name: Checkout
@@ -355,6 +356,32 @@ jobs:
           SHORT_SHA=$(git rev-parse --short=8 "${TARGET}")
           echo "target=${TARGET}" >> $GITHUB_OUTPUT
           echo "helm-chart-version=0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Resolve backstage-plugins image tag
+        id: backstage-tag
+        env:
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release-branch }}
+        run: |
+          # openchoreo-ui (Backstage) images are tagged with the backstage-plugins
+          # commit short SHA. Resolve the backstage-plugins branch that mirrors the
+          # openchoreo release branch; fall back to latest-dev when absent
+          # (e.g. prereleases, which cut no mirror branch).
+          BS_REPO="https://github.com/${{ github.repository_owner }}/backstage-plugins.git"
+          # Run git ls-remote without a pipe so its exit status isn't masked by
+          # awk's: a transient failure must error, not fall back to latest-dev.
+          if ! LS_OUTPUT=$(git ls-remote "$BS_REPO" "refs/heads/${RELEASE_BRANCH}"); then
+            echo "::error::git ls-remote failed for backstage-plugins branch ${RELEASE_BRANCH} (transient lookup failure); refusing to fall back to latest-dev."
+            exit 1
+          fi
+          TIP=$(printf '%s\n' "$LS_OUTPUT" | awk 'NR==1{print $1}')
+          if [ -n "$TIP" ]; then
+            TAG=$(printf '%s' "$TIP" | cut -c1-8)
+            echo "Backstage image tag: ${TAG} (backstage-plugins ${RELEASE_BRANCH} @ ${TIP})"
+          else
+            TAG="latest-dev"
+            echo "::warning::backstage-plugins branch ${RELEASE_BRANCH} not found; falling back to ${TAG}"
+          fi
+          echo "backstage-image-tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for build-and-test workflow
         env:
@@ -438,6 +465,7 @@ jobs:
     with:
       ref: ${{ needs.resolve-target.outputs.target }}
       helm_chart_version: ${{ needs.resolve-target.outputs.helm-chart-version }}
+      backstage_image_tag: ${{ needs.resolve-target.outputs.backstage-image-tag }}
 
   # ----------------------------------------------------------------
   # Record e2e pass: stamp the gated commit with a release-e2e-gate

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -13,6 +13,13 @@ E2E_WITH_OBSERVABILITY ?= false
 # (see test/ui/). Off by default so the existing e2e workflow keeps the lighter
 # Backstage-disabled install.
 E2E_WITH_UI            ?= false
+# Optional Backstage (openchoreo-ui) image tag for the UI install. The
+# openchoreo-ui image is built by the separate backstage-plugins repo and tagged
+# with that repo's commit short SHA, so the chart's AppVersion default (the
+# openchoreo commit SHA) has no matching image during the release e2e gate. The
+# release orchestrator resolves the backstage-plugins release-branch tip and
+# passes its short SHA here. Empty keeps the chart's AppVersion default.
+E2E_BACKSTAGE_IMAGE_TAG ?=
 # Go duration for the test suite (go test -timeout)
 E2E_TEST_TIMEOUT       ?= 20m
 # Go duration for each individual helm install and kubectl wait (not the overall setup timeout)
@@ -49,9 +56,14 @@ UI_DIR                 := $(PROJECT_DIR)/test/ui
 UI_K3D_DIR             := $(UI_DIR)/k3d
 
 # When the UI suite is enabled, layer the cp-ui overlay on top of the default
-# control-plane values so Backstage gets switched on.
+# control-plane values so Backstage gets switched on. When a Backstage image tag
+# is supplied, pin it so the install does not fall back to the chart AppVersion
+# (the openchoreo SHA), which has no matching openchoreo-ui image.
 ifeq ($(E2E_WITH_UI),true)
   E2E_CP_EXTRA_VALUES := --values $(UI_K3D_DIR)/values-cp-ui.yaml
+  ifneq ($(strip $(E2E_BACKSTAGE_IMAGE_TAG)),)
+    E2E_CP_EXTRA_VALUES += --set-string backstage.image.tag=$(E2E_BACKSTAGE_IMAGE_TAG)
+  endif
 else
   E2E_CP_EXTRA_VALUES :=
 endif


### PR DESCRIPTION
## Purpose
The release e2e gate's UI/Playwright leg fails at cluster install. The sha-pinned control-plane chart (`0.0.0-<openchoreo-sha>`) resolves the Backstage image to `ghcr.io/openchoreo/openchoreo-ui:<openchoreo-sha>` (from the chart's `AppVersion`), which never exists — `openchoreo-ui` is built by the **backstage-plugins** repo and tagged with *that* repo's commit short SHAs. The pod stays in `ImagePullBackOff`, so `kubectl wait` times out and the gate fails. Direct/nightly e2e runs pass only because they use the `0.0.0-latest-dev` chart, whose `AppVersion` resolves to the existing `openchoreo-ui:latest-dev`.

## Approach
Resolve the backstage-plugins release branch — its name mirrors the openchoreo release branch — tip short SHA and feed it to the UI leg as the Backstage image tag:

- **release-orchestrator.yml** — `resolve-target` resolves the backstage-plugins branch tip (`git ls-remote`, `--short=8`) and passes `backstage_image_tag` to the e2e gate. Falls back to `latest-dev` when no mirror branch exists (e.g. prereleases).
- **e2e-gate.yml** — new `backstage_image_tag` input (dispatch + call), surfaced to the UI leg as `E2E_BACKSTAGE_IMAGE_TAG`. Empty on schedule/dispatch, so those keep resolving `latest-dev` via the chart `AppVersion` (unchanged).
- **make/e2e.mk** — when `E2E_BACKSTAGE_IMAGE_TAG` is set with UI enabled, append `--set backstage.image.tag=<sha>` to the control-plane install.

Verified against the backstage-plugins workflows: branch naming (`release-v<major>.<minor>`) and 8-char short-SHA image tagging match the resolver.

## Related Issues
Fixes #3834

## Checklist
- [ ] Tests added or updated (unit, integration, etc.) — N/A (CI/release workflow change; validated via make-variable expansion + YAML parse)
- [ ] Samples updated (if applicable) — N/A
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
The companion release-process reordering (branch backstage-plugins before tagging openchoreo; tag backstage-plugins after) is a separate change in the `openchoreo/.github` release issue template and is not part of this PR.
