### PR TITLE
feat: support deployment status debug in portal assistant

### DIFF
--- a/agents/portal-assistant/src/agent/builder.py
+++ b/agents/portal-assistant/src/agent/builder.py
@@ -77,6 +77,7 @@ _DEFAULT_RECURSION_LIMIT = 30
 _RECURSION_LIMIT_FOR_CASE: dict[str, int] = {
     "build_failure": 15,
     "runtime_debug": 15,
+    "dependency_pending": 15,
 }
 
 
@@ -139,6 +140,21 @@ _TOOLS_FOR_CASE: dict[str, set[str]] = {
         "list_rca_reports",
         "get_rca_report",
         "analyze_runtime_state",
+    },
+    "dependency_pending": {
+        # Topology — locate the dependent binding and the down dependency.
+        # The dependent's pendingConnections name the target component; the
+        # binding/component getters explain whether the target is
+        # undeployed, not-ready, or missing an endpoint.
+        "list_components",
+        "get_component",
+        "list_release_bindings",
+        "get_release_binding",
+        # Why is the dependency down? — when the target IS deployed but not
+        # ready (crashlooping, erroring), its logs / active incidents carry
+        # the root cause behind the unresolved connection.
+        "query_component_logs",
+        "query_incidents",
     },
 }
 

--- a/agents/portal-assistant/src/api/agent_routes.py
+++ b/agents/portal-assistant/src/api/agent_routes.py
@@ -77,6 +77,26 @@ class PrefetchedLogEntry(BaseModel):
     )
 
 
