### PR TITLE
test: create projects through the per-ProjectType template flow

### DIFF
--- a/test/ui/po/create.ts
+++ b/test/ui/po/create.ts
@@ -4,17 +4,13 @@
 import { type Page } from '@playwright/test';
 import { SidebarPO } from './sidebar';
 
-// The OpenChoreo "Create" page (CustomTemplateListPage). The landing view shows
-// a card per scaffolder template (Project, ComponentType, Trait, …) plus two
-// navigation cards — "Component" and "Resource" — that drill into their own
-// per-type template lists. Each template card renders a
-// `<button aria-label="Use template <title>">`, and the navigation cards are
-// role=button elements whose accessible name is "<Title> <description>".
-//
-// Reaching a template form is therefore a pure click flow (sidebar → Create →
-// card), so specs never need to deep-link to `/create/templates/...`. The
-// NamespaceEntityPicker falls back to the `default` namespace on its own, so the
-// `?namespace=` query the old URLs carried is unnecessary.
+// The OpenChoreo "Create" page (CustomTemplateListPage). "Application
+// Resources" are three navigation cards — "Project", "Component", "Resource" —
+// that drill into per-type template sub-lists; "Platform Resources" are direct
+// template cards (Namespace, Environment, ComponentType, Trait, …). Template
+// cards render `<button aria-label="Use template <title>">`; navigation cards
+// are role=button elements named "<Title> <description>". Reaching a form is a
+// pure click flow, so specs never deep-link to `/create/templates/...`.
 export class CreatePO {
   constructor(private readonly page: Page) {}
 
@@ -23,10 +19,20 @@ export class CreatePO {
     await new SidebarPO(this.page).goCreate();
   }
 
-  // Choose a landing-view template card (e.g. "Project", "ComponentType",
-  // "Trait") and land on its scaffolder form.
+  // Choose a "Platform Resources" template card (e.g. "Namespace",
+  // "ComponentType", "Trait") and land on its scaffolder form.
   async chooseTemplate(title: string): Promise<void> {
     await this.open();
+    await this.useTemplate(title);
+  }
+
+  // Project templates live behind the "Project" navigation card, which opens
+  // the per-ProjectType template list; pick the template from there.
+  async chooseProjectTemplate(title: string): Promise<void> {
+    await this.open();
+    await this.page
+      .getByRole('button', { name: /Project Browse project templates/i })
+      .click();
     await this.useTemplate(title);
   }
 

--- a/test/ui/po/project.ts
+++ b/test/ui/po/project.ts
@@ -4,32 +4,43 @@
 import { expect, type Page } from '@playwright/test';
 import { CreatePO } from './create';
 
+// Template card title for the default cluster-scoped ClusterProjectType; each
+// (Cluster)ProjectType yields one card titled by its display name.
+export const DEFAULT_PROJECT_TYPE_TEMPLATE = 'Default Project Type';
+
 export interface CreateProjectInput {
   name: string;
   namespace?: string; // defaults to "default"; preselected via ?namespace query.
   displayName?: string;
   description?: string;
   pipeline?: string; // matches a Deployment Pipeline entity name.
+  projectType?: string; // template card title; defaults to DEFAULT_PROJECT_TYPE_TEMPLATE.
 }
 
-// Project creation flows through the Backstage Scaffolder template
-// `create-openchoreo-project`, reached by clicking the "Project" card on the
-// Create page (CreatePO). The NamespaceEntityPicker auto-selects the `default`
-// namespace when no preselection is supplied, so the click flow needs no
-// `?namespace=` query.
+// Project creation flows through a per-(Cluster)ProjectType Scaffolder template,
+// reached via the "Project" navigation card on the Create page (CreatePO) then
+// the type's template card. The NamespaceEntityPicker auto-selects the `default`
+// namespace, so the click flow needs no `?namespace=` query.
 //
-// Field titles come from the template YAML: "Namespace Name", "Project Name",
-// "Display Name", "Description", "Deployment Pipeline". MUI labels are wired
-// through aria-labelledby, so getByLabel resolves each.
+// Field titles: "Namespace", "Project Name", "Display Name", "Description",
+// "Deployment Pipeline". MUI labels are wired through aria-labelledby, so
+// getByLabel resolves each.
 export class ProjectPO {
   constructor(private readonly page: Page) {}
 
-  // `namespace` is accepted for API symmetry; only the auto-selected `default`
-  // namespace is exercised. A non-default namespace would need the
-  // NamespaceEntityPicker driven explicitly here.
-  async openCreateForm(namespace = 'default'): Promise<void> {
-    void namespace;
-    await new CreatePO(this.page).chooseTemplate('Project');
+  // Only the auto-selected `default` namespace is supported here; a non-default
+  // namespace needs the NamespaceEntityPicker driven explicitly, so reject it
+  // rather than silently creating the project under `default`.
+  async openCreateForm(
+    namespace = 'default',
+    projectType = DEFAULT_PROJECT_TYPE_TEMPLATE,
+  ): Promise<void> {
+    if (namespace !== 'default') {
+      throw new Error(
+        `ProjectPO.openCreateForm: unsupported namespace "${namespace}"; drive the NamespaceEntityPicker explicitly for non-default namespaces.`,
+      );
+    }
+    await new CreatePO(this.page).chooseProjectTemplate(projectType);
   }
 
   async fillCreateForm(input: CreateProjectInput): Promise<void> {
@@ -56,13 +67,10 @@ export class ProjectPO {
   }
 
   async submitCreate(): Promise<void> {
-    // Scaffolder uses a multi-step layout. The Project template surfaces
-    // step 1 with a "Review" button (advances to step 2) and step 2 with a
-    // "Create" button (submits). Some templates also intersperse "Next" on
-    // wider steps, so that label is probed but optional. "Review" and
-    // "Create" are mandatory: a timeout there means a slow/broken render and
-    // must fail loudly — treating it as "absent" would skip the submit and
-    // surface as a confusing downstream failure.
+    // Multi-step scaffolder: "Next" advances optional intermediate steps;
+    // "Review" then "Create" submit. "Review"/"Create" are mandatory — a
+    // timeout there is a slow/broken render and must fail loudly, not be
+    // skipped.
     for (const { label, required } of [
       { label: 'Next', required: false },
       { label: 'Review', required: true },
@@ -80,7 +88,7 @@ export class ProjectPO {
   }
 
   async create(input: CreateProjectInput): Promise<void> {
-    await this.openCreateForm(input.namespace);
+    await this.openCreateForm(input.namespace, input.projectType);
     await this.fillCreateForm(input);
     await this.submitCreate();
   }

--- a/test/ui/specs/pe-ops/pe-ops-namespace.spec.ts
+++ b/test/ui/specs/pe-ops/pe-ops-namespace.spec.ts
@@ -9,6 +9,7 @@ import { DeletePO } from '../../po/delete';
 import { CatalogTablePO } from '../../po/catalogTable';
 import { ScaffolderWizardPO } from '../../po/scaffolderWizard';
 import { CreatePO } from '../../po/create';
+import { DEFAULT_PROJECT_TYPE_TEMPLATE } from '../../po/project';
 
 // Namespace names must be valid Kubernetes namespace names: lowercase
 // alphanumeric + '-', no leading/trailing hyphens, max 63 characters.
@@ -170,12 +171,12 @@ test.describe('pe-ops: Namespace lifecycle through the Backstage UI', () => {
     test.setTimeout(300_000);
 
     await page.goto('/');
-    await new CreatePO(page).chooseTemplate('Project');
+    await new CreatePO(page).chooseProjectTemplate(DEFAULT_PROJECT_TYPE_TEMPLATE);
 
     const wizard = new ScaffolderWizardPO(page);
 
     // The NamespaceEntityPicker auto-selects 'default'; override to our namespace.
-    await wizard.selectMuiOption('Namespace Name', NAMESPACE_NAME);
+    await wizard.selectMuiOption('Namespace', NAMESPACE_NAME);
 
     // The DeploymentPipelinePicker auto-populates once the namespace is set.
     // Wait for it to resolve before filling other fields.


### PR DESCRIPTION
## Purpose
The nightly UI E2E leg started failing on `main` after `openchoreo-ui:latest-dev` picked up backstage-plugins https://github.com/openchoreo/backstage-plugins/pull/653, which replaced the static `create-openchoreo-project` template with a per-ProjectType wizard. "Project" is now a navigation card ("Browse project templates") on the Create page rather than a direct template card, so the four specs that create a Project via the UI timed out clicking the old `Use template Project` button.

## Approach
- Add `CreatePO.chooseProjectTemplate()` that clicks the "Project" nav card then the per-type template card (mirrors `chooseComponentTemplate`).
- Route `ProjectPO` through it, defaulting to the seeded `Default Project Type` template.
- Update the `pe-ops-namespace` project step to the new flow and the renamed namespace field label (`Namespace`).

## Checklist
- [x] Tests added or updated
- [ ] Samples updated (n/a)
- [ ] backport label (n/a)