### PR TITLE
feat(api): make component:exec environment-conditionable

### DIFF
--- a/internal/authz/core/condition_registry.go
+++ b/internal/authz/core/condition_registry.go
@@ -87,6 +87,7 @@ var conditionRegistry = map[string][]AttributeSpec{
 	ActionViewProjectReleaseBinding:    {AttrResourceEnvironment},
 	ActionUpdateProjectReleaseBinding:  {AttrResourceEnvironment},
 	ActionDeleteProjectReleaseBinding:  {AttrResourceEnvironment},
+	ActionExecComponent:                {AttrResourceEnvironment},
 	ActionViewLogs:                     {AttrResourceEnvironment},
 	ActionViewWirelogs:                 {AttrResourceEnvironment},
 	ActionViewMetrics:                  {AttrResourceEnvironment},

--- a/internal/authz/core/condition_registry_test.go
+++ b/internal/authz/core/condition_registry_test.go
@@ -38,6 +38,12 @@ func TestLookupConditions(t *testing.T) {
 		require.Nil(t, specs)
 	})
 
+	t.Run("component:exec supports resource.environment", func(t *testing.T) {
+		specs := LookupConditions(ActionExecComponent)
+		require.Len(t, specs, 1)
+		require.Equal(t, AttrResourceEnvironment.Key, specs[0].Key)
+	})
+
 	t.Run("resourcereleasebinding actions support resource.environment", func(t *testing.T) {
 		for _, action := range []string{
 			ActionCreateResourceReleaseBinding,

--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -78,7 +78,21 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := h.logger.With("namespace", namespace, "component", componentName)
 	logger.Info("Exec request received", "env", envName, "pod", podName, "container", container)
 
-	// Authorize: check that the caller has component:exec permission.
+	// Resolve the target environment before authorizing so per-environment exec
+	// conditions are evaluated against it (`env` may be omitted by the client).
+	effectiveEnv, err := h.resolveEnvName(ctx, namespace, project, envName)
+	if err != nil {
+		status := http.StatusBadRequest
+		var infraErr *execInfraError
+		if errors.As(err, &infraErr) {
+			status = http.StatusServiceUnavailable
+		}
+		logger.Warn("Failed to resolve environment for exec", "error", err)
+		http.Error(w, fmt.Sprintf("failed to resolve environment: %v", err), status)
+		return
+	}
+
+	// Authorize: check that the caller has component:exec permission for this environment.
 	if h.authzChecker == nil {
 		logger.Error("Authorization checker not configured")
 		http.Error(w, "authorization not configured", http.StatusInternalServerError)
@@ -92,6 +106,11 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Namespace: namespace,
 			Project:   project,
 		},
+		Context: authz.Context{
+			Resource: authz.ResourceAttribute{
+				Environment: svcpkg.FormatDualScopedResourceName(namespace, effectiveEnv, false),
+			},
+		},
 	}); err != nil {
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			http.Error(w, "you do not have permission to exec into this component", http.StatusForbidden)
@@ -103,7 +122,7 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve the pod to exec into
-	podInfo, err := h.resolvePod(ctx, namespace, componentName, project, envName, podName)
+	podInfo, err := h.resolvePod(ctx, namespace, componentName, project, effectiveEnv, podName)
 	if err != nil {
 		status := http.StatusBadRequest
 		var infraErr *execInfraError
@@ -226,6 +245,18 @@ type execPodInfo struct {
 	podName      string
 	containers   []string // container names present in the pod
 	plane        execPlaneInfo
+}
+
+// resolveEnvName returns the effective environment, deriving the lowest env from
+// the project's deployment pipeline when the `env` query param is omitted.
+func (h *ExecHandler) resolveEnvName(ctx context.Context, namespace, project, envName string) (string, error) {
+	if envName != "" {
+		return envName, nil
+	}
+	if project == "" {
+		return "", fmt.Errorf("--project or --env is required")
+	}
+	return h.resolveLowestEnvironment(ctx, namespace, project)
 }
 
 // resolvePod resolves the target pod for exec by traversing:
@@ -475,7 +506,10 @@ func (h *ExecHandler) resolveLowestEnvironment(ctx context.Context, namespace, p
 
 	pipeline := &openchoreov1alpha1.DeploymentPipeline{}
 	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: proj.Spec.DeploymentPipelineRef.Name}, pipeline); err != nil {
-		return "", fmt.Errorf("deployment pipeline not found: %w", err)
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("deployment pipeline %q not found in namespace %q", proj.Spec.DeploymentPipelineRef.Name, namespace)
+		}
+		return "", infraErrorf("failed to look up deployment pipeline %q: %w", proj.Spec.DeploymentPipelineRef.Name, err)
 	}
 
 	if len(pipeline.Spec.PromotionPaths) == 0 {

--- a/internal/openchoreo-api/api/handlers/exec_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/testutil"
+)
+
+func newExecHandler(t *testing.T, pdp *testutil.CapturingPDP, objs ...client.Object) *ExecHandler {
+	t.Helper()
+	return &ExecHandler{
+		k8sClient:    fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(objs...).Build(),
+		authzChecker: testutil.NewTestAuthzChecker(pdp),
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// These tests assert the exec authz check carries the target environment in its
+// ABAC context. The fake client has no Component, so the request fails right
+// after the check — but by then the PDP has captured the evaluate request.
+
+func TestExecHandler_AuthzEnvironmentContext_ExplicitEnv(t *testing.T) {
+	pdp := testutil.AllowPDP()
+	h := newExecHandler(t, pdp)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/greeter-service?env=development&project=default",
+		nil).WithContext(testutil.AuthzContext())
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, pdp.Captured, 1, "authz check should run before pod resolution")
+	testutil.RequireEvalRequest(t, pdp.Captured[0],
+		authz.ActionExecComponent, "component", "greeter-service",
+		authz.ResourceHierarchy{Namespace: "default", Project: "default"})
+	require.Equal(t,
+		services.FormatDualScopedResourceName("default", "development", false),
+		pdp.Captured[0].Context.Resource.Environment)
+}
+
+// When `env` is omitted, the environment is derived from the project's deployment
+// pipeline (the root env) and must still reach the ABAC context.
+func TestExecHandler_AuthzEnvironmentContext_DerivedEnv(t *testing.T) {
+	pdp := testutil.AllowPDP()
+	proj := &openchoreov1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "default"},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default-pipeline"},
+		},
+	}
+	// development → production, so "development" is the root (never a target).
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "default-pipeline"},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{{
+				SourceEnvironmentRef:  openchoreov1alpha1.EnvironmentRef{Name: "development"},
+				TargetEnvironmentRefs: []openchoreov1alpha1.TargetEnvironmentRef{{Name: "production"}},
+			}},
+		},
+	}
+	h := newExecHandler(t, pdp, proj, pipeline)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/greeter-service?project=default",
+		nil).WithContext(testutil.AuthzContext())
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, pdp.Captured, 1)
+	require.Equal(t,
+		services.FormatDualScopedResourceName("default", "development", false),
+		pdp.Captured[0].Context.Resource.Environment,
+		"pipeline-derived environment must reach the ABAC context when env is omitted")
+}


