### PR TITLE
feat(controller): implement ProjectReleaseBinding deletion handling

### DIFF
--- a/internal/controller/environment/controller_finalize.go
+++ b/internal/controller/environment/controller_finalize.go
@@ -42,7 +42,7 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, environment *openchore
 // finalize cleans up the resources associated with the environment.
 // The finalization flow is:
 //  1. Check if the environment is referenced by any DeploymentPipeline — if so, block deletion.
-//  2. Wait for all ReleaseBindings that reference this environment to be gone.
+//  2. Wait for all ReleaseBindings and ProjectReleaseBindings that reference this environment to be gone.
 //  3. Delete the data plane namespaces associated with the environment.
 //  4. Wait for namespace deletion to complete.
 //  5. Remove the finalizer to allow garbage collection.
@@ -77,11 +77,20 @@ func (r *Reconciler) finalize(ctx context.Context, old, environment *openchoreov
 		return ctrl.Result{}, nil
 	}
 
-	// Step 2: Delete all release bindings referencing this environment and wait for them to be gone.
-	pendingCount, err := r.deleteAndCountReleaseBindings(ctx, environment)
+	// Step 2: Delete all bindings referencing this environment and wait for them to be gone.
+	// Each binding owns a RenderedRelease whose own finalizer resolves the data-plane
+	// client through this Environment; the Environment must outlive them, or the
+	// RenderedRelease finalizer strands on a missing Environment and the namespace
+	// never finishes terminating.
+	pendingReleaseBindings, err := r.deleteAndCountReleaseBindings(ctx, environment)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	pendingProjectReleaseBindings, err := r.deleteAndCountProjectReleaseBindings(ctx, environment)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	pendingCount := pendingReleaseBindings + pendingProjectReleaseBindings
 	if pendingCount > 0 {
 		msg := fmt.Sprintf("Deleting %d release binding(s)", pendingCount)
 		logger.Info(msg)
@@ -244,6 +253,32 @@ func (r *Reconciler) deleteAndCountReleaseBindings(ctx context.Context, environm
 		if rb.DeletionTimestamp.IsZero() {
 			if err := r.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
 				return 0, fmt.Errorf("failed to delete release binding %s: %w", rb.Name, err)
+			}
+		}
+	}
+
+	return count, nil
+}
+
+// deleteAndCountProjectReleaseBindings deletes all project release bindings that
+// reference this environment and returns the count of those still present
+// (pending deletion or not yet deleted).
+func (r *Reconciler) deleteAndCountProjectReleaseBindings(ctx context.Context, environment *openchoreov1alpha1.Environment) (int, error) {
+	bindingList := &openchoreov1alpha1.ProjectReleaseBindingList{}
+	if err := r.List(ctx, bindingList, client.InNamespace(environment.Namespace)); err != nil {
+		return 0, fmt.Errorf("failed to list project release bindings: %w", err)
+	}
+
+	count := 0
+	for i := range bindingList.Items {
+		binding := &bindingList.Items[i]
+		if binding.Spec.Environment != environment.Name {
+			continue
+		}
+		count++
+		if binding.DeletionTimestamp.IsZero() {
+			if err := r.Delete(ctx, binding); err != nil && !apierrors.IsNotFound(err) {
+				return 0, fmt.Errorf("failed to delete project release binding %s: %w", binding.Name, err)
 			}
 		}
 	}

--- a/internal/controller/environment/controller_finalize_unit_test.go
+++ b/internal/controller/environment/controller_finalize_unit_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package environment
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+// prbTestScheme builds a scheme registered with the OpenChoreo API types. These
+// fake-client unit tests run alongside the envtest Ginkgo suite, so they must
+// not rely on the suite's BeforeSuite having registered the global scheme.
+func prbTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add openchoreo scheme: %v", err)
+	}
+	return s
+}
+
+func newPRBForEnv(name, env string, deleting bool) *openchoreov1alpha1.ProjectReleaseBinding {
+	prb := &openchoreov1alpha1.ProjectReleaseBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: "p"},
+			Environment: env,
+		},
+	}
+	if deleting {
+		now := metav1.Now()
+		prb.DeletionTimestamp = &now
+		prb.Finalizers = []string{"openchoreo.dev/projectreleasebinding-cleanup"}
+	}
+	return prb
+}
+
+func TestDeleteAndCountProjectReleaseBindings(t *testing.T) {
+	s := prbTestScheme(t)
+	env := &openchoreov1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "ns"}}
+
+	t.Run("counts matching bindings and leaves other environments untouched", func(t *testing.T) {
+		match1 := newPRBForEnv("m1", "dev", false)
+		match2 := newPRBForEnv("m2", "dev", false)
+		other := newPRBForEnv("other", "prod", false)
+		cli := fake.NewClientBuilder().WithScheme(s).WithObjects(match1, match2, other).Build()
+		r := &Reconciler{Client: cli, Scheme: s}
+
+		count, err := r.deleteAndCountProjectReleaseBindings(context.Background(), env)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("expected count 2, got %d", count)
+		}
+
+		got := &openchoreov1alpha1.ProjectReleaseBinding{}
+		if err := cli.Get(context.Background(), client.ObjectKey{Name: "other", Namespace: "ns"}, got); err != nil {
+			t.Fatalf("other-environment binding should remain: %v", err)
+		}
+		if got.DeletionTimestamp != nil {
+			t.Fatal("other-environment binding should not be marked for deletion")
+		}
+	})
+
+	t.Run("counts an already-deleting binding without re-deleting it", func(t *testing.T) {
+		deleting := newPRBForEnv("d1", "dev", true)
+		cli := fake.NewClientBuilder().WithScheme(s).WithObjects(deleting).Build()
+		r := &Reconciler{Client: cli, Scheme: s}
+
+		count, err := r.deleteAndCountProjectReleaseBindings(context.Background(), env)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("expected count 1, got %d", count)
+		}
+	})
+
+	t.Run("returns an error when listing bindings fails", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(s).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*openchoreov1alpha1.ProjectReleaseBindingList); ok {
+						return errors.New("simulated list error")
+					}
+					return c.List(ctx, list, opts...)
+				},
+			}).Build()
+		r := &Reconciler{Client: cli, Scheme: s}
+
+		if _, err := r.deleteAndCountProjectReleaseBindings(context.Background(), env); err == nil {
+			t.Fatal("expected error when listing project release bindings fails")
+		}
+	})
+
+	t.Run("returns an error when deleting a binding fails", func(t *testing.T) {
+		match := newPRBForEnv("m1", "dev", false)
+		cli := fake.NewClientBuilder().WithScheme(s).WithObjects(match).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*openchoreov1alpha1.ProjectReleaseBinding); ok {
+						return errors.New("simulated delete error")
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).Build()
+		r := &Reconciler{Client: cli, Scheme: s}
+
+		if _, err := r.deleteAndCountProjectReleaseBindings(context.Background(), env); err == nil {
+			t.Fatal("expected error when deleting a project release binding fails")
+		}
+	})
+}
+
+// TestFinalizePropagatesProjectReleaseBindingListError verifies that a failure
+// listing ProjectReleaseBindings during environment finalization surfaces as an
+// error (so the reconcile requeues) rather than letting the environment proceed
+// to removal while bindings may still exist.
+func TestFinalizePropagatesProjectReleaseBindingListError(t *testing.T) {
+	s := prbTestScheme(t)
+	env := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "dev",
+			Namespace:  "ns",
+			Finalizers: []string{EnvCleanupFinalizer},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(env).
+		WithStatusSubresource(&openchoreov1alpha1.Environment{}).
+		WithIndex(&openchoreov1alpha1.DeploymentPipeline{}, controller.IndexKeyDeploymentPipelineEnvironmentRef,
+			func(client.Object) []string { return nil }).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*openchoreov1alpha1.ProjectReleaseBindingList); ok {
+					return errors.New("simulated list error")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+	r := &Reconciler{Client: cli, Scheme: s}
+
+	ctx := context.Background()
+	if err := cli.Delete(ctx, env); err != nil {
+		t.Fatalf("delete env: %v", err)
+	}
+	live := &openchoreov1alpha1.Environment{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: "dev", Namespace: "ns"}, live); err != nil {
+		t.Fatalf("get env: %v", err)
+	}
+
+	// First finalize sets the Finalizing condition and returns; the second
+	// proceeds to the binding-deletion step, where the ProjectReleaseBinding
+	// list fails and the error must propagate.
+	if _, err := r.finalize(ctx, live.DeepCopy(), live); err != nil {
+		t.Fatalf("first finalize: %v", err)
+	}
+	if _, err := r.finalize(ctx, live.DeepCopy(), live); err == nil {
+		t.Fatal("expected error from ProjectReleaseBinding list failure during finalize")
+	}
+}

