### PR TITLE
test(helm): render charts against bundled install values in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Run linter
         run: make lint
 
+  helm-render-test:
+    name: Helm Render Test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Render charts against bundled install values
+        run: make helm-render-test
+
   gen-check:
     name: Code Generation
     runs-on: ubuntu-24.04
@@ -135,7 +145,7 @@ jobs:
   publish:
     name: ${{ github.event_name == 'push' && 'Publish' || 'Verify Packaging' }}
     runs-on: ubuntu-24.04
-    needs: [ lint, gen-check, test, build ]
+    needs: [ lint, helm-render-test, gen-check, test, build ]
     permissions:
       packages: write
     steps:

--- a/hack/test-helm-render.sh
+++ b/hack/test-helm-render.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Render each plane chart against the bundled install value files (k3d + quick-start).
+
+set -euo pipefail
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm is required but not found on PATH" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CHARTS_DIR="install/helm"
+
+chart_for_suffix() {
+  case "$1" in
+    cp) echo "openchoreo-control-plane" ;;
+    dp) echo "openchoreo-data-plane" ;;
+    op) echo "openchoreo-observability-plane" ;;
+    wp) echo "openchoreo-workflow-plane" ;;
+    *)  echo "" ;;
+  esac
+}
+
+VALUE_DIRS=(
+  "install/k3d/single-cluster"
+  "install/k3d/multi-cluster"
+  "install/quick-start"
+)
+
+# Register dependency repos, then vendor dependencies for charts that have them.
+repo_idx=0
+for chart in "$CHARTS_DIR"/*/; do
+  grep -qs '^dependencies:' "${chart}Chart.yaml" || continue
+  while read -r repo_url; do
+    helm repo add "render-test-$repo_idx" "$repo_url" >/dev/null 2>&1 || true
+    repo_idx=$((repo_idx + 1))
+  done < <(grep -E '^[[:space:]]*repository:[[:space:]]*"?https?://' "${chart}Chart.yaml" \
+    | sed -E 's/.*repository:[[:space:]]*"?([^"[:space:]]+).*/\1/')
+  helm dependency build "$chart" >/dev/null
+done
+
+failures=0
+checked=0
+for dir in "${VALUE_DIRS[@]}"; do
+  for values in "$dir"/values-*.yaml "$dir"/.values-*.yaml; do
+    [ -f "$values" ] || continue
+    suffix="$(basename "$values" .yaml)"
+    suffix="${suffix##*-}"
+    chart_name="$(chart_for_suffix "$suffix")"
+    [ -n "$chart_name" ] || continue
+
+    checked=$((checked + 1))
+    if output="$(helm template render-test "$CHARTS_DIR/$chart_name" -f "$values" 2>&1)"; then
+      echo "PASS  $values -> $chart_name"
+    else
+      echo "FAIL  $values -> $chart_name"
+      echo "$output" | sed 's/^/      /'
+      failures=$((failures + 1))
+    fi
+  done
+done
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "$failures of $checked render(s) failed."
+  exit 1
+fi
+echo "All $checked render(s) passed."

--- a/install/quick-start/.values-op.yaml
+++ b/install/quick-start/.values-op.yaml
@@ -7,6 +7,7 @@ global:
 # OpenChoreo Observer Service Configuration
 observer:
   secretName: observer-secret
+  controlPlaneApiUrl: "http://api.openchoreo.localhost:8080"
   http:
     hostnames:
     - host.k3d.internal

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -98,3 +98,7 @@ helm-push.%: helm-package.% ## Push helm chart for the specified chart name.
 
 .PHONY: helm-push
 helm-push: $(addprefix helm-push., $(HELM_CHART_NAMES)) ## Push all helm charts.
+
+.PHONY: helm-render-test
+helm-render-test: ## Render each plane chart from local source against every bundled install value file.
+	$(PROJECT_DIR)/hack/test-helm-render.sh


### PR DESCRIPTION
## Purpose
Resolves #3852. Chart PRs aren't validated against the value files we install them with. The quick-start smoke test runs a PR's values against the published charts, so a template or guard change is only exercised after it merges and republishes. That let install-time breakage onto main: #3845 added a hostname guard and updated the k3d overlays but missed the quick-start `.values-op.yaml`, so rendering that chart with its own values now fails.

## Approach
- Add `install/helm/test-render.sh` (and a `make helm-render-test` target wired into build-and-test) that renders every plane chart from local source against each bundled value file: k3d single/multi-cluster overlays and quick-start. No cluster or published charts involved, so chart and value changes are checked together.
- Add the missing `observer.controlPlaneApiUrl` to the quick-start observability values, which this check surfaces as a failing render on main.

## Remarks
The script renders all 12 chart/value combinations and fails if any one does.