### PR TITLE
chore: use Gateway API standard channel for kgateway

### DIFF
--- a/install/k3d/k3d-prerequisites.sh
+++ b/install/k3d/k3d-prerequisites.sh
@@ -31,7 +31,7 @@ step() {
 
 step "Installing Gateway API CRDs ($GATEWAY_API_VERSION)..."
 kubectl apply --server-side \
-    -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml"
+    -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
 
 step "Installing cert-manager ($CERT_MANAGER_VERSION)..."
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
@@ -57,8 +57,7 @@ helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/k
 step "Installing kgateway ($KGATEWAY_VERSION)..."
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
     --namespace "$CONTROL_PLANE_NS" --create-namespace \
-    --version "$KGATEWAY_VERSION" \
-    --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+    --version "$KGATEWAY_VERSION"
 
 step "Installing OpenBao ($OPENBAO_CHART_VERSION)..."
 helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -43,7 +43,7 @@ k3d cluster create --config install/k3d/multi-cluster/config-cp.yaml
 ```bash
 # Gateway API CRDs
 kubectl apply --context k3d-openchoreo-cp --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 # cert-manager
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
@@ -63,8 +63,7 @@ helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/k
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace --kube-context k3d-openchoreo-cp \
-  --version v2.3.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 ```
 
 ### Thunder (Identity Provider)
@@ -135,7 +134,7 @@ docker exec k3d-openchoreo-dp-server-0 sh -c \
 ```bash
 # Gateway API CRDs
 kubectl apply --context k3d-openchoreo-dp --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 # cert-manager
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
@@ -166,8 +165,7 @@ helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/k
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-data-plane --create-namespace --kube-context k3d-openchoreo-dp \
-  --version v2.3.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 ```
 
 ### CoreDNS Rewrite and Certificates
@@ -406,7 +404,7 @@ docker exec k3d-openchoreo-op-server-0 sh -c \
 ```bash
 # Gateway API CRDs
 kubectl apply --context k3d-openchoreo-op --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 # kgateway
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
@@ -415,8 +413,7 @@ helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/k
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-observability-plane --create-namespace --kube-context k3d-openchoreo-op \
-  --version v2.3.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 
 # cert-manager
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -29,7 +29,7 @@ docker exec k3d-openchoreo-server-0 sh -c \
 
 ```bash
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 ### cert-manager
@@ -73,8 +73,7 @@ helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/k
 
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace \
-  --version v2.3.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 ```
 
 ## 3. Setup Control Plane

--- a/install/quick-start/.helpers.sh
+++ b/install/quick-start/.helpers.sh
@@ -567,7 +567,7 @@ install_eso() {
 install_gateway_crds() {
     log_info "Installing Gateway API CRDs..."
     kubectl apply --server-side \
-        -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml >/dev/null
+        -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml >/dev/null
     log_success "Gateway API CRDs installed"
 }
 
@@ -581,8 +581,7 @@ install_kgateway() {
         "--version" "$KGATEWAY_VERSION"
 
     install_helm_chart "kgateway" "$chart_ref/kgateway" "$CONTROL_PLANE_NS" "true" "false" "false" "300" \
-        "--version" "$KGATEWAY_VERSION" \
-        "--set" "controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true"
+        "--version" "$KGATEWAY_VERSION"
 
     log_success "kgateway installed"
 }

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -88,10 +88,10 @@ E2E_WP_NS              := openchoreo-workflow-plane
 E2E_OP_NS              := openchoreo-observability-plane
 
 # Dependency versions (keep in sync with install/k3d/single-cluster/README.md)
-GATEWAY_API_VERSION    ?= v1.4.1
+GATEWAY_API_VERSION    ?= v1.5.1
 CERT_MANAGER_VERSION   ?= v1.19.4
 ESO_VERSION            ?= 2.0.1
-KGATEWAY_VERSION       ?= v2.2.1
+KGATEWAY_VERSION       ?= v2.3.1
 OPENBAO_CHART_VERSION  ?= 0.25.6
 THUNDER_VERSION        ?= 0.28.0
 DEX_VERSION            ?= 0.24.1
@@ -366,7 +366,7 @@ e2e.setup-cluster: ## Create k3d cluster
 e2e.setup-prerequisites: ## Install Gateway API, cert-manager, ESO, kgateway
 	@$(call log_info, Installing Gateway API CRDs $(GATEWAY_API_VERSION))
 	$(E2E_KUBECTL) apply --server-side \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
 	@$(call log_info, Installing cert-manager $(CERT_MANAGER_VERSION))
 	$(E2E_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
 		--namespace cert-manager --create-namespace \
@@ -756,7 +756,7 @@ e2e.multi.setup-clusters: ## Create all four k3d clusters (CP, DP, WP, OP)
 e2e.multi.setup-prerequisites: ## Install prerequisites into each cluster
 	@$(call log_info, === CP cluster prerequisites ===)
 	$(E2E_MC_CP_KUBECTL) apply --server-side \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
 	$(E2E_MC_CP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
 		--namespace cert-manager --create-namespace \
 		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
@@ -774,7 +774,7 @@ e2e.multi.setup-prerequisites: ## Install prerequisites into each cluster
 	$(E2E_MC_CP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/secretstore.yaml
 	@$(call log_info, === DP cluster prerequisites ===)
 	$(E2E_MC_DP_KUBECTL) apply --server-side \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
 	$(E2E_MC_DP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
 		--namespace cert-manager --create-namespace \
 		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \
@@ -804,7 +804,7 @@ e2e.multi.setup-prerequisites: ## Install prerequisites into each cluster
 	$(E2E_MC_WP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/secretstore.yaml
 	@$(call log_info, === OP cluster prerequisites ===)
 	$(E2E_MC_OP_KUBECTL) apply --server-side \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
 	$(E2E_MC_OP_HELM) upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
 		--namespace cert-manager --create-namespace \
 		--version $(CERT_MANAGER_VERSION) --set crds.enabled=true \


### PR DESCRIPTION
## Purpose
Switch all Gateway API CRD installs from the experimental to the standard channel and remove the KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES kgateway flag. TLSRoute graduated to the standard channel in Gateway API 1.5 (already pinned at v1.5.1 / kgateway v2.3.1), so neither the experimental channel nor the flag is required.

Also bump the e2e to v1.5.1 / v2.3.1 to match the install guides and move it to the standard channel

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3836

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