--- a/internal/controller/environment/controller_integration_test.go
+++ b/internal/controller/environment/controller_integration_test.go
@@ -857,6 +857,187 @@ var _ = Describe("Environment Controller", func() {
 				Expect(rb.DeletionTimestamp).To(BeNil())
 			})
 		})
+
+		Context("waiting for project release bindings during finalization", func() {
+			var nn types.NamespacedName
+			var prbNN types.NamespacedName
+
+			BeforeEach(func() {
+				nn = types.NamespacedName{Namespace: ns, Name: "env-prb-cleanup"}
+				env := &openchoreov1alpha1.Environment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       nn.Name,
+						Namespace:  ns,
+						Finalizers: []string{EnvCleanupFinalizer},
+					},
+					Spec: openchoreov1alpha1.EnvironmentSpec{IsProduction: false},
+				}
+				Expect(k8sClient.Create(ctx, env)).To(Succeed())
+
+				prbNN = types.NamespacedName{Namespace: ns, Name: "prb-for-env-cleanup"}
+				prb := &openchoreov1alpha1.ProjectReleaseBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       prbNN.Name,
+						Namespace:  ns,
+						Finalizers: []string{"openchoreo.dev/projectreleasebinding-cleanup"},
+					},
+					Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+						Owner: openchoreov1alpha1.ProjectReleaseBindingOwner{
+							ProjectName: "test-project",
+						},
+						Environment: nn.Name,
+					},
+				}
+				Expect(k8sClient.Create(ctx, prb)).To(Succeed())
+
+				Expect(k8sClient.Delete(ctx, env)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				forceDeleteEnv(nn)
+				// Clean up ProjectReleaseBinding if it still exists
+				prb := &openchoreov1alpha1.ProjectReleaseBinding{}
+				if err := k8sClient.Get(ctx, prbNN, prb); err == nil {
+					controllerutil.RemoveFinalizer(prb, "openchoreo.dev/projectreleasebinding-cleanup")
+					_ = k8sClient.Update(ctx, prb)
+					_ = k8sClient.Delete(ctx, prb)
+				}
+			})
+
+			It("should delete project release bindings and requeue while they are still present", func() {
+				r := newTestReconciler()
+
+				By("first reconcile — sets Finalizing condition")
+				result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+
+				By("second reconcile — deletes project release binding and requeues")
+				result, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+				By("verifying the project release binding is being deleted")
+				// Eventually rather than a single Get+expect: on slow CI runners
+				// the envtest apiserver can race the test, returning the prb's
+				// pre-delete state in the ~ms after r.Delete() resolved.
+				prb := &openchoreov1alpha1.ProjectReleaseBinding{}
+				Eventually(func() *metav1.Time {
+					if err := k8sClient.Get(ctx, prbNN, prb); err != nil {
+						return nil
+					}
+					return prb.DeletionTimestamp
+				}, "5s", "100ms").ShouldNot(BeNil())
+
+				By("verifying the ReleaseBindingsPending condition is set")
+				env := &openchoreov1alpha1.Environment{}
+				Expect(k8sClient.Get(ctx, nn, env)).To(Succeed())
+				cond := apimeta.FindStatusCondition(env.Status.Conditions, ConditionReady.String())
+				Expect(cond).NotTo(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal(string(ReasonReleaseBindingsPending)))
+			})
+
+			It("should proceed with finalization after project release bindings are deleted", func() {
+				r := newTestReconciler()
+
+				By("first reconcile — sets Finalizing condition")
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("second reconcile — deletes the project release binding and requeues")
+				result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+				By("simulating ProjectReleaseBinding controller: removing finalizer so deletion completes")
+				prb := &openchoreov1alpha1.ProjectReleaseBinding{}
+				Eventually(func() *metav1.Time {
+					if err := k8sClient.Get(ctx, prbNN, prb); err != nil {
+						return nil
+					}
+					return prb.DeletionTimestamp
+				}, "5s", "100ms").ShouldNot(BeNil())
+				controllerutil.RemoveFinalizer(prb, "openchoreo.dev/projectreleasebinding-cleanup")
+				Expect(k8sClient.Update(ctx, prb)).To(Succeed())
+				Eventually(func() bool {
+					return apierrors.IsNotFound(k8sClient.Get(ctx, prbNN, &openchoreov1alpha1.ProjectReleaseBinding{}))
+				}, "5s", "100ms").Should(BeTrue())
+
+				By("third reconcile — no bindings, Finalizing guard passes, proceeds to namespace cleanup")
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("fourth reconcile — proceeds to namespace cleanup (DataPlane not found, removes finalizer)")
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("verifying the environment is gone")
+				Eventually(func() bool {
+					return apierrors.IsNotFound(k8sClient.Get(ctx, nn, &openchoreov1alpha1.Environment{}))
+				}, "5s", "100ms").Should(BeTrue())
+			})
+		})
+
+		Context("project release bindings for other environments are not deleted", func() {
+			var nn types.NamespacedName
+			var otherPRBNN types.NamespacedName
+
+			BeforeEach(func() {
+				nn = types.NamespacedName{Namespace: ns, Name: "env-prb-isolation"}
+				env := &openchoreov1alpha1.Environment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       nn.Name,
+						Namespace:  ns,
+						Finalizers: []string{EnvCleanupFinalizer},
+					},
+					Spec: openchoreov1alpha1.EnvironmentSpec{IsProduction: false},
+				}
+				Expect(k8sClient.Create(ctx, env)).To(Succeed())
+
+				// ProjectReleaseBinding for a DIFFERENT environment
+				otherPRBNN = types.NamespacedName{Namespace: ns, Name: "prb-other-env"}
+				prb := &openchoreov1alpha1.ProjectReleaseBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      otherPRBNN.Name,
+						Namespace: ns,
+					},
+					Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+						Owner: openchoreov1alpha1.ProjectReleaseBindingOwner{
+							ProjectName: "test-project",
+						},
+						Environment: "some-other-environment",
+					},
+				}
+				Expect(k8sClient.Create(ctx, prb)).To(Succeed())
+
+				Expect(k8sClient.Delete(ctx, env)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				forceDeleteEnv(nn)
+				_ = k8sClient.Delete(ctx, &openchoreov1alpha1.ProjectReleaseBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: otherPRBNN.Name, Namespace: ns},
+				})
+			})
+
+			It("should not delete project release bindings belonging to other environments", func() {
+				r := newTestReconciler()
+
+				By("first reconcile — sets Finalizing condition")
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("second reconcile — no matching bindings, proceeds to namespace cleanup")
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("verifying the other environment's project release binding is untouched")
+				prb := &openchoreov1alpha1.ProjectReleaseBinding{}
+				Expect(k8sClient.Get(ctx, otherPRBNN, prb)).To(Succeed())
+				Expect(prb.DeletionTimestamp).To(BeNil())
+			})
+		})
 	})
 
 	// -------------------------------------------------------------------------

