### PR TITLE
chore: add external compatibility scan

### DIFF
--- a/.github/external-compatibility-sources.json
+++ b/.github/external-compatibility-sources.json
@@ -1,0 +1,441 @@
+{
+  "version": 1,
+  "defaults": {
+    "keywords": [
+      "breaking change",
+      "deprecated",
+      "deprecation",
+      "end of support",
+      "end-of-support",
+      "removed",
+      "removal",
+      "retired",
+      "retirement",
+      "sunset"
+    ]
+  },
+  "sources": [
+    {
+      "id": "github-rest-api-versions",
+      "name": "GitHub REST API versions",
+      "type": "github_api_versions",
+      "url": "https://api.github.com/versions",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml",
+        "samples/workflows/scm-create-repo/github-create-repo.yaml",
+        "install/helm/openchoreo-control-plane/values.yaml",
+        "docs/integrations/github-actions.md"
+      ],
+      "action": "The pinned X-GitHub-Api-Version may no longer be supported or may be approaching its support deadline. Review direct GitHub API calls and update before any sunset date.",
+      "pinned_version": "2022-11-28",
+      "supported_until": "2028-03-10",
+      "warn_within_days": 180,
+      "request_headers": {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2026-03-10"
+      }
+    },
+    {
+      "id": "github-rest-breaking-changes",
+      "name": "GitHub REST API breaking changes",
+      "type": "reference_page",
+      "url": "https://docs.github.com/en/rest/about-the-rest-api/breaking-changes",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml",
+        "samples/workflows/scm-create-repo/github-create-repo.yaml",
+        "internal/openchoreo-api/services/git/github.go"
+      ],
+      "action": "Use this as a reference page when GitHub Changelog or REST response headers report an API compatibility notice."
+    },
+    {
+      "id": "github-webhooks",
+      "name": "GitHub webhook contract documentation",
+      "type": "reference_page",
+      "url": "https://docs.github.com/en/webhooks",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "internal/openchoreo-api/services/git/github.go"
+      ],
+      "action": "Use this as a reference page when GitHub Changelog reports webhook signature, header, event, or payload changes.",
+      "keywords": [
+        "breaking change",
+        "deprecated",
+        "payload",
+        "removed",
+        "signature",
+        "webhook",
+        "x-hub-signature"
+      ]
+    },
+    {
+      "id": "github-changelog-feed",
+      "name": "GitHub Changelog feed",
+      "type": "feed",
+      "url": "https://github.blog/changelog/feed/",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml",
+        "samples/workflows/scm-create-repo/github-create-repo.yaml",
+        "internal/openchoreo-api/services/git/github.go"
+      ],
+      "action": "Check whether direct GitHub API calls or GitHub webhook parsing need updates.",
+      "keywords": [
+        "breaking change",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal",
+        "retired",
+        "retirement",
+        "sunset"
+      ],
+      "required_terms": [
+        "api version",
+        "payload",
+        "REST API",
+        "signature",
+        "webhook",
+        "X-GitHub-Api-Version",
+        "x-hub-signature"
+      ]
+    },
+    {
+      "id": "gitlab-breaking-changes-feed",
+      "name": "GitLab breaking changes feed",
+      "type": "feed",
+      "url": "https://docs.gitlab.com/releases/breaking-changes.xml",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "internal/openchoreo-api/services/git/gitlab.go"
+      ],
+      "action": "Check whether GitLab webhook token/header or push payload parsing needs updates.",
+      "keywords": [
+        "breaking change",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal",
+        "retired",
+        "retirement",
+        "sunset"
+      ],
+      "required_terms": [
+        "payload",
+        "push event",
+        "secret token",
+        "signature",
+        "webhook",
+        "x-gitlab-token"
+      ]
+    },
+    {
+      "id": "gitlab-webhooks",
+      "name": "GitLab webhook contract documentation",
+      "type": "reference_page",
+      "url": "https://docs.gitlab.com/user/project/integrations/webhooks/",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "internal/openchoreo-api/services/git/gitlab.go"
+      ],
+      "action": "Use this as a reference page when GitLab release notes report webhook authentication or push payload changes."
+    },
+    {
+      "id": "bitbucket-cloud-changelog",
+      "name": "Bitbucket Cloud changelog",
+      "type": "reference_page",
+      "url": "https://developer.atlassian.com/cloud/bitbucket/changelog/",
+      "severity": "medium",
+      "owner": "control-plane",
+      "affected_files": [
+        "internal/openchoreo-api/services/git/bitbucket.go"
+      ],
+      "action": "Use this as a reference page when Atlassian reports Bitbucket webhook event or push payload changes."
+    },
+    {
+      "id": "aws-codecommit-docs",
+      "name": "AWS CodeCommit documentation",
+      "type": "reference_page",
+      "url": "https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "samples/getting-started/workflow-templates/checkout-source.yaml",
+        "samples/workflows/scm-create-repo/codecommit-create-repo.yaml",
+        "internal/openchoreo-api/models/request.go"
+      ],
+      "action": "Use this as a reference page when AWS What's New or AWS Health reports a CodeCommit lifecycle, availability, auth, or CLI notice."
+    },
+    {
+      "id": "aws-whats-new",
+      "name": "AWS What's New feed",
+      "type": "feed",
+      "url": "https://aws.amazon.com/new/feed/",
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "samples/getting-started/workflow-templates/checkout-source.yaml",
+        "samples/workflows/scm-create-repo/codecommit-create-repo.yaml"
+      ],
+      "action": "Review AWS service lifecycle or CLI/auth changes that affect CodeCommit workflows.",
+      "keywords": [
+        "deprecated",
+        "discontinued",
+        "end of support",
+        "end-of-support",
+        "removed",
+        "removal",
+        "retired",
+        "retirement",
+        "sunset"
+      ],
+      "required_terms": [
+        "CodeCommit"
+      ]
+    },
+    {
+      "id": "kubernetes-1-36-eol",
+      "name": "Kubernetes 1.36 end-of-life",
+      "type": "eol_api",
+      "url": "https://endoflife.date/api/kubernetes.json",
+      "severity": "medium",
+      "owner": "platform",
+      "cycle": "1.36",
+      "warn_within_days": 180,
+      "affected_files": [
+        "config/crd/bases/*.yaml",
+        "install/helm/**/templates/*.yaml",
+        "install/helm/**/crds/*.yaml"
+      ],
+      "action": "Plan Kubernetes target-version upgrade and run rendered manifest compatibility checks before the 1.36 support window closes."
+    },
+    {
+      "id": "kubernetes-deprecation-guide",
+      "name": "Kubernetes Deprecated API Migration Guide",
+      "type": "reference_page",
+      "url": "https://kubernetes.io/docs/reference/using-api/deprecation-guide/",
+      "severity": "medium",
+      "owner": "platform",
+      "affected_files": [
+        "config/crd/bases/*.yaml",
+        "install/helm/**/templates/*.yaml",
+        "install/helm/**/crds/*.yaml"
+      ],
+      "action": "Use this as a reference page during Kubernetes upgrade planning or if rendered manifests start using deprecated API versions."
+    },
+    {
+      "id": "argo-workflows-releases",
+      "name": "Argo Workflows releases",
+      "type": "feed",
+      "url": "https://github.com/argoproj/argo-workflows/releases.atom",
+      "severity": "medium",
+      "owner": "workflow-plane",
+      "affected_files": [
+        "install/helm/openchoreo-workflow-plane/Chart.yaml",
+        "samples/getting-started/workflow-templates/*.yaml",
+        "internal/dataplane/kubernetes/types"
+      ],
+      "action": "Review Argo Workflows API or CRD compatibility before chart/app upgrades.",
+      "keywords": [
+        "breaking change:",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal"
+      ],
+      "required_terms": [
+        "apiVersion",
+        "ClusterWorkflowTemplate",
+        "CRD",
+        "WorkflowTemplate"
+      ]
+    },
+    {
+      "id": "external-secrets-releases",
+      "name": "External Secrets releases",
+      "type": "feed",
+      "url": "https://github.com/external-secrets/external-secrets/releases.atom",
+      "severity": "medium",
+      "owner": "platform",
+      "affected_files": [
+        "internal/dataplane/kubernetes/types",
+        "internal/openchoreo-api/services/git"
+      ],
+      "action": "Review External Secrets CRD/API compatibility for secret integration paths.",
+      "keywords": [
+        "breaking change:",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal"
+      ],
+      "required_terms": [
+        "apiVersion",
+        "CRD",
+        "ClusterExternalSecret",
+        "ExternalSecret",
+        "SecretStore"
+      ]
+    },
+    {
+      "id": "gateway-api-releases",
+      "name": "Gateway API releases",
+      "type": "feed",
+      "url": "https://github.com/kubernetes-sigs/gateway-api/releases.atom",
+      "severity": "medium",
+      "owner": "platform",
+      "affected_files": [
+        "install/helm/**/templates/*.yaml",
+        "samples/getting-started"
+      ],
+      "action": "Review Gateway API compatibility for Gateway, HTTPRoute, and TLSRoute usage.",
+      "keywords": [
+        "breaking change:",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal"
+      ],
+      "required_terms": [
+        "GatewayClass",
+        "GRPCRoute",
+        "HTTPRoute",
+        "TLSRoute",
+        "v1alpha",
+        "v1beta"
+      ]
+    },
+    {
+      "id": "opencost-releases",
+      "name": "OpenCost releases",
+      "type": "feed",
+      "url": "https://github.com/opencost/opencost/releases.atom",
+      "severity": "medium",
+      "owner": "agents",
+      "affected_files": [
+        "agents/finops-agent"
+      ],
+      "action": "Review OpenCost query/API compatibility for FinOps agent behavior.",
+      "keywords": [
+        "breaking change:",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal"
+      ],
+      "required_terms": [
+        "allocation",
+        "API",
+        "query"
+      ]
+    },
+    {
+      "id": "opensearch-operator-releases",
+      "name": "OpenSearch Kubernetes Operator releases",
+      "type": "feed",
+      "url": "https://github.com/opensearch-project/opensearch-k8s-operator/releases.atom",
+      "severity": "medium",
+      "owner": "observability-plane",
+      "affected_files": [
+        "internal/observer/service/*",
+        "install/helm/openchoreo-observability-plane"
+      ],
+      "action": "Review OpenSearch operator/API compatibility for observability install and query paths.",
+      "keywords": [
+        "breaking change:",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal"
+      ],
+      "required_terms": [
+        "apiVersion",
+        "CRD",
+        "OpenSearchCluster",
+        "OpenSearchDashboards"
+      ]
+    },
+    {
+      "id": "prometheus-releases",
+      "name": "Prometheus releases",
+      "type": "feed",
+      "url": "https://github.com/prometheus/prometheus/releases.atom",
+      "severity": "medium",
+      "owner": "observability-plane",
+      "affected_files": [
+        "internal/observer/service/*",
+        "install/helm/openchoreo-observability-plane"
+      ],
+      "action": "Review Prometheus query/API compatibility for observer behavior.",
+      "keywords": [
+        "breaking change:",
+        "deprecated",
+        "deprecation",
+        "removed",
+        "removal"
+      ],
+      "required_terms": [
+        "metadata",
+        "PromQL",
+        "query",
+        "remote read",
+        "remote write",
+        "service discovery"
+      ]
+    }
+  ],
+  "manifest_scans": [
+    {
+      "id": "kubernetes-static-api-versions",
+      "name": "Kubernetes static manifest API versions",
+      "type": "kubernetes_api_versions",
+      "severity": "high",
+      "owner": "platform",
+      "paths": [
+        "config/crd/bases/*.yaml",
+        "install/helm/**/*.yaml",
+        "install/k3d/**/*.yaml",
+        "samples/getting-started/workflow-templates/*.yaml"
+      ],
+      "affected_files": [
+        "config/crd/bases/*.yaml",
+        "install/helm/**/*.yaml",
+        "install/k3d/**/*.yaml",
+        "samples/getting-started/workflow-templates/*.yaml"
+      ],
+      "action": "Migrate removed Kubernetes API versions before installing or upgrading against the target Kubernetes version."
+    }
+  ],
+  "header_probes": [
+    {
+      "id": "github-rest-api-version-header",
+      "name": "GitHub REST API version response headers",
+      "url": "https://api.github.com/repos/openchoreo/openchoreo",
+      "method": "GET",
+      "auth_env": "GITHUB_TOKEN",
+      "request_headers": {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28"
+      },
+      "watched_headers": [
+        "Deprecation",
+        "Sunset",
+        "Warning"
+      ],
+      "severity": "high",
+      "owner": "control-plane",
+      "affected_files": [
+        "samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml",
+        "samples/workflows/scm-create-repo/github-create-repo.yaml"
+      ],
+      "action": "If GitHub returns Deprecation or Sunset headers, migrate pinned REST API version usage before the indicated date."
+    }
+  ]
+}

