### PR TITLE
feat(api): add scheduled-task runs/retries endpoints to observer

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -131,6 +131,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Initialize runs service (scheduled-task runs/retries derived from the same events stream)
+	runsService, runsServiceErr := service.NewRunsService(
+		concreteLogsAdapter, uidResolver, cfg, logger.With("component", "runs-service"),
+	)
+	if runsServiceErr != nil {
+		logger.Error("Failed to initialize runs service", "error", runsServiceErr)
+		os.Exit(1)
+	}
+
 	// Use the metrics adapter as the MetricsQuerier (forwards to external metrics-adapter service)
 	var metricsService service.MetricsQuerier = metricsAdapter
 
@@ -208,6 +217,8 @@ func main() {
 	authzLogsService := service.NewLogsServiceWithAuthz(logsService, authzClient, logger.With("component", "authz-logs"))
 	authzEventsService := service.NewEventsServiceWithAuthz(
 		eventsService, authzClient, logger.With("component", "authz-events"))
+	authzRunsService := service.NewRunsServiceWithAuthz(
+		runsService, authzClient, logger.With("component", "authz-runs"))
 	authzMetricsService := service.NewMetricsServiceWithAuthz(
 		metricsService, authzClient, logger.With("component", "authz-metrics"))
 	authzTracesService := service.NewTracesServiceWithAuthz(
@@ -220,6 +231,7 @@ func main() {
 		healthService,
 		authzLogsService,
 		authzEventsService,
+		authzRunsService,
 		authzMetricsService,
 		authzAlertIncidentService,
 		authzTracesService,
@@ -260,6 +272,8 @@ func main() {
 	// ===== New API Routes (v1) =====
 	api.HandleFunc("POST /api/v1/logs/query", newAPIHandler.QueryLogs)
 	api.HandleFunc("POST /api/v1/events/query", newAPIHandler.QueryEvents)
+	api.HandleFunc("POST /api/v1/scheduled-tasks/runs/query", newAPIHandler.QueryRuns)
+	api.HandleFunc("POST /api/v1/scheduled-tasks/runs/{jobName}/retries/query", newAPIHandler.QueryRetries)
 	api.HandleFunc("POST /api/v1/metrics/query", newAPIHandler.QueryMetrics)
 
 	// ===== New API Routes (v1alpha1) Traces, Incidents & Runtime topology =====

--- a/internal/observer/api/handlers/handler.go
+++ b/internal/observer/api/handlers/handler.go
@@ -48,6 +48,7 @@ type Handler struct {
 	healthService        service.HealthChecker
 	logsService          service.LogsQuerier
 	eventsService        service.EventsQuerier
+	runsService          service.RunsQuerier
 	metricsService       service.MetricsQuerier
 	alertIncidentService service.AlertIncidentService
 	tracesService        service.TracesQuerier
@@ -58,6 +59,7 @@ func NewHandler(
 	healthService service.HealthChecker,
 	logsService service.LogsQuerier,
 	eventsService service.EventsQuerier,
+	runsService service.RunsQuerier,
 	metricsService service.MetricsQuerier,
 	alertIncidentService service.AlertIncidentService,
 	tracesService service.TracesQuerier,
@@ -68,6 +70,7 @@ func NewHandler(
 		healthService:        healthService,
 		logsService:          logsService,
 		eventsService:        eventsService,
+		runsService:          runsService,
 		metricsService:       metricsService,
 		alertIncidentService: alertIncidentService,
 		tracesService:        tracesService,

--- a/internal/observer/api/handlers/runs.go
+++ b/internal/observer/api/handlers/runs.go
@@ -46,6 +46,11 @@ func (h *Handler) QueryRuns(w http.ResponseWriter, r *http.Request) {
 			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
 			return
 		}
+		if errors.Is(err, service.ErrRunsInvalidRequest) {
+			h.logger.Debug("Invalid runs request", "error", err)
+			h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", err.Error())
+			return
+		}
 		h.logger.Error("Failed to query runs", "error", err)
 		if errors.Is(err, service.ErrRunsResolveSearchScope) {
 			h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, types.ErrorCodeV1LogsResolverFailed, "Failed to resolve search scope")
@@ -73,8 +78,9 @@ func (h *Handler) QueryRetries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.SearchScope == nil {
-		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "searchScope is required")
+	if err := validateRetriesQueryRequest(&req); err != nil {
+		h.logger.Debug("Validation failed", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", err.Error())
 		return
 	}
 
@@ -92,6 +98,11 @@ func (h *Handler) QueryRetries(w http.ResponseWriter, r *http.Request) {
 		}
 		if errors.Is(err, observerAuthz.ErrAuthzUnauthorized) {
 			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
+			return
+		}
+		if errors.Is(err, service.ErrRunsInvalidRequest) {
+			h.logger.Debug("Invalid retries request", "error", err)
+			h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", err.Error())
 			return
 		}
 		h.logger.Error("Failed to query retries", "error", err)
@@ -125,6 +136,25 @@ func validateRunsQueryRequest(req *types.RunsQueryRequest) error {
 	}
 	if req.SearchScope.Environment == "" {
 		return fmt.Errorf("searchScope.environment is required for run queries")
+	}
+	return nil
+}
+
+// validateRetriesQueryRequest validates the retries query request. It mirrors the
+// runs validation minus the time-range checks, since retries default to a 30-day
+// lookback when no explicit window is provided.
+func validateRetriesQueryRequest(req *types.RetriesQueryRequest) error {
+	if req.SearchScope == nil {
+		return fmt.Errorf("searchScope is required")
+	}
+	if req.SearchScope.Namespace == "" {
+		return fmt.Errorf("searchScope.namespace is required")
+	}
+	if req.SearchScope.Component == "" {
+		return fmt.Errorf("searchScope.component is required for retry queries")
+	}
+	if req.SearchScope.Environment == "" {
+		return fmt.Errorf("searchScope.environment is required for retry queries")
 	}
 	return nil
 }

--- a/internal/observer/api/handlers/runs.go
+++ b/internal/observer/api/handlers/runs.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/httputil"
+	"github.com/openchoreo/openchoreo/internal/observer/service"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// QueryRuns handles POST /api/v1/scheduled-tasks/runs/query
+func (h *Handler) QueryRuns(w http.ResponseWriter, r *http.Request) {
+	var req types.RunsQueryRequest
+	if err := httputil.BindJSON(r, &req); err != nil {
+		h.logger.Error("Failed to bind request", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "Invalid request format")
+		return
+	}
+
+	if err := validateRunsQueryRequest(&req); err != nil {
+		h.logger.Debug("Validation failed", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	if h.runsService == nil {
+		h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, "", "Runs service is not initialized")
+		return
+	}
+
+	result, err := h.runsService.QueryRuns(ctx, &req)
+	if err != nil {
+		if errors.Is(err, observerAuthz.ErrAuthzForbidden) {
+			h.writeErrorResponse(w, http.StatusForbidden, gen.Forbidden, "", "Access denied")
+			return
+		}
+		if errors.Is(err, observerAuthz.ErrAuthzUnauthorized) {
+			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
+			return
+		}
+		h.logger.Error("Failed to query runs", "error", err)
+		if errors.Is(err, service.ErrRunsResolveSearchScope) {
+			h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, types.ErrorCodeV1LogsResolverFailed, "Failed to resolve search scope")
+			return
+		}
+		h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, "", "Failed to retrieve runs")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, result)
+}
+
+// QueryRetries handles POST /api/v1/scheduled-tasks/runs/{jobName}/retries/query
+func (h *Handler) QueryRetries(w http.ResponseWriter, r *http.Request) {
+	jobName := r.PathValue("jobName")
+	if jobName == "" {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "jobName path parameter is required")
+		return
+	}
+
+	var req types.RetriesQueryRequest
+	if err := httputil.BindJSON(r, &req); err != nil {
+		h.logger.Error("Failed to bind request", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "Invalid request format")
+		return
+	}
+
+	if req.SearchScope == nil {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "searchScope is required")
+		return
+	}
+
+	ctx := r.Context()
+	if h.runsService == nil {
+		h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, "", "Runs service is not initialized")
+		return
+	}
+
+	result, err := h.runsService.QueryRetries(ctx, jobName, &req)
+	if err != nil {
+		if errors.Is(err, observerAuthz.ErrAuthzForbidden) {
+			h.writeErrorResponse(w, http.StatusForbidden, gen.Forbidden, "", "Access denied")
+			return
+		}
+		if errors.Is(err, observerAuthz.ErrAuthzUnauthorized) {
+			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
+			return
+		}
+		h.logger.Error("Failed to query retries", "error", err)
+		if errors.Is(err, service.ErrRunsResolveSearchScope) {
+			h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, types.ErrorCodeV1LogsResolverFailed, "Failed to resolve search scope")
+			return
+		}
+		h.writeErrorResponse(w, http.StatusInternalServerError, gen.InternalServerError, "", "Failed to retrieve retries")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, result)
+}
+
+// validateRunsQueryRequest validates the runs query request.
+func validateRunsQueryRequest(req *types.RunsQueryRequest) error {
+	if req.SearchScope == nil {
+		return fmt.Errorf("searchScope is required")
+	}
+	if req.SearchScope.Namespace == "" {
+		return fmt.Errorf("searchScope.namespace is required")
+	}
+	if req.StartTime == "" {
+		return fmt.Errorf("startTime is required")
+	}
+	if req.EndTime == "" {
+		return fmt.Errorf("endTime is required")
+	}
+	if req.SearchScope.Component == "" {
+		return fmt.Errorf("searchScope.component is required for run queries")
+	}
+	if req.SearchScope.Environment == "" {
+		return fmt.Errorf("searchScope.environment is required for run queries")
+	}
+	return nil
+}

--- a/internal/observer/authz/helpers.go
+++ b/internal/observer/authz/helpers.go
@@ -92,6 +92,17 @@ func EventsScopeAuthz(req *types.EventsQueryRequest) (ResourceType, string, auth
 	return searchScopeAuthz(req.SearchScope)
 }
 
+// RunsScopeAuthz determines the authorization resource type, name, and hierarchy
+// for scheduled-task runs and retries queries. The runs/retries APIs accept a
+// component-only scope, which we wrap into the shared SearchScope envelope to
+// reuse the same authz pathway as events.
+func RunsScopeAuthz(scope *types.ComponentSearchScope) (ResourceType, string, authzcore.ResourceHierarchy, error) {
+	if scope == nil {
+		return "", "", authzcore.ResourceHierarchy{}, fmt.Errorf("searchScope is required")
+	}
+	return searchScopeAuthz(&types.SearchScope{Component: scope})
+}
+
 // CheckAuthorization performs a complete authorization check for observer operations.
 func CheckAuthorization(
 	ctx context.Context,

--- a/internal/observer/service/interfaces.go
+++ b/internal/observer/service/interfaces.go
@@ -25,6 +25,13 @@ type EventsQuerier interface {
 	QueryEvents(ctx context.Context, req *types.EventsQueryRequest) (*types.EventsQueryResponse, error)
 }
 
+// RunsQuerier is the interface for querying scheduled-task runs (Jobs) and retries (Pods).
+// Backed by the events adapter; events are grouped in-memory into runs and retries.
+type RunsQuerier interface {
+	QueryRuns(ctx context.Context, req *types.RunsQueryRequest) (*types.RunsQueryResponse, error)
+	QueryRetries(ctx context.Context, jobName string, req *types.RetriesQueryRequest) (*types.RetriesQueryResponse, error)
+}
+
 // MetricsQuerier is the interface for querying metrics and runtime topology.
 type MetricsQuerier interface {
 	QueryMetrics(ctx context.Context, req *types.MetricsQueryRequest) (any, error)

--- a/internal/observer/service/runs.go
+++ b/internal/observer/service/runs.go
@@ -58,6 +58,10 @@ var (
 	ErrRunsResolveSearchScope = errors.New("runs search scope resolution failed")
 	// ErrRunsRetrieval indicates a failure while retrieving events from the adapter.
 	ErrRunsRetrieval = errors.New("runs retrieval failed")
+	// ErrRunsInvalidRequest indicates a caller-supplied request was malformed
+	// (e.g. an unparseable or inconsistent time window). Handlers should map this
+	// to HTTP 400 rather than treating it as an internal error.
+	ErrRunsInvalidRequest = errors.New("runs invalid request")
 )
 
 // NewRunsService creates a new RunsService backed by the HTTP logs adapter.
@@ -101,7 +105,7 @@ func (s *RunsService) QueryRuns(ctx context.Context, req *types.RunsQueryRequest
 
 	startTime, endTime, err := parseTimeRange(req.StartTime, req.EndTime)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrRunsInvalidRequest, err)
 	}
 
 	events, took, err := s.fetchComponentEvents(ctx, componentScope, startTime, endTime, req.SortOrder)
@@ -149,7 +153,7 @@ func (s *RunsService) QueryRetries(ctx context.Context, jobName string, req *typ
 	// per-call event cap truncating retries for high-frequency CronJobs.
 	startTime, endTime, err := parseOptionalTimeRange(req.StartTime, req.EndTime)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrRunsInvalidRequest, err)
 	}
 
 	events, took, err := s.fetchComponentEvents(ctx, componentScope, startTime, endTime, "asc")
@@ -206,6 +210,8 @@ func (s *RunsService) fetchComponentEvents(
 }
 
 // parseTimeRange validates and parses required RFC3339 startTime / endTime.
+// It also enforces endTime >= startTime so callers cannot request an
+// impossible window (which would silently return zero results).
 func parseTimeRange(startStr, endStr string) (time.Time, time.Time, error) {
 	startTime, err := time.Parse(time.RFC3339, startStr)
 	if err != nil {
@@ -215,15 +221,22 @@ func parseTimeRange(startStr, endStr string) (time.Time, time.Time, error) {
 	if err != nil {
 		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse end time: %w", err)
 	}
+	if endTime.Before(startTime) {
+		return time.Time{}, time.Time{}, fmt.Errorf("end time must be greater than or equal to start time")
+	}
 	return startTime, endTime, nil
 }
 
 // parseOptionalTimeRange parses RFC3339 startTime / endTime when provided, and
-// falls back to a 30-day lookback ending at now when either is empty.
+// falls back to a 30-day lookback ending at now when both are empty. If exactly
+// one of the two is provided, that is a client error (ambiguous window).
 func parseOptionalTimeRange(startStr, endStr string) (time.Time, time.Time, error) {
-	if startStr == "" || endStr == "" {
+	if startStr == "" && endStr == "" {
 		endTime := time.Now().UTC()
 		return endTime.Add(-30 * 24 * time.Hour), endTime, nil
+	}
+	if startStr == "" || endStr == "" {
+		return time.Time{}, time.Time{}, fmt.Errorf("startTime and endTime must be provided together")
 	}
 	return parseTimeRange(startStr, endStr)
 }

--- a/internal/observer/service/runs.go
+++ b/internal/observer/service/runs.go
@@ -22,6 +22,23 @@ import (
 // a reasonable time window this is comfortably above typical event counts.
 const adapterEventLimit = 1000
 
+// Run-level statuses (lowercase to match the existing JSON contract).
+const (
+	runStatusSucceeded = "succeeded"
+	runStatusFailed    = "failed"
+	runStatusRunning   = "running"
+	runStatusUnknown   = "unknown"
+)
+
+// Retry-level statuses (capitalized to match Kubernetes Pod phase conventions
+// already exposed by the API).
+const (
+	retryStatusSucceeded = "Succeeded"
+	retryStatusFailed    = "Failed"
+	retryStatusRunning   = "Running"
+	retryStatusUnknown   = "Unknown"
+)
+
 // RunsService groups Kubernetes events into scheduled-task runs (Jobs) and retries (Pods).
 //
 // It fetches events from the upstream logs adapter (no direct OpenSearch access) and
@@ -262,10 +279,10 @@ func groupRuns(events []observability.EventEntry, includeEvents bool) []types.Ru
 			StartTime:  st.earliestTS.UTC().Format(time.RFC3339),
 			EventCount: st.eventCount,
 		}
-		if !st.latestTS.IsZero() && (status == "succeeded" || status == "failed") {
+		if !st.latestTS.IsZero() && (status == runStatusSucceeded || status == runStatusFailed) {
 			run.CompletionTime = st.latestTS.UTC().Format(time.RFC3339)
 		}
-		if status == "failed" {
+		if status == runStatusFailed {
 			run.FailureReason = deriveFailureReasonFromMap(st.reasons)
 		}
 		if includeEvents {
@@ -395,21 +412,21 @@ func applyRunStatusOverride(retries []types.RetryEntry, jobStatus string) {
 		return
 	}
 	switch jobStatus {
-	case "failed":
+	case runStatusFailed:
 		for i := range retries {
-			retries[i].Status = "Failed"
+			retries[i].Status = retryStatusFailed
 		}
-	case "succeeded":
+	case runStatusSucceeded:
 		for i := range retries {
 			if i == len(retries)-1 {
-				retries[i].Status = "Succeeded"
+				retries[i].Status = retryStatusSucceeded
 			} else {
-				retries[i].Status = "Failed"
+				retries[i].Status = retryStatusFailed
 			}
 		}
-	case "running":
+	case runStatusRunning:
 		for i := 0; i < len(retries)-1; i++ {
-			retries[i].Status = "Failed"
+			retries[i].Status = retryStatusFailed
 		}
 	}
 }
@@ -417,21 +434,21 @@ func applyRunStatusOverride(retries []types.RetryEntry, jobStatus string) {
 // deriveRunStatusFromMap determines run status from a reason-frequency map.
 func deriveRunStatusFromMap(reasons map[string]int) string {
 	if _, ok := reasons["Completed"]; ok {
-		return "succeeded"
+		return runStatusSucceeded
 	}
 	if _, ok := reasons["BackoffLimitExceeded"]; ok {
-		return "failed"
+		return runStatusFailed
 	}
 	if _, ok := reasons["DeadlineExceeded"]; ok {
-		return "failed"
+		return runStatusFailed
 	}
 	if _, ok := reasons["FailedCreate"]; ok {
-		return "failed"
+		return runStatusFailed
 	}
 	if _, ok := reasons["SuccessfulCreate"]; ok {
-		return "running"
+		return runStatusRunning
 	}
-	return "unknown"
+	return runStatusUnknown
 }
 
 // deriveFailureReasonFromMap returns the K8s event reason that caused the Job to fail,
@@ -452,17 +469,17 @@ func deriveFailureReasonFromMap(reasons map[string]int) string {
 // parent Job's terminal status.
 func deriveRetryStatusFromMap(reasons map[string]int) string {
 	if _, ok := reasons["Completed"]; ok {
-		return "Succeeded"
+		return retryStatusSucceeded
 	}
 	for _, key := range []string{"OOMKilled", "CrashLoopBackOff", "BackOff"} {
 		if _, ok := reasons[key]; ok {
-			return "Failed"
+			return retryStatusFailed
 		}
 	}
 	for _, key := range []string{"Started", "Pulled"} {
 		if _, ok := reasons[key]; ok {
-			return "Running"
+			return retryStatusRunning
 		}
 	}
-	return "Unknown"
+	return retryStatusUnknown
 }

--- a/internal/observer/service/runs.go
+++ b/internal/observer/service/runs.go
@@ -1,0 +1,468 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openchoreo/openchoreo/internal/observer/config"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+	"github.com/openchoreo/openchoreo/pkg/observability"
+)
+
+// adapterEventLimit is the per-call cap on events fetched from the logs adapter.
+// 1000 is the adapter's documented maximum; for scheduled-task observability over
+// a reasonable time window this is comfortably above typical event counts.
+const adapterEventLimit = 1000
+
+// RunsService groups Kubernetes events into scheduled-task runs (Jobs) and retries (Pods).
+//
+// It fetches events from the upstream logs adapter (no direct OpenSearch access) and
+// groups them in-memory by involvedObject. Status is derived from event reasons
+// (see deriveRunStatus / deriveRetryStatus). Pod-level Succeeded/Failed events
+// are not native K8s events, so applyRunStatusOverride uses the parent Job's outcome
+// to fix up per-retry status for finished runs.
+type RunsService struct {
+	eventsAdapter observability.EventsAdapter
+	config        *config.Config
+	resolver      *ResourceUIDResolver
+	logger        *slog.Logger
+}
+
+var (
+	// ErrRunsResolveSearchScope indicates a failure while resolving scope/resource identifiers.
+	ErrRunsResolveSearchScope = errors.New("runs search scope resolution failed")
+	// ErrRunsRetrieval indicates a failure while retrieving events from the adapter.
+	ErrRunsRetrieval = errors.New("runs retrieval failed")
+)
+
+// NewRunsService creates a new RunsService backed by the HTTP logs adapter.
+func NewRunsService(
+	eventsAdapter observability.EventsAdapter,
+	resolver *ResourceUIDResolver,
+	cfg *config.Config,
+	logger *slog.Logger,
+) (*RunsService, error) {
+	if eventsAdapter == nil {
+		return nil, fmt.Errorf("events adapter is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RunsService{
+		eventsAdapter: eventsAdapter,
+		config:        cfg,
+		resolver:      resolver,
+		logger:        logger,
+	}, nil
+}
+
+// QueryRuns lists runs (Jobs) for a scheduled task component over the given time window.
+func (s *RunsService) QueryRuns(ctx context.Context, req *types.RunsQueryRequest) (*types.RunsQueryResponse, error) {
+	if req == nil || req.SearchScope == nil {
+		return nil, fmt.Errorf("request and searchScope are required")
+	}
+
+	s.logger.Debug("QueryRuns called",
+		"namespace", req.SearchScope.Namespace,
+		"component", req.SearchScope.Component,
+		"environment", req.SearchScope.Environment,
+		"startTime", req.StartTime,
+		"endTime", req.EndTime)
+
+	componentScope, err := s.resolveComponentScope(ctx, req.SearchScope)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRunsResolveSearchScope, err)
+	}
+
+	startTime, endTime, err := parseTimeRange(req.StartTime, req.EndTime)
+	if err != nil {
+		return nil, err
+	}
+
+	events, took, err := s.fetchComponentEvents(ctx, componentScope, startTime, endTime, req.SortOrder)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRunsRetrieval, err)
+	}
+
+	runs := groupRuns(events, req.IncludeEvents)
+	sortOrder := req.SortOrder
+	if sortOrder == "" {
+		sortOrder = "desc"
+	}
+	sortRuns(runs, sortOrder)
+
+	total := len(runs)
+	runs = paginate(runs, req.Offset, req.Limit)
+
+	return &types.RunsQueryResponse{
+		Runs:   runs,
+		Total:  total,
+		TookMs: took,
+	}, nil
+}
+
+// QueryRetries lists retries (Pods) for a specific run (Job).
+func (s *RunsService) QueryRetries(ctx context.Context, jobName string, req *types.RetriesQueryRequest) (*types.RetriesQueryResponse, error) {
+	if req == nil || req.SearchScope == nil {
+		return nil, fmt.Errorf("request and searchScope are required")
+	}
+	if jobName == "" {
+		return nil, fmt.Errorf("jobName is required")
+	}
+
+	s.logger.Debug("QueryRetries called",
+		"jobName", jobName,
+		"namespace", req.SearchScope.Namespace)
+
+	componentScope, err := s.resolveComponentScope(ctx, req.SearchScope)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRunsResolveSearchScope, err)
+	}
+
+	// Use the request's window if provided; otherwise fall back to a wide 30-day
+	// lookback. A narrow window scoped to the run's lifetime avoids the adapter's
+	// per-call event cap truncating retries for high-frequency CronJobs.
+	startTime, endTime, err := parseOptionalTimeRange(req.StartTime, req.EndTime)
+	if err != nil {
+		return nil, err
+	}
+
+	events, took, err := s.fetchComponentEvents(ctx, componentScope, startTime, endTime, "asc")
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRunsRetrieval, err)
+	}
+
+	retries, jobStatus := groupRetries(events, jobName)
+	applyRunStatusOverride(retries, jobStatus)
+
+	return &types.RetriesQueryResponse{
+		Retries: retries,
+		Total:   len(retries),
+		TookMs:  took,
+	}, nil
+}
+
+// resolveComponentScope returns a fully resolved (UIDs present) component scope.
+func (s *RunsService) resolveComponentScope(
+	ctx context.Context,
+	scope *types.ComponentSearchScope,
+) (*internalSearchScope, error) {
+	return resolveSearchScope(ctx, s.resolver, &types.SearchScope{Component: scope})
+}
+
+// fetchComponentEvents pulls events for the component from the logs adapter.
+func (s *RunsService) fetchComponentEvents(
+	ctx context.Context,
+	scope *internalSearchScope,
+	startTime, endTime time.Time,
+	sortOrder string,
+) ([]observability.EventEntry, int, error) {
+	if sortOrder == "" {
+		sortOrder = "desc"
+	}
+	params := observability.ComponentEventsParams{
+		ComponentID:   scope.ComponentUID,
+		EnvironmentID: scope.EnvironmentUID,
+		ProjectID:     scope.ProjectUID,
+		Namespace:     scope.NamespaceName,
+		StartTime:     startTime,
+		EndTime:       endTime,
+		Limit:         adapterEventLimit,
+		SortOrder:     sortOrder,
+	}
+	result, err := s.eventsAdapter.GetComponentEvents(ctx, params)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get component events from adapter: %w", err)
+	}
+	if result == nil {
+		return nil, 0, fmt.Errorf("component events adapter returned nil result")
+	}
+	return result.Events, result.Took, nil
+}
+
+// parseTimeRange validates and parses required RFC3339 startTime / endTime.
+func parseTimeRange(startStr, endStr string) (time.Time, time.Time, error) {
+	startTime, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse start time: %w", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse end time: %w", err)
+	}
+	return startTime, endTime, nil
+}
+
+// parseOptionalTimeRange parses RFC3339 startTime / endTime when provided, and
+// falls back to a 30-day lookback ending at now when either is empty.
+func parseOptionalTimeRange(startStr, endStr string) (time.Time, time.Time, error) {
+	if startStr == "" || endStr == "" {
+		endTime := time.Now().UTC()
+		return endTime.Add(-30 * 24 * time.Hour), endTime, nil
+	}
+	return parseTimeRange(startStr, endStr)
+}
+
+// groupRuns groups Job-kind events by Job name into RunEntry list.
+func groupRuns(events []observability.EventEntry, includeEvents bool) []types.RunEntry {
+	type runState struct {
+		earliestTS time.Time
+		latestTS   time.Time
+		eventCount int
+		reasons    map[string]int
+		events     []types.RunEvent
+	}
+	byName := make(map[string]*runState)
+
+	for _, e := range events {
+		if e.ObjectKind != "Job" {
+			continue
+		}
+		name := e.ObjectName
+		if name == "" {
+			continue
+		}
+		st, ok := byName[name]
+		if !ok {
+			st = &runState{reasons: make(map[string]int)}
+			byName[name] = st
+		}
+		st.eventCount++
+		st.reasons[e.Reason]++
+		if st.earliestTS.IsZero() || e.Timestamp.Before(st.earliestTS) {
+			st.earliestTS = e.Timestamp
+		}
+		if e.Timestamp.After(st.latestTS) {
+			st.latestTS = e.Timestamp
+		}
+		if includeEvents {
+			st.events = append(st.events, types.RunEvent{
+				Reason:    e.Reason,
+				Message:   e.Message,
+				Timestamp: e.Timestamp.UTC().Format(time.RFC3339),
+				Type:      e.Type,
+			})
+		}
+	}
+
+	out := make([]types.RunEntry, 0, len(byName))
+	for name, st := range byName {
+		status := deriveRunStatusFromMap(st.reasons)
+		run := types.RunEntry{
+			JobName:    name,
+			Status:     status,
+			StartTime:  st.earliestTS.UTC().Format(time.RFC3339),
+			EventCount: st.eventCount,
+		}
+		if !st.latestTS.IsZero() && (status == "succeeded" || status == "failed") {
+			run.CompletionTime = st.latestTS.UTC().Format(time.RFC3339)
+		}
+		if status == "failed" {
+			run.FailureReason = deriveFailureReasonFromMap(st.reasons)
+		}
+		if includeEvents {
+			// Event list should be ascending for readability.
+			sort.SliceStable(st.events, func(i, j int) bool {
+				return st.events[i].Timestamp < st.events[j].Timestamp
+			})
+			run.Events = st.events
+		}
+		out = append(out, run)
+	}
+	return out
+}
+
+// groupRetries groups Pod-kind events whose pod name belongs to the given Job into
+// RetryEntry list. Returns the parent Job's status alongside (needed for status override).
+func groupRetries(events []observability.EventEntry, jobName string) ([]types.RetryEntry, string) {
+	type retryState struct {
+		earliestTS time.Time
+		eventCount int
+		reasons    map[string]int
+		events     []types.RetryEvent
+	}
+	byPod := make(map[string]*retryState)
+	jobReasons := make(map[string]int)
+	podPrefix := jobName + "-"
+
+	for _, e := range events {
+		// Parent Job's events drive the run-level status used by the status override.
+		if e.ObjectKind == "Job" && e.ObjectName == jobName {
+			jobReasons[e.Reason]++
+			continue
+		}
+		if e.ObjectKind != "Pod" {
+			continue
+		}
+		if !strings.HasPrefix(e.ObjectName, podPrefix) {
+			continue
+		}
+		name := e.ObjectName
+		st, ok := byPod[name]
+		if !ok {
+			st = &retryState{reasons: make(map[string]int)}
+			byPod[name] = st
+		}
+		st.eventCount++
+		st.reasons[e.Reason]++
+		if st.earliestTS.IsZero() || e.Timestamp.Before(st.earliestTS) {
+			st.earliestTS = e.Timestamp
+		}
+		st.events = append(st.events, types.RetryEvent{
+			Reason:    e.Reason,
+			Message:   e.Message,
+			Timestamp: e.Timestamp.UTC().Format(time.RFC3339),
+			Type:      e.Type,
+		})
+	}
+
+	retries := make([]types.RetryEntry, 0, len(byPod))
+	for name, st := range byPod {
+		sort.SliceStable(st.events, func(i, j int) bool {
+			return st.events[i].Timestamp < st.events[j].Timestamp
+		})
+		retries = append(retries, types.RetryEntry{
+			PodName:    name,
+			Status:     deriveRetryStatusFromMap(st.reasons),
+			StartTime:  st.earliestTS.UTC().Format(time.RFC3339),
+			EventCount: st.eventCount,
+			Events:     st.events,
+		})
+	}
+	// Retries are listed by first_seen ascending (so the "last retry" used by the
+	// status-override logic is well-defined as the final element).
+	sort.SliceStable(retries, func(i, j int) bool {
+		return retries[i].StartTime < retries[j].StartTime
+	})
+
+	return retries, deriveRunStatusFromMap(jobReasons)
+}
+
+// sortRuns orders runs by StartTime in the requested order. Stable so that runs with
+// identical timestamps keep map-iteration order (rare with K8s ms-precision timestamps).
+func sortRuns(runs []types.RunEntry, sortOrder string) {
+	if sortOrder == "asc" {
+		sort.SliceStable(runs, func(i, j int) bool {
+			return runs[i].StartTime < runs[j].StartTime
+		})
+		return
+	}
+	sort.SliceStable(runs, func(i, j int) bool {
+		return runs[i].StartTime > runs[j].StartTime
+	})
+}
+
+// paginate returns the slice between offset and offset+limit, with the same
+// "limit <= 0 means no limit" convention used by the prior implementation.
+func paginate(runs []types.RunEntry, offset, limit int) []types.RunEntry {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(runs) {
+		return []types.RunEntry{}
+	}
+	runs = runs[offset:]
+	if limit > 0 && limit < len(runs) {
+		runs = runs[:limit]
+	}
+	return runs
+}
+
+// applyRunStatusOverride mutates retries in-place so their statuses reflect the parent
+// Job's outcome. Retries are expected to be ordered by start_time ascending.
+//
+// Why this override exists: native K8s does not emit a Pod-level "Succeeded" / "Failed"
+// event on container exit, so deriveRetryStatus from pod events alone reports "Running"
+// forever for finished pods. We use the parent Job's terminal status to fix this up.
+//
+//   - Job failed: every retry is Failed.
+//   - Job succeeded: the last retry succeeded; any earlier ones are by definition the
+//     reason the Job retried, so they are Failed.
+//   - Job running with 2+ retries: under restartPolicy: Never the Job controller only
+//     spawns a new pod when the previous one failed, so all but the last retry are Failed.
+//     The last retry keeps whatever deriveRetryStatus produced (it may still be running).
+//   - Job unknown / running with a single retry: leave deriveRetryStatus output alone.
+func applyRunStatusOverride(retries []types.RetryEntry, jobStatus string) {
+	if len(retries) == 0 {
+		return
+	}
+	switch jobStatus {
+	case "failed":
+		for i := range retries {
+			retries[i].Status = "Failed"
+		}
+	case "succeeded":
+		for i := range retries {
+			if i == len(retries)-1 {
+				retries[i].Status = "Succeeded"
+			} else {
+				retries[i].Status = "Failed"
+			}
+		}
+	case "running":
+		for i := 0; i < len(retries)-1; i++ {
+			retries[i].Status = "Failed"
+		}
+	}
+}
+
+// deriveRunStatusFromMap determines run status from a reason-frequency map.
+func deriveRunStatusFromMap(reasons map[string]int) string {
+	if _, ok := reasons["Completed"]; ok {
+		return "succeeded"
+	}
+	if _, ok := reasons["BackoffLimitExceeded"]; ok {
+		return "failed"
+	}
+	if _, ok := reasons["DeadlineExceeded"]; ok {
+		return "failed"
+	}
+	if _, ok := reasons["FailedCreate"]; ok {
+		return "failed"
+	}
+	if _, ok := reasons["SuccessfulCreate"]; ok {
+		return "running"
+	}
+	return "unknown"
+}
+
+// deriveFailureReasonFromMap returns the K8s event reason that caused the Job to fail,
+// or "" if no failure-indicating reason is present. Reuses the same reasons map as
+// deriveRunStatusFromMap, so it costs nothing extra.
+func deriveFailureReasonFromMap(reasons map[string]int) string {
+	for _, key := range []string{"BackoffLimitExceeded", "DeadlineExceeded", "FailedCreate"} {
+		if _, ok := reasons[key]; ok {
+			return key
+		}
+	}
+	return ""
+}
+
+// deriveRetryStatusFromMap determines retry (Pod) status from pod-event reasons.
+// Pod-level Succeeded/Failed events do not exist natively, so this is a best-effort
+// guess from kubelet/scheduler events. applyRunStatusOverride corrects it using the
+// parent Job's terminal status.
+func deriveRetryStatusFromMap(reasons map[string]int) string {
+	if _, ok := reasons["Completed"]; ok {
+		return "Succeeded"
+	}
+	for _, key := range []string{"OOMKilled", "CrashLoopBackOff", "BackOff"} {
+		if _, ok := reasons[key]; ok {
+			return "Failed"
+		}
+	}
+	for _, key := range []string{"Started", "Pulled"} {
+		if _, ok := reasons[key]; ok {
+			return "Running"
+		}
+	}
+	return "Unknown"
+}

