### PR TITLE
docs: remove references to non-existent component samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -48,7 +48,7 @@ Low-level examples demonstrating how to define and use custom component types wi
 Reusable Workflow definitions for standalone automation tasks independent of any Component.
 
 **Available Samples:**
-- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres-create/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
+- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
 - **[GitHub Stats Report](./workflows/github-stats-report/)** - Fetch GitHub repository statistics, transform the data, and generate a formatted report
 - **[SCM Create Repo](./workflows/scm-create-repo/)** - Create repositories in GitHub or AWS CodeCommit
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -40,9 +40,7 @@ Low-level examples demonstrating how to define and use custom component types wi
 - **[HTTP Service Component](./component-types/component-http-service/)** - Define a reusable HTTP service component type
 - **[Web App Component](./component-types/component-web-app/)** - Define a reusable web application component type
 - **[Component with Configs](./component-types/component-with-configs/)** - Demonstrate configuration management
-- **[Component with Traits](./component-types/component-with-traits/)** - Demonstrate trait composition
 - **[Component with Embedded Traits](./component-types/component-with-embedded-traits/)** - Demonstrate PE-defined embedded traits
-- **[Component with API Management](./component-types/component-with-api-management/)** - Demonstrate API management via traits
 
 ### [Workflows](./workflows)
 Reusable Workflow definitions for standalone automation tasks independent of any Component.


### PR DESCRIPTION
Purpose

Removes references to component samples that no longer exist in the repository.

Approach

Removed the Component with Traits and Component with API Management entries from samples/README.md because the referenced directories are no longer present under samples/component-types.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Verified that the referenced sample directories are not present in the repository, so the README no longer contains dead links.