### PR TITLE
test: set required spec.type on e2e Project fixtures

### DIFF
--- a/test/e2e/suites/alerts/alerts_fixtures_test.go
+++ b/test/e2e/suites/alerts/alerts_fixtures_test.go
@@ -112,6 +112,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 	docs := []any{pipeline}

--- a/test/e2e/suites/authz/authz_test.go
+++ b/test/e2e/suites/authz/authz_test.go
@@ -599,6 +599,9 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default
 `, projA, nsA, projA)
 			output, err := framework.KubectlApplyLiteral(kubeContext, projAYAML)
 			Expect(err).NotTo(HaveOccurred(), "create project A: %s", output)
@@ -612,6 +615,9 @@ metadata:
     openchoreo.dev/name: %s
 spec:
   deploymentPipelineRef:
+    name: default
+  type:
+    kind: ClusterProjectType
     name: default
 `, projB, nsB, projB)
 			output, err = framework.KubectlApplyLiteral(kubeContext, projBYAML)

--- a/test/e2e/suites/authz/fixtures_test.go
+++ b/test/e2e/suites/authz/fixtures_test.go
@@ -69,6 +69,9 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default
 `, ns, projectName)
 }
 

--- a/test/e2e/suites/build/build_fixtures_test.go
+++ b/test/e2e/suites/build/build_fixtures_test.go
@@ -122,6 +122,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 	docs := []any{pipeline}

--- a/test/e2e/suites/connections/connections_fixtures_test.go
+++ b/test/e2e/suites/connections/connections_fixtures_test.go
@@ -122,7 +122,10 @@ func platformResourcesYAML(cpNamespace string, environments, projects []string) 
 					"openchoreo.dev/name": proj,
 				},
 			},
-			Spec: openchoreov1alpha1.ProjectSpec{DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"}},
+			Spec: openchoreov1alpha1.ProjectSpec{
+				DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+				Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
+			},
 		})
 	}
 

--- a/test/e2e/suites/gateway/gateway_fixtures_test.go
+++ b/test/e2e/suites/gateway/gateway_fixtures_test.go
@@ -143,6 +143,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 

--- a/test/e2e/suites/gitops/gitops_fixtures_test.go
+++ b/test/e2e/suites/gitops/gitops_fixtures_test.go
@@ -116,6 +116,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 	docs := []any{pipeline}

--- a/test/e2e/suites/mcp/mcp_fixtures_test.go
+++ b/test/e2e/suites/mcp/mcp_fixtures_test.go
@@ -115,7 +115,10 @@ func platformResourcesYAML(cpNamespace string, environments []string, projects [
 					"openchoreo.dev/name": proj,
 				},
 			},
-			Spec: openchoreov1alpha1.ProjectSpec{DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"}},
+			Spec: openchoreov1alpha1.ProjectSpec{
+				DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+				Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
+			},
 		})
 	}
 

--- a/test/e2e/suites/networkpolicy/networkpolicy_fixtures_test.go
+++ b/test/e2e/suites/networkpolicy/networkpolicy_fixtures_test.go
@@ -226,7 +226,10 @@ func platformResourcesYAML(cpNamespace string, environments, projects []string) 
 					"openchoreo.dev/name": proj,
 				},
 			},
-			Spec: openchoreov1alpha1.ProjectSpec{DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"}},
+			Spec: openchoreov1alpha1.ProjectSpec{
+				DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+				Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
+			},
 		})
 	}
 

--- a/test/e2e/suites/observability/observability_fixtures_test.go
+++ b/test/e2e/suites/observability/observability_fixtures_test.go
@@ -118,6 +118,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 	docs := []any{pipeline}

--- a/test/e2e/suites/occ/occ_fixtures_test.go
+++ b/test/e2e/suites/occ/occ_fixtures_test.go
@@ -110,6 +110,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 	docs := []any{pipeline}

--- a/test/e2e/suites/secrets/secrets_fixtures_test.go
+++ b/test/e2e/suites/secrets/secrets_fixtures_test.go
@@ -118,6 +118,7 @@ func platformResourcesYAML() string {
 			},
 			Spec: openchoreov1alpha1.ProjectSpec{
 				DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+				Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 			},
 		},
 	}

--- a/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
@@ -112,6 +112,7 @@ func platformResourcesYAML() string {
 		},
 		Spec: openchoreov1alpha1.ProjectSpec{
 			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
+			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
 	docs := []any{pipeline}


### PR DESCRIPTION
## Purpose

The project release lifecycle work made `Project.spec.type` a required field on the strict Project CRD (`spec.type.name` has `MinLength=1`). The e2e fixtures still created Project CRs without `spec.type`, so the strict CRD rejected them:

```
The Project "proj1" is invalid: spec.type.name: Invalid value: "":
spec.type.name in body should be at least 1 chars long
```

The first failing suite aborts in `BeforeAll` while applying platform resources, which turned both the Tier 1 and Tier 2 e2e gates red. This PR fixes the e2e fixtures. (The sample manifests were fixed separately in #3864.)

## Approach

- Add `spec.type` → the `default` ClusterProjectType (installed by `e2e.setup-configure`) to every e2e fixture that applies a Project CR directly via `kubectl`:
  - Go-struct fixtures (`platformResourcesYAML`): alerts, build, connections, gateway, gitops, mcp, networkpolicy, observability, occ, secrets, workloadtypes
  - Inline YAML: authz (suite project + project A/B)
- The MCP `create_project` path is left unchanged — the API already defaults `spec.type` to the `default` ClusterProjectType (`internal/openchoreo-api/services/project/service.go`).

Verified against a local control plane running the branch: a Project without `spec.type` is rejected with `spec.type: Required value`, while the fixed form is accepted, reconciles to `Ready=True`, and cuts a `ProjectRelease`.

## Related Issues

https://github.com/openchoreo/openchoreo/issues/3736

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)