### PR TITLE
fix: emit K8s event on autoDeploy webhook rejection (#3560)

### DIFF
--- a/internal/controller/component/controller.go
+++ b/internal/controller/component/controller.go
@@ -181,9 +181,10 @@ func (r *Reconciler) reconcileWithComponentType(ctx context.Context, comp *openc
 			msg := fmt.Sprintf("Failed to handle autoDeploy: %v", err)
 			controller.MarkFalseCondition(comp, ConditionReady, ReasonAutoDeployFailed, msg)
 			logger.Error(err, "Failed to handle autoDeploy")
-			r.Recorder.Event(comp, corev1.EventTypeWarning, string(ReasonAutoDeployFailed), msg)
-			// Do not retry permanent admission/validation errors
-			if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) || apierrors.IsBadRequest(err) {
+			// Do not retry permanent admission/validation errors; emit an event so the
+			// user can discover the rejection reason via kubectl describe / kubectl get events.
+			if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) {
+				r.Recorder.Event(comp, corev1.EventTypeWarning, string(ReasonAutoDeployFailed), msg)
 				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{}, err

--- a/internal/controller/component/controller.go
+++ b/internal/controller/component/controller.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -29,7 +31,8 @@ import (
 // Reconciler reconciles a Component object
 type Reconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=components,verbs=get;list;watch;create;update;patch;delete
@@ -47,6 +50,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=workflowruns,verbs=list;delete
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=projects,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=deploymentpipelines,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -177,6 +181,11 @@ func (r *Reconciler) reconcileWithComponentType(ctx context.Context, comp *openc
 			msg := fmt.Sprintf("Failed to handle autoDeploy: %v", err)
 			controller.MarkFalseCondition(comp, ConditionReady, ReasonAutoDeployFailed, msg)
 			logger.Error(err, "Failed to handle autoDeploy")
+			r.Recorder.Event(comp, corev1.EventTypeWarning, string(ReasonAutoDeployFailed), msg)
+			// Do not retry permanent admission/validation errors
+			if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) || apierrors.IsBadRequest(err) {
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	}
@@ -853,6 +862,10 @@ func (r *Reconciler) ensureReleaseBinding(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor("component-controller")
+	}
+
 	ctx := context.Background()
 
 	// Set up field indexes for efficient lookups

--- a/internal/controller/component/controller_integration_test.go
+++ b/internal/controller/component/controller_integration_test.go
@@ -13,7 +13,9 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -1240,6 +1242,92 @@ var _ = Describe("Component Controller — Finalization", func() {
 				}
 				return fetchComp(ctx, compName) == nil
 			}, itTimeout, itInterval).Should(BeTrue())
+		})
+	})
+})
+
+// ── AutoDeploy webhook rejection ──────────────────────────────────────────────
+
+// webhookRejectClient wraps a real client and makes ComponentRelease Create
+// calls fail with an admission-style Invalid error, simulating a webhook rejection.
+type webhookRejectClient struct {
+	client.Client
+}
+
+func (c *webhookRejectClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*openchoreov1alpha1.ComponentRelease); ok {
+		return k8serrors.NewInvalid(
+			schema.GroupKind{Group: "openchoreo.dev", Kind: "ComponentRelease"},
+			obj.GetName(),
+			field.ErrorList{field.Invalid(field.NewPath("spec"), nil, "simulated webhook rejection")},
+		)
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+var _ = Describe("Component Controller — AutoDeploy webhook rejection", func() {
+	Context("When webhook rejects ComponentRelease creation with a permanent error", func() {
+		const (
+			ctName       = "webhook-reject-ct"
+			compName     = "webhook-reject-comp"
+			wlName       = "webhook-reject-wl"
+			project      = "webhook-reject-proj"
+			pipelineName = "webhook-reject-pipe"
+		)
+		var ct *openchoreov1alpha1.ComponentType
+		var wl *openchoreov1alpha1.Workload
+		var proj *openchoreov1alpha1.Project
+		var pipe *openchoreov1alpha1.DeploymentPipeline
+		var comp *openchoreov1alpha1.Component
+		var fakeRecorder *record.FakeRecorder
+
+		BeforeEach(func() {
+			ct = minimalCT(ctName, "deployment")
+			Expect(k8sClient.Create(ctx, ct)).To(Succeed())
+
+			wl = minimalWorkload(wlName, project, compName, "nginx:latest")
+			Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+
+			proj = minimalProject(project, pipelineName)
+			Expect(k8sClient.Create(ctx, proj)).To(Succeed())
+
+			pipe = minimalPipeline(pipelineName)
+			Expect(k8sClient.Create(ctx, pipe)).To(Succeed())
+
+			comp = minimalComp(compName, project, string(openchoreov1alpha1.ComponentTypeRefKindComponentType),
+				"deployment/"+ctName, true)
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+
+			fakeRecorder = record.NewFakeRecorder(100)
+		})
+
+		AfterEach(func() {
+			forceDeleteObj(ctx, comp)
+			_ = k8sClient.Delete(ctx, pipe)
+			_ = k8sClient.Delete(ctx, proj)
+			_ = k8sClient.Delete(ctx, wl)
+			_ = k8sClient.Delete(ctx, ct)
+		})
+
+		It("should emit a warning event, set AutoDeployFailed condition, and not retry", func() {
+			r := &Reconciler{
+				Client:   &webhookRejectClient{Client: k8sClient},
+				Scheme:   k8sClient.Scheme(),
+				Recorder: fakeRecorder,
+			}
+
+			By("Reconciling until AutoDeployFailed condition is set")
+			reconcileUntilCondition(ctx, r, compName, ReasonAutoDeployFailed)
+
+			By("Verifying condition is False with AutoDeployFailed reason")
+			c := fetchComp(ctx, compName)
+			cond := conditionFor(c)
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(string(ReasonAutoDeployFailed)))
+			Expect(cond.Message).To(ContainSubstring("simulated webhook rejection"))
+
+			By("Verifying a warning event was emitted")
+			Eventually(fakeRecorder.Events).Should(Receive(ContainSubstring("AutoDeployFailed")))
 		})
 	})
 })