--- a/internal/observer/service/runs_authz.go
+++ b/internal/observer/service/runs_authz.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+)
+
+// runsServiceWithAuthz wraps a RunsQuerier and adds authorization checks. Runs/retries
+// reuse the events authz pathway since they are derived from the same Kubernetes events
+// stream (an event-view permission grants visibility into run/retry derivations of those
+// events).
+type runsServiceWithAuthz struct {
+	internal RunsQuerier
+	pdp      authzcore.PDP
+	logger   *slog.Logger
+}
+
+var _ RunsQuerier = (*runsServiceWithAuthz)(nil)
+
+// NewRunsServiceWithAuthz wraps the provided RunsQuerier with authorization checks.
+func NewRunsServiceWithAuthz(s RunsQuerier, pdp authzcore.PDP, logger *slog.Logger) RunsQuerier {
+	return &runsServiceWithAuthz{internal: s, pdp: pdp, logger: logger}
+}
+
+func (s *runsServiceWithAuthz) QueryRuns(
+	ctx context.Context,
+	req *types.RunsQueryRequest,
+) (*types.RunsQueryResponse, error) {
+	var scope *types.ComponentSearchScope
+	if req != nil {
+		scope = req.SearchScope
+	}
+	if err := s.authorize(ctx, scope); err != nil {
+		return nil, err
+	}
+	return s.internal.QueryRuns(ctx, req)
+}
+
+func (s *runsServiceWithAuthz) QueryRetries(
+	ctx context.Context,
+	jobName string,
+	req *types.RetriesQueryRequest,
+) (*types.RetriesQueryResponse, error) {
+	var scope *types.ComponentSearchScope
+	if req != nil {
+		scope = req.SearchScope
+	}
+	if err := s.authorize(ctx, scope); err != nil {
+		return nil, err
+	}
+	return s.internal.QueryRetries(ctx, jobName, req)
+}
+
+func (s *runsServiceWithAuthz) authorize(ctx context.Context, scope *types.ComponentSearchScope) error {
+	resourceType, resourceName, hierarchy, err := observerAuthz.RunsScopeAuthz(scope)
+	if err != nil {
+		return err
+	}
+	// TODO: currently the obs API is not equipped to provide cluster level environments,
+	// once that is done update false to proper isClusterScoped value.
+	authzCtx := authzcore.Context{}
+	if scope != nil {
+		authzCtx.Resource = authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
+		}
+	}
+	return observerAuthz.CheckAuthorization(
+		ctx, s.logger, s.pdp,
+		observerAuthz.ActionViewEvents,
+		resourceType, resourceName, hierarchy,
+		authzCtx,
+	)
+}

