### PR TITLE
fix(controller): create observability-plane namespace before apply

### DIFF
--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,6 +126,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		logger.Error(err, "Failed to make desired resources")
 		return ctrl.Result{}, err
+	}
+
+	// Ensure namespaces exist before applying resources on the observability plane only.
+	// The data plane's cell namespace is owned by the ProjectReleaseBinding, so the DP
+	// apply path must not regain implicit namespace creation. On the observability plane
+	// nothing else creates the target namespace, so we create it here.
+	if targetPlane == targetPlaneObservabilityPlane {
+		desiredNamespaces := r.makeDesiredNamespaces(release, desiredResources)
+		if err := r.ensureNamespaces(ctx, planeClient, desiredNamespaces); err != nil {
+			logger.Error(err, "Failed to ensure namespaces on observability plane")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// PHASE 1: Apply desired resources to the target plane
@@ -313,6 +326,73 @@ func injectRestartedAt(obj *unstructured.Unstructured, value string) error {
 	if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
 		return fmt.Errorf("set pod template annotations: %w", err)
 	}
+	return nil
+}
+
+// makeDesiredNamespaces creates namespace objects from the desired resources with proper labels
+func (r *Reconciler) makeDesiredNamespaces(release *openchoreov1alpha1.RenderedRelease, resources []*unstructured.Unstructured) []*corev1.Namespace {
+	namespaceMap := make(map[string]*corev1.Namespace)
+
+	for _, obj := range resources {
+		namespaceName := obj.GetNamespace()
+		if namespaceName != "" {
+			if _, exists := namespaceMap[namespaceName]; !exists {
+				namespaceMap[namespaceName] = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespaceName,
+						Labels: map[string]string{
+							// Audit labels - track which release created this namespace
+							labels.LabelKeyCreatedBy:                ControllerName,
+							labels.LabelKeyRenderedReleaseName:      release.Name,
+							labels.LabelKeyRenderedReleaseNamespace: release.Namespace,
+							labels.LabelKeyRenderedReleaseUID:       string(release.UID),
+
+							// Identification labels - track where this namespace belongs
+							labels.LabelKeyNamespaceName:   release.Namespace,
+							labels.LabelKeyEnvironmentName: release.Spec.EnvironmentName,
+							labels.LabelKeyProjectName:     release.Spec.Owner.ProjectName,
+						},
+					},
+				}
+			}
+		}
+	}
+
+	// Convert the map to a slice
+	namespaces := make([]*corev1.Namespace, 0, len(namespaceMap))
+	for _, ns := range namespaceMap {
+		namespaces = append(namespaces, ns)
+	}
+
+	return namespaces
+}
+
+// ensureNamespaces ensures all required namespaces exist in the target plane
+func (r *Reconciler) ensureNamespaces(ctx context.Context, planeClient client.Client, namespaces []*corev1.Namespace) error {
+	for _, namespace := range namespaces {
+		existingNs := &corev1.Namespace{}
+		err := planeClient.Get(ctx, client.ObjectKey{Name: namespace.Name}, existingNs)
+
+		// Namespace already exists, skip to next
+		if err == nil {
+			continue
+		}
+
+		// Error other than NotFound
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to check namespace %s: %w", namespace.Name, err)
+		}
+
+		// Namespace doesn't exist, create it
+		if err := planeClient.Create(ctx, namespace); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Another controller/release created it concurrently - that's fine
+				continue
+			}
+			return fmt.Errorf("failed to create namespace %s: %w", namespace.Name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/controller/renderedrelease/controller_integration_test.go
+++ b/internal/controller/renderedrelease/controller_integration_test.go
@@ -949,6 +949,152 @@ var _ = Describe("RenderedRelease Controller", func() {
 	})
 
 	// ─────────────────────────────────────────────────────────────
+	// Reconcile: observability plane creates the target namespace
+	// ─────────────────────────────────────────────────────────────
+
+	Context("when an observability-plane RenderedRelease references a missing namespace", func() {
+		const (
+			releaseName = "release-op-ns-create"
+			envName     = "env-op-ns-create"
+			cdpName     = "cdp-op-ns-create"
+			copName     = "cop-op-ns-create"
+			planeID     = "plane-op-ns-create"
+			opPlaneID   = "obs-plane-op-ns-create"
+			targetNs    = "op-created-ns"
+		)
+		nn := types.NamespacedName{Name: releaseName, Namespace: testNs}
+		envNN := types.NamespacedName{Name: envName, Namespace: testNs}
+
+		AfterEach(func() {
+			forceDelete(ctx, nn)
+			forceDeleteEnvironment(ctx, envNN)
+			forceDeleteClusterDataPlane(ctx, cdpName)
+			forceDeleteClusterObservabilityPlane(ctx, copName)
+			// Best-effort cleanup of the namespace created by the controller.
+			nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNs}}
+			_ = k8sClient.Delete(ctx, nsObj)
+		})
+
+		It("creates the namespace before applying the resources", func() {
+			By("Creating prerequisite ClusterObservabilityPlane, ClusterDataPlane, and Environment")
+			Expect(k8sClient.Create(ctx, makeClusterObservabilityPlane(copName, opPlaneID))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeClusterDataPlaneWithOPRef(cdpName, planeID, copName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeEnvironment(envName, cdpName))).To(Succeed())
+
+			By("Confirming the target namespace does not exist yet")
+			ns := &corev1.Namespace{}
+			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: targetNs}, ns))).To(BeTrue())
+
+			By("Creating an OP-targeted RenderedRelease with a ConfigMap in the missing namespace")
+			release := makeMinimalRelease(releaseName, envName)
+			release.Spec.TargetPlane = targetPlaneObservabilityPlane
+			cmJSON := []byte(fmt.Sprintf(`{
+				"apiVersion": "v1",
+				"kind": "ConfigMap",
+				"metadata": {
+					"name": "test-cm-op-ns",
+					"namespace": %q
+				},
+				"data": {
+					"key": "op-value"
+				}
+			}`, targetNs))
+			release.Spec.Resources = []openchoreov1alpha1.RenderedManifest{
+				{
+					ID:     "cm-op-ns-1",
+					Object: &runtime.RawExtension{Raw: cmJSON},
+				},
+			}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			By("Using the envtest client as the observability plane client")
+			r := testReconcilerWithDPClient(k8sClient, planeID, cdpName)
+
+			By("First reconcile: adds finalizer")
+			mustReconcile(r, reconcileRequest(releaseName))
+
+			By("Second reconcile: creates the namespace and applies resources")
+			mustReconcile(r, reconcileRequest(releaseName))
+
+			By("Verifying the namespace was created with audit labels")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: targetNs}, ns)).To(Succeed())
+			Expect(ns.Labels[labels.LabelKeyCreatedBy]).To(Equal(ControllerName))
+			Expect(ns.Labels[labels.LabelKeyRenderedReleaseName]).To(Equal(releaseName))
+
+			By("Verifying the ConfigMap was applied into the created namespace")
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-cm-op-ns", Namespace: targetNs}, cm)).To(Succeed())
+			Expect(cm.Data["key"]).To(Equal("op-value"))
+		})
+	})
+
+	// ─────────────────────────────────────────────────────────────
+	// Reconcile: data plane does NOT create the target namespace
+	// ─────────────────────────────────────────────────────────────
+
+	Context("when a data-plane RenderedRelease references a missing namespace", func() {
+		const (
+			releaseName = "release-dp-ns-scope"
+			envName     = "env-dp-ns-scope"
+			cdpName     = "cdp-dp-ns-scope"
+			planeID     = "plane-dp-ns-scope"
+			targetNs    = "dp-uncreated-ns"
+		)
+		nn := types.NamespacedName{Name: releaseName, Namespace: testNs}
+		envNN := types.NamespacedName{Name: envName, Namespace: testNs}
+
+		AfterEach(func() {
+			forceDelete(ctx, nn)
+			forceDeleteEnvironment(ctx, envNN)
+			forceDeleteClusterDataPlane(ctx, cdpName)
+			nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNs}}
+			_ = k8sClient.Delete(ctx, nsObj)
+		})
+
+		It("does not create the namespace (ownership stays with the binding)", func() {
+			By("Creating prerequisite ClusterDataPlane and Environment")
+			Expect(k8sClient.Create(ctx, makeClusterDataPlane(cdpName, planeID))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeEnvironment(envName, cdpName))).To(Succeed())
+
+			By("Creating a DP-targeted RenderedRelease with a ConfigMap in a missing namespace")
+			release := makeMinimalRelease(releaseName, envName)
+			release.Spec.TargetPlane = "" // defaults to dataplane
+			cmJSON := []byte(fmt.Sprintf(`{
+				"apiVersion": "v1",
+				"kind": "ConfigMap",
+				"metadata": {
+					"name": "test-cm-dp-ns",
+					"namespace": %q
+				},
+				"data": {
+					"key": "dp-value"
+				}
+			}`, targetNs))
+			release.Spec.Resources = []openchoreov1alpha1.RenderedManifest{
+				{
+					ID:     "cm-dp-ns-1",
+					Object: &runtime.RawExtension{Raw: cmJSON},
+				},
+			}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			By("Using the envtest client as the data plane client")
+			r := testReconcilerWithDPClient(k8sClient, planeID, cdpName)
+
+			By("First reconcile: adds finalizer")
+			mustReconcile(r, reconcileRequest(releaseName))
+
+			By("Second reconcile: apply fails because the namespace was not created")
+			_, err := r.Reconcile(ctx, reconcileRequest(releaseName))
+			Expect(err).To(HaveOccurred())
+
+			By("Verifying the namespace was NOT created by the controller")
+			ns := &corev1.Namespace{}
+			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: targetNs}, ns))).To(BeTrue())
+		})
+	})
+
+	// ─────────────────────────────────────────────────────────────
 	// Reconcile: apply failure sets ResourcesApplied=False
 	// ─────────────────────────────────────────────────────────────
 

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -1083,6 +1084,132 @@ func TestMakeDesiredResources(t *testing.T) {
 			if obj.GetLabels()[labels.LabelKeyManagedBy] != ControllerName {
 				t.Errorf("tracking label missing on %s", obj.GetName())
 			}
+		}
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// makeDesiredNamespaces
+// ─────────────────────────────────────────────────────────────
+
+func TestMakeDesiredNamespaces(t *testing.T) {
+	r := &Reconciler{}
+
+	makeObjInNamespace := func(namespace string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+		if namespace != "" {
+			obj.SetNamespace(namespace)
+		}
+		return obj
+	}
+
+	t.Run("empty resources returns empty slice", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{}
+		result := r.makeDesiredNamespaces(release, nil)
+		if len(result) != 0 {
+			t.Errorf("expected 0, got %d", len(result))
+		}
+	})
+
+	t.Run("resources with empty namespace are skipped", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{}
+		result := r.makeDesiredNamespaces(release, []*unstructured.Unstructured{
+			makeObjInNamespace(""),
+			makeObjInNamespace(""),
+		})
+		if len(result) != 0 {
+			t.Errorf("expected 0 (cluster-scoped resources skipped), got %d", len(result))
+		}
+	})
+
+	t.Run("distinct namespaces are deduplicated", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{}
+		result := r.makeDesiredNamespaces(release, []*unstructured.Unstructured{
+			makeObjInNamespace("ns-a"),
+			makeObjInNamespace("ns-a"),
+			makeObjInNamespace("ns-b"),
+			makeObjInNamespace(""),
+		})
+		if len(result) != 2 {
+			t.Fatalf("expected 2 deduplicated namespaces, got %d", len(result))
+		}
+		names := map[string]bool{}
+		for _, ns := range result {
+			names[ns.Name] = true
+		}
+		if !names["ns-a"] || !names["ns-b"] {
+			t.Errorf("expected ns-a and ns-b, got %v", names)
+		}
+	})
+
+	t.Run("labels populated from the release", func(t *testing.T) {
+		release := &openchoreov1alpha1.RenderedRelease{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-release", Namespace: "cp-ns", UID: "uid-xyz"},
+			Spec: openchoreov1alpha1.RenderedReleaseSpec{
+				EnvironmentName: "dev",
+				Owner:           openchoreov1alpha1.RenderedReleaseOwner{ProjectName: "my-project"},
+			},
+		}
+		result := r.makeDesiredNamespaces(release, []*unstructured.Unstructured{makeObjInNamespace("op-ns")})
+		if len(result) != 1 {
+			t.Fatalf("expected 1, got %d", len(result))
+		}
+		ns := result[0]
+		if ns.Name != "op-ns" {
+			t.Errorf("expected namespace name op-ns, got %s", ns.Name)
+		}
+		checks := map[string]string{
+			labels.LabelKeyCreatedBy:                ControllerName,
+			labels.LabelKeyRenderedReleaseName:      "my-release",
+			labels.LabelKeyRenderedReleaseNamespace: "cp-ns",
+			labels.LabelKeyRenderedReleaseUID:       "uid-xyz",
+			labels.LabelKeyNamespaceName:            "cp-ns",
+			labels.LabelKeyEnvironmentName:          "dev",
+			labels.LabelKeyProjectName:              "my-project",
+		}
+		for key, want := range checks {
+			if got := ns.Labels[key]; got != want {
+				t.Errorf("label %s: expected %q, got %q", key, want, got)
+			}
+		}
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// ensureNamespaces
+// ─────────────────────────────────────────────────────────────
+
+func TestEnsureNamespaces(t *testing.T) {
+	ctx := context.Background()
+	r := &Reconciler{}
+
+	makeNamespace := func(name string) *corev1.Namespace {
+		return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+
+	t.Run("creates namespace that does not exist", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		if err := r.ensureNamespaces(ctx, cl, []*corev1.Namespace{makeNamespace("new-ns")}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &corev1.Namespace{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: "new-ns"}, got); err != nil {
+			t.Errorf("expected namespace to be created: %v", err)
+		}
+	})
+
+	t.Run("is idempotent when namespace already exists", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithObjects(makeNamespace("existing-ns")).Build()
+		if err := r.ensureNamespaces(ctx, cl, []*corev1.Namespace{makeNamespace("existing-ns")}); err != nil {
+			t.Fatalf("unexpected error for existing namespace: %v", err)
+		}
+	})
+
+	t.Run("empty list is a no-op", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		if err := r.ensureNamespaces(ctx, cl, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Purpose

OP-targeted `RenderedRelease`s no longer have their target namespace created, so applying a namespaced resource (e.g. the `ObservabilityAlertRule`) failing from the changes introduced in https://github.com/openchoreo/openchoreo/pull/3762.

Previously, the controller ensured namespaces for every target plane. The project release work removed those helpers because the data plane's cell namespace is now owned by the `ProjectReleaseBinding`. That fix was correct for the DP, but it also dropped namespace creation on the observability plane, where nothing else creates it.

This PR restores namespace creation **scoped to the observability-plane path only**, leaving the data-plane apply path binding-owned. It is an interim fix; the broader fixed-namespace model is tracked separately and needs community discussion.

**Note: this might be a temporary change, until we properly decide on where the ownership of the observability plane's namespace goes.** 

## Approach

- Restore `makeDesiredNamespaces` and `ensureNamespaces` (idempotent get-then-create, tolerating `IsNotFound`/`IsAlreadyExists`)
- Gate the call to the observability-plane path only, between building desired resources and applying them
- Keep the data-plane apply path free of implicit namespace creation; the cell namespace stays owned by the `ProjectReleaseBinding`
- Add unit tests for both helpers and OP/DP scope integration tests (OP creates the namespace and applies; DP does not create it)

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)