--- a/internal/controller/component/controller_integration_test.go
+++ b/internal/controller/component/controller_integration_test.go
@@ -18,7 +18,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -189,6 +191,31 @@ func reconcileUntilCondition(
 		g.Expect(cond.Reason).To(Equal(string(expectedReason)))
 	}, itTimeout, itInterval).Should(Succeed())
 }
+
+// ── SetupWithManager recorder initialisation ─────────────────────────────────
+
+var _ = Describe("Component Controller — SetupWithManager", func() {
+	It("initializes Recorder when it is nil", func() {
+		// Use a fresh manager so SetupWithManager can register its field indexes
+		// without conflicting with the indexes already registered on testMgr by BeforeSuite.
+		freshMgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:  k8sClient.Scheme(),
+			Metrics: metricsserver.Options{BindAddress: "0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		r := &Reconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			// Recorder intentionally left nil to exercise the nil-guard in SetupWithManager
+		}
+		Expect(r.Recorder).To(BeNil())
+
+		Expect(r.SetupWithManager(freshMgr)).To(Succeed())
+
+		Expect(r.Recorder).NotTo(BeNil())
+	})
+})
 
 // ── ComponentType resolution ──────────────────────────────────────────────────
 
@@ -1321,6 +1348,15 @@ var _ = Describe("Component Controller — AutoDeploy webhook rejection", func()
 				if expectRetry {
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(ContainSubstring("simulated")))
+
+					By("Verifying AutoDeployFailed condition is set even on retryable errors")
+					c := fetchComp(ctx, compName)
+					cond := conditionFor(c)
+					Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+					Expect(cond.Reason).To(Equal(string(ReasonAutoDeployFailed)))
+
+					By("Verifying no event is emitted for transient errors")
+					Consistently(fakeRecorder.Events, 100*time.Millisecond, 10*time.Millisecond).ShouldNot(Receive())
 				} else {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
@@ -1342,11 +1378,11 @@ var _ = Describe("Component Controller — AutoDeploy webhook rejection", func()
 				"test",
 				field.ErrorList{field.Invalid(field.NewPath("spec"), nil, "simulated webhook rejection")},
 			), false),
-			Entry("Forbidden error (permanent)", k8serrors.NewForbidden(
+			Entry("Forbidden error (retryable)", k8serrors.NewForbidden(
 				schema.GroupResource{Group: "openchoreo.dev", Resource: "ComponentRelease"},
 				"test",
 				errors.New("simulated forbidden"),
-			), false),
+			), true),
 			Entry("BadRequest error (permanent)", k8serrors.NewBadRequest("simulated bad request"), false),
 			Entry("Internal error (retryable)", k8serrors.NewInternalError(errors.New("simulated internal error")), true),
 		)

--- a/internal/controller/component/controller_integration_test.go
+++ b/internal/controller/component/controller_integration_test.go
@@ -5,6 +5,7 @@ package component
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"time"
 