+class PendingDependency(BaseModel):
+    """An unresolved outbound endpoint dependency the Deploy tab read off the
+    binding's ``pendingConnections``.
+
+    Forwarded on ``dependency_pending`` chats so the agent names *which*
+    dependency is blocking without a discovery tool call and spends its
+    first call inspecting *why* it's down. Each field is size-capped so a
+    client can't blow the per-request content budget (counted by the
+    ChatRequest total-content validator below, which walks list-of-dict
+    string values).
+    """
+
+    model_config = {"populate_by_name": True, "extra": "ignore"}
+
+    project: str | None = Field(default=None, max_length=253)
+    component: str = Field(max_length=253)
+    endpoint: str | None = Field(default=None, max_length=253)
+    reason: str | None = Field(default=None, max_length=512)
+
+
 class ChatScope(BaseModel):
     """Optional default scope hints derived from the Backstage entity context.
 
@@ -173,6 +193,17 @@ class ChatScope(BaseModel):
     # the validator below).
     prefetched_logs: list[PrefetchedLogEntry] | None = Field(
         default=None, alias="prefetchedLogs", max_length=50,
+    )
+
+    # ── Dependency-pending scope fields ────────────────────────────
+    # Set by the Deploy-tab "Investigate" button when a component is
+    # stuck NotReady because an outbound endpoint connection can't
+    # resolve. The dependency_pending prompt branch names these directly
+    # so the agent skips rediscovering them and inspects why each is down.
+    # Length-capped (per-row strings count toward _TOTAL_CONTENT_LIMIT
+    # via the validator below).
+    pending_dependencies: list[PendingDependency] | None = Field(
+        default=None, alias="pendingDependencies", max_length=50,
     )
 
     @field_validator("repo_url")

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -230,6 +230,102 @@ Set `fix_prompt: null` when:
 
 {% endif -%}
 
+{% if scope and scope.case_type == 'dependency_pending' -%}
+{% set pinned_deps = scope.pending_dependencies is defined and scope.pending_dependencies is not none and scope.pending_dependencies | length > 0 -%}
+## DEPENDENCY PENDING
+
+Opened from the Deploy tab / K8s-artifacts view. A component is stuck **NotReady** because one or more of its **outbound endpoint connections cannot be resolved** — it depends on another component's endpoint that isn't available. While unresolved, the controller blocks rendering the Release, so there are **no Kubernetes resources** to inspect; the cause is the *dependency*, not this component. Your job: name the blocking dependency, explain *why* it's unavailable, and give the recovery step.
+
+### Context
+- ns: `{{ scope.namespace or '<must ask>' }}`{% if scope.project %} / proj: `{{ scope.project }}`{% endif %}{% if scope.component %} / comp: `{{ scope.component }}` (the dependent, pending component){% endif %}
+- env: {% if scope.environment %}`{{ scope.environment }}`{% else %}**not in scope** — ask once; you need it to find the dependency's binding{% endif %}
+
+{% if pinned_deps -%}
+### Pending connections (authoritative — do NOT call get_release_binding just to re-find these)
+{% for d in scope.pending_dependencies -%}
+- target: {% if d.project %}`{{ d.project }}/`{% endif %}`{{ d.component }}`{% if d.endpoint %} endpoint `{{ d.endpoint }}`{% endif %}{% if d.reason %} — reason: `{{ d.reason }}`{% endif %}
+{% endfor -%}
+{% else -%}
+### Find the pending connections first
+{% if scope.component and scope.environment -%}
+Call `get_release_binding` for the dependent component (`{{ scope.component }}`) in env `{{ scope.environment }}` and read `status.pendingConnections[]`. Each entry names the target `component` / `endpoint` and a `reason`.
+{% else -%}
+You don't have enough scope to look up the binding — **ask the user which component and environment** to check for pending connections before calling any tool. Once they answer, call `get_release_binding` for that component in that environment and read `status.pendingConnections[]`. Never call `get_release_binding` with placeholder names.
+{% endif -%}
+{% endif %}
+
+### Investigation flow
+For each blocking target dependency:
+1. **Locate the target in this environment** — `get_release_binding` (or `list_release_bindings` filtered by the target component + env). The reason string already classifies it; confirm and deepen:
+   - `component is undeployed` / `ReleaseBinding not found …` → the dependency is **not deployed** to `{{ scope.environment or 'this env' }}` (or the dependency reference is wrong). It must be deployed before this component can resolve. **No further tool calls needed.**
+   - `endpoint … has no URL for visibility …` → the dependency **is** deployed but its endpoint isn't exposed at the visibility this connection needs. Point at the dependency's endpoint/visibility config.
+   - `endpoint … not yet resolved` → transient: the dependency is still coming up. Check its readiness next.
+2. **If the target is deployed but NotReady** (crashlooping / erroring, so its endpoint never publishes), find the root cause: `query_component_logs` for the *target* component in the same env, and `query_incidents` for active incidents on it. Quote the decisive error line.
+3. Stop as soon as the cause is clear. Don't browse unrelated components.
+
+### Response format
+
+The chat drawer is narrow (~340 px) — never use fenced code blocks for tabular data; quote any log line inline with backticks so it wraps.
+
+**Emit your reply in this exact markdown layout.** The drawer parses on the literal labels (``**Diagnosis**`` / ``**Evidence**`` / ``**Next action**``) to collapse **Evidence** behind a "Show details" expander — so keep them verbatim, in this order, with **one blank line between every label and its body and one blank line between sections** (without the blank line the drawer renders "Diagnosis <body>" run together).
+
+```
+**Diagnosis**
+
+<one sentence: `<component>` is pending because it can't reach `<project/component:endpoint>`, which is <undeployed | not ready | endpoint not exposed>.>
+
+**Evidence**
+
+- pending connection: `<project/component:endpoint>` — reason `<reason>`
+- `<dependency>` binding: <undeployed | NotReady | not found>{ + the decisive log/incident line when you fetched one}
+
+**Next action**
+
+<one concrete recovery step for the operator, targeted at the *dependency*. Up to three short bullets when genuinely multi-step.>
+```
+
+Rules for the body of each section:
+- **Evidence** — 2-4 real markdown ``-`` bullets; component names in backticks; quote any log/incident line trimmed to the actionable substring. Omit bullets you have no data for.
+- **Next action** — operator recovery only (deploy the dependency, fix its endpoint visibility, or fix why the dependency is unhealthy). Mutations are out of scope for you — describe them and point to the OpenChoreo UI/CLI. Never claim *this* component has a bug — its own resources don't exist yet; the fault is upstream.
+- One `ChatResponse` ends the turn.
+
+### External-agent investigation prompt (`fix_prompt`)
+
+`ChatResponse.fix_prompt` drives the drawer's "Prompt for AI Agents" Copy button. Populate it whenever you named a concrete blocking dependency — the recipient is an external AI assistant configured with the **OpenChoreo MCP server** (`get_release_binding`, `list_release_bindings`, `get_component`, `query_component_logs`, `query_incidents`) and `kubectl` access to the data-plane cluster; hand it the *next* step to confirm and remediate. `kubectl` / MCP hints are encouraged.
+
+**Shape (≤ 2000 chars, plain markdown):**
+
+```text
+Investigate why `<comp>` is stuck pending in OpenChoreo (ns `<ns>`, env `<env>`).
+
+Observed:
+`<comp>` cannot resolve its connection to `<project/component:endpoint>` — reason: <reason>.
+
+Scope:
+- namespace: <ns>
+- project: <proj or omit>
+- dependent component: <comp>
+- blocking dependency: <project/component:endpoint>
+- environment: <env>
+
+Suggested next steps:
+- `get_release_binding` for `<dependency>` in env `<env>` — confirm it is deployed and Ready
+- `query_component_logs(namespace="<ns>", component="<dependency>", ...)`  # if deployed but not ready
+- `kubectl -n <ns> get pods -l openchoreo.dev/component=<dependency>`
+- `kubectl -n <ns> describe pod <pod>`  # if the dependency pod is unhealthy
+
+Confirm the root cause and propose how to make `<dependency>` available.
+```
+
+Rules:
+- Use the **actual** `scope` values and the dependency you named — never the placeholders above.
+- 2-4 suggested steps — pick the ones that *actually advance* the diagnosis. If the dependency is simply undeployed, the action is "deploy `<dependency>` to `<env>`" — keep it short, drop the log/kubectl steps.
+- ≤ 2000 chars. No credentials / auth setup (the recipient already has access). Do NOT echo your `message` body verbatim.
+
+Set `fix_prompt: null` only when there is no concrete dependency to hand off (e.g. you could not read the binding at all).
+
+{% endif -%}
+
 {% if scope and scope.case_type == 'build_failure' -%}
 ## BUILD-FAILURE INVESTIGATION
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Currently portal assistant only suppot buidl failure and runtime logs and with this portal assistant will support deployment status issues which can be dependency issue, config issue or many more. 

## Approach
Provide deployment status debug.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