--- a/internal/observer/service/runs_test.go
+++ b/internal/observer/service/runs_test.go
@@ -352,6 +352,34 @@ func TestGroupRetries(t *testing.T) {
 	})
 }
 
+// ── parseTimeRange ──────────────────────────────────────────────────
+
+func TestParseTimeRange(t *testing.T) {
+	t.Run("valid range returns parsed window", func(t *testing.T) {
+		s, e, err := parseTimeRange("2026-06-22T00:00:00Z", "2026-06-22T01:00:00Z")
+		assert.NoError(t, err)
+		assert.Equal(t, "2026-06-22T00:00:00Z", s.UTC().Format(time.RFC3339))
+		assert.Equal(t, "2026-06-22T01:00:00Z", e.UTC().Format(time.RFC3339))
+	})
+	t.Run("equal start and end is allowed (zero-length window)", func(t *testing.T) {
+		_, _, err := parseTimeRange("2026-06-22T00:00:00Z", "2026-06-22T00:00:00Z")
+		assert.NoError(t, err)
+	})
+	t.Run("inverted range returns error", func(t *testing.T) {
+		_, _, err := parseTimeRange("2026-06-22T02:00:00Z", "2026-06-22T01:00:00Z")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "end time must be greater than or equal to start time")
+	})
+	t.Run("malformed start returns error", func(t *testing.T) {
+		_, _, err := parseTimeRange("not-a-time", "2026-06-22T01:00:00Z")
+		assert.Error(t, err)
+	})
+	t.Run("malformed end returns error", func(t *testing.T) {
+		_, _, err := parseTimeRange("2026-06-22T00:00:00Z", "not-a-time")
+		assert.Error(t, err)
+	})
+}
+
 // ── parseOptionalTimeRange ──────────────────────────────────────────
 
 func TestParseOptionalTimeRange(t *testing.T) {
@@ -361,11 +389,21 @@ func TestParseOptionalTimeRange(t *testing.T) {
 		assert.Equal(t, "2026-06-22T00:00:00Z", s.UTC().Format(time.RFC3339))
 		assert.Equal(t, "2026-06-22T01:00:00Z", e.UTC().Format(time.RFC3339))
 	})
