### PR TITLE
build(deps): add Dependabot coverage for agent Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
       - "/"
       - "/cmd/*"
       - "/install/*"
+      - "/agents/*"
     schedule:
       interval: "monthly"
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
$subject

## Approach
Adds Dependabot Docker update coverage for `agents/*` Dockerfiles.

The agent images are built, published, scanned, and released as part of OpenChoreo, but their Docker base images were not covered by the existing Dependabot Docker configuration. This extends the current Docker coverage from root, `cmd/*`, and `install/*` Dockerfiles to include the Python agent images.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3934

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
