### PR TITLE
chore: move observability adapter API specs from docs repo

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -197,7 +197,7 @@ openapi-codegen: oapi-codegen ## Generate Go server and client code from OpenAPI
 	@$(call log, "Generating Observer OpenAPI client")
 	$(OAPI_CODEGEN) -config internal/observer/api/cfg-client.yaml openapi/observer-api.yaml
 	@$(call log, "Generating Observer Logs Adapter API client")
-	$(OAPI_CODEGEN) -config internal/observer/api/cfg-logs-adapter-client.yaml https://openchoreo.dev/api-specs/observability-logs-adapter-api.yaml
+	$(OAPI_CODEGEN) -config internal/observer/api/cfg-logs-adapter-client.yaml openapi/observability-logs-adapter-api.yaml
 
 .PHONY: mockery-gen
 mockery-gen: mockery ## Regenerate mockery mocks.

--- a/openapi/observability-logs-adapter-api.yaml
+++ b/openapi/observability-logs-adapter-api.yaml
@@ -1,0 +1,798 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+openapi: 3.0.3
+info:
+  title: OpenChoreo Observability Logs Adapter API
+  description: |
+    This API specification defines the contract that a logging adapter must implement
+    to integrate with the OpenChoreo Observer. The Observer calls these endpoints to
+    query logs and manage alert rules from the logging backend provided by the module.
+  version: 1.0.0
+  contact:
+    name: OpenChoreo Team
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+tags:
+  - name: Logs
+    description: Log retrieval endpoints
+  - name: Alerts
+    description: Alert rule management endpoints
+  - name: Health
+    description: Health check endpoints
+
+paths:
+  /health:
+    get:
+      tags:
+        - Health
+      summary: Health check
+      description: Check the health status of the observer service.
+      operationId: health
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+        "503":
+          description: Service is unhealthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: unhealthy
+                  error:
+                    type: string
+                    example: "opensearch: connection failed"
+
+  # Logs query endpoint
+  /api/v1/logs/query:
+    post:
+      tags:
+        - Logs
+      summary: Query logs
+      description: Query logs from the observer service
+      operationId: queryLogs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogsQueryRequest"
+      responses:
+        "200":
+          description: Logs queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LogsQueryResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "badRequest"
+                errorCode: ""
+                message: "Missing required fields 'startTime' and 'endTime'"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "unauthorized"
+                errorCode: ""
+                message: "Invalid or missing token"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "forbidden"
+                errorCode: ""
+                message: "Subject <xyz> has no permission to view logs of Namespace foo, Project bar, Component baz in Environment development"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "internalServerError"
+                errorCode: "OBS-V1-L-29"
+                message: ""
+
+  /api/v1/events/query:
+    post:
+      tags:
+        - Events
+      summary: Query events
+      description: Query Kubernetes events from the observer service
+      operationId: queryEvents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventsQueryRequest"
+      responses:
+        "200":
+          description: Events queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventsQueryResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "badRequest"
+                errorCode: ""
+                message: "Missing required fields 'startTime' and 'endTime'"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "unauthorized"
+                errorCode: ""
+                message: "Invalid or missing token"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "forbidden"
+                errorCode: ""
+                message: "Subject <xyz> has no permission to view events of Namespace foo, Project bar, Component baz in Environment development"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "internalServerError"
+                errorCode: "OBS-V1-E-01"
+                message: ""
+
+  /api/v1alpha1/alerts/rules:
+    post:
+      tags:
+        - Alerts
+      summary: Create alert rule
+      description: Create an alert rule in the observer service
+      operationId: createAlertRule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AlertRuleRequest"
+      responses:
+        "201":
+          description: Alert rule created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Alert rule already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/webhook:
+    post:
+      tags:
+        - Alerts
+      summary: Handles triggered alerts from the alerting backend
+      description: Handles triggered alerts from the alerting backend
+      operationId: handleAlertWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: The request body can be any JSON object, as different alerting backends may send different payloads.
+      responses:
+        "200":
+          description: Alert webhook handled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertWebhookResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/rules/{ruleName}:
+    parameters:
+      - name: ruleName
+        in: path
+        required: true
+        description: The name of the alert rule
+        schema:
+          type: string
+    get:
+      tags:
+        - Alerts
+      summary: Get alert rule
+      description: Get an alert rule from the logging backend
+      operationId: getAlertRule
+      responses:
+        "200":
+          description: Alert rule retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertRuleResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - Alerts
+      summary: Update alert rule
+      description: Update an alert rule in the logging backend
+      operationId: updateAlertRule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AlertRuleRequest"
+      responses:
+        "200":
+          description: Alert rule updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags:
+        - Alerts
+      summary: Delete alert rule
+      description: Delete an alert rule in the observer service
+      operationId: deleteAlertRule
+      responses:
+        "200":
+          description: Alert rule deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    # Request schemas for logs
+    ComponentSearchScope:
+      type: object
+      properties:
+        namespace:
+          type: string
+        projectUid:
+          type: string
+        componentUid:
+          type: string
+        environmentUid:
+          type: string
+      required: [namespace]
+
+    WorkflowSearchScope:
+      type: object
+      properties:
+        namespace:
+          type: string
+        workflowRunName:
+          type: string
+        taskName:
+          type: string
+          description: Filter events to a specific workflow task
+      required: [namespace]
+
+    LogsQueryRequest:
+      type: object
+      properties:
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        limit:
+          type: integer
+          default: 100
+          minimum: 1
+          maximum: 1000
+          description: The maximum number of items to return
+        sortOrder:
+          type: string
+          description: The sort order of the query
+          enum:
+            - asc
+            - desc
+          default: desc
+        searchScope:
+          oneOf:
+            - $ref: "#/components/schemas/ComponentSearchScope"
+            - $ref: "#/components/schemas/WorkflowSearchScope"
+        logLevels:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum: ["DEBUG", "INFO", "WARN", "ERROR"]
+        searchPhrase:
+          type: string
+      required: [startTime, endTime, searchScope]
+
+    # Response schemas for logs
+    ComponentLogEntry:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the log entry
+          format: date-time
+        log:
+          type: string
+          description: The log message
+        level:
+          type: string
+          description: The log level
+        metadata:
+          type: object
+          description: The metadata of the log entry
+          properties:
+            componentName:
+              type: string
+              description: The OpenChoreo component name that generated the log
+            projectName:
+              type: string
+              description: The OpenChoreo project name that generated the log
+            environmentName:
+              type: string
+              description: The OpenChoreo environment name that generated the log
+            namespaceName:
+              type: string
+              description: The OpenChoreo namespace name that generated the log
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID that generated the log
+              format: uuid
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID that generated the log
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID that generated the log
+              format: uuid
+            containerName:
+              type: string
+              description: The container name that generated the log
+            podName:
+              type: string
+              description: The Kubernetes pod name that generated the log
+            podNamespace:
+              type: string
+              description: The namespace of the Kubernetes pod that generated the log
+
+    WorkflowLogEntry:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the log entry
+          format: date-time
+        log:
+          type: string
+          description: The log message
+
+    LogsQueryResponse:
+      type: object
+      properties:
+        logs:
+          oneOf:
+            - type: array
+              items:
+                $ref: "#/components/schemas/ComponentLogEntry"
+            - type: array
+              items:
+                $ref: "#/components/schemas/WorkflowLogEntry"
+          description: The logs queried successfully
+        total:
+          type: integer
+          description: The total number of matching log entries, capped at 1000
+        tookMs:
+          type: integer
+          description: The time taken to query the logs in milliseconds
+
+    # Request schema for events
+    EventsQueryRequest:
+      type: object
+      properties:
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        limit:
+          type: integer
+          default: 100
+          minimum: 1
+          maximum: 1000
+          description: The maximum number of items to return
+        sortOrder:
+          type: string
+          description: The sort order of the query
+          enum:
+            - asc
+            - desc
+          default: desc
+        searchScope:
+          oneOf:
+            - $ref: "#/components/schemas/ComponentSearchScope"
+            - $ref: "#/components/schemas/WorkflowSearchScope"
+      required: [startTime, endTime, searchScope]
+
+    # Response schemas for events
+    EventEntry:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the event
+          format: date-time
+        message:
+          type: string
+          description: The event message
+        type:
+          type: string
+          description: The event type (e.g. Normal, Warning)
+        reason:
+          type: string
+          description: The short, machine-readable reason for the event (e.g. SawCompletedJob)
+        metadata:
+          type: object
+          description: The metadata of the event
+          properties:
+            componentName:
+              type: string
+              description: The OpenChoreo component name the event is associated with
+            projectName:
+              type: string
+              description: The OpenChoreo project name the event is associated with
+            environmentName:
+              type: string
+              description: The OpenChoreo environment name the event is associated with
+            namespaceName:
+              type: string
+              description: The OpenChoreo namespace name the event is associated with
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID the event is associated with
+              format: uuid
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID the event is associated with
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID the event is associated with
+              format: uuid
+            objectKind:
+              type: string
+              description: The kind of the Kubernetes object the event involves (e.g. CronJob)
+            objectName:
+              type: string
+              description: The name of the Kubernetes object the event involves
+            objectNamespace:
+              type: string
+              description: The namespace of the Kubernetes object the event involves
+
+    EventsQueryResponse:
+      type: object
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/EventEntry"
+          description: The events queried successfully
+        total:
+          type: integer
+          description: The total number of matching events, capped at 1000
+        tookMs:
+          type: integer
+          description: The time taken to query the events in milliseconds
+
+    # Request schemas for alert rules
+    AlertRuleRequest:
+      type: object
+      required: [metadata, source, condition]
+      properties:
+        metadata:
+          type: object
+          required: [name, namespace, projectUid, environmentUid, componentUid]
+          properties:
+            name:
+              type: string
+              description: The name of the alert rule
+            namespace:
+              type: string
+              description: The namespace of the alert rule CR
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID to query
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID to query
+              format: uuid
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID to query
+              format: uuid
+        source:
+          type: object
+          required: [query]
+          properties:
+            query:
+              type: string
+              description: The query to execute for log based alerts
+        condition:
+          type: object
+          required: [enabled, window, interval, operator, threshold]
+          properties:
+            enabled:
+              type: boolean
+              description: Whether the alert rule is enabled
+            window:
+              type: string
+              description: The window of time to query for the alert rule
+            interval:
+              type: string
+              description: The interval of time to query for the alert rule
+            operator:
+              type: string
+              description: The operator to use for the alert rule
+              enum:
+                - gt
+                - gte
+                - lt
+                - lte
+                - eq
+                - neq
+            threshold:
+              type: number
+              description: The threshold value to use for the alert rule
+
+    # Response schemas for alert rules
+    AlertRuleResponse:
+      type: object
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the alert rule
+            namespace:
+              type: string
+              description: The namespace of the alert rule CR
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID to query
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID to query
+              format: uuid
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID to query
+              format: uuid
+        source:
+          type: object
+          properties:
+            query:
+              type: string
+              description: The query to execute for log based alerts
+            metric:
+              type: string
+              description: The metric to query for metric based alerts
+              enum:
+                - cpu_usage
+                - memory_usage
+        condition:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              description: Whether the alert rule is enabled
+            window:
+              type: string
+              description: The window of time to query for the alert rule
+            interval:
+              type: string
+              description: The interval of time to query for the alert rule
+            operator:
+              type: string
+              description: The operator to use for the alert rule
+              enum:
+                - gt
+                - gte
+                - lt
+                - lte
+                - eq
+                - neq
+            threshold:
+              type: number
+              description: The threshold value to use for the alert rule
+
+    AlertingRuleSyncResponse:
+      type: object
+      properties:
+        action:
+          type: string
+          description: The action taken on the alert rule
+          enum:
+            - created
+            - updated
+            - unchanged
+            - deleted
+        lastSyncedAt:
+          type: string
+          description: The timestamp of the last sync
+        status:
+          type: string
+          description: The status of the alert rule
+          enum:
+            - synced
+            - failed
+        ruleLogicalId:
+          type: string
+          description: The logical ID (name) of the alert rule
+        ruleBackendId:
+          type: string
+          description: The backend ID (UID from observability backend) of the alert rule
+
+    # Response schema for alert webhook
+    AlertWebhookResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message of the alert webhook
+        status:
+          type: string
+          description: The status of the alert webhook
+          enum:
+            - success
+            - error
+
+    # New error response schema
+    ErrorResponse:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The error message
+          enum:
+            - badRequest
+            - unauthorized
+            - forbidden
+            - notFound
+            - conflict
+            - internalServerError
+        errorCode:
+          type: string
+          description: The error code from observer service
+          example: OBS-V1-L-22
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Missing required fields 'startTime' and 'endTime'"

