### PR TITLE
fix: assert namespace termination status when marked for deletion

### DIFF
--- a/test/ui/specs/pe-ops/pe-ops-namespace.spec.ts
+++ b/test/ui/specs/pe-ops/pe-ops-namespace.spec.ts
@@ -286,16 +286,17 @@ test.describe('pe-ops: Namespace lifecycle through the Backstage UI', () => {
     await del.openOverflowAndDelete('Namespace');
     await del.confirm();
 
-    // Cross-check: the Kubernetes namespace must be gone (or terminating).
+    // Assert phase, not existence: gone ('') or Terminating both prove the delete
+    // fired; full teardown waits on the finalizer cascade we don't gate on. Default
+    // check:true so a real kubectl error fails instead of passing as empty output.
     await expect
       .poll(
         () =>
-          kubectl(
-            ['get', 'namespace', NAMESPACE_NAME, '--ignore-not-found', '-o', 'name'],
-            { check: false },
-          ).stdout.trim(),
+          kubectl([
+            'get', 'namespace', NAMESPACE_NAME, '--ignore-not-found', '-o', 'jsonpath={.status.phase}',
+          ]).stdout.trim(),
         { timeout: 60_000, intervals: [3_000] },
       )
-      .toBe('');
+      .not.toBe('Active');
   });
 });


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The UI e2e tests should be testing for termination is started rather than fully deleted.
Actual deletion is handled by the custom controller and should be tested in a different suit rather than the UI e2e test suit

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)