### PR TITLE
fix: write ballerina buildpack generated-artifacts to an emptyDir

### DIFF
--- a/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
@@ -20,6 +20,9 @@ spec:
             sizeLimit: 10Gi
         - name: app-dir
           emptyDir: {}
+        # Writable scratch for buildpack generated-artifacts (not used downstream).
+        - name: generated-artifacts
+          emptyDir: {}
         - name: registries-conf
           configMap:
             name: "{{workflow.parameters.workflowrun-name}}-registries-conf"
@@ -128,7 +131,7 @@ spec:
                 --builder "$BUILDER" \
                 --run-image "$RUN_IMAGE" \
                 --path "$WORKDIR/$APP_PATH" \
-                --volume "/mnt/vol:/app/generated-artifacts:rw" \
+                --volume "/generated-artifacts:/app/generated-artifacts:rw" \
                 --pull-policy always \
                 --publish \
                 $PACK_REGISTRY_ARGS \
@@ -147,7 +150,7 @@ spec:
               --run-image "$RUN_IMAGE" \
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
-              --volume "/mnt/vol:/app/generated-artifacts:rw" \
+              --volume "/generated-artifacts:/app/generated-artifacts:rw" \
               --pull-policy always \
               $PACK_REGISTRY_ARGS \
               $ENV_ARGS
@@ -163,6 +166,8 @@ spec:
             name: storage
           - mountPath: /app
             name: app-dir
+          - mountPath: /generated-artifacts
+            name: generated-artifacts
           - mountPath: /etc/containers/registries.conf.d/mirrors.conf
             subPath: mirrors.conf
             name: registries-conf

--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -241,6 +241,9 @@ spec:
             sizeLimit: 10Gi
         - name: app-dir
           emptyDir: {}
+        # Writable scratch for buildpack generated-artifacts (not used downstream).
+        - name: generated-artifacts
+          emptyDir: {}
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.2
         command:
@@ -316,7 +319,7 @@ spec:
               --run-image "$RUN_IMAGE" \
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
-              --volume "/mnt/vol:/app/generated-artifacts:rw" \
+              --volume "/generated-artifacts:/app/generated-artifacts:rw" \
               --pull-policy always \
               $ENV_ARGS
 
@@ -332,6 +335,8 @@ spec:
             name: storage
           - mountPath: /app
             name: app-dir
+          - mountPath: /generated-artifacts
+            name: generated-artifacts
 
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -16,6 +16,9 @@ spec:
             sizeLimit: 10Gi
         - name: app-dir
           emptyDir: {}
+        # Writable scratch for buildpack generated-artifacts (not used downstream).
+        - name: generated-artifacts
+          emptyDir: {}
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.2
         command:
@@ -91,7 +94,7 @@ spec:
               --run-image "$RUN_IMAGE" \
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
-              --volume "/mnt/vol:/app/generated-artifacts:rw" \
+              --volume "/generated-artifacts:/app/generated-artifacts:rw" \
               --pull-policy always \
               $ENV_ARGS
 
@@ -107,3 +110,5 @@ spec:
             name: storage
           - mountPath: /app
             name: app-dir
+          - mountPath: /generated-artifacts
+            name: generated-artifacts


### PR DESCRIPTION
## Purpose
Ballerina builds fail on EBS-backed clusters (EKS/gp3 and most CSI drivers): the buildpack runs as non-root but the workspace PVC is mounted into it at `/app/generated-artifacts` as `root:root`, so it cannot write there. Works on k3d only because local-path volumes are world-writable. Fixes #3879.

## Approach
Route the generated-artifacts to a dedicated writable `emptyDir` instead of the shared PVC. These artifacts (target/configs/cell-diagram/swagger) are not consumed by any workflow step or controller. The image tarball is still saved to the workspace PVC for the publish step. Applied to the getting-started template, the bundled `workflow-templates.yaml`, and the k3d build-cache variant.

## Related Issues
Fixes #3879

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added backport label

## Remarks
Validated end-to-end on EKS (AL2023, kernel 6.12): build-image → publish-image → generate-workload-cr all succeeded.