--- a/openapi/observability-metrics-adapter.yaml
+++ b/openapi/observability-metrics-adapter.yaml
@@ -473,6 +473,12 @@ components:
             $ref: "#/components/schemas/MetricsTimeSeriesItem"
 
     MetricsQueryResponse:
+      description: >-
+        Response for POST /api/v1/metrics/query. The variant is determined by
+        the request's `metric` field: `resource` yields a
+        ResourceMetricsTimeSeries and `http` yields an HttpMetricsTimeSeries.
+        The two variants have disjoint property sets, so the response carries no
+        separate discriminator field.
       oneOf:
         - $ref: "#/components/schemas/ResourceMetricsTimeSeries"
         - $ref: "#/components/schemas/HttpMetricsTimeSeries"
@@ -482,13 +488,25 @@ components:
       type: object
       description: |
         Request body for POST /api/v1alpha1/metrics/runtime-topology.
-        searchScope must include namespace, projectUid, and environmentUid —
-        runtime topology is project- and environment-scoped. The optional
+        Runtime topology is project- and environment-scoped, so searchScope
+        requires namespace, projectUid, and environmentUid. The optional
         componentUid, if set, restricts results to edges that touch that
         component.
       properties:
         searchScope:
-          $ref: "#/components/schemas/ComponentSearchScope"
+          type: object
+          description: Project- and environment-scoped search scope.
+          properties:
+            namespace:
+              type: string
+            projectUid:
+              type: string
+            environmentUid:
+              type: string
+            componentUid:
+              type: string
+              description: If set, restricts results to edges that touch this component.
+          required: [namespace, projectUid, environmentUid]
         startTime:
           type: string
           description: The start time of the query window

