### PR TITLE
perf(api): cache compiled CEL programs in authz enforcer

### DIFF
--- a/internal/authz/casbin/bench_cel_test.go
+++ b/internal/authz/casbin/bench_cel_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package casbin
+
+import (
+	"testing"
+
+	authzv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+)
+
+// benchExprs are representative authz CEL conditions (only `resource` is declared in the CEL env).
+var benchExprs = []string{
+	`resource.environment == "production"`,
+	`resource.environment == "dev" || resource.environment == "staging"`,
+	`resource.project == "payments" && resource.environment != "production"`,
+	`resource.environment == "production" && resource.project != "sandbox"`,
+}
+
+// BenchmarkConditionMatcher measures the full per-request, per-conditional-policy authz cost:
+// unmarshal condition JSON + filter by action + build CEL activation + compile + eval. This is the
+// representative number — list endpoints run it once per item. Run with and without the patch to
+// see the delta (compilation is the part the cache removes).
+func BenchmarkConditionMatcher(b *testing.B) {
+	ctx, _ := serializeAuthzContext(authzcore.Context{Resource: authzcore.ResourceAttribute{Environment: "dev"}})
+	cond, _ := serializeAuthzConditions([]authzv1alpha1.AuthzCondition{
+		{Actions: []string{"releasebinding:create"}, Expression: `resource.environment == "dev"`},
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !ConditionMatcher(ctx, "releasebinding:create", cond, "allow", "bench") {
+			b.Fatal("expected match")
+		}
+	}
+}
+
+// BenchmarkCompileCEL measures the cost of compileCEL, which evalCondition invokes on every
+// condition evaluation (per conditional policy, and per item on list endpoints).
+func BenchmarkCompileCEL(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := compileCEL(benchExprs[i%len(benchExprs)]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCompileAndEval mirrors the real hot path: obtain the program, then evaluate it.
+func BenchmarkCompileAndEval(b *testing.B) {
+	act := map[string]interface{}{
+		"resource": map[string]interface{}{"environment": "production", "project": "payments"},
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		prg, err := compileCEL(benchExprs[i%len(benchExprs)])
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _, _ = prg.Eval(act)
+	}
+}

--- a/internal/authz/casbin/helpers.go
+++ b/internal/authz/casbin/helpers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/interpreter"
@@ -593,8 +594,15 @@ func computePolicyDiff(oldPolicies, newPolicies [][]string) (added, removed [][]
 	return added, removed
 }
 
+// celProgramCache memoizes compiled CEL programs by expression string. cel.Program is immutable and
+// safe for concurrent Eval; policy expressions are a small, stable set, so no eviction is needed.
+var celProgramCache sync.Map // map[string]cel.Program
+
 // compileCEL compiles a CEL expression and returns a ready-to-evaluate Program.
 func compileCEL(expr string) (cel.Program, error) {
+	if p, ok := celProgramCache.Load(expr); ok {
+		return p.(cel.Program), nil
+	}
 	env, err := authzcore.GetCELEnv()
 	if err != nil {
 		return nil, fmt.Errorf("CEL environment unavailable: %w", err)
@@ -607,6 +615,7 @@ func compileCEL(expr string) (cel.Program, error) {
 	if err != nil {
 		return nil, fmt.Errorf("program construction error: %w", err)
 	}
+	celProgramCache.Store(expr, prg)
 	return prg, nil
 }
 


### PR DESCRIPTION
## Purpose
The authz enforcer recompiles the CEL condition program on every evaluation: `evalCondition` → `compileCEL` (`internal/authz/casbin/helpers.go`) runs once per conditional policy, and once **per item** on list endpoints (`internal/openchoreo-api/services/pagination.go`). It's redundant work on every authorized request and compounds with list size and request rate.

Resolves #3975.

## Approach
Memoize compiled programs by expression string (compile once per condition). Safe because keys are admin-authored policy expressions (request input only forms the eval activation, never the key), and `cel.Program` is immutable with the CEL env built once — a given expression always compiles to an equivalent program, and decisions are still evaluated per request.

Benchmarks (`go test ./internal/authz/casbin -bench . -benchtime=2s`; *before* = same benchmarks with the cache disabled):

| benchmark | before | after |
|---|---|---|
| `ConditionMatcher` (full per-request condition check) | 18,102 ns/op · 297 allocs | 2,229 ns/op · 48 allocs |
| `BenchmarkCompileCEL` | 24,973 ns/op · 384 allocs | 10 ns/op · 0 allocs |
| `BenchmarkCompileAndEval` | 24,508 ns/op · 386 allocs | 91 ns/op · 1 alloc |

The `ConditionMatcher` row is the representative per-request number: ~8x faster, ~6x fewer allocations. List endpoints run this once per item, so it compounds with list size and request rate (e.g. catalog-sync full walks over thousands of entities).

## Related Issues
Resolves #3975.

## Checklist
- [x] Tests added or updated — adds `BenchmarkConditionMatcher` / `BenchmarkCompileCEL` / `BenchmarkCompileAndEval`; existing `TestCasbinEnforcer_Evaluate_*` cover behavior (unchanged)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
The authz *decision* cache (`SyncedCachedEnforcer`) is ineffective here (decisions depend on per-request ABAC context); the *compile* cache is the right lever.