--- a/internal/controller/projectreleasebinding/controller.go
+++ b/internal/controller/projectreleasebinding/controller.go
@@ -58,10 +58,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Finalizer / deletion handling lands in a later Phase 4 commit. For now
-	// treat a deleting binding as a no-op.
+	old := binding.DeepCopy()
+
+	// Under deletion: run the cleanup finalizer so the owned RenderedRelease is
+	// torn down (and its data-plane resources cleaned up via the still-present
+	// Environment) before the binding is garbage collected.
 	if !binding.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, nil
+		return r.finalize(ctx, old, binding)
+	}
+
+	// Ensure the cleanup finalizer is present before reconciling so deletion is
+	// always gated on RenderedRelease teardown.
+	if added, err := r.ensureFinalizer(ctx, binding); err != nil || added {
+		return ctrl.Result{}, err
 	}
 
 	return r.reconcile(ctx, binding)

--- a/internal/controller/projectreleasebinding/controller_conditions.go
+++ b/internal/controller/projectreleasebinding/controller_conditions.go
@@ -4,6 +4,8 @@
 package projectreleasebinding
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openchoreo/openchoreo/internal/controller"
 )
 
@@ -30,6 +32,9 @@ const (
 
 	// ConditionReady aggregates Synced, NamespaceReady, and ResourcesReady.
 	ConditionReady controller.ConditionType = "Ready"
+
+	// ConditionFinalizing indicates the binding is being finalized (deleted).
+	ConditionFinalizing controller.ConditionType = "Finalizing"
 )
 
 // Condition reasons.