--- a/openapi/observability-metrics-adapter.yaml
+++ b/openapi/observability-metrics-adapter.yaml
@@ -1,0 +1,920 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+openapi: 3.0.3
+info:
+  title: OpenChoreo Observability Metrics Adapter API
+  description: |
+    This API specification defines the contract that a metrics adapter must implement
+    to integrate with the OpenChoreo Observer. The Observer calls these endpoints to
+    query metrics from the metrics backend provided by the module.
+  version: 1.0.0
+  contact:
+    name: OpenChoreo Team
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+tags:
+  - name: Metrics
+    description: Metrics retrieval endpoints
+  - name: Alerts
+    description: Alert rule management endpoints
+  - name: Health
+    description: Health check endpoints
+
+paths:
+  /healthz:
+    get:
+      tags:
+        - Health
+      summary: Health check
+      description: Check the health status of the metrics adapter service
+      operationId: health
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+        "503":
+          description: Service is unhealthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: unhealthy
+                  error:
+                    type: string
+                    example: "metrics backend: connection failed"
+
+  # Metrics query endpoint
+  /api/v1/metrics/query:
+    post:
+      tags:
+        - Metrics
+      summary: Query metrics
+      description: Query metrics from the metrics adapter service
+      operationId: queryMetrics
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetricsQueryRequest"
+      responses:
+        "200":
+          description: Metrics queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsQueryResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  # Runtime topology endpoint (for cell diagram with runtime observability)
+  /api/v1alpha1/metrics/runtime-topology:
+    post:
+      tags:
+        - Metrics
+      summary: Query runtime topology
+      description: |
+        Returns the live HTTP traffic topology for a project in a given environment:
+        a list of nodes (components, gateways, external endpoints) and a list of edges
+        (observed source -> target traffic flows), each with aggregated metrics
+        (request count, error count, latency percentiles) computed over the requested
+        time window. Identifiers are returned as OpenChoreo UIDs — the caller is
+        expected to map UIDs back to human-readable names.
+      operationId: queryRuntimeTopology
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RuntimeTopologyRequest"
+      responses:
+        "200":
+          description: Runtime topology queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RuntimeTopologyResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "501":
+          description: >-
+            Not Implemented. The metrics backend does not support runtime
+            topology (for example, it has no pod-to-pod traffic data to build
+            the graph from).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/rules:
+    post:
+      tags:
+        - Alerts
+      summary: Create alert rule
+      description: Create an alert rule in the metrics backend
+      operationId: createAlertRule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AlertRuleRequest"
+      responses:
+        "201":
+          description: Alert rule created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Alert rule already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/webhook:
+    post:
+      tags:
+        - Alerts
+      summary: Handles triggered alerts from the alerting backend
+      description: Handles triggered alerts from the alerting backend
+      operationId: handleAlertWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: The request body can be any JSON object, as different alerting backends may send different payloads.
+      responses:
+        "200":
+          description: Alert webhook handled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertWebhookResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/rules/{ruleName}:
+    parameters:
+      - name: ruleName
+        in: path
+        required: true
+        description: The name of the alert rule
+        schema:
+          type: string
+    get:
+      tags:
+        - Alerts
+      summary: Get alert rule
+      description: Get an alert rule from the metrics backend
+      operationId: getAlertRule
+      responses:
+        "200":
+          description: Alert rule retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertRuleResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - Alerts
+      summary: Update alert rule
+      description: Update an alert rule in the metrics backend
+      operationId: updateAlertRule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AlertRuleRequest"
+      responses:
+        "200":
+          description: Alert rule updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags:
+        - Alerts
+      summary: Delete alert rule
+      description: Delete an alert rule in the metrics backend
+      operationId: deleteAlertRule
+      responses:
+        "200":
+          description: Alert rule deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The error message
+          enum:
+            - badRequest
+            - unauthorized
+            - forbidden
+            - internalServerError
+            - notImplemented
+        errorCode:
+          type: string
+          description: The error code from observer service
+          example: OBS-V1-M-22
+        detail:
+          type: string
+          description: The error message
+          example: "Missing required fields 'startTime' and 'endTime'"
+
+    ComponentSearchScope:
+      type: object
+      properties:
+        namespace:
+          type: string
+        projectUid:
+          type: string
+        componentUid:
+          type: string
+        environmentUid:
+          type: string
+      required: [namespace]
+
+    # Request schemas for metrics
+    MetricsQueryRequest:
+      type: object
+      properties:
+        metric:
+          type: string
+          description: The type of query to execute
+          enum:
+            - resource
+            - http
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        step:
+          type: string
+          description: The step of the query to determine the number of points to return. E.g. 1m, 5m, 15m, 30m, 1h
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+      required: [metric, startTime, endTime, searchScope]
+
+    # Response schemas for metrics
+    MetricsTimeSeriesItem:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the time series item
+          format: date-time
+        value:
+          type: number
+          format: double
+          description: The value of the time series item
+
+    ResourceMetricsTimeSeries:
+      type: object
+      properties:
+        cpuUsage:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        cpuRequests:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        cpuLimits:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        memoryUsage:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        memoryRequests:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        memoryLimits:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+
+    HttpMetricsTimeSeries:
+      type: object
+      properties:
+        requestCount:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        successfulRequestCount:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        unsuccessfulRequestCount:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        meanLatency:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        latencyP50:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        latencyP90:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        latencyP99:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+
+    MetricsQueryResponse:
+      oneOf:
+        - $ref: "#/components/schemas/ResourceMetricsTimeSeries"
+        - $ref: "#/components/schemas/HttpMetricsTimeSeries"
+
+    # Runtime topology schemas
+    RuntimeTopologyRequest:
+      type: object
+      description: |
+        Request body for POST /api/v1alpha1/metrics/runtime-topology.
+        searchScope must include namespace, projectUid, and environmentUid —
+        runtime topology is project- and environment-scoped. The optional
+        componentUid, if set, restricts results to edges that touch that
+        component.
+      properties:
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+        startTime:
+          type: string
+          description: The start time of the query window
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query window
+          format: date-time
+        includeGateways:
+          type: boolean
+          description: |
+            Whether to include gateway -> component edges. Defaults to true.
+          default: true
+        includeExternal:
+          type: boolean
+          description: |
+            Whether to include edges to/from components outside the requested
+            project. Defaults to true.
+          default: true
+      required: [searchScope, startTime, endTime]
+
+    RuntimeTopologyMetrics:
+      type: object
+      description: |
+        Aggregate HTTP metrics over the requested window. Latency values are
+        in seconds, matching /api/v1/metrics/query.
+      properties:
+        requestCount:
+          type: number
+          format: double
+        unsuccessfulRequestCount:
+          type: number
+          format: double
+        meanLatency:
+          type: number
+          format: double
+        latencyP50:
+          type: number
+          format: double
+        latencyP90:
+          type: number
+          format: double
+        latencyP99:
+          type: number
+          format: double
+
+    RuntimeTopologyNodeRef:
+      oneOf:
+        - $ref: "#/components/schemas/RuntimeTopologyNodeRefComponent"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeRefGateway"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeRefExternal"
+      discriminator:
+        propertyName: kind
+        mapping:
+          component: "#/components/schemas/RuntimeTopologyNodeRefComponent"
+          gateway: "#/components/schemas/RuntimeTopologyNodeRefGateway"
+          external: "#/components/schemas/RuntimeTopologyNodeRefExternal"
+
+    RuntimeTopologyNodeRefComponent:
+      type: object
+      description: |
+        Reference to a component node in the runtime topology.
+      properties:
+        kind:
+          type: string
+          enum: [component]
+        component:
+          type: string
+          description: The component name (from pod label).
+        componentUid:
+          type: string
+          description: The component UID (from pod label).
+        project:
+          type: string
+          description: The project name (from pod label).
+        projectUid:
+          type: string
+          description: The project UID.
+        namespace:
+          type: string
+          description: The namespace name (from pod label).
+      required: [kind, component, componentUid]
+
+    RuntimeTopologyNodeRefGateway:
+      type: object
+      description: |
+        Reference to a gateway node in the runtime topology.
+      properties:
+        kind:
+          type: string
+          enum: [gateway]
+        gatewayName:
+          type: string
+          description: Gateway name (e.g., internet, intranet)
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+      required: [kind, gatewayName]
+
+    RuntimeTopologyNodeRefExternal:
+      type: object
+      description: |
+        Reference to an external node in the runtime topology.
+      properties:
+        kind:
+          type: string
+          enum: [external]
+        externalHost:
+          type: string
+        component:
+          type: string
+        componentUid:
+          type: string
+          format: uuid
+        projectUid:
+          type: string
+          format: uuid
+          description: Included when the source is in a different project
+        namespace:
+          type: string
+      required: [kind]
+
+    RuntimeTopologyNode:
+      oneOf:
+        - $ref: "#/components/schemas/RuntimeTopologyNodeComponent"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeGateway"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeExternal"
+      discriminator:
+        propertyName: kind
+        mapping:
+          component: "#/components/schemas/RuntimeTopologyNodeComponent"
+          gateway: "#/components/schemas/RuntimeTopologyNodeGateway"
+          external: "#/components/schemas/RuntimeTopologyNodeExternal"
+
+    RuntimeTopologyNodeComponent:
+      type: object
+      description: |
+        A component node observed in the runtime topology with its aggregated metrics.
+      properties:
+        kind:
+          type: string
+          enum: [component]
+        component:
+          type: string
+          description: The component name (from pod label).
+        componentUid:
+          type: string
+          description: The component UID (from pod label).
+          format: uuid
+        project:
+          type: string
+          description: The project name (from pod label).
+        projectUid:
+          type: string
+          description: The project UID.
+          format: uuid
+        namespace:
+          type: string
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [kind, component, componentUid]
+
+    RuntimeTopologyNodeGateway:
+      type: object
+      description: |
+        A gateway node observed in the runtime topology with its aggregated metrics.
+      properties:
+        kind:
+          type: string
+          enum: [gateway]
+        gatewayName:
+          type: string
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [kind, gatewayName]
+
+    RuntimeTopologyNodeExternal:
+      type: object
+      description: |
+        An external node observed in the runtime topology with its aggregated metrics.
+      properties:
+        kind:
+          type: string
+          enum: [external]
+        externalHost:
+          type: string
+        component:
+          type: string
+        componentUid:
+          type: string
+          format: uuid
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [kind]
+
+    RuntimeTopologyEdge:
+      type: object
+      description: An observed traffic flow from a source node to a target node.
+      properties:
+        id:
+          type: string
+          description: |
+            Stable identifier for the edge. Convention:
+              - component->component: `${srcComponentUid}->${dstComponentUid}`
+              - gateway->component:   `gateway:${gatewayName}->${dstComponentUid}`
+              - component->external:  `${srcComponentUid}->external:${externalHost}`
+        source:
+          $ref: "#/components/schemas/RuntimeTopologyNodeRef"
+        target:
+          $ref: "#/components/schemas/RuntimeTopologyNodeRef"
+        protocol:
+          type: string
+          enum: [http]
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [id, source, target, protocol]
+
+    RuntimeTopologySummary:
+      type: object
+      description: Metadata describing the query window.
+      properties:
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        generatedAt:
+          type: string
+          format: date-time
+      required: [startTime, endTime, generatedAt]
+
+    RuntimeTopologyResponse:
+      type: object
+      description: |
+        Runtime topology response. Nodes and edges only include entities for
+        which traffic was observed in the window — static topology comes from
+        a separate source.
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/RuntimeTopologyNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/RuntimeTopologyEdge"
+        summary:
+          $ref: "#/components/schemas/RuntimeTopologySummary"
+      required: [summary]
+
+    # Request schemas for alert rules
+    AlertRuleRequest:
+      type: object
+      required: [metadata, source, condition]
+      properties:
+        metadata:
+          type: object
+          required: [name, namespace, projectUid, environmentUid, componentUid]
+          properties:
+            name:
+              type: string
+              description: The name of the alert rule
+            namespace:
+              type: string
+              description: The namespace of the alert rule CR
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID to query
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID to query
+              format: uuid
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID to query
+              format: uuid
+        source:
+          type: object
+          required: [metric]
+          properties:
+            metric:
+              type: string
+              description: The metric to query for metric based alerts
+              enum:
+                - cpu_usage
+                - memory_usage
+                - budget
+        condition:
+          type: object
+          required: [enabled, window, interval, operator, threshold]
+          properties:
+            enabled:
+              type: boolean
+              description: Whether the alert rule is enabled
+            window:
+              type: string
+              description: The window of time to query for the alert rule
+            interval:
+              type: string
+              description: The interval of time to query for the alert rule
+            operator:
+              type: string
+              description: The operator to use for the alert rule
+              enum:
+                - gt
+                - gte
+                - lt
+                - lte
+                - eq
+                - neq
+            threshold:
+              type: number
+              description: The threshold value to use for the alert rule
+
+    # Response schemas for alert rules
+    AlertRuleResponse:
+      type: object
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the alert rule
+            namespace:
+              type: string
+              description: The namespace of the alert rule CR
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID to query
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID to query
+              format: uuid
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID to query
+              format: uuid
+        source:
+          type: object
+          properties:
+            metric:
+              type: string
+              description: The metric to query for metric based alerts
+              enum:
+                - cpu_usage
+                - memory_usage
+                - budget
+        condition:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              description: Whether the alert rule is enabled
+            window:
+              type: string
+              description: The window of time to query for the alert rule
+            interval:
+              type: string
+              description: The interval of time to query for the alert rule
+            operator:
+              type: string
+              description: The operator to use for the alert rule
+              enum:
+                - gt
+                - gte
+                - lt
+                - lte
+                - eq
+                - neq
+            threshold:
+              type: number
+              description: The threshold value to use for the alert rule
+
+    AlertingRuleSyncResponse:
+      type: object
+      properties:
+        action:
+          type: string
+          description: The action taken on the alert rule
+          enum:
+            - created
+            - updated
+            - unchanged
+            - deleted
+        lastSyncedAt:
+          type: string
+          description: The timestamp of the last sync
+        status:
+          type: string
+          description: The status of the alert rule
+          enum:
+            - synced
+            - failed
+        ruleLogicalId:
+          type: string
+          description: The logical ID (name) of the alert rule
+        ruleBackendId:
+          type: string
+          description: The backend ID (UID from observability backend) of the alert rule
+
+    # Response schema for alert webhook
+    AlertWebhookResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message of the alert webhook
+        status:
+          type: string
+          description: The status of the alert webhook
+          enum:
+            - success
+            - error

