### PR TITLE
fix(helm): gate placeholder-hostname checks on owning feature flags

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-control-plane/templates/NOTES.txt
@@ -1,4 +1,3 @@
-{{- include "openchoreo-control-plane.validateHostnames" . -}}
 OpenChoreo Control Plane installed in namespace "{{ .Release.Namespace }}".
 
 {{- if .Values.backstage.http.enabled }}

--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -230,19 +230,19 @@ Validate that placeholder .invalid hostnames have been replaced with real domain
 */}}
 {{- define "openchoreo-control-plane.validateHostnames" -}}
 {{- $errors := list -}}
-{{- if contains ".invalid" (join "," .Values.openchoreoApi.http.hostnames) -}}
+{{- if and .Values.openchoreoApi.http.enabled (contains ".invalid" (join "," .Values.openchoreoApi.http.hostnames)) -}}
   {{- $errors = append $errors "openchoreoApi.http.hostnames contains placeholder domain (.invalid)" -}}
 {{- end -}}
-{{- if contains ".invalid" (join "," .Values.backstage.http.hostnames) -}}
+{{- if and .Values.backstage.enabled .Values.backstage.http.enabled (contains ".invalid" (join "," .Values.backstage.http.hostnames)) -}}
   {{- $errors = append $errors "backstage.http.hostnames contains placeholder domain (.invalid)" -}}
 {{- end -}}
-{{- if contains ".invalid" .Values.backstage.baseUrl -}}
+{{- if and .Values.backstage.enabled (contains ".invalid" .Values.backstage.baseUrl) -}}
   {{- $errors = append $errors "backstage.baseUrl contains placeholder domain (.invalid)" -}}
 {{- end -}}
-{{- if and .Values.gateway.tls.enabled (contains ".invalid" .Values.gateway.tls.hostname) -}}
+{{- if and .Values.gateway.enabled .Values.gateway.tls.enabled (contains ".invalid" .Values.gateway.tls.hostname) -}}
   {{- $errors = append $errors "gateway.tls.hostname contains placeholder domain (.invalid)" -}}
 {{- end -}}
-{{- if contains ".invalid" .Values.security.oidc.issuer -}}
+{{- if and .Values.security.enabled (contains ".invalid" .Values.security.oidc.issuer) -}}
   {{- $errors = append $errors "security.oidc.issuer contains placeholder domain (.invalid)" -}}
 {{- end -}}
 {{- if and .Values.backstage.enabled (not .Values.backstage.secretName) -}}

--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -230,10 +230,10 @@ Validate that placeholder .invalid hostnames have been replaced with real domain
 */}}
 {{- define "openchoreo-control-plane.validateHostnames" -}}
 {{- $errors := list -}}
-{{- if and .Values.openchoreoApi.http.enabled (contains ".invalid" (join "," .Values.openchoreoApi.http.hostnames)) -}}
+{{- if and .Values.gateway.enabled .Values.openchoreoApi.enabled .Values.openchoreoApi.http.enabled (contains ".invalid" (join "," .Values.openchoreoApi.http.hostnames)) -}}
   {{- $errors = append $errors "openchoreoApi.http.hostnames contains placeholder domain (.invalid)" -}}
 {{- end -}}
-{{- if and .Values.backstage.enabled .Values.backstage.http.enabled (contains ".invalid" (join "," .Values.backstage.http.hostnames)) -}}
+{{- if and .Values.gateway.enabled .Values.backstage.enabled .Values.backstage.http.enabled (contains ".invalid" (join "," .Values.backstage.http.hostnames)) -}}
   {{- $errors = append $errors "backstage.http.hostnames contains placeholder domain (.invalid)" -}}
 {{- end -}}
 {{- if and .Values.backstage.enabled (contains ".invalid" .Values.backstage.baseUrl) -}}

--- a/install/helm/openchoreo-control-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-control-plane/templates/validate.yaml
@@ -1,0 +1,1 @@
+{{- include "openchoreo-control-plane.validateHostnames" . -}}

--- a/install/helm/openchoreo-data-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-data-plane/templates/NOTES.txt
@@ -1,4 +1,3 @@
-{{- include "openchoreo-data-plane.validateHostnames" . -}}
 OpenChoreo Data Plane installed in namespace "{{ .Release.Namespace }}".
 
 {{- if .Values.gateway.enabled }}

--- a/install/helm/openchoreo-data-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-data-plane/templates/validate.yaml
@@ -1,0 +1,1 @@
+{{- include "openchoreo-data-plane.validateHostnames" . -}}

--- a/install/helm/openchoreo-observability-plane/templates/NOTES.txt
+++ b/install/helm/openchoreo-observability-plane/templates/NOTES.txt
@@ -1,4 +1,3 @@
-{{- include "openchoreo-observability-plane.validateHostnames" . -}}
 OpenChoreo Observability Plane installed.
 
 Cross-cluster URLs default to placeholder ".invalid" domains and must be set per

--- a/install/helm/openchoreo-observability-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/validate.yaml
@@ -1,0 +1,1 @@
+{{- include "openchoreo-observability-plane.validateHostnames" . -}}


### PR DESCRIPTION
Fixes #3833

## Bug fix: feature-gate the placeholder checks

`validateHostnames` (control-plane chart) flagged `gateway.tls.hostname` whenever `gateway.tls.enabled` was truthy, ignoring the parent `gateway.enabled`. Since both default to `true` and the hostname defaults to `*.openchoreo.invalid`, `--set gateway.enabled=false` still aborted the render even though the gateway template emits nothing — blocking the bring-your-own-gateway path.

Each check is now scoped to whether its owning feature is enabled:

- `gateway.tls.hostname` → `gateway.enabled` && `gateway.tls.enabled`
- `backstage.http.hostnames` → `backstage.enabled` && `backstage.http.enabled`
- `backstage.baseUrl` → `backstage.enabled`
- `openchoreoApi.http.hostnames` → `openchoreoApi.http.enabled`
- `security.oidc.issuer` → `security.enabled`

(`backstage.secretName` already gated correctly.)

## Cleanup: move validation out of NOTES.txt

NOTES.txt is post-install guidance; a `fail` there couples config validation to the help message. The validation now runs from a dedicated `templates/validate.yaml` (renders nothing), matching how `clusterGateway.validateReplicas` is already wired from a real manifest. The observability-plane and data-plane charts had the same coupling, so they get the same move for consistency (all three charts now validate from `validate.yaml`). No behavior change — `fail` fires at `helm template`/`helm install` time either way.

## Verification

`helm template`, both charts:
- `gateway.enabled=false` with real hostnames elsewhere now renders
- `backstage.enabled=false` no longer flags backstage fields
- enabled-but-placeholder still fails, now via `validate.yaml`
- observability-plane validation still fires once its required fields are set
