### PR TITLE
fix: set required spec.type on sample Projects

### DIFF
--- a/samples/from-image/doclet/project.yaml
+++ b/samples/from-image/doclet/project.yaml
@@ -11,3 +11,6 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default

--- a/samples/from-image/url-shortener/project.yaml
+++ b/samples/from-image/url-shortener/project.yaml
@@ -11,3 +11,6 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default

--- a/samples/from-source/projects/latency-lab/project.yaml
+++ b/samples/from-source/projects/latency-lab/project.yaml
@@ -11,3 +11,6 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default

--- a/samples/from-source/projects/url-shortener/project.yaml
+++ b/samples/from-source/projects/url-shortener/project.yaml
@@ -11,3 +11,6 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default

--- a/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
+++ b/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
@@ -11,3 +11,6 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default


### PR DESCRIPTION
## Purpose

The project release lifecycle work added a required, immutable `spec.type` field to the `Project` CRD. Existing sample `Project` manifests omit it and are now rejected by the strict CRD schema. This updates the affected samples so they apply cleanly against the new CRD.

## Approach

- Add `spec.type` referencing the `default` `ClusterProjectType` to every sample `Project` that was missing it:
  - `samples/from-image/doclet/project.yaml`
  - `samples/from-image/url-shortener/project.yaml`
  - `samples/from-source/projects/latency-lab/project.yaml`
  - `samples/from-source/projects/url-shortener/project.yaml`
  - `samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml`
- These samples already depend on getting-started's `default` DeploymentPipeline, which ships the `default` `ClusterProjectType`, so no new dependency is introduced.
- `samples/getting-started/*` and `samples/project-release-lifecycle/*` already carried `spec.type` and were left unchanged.

## Related Issues

https://github.com/openchoreo/openchoreo/issues/3736

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)