### PR TITLE
fix(controller): set workflow failed condition on validation failure

### DIFF
--- a/internal/controller/workflowrun/controller_conditions.go
+++ b/internal/controller/workflowrun/controller_conditions.go
@@ -173,7 +173,7 @@ func setComponentValidationFailedCondition(workflowRun *openchoreov1alpha1.Workf
 	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
 		Type:               string(ConditionWorkflowRunning),
 		Status:             metav1.ConditionFalse,
-		Reason:             string(ReasonComponentValidationFailed),
+		Reason:             string(ReasonWorkflowRunning),
 		Message:            message,
 		ObservedGeneration: workflowRun.Generation,
 	})

--- a/internal/controller/workflowrun/controller_conditions.go
+++ b/internal/controller/workflowrun/controller_conditions.go
@@ -129,14 +129,14 @@ func setWorkflowNotFoundCondition(workflowRun *openchoreov1alpha1.WorkflowRun) {
 		Type:               string(ConditionWorkflowFailed),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(ReasonWorkflowFailed),
-		Message:            "Workflow has been deleted from the cluster",
+		Message:            "Workflow is not found in the cluster",
 		ObservedGeneration: workflowRun.Generation,
 	})
 	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
 		Type:               string(ConditionWorkflowCompleted),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(ReasonWorkflowFailed),
-		Message:            "Workflow has been deleted from the cluster",
+		Message:            "Workflow is not found in the cluster",
 		ObservedGeneration: workflowRun.Generation,
 	})
 }

--- a/internal/controller/workflowrun/controller_conditions.go
+++ b/internal/controller/workflowrun/controller_conditions.go
@@ -126,6 +126,13 @@ func setWorkflowNotFoundCondition(workflowRun *openchoreov1alpha1.WorkflowRun) {
 		ObservedGeneration: workflowRun.Generation,
 	})
 	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
+		Type:               string(ConditionWorkflowFailed),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(ReasonWorkflowFailed),
+		Message:            "Workflow has been deleted from the cluster",
+		ObservedGeneration: workflowRun.Generation,
+	})
+	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
 		Type:               string(ConditionWorkflowCompleted),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(ReasonWorkflowFailed),
@@ -163,6 +170,20 @@ func isWorkflowRunning(workflowRun *openchoreov1alpha1.WorkflowRun) bool {
 // setComponentValidationFailedCondition marks the workflow run as permanently failed
 // due to a component workflow validation error.
 func setComponentValidationFailedCondition(workflowRun *openchoreov1alpha1.WorkflowRun, message string) {
+	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
+		Type:               string(ConditionWorkflowRunning),
+		Status:             metav1.ConditionFalse,
+		Reason:             string(ReasonComponentValidationFailed),
+		Message:            message,
+		ObservedGeneration: workflowRun.Generation,
+	})
+	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
+		Type:               string(ConditionWorkflowFailed),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(ReasonComponentValidationFailed),
+		Message:            message,
+		ObservedGeneration: workflowRun.Generation,
+	})
 	meta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
 		Type:               string(ConditionWorkflowCompleted),
 		Status:             metav1.ConditionTrue,

--- a/internal/controller/workflowrun/controller_integration_test.go
+++ b/internal/controller/workflowrun/controller_integration_test.go
@@ -210,6 +210,14 @@ var _ = Describe("WorkflowRun Controller Integration", func() {
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(cond.Reason).To(Equal(string(ReasonWorkflowFailed)))
+
+			condFailed := meta.FindStatusCondition(wr.Status.Conditions, string(ConditionWorkflowFailed))
+			Expect(condFailed).NotTo(BeNil())
+			Expect(condFailed.Status).To(Equal(metav1.ConditionTrue))
+
+			condRunning := meta.FindStatusCondition(wr.Status.Conditions, string(ConditionWorkflowRunning))
+			Expect(condRunning).NotTo(BeNil())
+			Expect(condRunning.Status).To(Equal(metav1.ConditionFalse))
 		})
 	})
 
@@ -560,6 +568,14 @@ var _ = Describe("WorkflowRun Controller Integration", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(cond.Reason).To(Equal(string(ReasonComponentValidationFailed)))
 			Expect(cond.Message).To(ContainSubstring("must have both"))
+
+			condFailed := meta.FindStatusCondition(resource.Status.Conditions, string(ConditionWorkflowFailed))
+			Expect(condFailed).NotTo(BeNil())
+			Expect(condFailed.Status).To(Equal(metav1.ConditionTrue))
+
+			condRunning := meta.FindStatusCondition(resource.Status.Conditions, string(ConditionWorkflowRunning))
+			Expect(condRunning).NotTo(BeNil())
+			Expect(condRunning.Status).To(Equal(metav1.ConditionFalse))
 		})
 	})
 

--- a/internal/controller/workflowrun/controller_unit_test.go
+++ b/internal/controller/workflowrun/controller_unit_test.go
@@ -340,8 +340,9 @@ func TestConditionFunctions(t *testing.T) {
 	t.Run("setWorkflowNotFoundCondition", func(t *testing.T) {
 		wfr := newWFRun()
 		setWorkflowNotFoundCondition(wfr)
-		assertConditionCount(t, wfr, 2)
+		assertConditionCount(t, wfr, 3)
 		assertCondition(t, wfr, string(ConditionWorkflowRunning), metav1.ConditionFalse, "")
+		assertCondition(t, wfr, string(ConditionWorkflowFailed), metav1.ConditionTrue, string(ReasonWorkflowFailed))
 		assertCondition(t, wfr, string(ConditionWorkflowCompleted), metav1.ConditionTrue, string(ReasonWorkflowFailed))
 	})
 

--- a/internal/controller/workflowrun/controller_unit_test.go
+++ b/internal/controller/workflowrun/controller_unit_test.go
@@ -1530,7 +1530,9 @@ func TestValidationSkippedWhenRunReferenceSet(t *testing.T) {
 func TestSetComponentValidationFailedCondition(t *testing.T) {
 	wfr := &openchoreodevv1alpha1.WorkflowRun{ObjectMeta: metav1.ObjectMeta{Generation: 1}}
 	setComponentValidationFailedCondition(wfr, "test message")
-	assertConditionCount(t, wfr, 1)
+	assertConditionCount(t, wfr, 3)
+	assertCondition(t, wfr, string(ConditionWorkflowRunning), metav1.ConditionFalse, string(ReasonWorkflowRunning))
+	assertCondition(t, wfr, string(ConditionWorkflowFailed), metav1.ConditionTrue, string(ReasonComponentValidationFailed))
 	assertCondition(t, wfr, string(ConditionWorkflowCompleted), metav1.ConditionTrue, string(ReasonComponentValidationFailed))
 	cond := findConditionByType(wfr.Status.Conditions, string(ConditionWorkflowCompleted))
 	if cond.Message != "test message" {


### PR DESCRIPTION
When a workflow validation fails or workflow is not found, the controller previously only set the WorkflowCompleted condition to true. This caused the UI to continue showing the workflow in a pending state.

This PR explicitly sets WorkflowFailed to true and WorkflowRunning to false in these error cases to properly surface the failure.

Closes https://github.com/openchoreo/openchoreo/issues/2948