--- a/openapi/observability-tracing-adapter-api.yaml
+++ b/openapi/observability-tracing-adapter-api.yaml
@@ -220,7 +220,7 @@ components:
         errorCode:
           type: string
           description: The error code from observer service
-          example: OBS-L-22
+          example: OBS-T-22
         detail:
           type: string
           description: The error message
@@ -346,7 +346,7 @@ components:
                 description: The name of the span
               spanKind:
                 type: string
-                description: The name of the span
+                description: The kind of the span
               startTime:
                 type: string
                 description: The start time of the span
@@ -368,11 +368,18 @@ components:
                 description: The execution status of the span. One of "ok", "error", or "unset".
               attributes:
                 type: object
-                description: The span attributes
+                description: >-
+                  The span attributes as a key/value map. The list endpoint
+                  returns attributes in this compact map form; the span-details
+                  endpoint (GET /traces/{traceId}/spans/{spanId}) returns the
+                  same data as an array of {key, value} objects.
                 additionalProperties: true
               resourceAttributes:
                 type: object
-                description: The resource attributes
+                description: >-
+                  The resource attributes as a key/value map. As with
+                  `attributes`, the span-details endpoint returns these as an
+                  array of {key, value} objects.
                 additionalProperties: true
         total:
           type: integer
@@ -415,6 +422,11 @@ components:
           description: The execution status of the span. One of "ok", "error", or "unset".
         attributes:
           type: array
