### PR TITLE
test: set required spec.type on UI e2e Project fixtures

### DIFF
--- a/test/ui/specs/abac-ui/abac-env-restriction.spec.ts
+++ b/test/ui/specs/abac-ui/abac-env-restriction.spec.ts
@@ -55,6 +55,9 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterAuthzRole

--- a/test/ui/specs/catalog/catalog-sync.spec.ts
+++ b/test/ui/specs/catalog/catalog-sync.spec.ts
@@ -26,6 +26,9 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component

--- a/test/ui/specs/dev-ops/dev-ops-component.spec.ts
+++ b/test/ui/specs/dev-ops/dev-ops-component.spec.ts
@@ -29,6 +29,9 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default
 `;
 
 test.describe.configure({ mode: 'serial' });

--- a/test/ui/specs/observability/observability-panels.spec.ts
+++ b/test/ui/specs/observability/observability-panels.spec.ts
@@ -72,6 +72,9 @@ metadata:
 spec:
   deploymentPipelineRef:
     name: default
+  type:
+    kind: ClusterProjectType
+    name: default
 `;
 
 const postgresYAML = `


### PR DESCRIPTION
## Purpose

Add missing projectTypeRef to the project specs in e2e tests

## Approach

- Add `spec.type` (default `ClusterProjectType`) to the Project fixtures in the four UI specs that apply a Project via kubectl: `abac-ui`, `catalog`, `dev-ops`, `observability`.

## Related Issues

https://github.com/openchoreo/openchoreo/issues/3736

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)