### PR TITLE
feat: watch project type CRDs in event-forwarder

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml
@@ -23,6 +23,7 @@ rules:
   - observabilityplanes
   - resources
   - resourcetypes
+  - projecttypes
   - clustercomponenttypes
   - clustertraits
   - clusterworkflows
@@ -30,6 +31,7 @@ rules:
   - clusterobservabilityplanes
   - clusterworkflowplanes
   - clusterresourcetypes
+  - clusterprojecttypes
   verbs:
   - get
   - list

--- a/internal/eventforwarder/forwarder.go
+++ b/internal/eventforwarder/forwarder.go
@@ -98,6 +98,7 @@ func gvrList() []schema.GroupVersionResource {
 		"observabilityplanes",
 		"resources",
 		"resourcetypes",
+		"projecttypes",
 		// Cluster-scoped
 		"clustercomponenttypes",
 		"clustertraits",
@@ -106,6 +107,7 @@ func gvrList() []schema.GroupVersionResource {
 		"clusterobservabilityplanes",
 		"clusterworkflowplanes",
 		"clusterresourcetypes",
+		"clusterprojecttypes",
 	}
 
 	gvrs := make([]schema.GroupVersionResource, 0, len(resources))


### PR DESCRIPTION
## Purpose

The `event-forwarder` watches OpenChoreo CRDs and forwards create/update/delete events to webhook endpoints — chiefly Backstage's catalog event plugin for near-real-time catalog sync. It did not yet watch the project-type CRDs (`ProjectType`, `ClusterProjectType`) introduced under the project release lifecycle epic, so Backstage discovered those entities only during periodic full-sync rather than through event propagation.

This adds `ProjectType` and `ClusterProjectType` to the watch list, mirroring the `ResourceType` / `ClusterResourceType` work in #3525. `ProjectRelease` and `ProjectReleaseBinding` are intentionally excluded, consistent with the existing convention of not forwarding release / runtime-infra kinds.

## Approach

- Add `projecttypes` and `clusterprojecttypes` to `gvrList()` in `internal/eventforwarder/forwarder.go`. The informer + dispatch wiring is fully generic over this list, so no other code changes.
- Grant the event-forwarder ClusterRole `get/list/watch` on both kinds in `install/helm/openchoreo-control-plane/templates/event-forwarder/clusterrole.yaml`, without which the new informers fail their initial list / cache sync.

## Related Issues

Closes #3810
Related #3564

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Smoke-validated on k3d single-cluster: the event-forwarder pod logs `Watching resource … projecttypes` + `… clusterprojecttypes` and reaches `All informers synced` (RBAC + cache-sync OK). At debug level, `created`/`updated` events on a `ClusterProjectType` and `created`/`deleted` events on a namespaced `ProjectType` were each detected and dispatched successfully to the Backstage webhook on the first attempt.