-	t.Run("missing startTime falls back to 30d window", func(t *testing.T) {
+	t.Run("both empty falls back to 30d window", func(t *testing.T) {
 		s, e, err := parseOptionalTimeRange("", "")
 		assert.NoError(t, err)
 		// Fallback should be ~30 days; loose check to avoid flakiness.
 		assert.InDelta(t, 30*24*time.Hour, e.Sub(s), float64(time.Minute))
+	})
+	t.Run("only startTime provided returns error", func(t *testing.T) {
+		_, _, err := parseOptionalTimeRange("2026-06-22T00:00:00Z", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be provided together")
+	})
+	t.Run("only endTime provided returns error", func(t *testing.T) {
+		_, _, err := parseOptionalTimeRange("", "2026-06-22T01:00:00Z")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be provided together")
 	})
 	t.Run("invalid time returns error", func(t *testing.T) {
 		_, _, err := parseOptionalTimeRange("not-a-time", "2026-06-22T01:00:00Z")

--- a/internal/observer/service/runs_test.go
+++ b/internal/observer/service/runs_test.go
@@ -1,0 +1,374 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openchoreo/openchoreo/internal/observer/types"
+	"github.com/openchoreo/openchoreo/pkg/observability"
+)
+
+// ── deriveRunStatusFromMap ──────────────────────────────────────────
+
+func TestDeriveRunStatusFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		reasons map[string]int
+		want    string
+	}{
+		{"completed wins", map[string]int{"Completed": 1, "SuccessfulCreate": 1}, "succeeded"},
+		{"backoff limit means failed", map[string]int{"BackoffLimitExceeded": 1, "SuccessfulCreate": 1}, "failed"},
+		{"deadline means failed", map[string]int{"DeadlineExceeded": 1}, "failed"},
+		{"failed create means failed", map[string]int{"FailedCreate": 1}, "failed"},
+		{"only successful create means running", map[string]int{"SuccessfulCreate": 1}, "running"},
+		{"empty means unknown", map[string]int{}, "unknown"},
+		{"unrecognized reason means unknown", map[string]int{"Foo": 1}, "unknown"},
+		{"completed beats failed", map[string]int{"Completed": 1, "BackoffLimitExceeded": 1}, "succeeded"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deriveRunStatusFromMap(tc.reasons))
+		})
+	}
+}
+
+// ── deriveFailureReasonFromMap ──────────────────────────────────────
+
+func TestDeriveFailureReasonFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		reasons map[string]int
+		want    string
+	}{
+		{"backoff limit", map[string]int{"BackoffLimitExceeded": 1}, "BackoffLimitExceeded"},
+		{"deadline", map[string]int{"DeadlineExceeded": 1}, "DeadlineExceeded"},
+		{"failed create", map[string]int{"FailedCreate": 1}, "FailedCreate"},
+		{"backoff wins over deadline (ordered preference)", map[string]int{"DeadlineExceeded": 1, "BackoffLimitExceeded": 1}, "BackoffLimitExceeded"},
+		{"no failure reason returns empty", map[string]int{"Completed": 1}, ""},
+		{"empty returns empty", map[string]int{}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deriveFailureReasonFromMap(tc.reasons))
+		})
+	}
+}
+
+// ── deriveRetryStatusFromMap ────────────────────────────────────────
+
+func TestDeriveRetryStatusFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		reasons map[string]int
+		want    string
+	}{
+		{"completed", map[string]int{"Completed": 1}, "Succeeded"},
+		{"oom killed", map[string]int{"OOMKilled": 1}, "Failed"},
+		{"crashloop", map[string]int{"CrashLoopBackOff": 1}, "Failed"},
+		{"backoff", map[string]int{"BackOff": 1}, "Failed"},
+		{"started means running", map[string]int{"Started": 1}, "Running"},
+		{"pulled means running", map[string]int{"Pulled": 1}, "Running"},
+		{"completed beats failed", map[string]int{"Completed": 1, "OOMKilled": 1}, "Succeeded"},
+		{"failed beats running", map[string]int{"OOMKilled": 1, "Started": 1}, "Failed"},
+		{"empty means unknown", map[string]int{}, "Unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deriveRetryStatusFromMap(tc.reasons))
+		})
+	}
+}
+
+// ── applyRunStatusOverride ──────────────────────────────────────────
+
+func TestApplyRunStatusOverride(t *testing.T) {
+	mk := func(statuses ...string) []types.RetryEntry {
+		retries := make([]types.RetryEntry, len(statuses))
+		for i, s := range statuses {
+			retries[i] = types.RetryEntry{PodName: "p" + string(rune('1'+i)), Status: s}
+		}
+		return retries
+	}
+
+	t.Run("failed job marks every retry Failed", func(t *testing.T) {
+		retries := mk("Running", "Running", "Running")
+		applyRunStatusOverride(retries, "failed")
+		for _, r := range retries {
+			assert.Equal(t, "Failed", r.Status)
+		}
+	})
+
+	t.Run("succeeded job marks last Succeeded and earlier ones Failed", func(t *testing.T) {
+		retries := mk("Running", "Running", "Running")
+		applyRunStatusOverride(retries, "succeeded")
+		assert.Equal(t, "Failed", retries[0].Status)
+		assert.Equal(t, "Failed", retries[1].Status)
+		assert.Equal(t, "Succeeded", retries[2].Status)
+	})
+
+	t.Run("running job with multiple retries marks all but last Failed and preserves last", func(t *testing.T) {
+		retries := mk("Running", "Running", "Running")
+		applyRunStatusOverride(retries, "running")
+		assert.Equal(t, "Failed", retries[0].Status)
+		assert.Equal(t, "Failed", retries[1].Status)
+		assert.Equal(t, "Running", retries[2].Status, "last retry should keep its derived status")
+	})
+
+	t.Run("unknown job leaves statuses untouched", func(t *testing.T) {
+		retries := mk("Succeeded", "Failed", "Running")
+		applyRunStatusOverride(retries, "unknown")
+		assert.Equal(t, []string{"Succeeded", "Failed", "Running"}, []string{retries[0].Status, retries[1].Status, retries[2].Status})
+	})
+
+	t.Run("empty retries does not panic", func(t *testing.T) {
+		var retries []types.RetryEntry
+		applyRunStatusOverride(retries, "failed")
+		assert.Empty(t, retries)
+	})
+}
+
+// ── paginate ────────────────────────────────────────────────────────
+
+func TestPaginate(t *testing.T) {
+	mk := func(n int) []types.RunEntry {
+		out := make([]types.RunEntry, n)
+		for i := range out {
+			out[i].JobName = string(rune('a' + i))
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		input    []types.RunEntry
+		offset   int
+		limit    int
+		wantLen  int
+		wantHead string
+	}{
+		{"no limit returns everything from offset", mk(5), 0, 0, 5, "a"},
+		{"limit truncates", mk(5), 0, 2, 2, "a"},
+		{"offset skips", mk(5), 2, 2, 2, "c"},
+		{"offset past end returns empty", mk(5), 10, 0, 0, ""},
+		{"negative offset clamps to 0", mk(5), -1, 0, 5, "a"},
+		{"limit larger than remaining returns remaining", mk(3), 1, 10, 2, "b"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := paginate(tc.input, tc.offset, tc.limit)
+			assert.Len(t, got, tc.wantLen)
+			if tc.wantLen > 0 {
+				assert.Equal(t, tc.wantHead, got[0].JobName)
+			}
+		})
+	}
+}
+
+// ── sortRuns ─────────────────────────────────────────────────────────
+
+func TestSortRuns(t *testing.T) {
+	mk := func(ts ...string) []types.RunEntry {
+		out := make([]types.RunEntry, len(ts))
+		for i, t := range ts {
+			out[i].StartTime = t
+		}
+		return out
+	}
+
+	t.Run("desc sorts newest first", func(t *testing.T) {
+		runs := mk("2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z", "2026-06-02T00:00:00Z")
+		sortRuns(runs, "desc")
+		assert.Equal(t, "2026-06-03T00:00:00Z", runs[0].StartTime)
+		assert.Equal(t, "2026-06-01T00:00:00Z", runs[2].StartTime)
+	})
+
+	t.Run("asc sorts oldest first", func(t *testing.T) {
+		runs := mk("2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z", "2026-06-02T00:00:00Z")
+		sortRuns(runs, "asc")
+		assert.Equal(t, "2026-06-01T00:00:00Z", runs[0].StartTime)
+		assert.Equal(t, "2026-06-03T00:00:00Z", runs[2].StartTime)
+	})
+
+	t.Run("empty input does not panic", func(t *testing.T) {
+		var runs []types.RunEntry
+		sortRuns(runs, "desc")
+		assert.Empty(t, runs)
+	})
+}
+
+// ── groupRuns ───────────────────────────────────────────────────────
+
+func TestGroupRuns(t *testing.T) {
+	ts := func(s string) time.Time {
+		t, _ := time.Parse(time.RFC3339, s)
+		return t
+	}
+	evt := func(kind, name, reason string, when time.Time) observability.EventEntry {
+		return observability.EventEntry{
+			ObjectKind: kind, ObjectName: name,
+			Reason: reason, Message: reason + " happened",
+			Type: "Normal", Timestamp: when,
+		}
+	}
+
+	t.Run("non-Job events are ignored", func(t *testing.T) {
+		runs := groupRuns([]observability.EventEntry{
+			evt("Pod", "p-1", "Started", ts("2026-06-22T00:00:00Z")),
+			evt("CronJob", "ct", "SawCompletedJob", ts("2026-06-22T00:00:00Z")),
+		}, false)
+		assert.Empty(t, runs)
+	})
+
+	t.Run("Job events without name are dropped", func(t *testing.T) {
+		runs := groupRuns([]observability.EventEntry{evt("Job", "", "Completed", ts("2026-06-22T00:00:00Z"))}, false)
+		assert.Empty(t, runs)
+	})
+
+	t.Run("succeeded run aggregates timestamps and counts", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Job", "job-a", "SuccessfulCreate", ts("2026-06-22T00:00:00Z")),
+			evt("Job", "job-a", "Completed", ts("2026-06-22T00:00:30Z")),
+		}
+		runs := groupRuns(events, false)
+		assert.Len(t, runs, 1)
+		r := runs[0]
+		assert.Equal(t, "job-a", r.JobName)
+		assert.Equal(t, "succeeded", r.Status)
+		assert.Equal(t, 2, r.EventCount)
+		assert.Equal(t, "2026-06-22T00:00:00Z", r.StartTime)
+		assert.Equal(t, "2026-06-22T00:00:30Z", r.CompletionTime)
+		assert.Empty(t, r.Events, "events should be omitted when includeEvents=false")
+		assert.Empty(t, r.FailureReason)
+	})
+
+	t.Run("failed run sets failureReason", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Job", "job-b", "SuccessfulCreate", ts("2026-06-22T00:00:00Z")),
+			evt("Job", "job-b", "BackoffLimitExceeded", ts("2026-06-22T00:01:00Z")),
+		}
+		runs := groupRuns(events, false)
+		assert.Len(t, runs, 1)
+		assert.Equal(t, "failed", runs[0].Status)
+		assert.Equal(t, "BackoffLimitExceeded", runs[0].FailureReason)
+		assert.Equal(t, "2026-06-22T00:01:00Z", runs[0].CompletionTime)
+	})
+
+	t.Run("running run leaves completionTime empty", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Job", "job-c", "SuccessfulCreate", ts("2026-06-22T00:00:00Z")),
+		}
+		runs := groupRuns(events, false)
+		assert.Len(t, runs, 1)
+		assert.Equal(t, "running", runs[0].Status)
+		assert.Empty(t, runs[0].CompletionTime)
+	})
+
+	t.Run("includeEvents emits per-run events sorted ascending", func(t *testing.T) {
+		events := []observability.EventEntry{
+			// Intentionally out of order to verify sort.
+			evt("Job", "job-d", "Completed", ts("2026-06-22T00:00:30Z")),
+			evt("Job", "job-d", "SuccessfulCreate", ts("2026-06-22T00:00:00Z")),
+		}
+		runs := groupRuns(events, true)
+		assert.Len(t, runs, 1)
+		assert.Len(t, runs[0].Events, 2)
+		assert.Equal(t, "SuccessfulCreate", runs[0].Events[0].Reason)
+		assert.Equal(t, "Completed", runs[0].Events[1].Reason)
+	})
+}
+
+// ── groupRetries ────────────────────────────────────────────────────
+
+func TestGroupRetries(t *testing.T) {
+	ts := func(s string) time.Time {
+		t, _ := time.Parse(time.RFC3339, s)
+		return t
+	}
+	evt := func(kind, name, reason string, when time.Time) observability.EventEntry {
+		return observability.EventEntry{
+			ObjectKind: kind, ObjectName: name,
+			Reason: reason, Message: reason, Type: "Normal", Timestamp: when,
+		}
+	}
+
+	t.Run("pods belonging to the job become retries; others are ignored", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Job", "job-a", "SuccessfulCreate", ts("2026-06-22T00:00:00Z")),
+			evt("Pod", "job-a-aaa", "Scheduled", ts("2026-06-22T00:00:05Z")),
+			evt("Pod", "job-a-bbb", "Scheduled", ts("2026-06-22T00:00:10Z")),
+			evt("Pod", "unrelated-ccc", "Started", ts("2026-06-22T00:00:15Z")),
+		}
+		retries, jobStatus := groupRetries(events, "job-a")
+		assert.Equal(t, "running", jobStatus)
+		assert.Len(t, retries, 2)
+		assert.Equal(t, "job-a-aaa", retries[0].PodName)
+		assert.Equal(t, "job-a-bbb", retries[1].PodName, "ordered by start time ascending")
+	})
+
+	t.Run("parent Job's events feed the returned job status", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Job", "job-a", "SuccessfulCreate", ts("2026-06-22T00:00:00Z")),
+			evt("Job", "job-a", "Completed", ts("2026-06-22T00:01:00Z")),
+			evt("Pod", "job-a-aaa", "Started", ts("2026-06-22T00:00:05Z")),
+		}
+		_, jobStatus := groupRetries(events, "job-a")
+		assert.Equal(t, "succeeded", jobStatus)
+	})
+
+	t.Run("a different job's events do not pollute jobReasons", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Job", "job-a", "Completed", ts("2026-06-22T00:01:00Z")),
+			evt("Job", "job-b", "BackoffLimitExceeded", ts("2026-06-22T00:01:00Z")),
+			evt("Pod", "job-a-aaa", "Started", ts("2026-06-22T00:00:05Z")),
+		}
+		_, jobStatus := groupRetries(events, "job-a")
+		assert.Equal(t, "succeeded", jobStatus, "job-b's failure must not bleed into job-a's status")
+	})
+
+	t.Run("events per retry are sorted ascending and counted", func(t *testing.T) {
+		events := []observability.EventEntry{
+			evt("Pod", "job-a-aaa", "Started", ts("2026-06-22T00:00:10Z")),
+			evt("Pod", "job-a-aaa", "Scheduled", ts("2026-06-22T00:00:05Z")),
+		}
+		retries, _ := groupRetries(events, "job-a")
+		assert.Len(t, retries, 1)
+		assert.Equal(t, 2, retries[0].EventCount)
+		assert.Equal(t, "Scheduled", retries[0].Events[0].Reason)
+		assert.Equal(t, "Started", retries[0].Events[1].Reason)
+	})
+
+	t.Run("pod whose name does not start with jobName- is ignored", func(t *testing.T) {
+		// job-a-extra would prefix-match "job-a-" so use a name that doesn't.
+		events := []observability.EventEntry{
+			evt("Pod", "different-pod-xxx", "Started", ts("2026-06-22T00:00:05Z")),
+		}
+		retries, _ := groupRetries(events, "job-a")
+		assert.Empty(t, retries)
+	})
+}
+
+// ── parseOptionalTimeRange ──────────────────────────────────────────
+
+func TestParseOptionalTimeRange(t *testing.T) {
+	t.Run("both provided returns parsed window", func(t *testing.T) {
+		s, e, err := parseOptionalTimeRange("2026-06-22T00:00:00Z", "2026-06-22T01:00:00Z")
+		assert.NoError(t, err)
+		assert.Equal(t, "2026-06-22T00:00:00Z", s.UTC().Format(time.RFC3339))
+		assert.Equal(t, "2026-06-22T01:00:00Z", e.UTC().Format(time.RFC3339))
+	})
+	t.Run("missing startTime falls back to 30d window", func(t *testing.T) {
+		s, e, err := parseOptionalTimeRange("", "")
+		assert.NoError(t, err)
+		// Fallback should be ~30 days; loose check to avoid flakiness.
+		assert.InDelta(t, 30*24*time.Hour, e.Sub(s), float64(time.Minute))
+	})
+	t.Run("invalid time returns error", func(t *testing.T) {
+		_, _, err := parseOptionalTimeRange("not-a-time", "2026-06-22T01:00:00Z")
+		assert.Error(t, err)
+	})
+}