@@ -128,4 +133,19 @@ const (
 	// upstream validation breaks (snapshot deleted, environment removed,
 	// render now failing), giving a misleading status.
 	ReasonSyncedNotReady controller.ConditionReason = "SyncedNotReady"
+
+	// ReasonFinalizing indicates the binding is being finalized.
+	ReasonFinalizing controller.ConditionReason = "Finalizing"
 )
+
+// NewFinalizingCondition returns a Finalizing=True condition observed at the
+// given generation, used while the binding is being torn down.
+func NewFinalizingCondition(generation int64) metav1.Condition {
+	return controller.NewCondition(
+		ConditionFinalizing,
+		metav1.ConditionTrue,
+		ReasonFinalizing,
+		"ProjectReleaseBinding is finalizing",
+		generation,
+	)
+}

--- a/internal/controller/projectreleasebinding/controller_finalize.go
+++ b/internal/controller/projectreleasebinding/controller_finalize.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package projectreleasebinding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+const (
+	// ProjectReleaseBindingFinalizer gates deletion of the binding on cleanup
+	// of its owned RenderedRelease. The binding must outlive its RenderedRelease
+	// so the RenderedRelease finalizer can resolve the data-plane client through
+	// the (still-present) Environment during its own teardown.
+	ProjectReleaseBindingFinalizer = "openchoreo.dev/projectreleasebinding-cleanup"
+
+	// requeueWaitForChild is how long we wait between reconciles while the
+	// owned RenderedRelease is being torn down.
+	requeueWaitForChild = 5 * time.Second
+)
+
+// ensureFinalizer adds the projectreleasebinding-cleanup finalizer when
+// missing. The first return value indicates whether the finalizer was just
+// added (caller should requeue to pick up the change).
+func (r *Reconciler) ensureFinalizer(ctx context.Context, binding *openchoreov1alpha1.ProjectReleaseBinding) (bool, error) {
+	if !binding.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+	if controllerutil.AddFinalizer(binding, ProjectReleaseBindingFinalizer) {
+		return true, r.Update(ctx, binding)
+	}
+	return false, nil
+}
+
+// finalize handles the deletion path. The flow:
+//
+//  1. Set the Finalizing condition the first time we observe deletion so the
+//     status surfaces "deletion in progress" and exit (status update
+//     re-enqueues).
+//  2. Cascade-delete the owned RenderedRelease and requeue while it still
+//     exists.
+//  3. Once the RenderedRelease is gone, remove the finalizer; K8s GCs the
+//     binding.
+func (r *Reconciler) finalize(ctx context.Context, old, binding *openchoreov1alpha1.ProjectReleaseBinding) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("binding", binding.Name)
+
+	if !controllerutil.ContainsFinalizer(binding, ProjectReleaseBindingFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	if meta.SetStatusCondition(&binding.Status.Conditions, NewFinalizingCondition(binding.Generation)) {
+		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, binding)
+	}
+
+	rrName := makeRenderedReleaseName(binding)
+	rr := &openchoreov1alpha1.RenderedRelease{}
+	err := r.Get(ctx, types.NamespacedName{Name: rrName, Namespace: binding.Namespace}, rr)
+	switch {
+	case err == nil:
+		if rr.DeletionTimestamp.IsZero() {
+			if delErr := r.Delete(ctx, rr); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return ctrl.Result{}, fmt.Errorf("delete RenderedRelease %q: %w", rrName, delErr)
+			}
+			logger.Info("Cascaded RenderedRelease delete", "renderedRelease", rrName)
+		}
+		return ctrl.Result{RequeueAfter: requeueWaitForChild}, nil
+	case apierrors.IsNotFound(err):
+		// fall through: clear finalizer
+	default:
+		return ctrl.Result{}, fmt.Errorf("get RenderedRelease %q: %w", rrName, err)
+	}
+
+	if controllerutil.RemoveFinalizer(binding, ProjectReleaseBindingFinalizer) {
+		if err := r.Update(ctx, binding); err != nil {
+			return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
+		}
+	}
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/projectreleasebinding/controller_finalize_test.go
+++ b/internal/controller/projectreleasebinding/controller_finalize_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package projectreleasebinding
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	dpkubernetes "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
+)
+
+var _ = Describe("ProjectReleaseBinding controller — finalize", func() {
+	finCtx := context.Background()
+
+	newBinding := func(name string, withFinalizer bool) *openchoreov1alpha1.ProjectReleaseBinding {
+		om := metav1.ObjectMeta{Name: name, Namespace: "default"}
+		if withFinalizer {
+			om.Finalizers = []string{ProjectReleaseBindingFinalizer}
+		}
+		return &openchoreov1alpha1.ProjectReleaseBinding{
+			ObjectMeta: om,
+			Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+				Owner: openchoreov1alpha1.ProjectReleaseBindingOwner{
+					ProjectName: "p",
+				},
+				Environment:    "dev",
+				ProjectRelease: name + "-release",
+			},
+		}
+	}
+
+	// newRenderedRelease produces an RR with the same name the controller
+	// derives from {ProjectName=p, Environment=dev} via makeRenderedReleaseName,
+	// which is what every binding in this suite uses.
+	newRenderedRelease := func() *openchoreov1alpha1.RenderedRelease {
+		return &openchoreov1alpha1.RenderedRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dpkubernetes.GenerateK8sName("p_p", "dev"),
+				Namespace: "default",
+			},
+			Spec: openchoreov1alpha1.RenderedReleaseSpec{
+				Owner: openchoreov1alpha1.RenderedReleaseOwner{
+					ProjectName: "p",
+				},
+				EnvironmentName: "dev",
+				TargetPlane:     openchoreov1alpha1.TargetPlaneDataPlane,
+			},
+		}
+	}
+
+	buildClient := func(objs ...client.Object) client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(&openchoreov1alpha1.ProjectReleaseBinding{}).
+			Build()
+	}
+
+	newReconciler := func(cli client.Client) *Reconciler {
+		return &Reconciler{
+			Client: cli,
+			Scheme: scheme.Scheme,
+		}
+	}
+
+	It("cascades the RenderedRelease delete and clears the finalizer", func() {
+		b := newBinding("delete-binding", true)
+		rr := newRenderedRelease()
+		Expect(controllerutil.SetControllerReference(b, rr, scheme.Scheme)).To(Succeed())
+		cli := buildClient(b, rr)
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		// 1st reconcile: set Finalizing condition, return.
+		_, err := r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &openchoreov1alpha1.ProjectReleaseBinding{}
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(b), updated)).To(Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(ConditionFinalizing))
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+		// 2nd reconcile: cascade-delete the RR, requeue.
+		result, err := r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+		// 3rd reconcile: RR is gone, finalizer cleared, binding GC'd.
+		_, err = r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = cli.Get(finCtx, client.ObjectKeyFromObject(b), &openchoreov1alpha1.ProjectReleaseBinding{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "binding should be GC'd after finalizer is cleared")
+
+		err = cli.Get(finCtx, client.ObjectKeyFromObject(rr), &openchoreov1alpha1.RenderedRelease{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "RenderedRelease should be deleted")
+	})
+
+	It("clears the finalizer cleanly when the RenderedRelease is already absent", func() {
+		b := newBinding("no-rr-binding", true)
+		// No RenderedRelease in the fake client.
+		cli := buildClient(b)
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		// 1st: Finalizing condition. 2nd: RR not found, finalizer cleared.
+		_, err := r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = cli.Get(finCtx, client.ObjectKeyFromObject(b), &openchoreov1alpha1.ProjectReleaseBinding{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("is a no-op when the projectreleasebinding-cleanup finalizer is not present", func() {
+		// Post-cleanup state: binding has DeletionTimestamp, our finalizer
+		// is gone, but a stranger finalizer is still holding it open.
+		now := metav1.Now()
+		b := newBinding("noop-binding", false)
+		b.DeletionTimestamp = &now
+		b.Finalizers = []string{"other.example.com/protection"}
+
+		cli := buildClient()
+		r := newReconciler(cli)
+
+		result, err := r.finalize(finCtx, b.DeepCopy(), b)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+		Expect(meta.FindStatusCondition(b.Status.Conditions, string(ConditionFinalizing))).To(BeNil(),
+			"no Finalizing condition expected when our finalizer is absent")
+	})
+
+	It("ensureFinalizer is a no-op once the binding is being deleted", func() {
+		now := metav1.Now()
+		b := newBinding("ef-deleting", false)
+		b.DeletionTimestamp = &now
+		r := newReconciler(buildClient())
+
+		added, err := r.ensureFinalizer(finCtx, b)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(added).To(BeFalse())
+		Expect(b.Finalizers).NotTo(ContainElement(ProjectReleaseBindingFinalizer))
+	})
+
+	It("ensureFinalizer is a no-op when the finalizer is already present", func() {
+		b := newBinding("ef-present", true)
+		r := newReconciler(buildClient(b))
+
+		added, err := r.ensureFinalizer(finCtx, b)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(added).To(BeFalse())
+	})
+
+	It("requeues without re-deleting when the RenderedRelease is already terminating", func() {
+		b := newBinding("rr-terminating", true)
+		rr := newRenderedRelease()
+		// A residual finalizer keeps the RR around after Delete, so it lingers
+		// with a DeletionTimestamp — the state the binding should wait on.
+		rr.Finalizers = []string{"keep.example.com/hold"}
+		Expect(controllerutil.SetControllerReference(b, rr, scheme.Scheme)).To(Succeed())
+		cli := buildClient(b, rr)
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, rr)).To(Succeed())
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		_, err := r.Reconcile(finCtx, req) // 1st: Finalizing condition
+		Expect(err).NotTo(HaveOccurred())
+		result, err := r.Reconcile(finCtx, req) // 2nd: RR present + terminating → requeue
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(rr), &openchoreov1alpha1.RenderedRelease{})).To(Succeed())
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(b), &openchoreov1alpha1.ProjectReleaseBinding{})).To(Succeed(),
+			"binding finalizer should be retained while its RenderedRelease lingers")
+	})
+
+	It("propagates a transient error getting the RenderedRelease", func() {
+		b := newBinding("rr-get-err", true)
+		transientErr := errors.New("simulated transient API error")
+		cli := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(b).
+			WithStatusSubresource(&openchoreov1alpha1.ProjectReleaseBinding{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*openchoreov1alpha1.RenderedRelease); ok {
+						return transientErr
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			}).
+			Build()
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		_, err := r.Reconcile(finCtx, req) // 1st: Finalizing condition
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(finCtx, req) // 2nd: RR Get fails → error propagates
+		Expect(err).To(HaveOccurred())
+
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(b), &openchoreov1alpha1.ProjectReleaseBinding{})).To(Succeed(),
+			"binding finalizer must be retained when the RR lookup fails")
+	})
+
+	It("propagates an error deleting the RenderedRelease", func() {
+		b := newBinding("rr-del-err", true)
+		rr := newRenderedRelease()
+		Expect(controllerutil.SetControllerReference(b, rr, scheme.Scheme)).To(Succeed())
+		cli := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(b, rr).
+			WithStatusSubresource(&openchoreov1alpha1.ProjectReleaseBinding{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*openchoreov1alpha1.RenderedRelease); ok {
+						return errors.New("simulated delete error")
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		_, err := r.Reconcile(finCtx, req) // 1st: Finalizing condition
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(finCtx, req) // 2nd: RR Delete fails → error propagates
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("propagates an error removing the finalizer", func() {
+		b := newBinding("rmfin-err", true)
+		// No RenderedRelease → finalize falls through to the finalizer removal.
+		cli := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(b).
+			WithStatusSubresource(&openchoreov1alpha1.ProjectReleaseBinding{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if _, ok := obj.(*openchoreov1alpha1.ProjectReleaseBinding); ok {
+						return errors.New("simulated update error")
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		_, err := r.Reconcile(finCtx, req) // 1st: Finalizing condition (status update, not intercepted)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(finCtx, req) // 2nd: RR absent → remove finalizer Update fails
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Purpose

Implements the deletion / teardown path for `ProjectReleaseBinding` as part of the project-level release lifecycle. `ProjectReleaseBinding` deletion was previously a no-op — the finalizer was deferred during the initial controller implementation (#3736) — so deleting a project (or its namespace) left the owned `RenderedRelease` stranded and the namespace stuck in `Terminating`.

The project-level `RenderedRelease` carries a `dataplane-cleanup` finalizer that resolves its data-plane client via the `Environment` (Environment → DataPlane). During namespace deletion Kubernetes removes every resource concurrently, so the `Environment` — and the `ProjectReleaseBinding` that owns the `RenderedRelease` — can disappear before the `RenderedRelease` finishes finalizing, failing permanently with `Environment "<name>" not found`. This PR establishes the teardown ordering that prevents that.

## Approach

- Add a `openchoreo.dev/projectreleasebinding-cleanup` finalizer to `ProjectReleaseBinding`: on deletion it cascade-deletes the owned `RenderedRelease` and waits for it to be gone before the binding is garbage collected, mirroring `ReleaseBinding`/`ResourceReleaseBinding`. A `Finalizing` condition is surfaced while teardown is in progress.
- Extend the `Environment` finalizer to also delete and wait for `ProjectReleaseBindings` referencing the environment (alongside the existing `ReleaseBindings`), so the `Environment` outlives the `RenderedReleases` whose finalizers resolve the data-plane client through it.
- Add finalize unit tests for `ProjectReleaseBinding` and environment-finalizer integration tests (wait-for-binding and per-environment isolation).

## Related Issues

Closes #3907
Part of #3564

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
