### PR TITLE
docs: fix AWS RDS Postgres workflow sample link

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -48,7 +48,7 @@ Low-level examples demonstrating how to define and use custom component types wi
 Reusable Workflow definitions for standalone automation tasks independent of any Component.
 
 **Available Samples:**
-- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres-create/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
+- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
 - **[GitHub Stats Report](./workflows/github-stats-report/)** - Fetch GitHub repository statistics, transform the data, and generate a formatted report
 - **[SCM Create Repo](./workflows/scm-create-repo/)** - Create repositories in GitHub or AWS CodeCommit
 


### PR DESCRIPTION
Purpose

Fixes a broken link in samples/README.md where the AWS RDS Postgres workflow sample pointed to a non-existent directory.

Approach

Updated the workflow sample link from ./workflows/aws-rds-postgres-create/ to ./workflows/aws-rds-postgres/, which matches the existing directory structure.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Verified that the updated link points to the existing workflow sample directory.