### PR TITLE
fix: handle observer public URL via dedicated publicUrl config

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -246,7 +246,7 @@ func main() {
 	routes.HandleFunc("GET /health", newAPIHandler.Health)
 
 	// OAuth Protected Resource Metadata endpoint
-	routes.HandleFunc("GET /.well-known/oauth-protected-resource", oauthProtectedResourceMetadata(logger))
+	routes.HandleFunc("GET /.well-known/oauth-protected-resource", oauthProtectedResourceMetadata(cfg, logger))
 
 	// ===== Protected API Routes (JWT Authentication Required) =====
 
@@ -286,7 +286,7 @@ func main() {
 	newMCPServer := observermcp.NewHTTPServer(newMCPHandler)
 
 	// MCP endpoint with chained middleware (logger -> recovery -> auth401 -> jwt -> handler)
-	mcpMiddleware := initMCPMiddleware(logger)
+	mcpMiddleware := initMCPMiddleware(cfg, logger)
 	mcpRoutes := routes.Group(mcpMiddleware, jwtAuth)
 	mcpRoutes.Handle("/mcp", newMCPServer)
 
@@ -470,13 +470,12 @@ func initJWTMiddleware(cfg *config.Config, logger *slog.Logger) func(http.Handle
 }
 
 // initMCPMiddleware initializes the MCP middleware that adds WWW-Authenticate header to 401 responses
-func initMCPMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
-	// Get observer base URL from environment variables
-	observerBaseURL := os.Getenv("OBSERVER_BASE_URL")
+func initMCPMiddleware(cfg *config.Config, logger *slog.Logger) func(http.Handler) http.Handler {
+	observerBaseURL := cfg.Server.PublicURL
 	if observerBaseURL == "" {
 		// Default to localhost for development
 		observerBaseURL = "http://localhost:9097"
-		logger.Warn("OBSERVER_BASE_URL not set, using default", "url", observerBaseURL)
+		logger.Warn("server.public_url (OBSERVER_BASE_URL) not set, using default", "url", observerBaseURL)
 	}
 	resourceMetadataURL := observerBaseURL + "/.well-known/oauth-protected-resource"
 
@@ -485,13 +484,12 @@ func initMCPMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 
 // oauthProtectedResourceMetadata returns a handler for OAuth 2.0 protected resource metadata
 // as defined in RFC 9728 and related OAuth standards
-func oauthProtectedResourceMetadata(logger *slog.Logger) http.HandlerFunc {
-	// Get configuration from environment variables
-	observerBaseURL := os.Getenv("OBSERVER_BASE_URL")
+func oauthProtectedResourceMetadata(cfg *config.Config, logger *slog.Logger) http.HandlerFunc {
+	observerBaseURL := cfg.Server.PublicURL
 	if observerBaseURL == "" {
 		// Default to localhost for development
 		observerBaseURL = "http://localhost:9097"
-		logger.Warn("OBSERVER_BASE_URL not set, using default", "url", observerBaseURL)
+		logger.Warn("server.public_url (OBSERVER_BASE_URL) not set, using default", "url", observerBaseURL)
 	}
 
 	authServerBaseURL := os.Getenv(apiconfig.EnvAuthServerBaseURL)

--- a/install/helm/openchoreo-observability-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-observability-plane/templates/NOTES.txt
@@ -6,7 +6,6 @@ deployment (the observability plane typically runs on a separate cluster from th
 control plane):
 
   - observer.controlPlaneApiUrl
-  - observer.extraEnvs (OBSERVER_BASE_URL)
 {{- if .Values.rca.enabled }}
   - rca.openchoreoApiUrl
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
@@ -151,9 +151,6 @@ explicitly per deployment. k3d overlays supply real values.
 {{- if contains ".invalid" .Values.observer.controlPlaneApiUrl -}}
   {{- $errors = append $errors "observer.controlPlaneApiUrl contains placeholder domain (.invalid)" -}}
 {{- end -}}
-{{- if contains ".invalid" (toYaml .Values.observer.extraEnvs) -}}
-  {{- $errors = append $errors "observer.extraEnvs contains placeholder domain (.invalid) (e.g. OBSERVER_BASE_URL)" -}}
-{{- end -}}
 {{- if .Values.rca.enabled -}}
   {{- if contains ".invalid" .Values.rca.openchoreoApiUrl -}}
     {{- $errors = append $errors "rca.openchoreoApiUrl contains placeholder domain (.invalid)" -}}

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-config.yaml
@@ -25,6 +25,7 @@ data:
   ALERT_STORE_BACKEND: {{ .Values.observer.alertStoreBackend | default "sqlite" | quote }}
   ALERT_SUPPRESSION_WINDOW: {{ .Values.observer.alertSuppressionWindow | quote }}
   OBSERVER_AUTH_CONFIG_PATH: /etc/openchoreo/auth-config.yaml
+  OBSERVER_BASE_URL: {{ .Values.observer.publicUrl | quote }}
   AUTHZ_SERVICE_URL: {{ .Values.observer.controlPlaneApiUrl | quote }}
   AUTHZ_TLS_INSECURE_SKIP_VERIFY: {{ .Values.observer.authzTlsInsecureSkipVerify | default false | quote }}
   UID_RESOLVER_OPENCHOREO_API_URL: {{ .Values.observer.controlPlaneApiUrl | quote }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1466,6 +1466,12 @@
           "title": "oauthScope",
           "type": "string"
         },
+        "publicUrl": {
+          "default": "",
+          "description": "Observer's own external URL (sets OBSERVER_BASE_URL). Empty falls back to a localhost default.",
+          "title": "publicUrl",
+          "type": "string"
+        },
         "replicas": {
           "default": 1,
           "description": "Number of Observer pod replicas",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -379,6 +379,13 @@ observer:
   controlPlaneApiUrl: "http://api.openchoreo.invalid:8080"
 
   # @schema
+  # type: string
+  # description: Observer's own external URL (sets OBSERVER_BASE_URL). Empty falls back to a localhost default.
+  # default: ""
+  # @schema
+  publicUrl: ""
+
+  # @schema
   # type: boolean
   # description: Skip TLS certificate verification when calling the control plane authz service (use for self-signed certs)
   # default: false
@@ -551,8 +558,6 @@ observer:
   #       description: Environment variable value
   # @schema
   extraEnvs:
-  - name: OBSERVER_BASE_URL
-    value: "http://observer.openchoreo.invalid:11080"
   - name: AUTHZ_TIMEOUT
     value: "30s"
 

--- a/install/k3d/multi-cluster/values-op.yaml
+++ b/install/k3d/multi-cluster/values-op.yaml
@@ -3,14 +3,10 @@
 observer:
   secretName: observer-secret
   controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
+  publicUrl: "http://observer.openchoreo.localhost:11080"
   cors:
     allowedOrigins:
     - "http://openchoreo.localhost:8080"
-  extraEnvs:
-  - name: OBSERVER_BASE_URL
-    value: "http://observer.openchoreo.localhost:11080"
-  - name: AUTHZ_TIMEOUT
-    value: "30s"
   http:
     hostnames:
     - host.k3d.internal

--- a/install/k3d/single-cluster/values-op.yaml
+++ b/install/k3d/single-cluster/values-op.yaml
@@ -13,14 +13,10 @@ finOpsAgent:
 observer:
   secretName: observer-secret
   controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
+  publicUrl: "http://observer.openchoreo.localhost:11080"
   cors:
     allowedOrigins:
     - "http://openchoreo.localhost:8080"
-  extraEnvs:
-  - name: OBSERVER_BASE_URL
-    value: "http://observer.openchoreo.localhost:11080"
-  - name: AUTHZ_TIMEOUT
-    value: "30s"
   http:
     hostnames:
     - observer.openchoreo.localhost

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -7,13 +7,12 @@ global:
 # OpenChoreo Observer Service Configuration
 observer:
   secretName: observer-secret
+  controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
+  publicUrl: "http://observer.openchoreo.localhost:11080"
   http:
     hostnames:
     - host.k3d.internal
     - observer.openchoreo.localhost
-  extraEnvs:
-    - name: OBSERVER_BASE_URL
-      value: "http://observer.openchoreo.localhost:11080"
   resources:
     limits:
       cpu: 50m

--- a/internal/observer/config/config.go
+++ b/internal/observer/config/config.go
@@ -52,6 +52,7 @@ type ServerConfig struct {
 	ReadTimeout     time.Duration `koanf:"read.timeout"`
 	WriteTimeout    time.Duration `koanf:"write.timeout"`
 	ShutdownTimeout time.Duration `koanf:"shutdown.timeout"`
+	PublicURL       string        `koanf:"public_url"`
 }
 
 // CORSConfig holds CORS configuration
@@ -169,6 +170,7 @@ func Load() (*Config, error) {
 		"SERVER_READ_TIMEOUT":                   "server.read.timeout",
 		"SERVER_WRITE_TIMEOUT":                  "server.write.timeout",
 		"SERVER_SHUTDOWN_TIMEOUT":               "server.shutdown.timeout",
+		"OBSERVER_BASE_URL":                     "server.public_url",
 		"AUTH_JWT_SECRET":                       "auth.jwt.secret",
 		"AUTH_ENABLE_AUTH":                      "auth.enable.auth",
 		"AUTH_REQUIRED_ROLE":                    "auth.required.role",
@@ -289,6 +291,7 @@ func getDefaults() map[string]interface{} {
 			"read.timeout":     "30s",
 			"write.timeout":    "30s",
 			"shutdown.timeout": "10s",
+			"public_url":       "",
 		},
 		"auth": map[string]interface{}{
 			"enable.auth":   false,


### PR DESCRIPTION
## Purpose
Follow-up to #3845 (#3832). The `validateHostnames` guard added there also failed on `OBSERVER_BASE_URL` — but that's the observer's *own* external URL, advertised in OAuth 2.0 protected-resource metadata for its MCP server. It isn't known until the observability gateway has an address (after first install), so it can't be supplied upfront, and the guard blocked the documented bootstrap.

## Approach
- Observer reads it via koanf (`server.public_url`) instead of `os.Getenv`; empty falls back to the localhost default.
- Add a dedicated `observer.publicUrl` Helm value (mapped to `OBSERVER_BASE_URL` through the configmap) instead of burying it in `extraEnvs` — mirrors how the control-plane API handles `publicUrl`.
- Drop it from `validateHostnames`; `controlPlaneApiUrl` (known before install) stays guarded.
- k3d overlays set `observer.publicUrl` directly.