+          description: >-
+            The span attributes as an array of {key, value} objects. The
+            span-details endpoint returns attributes in this expanded form; the
+            spans-list endpoint (POST /traces/{traceId}/spans/query) returns the
+            same data as a key/value map.
           items:
             type: object
             description: The attributes of the span
@@ -427,6 +439,10 @@ components:
                 description: The value of the attribute
         resourceAttributes:
           type: array
+          description: >-
+            The resource attributes as an array of {key, value} objects. As with
+            `attributes`, the spans-list endpoint returns these as a key/value
+            map.
           items:
             type: object
             description: The attributes of the span related to the resource

--- a/openapi/observability-tracing-adapter-api.yaml
+++ b/openapi/observability-tracing-adapter-api.yaml
@@ -1,0 +1,439 @@
+openapi: 3.0.3
+info:
+  title: OpenChoreo Observability Tracing Adapter API
+  description: |
+    This API specification defines the contract that a tracing adapter must implement
+    to integrate with the OpenChoreo Observer.
+  version: 1.0.0
+  contact:
+    name: OpenChoreo Team
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+
+tags:
+  - name: Traces
+    description: Trace retrieval endpoints
+  - name: Health
+    description: Health check endpoints
+
+
+paths:
+  /healthz:
+    get:
+      tags:
+        - Health
+      summary: Health check
+      description: Check the health status of the tracing adapter service
+      operationId: health
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+        "503":
+          description: Service is unhealthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: unhealthy
+                  error:
+                    type: string
+                    example: "tracing backend: connection failed"
+
+
+  /api/v1alpha1/traces/query:
+    post:
+      tags:
+        - Traces
+      summary: Query traces
+      description: Query traces from the observer service
+      operationId: queryTraces
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TracesQueryRequest"
+      responses:
+        "200":
+          description: Traces queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TracesListResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+
+  /api/v1alpha1/traces/{traceId}/spans/query:
+    post:
+      tags:
+        - Traces
+      summary: Query spans for a trace
+      description: Query spans for a trace from the observer service
+      operationId: querySpansForTrace
+      parameters:
+        - name: traceId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TracesQueryRequest"
+      responses:
+        "200":
+          description: Spans queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceSpansListResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+
+  /api/v1alpha1/traces/{traceId}/spans/{spanId}:
+    get:
+      tags:
+        - Traces
+      summary: Get details of a span for a trace
+      description: Get details of a span for a trace
+      operationId: getSpanDetailsForTrace
+      parameters:
+        - name: traceId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: spanId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Span details queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceSpanDetailsResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+
+components:
+
+
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The error message
+          enum:
+            - badRequest
+            - unauthorized
+            - forbidden
+            - internalServerError
+        errorCode:
+          type: string
+          description: The error code from observer service
+          example: OBS-L-22
+        detail:
+          type: string
+          description: The error message
+          example: "Missing required fields 'startTime' and 'endTime'"
+
+
+    ComponentSearchScope:
+      type: object
+      properties:
+        namespace:
+          type: string
+        project:
+          type: string
+        component:
+          type: string
+        environment:
+          type: string
+      required: [namespace]
+
+
+    TracesQueryRequest:
+      type: object
+      properties:
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        limit:
+          type: integer
+          default: 100
+          minimum: 1
+          maximum: 1000
+          description: The maximum number of items to return
+        sortOrder:
+          type: string
+          description: The sort order of the query
+          enum:
+            - asc
+            - desc
+          default: desc
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+        includeAttributes:
+          type: boolean
+          description: Whether to include span attributes in the response. Defaults to false.
+          default: false
+      required: [startTime, endTime, searchScope]
+
+
+    TracesQueryResponse:
+      type: object
+      oneOf:
+        - $ref: "#/components/schemas/TracesListResponse"
+        - $ref: "#/components/schemas/TraceSpansListResponse"
+        - $ref: "#/components/schemas/TraceSpanDetailsResponse"
+
+
+    TracesListResponse:
+      type: object
+      properties:
+        traces:
+          type: array
+          description: The list of traces
+          items:
+            type: object
+            properties:
+              traceId:
+                type: string
+                description: The trace ID
+              traceName:
+                type: string
+                description: The name of the trace
+              spanCount:
+                type: integer
+                description: The number of spans in the trace
+              rootSpanId:
+                type: string
+              rootSpanName:
+                type: string
+              rootSpanKind:
+                type: string
+              startTime:
+                type: string
+                description: The start time of the trace
+                format: date-time
+              endTime:
+                type: string
+                description: The end time of the trace
+                format: date-time
+              durationNs:
+                type: integer
+                format: int64
+                description: The duration of the trace in nanoseconds
+              hasErrors:
+                type: boolean
+                description: Whether any span in the trace has an error status.
+        total:
+          type: integer
+          description: The total number of matching traces, capped at 1000
+        tookMs:
+          type: integer
+          description: The time taken to query the traces in milliseconds
+
+
+    TraceSpansListResponse:
+      type: object
+      properties:
+        spans:
+          type: array
+          description: The list of spans
+          items:
+            type: object
+            properties:
+              spanId:
+                type: string
+                description: The span ID
+              spanName:
+                type: string
+                description: The name of the span
+              spanKind:
+                type: string
+                description: The name of the span
+              startTime:
+                type: string
+                description: The start time of the span
+                format: date-time
+              endTime:
+                type: string
+                description: The end time of the span
+                format: date-time
+              durationNs:
+                type: integer
+                format: int64
+                description: The duration of the span in nanoseconds
+              parentSpanId:
+                type: string
+                description: The parent span ID
+              status:
+                type: string
+                enum: [ok, error, unset]
+                description: The execution status of the span. One of "ok", "error", or "unset".
+              attributes:
+                type: object
+                description: The span attributes
+                additionalProperties: true
+              resourceAttributes:
+                type: object
+                description: The resource attributes
+                additionalProperties: true
+        total:
+          type: integer
+          description: The total number of matching spans, capped at 1000
+        tookMs:
+          type: integer
+          description: The time taken to query the spans in milliseconds
+
+
+    TraceSpanDetailsResponse:
+      type: object
+      properties:
+        spanId:
+          type: string
+          description: The span ID
+        spanName:
+          type: string
+          description: The name of the span
+        spanKind:
+          type: string
+          description: The kind of the span
+        startTime:
+          type: string
+          description: The start time of the span
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the span
+          format: date-time
+        durationNs:
+          type: integer
+          format: int64
+          description: The duration of the span in nanoseconds
+        parentSpanId:
+          type: string
+          description: The parent span ID
+        status:
+          type: string
+          enum: [ok, error, unset]
+          description: The execution status of the span. One of "ok", "error", or "unset".
+        attributes:
+          type: array
+          items:
+            type: object
+            description: The attributes of the span
+            properties:
+              key:
+                type: string
+                description: The key of the attribute
+              value:
+                type: string
+                description: The value of the attribute
+        resourceAttributes:
+          type: array
+          items:
+            type: object
+            description: The attributes of the span related to the resource
+            properties:
+              key:
+                type: string
+                description: The key of the attribute
+              value:
+                type: string
+                description: The value of the attribute


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Bring the logs, metrics, and tracing adapter OpenAPI specs into the repo under openapi/ so they are version-controlled here as the source of truth. Point the logs-adapter oapi-codegen step at the local spec file instead of fetching it over the network from openchoreo.dev. Metrics and tracing specs are vendored for reference; their hand-written clients are unchanged.


## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3842

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
TODO:
- make metrics and tracing services to generate clients from the adapter openapi spec.
- backport the same change to versioned branches (1.2-m1, 1.1, 1.0)
- remove adapter openapi specs from docs repo and fix the swagger UIs in docs repo to point to versioned adapter api specs.

