### PR TITLE
test: update component endpoint sub-form button to 'Save'

### DIFF
--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -9,8 +9,8 @@ export interface CreateComponentInput {
   project: string; // project metadata name to select in the form's Project picker
   // Template card label on the "Browse component templates" page. Restricted
   // to the endpoint-bearing templates: create() drives the endpoint sub-form
-  // ("Add Endpoint" / "Apply changes") unconditionally, which non-HTTP
-  // templates (e.g. "Worker") don't render. Defaults to "Web Application".
+  // ("Add Endpoint" / "Save") unconditionally, which non-HTTP templates
+  // (e.g. "Worker") don't render. Defaults to "Web Application".
   template?: 'Web Application' | 'Service';
   image: string; // container image reference (Container Image deployment source)
   // Web Application / Service component types require at least one HTTP
@@ -125,7 +125,7 @@ export class ComponentPO {
     // an endpoint is still in edit mode ("Save or cancel the item you are
     // currently editing before proceeding.").
     await this.page
-      .getByRole('button', { name: 'Apply changes', exact: true })
+      .getByRole('button', { name: 'Save', exact: true })
       .click();
   }
 


### PR DESCRIPTION
## Purpose

The **E2E (UI / Playwright)** gate fails at the "Run UI e2e tests" step. Five specs fail on all retries — `abac-ui/abac-env-restriction`, `config/component-config-edits`, `dev-ops/dev-ops-component`, `lifecycle/full-lifecycle`, and `pe-ops/pe-ops-trait-attach` (BYOI) — every one dying in `ComponentPO.create → fillDetails`:

```
TimeoutError: locator.click: Timeout 15000ms exceeded.
  - waiting for getByRole('button', { name: 'Apply changes', exact: true })
    at test/ui/po/component.ts:129
```

The `openchoreo-ui` component-creation wizard renamed the endpoint sub-form's commit button — the editor now renders **Delete / Cancel / Save**, with no "Apply changes". The page object's selector was stale, so the wizard never committed the endpoint and timed out before reaching Review.

## Approach

Update the endpoint-commit locator in `test/ui/po/component.ts` from `'Apply changes'` to `'Save'` (and refresh the two comments referencing the old label). A single change clears all five failures since they all funnel through `ComponentPO.create`.

Scoped to the scaffolder endpoint editor only: the remaining `'Apply changes'` references (`overrides.ts`, `component-config-edits.spec.ts`) belong to the Environment Variable / File Mount editor (paired with "Cancel editing"), a separate component that still uses that label.

Confirmed against the failing run's Playwright report screenshot, which shows the open endpoint editor with a "Save" button; the form's own guard text ("**Save** or cancel the item you are currently editing") corroborates the rename.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)