@@ -1248,25 +1249,21 @@ var _ = Describe("Component Controller — Finalization", func() {
 
 // ── AutoDeploy webhook rejection ──────────────────────────────────────────────
 
-// webhookRejectClient wraps a real client and makes ComponentRelease Create
-// calls fail with an admission-style Invalid error, simulating a webhook rejection.
-type webhookRejectClient struct {
+// mockErrorClient wraps a real client and makes ComponentRelease Create calls fail with a specific error.
+type mockErrorClient struct {
 	client.Client
+	errToReturn error
 }
 
-func (c *webhookRejectClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func (c *mockErrorClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	if _, ok := obj.(*openchoreov1alpha1.ComponentRelease); ok {
-		return k8serrors.NewInvalid(
-			schema.GroupKind{Group: "openchoreo.dev", Kind: "ComponentRelease"},
-			obj.GetName(),
-			field.ErrorList{field.Invalid(field.NewPath("spec"), nil, "simulated webhook rejection")},
-		)
+		return c.errToReturn
 	}
 	return c.Client.Create(ctx, obj, opts...)
 }
 
 var _ = Describe("Component Controller — AutoDeploy webhook rejection", func() {
-	Context("When webhook rejects ComponentRelease creation with a permanent error", func() {
+	Context("When webhook rejects ComponentRelease creation", func() {
 		const (
 			ctName       = "webhook-reject-ct"
 			compName     = "webhook-reject-comp"
@@ -1309,25 +1306,49 @@ var _ = Describe("Component Controller — AutoDeploy webhook rejection", func()
 			_ = k8sClient.Delete(ctx, ct)
 		})
 
-		It("should emit a warning event, set AutoDeployFailed condition, and not retry", func() {
-			r := &Reconciler{
-				Client:   &webhookRejectClient{Client: k8sClient},
-				Scheme:   k8sClient.Scheme(),
-				Recorder: fakeRecorder,
-			}
+		DescribeTable("Admission error handling",
+			func(errToReturn error, expectRetry bool) {
+				r := &Reconciler{
+					Client:   &mockErrorClient{Client: k8sClient, errToReturn: errToReturn},
+					Scheme:   k8sClient.Scheme(),
+					Recorder: fakeRecorder,
+				}
 
-			By("Reconciling until AutoDeployFailed condition is set")
-			reconcileUntilCondition(ctx, r, compName, ReasonAutoDeployFailed)
+				By("Reconciling once to trigger error")
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: compName, Namespace: itNamespace}}
+				result, err := r.Reconcile(ctx, req)
 
-			By("Verifying condition is False with AutoDeployFailed reason")
-			c := fetchComp(ctx, compName)
-			cond := conditionFor(c)
-			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(cond.Reason).To(Equal(string(ReasonAutoDeployFailed)))
-			Expect(cond.Message).To(ContainSubstring("simulated webhook rejection"))
+				if expectRetry {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(ContainSubstring("simulated")))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
-			By("Verifying a warning event was emitted")
-			Eventually(fakeRecorder.Events).Should(Receive(ContainSubstring("AutoDeployFailed")))
-		})
+					By("Verifying AutoDeployFailed condition")
+					c := fetchComp(ctx, compName)
+					cond := conditionFor(c)
+					Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+					Expect(cond.Reason).To(Equal(string(ReasonAutoDeployFailed)))
+					Expect(cond.Message).To(ContainSubstring("simulated"))
+
+					By("Verifying a warning event was emitted")
+					Eventually(fakeRecorder.Events).Should(Receive(ContainSubstring("AutoDeployFailed")))
+				}
+			},
+			Entry("Invalid error (permanent)", k8serrors.NewInvalid(
+				schema.GroupKind{Group: "openchoreo.dev", Kind: "ComponentRelease"},
+				"test",
+				field.ErrorList{field.Invalid(field.NewPath("spec"), nil, "simulated webhook rejection")},
+			), false),
+			Entry("Forbidden error (permanent)", k8serrors.NewForbidden(
+				schema.GroupResource{Group: "openchoreo.dev", Resource: "ComponentRelease"},
+				"test",
+				errors.New("simulated forbidden"),
+			), false),
+			Entry("BadRequest error (permanent)", k8serrors.NewBadRequest("simulated bad request"), false),
+			Entry("Internal error (retryable)", k8serrors.NewInternalError(errors.New("simulated internal error")), true),
+		)
 	})
 })

--- a/internal/controller/component/controller_integration_test.go
+++ b/internal/controller/component/controller_integration_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -32,8 +33,9 @@ const (
 
 func itReconciler() *Reconciler {
 	return &Reconciler{
-		Client: k8sClient,
-		Scheme: k8sClient.Scheme(),
+		Client:   k8sClient,
+		Scheme:   k8sClient.Scheme(),
+		Recorder: record.NewFakeRecorder(100),
 	}
 }
 

--- a/internal/controller/component/suite_test.go
+++ b/internal/controller/component/suite_test.go
@@ -32,6 +32,7 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var testMgr ctrl.Manager
 var ctx context.Context
 var cancel context.CancelFunc
 
@@ -74,7 +75,7 @@ var _ = BeforeSuite(func() {
 	// Create a manager with cache enabled only for types that need field index queries
 	// (ComponentRelease, ReleaseBinding, Workload, WorkflowRun for owner lookups during finalization)
 	// Other types bypass cache to avoid staleness issues in tests
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	testMgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0", // Disable metrics server in tests
@@ -100,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Register field indices used by the component controller for finalization
-	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ComponentRelease{},
+	err = testMgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ComponentRelease{},
 		"spec.owner.componentName", func(obj client.Object) []string {
 			release := obj.(*openchoreov1alpha1.ComponentRelease)
 			if release.Spec.Owner.ComponentName == "" {
@@ -110,7 +111,7 @@ var _ = BeforeSuite(func() {
 		})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
+	err = testMgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
 		controller.IndexKeyReleaseBindingOwnerComponentName, func(obj client.Object) []string {
 			binding := obj.(*openchoreov1alpha1.ReleaseBinding)
 			if binding.Spec.Owner.ComponentName == "" {
@@ -120,7 +121,7 @@ var _ = BeforeSuite(func() {
 		})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
+	err = testMgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ReleaseBinding{},
 		controller.IndexKeyReleaseBindingOwnerEnv, func(obj client.Object) []string {
 			rb := obj.(*openchoreov1alpha1.ReleaseBinding)
 			if rb.Spec.Owner.ProjectName == "" || rb.Spec.Owner.ComponentName == "" || rb.Spec.Environment == "" {
@@ -135,7 +136,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Register field index for Workload by owner (projectName/componentName)
-	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Workload{},
+	err = testMgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Workload{},
 		workloadOwnerIndex, func(obj client.Object) []string {
 			workload := obj.(*openchoreov1alpha1.Workload)
 			ownerKey := fmt.Sprintf("%s/%s",
@@ -146,7 +147,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Register field index for Project by deploymentPipelineRef
-	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},
+	err = testMgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},
 		controller.IndexKeyProjectDeploymentPipelineRef, func(obj client.Object) []string {
 			project := obj.(*openchoreov1alpha1.Project)
 			if project.Spec.DeploymentPipelineRef.Name == "" {
@@ -157,7 +158,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Register field index for Component by owner project name
-	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Component{},
+	err = testMgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Component{},
 		controller.IndexKeyComponentOwnerProjectName, func(obj client.Object) []string {
 			component := obj.(*openchoreov1alpha1.Component)
 			if component.Spec.Owner.ProjectName == "" {
@@ -170,15 +171,15 @@ var _ = BeforeSuite(func() {
 	// Start the manager in a goroutine
 	go func() {
 		defer GinkgoRecover()
-		err := mgr.Start(ctx)
+		err := testMgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
 	// Wait for cache to sync before running tests
-	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+	Expect(testMgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 
 	// Use the manager's client which has field index support
-	k8sClient = mgr.GetClient()
+	k8sClient = testMgr.GetClient()
 	Expect(k8sClient).NotTo(BeNil())
 })
 


### PR DESCRIPTION
## Purpose
When autoDeploy creates a ComponentRelease and the admission webhook rejects it (for ex: trait parameters don't match the installed ClusterTrait schema), the rejection reason is only visible in controller logs. Users have no practical way to discover why their component failed to deploy. also, the controller returns the error causing exponential-backoff retries even though the failure is permanent.

This PR makes webhook rejection reasons visible via `kubectl describe component` / `kubectl get events` and stops retrying permanent admission errors. 

## Approach
- Added `Recorder record.EventRecorder` to the component controller `Reconciler` struct (mirrors existing pattern in `project`, `dataplane`, `environment` controllers)
- On autoDeploy failure, emit a `Warning` Kubernetes event on the `Component` resource with the full rejection message
- Classify `Invalid`, `Forbidden`, and `BadRequest` errors as permanent — return `nil` instead of `err` to stop exponential-backoff retries
- Initialize the recorder in `SetupWithManager`; added RBAC marker for `events` permission
- Updated test helper with `record.NewFakeRecorder`

## Related Issues
Resolves #3560

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
- Integration tests (16 Ginkgo specs) all pass with envtest.
