### PR TITLE
fix: run tier3 diagnostics and teardown on test failure

### DIFF
--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -701,8 +701,9 @@ e2e.down: ## Delete k3d cluster
 e2e.multi: ## Full multi-cluster e2e lifecycle: setup → test → down (collects diagnostics on failure)
 	@setup_ok=0; \
 	$(MAKE) e2e.multi.setup && setup_ok=1; \
+	test_exit=0; \
 	if [ $$setup_ok -eq 1 ]; then \
-		$(MAKE) e2e.multi.test; test_exit=$$?; \
+		$(MAKE) e2e.multi.test || test_exit=$$?; \
 		if [ $$test_exit -ne 0 ]; then $(MAKE) e2e.multi.diagnostics || true; fi; \
 	else \
 		test_exit=1; \
@@ -1282,6 +1283,19 @@ e2e.multi.diagnostics: ## Collect logs, events, and resource dumps from all four
 	done
 	@$(E2E_MC_CP_KUBECTL) get clusterdataplane,clusterworkflowplane,clusterobservabilityplane -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/plane-resources.yaml 2>&1 || true
 	@$(E2E_MC_CP_KUBECTL) get component,componentrelease,releasebinding,renderedrelease -A -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/release-chain.yaml 2>&1 || true
+	@# Build/workflow state: WorkflowRuns (per-test CP namespaces) and the Argo
+	@# Workflows + build pods (per-test WP "workflows-*" namespaces) — not covered
+	@# by the fixed plane namespaces above, but the usual tier3 failure point.
+	@$(E2E_MC_CP_KUBECTL) get workflowrun -A -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/cp-workflowruns.yaml 2>&1 || true
+	@kubectl --context $(E2E_MC_WP_KUBECONTEXT) get workflows.argoproj.io -A -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/wp-argo-workflows.yaml 2>&1 || true
+	@for ns in $$(kubectl --context $(E2E_MC_WP_KUBECONTEXT) get ns -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep '^workflows-'); do \
+		kubectl --context $(E2E_MC_WP_KUBECONTEXT) get pods -n $$ns -o wide > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-pods.txt 2>&1 || true; \
+		kubectl --context $(E2E_MC_WP_KUBECONTEXT) get events -n $$ns --sort-by=.lastTimestamp > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-events.txt 2>&1 || true; \
+		kubectl --context $(E2E_MC_WP_KUBECONTEXT) describe pods -n $$ns > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-describe.txt 2>&1 || true; \
+		for pod in $$(kubectl --context $(E2E_MC_WP_KUBECONTEXT) get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
+			kubectl --context $(E2E_MC_WP_KUBECONTEXT) logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-logs-$$pod.txt 2>&1 || true; \
+		done; \
+	done
 	@# Host-level resource usage of the k3d node containers. Captured from the
 	@# runner (not via kubectl) so it works even when a cluster's API server is
 	@# unresponsive — the CPU/memory-overcommit failure mode we most need to see.


### PR DESCRIPTION
## Purpose
Tier-3 (multi-cluster) e2e failures upload an empty diagnostics artifact and leak clusters, making the recurring "build never reaches WorkflowSucceeded" flake impossible to debug after the fact.

Root cause: recipes run under `set -e` (`.SHELLFLAGS = -ec` in make/common.mk), but the `e2e.multi` recipe used `make e2e.multi.test; test_exit=$?`. Under`set -e` the shell exits at the failing test, so `e2e.multi.diagnostics` and `e2e.multi.down` never run.

## Approach
- Switch `e2e.multi` to the safe `|| test_exit=$?` form (with `test_exit=0` init) already used by the single-cluster `e2e` target, so diagnostics and teardown run on test failure.
- Extend `e2e.multi.diagnostics` to also dump the per-test build namespaces: CP WorkflowRuns, WP Argo Workflows, and the `workflows-*` build pods' describe/events/logs — the actual tier3 failure point, not covered by the fixed plane namespaces.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
Makefile-only, no behavior change on the success path. This restores diagnostics so the underlying build-timeout flake (likely runner resource starvation) can be confirmed on the next occurrence; it does not itself cure that flake.