--- a/internal/observer/types/runs.go
+++ b/internal/observer/types/runs.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// RunsQueryRequest represents the request for listing runs (Jobs) of a scheduled task component.
+type RunsQueryRequest struct {
+	SearchScope *ComponentSearchScope `json:"searchScope" validate:"required"`
+	StartTime   string                `json:"startTime" validate:"required"`
+	EndTime     string                `json:"endTime" validate:"required"`
+	Limit       int                   `json:"limit,omitempty"`
+	Offset      int                   `json:"offset,omitempty"`
+	SortOrder   string                `json:"sortOrder,omitempty"` // asc or desc, default: desc
+	// IncludeEvents controls whether each RunEntry's Events array is populated.
+	// Defaults to false: callers that only render the run row (status, times, count) get
+	// a smaller payload and the backend skips the per-run top_hits sub-aggregation.
+	IncludeEvents bool `json:"includeEvents,omitempty"`
+}
+
+// RunEvent represents a single event within a run.
+type RunEvent struct {
+	Reason    string `json:"reason"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+	Type      string `json:"type"` // Normal or Warning
+}
+
+// RunEntry represents a single CronJob run (Job) with derived metadata.
+type RunEntry struct {
+	// JobName is the Kubernetes Job name (unique identifier for this run).
+	JobName string `json:"jobName"`
+
+	// Status is derived from events: "succeeded", "failed", "running", "unknown".
+	Status string `json:"status"`
+
+	// StartTime is the earliest event timestamp for this run.
+	StartTime string `json:"startTime"`
+
+	// CompletionTime is the latest event timestamp (approximate completion time).
+	CompletionTime string `json:"completionTime,omitempty"`
+
+	// EventCount is the total number of events for this run.
+	EventCount int `json:"eventCount"`
+
+	// FailureReason is the K8s event reason that caused the failure
+	// (e.g. "BackoffLimitExceeded", "DeadlineExceeded"). Only set when Status == "failed";
+	// derived from the same reasons aggregation that drives Status, so it costs nothing extra.
+	FailureReason string `json:"failureReason,omitempty"`
+
+	// Events is the list of events associated with this run.
+	Events []RunEvent `json:"events,omitempty"`
+}
+
+// RunsQueryResponse is the response for listing runs.
+type RunsQueryResponse struct {
+	Runs   []RunEntry `json:"runs"`
+	Total  int        `json:"total"`
+	TookMs int        `json:"tookMs"`
+}
+
+// RetriesQueryRequest represents the request for listing retries (Pods) of a specific run.
+// Optional StartTime / EndTime narrow the event-fetch window to the run's lifetime,
+// avoiding truncation by the adapter's per-call event cap for high-frequency CronJobs.
+// When omitted, a wide 30-day window is used.
+type RetriesQueryRequest struct {
+	SearchScope *ComponentSearchScope `json:"searchScope" validate:"required"`
+	StartTime   string                `json:"startTime,omitempty"`
+	EndTime     string                `json:"endTime,omitempty"`
+}
+
+// RetryEvent represents a single event within a retry.
+type RetryEvent struct {
+	Reason    string `json:"reason"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+	Type      string `json:"type"`
+}
+
+// RetryEntry represents a single retry (Pod) within a run.
+type RetryEntry struct {
+	// PodName is the Kubernetes Pod name.
+	PodName string `json:"podName"`
+
+	// Status is derived from events: "Succeeded", "Failed", "Running", "Unknown".
+	Status string `json:"status"`
+
+	// StartTime is the earliest event timestamp for this pod.
+	StartTime string `json:"startTime"`
+
+	// EventCount is the total number of events for this pod.
+	EventCount int `json:"eventCount"`
+
+	// Events is the list of events associated with this retry.
+	Events []RetryEvent `json:"events,omitempty"`
+}
+
+// RetriesQueryResponse is the response for listing retries.
+type RetriesQueryResponse struct {
+	Retries []RetryEntry `json:"retries"`
+	Total   int          `json:"total"`
+	TookMs  int          `json:"tookMs"`
+}

