### PR TITLE
fix(helm): move observability-plane localhost defaults to k3d overlays

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-observability-plane/templates/NOTES.txt
@@ -1,0 +1,21 @@
+{{- include "openchoreo-observability-plane.validateHostnames" . -}}
+OpenChoreo Observability Plane installed.
+
+Cross-cluster URLs default to placeholder ".invalid" domains and must be set per
+deployment (the observability plane typically runs on a separate cluster from the
+control plane):
+
+  - observer.controlPlaneApiUrl
+  - observer.extraEnvs (OBSERVER_BASE_URL)
+{{- if .Values.rca.enabled }}
+  - rca.openchoreoApiUrl
+{{- end }}
+{{- if .Values.finOpsAgent.enabled }}
+  - finOpsAgent.openchoreoApiUrl
+{{- end }}
+
+Browser-facing CORS origins default to [] (CORS disabled); set
+observer.cors.allowedOrigins (and rca/finOpsAgent equivalents) for browser clients.
+
+For local k3d, the single-cluster and multi-cluster overlays under install/k3d
+supply working values.

--- a/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
@@ -139,3 +139,32 @@ Cluster Agent service account name
 {{- default "default" .Values.clusterAgent.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate that placeholder .invalid hostnames have been replaced with real domains.
+The chart ships .invalid defaults for cross-cluster URLs (the observability plane
+typically runs on a separate cluster from the control plane), so they must be set
+explicitly per deployment. k3d overlays supply real values.
+*/}}
+{{- define "openchoreo-observability-plane.validateHostnames" -}}
+{{- $errors := list -}}
+{{- if contains ".invalid" .Values.observer.controlPlaneApiUrl -}}
+  {{- $errors = append $errors "observer.controlPlaneApiUrl contains placeholder domain (.invalid)" -}}
+{{- end -}}
+{{- if contains ".invalid" (toYaml .Values.observer.extraEnvs) -}}
+  {{- $errors = append $errors "observer.extraEnvs contains placeholder domain (.invalid) (e.g. OBSERVER_BASE_URL)" -}}
+{{- end -}}
+{{- if .Values.rca.enabled -}}
+  {{- if contains ".invalid" .Values.rca.openchoreoApiUrl -}}
+    {{- $errors = append $errors "rca.openchoreoApiUrl contains placeholder domain (.invalid)" -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.finOpsAgent.enabled -}}
+  {{- if contains ".invalid" .Values.finOpsAgent.openchoreoApiUrl -}}
+    {{- $errors = append $errors "finOpsAgent.openchoreoApiUrl contains placeholder domain (.invalid)" -}}
+  {{- end -}}
+{{- end -}}
+{{- if gt (len $errors) 0 -}}
+  {{- fail (printf "Placeholder domains found. Set real URLs for:\n  - %s" (join "\n  - " $errors)) -}}
+{{- end -}}
+{{- end -}}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -996,7 +996,7 @@
           "type": "string"
         },
         "openchoreoApiUrl": {
-          "default": "http://api.openchoreo.localhost:8080",
+          "default": "http://api.openchoreo.invalid:8080",
           "description": "OpenChoreo API URL for authorization service",
           "title": "openchoreoApiUrl",
           "type": "string"
@@ -1308,7 +1308,7 @@
           "type": "boolean"
         },
         "controlPlaneApiUrl": {
-          "default": "http://api.openchoreo.localhost:8080",
+          "default": "http://api.openchoreo.invalid:8080",
           "description": "Control plane API base URL used by observer",
           "title": "controlPlaneApiUrl",
           "type": "string"
@@ -1814,7 +1814,7 @@
           "type": "string"
         },
         "openchoreoApiUrl": {
-          "default": "http://api.openchoreo.localhost:8080",
+          "default": "http://api.openchoreo.invalid:8080",
           "description": "OpenChoreo API base URL used by rca-agent",
           "title": "openchoreoApiUrl",
           "type": "string"

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -374,9 +374,9 @@ observer:
   # @schema
   # type: string
   # description: Control plane API base URL used by observer
-  # default: "http://api.openchoreo.localhost:8080"
+  # default: "http://api.openchoreo.invalid:8080"
   # @schema
-  controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
+  controlPlaneApiUrl: "http://api.openchoreo.invalid:8080"
 
   # @schema
   # type: boolean
@@ -535,8 +535,7 @@ observer:
     # items:
     #   type: string
     # @schema
-    allowedOrigins:
-    - "http://openchoreo.localhost:8080"
+    allowedOrigins: []
 
   # @schema
   # type: array
@@ -553,7 +552,7 @@ observer:
   # @schema
   extraEnvs:
   - name: OBSERVER_BASE_URL
-    value: "http://observer.openchoreo.localhost:11080"
+    value: "http://observer.openchoreo.invalid:11080"
   - name: AUTHZ_TIMEOUT
     value: "30s"
 
@@ -1315,8 +1314,7 @@ rca:
     # items:
     #   type: string
     # @schema
-    allowedOrigins:
-    - "http://openchoreo.localhost:8080"
+    allowedOrigins: []
 
   # @schema
   # type: object
@@ -1412,9 +1410,9 @@ rca:
   # @schema
   # type: string
   # description: OpenChoreo API base URL used by rca-agent
-  # default: "http://api.openchoreo.localhost:8080"
+  # default: "http://api.openchoreo.invalid:8080"
   # @schema
-  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
+  openchoreoApiUrl: "http://api.openchoreo.invalid:8080"
 
   # @schema
   # type: string
@@ -1556,8 +1554,7 @@ finOpsAgent:
     # items:
     #   type: string
     # @schema
-    allowedOrigins:
-    - "http://openchoreo.localhost:8080"
+    allowedOrigins: []
 
   # @schema
   # type: object
@@ -1729,9 +1726,9 @@ finOpsAgent:
   # @schema
   # type: string
   # description: OpenChoreo API URL for authorization service
-  # default: "http://api.openchoreo.localhost:8080"
+  # default: "http://api.openchoreo.invalid:8080"
   # @schema
-  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
+  openchoreoApiUrl: "http://api.openchoreo.invalid:8080"
 
   # @schema
   # type: object

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -2,6 +2,10 @@
 
 observer:
   secretName: observer-secret
+  controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
+  cors:
+    allowedOrigins:
+    - "http://openchoreo.localhost:8080"
   extraEnvs:
   - name: OBSERVER_BASE_URL
     value: "http://observer.openchoreo.localhost:11080"
@@ -39,6 +43,10 @@ tls:
     - "*.observability.openchoreo.localhost"
 
 rca:
+  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
+  cors:
+    allowedOrigins:
+    - "http://openchoreo.localhost:8080"
   http:
     hostnames:
     - host.k3d.internal

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -1,6 +1,10 @@
 # Helm values for OpenChoreo Observability Plane in k3d single-cluster setup
 
 finOpsAgent:
+  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
+  cors:
+    allowedOrigins:
+    - "http://openchoreo.localhost:8080"
   http:
     hostnames:
     - finops-agent.openchoreo.localhost
@@ -8,6 +12,15 @@ finOpsAgent:
 # Observer API - REST API for querying logs and metrics
 observer:
   secretName: observer-secret
+  controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
+  cors:
+    allowedOrigins:
+    - "http://openchoreo.localhost:8080"
+  extraEnvs:
+  - name: OBSERVER_BASE_URL
+    value: "http://observer.openchoreo.localhost:11080"
+  - name: AUTHZ_TIMEOUT
+    value: "30s"
   http:
     hostnames:
     - observer.openchoreo.localhost
@@ -19,6 +32,10 @@ security:
     authServerBaseUrl: "http://thunder.openchoreo.localhost:8080"
 
 rca:
+  openchoreoApiUrl: "http://api.openchoreo.localhost:8080"
+  cors:
+    allowedOrigins:
+    - "http://openchoreo.localhost:8080"
   http:
     hostnames:
     - rca-agent.openchoreo.localhost


### PR DESCRIPTION
## Purpose
Resolves #3832. The `openchoreo-observability-plane` chart shipped `*.localhost` defaults (observer/rca/finOpsAgent control-plane API URLs, CORS origins, `OBSERVER_BASE_URL`) that only resolve on k3d, with the coupling split half in the chart and half in the overlays.

## Approach
- Default the cross-cluster API URLs and `OBSERVER_BASE_URL` to `.invalid` placeholders, guarded by a `validateHostnames` helper (invoked from `NOTES.txt`) that fails the install if they aren't overridden. Mirrors the control-plane chart.
- Default CORS `allowedOrigins` to `[]`.
- Move the real `*.localhost` values into the single- and multi-cluster k3d overlays.

Observer URLs are validated unconditionally (it always deploys); rca/finOpsAgent only when enabled.