--- a/.github/external-compatibility-sources.json
+++ b/.github/external-compatibility-sources.json
@@ -244,7 +244,7 @@
       ],
       "action": "Review Argo Workflows API or CRD compatibility before chart/app upgrades.",
       "keywords": [
-        "breaking change:",
+        "breaking change",
         "deprecated",
         "deprecation",
         "removed",
@@ -270,7 +270,7 @@
       ],
       "action": "Review External Secrets CRD/API compatibility for secret integration paths.",
       "keywords": [
-        "breaking change:",
+        "breaking change",
         "deprecated",
         "deprecation",
         "removed",
@@ -297,7 +297,7 @@
       ],
       "action": "Review Gateway API compatibility for Gateway, HTTPRoute, and TLSRoute usage.",
       "keywords": [
-        "breaking change:",
+        "breaking change",
         "deprecated",
         "deprecation",
         "removed",
@@ -324,7 +324,7 @@
       ],
       "action": "Review OpenCost query/API compatibility for FinOps agent behavior.",
       "keywords": [
-        "breaking change:",
+        "breaking change",
         "deprecated",
         "deprecation",
         "removed",
@@ -349,7 +349,7 @@
       ],
       "action": "Review OpenSearch operator/API compatibility for observability install and query paths.",
       "keywords": [
-        "breaking change:",
+        "breaking change",
         "deprecated",
         "deprecation",
         "removed",
@@ -375,7 +375,7 @@
       ],
       "action": "Review Prometheus query/API compatibility for observer behavior.",
       "keywords": [
-        "breaking change:",
+        "breaking change",
         "deprecated",
         "deprecation",
         "removed",

--- a/.github/external-compatibility-sources.md
+++ b/.github/external-compatibility-sources.md
@@ -1,0 +1,120 @@
+# External Compatibility Scan Sources
+
+`external-compatibility-scan.yaml` reads
+`.github/external-compatibility-sources.json` and checks a curated list of
+external API, webhook, SaaS, model, and CRD/API contract sources.
+
+The scan is intentionally high-signal:
+
+- It posts feed notices matching configured deprecation, sunset, retirement,
+  removal, end-of-support, or breaking-change keywords.
+- It checks static Kubernetes manifests and Helm templates for API versions that
+  are already removed in supported Kubernetes releases.
+- It does not create Slack findings from generic page keyword snippets. Static
+  documentation pages are either reference-only or checked for specific expected
+  values.
+- It reports source-health failures as deduped findings so a broken monitored
+  source does not silently remove coverage. A single transient failure is
+  recorded in state but Slack starts at the second consecutive failure.
+- It baselines the first run by recording historical matches without sending a
+  Slack message.
+- It keeps new findings pending until a Slack POST succeeds. If Slack delivery
+  fails or the webhook secret is missing, the same pending findings are retried
+  on the next run instead of being marked delivered.
+- It splits Slack notices into multiple payloads when more than 10 findings are
+  pending, and only marks them delivered after all payloads post successfully.
+- It deduplicates future notices using the previous successful run's
+  `external-compatibility-scan-state` artifact, with separate observed and
+  notified state.
+- It does not report routine Dependabot updates, normal Docker image refreshes,
+  normal Helm chart bumps, or e2e failures.
+
+## Slack Setup
+
+Create a GitHub Actions secret named
+`SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL` with a Slack incoming webhook URL.
+Until the secret exists, the workflow still runs and prints any would-be Slack
+payload in the job log.
+
+Manual runs support:
+
+- `notify_on_first_run`: send matching historical findings if no prior state is
+  available. Keep this disabled for normal use.
+- `post_to_slack`: disable Slack posting while testing source/config changes.
+
+## Adding A Source
+
+Add an entry to `.github/external-compatibility-sources.json` with:
+
+- `id`: stable unique identifier.
+- `name`: human-readable source name.
+- `type`: `feed`, `github_api_versions`, `page_contains`, `page_terms`,
+  `reference_page`, or `eol_api`.
+- `url`: provider page, RSS feed, or Atom feed.
+- `severity`: `critical`, `high`, `medium`, or `low`.
+- `owner`: expected OpenChoreo owner area.
+- `affected_files`: files or directories that explain why the source matters.
+- `action`: what the team should do when a new matching notice appears.
+- `keywords`: source-specific feed keywords when the defaults are too broad or
+  too narrow.
+- `required_terms`: optional source-specific relevance terms. When present for
+  a feed, an item must match `keywords` and at least one nearby
+  `required_terms` entry before it can produce a Slack finding.
+- `required_terms_context_chars`: optional proximity window for feed
+  `required_terms`; defaults to 350 characters around the matched keyword.
+- `required_text`: for `page_contains`, specific text that must remain present.
+- `match_terms`: for `page_terms`, model names, endpoint paths, or provider
+  terms to look for near deprecation or breaking-change keywords on a provider
+  page.
+- `pinned_version`, `supported_until`, and `warn_within_days`: for
+  `github_api_versions`, the REST API version OpenChoreo pins and the support
+  deadline to warn on.
+- `cycle` and `warn_within_days`: for `eol_api`, the lifecycle cycle to monitor
+  and the alert window.
+
+Use `header_probes` for providers that announce deprecation or sunset through
+HTTP response headers such as `Deprecation`, `Sunset`, or `Warning`.
+
+Use `manifest_scans` for local repository checks that do not need a remote URL.
+The current `kubernetes_api_versions` scan checks configured YAML paths for
+Kubernetes API versions removed in recent releases. It is a lightweight static
+guard; use rendered `helm template` output plus `pluto` or `kubent` when chart
+templating makes the static source insufficient.
+
+`reference_page` entries are source-health checks only. They keep important
+provider pages visible in the report, but do not generate compatibility
+findings from generic keyword matches.
+
+The workflow stores state artifacts for 90 days. If scheduled scans are paused
+longer than that and no state artifact remains, the next run establishes a new
+baseline unless manually run with `notify_on_first_run`.
+
+Prefer feeds, provider APIs, header probes, and explicit expected-value checks
+over generic documentation-page keyword matching.
+
+## Maintenance Notes
+
+Feed `required_terms` intentionally trade recall for precision. A provider
+notice must use one of the configured scope terms near a lifecycle or
+breaking-change keyword before it can produce a Slack finding. This keeps Slack
+high-signal, but it also means coverage can narrow silently if an upstream
+provider changes terminology or release-note structure.
+
+Review `required_terms` periodically, especially after adding or changing an
+integration. For the most critical compatibility risks, prefer direct checks
+such as provider lifecycle APIs, `Deprecation` / `Sunset` response headers, or
+local manifest scans instead of relying only on feed wording.
+
+## Validation
+
+Validate config locally without fetching remote sources:
+
+```sh
+python3 .github/scripts/external_compatibility_scan.py \
+  --config .github/external-compatibility-sources.json \
+  --state /tmp/external-compatibility-state.json \
+  --state-out /tmp/external-compatibility-state.json \
+  --slack-payload /tmp/external-compatibility-slack.json \
+  --report /tmp/external-compatibility-report.json \
+  --validate-only
+```

--- a/.github/external-compatibility-sources.md
+++ b/.github/external-compatibility-sources.md
@@ -8,6 +8,8 @@ The scan is intentionally high-signal:
 
 - It posts feed notices matching configured deprecation, sunset, retirement,
   removal, end-of-support, or breaking-change keywords.
+- It scans every RSS/Atom item returned within the 10 MiB response safety cap;
+  feed order does not determine whether an item is checked.
 - It checks static Kubernetes manifests and Helm templates for API versions that
   are already removed in supported Kubernetes releases.
 - It does not create Slack findings from generic page keyword snippets. Static
@@ -20,12 +22,17 @@ The scan is intentionally high-signal:
   Slack message.
 - It keeps new findings pending until a Slack POST succeeds. If Slack delivery
   fails or the webhook secret is missing, the same pending findings are retried
-  on the next run instead of being marked delivered.
+  on the next run instead of being marked delivered. Pending source-health
+  failures are removed if that source recovers before delivery, because posting
+  them later would describe stale health.
 - It splits Slack notices into multiple payloads when more than 10 findings are
   pending, and only marks them delivered after all payloads post successfully.
 - It deduplicates future notices using the previous successful run's
   `external-compatibility-scan-state` artifact, with separate observed and
   notified state.
+- It retains at most 2,000 observed and 2,000 notified records, preferring
+  recently observed records. General pending compatibility notices are never
+  silently trimmed; a warning is reported if that queue exceeds 200 findings.
 - It does not report routine Dependabot updates, normal Docker image refreshes,
   normal Helm chart bumps, or e2e failures.
 

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -1,0 +1,1133 @@
+#!/usr/bin/env python3
+"""Scan curated external compatibility sources and produce a Slack digest.
+
+The scanner is intentionally dependency-free so it can run in GitHub Actions
+without installing Python packages. It supports:
+
+- RSS/Atom feeds, scanned item-by-item.
+- Reference pages, fetched for source-health visibility but not converted into
+  keyword-based Slack findings.
+- Page contains checks, which alert only when expected text disappears from a
+  provider page.
+- Machine-readable endoflife.date checks.
+- HTTP response header probes for Deprecation, Sunset, Warning, and similar
+  provider headers.
+
+On the first run with an empty state file, findings are recorded but not sent by
+default. This baselines historical compatibility notices and prevents Slack noise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import os
+import re
+import sys
+import time
+import textwrap
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+USER_AGENT = "openchoreo-external-compatibility-scan/1.0 (+https://github.com/openchoreo/openchoreo)"
+MAX_FINDINGS_PER_SLACK_MESSAGE = 10
+MAX_SEEN_ITEMS = 2000
+RETRYABLE_HTTP_STATUS = {403, 429, 500, 502, 503, 504}
+NEGATION_BEFORE_KEYWORD = re.compile(
+    r"\b(?:no\s+longer|not(?:\s+an?|\s+any)?|never)\s+(?:\w+\s+){0,3}$",
+    re.IGNORECASE,
+)
+DEFAULT_DEPRECATED_K8S_APIS = {
+    "admissionregistration.k8s.io/v1beta1": "1.22",
+    "apiextensions.k8s.io/v1beta1": "1.22",
+    "apiregistration.k8s.io/v1beta1": "1.22",
+    "apps/v1beta1": "1.16",
+    "apps/v1beta2": "1.16",
+    "autoscaling/v2beta1": "1.25",
+    "autoscaling/v2beta2": "1.26",
+    "batch/v1beta1": "1.25",
+    "certificates.k8s.io/v1beta1": "1.22",
+    "coordination.k8s.io/v1beta1": "1.22",
+    "discovery.k8s.io/v1beta1": "1.25",
+    "events.k8s.io/v1beta1": "1.25",
+    "extensions/v1beta1": "1.22",
+    "flowcontrol.apiserver.k8s.io/v1beta1": "1.26",
+    "flowcontrol.apiserver.k8s.io/v1beta2": "1.29",
+    "flowcontrol.apiserver.k8s.io/v1beta3": "1.32",
+    "networking.k8s.io/v1beta1": "1.22",
+    "node.k8s.io/v1beta1": "1.22",
+    "policy/v1beta1": "1.25",
+    "rbac.authorization.k8s.io/v1beta1": "1.22",
+    "scheduling.k8s.io/v1beta1": "1.22",
+    "storage.k8s.io/v1beta1": "1.22",
+}
+
+
+@dataclass
+class FetchResult:
+    url: str
+    status: int
+    headers: dict[str, str]
+    body: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="Path to external compatibility source JSON")
+    parser.add_argument("--state", required=True, help="Path to existing scanner state JSON")
+    parser.add_argument("--state-out", required=True, help="Path to write updated state JSON")
+    parser.add_argument("--slack-payload", required=True, help="Path to write Slack webhook payload JSON")
+    parser.add_argument("--report", required=True, help="Path to write scan report JSON")
+    parser.add_argument("--timeout", type=float, default=20.0, help="HTTP timeout in seconds")
+    parser.add_argument(
+        "--notify-on-first-run",
+        action="store_true",
+        help="Send matching historical findings when no previous state exists",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate config and exit without fetching remote sources",
+    )
+    parser.add_argument(
+        "--mark-notified",
+        action="store_true",
+        help="Mark the current pending Slack findings as notified and exit",
+    )
+    parser.add_argument(
+        "--mark-notified-ids",
+        help="Path to a JSON array of finding IDs to mark as notified",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists() or path.stat().st_size == 0:
+        return default
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def contains_glob(pattern: str) -> bool:
+    return any(char in pattern for char in "*?[")
+
+
+def path_pattern_exists(root: Path, pattern: str) -> bool:
+    path = root / pattern
+    if contains_glob(pattern):
+        return any(root.glob(pattern))
+    return path.exists()
+
+
+def validate_path_patterns(root: Path | None, owner: str, patterns: list[Any], errors: list[str]) -> None:
+    if root is None:
+        return
+    for pattern in patterns:
+        pattern_text = str(pattern)
+        if not path_pattern_exists(root, pattern_text):
+            errors.append(f"{owner}: path does not match repository files: {pattern_text}")
+
+
+def validate_config(config: dict[str, Any], root: Path | None = None) -> list[str]:
+    errors: list[str] = []
+    source_ids: set[str] = set()
+    for key in ("sources", "header_probes", "manifest_scans"):
+        if key in config and not isinstance(config[key], list):
+            errors.append(f"{key} must be a list")
+
+    for source in config.get("sources", []):
+        source_id = source.get("id")
+        if not source_id:
+            errors.append("source is missing id")
+        elif source_id in source_ids:
+            errors.append(f"duplicate source id: {source_id}")
+        else:
+            source_ids.add(source_id)
+        if source.get("type") not in {
+            "feed",
+            "github_api_versions",
+            "page_contains",
+            "page_terms",
+            "reference_page",
+            "eol_api",
+        }:
+            errors.append(
+                f"{source_id}: type must be feed, github_api_versions, "
+                "page_contains, page_terms, reference_page, or eol_api"
+            )
+        if not source.get("url"):
+            errors.append(f"{source_id}: missing url")
+        if not source.get("affected_files"):
+            errors.append(f"{source_id}: missing affected_files")
+        else:
+            validate_path_patterns(root, f"{source_id}.affected_files", source.get("affected_files", []), errors)
+        if not source.get("action"):
+            errors.append(f"{source_id}: missing action")
+        if source.get("type") == "page_contains" and not source.get("required_text"):
+            errors.append(f"{source_id}: page_contains sources require required_text")
+        if source.get("type") == "page_terms" and not source.get("match_terms"):
+            errors.append(f"{source_id}: page_terms sources require match_terms")
+        if source.get("required_terms") is not None and not isinstance(source.get("required_terms"), list):
+            errors.append(f"{source_id}: required_terms must be a list")
+        if not isinstance(source.get("required_terms_context_chars", 350), int):
+            errors.append(f"{source_id}: required_terms_context_chars must be an integer")
+        if source.get("type") == "github_api_versions" and not source.get("pinned_version"):
+            errors.append(f"{source_id}: github_api_versions sources require pinned_version")
+        if source.get("type") == "eol_api":
+            if not source.get("cycle"):
+                errors.append(f"{source_id}: eol_api sources require cycle")
+            if not isinstance(source.get("warn_within_days", 180), int):
+                errors.append(f"{source_id}: warn_within_days must be an integer")
+
+    probe_ids: set[str] = set()
+    for probe in config.get("header_probes", []):
+        probe_id = probe.get("id")
+        if not probe_id:
+            errors.append("header probe is missing id")
+        elif probe_id in probe_ids:
+            errors.append(f"duplicate header probe id: {probe_id}")
+        else:
+            probe_ids.add(probe_id)
+        if not probe.get("url"):
+            errors.append(f"{probe_id}: missing url")
+        if not probe.get("watched_headers"):
+            errors.append(f"{probe_id}: missing watched_headers")
+        if not probe.get("affected_files"):
+            errors.append(f"{probe_id}: missing affected_files")
+        else:
+            validate_path_patterns(root, f"{probe_id}.affected_files", probe.get("affected_files", []), errors)
+        if not probe.get("action"):
+            errors.append(f"{probe_id}: missing action")
+
+    manifest_ids: set[str] = set()
+    for scan in config.get("manifest_scans", []):
+        scan_id = scan.get("id")
+        if not scan_id:
+            errors.append("manifest scan is missing id")
+        elif scan_id in manifest_ids:
+            errors.append(f"duplicate manifest scan id: {scan_id}")
+        else:
+            manifest_ids.add(scan_id)
+        if scan.get("type") != "kubernetes_api_versions":
+            errors.append(f"{scan_id}: type must be kubernetes_api_versions")
+        if not scan.get("paths"):
+            errors.append(f"{scan_id}: missing paths")
+        else:
+            validate_path_patterns(root, f"{scan_id}.paths", scan.get("paths", []), errors)
+        if not scan.get("affected_files"):
+            errors.append(f"{scan_id}: missing affected_files")
+        else:
+            validate_path_patterns(root, f"{scan_id}.affected_files", scan.get("affected_files", []), errors)
+        if not scan.get("action"):
+            errors.append(f"{scan_id}: missing action")
+
+    return errors
+
+
+def fetch_url(
+    url: str,
+    timeout: float,
+    method: str = "GET",
+    request_headers: dict[str, str] | None = None,
+    auth_env: str | None = None,
+) -> FetchResult:
+    headers = {"User-Agent": USER_AGENT}
+    headers.update(request_headers or {})
+
+    if auth_env:
+        token = os.getenv(auth_env)
+        if token and "Authorization" not in headers:
+            headers["Authorization"] = f"Bearer {token}"
+
+    last_error: Exception | None = None
+    attempts = 3
+    for attempt in range(attempts):
+        request = urllib.request.Request(url, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read()
+                charset = response.headers.get_content_charset() or "utf-8"
+                body = raw.decode(charset, errors="replace")
+                return FetchResult(
+                    url=url,
+                    status=response.status,
+                    headers={key.lower(): value for key, value in response.headers.items()},
+                    body=body,
+                )
+        except urllib.error.HTTPError as exc:
+            if exc.code not in RETRYABLE_HTTP_STATUS or attempt == attempts - 1:
+                raw = exc.read()
+                charset = exc.headers.get_content_charset() or "utf-8"
+                return FetchResult(
+                    url=url,
+                    status=exc.code,
+                    headers={key.lower(): value for key, value in exc.headers.items()},
+                    body=raw.decode(charset, errors="replace"),
+                )
+            last_error = exc
+            time.sleep(retry_delay_seconds(exc.headers.get("Retry-After"), attempt))
+        except urllib.error.URLError as exc:
+            if attempt == attempts - 1:
+                raise
+            last_error = exc
+            time.sleep(retry_delay_seconds(None, attempt))
+
+    raise last_error or RuntimeError(f"failed to fetch {url}")
+
+
+def retry_delay_seconds(retry_after: str | None, attempt: int) -> float:
+    if retry_after:
+        try:
+            return min(float(retry_after), 10.0)
+        except ValueError:
+            pass
+    return min(0.5 * (2 ** attempt), 4.0)
+
+
+def require_success(result: FetchResult) -> None:
+    if result.status < 200 or result.status >= 300:
+        raise ValueError(f"{result.url} returned HTTP {result.status}")
+
+
+def normalized_text_from_html(body: str) -> str:
+    body = re.sub(r"(?is)<(script|style).*?>.*?</\1>", " ", body)
+    body = re.sub(r"(?is)<[^>]+>", " ", body)
+    body = html.unescape(body)
+    return re.sub(r"\s+", " ", body).strip()
+
+
+def keyword_patterns(keywords: list[str]) -> list[re.Pattern[str]]:
+    patterns: list[re.Pattern[str]] = []
+    for keyword in keywords:
+        variants = [keyword]
+        if keyword.lower() in {"breaking change", "deprecation", "removal", "retirement"}:
+            variants.append(f"{keyword}s")
+        alternatives = "|".join(re.escape(variant) for variant in variants)
+        patterns.append(re.compile(rf"(?<![A-Za-z0-9])(?:{alternatives})(?![A-Za-z0-9])", re.IGNORECASE))
+    return patterns
+
+
+def matches_keywords(text: str, keywords: list[str]) -> bool:
+    for pattern in keyword_patterns(keywords):
+        for match in pattern.finditer(text):
+            if not is_negated_keyword_match(text, match):
+                return True
+    return False
+
+
+def matches_keywords_near_required_terms(
+    text: str,
+    keywords: list[str],
+    required_terms: list[str],
+    context_chars: int = 350,
+) -> bool:
+    for pattern in keyword_patterns(keywords):
+        for match in pattern.finditer(text):
+            if is_negated_keyword_match(text, match):
+                continue
+            start = max(0, match.start() - context_chars)
+            end = min(len(text), match.end() + context_chars)
+            if matches_keywords(text[start:end], required_terms):
+                return True
+    return False
+
+
+def is_negated_keyword_match(text: str, match: re.Match[str]) -> bool:
+    before = text[max(0, match.start() - 80):match.start()]
+    if before.lower().endswith("un-"):
+        return True
+    return bool(NEGATION_BEFORE_KEYWORD.search(before))
+
+
+def stable_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+
+
+def finding_id(*parts: str) -> str:
+    return stable_hash("\0".join(parts))
+
+
+def normalize_feed_link(link: str) -> str:
+    parsed = urllib.parse.urlsplit(link.strip())
+    if not parsed.scheme or not parsed.netloc:
+        return link.strip()
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    filtered_query = [
+        (key, value)
+        for key, value in query
+        if not key.lower().startswith("utm_") and key.lower() not in {"fbclid", "gclid"}
+    ]
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/") or "/",
+            urllib.parse.urlencode(filtered_query),
+            "",
+        )
+    )
+
+
+def parse_feed_items(body: str) -> list[dict[str, str]]:
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as exc:
+        raise ValueError(f"feed XML parse failed: {exc}") from exc
+
+    items: list[dict[str, str]] = []
+    for node in root.findall(".//item"):
+        items.append(
+            {
+                "title": text_of(node, "title"),
+                "link": text_of(node, "link"),
+                "summary": text_of(node, "description"),
+                "published": text_of(node, "pubDate"),
+            }
+        )
+
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    for node in root.findall(".//atom:entry", ns):
+        link = ""
+        for link_node in node.findall("atom:link", ns):
+            if link_node.attrib.get("href"):
+                link = link_node.attrib["href"]
+                break
+        items.append(
+            {
+                "title": text_of(node, "atom:title", ns),
+                "link": link,
+                "summary": text_of(node, "atom:summary", ns) or text_of(node, "atom:content", ns),
+                "published": text_of(node, "atom:updated", ns) or text_of(node, "atom:published", ns),
+            }
+        )
+    return items
+
+
+def text_of(node: ET.Element, path: str, namespaces: dict[str, str] | None = None) -> str:
+    child = node.find(path, namespaces or {})
+    if child is None or child.text is None:
+        return ""
+    return re.sub(r"\s+", " ", html.unescape(child.text)).strip()
+
+
+def source_keywords(config: dict[str, Any], source: dict[str, Any]) -> list[str]:
+    defaults = config.get("defaults", {}).get("keywords", [])
+    keywords = source.get("keywords") or defaults
+    return [str(keyword).lower() for keyword in keywords]
+
+
+def common_finding_fields(source: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_id": source["id"],
+        "source_name": source["name"],
+        "severity": source.get("severity", "medium"),
+        "owner": source.get("owner", "unassigned"),
+        "affected_files": source.get("affected_files", []),
+        "action": source.get("action", "Review the linked source and assess impact."),
+    }
+
+
+def scan_reference_page(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(source["url"], timeout)
+    require_success(result)
+    text = normalized_text_from_html(result.body)
+    return [], {
+        "status": result.status,
+        "content_hash": stable_hash(text),
+        "matches": 0,
+        "url": source["url"],
+    }
+
+
+def scan_page_contains(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(source["url"], timeout)
+    require_success(result)
+    text = normalized_text_from_html(result.body).lower()
+    missing = [needle for needle in source.get("required_text", []) if str(needle).lower() not in text]
+    findings: list[dict[str, Any]] = []
+    if missing:
+        title = f"{source['name']} no longer contains expected supported value(s)"
+        summary = "Missing expected text: " + ", ".join(missing)
+        findings.append(
+            {
+                **common_finding_fields(source),
+                "id": finding_id(source["id"], source["url"], json.dumps(sorted(missing))),
+                "title": title,
+                "url": source["url"],
+                "summary": summary,
+                "observed_at": now_iso(),
+                "kind": "page_contains",
+            }
+        )
+    return findings, {
+        "status": result.status,
+        "required_text": source.get("required_text", []),
+        "missing": missing,
+        "matches": len(findings),
+        "url": source["url"],
+    }
+
+
+def source_request_headers(source: dict[str, Any]) -> dict[str, str]:
+    return {str(key): str(value) for key, value in source.get("request_headers", {}).items()}
+
+
+def scan_github_api_versions(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(
+        source["url"],
+        timeout,
+        request_headers=source_request_headers(source),
+        auth_env=source.get("auth_env"),
+    )
+    require_success(result)
+    versions = json.loads(result.body)
+    if not isinstance(versions, list):
+        raise ValueError("GitHub versions response must be a list")
+    supported_versions = [str(version) for version in versions]
+    pinned = str(source["pinned_version"])
+    latest = max(supported_versions) if supported_versions else ""
+    findings: list[dict[str, Any]] = []
+
+    if pinned not in supported_versions:
+        findings.append(
+            {
+                **common_finding_fields(source),
+                "id": finding_id(source["id"], pinned, "missing"),
+                "title": f"GitHub REST API version {pinned} is no longer supported",
+                "url": source["url"],
+                "summary": f"Supported versions from GitHub: {', '.join(supported_versions)}",
+                "observed_at": now_iso(),
+                "kind": "github_api_versions",
+            }
+        )
+
+    supported_until = source.get("supported_until")
+    days_until_eol: int | None = None
+    if supported_until:
+        eol_date = date.fromisoformat(str(supported_until))
+        days_until_eol = (eol_date - datetime.now(timezone.utc).date()).days
+        if days_until_eol <= int(source.get("warn_within_days", 180)):
+            findings.append(
+                {
+                    **common_finding_fields(source),
+                    "id": finding_id(source["id"], pinned, str(supported_until)),
+                    "title": f"GitHub REST API version {pinned} support window is closing",
+                    "url": source["url"],
+                    "summary": (
+                        f"pinned_version={pinned}, supported_until={supported_until}, "
+                        f"days_until_eol={days_until_eol}"
+                    ),
+                    "observed_at": now_iso(),
+                    "kind": "github_api_versions",
+                }
+            )
+
+    if source.get("warn_if_not_latest") and latest and pinned != latest:
+        findings.append(
+            {
+                **common_finding_fields(source),
+                "id": finding_id(source["id"], pinned, latest, "not-latest"),
+                "title": f"GitHub REST API version {pinned} is not the latest supported version",
+                "url": source["url"],
+                "summary": f"latest_supported_version={latest}, supported_versions={', '.join(supported_versions)}",
+                "observed_at": now_iso(),
+                "kind": "github_api_versions",
+            }
+        )
+
+    return findings, {
+        "status": result.status,
+        "pinned_version": pinned,
+        "latest_supported_version": latest,
+        "supported_versions": supported_versions,
+        "supported_until": supported_until,
+        "days_until_eol": days_until_eol,
+        "matches": len(findings),
+        "url": source["url"],
+    }
+
+
+def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(source["url"], timeout)
+    require_success(result)
+    text = normalized_text_from_html(result.body)
+    lowered = text.lower()
+    keywords = source_keywords({"defaults": {"keywords": source.get("keywords", [])}}, source)
+    context_chars = int(source.get("context_chars", 500))
+    findings: list[dict[str, Any]] = []
+    matched_terms: list[str] = []
+    for term in source.get("match_terms", []):
+        term_text = str(term)
+        index = lowered.find(term_text.lower())
+        if index < 0:
+            continue
+        start = max(0, index - context_chars)
+        end = min(len(text), index + len(term_text) + context_chars)
+        context = text[start:end].strip()
+        if keywords and not matches_keywords(context, keywords):
+            continue
+        matched_terms.append(term_text)
+        findings.append(
+            {
+                **common_finding_fields(source),
+                "id": finding_id(source["id"], source["url"], term_text),
+                "title": f"{source['name']} mentions monitored term: {term_text}",
+                "url": source["url"],
+                "summary": context[:700],
+                "observed_at": now_iso(),
+                "kind": "page_terms",
+            }
+        )
+    return findings, {
+        "status": result.status,
+        "match_terms": source.get("match_terms", []),
+        "matched_terms": matched_terms,
+        "matches": len(findings),
+        "url": source["url"],
+    }
+
+
+def scan_eol_api(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(source["url"], timeout)
+    require_success(result)
+    payload = json.loads(result.body)
+    if not isinstance(payload, list):
+        raise ValueError("endoflife.date response must be a list")
+
+    cycle = str(source["cycle"])
+    warn_within_days = int(source.get("warn_within_days", 180))
+    matching = next((item for item in payload if str(item.get("cycle")) == cycle), None)
+    if not matching:
+        raise ValueError(f"cycle {cycle} not found in {source['url']}")
+
+    eol_value = matching.get("eol")
+    findings: list[dict[str, Any]] = []
+    days_until_eol: int | None = None
+    should_alert = False
+    title = f"{source['name']} cycle {cycle} end-of-life status"
+    summary = f"cycle={cycle}, eol={eol_value}"
+
+    if eol_value is True:
+        should_alert = True
+        summary += ", status=already EOL"
+    elif isinstance(eol_value, str):
+        eol_date = date.fromisoformat(eol_value)
+        days_until_eol = (eol_date - datetime.now(timezone.utc).date()).days
+        should_alert = days_until_eol <= warn_within_days
+        summary += f", days_until_eol={days_until_eol}, warn_within_days={warn_within_days}"
+
+    if should_alert:
+        findings.append(
+            {
+                **common_finding_fields(source),
+                "id": finding_id(source["id"], cycle, str(eol_value)),
+                "title": title,
+                "url": source["url"],
+                "summary": summary,
+                "observed_at": now_iso(),
+                "kind": "eol_api",
+            }
+        )
+
+    return findings, {
+        "status": result.status,
+        "cycle": cycle,
+        "eol": eol_value,
+        "days_until_eol": days_until_eol,
+        "matches": len(findings),
+        "url": source["url"],
+    }
+
+
+def scan_feed(config: dict[str, Any], source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(source["url"], timeout)
+    require_success(result)
+    keywords = source_keywords(config, source)
+    required_terms = [str(term).lower() for term in source.get("required_terms", [])]
+    required_terms_context_chars = int(source.get("required_terms_context_chars", 350))
+    findings: list[dict[str, Any]] = []
+    items = parse_feed_items(result.body)
+    if not items:
+        raise ValueError(f"{source['url']} contained no RSS/Atom items")
+    for item in items[:50]:
+        haystack = " ".join([item.get("title", ""), item.get("summary", "")])
+        if required_terms:
+            if not matches_keywords_near_required_terms(
+                haystack,
+                keywords,
+                required_terms,
+                context_chars=required_terms_context_chars,
+            ):
+                continue
+        elif not matches_keywords(haystack, keywords):
+            continue
+        link = item.get("link") or source["url"]
+        title = item.get("title") or source["name"]
+        summary = normalized_text_from_html(item.get("summary", ""))[:700]
+        dedupe_key = normalize_feed_link(link) if item.get("link") else f"{source['url']}#{title}"
+        findings.append(
+            {
+                **common_finding_fields(source),
+                "id": finding_id(source["id"], dedupe_key),
+                "title": title,
+                "url": link,
+                "summary": summary,
+                "published": item.get("published", ""),
+                "observed_at": now_iso(),
+                "kind": "feed",
+            }
+        )
+    return findings, {
+        "status": result.status,
+        "items": len(items),
+        "matches": len(findings),
+        "required_terms": source.get("required_terms", []),
+        "required_terms_context_chars": required_terms_context_chars if required_terms else None,
+        "url": source["url"],
+    }
+
+
+def scan_header_probe(probe: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    result = fetch_url(
+        probe["url"],
+        timeout,
+        method=probe.get("method", "GET"),
+        request_headers=probe.get("request_headers", {}),
+        auth_env=probe.get("auth_env"),
+    )
+    if result.status != 410:
+        require_success(result)
+    headers_found: dict[str, str] = {}
+    for header in probe.get("watched_headers", []):
+        value = result.headers.get(header.lower())
+        if value:
+            headers_found[header] = value
+
+    findings: list[dict[str, Any]] = []
+    if headers_found or result.status == 410:
+        title = f"{probe['name']} returned deprecation-related response signal"
+        summary_parts = [f"HTTP status: {result.status}"]
+        for header, value in sorted(headers_found.items()):
+            summary_parts.append(f"{header}: {value}")
+        findings.append(
+            {
+                "source_id": probe["id"],
+                "source_name": probe["name"],
+                "severity": "critical" if result.status == 410 else probe.get("severity", "high"),
+                "owner": probe.get("owner", "unassigned"),
+                "affected_files": probe.get("affected_files", []),
+                "action": probe.get("action", "Review the response headers and migrate before the sunset date."),
+                "id": finding_id(probe["id"], probe["url"], str(result.status), json.dumps(headers_found, sort_keys=True)),
+                "title": title,
+                "url": probe["url"],
+                "summary": "; ".join(summary_parts),
+                "observed_at": now_iso(),
+                "kind": "header_probe",
+            }
+        )
+
+    return findings, {"status": result.status, "headers_found": headers_found, "url": probe["url"]}
+
+
+def scan_kubernetes_api_versions(scan: dict[str, Any], root: Path | None = None) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    root = root or Path.cwd()
+    deprecated = dict(DEFAULT_DEPRECATED_K8S_APIS)
+    deprecated.update(scan.get("deprecated_api_versions", {}))
+    api_pattern = re.compile(r"^\s*apiVersion:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
+    findings: list[dict[str, Any]] = []
+    checked_files = 0
+    for pattern in scan.get("paths", []):
+        for path in sorted(root.glob(str(pattern))):
+            if not path.is_file():
+                continue
+            checked_files += 1
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for match in api_pattern.finditer(text):
+                api_version = match.group(1)
+                if "{{" in api_version or api_version not in deprecated:
+                    continue
+                line = text.count("\n", 0, match.start()) + 1
+                removed_in = deprecated[api_version]
+                findings.append(
+                    {
+                        "source_id": scan["id"],
+                        "source_name": scan["name"],
+                        "severity": scan.get("severity", "high"),
+                        "owner": scan.get("owner", "platform"),
+                        "affected_files": scan.get("affected_files", []),
+                        "action": scan.get("action", "Migrate the manifest to a supported Kubernetes API version."),
+                        "id": finding_id(scan["id"], str(path.relative_to(root)), str(line), api_version, str(removed_in)),
+                        "title": f"{api_version} is removed in Kubernetes {removed_in}",
+                        "url": str(path.relative_to(root)),
+                        "summary": f"{path.relative_to(root)}:{line} uses apiVersion {api_version}, removed in Kubernetes {removed_in}.",
+                        "observed_at": now_iso(),
+                        "kind": "kubernetes_api_version",
+                    }
+                )
+    return findings, {
+        "checked_files": checked_files,
+        "matches": len(findings),
+        "paths": scan.get("paths", []),
+    }
+
+
+def source_health_findings(state: dict[str, Any], errors: list[dict[str, str]], checked_ids: set[str]) -> list[dict[str, Any]]:
+    health = state.setdefault("source_health", {})
+    by_id = {str(error.get("id") or "unknown-source"): error for error in errors}
+    findings: list[dict[str, Any]] = []
+    for source_id in checked_ids:
+        if source_id not in by_id:
+            if source_id in health:
+                health[source_id]["consecutive_failures"] = 0
+                health[source_id]["last_success_at"] = now_iso()
+            continue
+
+        error = by_id[source_id]
+        url = str(error.get("url") or "")
+        message = str(error.get("error") or "unknown error")
+        previous = health.get(source_id, {})
+        previous_message = previous.get("last_error")
+        consecutive = int(previous.get("consecutive_failures", 0)) + 1
+        health[source_id] = {
+            "consecutive_failures": consecutive,
+            "last_error": message,
+            "last_failure_at": now_iso(),
+            "url": url,
+        }
+
+        alert_counts = {2, 3, 7, 14, 30}
+        if consecutive not in alert_counts and consecutive % 30 != 0:
+            continue
+
+        findings.append(
+            {
+                "source_id": f"{source_id}-source-health",
+                "source_name": f"Source health: {source_id}",
+                "severity": "high",
+                "owner": "platform",
+                "affected_files": [
+                    ".github/external-compatibility-sources.json",
+                    ".github/workflows/external-compatibility-scan.yaml",
+                ],
+                "action": "Fix or remove the monitored source so external compatibility coverage does not silently go dark.",
+                "id": finding_id("source_error", source_id, url, message, str(consecutive)),
+                "title": "External compatibility scan source failed",
+                "url": url,
+                "summary": f"{message}; consecutive_failures={consecutive}",
+                "observed_at": now_iso(),
+                "kind": "source_error",
+            }
+        )
+    return findings
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def trim_state(state: dict[str, Any]) -> dict[str, Any]:
+    seen = state.get("seen", {})
+    if len(seen) <= MAX_SEEN_ITEMS:
+        return state
+    ordered = sorted(seen.items(), key=lambda item: item[1].get("last_seen_at", ""))
+    state["seen"] = dict(ordered[-MAX_SEEN_ITEMS:])
+    return state
+
+
+def update_state_and_filter(
+    state: dict[str, Any],
+    findings: list[dict[str, Any]],
+    first_run: bool,
+    notify_on_first_run: bool,
+) -> list[dict[str, Any]]:
+    seen = state.setdefault("seen", {})
+    notified = state.setdefault("notified", {})
+    pending = state.setdefault("pending", {})
+    new_findings: list[dict[str, Any]] = []
+    for finding in findings:
+        existing = seen.get(finding["id"])
+        should_notify = finding["id"] not in notified and (notify_on_first_run or not first_run)
+        if should_notify:
+            new_findings.append(finding)
+            pending[finding["id"]] = finding
+        elif not should_notify and first_run and not notify_on_first_run:
+            notified[finding["id"]] = {
+                "source_id": finding["source_id"],
+                "title": finding["title"],
+                "url": finding["url"],
+                "baselined_at": finding["observed_at"],
+            }
+        seen[finding["id"]] = {
+            "source_id": finding["source_id"],
+            "title": finding["title"],
+            "url": finding["url"],
+            "first_seen_at": existing.get("first_seen_at") if existing else finding["observed_at"],
+            "last_seen_at": finding["observed_at"],
+        }
+    state["last_scan_at"] = now_iso()
+    state["initialized"] = True
+    return new_findings
+
+
+def pending_findings(state: dict[str, Any]) -> list[dict[str, Any]]:
+    pending = state.get("pending", {})
+    if not isinstance(pending, dict):
+        return []
+    return [finding for _, finding in sorted(pending.items(), key=lambda item: item[1].get("observed_at", ""))]
+
+
+def mark_pending_notified(state: dict[str, Any], finding_ids: set[str] | None = None) -> int:
+    pending = state.setdefault("pending", {})
+    notified = state.setdefault("notified", {})
+    marked = 0
+    for finding_id_value, finding in list(pending.items()):
+        if finding_ids is not None and finding_id_value not in finding_ids:
+            continue
+        notified[finding_id_value] = {
+            "source_id": finding.get("source_id"),
+            "title": finding.get("title"),
+            "url": finding.get("url"),
+            "notified_at": now_iso(),
+        }
+        del pending[finding_id_value]
+        marked += 1
+    return marked
+
+
+def workflow_run_url() -> str:
+    server = os.getenv("GITHUB_SERVER_URL")
+    repository = os.getenv("GITHUB_REPOSITORY")
+    run_id = os.getenv("GITHUB_RUN_ID")
+    if not server or not repository or not run_id:
+        return ""
+    return f"{server.rstrip('/')}/{repository}/actions/runs/{run_id}"
+
+
+def slack_payload(
+    findings: list[dict[str, Any]],
+    first_run: bool,
+    total_matches: int,
+    part: int = 1,
+    total_parts: int = 1,
+) -> dict[str, Any]:
+    baseline_note = " First-run baseline mode was enabled." if first_run else ""
+    source_errors = sum(1 for finding in findings if finding.get("kind") == "source_error")
+    compatibility_findings = len(findings) - source_errors
+    part_note = f" Part {part}/{total_parts}." if total_parts > 1 else ""
+    lines = [
+        f"OpenChoreo external compatibility scan found {compatibility_findings} compatibility notice(s) and {source_errors} source-health issue(s) in this message.{baseline_note}{part_note}",
+        f"Total matching notices observed this run: {total_matches}.",
+        "See the external-compatibility-scan-state artifact for report.json and full finding details.",
+    ]
+    run_url = workflow_run_url()
+    if run_url:
+        lines.append(f"Workflow run: {run_url}")
+    for finding in findings:
+        affected = ", ".join(finding.get("affected_files", [])[:3])
+        if len(finding.get("affected_files", [])) > 3:
+            affected += ", ..."
+        lines.append(
+            "\n".join(
+                [
+                    "",
+                    f"*{finding['severity'].upper()}* - {finding['source_name']}",
+                    finding["title"],
+                    f"Source: {finding['url']}",
+                    f"Affected: {affected}",
+                    f"Owner: {finding.get('owner', 'unassigned')}",
+                    f"Action: {finding['action']}",
+                ]
+            )
+        )
+    return {"text": "\n".join(lines)}
+
+
+def slack_payload_dir(slack_payload_path: Path) -> Path:
+    return slack_payload_path.parent / f"{slack_payload_path.stem}s"
+
+
+def write_slack_payloads(
+    slack_payload_path: Path,
+    findings: list[dict[str, Any]],
+    first_run: bool,
+    total_matches: int,
+) -> None:
+    payload_dir = slack_payload_dir(slack_payload_path)
+    payload_dir.mkdir(parents=True, exist_ok=True)
+    for existing in payload_dir.glob("*.json"):
+        existing.unlink()
+
+    if not findings:
+        if slack_payload_path.exists():
+            slack_payload_path.unlink()
+        return
+
+    chunks = [
+        findings[index:index + MAX_FINDINGS_PER_SLACK_MESSAGE]
+        for index in range(0, len(findings), MAX_FINDINGS_PER_SLACK_MESSAGE)
+    ]
+    total_parts = len(chunks)
+    for index, chunk in enumerate(chunks, start=1):
+        payload = slack_payload(chunk, first_run, total_matches, part=index, total_parts=total_parts)
+        payload_path = payload_dir / f"{index:03d}.payload.json"
+        ids_path = payload_dir / f"{index:03d}.ids.json"
+        write_json(payload_path, payload)
+        write_json(ids_path, [finding["id"] for finding in chunk])
+        if index == 1:
+            write_json(slack_payload_path, payload)
+
+
+def main() -> int:
+    args = parse_args()
+    config_path = Path(args.config)
+    state_path = Path(args.state)
+    state_out_path = Path(args.state_out)
+    slack_payload_path = Path(args.slack_payload)
+    report_path = Path(args.report)
+
+    config = load_json(config_path, {})
+    errors = validate_config(config, root=Path.cwd())
+    if errors:
+        for error in errors:
+            print(f"config error: {error}", file=sys.stderr)
+        return 2
+    if args.validate_only:
+        print(
+            f"validated {len(config.get('sources', []))} sources, "
+            f"{len(config.get('manifest_scans', []))} manifest scans, "
+            f"and {len(config.get('header_probes', []))} header probes"
+        )
+        return 0
+
+    state = load_json(state_path, {"seen": {}})
+    if args.mark_notified or args.mark_notified_ids:
+        finding_ids = None
+        if args.mark_notified_ids:
+            finding_ids = {str(finding_id_value) for finding_id_value in load_json(Path(args.mark_notified_ids), [])}
+        marked = mark_pending_notified(state, finding_ids=finding_ids)
+        state["last_notification_at"] = now_iso()
+        write_json(state_out_path, state)
+        print(f"marked {marked} pending finding(s) as notified")
+        return 0
+
+    first_run = not state.get("initialized", False)
+    report: dict[str, Any] = {
+        "config": str(config_path),
+        "first_run": first_run,
+        "notify_on_first_run": args.notify_on_first_run,
+        "source_results": [],
+        "manifest_results": [],
+        "probe_results": [],
+        "errors": [],
+    }
+
+    all_findings: list[dict[str, Any]] = []
+    for source in config.get("sources", []):
+        try:
+            if source["type"] == "feed":
+                findings, source_report = scan_feed(config, source, args.timeout)
+            elif source["type"] == "github_api_versions":
+                findings, source_report = scan_github_api_versions(source, args.timeout)
+            elif source["type"] == "page_contains":
+                findings, source_report = scan_page_contains(source, args.timeout)
+            elif source["type"] == "page_terms":
+                findings, source_report = scan_page_terms(source, args.timeout)
+            elif source["type"] == "reference_page":
+                findings, source_report = scan_reference_page(source, args.timeout)
+            elif source["type"] == "eol_api":
+                findings, source_report = scan_eol_api(source, args.timeout)
+            else:
+                raise ValueError(f"unsupported source type: {source['type']}")
+            source_report.update({"id": source["id"], "name": source["name"], "type": source["type"]})
+            report["source_results"].append(source_report)
+            all_findings.extend(findings)
+        except Exception as exc:  # noqa: BLE001 - report and continue across independent sources
+            report["errors"].append({"id": source.get("id"), "url": source.get("url"), "error": str(exc)})
+
+    for scan in config.get("manifest_scans", []):
+        try:
+            findings, manifest_report = scan_kubernetes_api_versions(scan)
+            manifest_report.update({"id": scan["id"], "name": scan["name"], "type": scan["type"]})
+            report["manifest_results"].append(manifest_report)
+            all_findings.extend(findings)
+        except Exception as exc:  # noqa: BLE001 - report and continue across independent manifest scans
+            report["errors"].append({"id": scan.get("id"), "url": "local manifests", "error": str(exc)})
+
+    for probe in config.get("header_probes", []):
+        try:
+            findings, probe_report = scan_header_probe(probe, args.timeout)
+            probe_report.update({"id": probe["id"], "name": probe["name"], "type": "header_probe"})
+            report["probe_results"].append(probe_report)
+            all_findings.extend(findings)
+        except Exception as exc:  # noqa: BLE001 - report and continue across independent probes
+            report["errors"].append({"id": probe.get("id"), "url": probe.get("url"), "error": str(exc)})
+
+    checked_ids = {str(source.get("id")) for source in config.get("sources", [])}
+    checked_ids.update(str(scan.get("id")) for scan in config.get("manifest_scans", []))
+    checked_ids.update(str(probe.get("id")) for probe in config.get("header_probes", []))
+
+    new_findings = update_state_and_filter(
+        state,
+        all_findings,
+        first_run=first_run,
+        notify_on_first_run=args.notify_on_first_run,
+    )
+    source_error_findings = source_health_findings(state, report["errors"], checked_ids)
+    new_error_findings = update_state_and_filter(
+        state,
+        source_error_findings,
+        first_run=False,
+        notify_on_first_run=True,
+    )
+    new_findings.extend(new_error_findings)
+    trim_state(state)
+
+    report.update(
+        {
+            "total_matches": len(all_findings),
+            "new_findings": len(new_findings),
+            "new_source_errors": len(new_error_findings),
+            "baselined_findings": len(all_findings) if first_run and not args.notify_on_first_run else 0,
+            "findings": new_findings,
+            "pending_notifications": len(pending_findings(state)),
+        }
+    )
+    write_json(state_out_path, state)
+    write_json(report_path, report)
+
+    current_pending = pending_findings(state)
+    write_slack_payloads(slack_payload_path, current_pending, first_run, len(all_findings))
+
+    summary = textwrap.dedent(
+        f"""
+        External compatibility scan complete.
+        first_run={first_run}
+        total_matches={len(all_findings)}
+        new_findings={len(new_findings)}
+        errors={len(report['errors'])}
+        state={state_out_path}
+        report={report_path}
+        """
+    ).strip()
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -42,6 +42,12 @@ USER_AGENT = "openchoreo-external-compatibility-scan/1.0 (+https://github.com/op
 MAX_FINDINGS_PER_SLACK_MESSAGE = 10
 MAX_SEEN_ITEMS = 2000
 RETRYABLE_HTTP_STATUS = {403, 429, 500, 502, 503, 504}
+SLACK_SEVERITY_COLORS = {
+    "critical": "#d1242f",
+    "high": "#fb8500",
+    "medium": "#d4a72c",
+    "low": "#6e7781",
+}
 NEGATION_BEFORE_KEYWORD = re.compile(
     r"\b(?:no\s+longer|not(?:\s+an?|\s+any)?|never)\s+(?:\w+\s+){0,3}$",
     re.IGNORECASE,
@@ -919,6 +925,67 @@ def workflow_run_url() -> str:
     return f"{server.rstrip('/')}/{repository}/actions/runs/{run_id}"
 
 
+def slack_mrkdwn_escape(value: Any) -> str:
+    return str(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def slack_link(url: str, label: str = "Open source") -> str:
+    if not url.startswith(("http://", "https://")):
+        return slack_mrkdwn_escape(url)
+    return f"<{url}|{slack_mrkdwn_escape(label)}>"
+
+
+def slack_severity_color(severity: str) -> str:
+    return SLACK_SEVERITY_COLORS.get(severity.lower(), "#6e7781")
+
+
+def slack_finding_attachment(finding: dict[str, Any]) -> dict[str, Any]:
+    affected_files = finding.get("affected_files", [])
+    affected = ", ".join(affected_files[:3]) if affected_files else "Not specified"
+    if len(affected_files) > 3:
+        affected += ", ..."
+
+    severity = str(finding.get("severity", "medium")).upper()
+    source_name = slack_mrkdwn_escape(finding.get("source_name", "Unknown source"))
+    title = slack_mrkdwn_escape(finding.get("title", "Untitled finding"))
+    action = slack_mrkdwn_escape(finding.get("action", "Review the source and assess impact."))
+    owner = slack_mrkdwn_escape(finding.get("owner", "unassigned"))
+
+    return {
+        "color": slack_severity_color(str(finding.get("severity", "medium"))),
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*{severity}* | *{source_name}*\n{title}",
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Source*\n{slack_link(str(finding.get('url', '')))}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Owner*\n{owner}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Affected*\n{slack_mrkdwn_escape(affected)}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Action*\n{action}",
+                    },
+                ],
+            },
+        ],
+    }
+
+
 def slack_payload(
     findings: list[dict[str, Any]],
     first_run: bool,
@@ -926,23 +993,65 @@ def slack_payload(
     part: int = 1,
     total_parts: int = 1,
 ) -> dict[str, Any]:
-    baseline_note = " First-run baseline mode was enabled." if first_run else ""
+    first_run_note = " First scan state for this branch." if first_run else ""
     source_errors = sum(1 for finding in findings if finding.get("kind") == "source_error")
     compatibility_findings = len(findings) - source_errors
     part_note = f" Part {part}/{total_parts}." if total_parts > 1 else ""
-    lines = [
-        f"OpenChoreo external compatibility scan found {compatibility_findings} compatibility notice(s) and {source_errors} source-health issue(s) in this message.{baseline_note}{part_note}",
+    title = "OpenChoreo external compatibility scan"
+    summary = (
+        f"Found *{compatibility_findings}* compatibility notice(s) and "
+        f"*{source_errors}* source-health issue(s) in this message."
+        f"{first_run_note}{part_note}"
+    )
+    fallback_lines = [
+        f"{title}: {compatibility_findings} compatibility notice(s), {source_errors} source-health issue(s).{first_run_note}{part_note}",
         f"Total matching notices observed this run: {total_matches}.",
-        "See the external-compatibility-scan-state artifact for report.json and full finding details.",
+        "See the external-compatibility-scan-state artifact for report.json and full details.",
+    ]
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": title,
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": summary,
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"Total matching notices observed this run: *{total_matches}*. Full details are in the `external-compatibility-scan-state` artifact.",
+                }
+            ],
+        },
     ]
     run_url = workflow_run_url()
     if run_url:
-        lines.append(f"Workflow run: {run_url}")
+        fallback_lines.append(f"Workflow run: {run_url}")
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Workflow run: {slack_link(run_url, 'open in GitHub Actions')}",
+                    }
+                ],
+            }
+        )
     for finding in findings:
         affected = ", ".join(finding.get("affected_files", [])[:3])
         if len(finding.get("affected_files", [])) > 3:
             affected += ", ..."
-        lines.append(
+        fallback_lines.append(
             "\n".join(
                 [
                     "",
@@ -955,7 +1064,11 @@ def slack_payload(
                 ]
             )
         )
-    return {"text": "\n".join(lines)}
+    return {
+        "text": "\n".join(fallback_lines),
+        "blocks": blocks,
+        "attachments": [slack_finding_attachment(finding) for finding in findings],
+    }
 
 
 def slack_payload_dir(slack_payload_path: Path) -> Path:

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -36,6 +36,10 @@ USER_AGENT = "openchoreo-external-compatibility-scan/1.0 (+https://github.com/op
 MAX_FINDINGS_PER_SLACK_MESSAGE = 10
 MAX_SEEN_ITEMS = 2000
 RETRYABLE_HTTP_STATUS = {403, 429, 500, 502, 503, 504}
+# Hostnames permitted to receive an Authorization token. Kept as an explicit
+# allowlist so a misconfigured or redirected URL cannot exfiltrate a secret
+# (e.g. GITHUB_TOKEN) to an arbitrary host.
+TOKEN_ALLOWED_HOSTS = {"api.github.com"}
 SLACK_SEVERITY_COLORS = {
     "critical": "#d1242f",
     "high": "#fb8500",
@@ -179,8 +183,12 @@ def validate_config(config: dict[str, Any], root: Path | None = None) -> list[st
             validate_path_patterns(root, f"{source_id}.affected_files", source.get("affected_files", []), errors)
         if not source.get("action"):
             errors.append(f"{source_id}: missing action")
-        if source.get("type") == "page_contains" and not source.get("required_text"):
-            errors.append(f"{source_id}: page_contains sources require required_text")
+        if source.get("type") == "page_contains":
+            required_text = source.get("required_text")
+            if not required_text:
+                errors.append(f"{source_id}: page_contains sources require required_text")
+            elif not isinstance(required_text, (str, list)):
+                errors.append(f"{source_id}: required_text must be a string or list of strings")
         if source.get("type") == "page_terms" and not source.get("match_terms"):
             errors.append(f"{source_id}: page_terms sources require match_terms")
         if source.get("required_terms") is not None and not isinstance(source.get("required_terms"), list):
@@ -253,6 +261,13 @@ def fetch_url(
     if auth_env:
         token = os.getenv(auth_env)
         if token and "Authorization" not in headers:
+            parsed = urllib.parse.urlsplit(url)
+            if parsed.scheme != "https":
+                raise ValueError(f"refusing to send {auth_env} token to non-HTTPS URL: {url}")
+            if (parsed.hostname or "").lower() not in TOKEN_ALLOWED_HOSTS:
+                raise ValueError(
+                    f"refusing to send {auth_env} token to non-allowlisted host: {parsed.hostname}"
+                )
             headers["Authorization"] = f"Bearer {token}"
 
     last_error: Exception | None = None
@@ -469,7 +484,10 @@ def scan_page_contains(source: dict[str, Any], timeout: float) -> tuple[list[dic
     result = fetch_url(source["url"], timeout)
     require_success(result)
     text = normalized_text_from_html(result.body).lower()
-    missing = [needle for needle in source.get("required_text", []) if str(needle).lower() not in text]
+    required_text = source.get("required_text", [])
+    if isinstance(required_text, str):
+        required_text = [required_text]
+    missing = [needle for needle in required_text if str(needle).lower() not in text]
     findings: list[dict[str, Any]] = []
     if missing:
         title = f"{source['name']} no longer contains expected supported value(s)"
@@ -487,7 +505,7 @@ def scan_page_contains(source: dict[str, Any], timeout: float) -> tuple[list[dic
         )
     return findings, {
         "status": result.status,
-        "required_text": source.get("required_text", []),
+        "required_text": required_text,
         "missing": missing,
         "matches": len(findings),
         "url": source["url"],
@@ -595,26 +613,34 @@ def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[s
     matched_terms: list[str] = []
     for term in source.get("match_terms", []):
         term_text = str(term)
-        index = lowered.find(term_text.lower())
-        if index < 0:
-            continue
-        start = max(0, index - context_chars)
-        end = min(len(text), index + len(term_text) + context_chars)
-        context = text[start:end].strip()
-        if keywords and not matches_keywords(context, keywords):
-            continue
-        matched_terms.append(term_text)
-        findings.append(
-            {
-                **common_finding_fields(source),
-                "id": finding_id(source["id"], source["url"], term_text),
-                "title": f"{source['name']} mentions monitored term: {term_text}",
-                "url": source["url"],
-                "summary": context[:700],
-                "observed_at": now_iso(),
-                "kind": "page_terms",
-            }
-        )
+        term_lower = term_text.lower()
+        # Walk every occurrence of the term; a term can appear first in a benign
+        # context and only later next to a change keyword, so stop at the first
+        # keyword-adjacent occurrence rather than only checking the first hit.
+        search_from = 0
+        while True:
+            index = lowered.find(term_lower, search_from)
+            if index < 0:
+                break
+            start = max(0, index - context_chars)
+            end = min(len(text), index + len(term_text) + context_chars)
+            context = text[start:end].strip()
+            search_from = index + max(1, len(term_text))
+            if keywords and not matches_keywords(context, keywords):
+                continue
+            matched_terms.append(term_text)
+            findings.append(
+                {
+                    **common_finding_fields(source),
+                    "id": finding_id(source["id"], source["url"], term_text),
+                    "title": f"{source['name']} mentions monitored term: {term_text}",
+                    "url": source["url"],
+                    "summary": context[:700],
+                    "observed_at": now_iso(),
+                    "kind": "page_terms",
+                }
+            )
+            break
     return findings, {
         "status": result.status,
         "match_terms": source.get("match_terms", []),

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -935,6 +935,10 @@ def slack_link(url: str, label: str = "Open source") -> str:
     return f"<{url}|{slack_mrkdwn_escape(label)}>"
 
 
+def is_http_url(url: str) -> bool:
+    return url.startswith(("http://", "https://"))
+
+
 def slack_severity_color(severity: str) -> str:
     return SLACK_SEVERITY_COLORS.get(severity.lower(), "#6e7781")
 
@@ -950,23 +954,35 @@ def slack_finding_attachment(finding: dict[str, Any]) -> dict[str, Any]:
     title = slack_mrkdwn_escape(finding.get("title", "Untitled finding"))
     action = slack_mrkdwn_escape(finding.get("action", "Review the source and assess impact."))
     owner = slack_mrkdwn_escape(finding.get("owner", "unassigned"))
+    url = str(finding.get("url", ""))
+    first_block: dict[str, Any] = {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f"*{title}*\n{source_name}",
+        },
+    }
+    if is_http_url(url):
+        first_block["accessory"] = {
+            "type": "button",
+            "text": {
+                "type": "plain_text",
+                "text": "View notice",
+            },
+            "url": url,
+        }
 
     return {
         "color": slack_severity_color(str(finding.get("severity", "medium"))),
+        "fallback": f"{severity} - {finding.get('source_name', 'Unknown source')}: {finding.get('title', 'Untitled finding')}",
         "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*{severity}* | *{source_name}*\n{title}",
-                },
-            },
+            first_block,
             {
                 "type": "section",
                 "fields": [
                     {
                         "type": "mrkdwn",
-                        "text": f"*Source*\n{slack_link(str(finding.get('url', '')))}",
+                        "text": f"*Severity*\n{severity}",
                     },
                     {
                         "type": "mrkdwn",
@@ -978,9 +994,16 @@ def slack_finding_attachment(finding: dict[str, Any]) -> dict[str, Any]:
                     },
                     {
                         "type": "mrkdwn",
-                        "text": f"*Action*\n{action}",
+                        "text": f"*Source*\n{slack_link(url, 'Notice link')}",
                     },
                 ],
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Action*\n{action}",
+                },
             },
         ],
     }
@@ -997,12 +1020,8 @@ def slack_payload(
     source_errors = sum(1 for finding in findings if finding.get("kind") == "source_error")
     compatibility_findings = len(findings) - source_errors
     part_note = f" Part {part}/{total_parts}." if total_parts > 1 else ""
-    title = "OpenChoreo external compatibility scan"
-    summary = (
-        f"Found *{compatibility_findings}* compatibility notice(s) and "
-        f"*{source_errors}* source-health issue(s) in this message."
-        f"{first_run_note}{part_note}"
-    )
+    title = "OpenChoreo External Compatibility Scan"
+    summary = "External API, webhook, SaaS, lifecycle, and Kubernetes compatibility notices."
     fallback_lines = [
         f"{title}: {compatibility_findings} compatibility notice(s), {source_errors} source-health issue(s).{first_run_note}{part_note}",
         f"Total matching notices observed this run: {total_matches}.",
@@ -1024,11 +1043,32 @@ def slack_payload(
             },
         },
         {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Compatibility notices*\n{compatibility_findings}",
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Source-health issues*\n{source_errors}",
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Total matches this run*\n{total_matches}",
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Run context*\n{('First scan state' if first_run else 'Existing scan state')}{part_note}",
+                },
+            ],
+        },
+        {
             "type": "context",
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": f"Total matching notices observed this run: *{total_matches}*. Full details are in the `external-compatibility-scan-state` artifact.",
+                    "text": "Full details are in the `external-compatibility-scan-state` artifact.",
                 }
             ],
         },
@@ -1047,6 +1087,7 @@ def slack_payload(
                 ],
             }
         )
+    blocks.append({"type": "divider"})
     for finding in findings:
         affected = ", ".join(finding.get("affected_files", [])[:3])
         if len(finding.get("affected_files", [])) > 3:

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -35,6 +35,9 @@ from typing import Any
 USER_AGENT = "openchoreo-external-compatibility-scan/1.0 (+https://github.com/openchoreo/openchoreo)"
 MAX_FINDINGS_PER_SLACK_MESSAGE = 10
 MAX_SEEN_ITEMS = 2000
+# Cap response buffering so a huge or endless body from an external source
+# cannot exhaust the runner's memory. Feeds/pages/JSON here are well under this.
+MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 RETRYABLE_HTTP_STATUS = {403, 429, 500, 502, 503, 504}
 # Hostnames permitted to receive an Authorization token. Kept as an explicit
 # allowlist so a misconfigured or redirected URL cannot exfiltrate a secret
@@ -150,19 +153,25 @@ def validate_path_patterns(root: Path | None, owner: str, patterns: list[Any], e
 
 def validate_config(config: dict[str, Any], root: Path | None = None) -> list[str]:
     errors: list[str] = []
-    source_ids: set[str] = set()
+    # One shared identifier namespace across every registry section: source,
+    # probe, and manifest-scan IDs must be globally unique because downstream
+    # dedupe (finding_id), checked_ids, and source_health all key on the bare id.
+    seen_ids: set[str] = set()
     for key in ("sources", "header_probes", "manifest_scans"):
         if key in config and not isinstance(config[key], list):
             errors.append(f"{key} must be a list")
+            # Normalize to an empty list so the loops below (and main's scan
+            # loops) never call dict methods on an invalid non-list value.
+            config[key] = []
 
     for source in config.get("sources", []):
         source_id = source.get("id")
         if not source_id:
             errors.append("source is missing id")
-        elif source_id in source_ids:
+        elif source_id in seen_ids:
             errors.append(f"duplicate source id: {source_id}")
         else:
-            source_ids.add(source_id)
+            seen_ids.add(source_id)
         if source.get("type") not in {
             "feed",
             "github_api_versions",
@@ -203,15 +212,14 @@ def validate_config(config: dict[str, Any], root: Path | None = None) -> list[st
             if not isinstance(source.get("warn_within_days", 180), int):
                 errors.append(f"{source_id}: warn_within_days must be an integer")
 
-    probe_ids: set[str] = set()
     for probe in config.get("header_probes", []):
         probe_id = probe.get("id")
         if not probe_id:
             errors.append("header probe is missing id")
-        elif probe_id in probe_ids:
+        elif probe_id in seen_ids:
             errors.append(f"duplicate header probe id: {probe_id}")
         else:
-            probe_ids.add(probe_id)
+            seen_ids.add(probe_id)
         if not probe.get("url"):
             errors.append(f"{probe_id}: missing url")
         if not probe.get("watched_headers"):
@@ -223,15 +231,14 @@ def validate_config(config: dict[str, Any], root: Path | None = None) -> list[st
         if not probe.get("action"):
             errors.append(f"{probe_id}: missing action")
 
-    manifest_ids: set[str] = set()
     for scan in config.get("manifest_scans", []):
         scan_id = scan.get("id")
         if not scan_id:
             errors.append("manifest scan is missing id")
-        elif scan_id in manifest_ids:
+        elif scan_id in seen_ids:
             errors.append(f"duplicate manifest scan id: {scan_id}")
         else:
-            manifest_ids.add(scan_id)
+            seen_ids.add(scan_id)
         if scan.get("type") != "kubernetes_api_versions":
             errors.append(f"{scan_id}: type must be kubernetes_api_versions")
         if not scan.get("paths"):
@@ -276,7 +283,7 @@ def fetch_url(
         request = urllib.request.Request(url, method=method, headers=headers)
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
-                raw = response.read()
+                raw = read_capped(response, url)
                 charset = response.headers.get_content_charset() or "utf-8"
                 body = raw.decode(charset, errors="replace")
                 return FetchResult(
@@ -287,7 +294,7 @@ def fetch_url(
                 )
         except urllib.error.HTTPError as exc:
             if exc.code not in RETRYABLE_HTTP_STATUS or attempt == attempts - 1:
-                raw = exc.read()
+                raw = read_capped(exc, url)
                 charset = exc.headers.get_content_charset() or "utf-8"
                 return FetchResult(
                     url=url,
@@ -313,6 +320,18 @@ def retry_delay_seconds(retry_after: str | None, attempt: int) -> float:
         except ValueError:
             pass
     return min(0.5 * (2 ** attempt), 4.0)
+
+
+def read_capped(reader: Any, url: str) -> bytes:
+    """Read at most MAX_RESPONSE_BYTES, rejecting anything larger.
+
+    Reads one byte past the limit so an over-size body is detected without
+    buffering the whole thing.
+    """
+    raw = reader.read(MAX_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise ValueError(f"{url} response exceeded {MAX_RESPONSE_BYTES} byte limit")
+    return raw
 
 
 def require_success(result: FetchResult) -> None:
@@ -597,7 +616,7 @@ def scan_github_api_versions(source: dict[str, Any], timeout: float) -> tuple[li
     }
 
 
-def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+def scan_page_terms(config: dict[str, Any], source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Alert when a monitored term appears on a page near a change keyword.
 
     A term only produces a finding if a deprecation/removal keyword also occurs
@@ -607,7 +626,11 @@ def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[s
     require_success(result)
     text = normalized_text_from_html(result.body)
     lowered = text.lower()
-    keywords = source_keywords({"defaults": {"keywords": source.get("keywords", [])}}, source)
+    keywords = source_keywords(config, source)
+    if not keywords:
+        # Without lifecycle keywords the scan would flag every term occurrence,
+        # so require at least one (from the source or the global defaults).
+        raise ValueError("page_terms sources require keywords (set them or configure defaults.keywords)")
     context_chars = int(source.get("context_chars", 500))
     findings: list[dict[str, Any]] = []
     matched_terms: list[str] = []
@@ -626,13 +649,16 @@ def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[s
             end = min(len(text), index + len(term_text) + context_chars)
             context = text[start:end].strip()
             search_from = index + max(1, len(term_text))
-            if keywords and not matches_keywords(context, keywords):
+            if not matches_keywords(context, keywords):
                 continue
             matched_terms.append(term_text)
             findings.append(
                 {
                     **common_finding_fields(source),
-                    "id": finding_id(source["id"], source["url"], term_text),
+                    # Fingerprint the keyword-adjacent context so two distinct
+                    # announcements for the same term dedupe separately, while
+                    # re-seeing the same notice keeps a stable id.
+                    "id": finding_id(source["id"], source["url"], term_text, stable_hash(context)),
                     "title": f"{source['name']} mentions monitored term: {term_text}",
                     "url": source["url"],
                     "summary": context[:700],
@@ -1037,6 +1063,7 @@ def slack_finding_attachment(finding: dict[str, Any]) -> dict[str, Any]:
     action = slack_mrkdwn_escape(finding.get("action", "Review the source and assess impact."))
     owner = slack_mrkdwn_escape(finding.get("owner", "unassigned"))
     url = str(finding.get("url", ""))
+    summary = slack_mrkdwn_escape(str(finding.get("summary", ""))[:700])
     first_block: dict[str, Any] = {
         "type": "section",
         "text": {
@@ -1054,11 +1081,19 @@ def slack_finding_attachment(finding: dict[str, Any]) -> dict[str, Any]:
             "url": url,
         }
 
-    return {
-        "color": slack_severity_color(str(finding.get("severity", "medium"))),
-        "fallback": f"{severity} - {finding.get('source_name', 'Unknown source')}: {finding.get('title', 'Untitled finding')}",
-        "blocks": [
-            first_block,
+    blocks: list[dict[str, Any]] = [first_block]
+    if summary:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Summary*\n{summary}",
+                },
+            }
+        )
+    blocks.extend(
+        [
             {
                 "type": "section",
                 "fields": [
@@ -1087,7 +1122,13 @@ def slack_finding_attachment(finding: dict[str, Any]) -> dict[str, Any]:
                     "text": f"*Action*\n{action}",
                 },
             },
-        ],
+        ]
+    )
+
+    return {
+        "color": slack_severity_color(str(finding.get("severity", "medium"))),
+        "fallback": f"{severity} - {finding.get('source_name', 'Unknown source')}: {finding.get('title', 'Untitled finding')}",
+        "blocks": blocks,
     }
 
 
@@ -1180,6 +1221,7 @@ def slack_payload(
                     "",
                     f"*{finding['severity'].upper()}* - {finding['source_name']}",
                     finding["title"],
+                    f"Summary: {str(finding.get('summary', ''))[:700]}",
                     f"Source: {finding['url']}",
                     f"Affected: {affected}",
                     f"Owner: {finding.get('owner', 'unassigned')}",
@@ -1290,7 +1332,7 @@ def main() -> int:
             elif source["type"] == "page_contains":
                 findings, source_report = scan_page_contains(source, args.timeout)
             elif source["type"] == "page_terms":
-                findings, source_report = scan_page_terms(source, args.timeout)
+                findings, source_report = scan_page_terms(config, source, args.timeout)
             elif source["type"] == "reference_page":
                 findings, source_report = scan_reference_page(source, args.timeout)
             elif source["type"] == "eol_api":

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 """Scan curated external compatibility sources and produce a Slack digest.
 
-The scanner is intentionally dependency-free so it can run in GitHub Actions
-without installing Python packages. It supports:
+Dependency-free so it runs in GitHub Actions with no package install. Sources
+are declared in the config JSON; each has a `type` handled by a `scan_*`
+function (RSS/Atom feeds, provider pages, endoflife.date, GitHub API versions,
+response-header probes, and static Kubernetes manifest API-version scans).
 
-- RSS/Atom feeds, scanned item-by-item.
-- Reference pages, fetched for source-health visibility but not converted into
-  keyword-based Slack findings.
-- Page contains checks, which alert only when expected text disappears from a
-  provider page.
-- Machine-readable endoflife.date checks.
-- HTTP response header probes for Deprecation, Sunset, Warning, and similar
-  provider headers.
-
-On the first run with an empty state file, findings are recorded but not sent by
-default. This baselines historical compatibility notices and prevents Slack noise.
+State is persisted between runs to dedupe already-seen notices. On the first
+run (empty state) findings are baselined rather than sent, so Slack only ever
+receives notices that are new since the previous scan.
 """
 
 from __future__ import annotations
@@ -450,6 +444,11 @@ def common_finding_fields(source: dict[str, Any]) -> dict[str, Any]:
 
 
 def scan_reference_page(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Fetch a page for source-health only; it never produces findings.
+
+    Used for reference docs where keyword matching would be too noisy. The
+    returned report records a content hash so drift is visible in report.json.
+    """
     result = fetch_url(source["url"], timeout)
     require_success(result)
     text = normalized_text_from_html(result.body)
@@ -462,6 +461,11 @@ def scan_reference_page(source: dict[str, Any], timeout: float) -> tuple[list[di
 
 
 def scan_page_contains(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Alert when expected text disappears from a provider page.
+
+    Inverts the usual keyword scan: a finding is raised when a required_text
+    value (e.g. a currently-supported version) is no longer present.
+    """
     result = fetch_url(source["url"], timeout)
     require_success(result)
     text = normalized_text_from_html(result.body).lower()
@@ -495,6 +499,12 @@ def source_request_headers(source: dict[str, Any]) -> dict[str, str]:
 
 
 def scan_github_api_versions(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Check the pinned GitHub REST API version against the supported list.
+
+    Raises findings when the pinned version has dropped off the supported list,
+    when its `supported_until` window is closing, or (optionally) when it is no
+    longer the latest supported version.
+    """
     result = fetch_url(
         source["url"],
         timeout,
@@ -570,6 +580,11 @@ def scan_github_api_versions(source: dict[str, Any], timeout: float) -> tuple[li
 
 
 def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Alert when a monitored term appears on a page near a change keyword.
+
+    A term only produces a finding if a deprecation/removal keyword also occurs
+    within `context_chars` of it, keeping incidental mentions out of Slack.
+    """
     result = fetch_url(source["url"], timeout)
     require_success(result)
     text = normalized_text_from_html(result.body)
@@ -610,6 +625,11 @@ def scan_page_terms(source: dict[str, Any], timeout: float) -> tuple[list[dict[s
 
 
 def scan_eol_api(source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Check a cycle's end-of-life date from an endoflife.date response.
+
+    Alerts when the cycle is already EOL, or when its EOL date is within
+    `warn_within_days`.
+    """
     result = fetch_url(source["url"], timeout)
     require_success(result)
     payload = json.loads(result.body)
@@ -662,6 +682,12 @@ def scan_eol_api(source: dict[str, Any], timeout: float) -> tuple[list[dict[str,
 
 
 def scan_feed(config: dict[str, Any], source: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Scan the newest RSS/Atom items for change keywords.
+
+    Each item's title and summary are matched against the source's keywords. If
+    `required_terms` is set, a keyword only counts when one of those terms also
+    appears nearby, narrowing a broad feed to items relevant to OpenChoreo.
+    """
     result = fetch_url(source["url"], timeout)
     require_success(result)
     keywords = source_keywords(config, source)
@@ -710,6 +736,11 @@ def scan_feed(config: dict[str, Any], source: dict[str, Any], timeout: float) ->
 
 
 def scan_header_probe(probe: dict[str, Any], timeout: float) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Probe an endpoint for RFC 8594 deprecation signals.
+
+    Raises a finding when any watched response header (Deprecation, Sunset,
+    Warning, ...) is present, or when the endpoint returns HTTP 410 Gone.
+    """
     result = fetch_url(
         probe["url"],
         timeout,
@@ -752,6 +783,11 @@ def scan_header_probe(probe: dict[str, Any], timeout: float) -> tuple[list[dict[
 
 
 def scan_kubernetes_api_versions(scan: dict[str, Any], root: Path | None = None) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Statically scan local manifests for removed Kubernetes API versions.
+
+    Reads each matched file's `apiVersion:` lines and flags any that appear in
+    the removed-API table. Templated values (containing `{{`) are skipped.
+    """
     root = root or Path.cwd()
     deprecated = dict(DEFAULT_DEPRECATED_K8S_APIS)
     deprecated.update(scan.get("deprecated_api_versions", {}))
@@ -794,6 +830,13 @@ def scan_kubernetes_api_versions(scan: dict[str, Any], root: Path | None = None)
 
 
 def source_health_findings(state: dict[str, Any], errors: list[dict[str, str]], checked_ids: set[str]) -> list[dict[str, Any]]:
+    """Track per-source failures and alert once they persist.
+
+    A source that succeeds has its failure counter reset. A failing source only
+    raises a finding at escalating thresholds (2, 3, 7, 14, 30 consecutive
+    failures, then every 30) so a single transient outage stays quiet while a
+    genuinely dark source is surfaced.
+    """
     health = state.setdefault("source_health", {})
     by_id = {str(error.get("id") or "unknown-source"): error for error in errors}
     findings: list[dict[str, Any]] = []
@@ -862,6 +905,13 @@ def update_state_and_filter(
     first_run: bool,
     notify_on_first_run: bool,
 ) -> list[dict[str, Any]]:
+    """Record findings in state and return the ones that should be notified.
+
+    A finding is notified unless it was already notified before, or this is the
+    first run and first-run notification is disabled — in which case it is
+    baselined (marked notified without sending). `seen` retains every finding's
+    first/last observation for auditing.
+    """
     seen = state.setdefault("seen", {})
     notified = state.setdefault("notified", {})
     pending = state.setdefault("pending", {})
@@ -872,7 +922,7 @@ def update_state_and_filter(
         if should_notify:
             new_findings.append(finding)
             pending[finding["id"]] = finding
-        elif not should_notify and first_run and not notify_on_first_run:
+        elif first_run and not notify_on_first_run:
             notified[finding["id"]] = {
                 "source_id": finding["source_id"],
                 "title": finding["title"],
@@ -899,6 +949,12 @@ def pending_findings(state: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def mark_pending_notified(state: dict[str, Any], finding_ids: set[str] | None = None) -> int:
+    """Move pending findings to notified after Slack delivery succeeds.
+
+    Called by --mark-notified once the workflow has posted a chunk, so a failed
+    post leaves findings pending and they are retried on the next run. With
+    finding_ids given, only those are marked; otherwise all pending are marked.
+    """
     pending = state.setdefault("pending", {})
     notified = state.setdefault("notified", {})
     marked = 0
@@ -1122,6 +1178,13 @@ def write_slack_payloads(
     first_run: bool,
     total_matches: int,
 ) -> None:
+    """Write Slack payloads, chunked to stay under Slack's per-message limits.
+
+    Findings are split into groups of MAX_FINDINGS_PER_SLACK_MESSAGE; each chunk
+    gets a numbered payload plus a matching `.ids.json` the workflow feeds back
+    to --mark-notified-ids after posting. The stale payload dir is cleared first,
+    and the first chunk is also written to the primary payload path.
+    """
     payload_dir = slack_payload_dir(slack_payload_path)
     payload_dir.mkdir(parents=True, exist_ok=True)
     for existing in payload_dir.glob("*.json"):

--- a/.github/scripts/external_compatibility_scan.py
+++ b/.github/scripts/external_compatibility_scan.py
@@ -35,6 +35,8 @@ from typing import Any
 USER_AGENT = "openchoreo-external-compatibility-scan/1.0 (+https://github.com/openchoreo/openchoreo)"
 MAX_FINDINGS_PER_SLACK_MESSAGE = 10
 MAX_SEEN_ITEMS = 2000
+MAX_NOTIFIED_ITEMS = 2000
+PENDING_HIGH_WATER_MARK = 200
 # Cap response buffering so a huge or endless body from an external source
 # cannot exhaust the runner's memory. Feeds/pages/JSON here are well under this.
 MAX_RESPONSE_BYTES = 10 * 1024 * 1024
@@ -749,7 +751,7 @@ def scan_feed(config: dict[str, Any], source: dict[str, Any], timeout: float) ->
     items = parse_feed_items(result.body)
     if not items:
         raise ValueError(f"{source['url']} contained no RSS/Atom items")
-    for item in items[:50]:
+    for item in items:
         haystack = " ".join([item.get("title", ""), item.get("summary", "")])
         if required_terms:
             if not matches_keywords_near_required_terms(
@@ -881,13 +883,33 @@ def scan_kubernetes_api_versions(scan: dict[str, Any], root: Path | None = None)
     }
 
 
+def clear_pending_source_health_findings(state: dict[str, Any], source_id: str) -> int:
+    """Drop undelivered failure alerts once their source has recovered."""
+    pending = state.get("pending", {})
+    if not isinstance(pending, dict):
+        return 0
+
+    health_source_id = f"{source_id}-source-health"
+    cleared = 0
+    for finding_id_value, finding in list(pending.items()):
+        if (
+            isinstance(finding, dict)
+            and finding.get("kind") == "source_error"
+            and finding.get("source_id") == health_source_id
+        ):
+            del pending[finding_id_value]
+            cleared += 1
+    return cleared
+
+
 def source_health_findings(state: dict[str, Any], errors: list[dict[str, str]], checked_ids: set[str]) -> list[dict[str, Any]]:
     """Track per-source failures and alert once they persist.
 
     A source that succeeds has its failure counter reset. A failing source only
     raises a finding at escalating thresholds (2, 3, 7, 14, 30 consecutive
     failures, then every 30) so a single transient outage stays quiet while a
-    genuinely dark source is surfaced.
+    genuinely dark source is surfaced. Each failure incident after a recovery
+    gets a new generation so it is not deduped against an older incident.
     """
     health = state.setdefault("source_health", {})
     by_id = {str(error.get("id") or "unknown-source"): error for error in errors}
@@ -897,16 +919,25 @@ def source_health_findings(state: dict[str, Any], errors: list[dict[str, str]], 
             if source_id in health:
                 health[source_id]["consecutive_failures"] = 0
                 health[source_id]["last_success_at"] = now_iso()
+                clear_pending_source_health_findings(state, source_id)
             continue
 
         error = by_id[source_id]
         url = str(error.get("url") or "")
         message = str(error.get("error") or "unknown error")
         previous = health.get(source_id, {})
-        previous_message = previous.get("last_error")
-        consecutive = int(previous.get("consecutive_failures", 0)) + 1
+        previous_consecutive = int(previous.get("consecutive_failures", 0))
+        incident_generation = int(previous.get("incident_generation", 0))
+        if previous and "incident_generation" not in previous:
+            # Migrate active and recovered legacy records away from finding IDs
+            # that may already belong to an older incident.
+            incident_generation = 1
+        elif previous and previous_consecutive == 0:
+            incident_generation += 1
+        consecutive = previous_consecutive + 1
         health[source_id] = {
             "consecutive_failures": consecutive,
+            "incident_generation": incident_generation,
             "last_error": message,
             "last_failure_at": now_iso(),
             "url": url,
@@ -915,6 +946,12 @@ def source_health_findings(state: dict[str, Any], errors: list[dict[str, str]], 
         alert_counts = {2, 3, 7, 14, 30}
         if consecutive not in alert_counts and consecutive % 30 != 0:
             continue
+
+        finding_id_parts = ["source_error", source_id, url, message, str(consecutive)]
+        if incident_generation:
+            # Post-recovery and migrated incidents need a generation to bypass
+            # finding IDs retained in notification history.
+            finding_id_parts.append(str(incident_generation))
 
         findings.append(
             {
@@ -927,7 +964,7 @@ def source_health_findings(state: dict[str, Any], errors: list[dict[str, str]], 
                     ".github/workflows/external-compatibility-scan.yaml",
                 ],
                 "action": "Fix or remove the monitored source so external compatibility coverage does not silently go dark.",
-                "id": finding_id("source_error", source_id, url, message, str(consecutive)),
+                "id": finding_id(*finding_id_parts),
                 "title": "External compatibility scan source failed",
                 "url": url,
                 "summary": f"{message}; consecutive_failures={consecutive}",
@@ -944,11 +981,37 @@ def now_iso() -> str:
 
 def trim_state(state: dict[str, Any]) -> dict[str, Any]:
     seen = state.get("seen", {})
-    if len(seen) <= MAX_SEEN_ITEMS:
-        return state
-    ordered = sorted(seen.items(), key=lambda item: item[1].get("last_seen_at", ""))
-    state["seen"] = dict(ordered[-MAX_SEEN_ITEMS:])
+    if len(seen) > MAX_SEEN_ITEMS:
+        ordered = sorted(seen.items(), key=lambda item: item[1].get("last_seen_at", ""))
+        state["seen"] = dict(ordered[-MAX_SEEN_ITEMS:])
+
+    notified = state.get("notified", {})
+    if len(notified) > MAX_NOTIFIED_ITEMS:
+        def notification_recency(item: tuple[str, dict[str, Any]]) -> tuple[str, str]:
+            finding_id_value, notification = item
+            observation = seen.get(finding_id_value, {})
+            timestamp = (
+                observation.get("last_seen_at")
+                or notification.get("notified_at")
+                or notification.get("baselined_at")
+                or ""
+            )
+            return str(timestamp), finding_id_value
+
+        ordered = sorted(notified.items(), key=notification_recency)
+        state["notified"] = dict(ordered[-MAX_NOTIFIED_ITEMS:])
     return state
+
+
+def pending_queue_warning(state: dict[str, Any]) -> str | None:
+    count = len(pending_findings(state))
+    if count <= PENDING_HIGH_WATER_MARK:
+        return None
+    return (
+        f"pending notification queue contains {count} undelivered findings, "
+        f"above the high-water mark of {PENDING_HIGH_WATER_MARK}; "
+        "investigate Slack delivery without discarding compatibility notices"
+    )
 
 
 def update_state_and_filter(
@@ -1306,6 +1369,7 @@ def main() -> int:
         if args.mark_notified_ids:
             finding_ids = {str(finding_id_value) for finding_id_value in load_json(Path(args.mark_notified_ids), [])}
         marked = mark_pending_notified(state, finding_ids=finding_ids)
+        trim_state(state)
         state["last_notification_at"] = now_iso()
         write_json(state_out_path, state)
         print(f"marked {marked} pending finding(s) as notified")
@@ -1320,6 +1384,7 @@ def main() -> int:
         "manifest_results": [],
         "probe_results": [],
         "errors": [],
+        "warnings": [],
     }
 
     all_findings: list[dict[str, Any]] = []
@@ -1382,6 +1447,10 @@ def main() -> int:
     )
     new_findings.extend(new_error_findings)
     trim_state(state)
+    warning = pending_queue_warning(state)
+    if warning:
+        report["warnings"].append(warning)
+        print(f"::warning::{warning}")
 
     report.update(
         {

--- a/.github/scripts/test_external_compatibility_scan.py
+++ b/.github/scripts/test_external_compatibility_scan.py
@@ -212,6 +212,7 @@ class ExternalCompatibilityScanTests(unittest.TestCase):
         scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
         try:
             findings, report = scanner.scan_page_terms(
+                {},
                 {
                     "id": "openai",
                     "name": "OpenAI deprecations",
@@ -430,10 +431,13 @@ class ExternalCompatibilityScanTests(unittest.TestCase):
         self.assertIn("attachments", payload)
         self.assertEqual(payload["blocks"][0]["type"], "header")
         self.assertEqual(payload["attachments"][0]["color"], "#fb8500")
-        self.assertEqual(payload["attachments"][0]["blocks"][0]["accessory"]["text"]["text"], "View notice")
-        self.assertIn("*Severity*\nHIGH", payload["attachments"][0]["blocks"][1]["fields"][0]["text"])
-        self.assertIn("|Notice link>", payload["attachments"][0]["blocks"][1]["fields"][3]["text"])
-        self.assertIn("*Action*", payload["attachments"][0]["blocks"][2]["text"]["text"])
+        attachment_blocks = payload["attachments"][0]["blocks"]
+        self.assertEqual(attachment_blocks[0]["accessory"]["text"]["text"], "View notice")
+        self.assertIn("*Summary*\nA deprecated API was found.", attachment_blocks[1]["text"]["text"])
+        self.assertIn("*Severity*\nHIGH", attachment_blocks[2]["fields"][0]["text"])
+        self.assertIn("|Notice link>", attachment_blocks[2]["fields"][3]["text"])
+        self.assertIn("*Action*", attachment_blocks[3]["text"]["text"])
+        self.assertIn("Summary: A deprecated API was found.", payload["text"])
 
     def test_validate_config_rejects_dead_affected_file_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/.github/scripts/test_external_compatibility_scan.py
+++ b/.github/scripts/test_external_compatibility_scan.py
@@ -430,7 +430,10 @@ class ExternalCompatibilityScanTests(unittest.TestCase):
         self.assertIn("attachments", payload)
         self.assertEqual(payload["blocks"][0]["type"], "header")
         self.assertEqual(payload["attachments"][0]["color"], "#fb8500")
-        self.assertIn("*HIGH*", payload["attachments"][0]["blocks"][0]["text"]["text"])
+        self.assertEqual(payload["attachments"][0]["blocks"][0]["accessory"]["text"]["text"], "View notice")
+        self.assertIn("*Severity*\nHIGH", payload["attachments"][0]["blocks"][1]["fields"][0]["text"])
+        self.assertIn("|Notice link>", payload["attachments"][0]["blocks"][1]["fields"][3]["text"])
+        self.assertIn("*Action*", payload["attachments"][0]["blocks"][2]["text"]["text"])
 
     def test_validate_config_rejects_dead_affected_file_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/.github/scripts/test_external_compatibility_scan.py
+++ b/.github/scripts/test_external_compatibility_scan.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("external_compatibility_scan.py")
+SPEC = importlib.util.spec_from_file_location("external_compatibility_scan", SCRIPT_PATH)
+assert SPEC is not None
+scanner = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = scanner
+SPEC.loader.exec_module(scanner)
+
+
+def finding(finding_id: str = "finding-1") -> dict[str, object]:
+    return {
+        "id": finding_id,
+        "source_id": "source-1",
+        "source_name": "Source 1",
+        "severity": "high",
+        "owner": "platform",
+        "affected_files": [".github/external-compatibility-sources.json"],
+        "action": "Review.",
+        "title": "Deprecated API",
+        "url": "https://example.com/deprecation",
+        "summary": "A deprecated API was found.",
+        "observed_at": "2026-06-23T00:00:00Z",
+        "kind": "feed",
+    }
+
+
+class ExternalCompatibilityScanTests(unittest.TestCase):
+    def test_validate_accepts_page_terms_with_match_terms(self) -> None:
+        config = {
+            "sources": [
+                {
+                    "id": "openai",
+                    "name": "OpenAI",
+                    "type": "page_terms",
+                    "url": "https://example.com",
+                    "affected_files": ["agents"],
+                    "action": "Review.",
+                    "match_terms": ["gpt-5"],
+                }
+            ]
+        }
+
+        self.assertEqual(scanner.validate_config(config), [])
+
+    def test_validate_rejects_page_terms_without_match_terms(self) -> None:
+        config = {
+            "sources": [
+                {
+                    "id": "openai",
+                    "name": "OpenAI",
+                    "type": "page_terms",
+                    "url": "https://example.com",
+                    "affected_files": ["agents"],
+                    "action": "Review.",
+                }
+            ]
+        }
+
+        self.assertIn("openai: page_terms sources require match_terms", scanner.validate_config(config))
+
+    def test_validate_rejects_non_list_required_terms(self) -> None:
+        config = {
+            "sources": [
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["agents"],
+                    "action": "Review.",
+                    "required_terms": "webhook",
+                }
+            ]
+        }
+
+        self.assertIn("feed: required_terms must be a list", scanner.validate_config(config))
+
+    def test_validate_rejects_non_integer_required_terms_context_chars(self) -> None:
+        config = {
+            "sources": [
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["agents"],
+                    "action": "Review.",
+                    "required_terms": ["webhook"],
+                    "required_terms_context_chars": "near",
+                }
+            ]
+        }
+
+        self.assertIn("feed: required_terms_context_chars must be an integer", scanner.validate_config(config))
+
+    def test_feed_http_error_is_not_treated_as_empty_feed(self) -> None:
+        original_fetch = scanner.fetch_url
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 404, {}, "not found")
+        try:
+            with self.assertRaisesRegex(ValueError, "HTTP 404"):
+                scanner.scan_feed(
+                    {"defaults": {"keywords": ["deprecated"]}},
+                    {
+                        "id": "feed",
+                        "name": "Feed",
+                        "type": "feed",
+                        "url": "https://example.com/feed.xml",
+                        "affected_files": ["x"],
+                        "action": "Review.",
+                    },
+                    1,
+                )
+        finally:
+            scanner.fetch_url = original_fetch
+
+    def test_malformed_feed_is_a_source_error(self) -> None:
+        original_fetch = scanner.fetch_url
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, "not xml")
+        try:
+            with self.assertRaisesRegex(ValueError, "feed XML parse failed"):
+                scanner.scan_feed(
+                    {"defaults": {"keywords": ["deprecated"]}},
+                    {
+                        "id": "feed",
+                        "name": "Feed",
+                        "type": "feed",
+                        "url": "https://example.com/feed.xml",
+                        "affected_files": ["x"],
+                        "action": "Review.",
+                    },
+                    1,
+                )
+        finally:
+            scanner.fetch_url = original_fetch
+
+    def test_pending_findings_are_retried_until_marked_notified(self) -> None:
+        state: dict[str, object] = {"initialized": True, "seen": {}}
+        first = scanner.update_state_and_filter(
+            state,
+            [finding()],
+            first_run=False,
+            notify_on_first_run=False,
+        )
+        second = scanner.update_state_and_filter(
+            state,
+            [finding()],
+            first_run=False,
+            notify_on_first_run=False,
+        )
+
+        self.assertEqual([item["id"] for item in first], ["finding-1"])
+        self.assertEqual([item["id"] for item in second], ["finding-1"])
+        self.assertIn("finding-1", state["pending"])
+        self.assertNotIn("finding-1", state["notified"])
+
+        self.assertEqual(scanner.mark_pending_notified(state), 1)
+        self.assertEqual(state["pending"], {})
+        self.assertIn("finding-1", state["notified"])
+
+        third = scanner.update_state_and_filter(
+            state,
+            [finding()],
+            first_run=False,
+            notify_on_first_run=False,
+        )
+        self.assertEqual(third, [])
+
+    def test_can_mark_only_one_pending_chunk_notified(self) -> None:
+        state: dict[str, object] = {
+            "pending": {
+                "finding-1": finding("finding-1"),
+                "finding-2": finding("finding-2"),
+            },
+            "notified": {},
+        }
+
+        self.assertEqual(scanner.mark_pending_notified(state, {"finding-1"}), 1)
+
+        self.assertNotIn("finding-1", state["pending"])
+        self.assertIn("finding-2", state["pending"])
+        self.assertIn("finding-1", state["notified"])
+        self.assertNotIn("finding-2", state["notified"])
+
+    def test_first_run_baseline_marks_findings_notified_without_pending(self) -> None:
+        state: dict[str, object] = {"seen": {}}
+
+        new_findings = scanner.update_state_and_filter(
+            state,
+            [finding()],
+            first_run=True,
+            notify_on_first_run=False,
+        )
+
+        self.assertEqual(new_findings, [])
+        self.assertEqual(state["pending"], {})
+        self.assertIn("finding-1", state["notified"])
+
+    def test_page_terms_finds_monitored_model_near_deprecation_keyword(self) -> None:
+        original_fetch = scanner.fetch_url
+        body = "<html><body>Upcoming deprecations: gpt-5 will shut down soon.</body></html>"
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
+        try:
+            findings, report = scanner.scan_page_terms(
+                {
+                    "id": "openai",
+                    "name": "OpenAI deprecations",
+                    "type": "page_terms",
+                    "url": "https://example.com/deprecations",
+                    "affected_files": ["agents"],
+                    "action": "Review.",
+                    "match_terms": ["gpt-5"],
+                    "keywords": ["deprecations", "shut down"],
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(report["matched_terms"], ["gpt-5"])
+
+    def test_keyword_matching_uses_boundaries_and_ignores_simple_negation(self) -> None:
+        self.assertTrue(scanner.matches_keywords("This release removes a deprecated API.", ["deprecated"]))
+        self.assertTrue(scanner.matches_keywords("Breaking changes are planned.", ["breaking change"]))
+        self.assertTrue(scanner.matches_keywords("Upcoming deprecations are planned.", ["deprecation"]))
+        self.assertFalse(scanner.matches_keywords("This API is no longer deprecated.", ["deprecated"]))
+        self.assertFalse(scanner.matches_keywords("This endpoint is not a breaking change.", ["breaking change"]))
+        self.assertFalse(scanner.matches_keywords("The flag was undeprecated.", ["deprecated"]))
+
+    def test_kubernetes_api_version_scan_finds_removed_api(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            manifest = root / "manifests" / "pdb.yaml"
+            manifest.parent.mkdir()
+            manifest.write_text(
+                "apiVersion: policy/v1beta1\nkind: PodDisruptionBudget\n",
+                encoding="utf-8",
+            )
+
+            findings, report = scanner.scan_kubernetes_api_versions(
+                {
+                    "id": "k8s",
+                    "name": "Kubernetes APIs",
+                    "type": "kubernetes_api_versions",
+                    "paths": ["manifests/*.yaml"],
+                    "affected_files": ["manifests/*.yaml"],
+                    "action": "Migrate.",
+                },
+                root=root,
+            )
+
+        self.assertEqual(report["checked_files"], 1)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("policy/v1beta1", findings[0]["title"])
+
+    def test_github_api_versions_finds_missing_pinned_version(self) -> None:
+        original_fetch = scanner.fetch_url
+        scanner.fetch_url = lambda *args, **kwargs: scanner.FetchResult(
+            "https://api.github.com/versions",
+            200,
+            {},
+            '["2026-03-10"]',
+        )
+        try:
+            findings, report = scanner.scan_github_api_versions(
+                {
+                    "id": "github",
+                    "name": "GitHub versions",
+                    "type": "github_api_versions",
+                    "url": "https://api.github.com/versions",
+                    "affected_files": ["workflow.yaml"],
+                    "action": "Migrate.",
+                    "pinned_version": "2022-11-28",
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        self.assertEqual(report["latest_supported_version"], "2026-03-10")
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no longer supported", findings[0]["title"])
+
+    def test_feed_dedup_uses_normalized_link_not_title_or_date(self) -> None:
+        original_fetch = scanner.fetch_url
+        body = """<?xml version="1.0"?>
+        <rss><channel>
+          <item>
+            <title>Deprecated API notice</title>
+            <link>https://example.com/post?utm_source=newsletter#section</link>
+            <description>Deprecated API notice.</description>
+            <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+          </item>
+        </channel></rss>"""
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
+        try:
+            first, _ = scanner.scan_feed(
+                {"defaults": {"keywords": ["deprecated"]}},
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["x"],
+                    "action": "Review.",
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        body = body.replace("Deprecated API notice", "Deprecated API notice updated").replace(
+            "Mon, 01 Jun 2026 00:00:00 GMT",
+            "Tue, 02 Jun 2026 00:00:00 GMT",
+        )
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
+        try:
+            second, _ = scanner.scan_feed(
+                {"defaults": {"keywords": ["deprecated"]}},
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["x"],
+                    "action": "Review.",
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        self.assertEqual(first[0]["id"], second[0]["id"])
+
+    def test_feed_required_terms_reduce_unrelated_matches(self) -> None:
+        original_fetch = scanner.fetch_url
+        body = """<?xml version="1.0"?>
+        <rss><channel>
+          <item>
+            <title>Deprecated Python runtime</title>
+            <link>https://example.com/python</link>
+            <description>Python 3.9 is deprecated.</description>
+          </item>
+          <item>
+            <title>Webhook payload deprecated</title>
+            <link>https://example.com/webhook</link>
+            <description>A webhook payload field is deprecated.</description>
+          </item>
+        </channel></rss>"""
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
+        try:
+            findings, report = scanner.scan_feed(
+                {"defaults": {"keywords": ["deprecated"]}},
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["x"],
+                    "action": "Review.",
+                    "required_terms": ["webhook", "payload"],
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["url"], "https://example.com/webhook")
+        self.assertEqual(report["required_terms"], ["webhook", "payload"])
+
+    def test_feed_required_terms_must_be_near_keyword(self) -> None:
+        original_fetch = scanner.fetch_url
+        body = """<?xml version="1.0"?>
+        <rss><channel>
+          <item>
+            <title>Release notes</title>
+            <link>https://example.com/release</link>
+            <description>Removed an unrelated UI asset. This paragraph is filler text that separates unrelated sections. PromQL query behavior is unchanged.</description>
+          </item>
+        </channel></rss>"""
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
+        try:
+            findings, _ = scanner.scan_feed(
+                {"defaults": {"keywords": ["removed"]}},
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["x"],
+                    "action": "Review.",
+                    "required_terms": ["PromQL"],
+                    "required_terms_context_chars": 30,
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        self.assertEqual(findings, [])
+
+    def test_slack_payloads_are_chunked_without_dropping_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            payload_path = Path(temp_dir) / "slack-payload.json"
+            findings = [finding(f"finding-{index}") for index in range(25)]
+            scanner.write_slack_payloads(payload_path, findings, False, len(findings))
+            payload_files = sorted(scanner.slack_payload_dir(payload_path).glob("*.payload.json"))
+            ids_files = sorted(scanner.slack_payload_dir(payload_path).glob("*.ids.json"))
+
+        self.assertEqual(len(payload_files), 3)
+        self.assertEqual(len(ids_files), 3)
+
+    def test_validate_config_rejects_dead_affected_file_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "live.yaml").write_text("kind: ConfigMap\n", encoding="utf-8")
+            config = {
+                "sources": [
+                    {
+                        "id": "source",
+                        "name": "Source",
+                        "type": "reference_page",
+                        "url": "https://example.com",
+                        "affected_files": ["missing.yaml"],
+                        "action": "Review.",
+                    }
+                ],
+                "manifest_scans": [
+                    {
+                        "id": "scan",
+                        "name": "Scan",
+                        "type": "kubernetes_api_versions",
+                        "paths": ["live.yaml"],
+                        "affected_files": ["live.yaml"],
+                        "action": "Review.",
+                    }
+                ],
+            }
+
+            errors = scanner.validate_config(config, root=root)
+
+        self.assertIn("source.affected_files: path does not match repository files: missing.yaml", errors)
+
+    def test_source_health_waits_for_repeated_failure(self) -> None:
+        state: dict[str, object] = {}
+        errors = [{"id": "feed", "url": "https://example.com/feed", "error": "timeout"}]
+
+        first = scanner.source_health_findings(state, errors, {"feed"})
+        second = scanner.source_health_findings(state, errors, {"feed"})
+
+        self.assertEqual(first, [])
+        self.assertEqual(len(second), 1)
+        self.assertIn("consecutive_failures=2", second[0]["summary"])
+
+    def test_source_health_repeats_after_thirty_failures(self) -> None:
+        state: dict[str, object] = {
+            "source_health": {
+                "feed": {
+                    "consecutive_failures": 59,
+                    "last_error": "timeout",
+                    "url": "https://example.com/feed",
+                }
+            }
+        }
+        errors = [{"id": "feed", "url": "https://example.com/feed", "error": "timeout"}]
+
+        findings = scanner.source_health_findings(state, errors, {"feed"})
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn("consecutive_failures=60", findings[0]["summary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_external_compatibility_scan.py
+++ b/.github/scripts/test_external_compatibility_scan.py
@@ -422,6 +422,16 @@ class ExternalCompatibilityScanTests(unittest.TestCase):
         self.assertEqual(len(payload_files), 3)
         self.assertEqual(len(ids_files), 3)
 
+    def test_slack_payload_uses_blocks_and_severity_colors(self) -> None:
+        payload = scanner.slack_payload([finding()], False, 1)
+
+        self.assertIn("text", payload)
+        self.assertIn("blocks", payload)
+        self.assertIn("attachments", payload)
+        self.assertEqual(payload["blocks"][0]["type"], "header")
+        self.assertEqual(payload["attachments"][0]["color"], "#fb8500")
+        self.assertIn("*HIGH*", payload["attachments"][0]["blocks"][0]["text"]["text"])
+
     def test_validate_config_rejects_dead_affected_file_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/.github/scripts/test_external_compatibility_scan.py
+++ b/.github/scripts/test_external_compatibility_scan.py
@@ -144,6 +144,40 @@ class ExternalCompatibilityScanTests(unittest.TestCase):
         finally:
             scanner.fetch_url = original_fetch
 
+    def test_feed_scans_items_after_the_first_fifty(self) -> None:
+        original_fetch = scanner.fetch_url
+        ordinary_items = "".join(
+            f"<item><title>Routine release {index}</title><link>https://example.com/{index}</link></item>"
+            for index in range(50)
+        )
+        body = (
+            "<?xml version=\"1.0\"?><rss><channel>"
+            f"{ordinary_items}"
+            "<item><title>Deprecated webhook contract</title>"
+            "<link>https://example.com/important</link></item>"
+            "</channel></rss>"
+        )
+        scanner.fetch_url = lambda url, timeout: scanner.FetchResult(url, 200, {}, body)
+        try:
+            findings, report = scanner.scan_feed(
+                {"defaults": {"keywords": ["deprecated"]}},
+                {
+                    "id": "feed",
+                    "name": "Feed",
+                    "type": "feed",
+                    "url": "https://example.com/feed.xml",
+                    "affected_files": ["x"],
+                    "action": "Review.",
+                },
+                1,
+            )
+        finally:
+            scanner.fetch_url = original_fetch
+
+        self.assertEqual(report["items"], 51)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["url"], "https://example.com/important")
+
     def test_pending_findings_are_retried_until_marked_notified(self) -> None:
         state: dict[str, object] = {"initialized": True, "seen": {}}
         first = scanner.update_state_and_filter(
@@ -497,6 +531,159 @@ class ExternalCompatibilityScanTests(unittest.TestCase):
 
         self.assertEqual(len(findings), 1)
         self.assertIn("consecutive_failures=60", findings[0]["summary"])
+
+    def test_source_health_notifies_again_after_recovery(self) -> None:
+        state: dict[str, object] = {"initialized": True, "seen": {}}
+        errors = [{"id": "feed", "url": "https://example.com/feed", "error": "timeout"}]
+
+        scanner.source_health_findings(state, errors, {"feed"})
+        first_incident = scanner.source_health_findings(state, errors, {"feed"})
+        first_notifications = scanner.update_state_and_filter(
+            state,
+            first_incident,
+            first_run=False,
+            notify_on_first_run=True,
+        )
+        scanner.mark_pending_notified(state)
+
+        scanner.source_health_findings(state, [], {"feed"})
+        scanner.source_health_findings(state, errors, {"feed"})
+        second_incident = scanner.source_health_findings(state, errors, {"feed"})
+        second_notifications = scanner.update_state_and_filter(
+            state,
+            second_incident,
+            first_run=False,
+            notify_on_first_run=True,
+        )
+
+        self.assertEqual(len(first_notifications), 1)
+        self.assertEqual(len(second_notifications), 1)
+        self.assertNotEqual(first_notifications[0]["id"], second_notifications[0]["id"])
+        self.assertEqual(state["source_health"]["feed"]["incident_generation"], 1)
+
+    def test_source_health_migrates_active_legacy_incident(self) -> None:
+        state: dict[str, object] = {
+            "source_health": {
+                "feed": {
+                    "consecutive_failures": 1,
+                    "last_error": "timeout",
+                    "url": "https://example.com/feed",
+                }
+            }
+        }
+        errors = [{"id": "feed", "url": "https://example.com/feed", "error": "timeout"}]
+
+        findings = scanner.source_health_findings(state, errors, {"feed"})
+
+        self.assertEqual(len(findings), 1)
+        self.assertNotEqual(
+            findings[0]["id"],
+            scanner.finding_id(
+                "source_error",
+                "feed",
+                "https://example.com/feed",
+                "timeout",
+                "2",
+            ),
+        )
+        self.assertEqual(state["source_health"]["feed"]["incident_generation"], 1)
+
+    def test_source_health_migrates_recovered_legacy_incident(self) -> None:
+        state: dict[str, object] = {
+            "source_health": {
+                "feed": {
+                    "consecutive_failures": 0,
+                    "last_error": "timeout",
+                    "last_success_at": "2026-07-28T00:00:00Z",
+                    "url": "https://example.com/feed",
+                }
+            }
+        }
+        errors = [{"id": "feed", "url": "https://example.com/feed", "error": "timeout"}]
+
+        scanner.source_health_findings(state, errors, {"feed"})
+        findings = scanner.source_health_findings(state, errors, {"feed"})
+
+        self.assertEqual(len(findings), 1)
+        self.assertNotEqual(
+            findings[0]["id"],
+            scanner.finding_id(
+                "source_error",
+                "feed",
+                "https://example.com/feed",
+                "timeout",
+                "2",
+            ),
+        )
+        self.assertEqual(state["source_health"]["feed"]["incident_generation"], 1)
+
+    def test_source_health_recovery_clears_only_its_pending_failures(self) -> None:
+        compatibility_finding = finding("compatibility-finding")
+        source_health_finding = {
+            **finding("source-health-finding"),
+            "source_id": "feed-source-health",
+            "kind": "source_error",
+        }
+        other_source_health_finding = {
+            **finding("other-source-health-finding"),
+            "source_id": "other-source-health",
+            "kind": "source_error",
+        }
+        state: dict[str, object] = {
+            "pending": {
+                compatibility_finding["id"]: compatibility_finding,
+                source_health_finding["id"]: source_health_finding,
+                other_source_health_finding["id"]: other_source_health_finding,
+            },
+            "source_health": {
+                "feed": {
+                    "consecutive_failures": 2,
+                    "incident_generation": 1,
+                }
+            },
+        }
+
+        scanner.source_health_findings(state, [], {"feed"})
+
+        self.assertNotIn(source_health_finding["id"], state["pending"])
+        self.assertIn(compatibility_finding["id"], state["pending"])
+        self.assertIn(other_source_health_finding["id"], state["pending"])
+
+    def test_trim_state_caps_notified_by_observation_recency_without_dropping_pending(self) -> None:
+        notified = {
+            f"finding-{index}": {"notified_at": f"{index:04d}"}
+            for index in range(scanner.MAX_NOTIFIED_ITEMS + 1)
+        }
+        pending = {"pending-finding": finding("pending-finding")}
+        state: dict[str, object] = {
+            "seen": {
+                "finding-0": {
+                    "last_seen_at": "9999",
+                }
+            },
+            "notified": notified,
+            "pending": pending,
+        }
+
+        scanner.trim_state(state)
+
+        self.assertEqual(len(state["notified"]), scanner.MAX_NOTIFIED_ITEMS)
+        self.assertIn("finding-0", state["notified"])
+        self.assertNotIn("finding-1", state["notified"])
+        self.assertEqual(state["pending"], pending)
+
+    def test_pending_queue_warning_does_not_drop_findings(self) -> None:
+        pending = {
+            f"finding-{index}": finding(f"finding-{index}")
+            for index in range(scanner.PENDING_HIGH_WATER_MARK + 1)
+        }
+        state: dict[str, object] = {"pending": pending}
+
+        warning = scanner.pending_queue_warning(state)
+
+        self.assertIsNotNone(warning)
+        self.assertIn(str(scanner.PENDING_HIGH_WATER_MARK), warning)
+        self.assertEqual(state["pending"], pending)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/external-compatibility-scan-tests.yaml
+++ b/.github/workflows/external-compatibility-scan-tests.yaml
@@ -1,0 +1,38 @@
+name: External Compatibility Scanner Tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/external-compatibility-sources.json"
+      - ".github/external-compatibility-sources.md"
+      - ".github/scripts/external_compatibility_scan.py"
+      - ".github/scripts/test_external_compatibility_scan.py"
+      - ".github/workflows/external-compatibility-scan.yaml"
+      - ".github/workflows/external-compatibility-scan-tests.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Validate scanner config and tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate source configuration
+        run: |
+          python3 .github/scripts/external_compatibility_scan.py \
+            --config .github/external-compatibility-sources.json \
+            --state /tmp/external-compatibility-state.json \
+            --state-out /tmp/external-compatibility-state.json \
+            --slack-payload /tmp/external-compatibility-slack.json \
+            --report /tmp/external-compatibility-report.json \
+            --validate-only
+
+      - name: Run scanner unit tests
+        run: python3 -m unittest discover .github/scripts -p "test_*.py"

--- a/.github/workflows/external-compatibility-scan.yaml
+++ b/.github/workflows/external-compatibility-scan.yaml
@@ -1,0 +1,157 @@
+name: External Compatibility Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      notify_on_first_run:
+        description: "Send matching historical findings when no previous state exists"
+        required: false
+        default: false
+        type: boolean
+      post_to_slack:
+        description: "Post new findings to Slack when SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL is configured"
+        required: false
+        default: true
+        type: boolean
+  schedule:
+    # Run weekly on Monday at 03:10 UTC (08:40 IST).
+    - cron: "10 3 * * 1"
+
+concurrency:
+  group: external-compatibility-scan-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  scan:
+    name: Scan curated external compatibility sources
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+      NOTIFY_ON_FIRST_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.notify_on_first_run || false }}
+      POST_TO_SLACK: ${{ github.event_name != 'workflow_dispatch' || inputs.post_to_slack }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Restore previous external compatibility scan state
+        run: |
+          mkdir -p .external-compatibility-scan
+
+          previous_run_id="$(
+            gh run list \
+              --workflow external-compatibility-scan.yaml \
+              --branch "${{ github.ref_name }}" \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // ""'
+          )"
+
+          if [ -z "${previous_run_id}" ]; then
+            echo "No previous successful external compatibility scan found for ${{ github.ref_name }}; this run will establish a baseline."
+            exit 0
+          fi
+
+          echo "Restoring external compatibility scan state from run ${previous_run_id}"
+          gh run download "${previous_run_id}" \
+            --name external-compatibility-scan-state \
+            --dir .external-compatibility-scan \
+            || echo "No previous state artifact found; this run will establish a baseline."
+
+      - name: Validate source configuration
+        run: |
+          python3 .github/scripts/external_compatibility_scan.py \
+            --config .github/external-compatibility-sources.json \
+            --state .external-compatibility-scan/state.json \
+            --state-out .external-compatibility-scan/state.json \
+            --slack-payload .external-compatibility-scan/slack-payload.json \
+            --report .external-compatibility-scan/report.json \
+            --validate-only
+
+      - name: Run external compatibility scan
+        run: |
+          args=()
+          if [ "${NOTIFY_ON_FIRST_RUN}" = "true" ]; then
+            args+=(--notify-on-first-run)
+          fi
+
+          python3 .github/scripts/external_compatibility_scan.py \
+            --config .github/external-compatibility-sources.json \
+            --state .external-compatibility-scan/state.json \
+            --state-out .external-compatibility-scan/state.json \
+            --slack-payload .external-compatibility-scan/slack-payload.json \
+            --report .external-compatibility-scan/report.json \
+            "${args[@]}"
+
+      - name: Post Slack digest
+        id: slack
+        run: |
+          if [ ! -d .external-compatibility-scan/slack-payloads ] || ! compgen -G ".external-compatibility-scan/slack-payloads/*.payload.json" > /dev/null; then
+            echo "No new external compatibility findings to post."
+            echo "posted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ "${POST_TO_SLACK}" != "true" ]; then
+            echo "Slack posting disabled for this run. Payloads:"
+            cat .external-compatibility-scan/slack-payloads/*.payload.json
+            echo "posted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL is not configured. Payloads:"
+            cat .external-compatibility-scan/slack-payloads/*.payload.json
+            echo "posted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          for payload in .external-compatibility-scan/slack-payloads/*.payload.json; do
+            ids="${payload%.payload.json}.ids.json"
+            curl -fsS \
+              -X POST \
+              -H 'Content-Type: application/json' \
+              --data @"${payload}" \
+              "${SLACK_WEBHOOK_URL}"
+            python3 .github/scripts/external_compatibility_scan.py \
+              --config .github/external-compatibility-sources.json \
+              --state .external-compatibility-scan/state.json \
+              --state-out .external-compatibility-scan/state.json \
+              --slack-payload .external-compatibility-scan/slack-payload.json \
+              --report .external-compatibility-scan/report.json \
+              --mark-notified-ids "${ids}"
+          done
+          echo "posted=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Mark Slack digest as notified
+        if: steps.slack.outputs.posted == 'true'
+        run: |
+          python3 .github/scripts/external_compatibility_scan.py \
+            --config .github/external-compatibility-sources.json \
+            --state .external-compatibility-scan/state.json \
+            --state-out .external-compatibility-scan/state.json \
+            --slack-payload .external-compatibility-scan/slack-payload.json \
+            --report .external-compatibility-scan/report.json \
+            --mark-notified
+
+      - name: Upload external compatibility scan state
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: external-compatibility-scan-state
+          path: |
+            .external-compatibility-scan/state.json
+            .external-compatibility-scan/report.json
+            .external-compatibility-scan/slack-payload.json
+            .external-compatibility-scan/slack-payloads/*.json
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.github/workflows/external-compatibility-scan.yaml
+++ b/.github/workflows/external-compatibility-scan.yaml
@@ -34,7 +34,6 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       NOTIFY_ON_FIRST_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.notify_on_first_run || false }}
       POST_TO_SLACK: ${{ github.event_name != 'workflow_dispatch' || inputs.post_to_slack }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL }}
 
     steps:
       - name: Checkout code
@@ -43,13 +42,15 @@ jobs:
           persist-credentials: false
 
       - name: Restore previous external compatibility scan state
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p .external-compatibility-scan
 
           previous_run_id="$(
             gh run list \
               --workflow external-compatibility-scan.yaml \
-              --branch "${{ github.ref_name }}" \
+              --branch "${REF_NAME}" \
               --status success \
               --limit 1 \
               --json databaseId \
@@ -57,7 +58,7 @@ jobs:
           )"
 
           if [ -z "${previous_run_id}" ]; then
-            echo "No previous successful external compatibility scan found for ${{ github.ref_name }}; this run will establish a baseline."
+            echo "No previous successful external compatibility scan found for ${REF_NAME}; this run will establish a baseline."
             exit 0
           fi
 
@@ -94,6 +95,8 @@ jobs:
 
       - name: Post Slack digest
         id: slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL }}
         run: |
           if [ ! -d .external-compatibility-scan/slack-payloads ] || ! compgen -G ".external-compatibility-scan/slack-payloads/*.payload.json" > /dev/null; then
             echo "No new external compatibility findings to post."
@@ -118,6 +121,8 @@ jobs:
           for payload in .external-compatibility-scan/slack-payloads/*.payload.json; do
             ids="${payload%.payload.json}.ids.json"
             curl -fsS \
+              --connect-timeout 10 \
+              --max-time 30 \
               -X POST \
               -H 'Content-Type: application/json' \
               --data @"${payload}" \


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
This PR adds external compatibility notice monitoring for OpenChoreo dependencies on provider APIs, webhooks, SaaS services, Kubernetes APIs, and upstream API/CRD contracts. It introduces a scheduled/manual GitHub Action backed by a dependency-free Python scanner and a curated source allowlist. 

The scanner checks provider feeds, lifecycle APIs, GitHub REST API versions and response headers, static Kubernetes manifests, and selected upstream release feeds, then deduplicates findings through a persisted state artifact before sending actionable Slack digests via SLACK_EXTERNAL_COMPATIBILITY_WEBHOOK_URL. Feed matching is scoped to reduce noise by requiring both lifecycle/breaking-change keywords and nearby OpenChoreo-relevant terms. 

Slack messages include a summary, severity coloring, affected files, owner, action, and a View notice button. The PR also adds a test workflow for config validation and unit tests, plus documentation for maintaining the monitored source list. Validation included local config validation, unit tests, a live source scan confirming configured sources are reachable, and a live Slack test that posted Gateway API compatibility notices.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3934

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