--- a/openapi/observer-runs-api.yaml
+++ b/openapi/observer-runs-api.yaml
@@ -1,0 +1,472 @@
+openapi: 3.0.3
+info:
+  title: OpenChoreo Observer - Run-Based Logs API
+  description: |
+    API for querying scheduled task runs (Jobs) and retries (Pods).
+    Events are fetched from the upstream observability logs adapter and grouped
+    by involved-object kind in the observer service.
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8081
+    description: Observer internal (no auth, port-forwarded)
+  - url: http://localhost:8080
+    description: Observer external (requires JWT)
+
+paths:
+  /api/v1/scheduled-tasks/runs/query:
+    post:
+      operationId: queryRuns
+      summary: List runs (Jobs) for a scheduled task component
+      description: |
+        Returns a list of CronJob runs (Jobs) with derived status, event counts,
+        and (optionally) individual events. The observer queries Kubernetes events
+        for the component from the logs adapter and groups them by Job name in-memory.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunsQueryRequest'
+            examples:
+              withUIDs:
+                summary: Query with direct UIDs (bypasses scope resolution auth)
+                value:
+                  searchScope:
+                    namespace: default
+                    project: default
+                    component: scheduled-task-2
+                    environment: development
+                    componentUID: "13a8eee6-6baf-4348-965e-800caf1890bd"
+                    environmentUID: "test-env-uid"
+                    projectUID: "test-proj-uid"
+                  startTime: "2026-04-01T00:00:00Z"
+                  endTime: "2026-04-30T23:59:59Z"
+                  limit: 10
+                  sortOrder: desc
+              withoutUIDs:
+                summary: Query with names only (requires scope resolution auth)
+                value:
+                  searchScope:
+                    namespace: default
+                    project: default
+                    component: scheduled-task-2
+                    environment: development
+                  startTime: "2026-04-01T00:00:00Z"
+                  endTime: "2026-04-30T23:59:59Z"
+                  limit: 20
+                  offset: 0
+                  sortOrder: desc
+      responses:
+        '200':
+          description: Runs retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunsQueryResponse'
+              example:
+                runs:
+                  - jobName: test-scheduled-task-29599605
+                    status: succeeded
+                    startTime: "2026-04-12T06:45:00Z"
+                    completionTime: "2026-04-12T06:45:11Z"
+                    eventCount: 2
+                    events:
+                      - reason: SuccessfulCreate
+                        message: "Created pod: test-scheduled-task-29599605-7xpg9"
+                        timestamp: "2026-04-12T06:45:00Z"
+                        type: Normal
+                      - reason: Completed
+                        message: Job completed
+                        timestamp: "2026-04-12T06:45:11Z"
+                        type: Normal
+                  - jobName: test-scheduled-task-29599668
+                    status: failed
+                    startTime: "2026-04-12T07:48:00Z"
+                    completionTime: "2026-04-12T07:50:30Z"
+                    eventCount: 4
+                    events:
+                      - reason: SuccessfulCreate
+                        message: "Created pod: test-scheduled-task-29599668-abc12"
+                        timestamp: "2026-04-12T07:48:00Z"
+                        type: Normal
+                      - reason: SuccessfulCreate
+                        message: "Created pod: test-scheduled-task-29599668-def34"
+                        timestamp: "2026-04-12T07:48:15Z"
+                        type: Normal
+                      - reason: SuccessfulCreate
+                        message: "Created pod: test-scheduled-task-29599668-ghi56"
+                        timestamp: "2026-04-12T07:48:30Z"
+                        type: Normal
+                      - reason: BackoffLimitExceeded
+                        message: Job has reached the specified backoff limit
+                        timestamp: "2026-04-12T07:50:30Z"
+                        type: Warning
+                total: 63
+                tookMs: 121
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/scheduled-tasks/runs/{jobName}/retries/query:
+    post:
+      operationId: queryRetries
+      summary: List retries (Pods) for a specific run (Job)
+      description: |
+        Returns a list of Pod retries for a given Job run. Each retry includes
+        its derived status and the K8s events associated with it (Scheduled, Pulling,
+        Pulled, Created, Started, etc.).
+      parameters:
+        - name: jobName
+          in: path
+          required: true
+          description: The Kubernetes Job name (from the runs query response)
+          schema:
+            type: string
+          example: test-scheduled-task-29599668
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetriesQueryRequest'
+            examples:
+              withUIDs:
+                summary: Query with direct UIDs
+                value:
+                  searchScope:
+                    namespace: default
+                    project: default
+                    component: scheduled-task-2
+                    environment: development
+                    componentUID: "13a8eee6-6baf-4348-965e-800caf1890bd"
+                    environmentUID: "test-env-uid"
+                    projectUID: "test-proj-uid"
+      responses:
+        '200':
+          description: Retries retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetriesQueryResponse'
+              example:
+                retries:
+                  - podName: test-scheduled-task-29599668-abc12
+                    status: Failed
+                    startTime: "2026-04-12T07:48:02Z"
+                    eventCount: 5
+                    events:
+                      - reason: Scheduled
+                        message: "Successfully assigned dp-default-default-development-f8e58905/test-scheduled-task-29599668-abc12 to k3d-openchoreo-quick-start-server-0"
+                        timestamp: "2026-04-12T07:48:02Z"
+                        type: Normal
+                      - reason: Pulling
+                        message: "Pulling image \"busybox:latest\""
+                        timestamp: "2026-04-12T07:48:02Z"
+                        type: Normal
+                      - reason: Pulled
+                        message: "Successfully pulled image \"busybox:latest\""
+                        timestamp: "2026-04-12T07:48:04Z"
+                        type: Normal
+                      - reason: Created
+                        message: "Created container: task"
+                        timestamp: "2026-04-12T07:48:04Z"
+                        type: Normal
+                      - reason: Started
+                        message: Started container task
+                        timestamp: "2026-04-12T07:48:04Z"
+                        type: Normal
+                  - podName: test-scheduled-task-29599668-def34
+                    status: Failed
+                    startTime: "2026-04-12T07:48:15Z"
+                    eventCount: 3
+                    events:
+                      - reason: Scheduled
+                        message: "Successfully assigned ..."
+                        timestamp: "2026-04-12T07:48:15Z"
+                        type: Normal
+                      - reason: Pulled
+                        message: "Container image already present"
+                        timestamp: "2026-04-12T07:48:15Z"
+                        type: Normal
+                      - reason: Started
+                        message: Started container task
+                        timestamp: "2026-04-12T07:48:16Z"
+                        type: Normal
+                total: 3
+                tookMs: 8
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    ComponentSearchScope:
+      type: object
+      required:
+        - namespace
+        - component
+        - environment
+      properties:
+        namespace:
+          type: string
+          description: OpenChoreo namespace
+          example: default
+        project:
+          type: string
+          description: OpenChoreo project name
+          example: default
+        component:
+          type: string
+          description: OpenChoreo component name
+          example: scheduled-task-2
+        environment:
+          type: string
+          description: OpenChoreo environment name
+          example: development
+        componentUID:
+          type: string
+          description: Component UID (bypasses scope resolution when provided with environmentUID)
+          example: 13a8eee6-6baf-4348-965e-800caf1890bd
+        environmentUID:
+          type: string
+          description: Environment UID (bypasses scope resolution when provided with componentUID)
+          example: test-env-uid
+        projectUID:
+          type: string
+          description: Project UID
+          example: test-proj-uid
+
+    RunsQueryRequest:
+      type: object
+      required:
+        - searchScope
+        - startTime
+        - endTime
+      properties:
+        searchScope:
+          $ref: '#/components/schemas/ComponentSearchScope'
+        startTime:
+          type: string
+          format: date-time
+          description: Start of time range (ISO 8601)
+          example: "2026-04-01T00:00:00Z"
+        endTime:
+          type: string
+          format: date-time
+          description: End of time range (ISO 8601)
+          example: "2026-04-30T23:59:59Z"
+        limit:
+          type: integer
+          description: Maximum number of runs to return (default 20)
+          default: 20
+          example: 10
+        offset:
+          type: integer
+          description: Number of runs to skip for pagination
+          default: 0
+          example: 0
+        sortOrder:
+          type: string
+          description: Sort order by start time
+          enum: [asc, desc]
+          default: desc
+          example: desc
+        includeEvents:
+          type: boolean
+          description: >
+            When true, each RunEntry's `events` array is populated from a per-run
+            top_hits aggregation. Defaults to false to keep responses small for callers that
+            only render the run row (status, times, event count) and fetch retries +
+            their events on demand.
+          default: false
+          example: false
+
+    RunsQueryResponse:
+      type: object
+      properties:
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RunEntry'
+        total:
+          type: integer
+          description: Total number of runs matching the query
+          example: 63
+        tookMs:
+          type: integer
+          description: Query execution time in milliseconds
+          example: 121
+
+    RunEntry:
+      type: object
+      properties:
+        jobName:
+          type: string
+          description: Kubernetes Job name (unique identifier for this run)
+          example: test-scheduled-task-29599605
+        status:
+          type: string
+          description: "Derived status: succeeded, failed, running, or unknown"
+          enum: [succeeded, failed, running, unknown]
+          example: succeeded
+        startTime:
+          type: string
+          format: date-time
+          description: Earliest event timestamp for this run
+          example: "2026-04-12T06:45:00Z"
+        completionTime:
+          type: string
+          format: date-time
+          description: Latest event timestamp (approximate completion time)
+          example: "2026-04-12T06:45:11Z"
+        eventCount:
+          type: integer
+          description: Total number of events for this run
+          example: 2
+        failureReason:
+          type: string
+          description: >
+            K8s event reason that caused the failure (e.g. `BackoffLimitExceeded`,
+            `DeadlineExceeded`, `FailedCreate`). Only present when `status == failed`.
+            Derived from the same reasons aggregation that drives `status`, so it does
+            not require `includeEvents=true`.
+          example: BackoffLimitExceeded
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/RunEvent'
+
+    RunEvent:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: K8s event reason
+          example: Completed
+        message:
+          type: string
+          description: Human-readable event message
+          example: Job completed
+        timestamp:
+          type: string
+          format: date-time
+          example: "2026-04-12T06:45:11Z"
+        type:
+          type: string
+          description: Event severity
+          enum: [Normal, Warning]
+          example: Normal
+
+    RetriesQueryRequest:
+      type: object
+      required:
+        - searchScope
+      properties:
+        searchScope:
+          $ref: '#/components/schemas/ComponentSearchScope'
+        startTime:
+          type: string
+          format: date-time
+          description: |
+            Optional. RFC3339 lower bound on the event window used to find the run's retries.
+            When provided alongside endTime, narrows the adapter query to the run's lifetime,
+            avoiding truncation by the adapter's per-call event cap for high-frequency CronJobs.
+            When omitted, a 30-day lookback ending at now is used.
+          example: '2026-06-22T05:00:00Z'
+        endTime:
+          type: string
+          format: date-time
+          description: Optional. RFC3339 upper bound on the event window. See startTime.
+          example: '2026-06-22T07:30:00Z'
+
+    RetriesQueryResponse:
+      type: object
+      properties:
+        retries:
+          type: array
+          items:
+            $ref: '#/components/schemas/RetryEntry'
+        total:
+          type: integer
+          description: Total number of retries
+          example: 3
+        tookMs:
+          type: integer
+          description: Query execution time in milliseconds
+          example: 8
+
+    RetryEntry:
+      type: object
+      properties:
+        podName:
+          type: string
+          description: Kubernetes Pod name
+          example: test-scheduled-task-29599668-abc12
+        status:
+          type: string
+          description: "Derived status: Succeeded, Failed, Running, or Unknown"
+          enum: [Succeeded, Failed, Running, Unknown]
+          example: Failed
+        startTime:
+          type: string
+          format: date-time
+          description: Earliest event timestamp for this retry
+          example: "2026-04-12T07:48:02Z"
+        eventCount:
+          type: integer
+          description: Total number of events for this retry
+          example: 5
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/RetryEvent'
+
+    RetryEvent:
+      type: object
+      properties:
+        reason:
+          type: string
+          example: Started
+        message:
+          type: string
+          example: Started container task
+        timestamp:
+          type: string
+          format: date-time
+          example: "2026-04-12T07:48:04Z"
+        type:
+          type: string
+          enum: [Normal, Warning]
+          example: Normal
+
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          example: BadRequest
+        errorCode:
+          type: string
+          example: ""
+        message:
+          type: string
+          example: "searchScope is required"

