### PR TITLE
fix: use TLSRoute v1 from Gateway API standard channel

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/tlsroute.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/tlsroute.yaml
@@ -2,7 +2,7 @@
 ---
 # TLSRoute for TLS passthrough
 # Required for end-to-end mTLS with cluster agents
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-tls

--- a/internal/controller/releasebinding/endpoint_resolve_test.go
+++ b/internal/controller/releasebinding/endpoint_resolve_test.go
@@ -153,7 +153,7 @@ func makeTLSRouteJSON(opts tlsRouteOpts) []byte {
 	}
 
 	route := map[string]interface{}{
-		"apiVersion": "gateway.networking.k8s.io/v1alpha2",
+		"apiVersion": "gateway.networking.k8s.io/v1",
 		"kind":       "TLSRoute",
 		"metadata":   metadata,
 	}

--- a/internal/pipeline/component/trait/processor_test.go
+++ b/internal/pipeline/component/trait/processor_test.go
@@ -2170,7 +2170,7 @@ func TestApplyTraitRemoves(t *testing.T) {
   kind: Service
   metadata:
     name: app-svc
-- apiVersion: gateway.networking.k8s.io/v1alpha2
+- apiVersion: gateway.networking.k8s.io/v1
   kind: TLSRoute
   metadata:
     name: app-tls-route
@@ -2203,7 +2203,7 @@ spec:
   kind: Service
   metadata:
     name: app-svc
-- apiVersion: gateway.networking.k8s.io/v1alpha2
+- apiVersion: gateway.networking.k8s.io/v1
   kind: TLSRoute
   metadata:
     name: app-tls-route
@@ -2687,7 +2687,7 @@ metadata:
 spec:
   creates:
     - template:
-        apiVersion: gateway.networking.k8s.io/v1alpha2
+        apiVersion: gateway.networking.k8s.io/v1
         kind: TLSRoute
         metadata:
           name: app-tls-route
@@ -2721,7 +2721,7 @@ spec:
     name: app-svc
     labels:
       tls-mode: passthrough
-- apiVersion: gateway.networking.k8s.io/v1alpha2
+- apiVersion: gateway.networking.k8s.io/v1
   kind: TLSRoute
   metadata:
     name: app-tls-route

--- a/samples/component-types/component-tls-service/tls-service-component.yaml
+++ b/samples/component-types/component-tls-service/tls-service-component.yaml
@@ -90,7 +90,7 @@ spec:
       forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility, ep)}'
       var: endpoint
       template:
-        apiVersion: gateway.networking.k8s.io/v1alpha2
+        apiVersion: gateway.networking.k8s.io/v1
         kind: TLSRoute
         metadata:
           name: ${oc_generate_name(metadata.componentName, endpoint.key)}

--- a/test/e2e/k3d/multi-cluster/opensearch-tls-route.yaml
+++ b/test/e2e/k3d/multi-cluster/opensearch-tls-route.yaml
@@ -8,7 +8,7 @@
 # does not support OPENSEARCH_INITIAL_ADMIN_PASSWORD injection for 3.x), so
 # we apply it manually. The template mirrors the chart's
 # opensearch-cluster/tls-route.yaml exactly.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: opensearch


### PR DESCRIPTION
## Purpose

Follow-up to #3883, which switched all Gateway API CRD installs from the experimental to the standard channel. In Gateway API v1.5 (now pinned at v1.5.1), the `TLSRoute` CRD serves `gateway.networking.k8s.io/v1`. Our chart templates and samples still emitted `v1alpha2`, so on a standard-channel cluster the API server rejects them:

```
no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1alpha2"
```

## Approach

This PR bumps every TLSRoute we emit from `v1alpha2` to `v1`:
  - `install/helm/openchoreo-control-plane/templates/cluster-gateway/tlsroute.yaml` (the actual fix)
  - `samples/component-types/component-tls-service/tls-service-component.yaml`
  - `test/e2e/k3d/multi-cluster/opensearch-tls-route.yaml`
  - unit-test fixtures in `internal/pipeline/component/trait` and `internal/controller/releasebinding`

## Related Issues
Follow-up to #3883 (https://github.com/openchoreo/openchoreo/issues/3836)

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
The multi-cluster Tier 3 e2e installs from the **published** `0.0.0-latest-dev` OCI chart (`E2E_HELM_SOURCE=oci`), not branch source, so the gate only goes green once this lands on upstream `main` and the dev chart is republished.
