### PR TITLE
feat(helm): make gatewayClassName configurable in control and observability planes

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  gatewayClassName: kgateway
+  gatewayClassName: {{ .Values.gateway.gatewayClassName | default "kgateway" }}
   {{- with .Values.gateway.infrastructure }}
   infrastructure:
     {{- toYaml . | nindent 4 }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2655,6 +2655,12 @@
           "title": "enabled",
           "type": "boolean"
         },
+        "gatewayClassName": {
+          "default": "kgateway",
+          "description": "GatewayClass name to reference in the Gateway CR",
+          "title": "gatewayClassName",
+          "type": "string"
+        },
         "httpPort": {
           "default": 80,
           "description": "HTTP listener port",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3698,6 +3698,13 @@ gateway:
   enabled: true
 
   # @schema
+  # type: string
+  # description: GatewayClass name to reference in the Gateway CR
+  # default: "kgateway"
+  # @schema
+  gatewayClassName: "kgateway"
+
+  # @schema
   # type: object
   # additionalProperties: true
   # description: |

--- a/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  gatewayClassName: kgateway
+  gatewayClassName: {{ .Values.gateway.gatewayClassName | default "kgateway" }}
   {{- with .Values.gateway.infrastructure }}
   infrastructure:
     {{- toYaml . | nindent 4 }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1152,6 +1152,12 @@
           "title": "enabled",
           "type": "boolean"
         },
+        "gatewayClassName": {
+          "default": "kgateway",
+          "description": "GatewayClass name to reference in the Gateway CR",
+          "title": "gatewayClassName",
+          "type": "string"
+        },
         "httpPort": {
           "default": 80,
           "description": "HTTP listener port",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -1084,6 +1084,13 @@ gateway:
   enabled: true
 
   # @schema
+  # type: string
+  # description: GatewayClass name to reference in the Gateway CR
+  # default: "kgateway"
+  # @schema
+  gatewayClassName: "kgateway"
+
+  # @schema
   # type: object
   # additionalProperties: true
   # description: |


### PR DESCRIPTION
## Purpose
Currently, only the `openchoreo-data-plane` Helm chart exposes a templated `gatewayClassName`, allowing users to swap the default `kgateway` implementation. The `openchoreo-control-plane` and `openchoreo-observability-plane` charts had hardcoded `gatewayClassName: kgateway`.
This PR makes gateways modular across the whole platform by supporting a templated `gatewayClassName` in the control plane and observability plane, enabling users to run OpenChoreo on top of a service mesh like Istio or with a CNI like Cilium.

## Approach
- Updated `templates/gateway/gateway.yaml` in both `openchoreo-control-plane` and `openchoreo-observability-plane` to template the `gatewayClassName` field with a fallback to `"kgateway"`.
- Added `gatewayClassName` property to `values.yaml` and `values.schema.json` for both planes.

## Related Issues
Fixes https://github.com/openchoreo/openchoreo/issues/3700

## Checklist
- [x] Tests added or updated (unit, integration, etc.) (N/A - Helm chart changes)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
N/A