--- a/openapi/observer-runs-api.yaml
+++ b/openapi/observer-runs-api.yaml
@@ -13,6 +13,9 @@ servers:
   - url: http://localhost:8080
     description: Observer external (requires JWT)
 
+security:
+  - bearerAuth: []
+
 paths:
   /api/v1/scheduled-tasks/runs/query:
     post:
@@ -106,6 +109,18 @@ paths:
                 tookMs: 121
         '400':
           description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden — the subject does not have permission to view scheduled-task runs for this component in this environment
           content:
             application/json:
               schema:
@@ -210,6 +225,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden — the subject does not have permission to view scheduled-task retries for this component in this environment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
           content:
@@ -218,6 +245,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     ComponentSearchScope:
       type: object


### PR DESCRIPTION
## Purpose

Adds a hierarchical observability surface for scheduled-task (CronJob) components — `Component → Runs (Jobs) → Retries (Pods)` — built on top of the upstream observability events pipeline introduced in v1.2.0-m.1.

The existing `POST /api/v1/events/query` returns a flat event stream. For scheduled tasks, users need to see *which run* succeeded/failed, *which retries* it spawned, and what events those retries produced. This PR introduces two new endpoints that group the same events into the run-shaped UX the Backstage Runs tab consumes:

- `POST /api/v1/scheduled-tasks/runs/query`
- `POST /api/v1/scheduled-tasks/runs/{jobName}/retries/query`

