### PR TITLE
feat(helm): make Backstage wirelogs stream timeout configurable

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -152,6 +152,12 @@ spec:
         # skipped so the system runs in poll-only mode.
         - name: OPENCHOREO_EVENTS_ENABLED
           value: {{ .Values.eventForwarder.enabled | quote }}
+        # Observability tuning — hard cap (seconds) on a single wirelogs SSE
+        # stream before the backend ends it. The UI shows soft warnings at
+        # ~1/3 and ~2/3 of this value and a toast when the server stops it.
+        # Defaults to 900 (15 minutes).
+        - name: OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS
+          value: {{ .Values.backstage.observability.wirelogs.streamTimeoutSeconds | default 900 | quote }}
         # External CI Platform Integrations
         # Jenkins: requires jenkins.io/job-full-name annotation on entity
         - name: JENKINS_BASE_URL

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -801,6 +801,31 @@
           "title": "nodeSelector",
           "type": "object"
         },
+        "observability": {
+          "additionalProperties": false,
+          "description": "Observability plane tuning for Backstage. Separate from the features.observability feature flag above — this controls runtime behaviour of observability views, not whether they are shown.",
+          "properties": {
+            "wirelogs": {
+              "additionalProperties": false,
+              "description": "Wirelogs (Cilium Hubble flow) stream tuning.",
+              "properties": {
+                "streamTimeoutSeconds": {
+                  "default": 900,
+                  "description": "Hard cap in seconds on a single wirelogs SSE stream before the Backstage backend ends it. The UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast when the server stops the stream. Maps to OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS in the Backstage container.",
+                  "minimum": 1,
+                  "title": "streamTimeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [],
+              "title": "wirelogs",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "observability",
+          "type": "object"
+        },
         "openchoreoApi": {
           "additionalProperties": false,
           "description": "OpenChoreo API connection configuration",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2547,6 +2547,24 @@ backstage:
 
   # @schema
   # type: object
+  # description: Observability plane tuning for Backstage. Separate from the features.observability feature flag above — this controls runtime behaviour of observability views, not whether they are shown.
+  # @schema
+  observability:
+    # @schema
+    # type: object
+    # description: Wirelogs (Cilium Hubble flow) stream tuning.
+    # @schema
+    wirelogs:
+      # @schema
+      # type: integer
+      # description: Hard cap in seconds on a single wirelogs SSE stream before the Backstage backend ends it. The UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast when the server stops the stream. Maps to OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS in the Backstage container.
+      # default: 900
+      # minimum: 1
+      # @schema
+      streamTimeoutSeconds: 900
+
+  # @schema
+  # type: object
   # description: External CI platform integrations (Jenkins, GitHub Actions). GitLab support coming soon.
   # @schema
   externalCI:


### PR DESCRIPTION
## Purpose

The Backstage backend caps each wirelogs (Cilium Hubble flow) SSE stream at a hard limit — default 15 minutes — so a forgotten tab can't hold an open connection for hours. The backend reads this cap from `OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS` (via `app-config.yaml`), but the control-plane chart had no way to set it, so operators couldn't tune the cap without baking a custom image. This wires the chart to inject the variable from a values knob.

## Approach

- Add `backstage.observability.wirelogs.streamTimeoutSeconds` to the control-plane chart values (default `900` = 15 min, `minimum: 1`) with `@schema` annotations, and regenerate `values.schema.json`.
- Inject `OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS` into the Backstage deployment from that value, alongside the other OpenChoreo tuning env vars (mirrors the `catalogSync.frequency` pattern).
- Leave the gateway route timeouts from #3800 permissive on purpose (`request: 0s`, `streamIdle: 24h`): the application-layer cap fires first, so the backend can emit its graceful `timeout` SSE frame before the connection closes. A gateway-level cut would break that UX.

Validation:
- `helm lint` passes.
- `helm template` renders `value: "900"` by default and the overridden value when set (`--set backstage.observability.wirelogs.streamTimeoutSeconds=120` → `"120"`).
- Schema validation rejects non-positive values (`--set …=0` → `minimum: got 0, want 1`).

## Related Issues
- https://github.com/openchoreo/openchoreo/issues/3978
- Builds on #3800 (gateway timeout policies for the Backstage wirelogs streaming route).
- Pairs with the corresponding `openchoreo/backstage-plugins` change that introduced the backend stream cap and reads this env var.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.) — chart-only change; no helm-unittest suite exists for this chart. Validated via `helm lint` / `helm template` as above.
- [ ] Samples updated (if applicable) — N/A.
- [ ] Added `backport/<release-branch>` label if this should be backported.

## Remarks

- `values.schema.json` was regenerated with the pinned `helm-schema` tool only. A full `make helm-generate.openchoreo-control-plane` additionally re-runs `make manifests` (CRD churn unrelated to this change), so it was intentionally not run here.
- Branch is based on `main` at `50791c12`; rebase onto latest `main` before merge if it has moved.