### PR DESCRIPTION
## What
Make the `component:exec` authorization action support per-environment ABAC conditions (the `resource.environment` attribute), the same way `logs:view` and the release-binding actions already do.

## Why
`component:exec` is not in the condition registry today, so:
- the action catalog (`/api/v1/authz/actions`) reports no conditionable attributes for it — the Access Control UI shows *"none of these actions support conditions"* and won't let you scope exec by environment;
- the `authzrolebinding` validating webhook rejects any condition on `component:exec` (`conditions are not supported for the specified action set`);
- the CEL evaluator can't reference `resource.environment` for exec.

This makes it impossible to grant, e.g., exec in non-production environments but deny it in production.

## Changes
- `internal/authz/core/condition_registry.go`: register `ActionExecComponent: {AttrResourceEnvironment}`. This one entry drives the catalog, the validating webhook, and the CEL activation.
- `internal/openchoreo-api/api/handlers/exec.go`: resolve the effective environment up front (the `env` query param may be omitted, so it's derived from the project's deployment pipeline) and pass `Context.Resource.Environment` (namespace-scoped via `FormatDualScopedResourceName`) into the exec authz check. Without this the WS-upgrade check would evaluate with an empty env and over-deny once any exec condition exists.
- Tests: registry sub-test (`component:exec` exposes `resource.environment`) + exec handler test (authz check attaches the env to the ABAC context).

## Testing
- `go test ./internal/authz/... ./internal/openchoreo-api/...` passes.
- Verified end-to-end on a k3d cluster: with a condition `resource.environment in ["<ns>/<env>"]` on a binding's `component:exec` mapping, exec is **allowed in the matching environment and denied (403) elsewhere** — across the catalog/UI condition editor, the `/exec/init` check, and the exec WebSocket upgrade.