Backstage UI for this lives in [`openchoreo/backstage-plugins`](https://github.com/openchoreo/backstage-plugins) and consumes these endpoints.

## Approach

- **No new infrastructure.** The observer fetches events through the existing `observability.EventsAdapter` (HTTP-backed `logs-adapter`). It never queries OpenSearch directly.
- **Grouping happens in-memory** in a new `RunsService`. Events with `metadata.objectKind == \"Job\"` become runs, keyed by `objectName`. Events with `objectKind == \"Pod\"` whose `objectName` is prefixed by the Job's name become that run's retries.
- **Status derivation** is reason-based (existing pattern in the codebase): `Completed` → succeeded; `BackoffLimitExceeded`/`DeadlineExceeded`/`FailedCreate` → failed (with `failureReason`); only `SuccessfulCreate` → running.
- **Pod-status override**: native K8s does not emit pod-phase Succeeded/Failed events on container exit, so `applyRunStatusOverride` infers per-retry status from the parent Job's terminal status (matches the heuristic documented in the contributor guide).
- **Auth + scope resolution** reuse the existing pathway — the runs service is wrapped in a `runsServiceWithAuthz` that calls the same `ActionViewEvents` check the events endpoint uses.
- **Optional `startTime`/`endTime`** on `RetriesQueryRequest` so the UI can scope the event fetch to a specific run's lifetime, avoiding truncation by the adapter's 1000-event-per-call cap on high-frequency CronJobs. Defaults to a 30-day lookback when omitted.

Two small dev-loop scripts (`hack/redeploy-observer.sh`, `hack/patch-observer-cors-for-local-dev.sh`) and a contributor guide (`docs/contributors/run-based-logs.md`) round out the change.

## Related Issues

- Discussion #1894 — Kube Events Persistence (the motivating proposal)
- PR #3738 — k8s events querying functionality in observer API (the upstream events endpoint this PR layers on top of)
- PR #3781 — Kubernetes events collection to observability plane (the upstream OTel collector)
- backstage-plugins PR #617 — component events view (complementary flat-events UI)

## Checklist
- [x] Tests added (`internal/observer/service/runs_test.go` — table-driven tests for grouping, status derivation, pagination, sorting, optional time-range parsing)
- [ ] Samples updated — N/A (no sample changes; existing `samples/from-image/issue-reporter-schedule-task/` is the natural test fixture)
- [ ] `backport/...` label — not requesting backport

## Remarks

- **Limitations** (documented in the contributor guide): pod-phase events do not exist natively in K8s, the `OnFailure` restart policy collapses retries into a single pod, and the adapter's 1000-event cap can truncate retries lookups for very high-frequency CronJobs (mitigated by the optional time window).
- **Future work**: a synthetic-events processor (either upstream of the OTel collector or as a `k8seventenrich` extension) would let us drop the heuristic pod-status override entirely.