### PR TITLE
docs: add language identifiers to markdown code blocks

### DIFF
--- a/docs/contributors/build-engines.md
+++ b/docs/contributors/build-engines.md
@@ -14,7 +14,7 @@ OpenChoreo supports multiple build engines through a pluggable architecture that
 
 ### High-Level Architecture
 
-```
+```text
 Control Plane                                  Workflow Plane
 ┌───────────────────────────────────────┐      ┌─────────────────────────────┐
 │                                       │      │                             │
@@ -86,7 +86,7 @@ Build Lifecycle Flow:
 
 ### Component Structure
 
-```
+```text
 internal/controller/build/
 ├── builder.go                    # Builder mediator pattern (engine selection, lifecycle)
 ├── controller.go                 # Main build controller

--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -52,7 +52,7 @@ git remote -v
 
 Expected output:
 
-```
+```text
 origin    https://github.com/<your-username>/openchoreo.git (fetch)
 origin    https://github.com/<your-username>/openchoreo.git (push)
 upstream  https://github.com/openchoreo/openchoreo.git (fetch)
@@ -140,7 +140,7 @@ PR titles must follow this format and are validated by the `lint-pr.yml` CI work
 
 ### Format
 
-```
+```text
 <type>(<scope>): <subject>
 ```
 
@@ -178,7 +178,7 @@ Scope is optional. If a change spans multiple areas, either use the most relevan
 
 ### Examples
 
-```
+```text
 feat(controller): add ComponentRelease reconciler
 fix(api): handle missing organization gracefully
 chore(deps): bump sigs.k8s.io/controller-runtime

--- a/docs/resource-kind-reference-guide.md
+++ b/docs/resource-kind-reference-guide.md
@@ -83,7 +83,7 @@ erDiagram
 
 ### Core Deployment Flow
 
-```
+```text
 Project (defines deployment pipeline)
   └── Component (references ComponentType, attaches Traits, configures Workflow)
        ├── Workload (container spec, endpoints, dependencies on endpoints + resources)
@@ -94,7 +94,7 @@ Project (defines deployment pipeline)
 
 ### Managed-Infrastructure Flow
 
-```
+```text
 Project
   └── Resource (references ResourceType, supplies parameters)
        └── ResourceRelease (immutable snapshot of Resource.spec + ResourceType.spec)
@@ -107,7 +107,7 @@ referenced ResourceReleaseBinding to be Ready before producing its RenderedRelea
 
 ### Platform Infrastructure
 
-```
+```text
 DeploymentPipeline (defines promotion paths between Environments)
 Environment (runtime context: dev/staging/prod, references DataPlane)
 DataPlane / ClusterDataPlane (target K8s cluster, agent-based connectivity)

--- a/docs/templating/templating.md
+++ b/docs/templating/templating.md
@@ -110,7 +110,7 @@ Bracket notation is **required** for:
 
 The `in` operator checks membership in maps and lists:
 
-```
+```cel
 # Check if a key exists in a map
 parameters.endpointName in workload.endpoints
 
@@ -120,7 +120,7 @@ parameters.endpointName in workload.endpoints
 
 For maps, `exists()` and `all()` iterate over **keys** — use bracket notation to access values:
 
-```
+```cel
 # Check if any endpoint is of type HTTP
 workload.endpoints.exists(name, workload.endpoints[name].type == 'HTTP')
 

--- a/docs/templating/validations.md
+++ b/docs/templating/validations.md
@@ -123,7 +123,7 @@ spec:
 
 When validation rules fail, error messages include the rule index, rule text, and the user-provided message:
 
-```
+```text
 component type validation failed: rule[0] "${size(workload.endpoints) > 0}" evaluated to false: A deployment/service must expose at least one endpoint.
 ```
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -48,7 +48,7 @@ Low-level examples demonstrating how to define and use custom component types wi
 Reusable Workflow definitions for standalone automation tasks independent of any Component.
 
 **Available Samples:**
-- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres-create/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
+- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
 - **[GitHub Stats Report](./workflows/github-stats-report/)** - Fetch GitHub repository statistics, transform the data, and generate a formatted report
 - **[SCM Create Repo](./workflows/scm-create-repo/)** - Create repositories in GitHub or AWS CodeCommit
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -40,15 +40,13 @@ Low-level examples demonstrating how to define and use custom component types wi
 - **[HTTP Service Component](./component-types/component-http-service/)** - Define a reusable HTTP service component type
 - **[Web App Component](./component-types/component-web-app/)** - Define a reusable web application component type
 - **[Component with Configs](./component-types/component-with-configs/)** - Demonstrate configuration management
-- **[Component with Traits](./component-types/component-with-traits/)** - Demonstrate trait composition
 - **[Component with Embedded Traits](./component-types/component-with-embedded-traits/)** - Demonstrate PE-defined embedded traits
-- **[Component with API Management](./component-types/component-with-api-management/)** - Demonstrate API management via traits
 
 ### [Workflows](./workflows)
 Reusable Workflow definitions for standalone automation tasks independent of any Component.
 
 **Available Samples:**
-- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
+- **[AWS RDS Postgres Create](./workflows/aws-rds-postgres-create/)** - Provision and destroy AWS RDS PostgreSQL instances using Terraform
 - **[GitHub Stats Report](./workflows/github-stats-report/)** - Fetch GitHub repository statistics, transform the data, and generate a formatted report
 - **[SCM Create Repo](./workflows/scm-create-repo/)** - Create repositories in GitHub or AWS CodeCommit
 

--- a/samples/from-image/doclet/README.md
+++ b/samples/from-image/doclet/README.md
@@ -12,7 +12,7 @@ A sample application that demonstrates how an OpenChoreo Workload consumes manag
 
 ## Architecture
 
-```
+```text
                   external HTTP
                        │
                        ▼

--- a/samples/from-image/echo-websocket-service/README.md
+++ b/samples/from-image/echo-websocket-service/README.md
@@ -62,7 +62,7 @@ Once connected, type any message and press Enter. The server will echo back the 
 
 ### Example Session
 
-```
+```text
 Connected (press CTRL+C to quit)
 > Hello, WebSocket!
 < Hello, WebSocket!

--- a/samples/from-image/react-starter-web-app/README.md
+++ b/samples/from-image/react-starter-web-app/README.md
@@ -22,7 +22,7 @@ kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/sa
 
 Once the application is deployed, you can access the React application at:
 
-```
+```text
 http://http-react-starter-development-default-cde5190f.openchoreoapis.localhost:19080
 ```
 

--- a/samples/mcp/resource-optimization/README.md
+++ b/samples/mcp/resource-optimization/README.md
@@ -25,7 +25,7 @@ In real clusters, services often get allocated far more CPU and memory than they
 
 ### Architecture context
 
-```
+```text
 frontend (over-provisioned: 2 CPU, 2Gi memory)
 checkout (over-provisioned: 2 CPU, 2Gi memory)
 cart     (over-provisioned: 1 CPU, 1Gi memory)
@@ -66,7 +66,7 @@ Wait a couple of minutes for the pods to restart and for usage metrics to start 
 
 Ask the AI assistant to check the current resource configuration across the project.
 
-```
+```text
 Show me the resource configuration (CPU and memory requests and limits) from
 the release bindings for all components in the "default" namespace,
 "gcp-microservice-demo" project.
@@ -84,7 +84,7 @@ the release bindings for all components in the "default" namespace,
 
 Now compare the allocations against what the services are actually consuming.
 
-```
+```text
 Query the CPU and memory usage metrics for the frontend, checkout, and cart
 components in the "default" namespace, "gcp-microservice-demo" project,
 "development" environment over the last 15 minutes. Compare with their
@@ -102,7 +102,7 @@ configured limits.
 
 Ask the AI assistant to analyze the waste and suggest optimal values.
 
-```
+```text
 Based on the actual usage data, these services look over-provisioned.
 Suggest optimal CPU and memory requests and limits for frontend, checkout,
 and cart. Include a safety buffer and explain your reasoning.
@@ -118,7 +118,7 @@ and cart. Include a safety buffer and explain your reasoning.
 
 Apply the optimized resource configuration using the MCP server.
 
-```
+```text
 Update the release bindings for frontend, checkout, and cart with the recommended resource values.
 ```
 

--- a/samples/mcp/service-deployment/developer-chat/README.md
+++ b/samples/mcp/service-deployment/developer-chat/README.md
@@ -20,7 +20,7 @@ This guide uses a conversational workflow where you interact naturally with your
 
 ### Step 1: Enter the Agent's system prompt
 
-```
+```text
 You're a useful agent to help make OpenChoreo tasks easier for OpenChoreo users. You can use only the OpenChoreo MCP server. Specifically, you can't use curl and kubectl. You may refer to OpenChoreo docs: https://openchoreo.dev/docs/. You may ask back the user questions when you want further input for a task.
 
 You execute the MCP tools efficiently and avoid unnecessary tool calls. You reply concisely and keep the conversation clean. You don't generate .md files and other artifacts unless you're asked to.
@@ -32,7 +32,7 @@ The Agent will respond with the available MCP tools
 
 ### Step 2: Request Deployment
 
-```
+```text
 I want to deploy my Go REST API service on OpenChoreo. Source: https://github.com/openchoreo/sample-workloads/tree/main/service-go-greeter
 The source contains a Dockerfile. You can use it for the deployment.
 ```

--- a/samples/mcp/service-deployment/step-by-step/README.md
+++ b/samples/mcp/service-deployment/step-by-step/README.md
@@ -28,7 +28,7 @@ You'll learn to:
 
 First, verify that your OpenChoreo instance has the necessary infrastructure.
 Prompt:
-```
+```text
 List the environments in my "default" namespace
 ```
 
@@ -39,7 +39,7 @@ List the environments in my "default" namespace
 Let's create a project called "greeter" for our application.
 
 Prompt:
-```
+```text
 Create a new project called "greeter" in the "default" namespace with description "Simple greeter service in Go"
 ```
 
@@ -53,7 +53,7 @@ Create a new project called "greeter" in the "default" namespace with descriptio
 Now let's create the greeter service component and configure its build workflow.
 
 Prompt:
-```
+```text
 Create a component called "greeter-service" in the greeter project. 
 It should be a deployment/service type, listening on port 9090, 
 with 1 replica, and publicly exposed. Configure it to build from 
@@ -76,7 +76,7 @@ Now let's build the container image for our greeter service.
 ### Build Greeter Service
 
 Prompt:
-```
+```text
 Trigger a build for the greeter-service component in the greeter project using the main branch
 ```
 
@@ -88,7 +88,7 @@ Trigger a build for the greeter-service component in the greeter project using t
 ### Monitor Build Progress
 
 Prompt:
-```
+```text
 What's the status of the greeter-service build? Check periodically until the build finishes
 ```
 
@@ -107,7 +107,7 @@ Let's verify that the greeter service is running correctly.
 ### Check Component Status
 
 Prompt:
-```
+```text
 Show me the deployment status of the greeter-service in the greeter project
 ```
 
@@ -119,7 +119,7 @@ Show me the deployment status of the greeter-service in the greeter project
 ### Get Access URL
 
 Prompt:
-```
+```text
 What is the endpoint URL for my greeter service in development? The gateway is running on the port 19080
 ```
 
@@ -130,12 +130,12 @@ What is the endpoint URL for my greeter service in development? The gateway is r
 ### Test the Service
 
 **Sample Curl**
-```
+```sh
 curl http://development-default.openchoreoapis.localhost:19080/greeter/greet?name=World
 ```
 
 **Expected response:**
-```
+```text
 Hello, World
 ```
 
@@ -148,7 +148,7 @@ After testing in development, let's promote the greeter service to production.
 ### Promote the Service
 
 Prompt:
-```
+```text
 Promote the greeter-service up to the production environment
 ```
 

--- a/samples/workflows/aws-rds-postgres/README.md
+++ b/samples/workflows/aws-rds-postgres/README.md
@@ -8,7 +8,7 @@ The instance is a minimal, publicly accessible `db.t3.micro` (free-tier eligible
 
 ## Pipeline Overview
 
-```
+```text
 WorkflowRun
     │
     ▼
@@ -161,7 +161,7 @@ spec:
 
 ## Example Output
 
-```
+```text
 =================================================
   AWS RDS PostgreSQL Instance Created
 =================================================
@@ -208,7 +208,7 @@ kubectl apply -f aws-rds-postgres-delete.yaml
 ## Terraform State
 
 State is stored at:
-```
+```text
 s3://<tfState.s3Bucket>/rds/<db.identifier>/terraform.tfstate
 ```
 

--- a/samples/workflows/azure-sql-database/README.md
+++ b/samples/workflows/azure-sql-database/README.md
@@ -8,7 +8,7 @@ The database uses the Basic SKU (5 DTUs) — sized for dev/test, not production.
 
 ## Pipeline Overview
 
-```
+```text
 WorkflowRun
     │
     ▼
@@ -157,7 +157,7 @@ spec:
 
 ## Example Output
 
-```
+```text
 =================================================
   Azure SQL Database Created
 =================================================
@@ -205,7 +205,7 @@ kubectl apply -f azure-sql-database-delete.yaml
 ## Terraform State
 
 State is stored at:
-```
+```text
 Azure Storage Account: <tfState.storageAccount>
 Container:             tfstate
 Blob:                  azuresql/<server.name>/terraform.tfstate

--- a/samples/workflows/custom-steps/README.md
+++ b/samples/workflows/custom-steps/README.md
@@ -19,7 +19,7 @@ Each subdirectory covers a category of custom step with its own README and sampl
 
 A standard OpenChoreo build pipeline runs these steps in order:
 
-```
+```text
 checkout-source → build-image → publish-image → generate-workload-cr
 ```
 

--- a/samples/workflows/custom-steps/linter/README.md
+++ b/samples/workflows/custom-steps/linter/README.md
@@ -14,7 +14,7 @@ This sample demonstrates how to add an API linting step to an OpenChoreo CI work
 
 The `dockerfile-builder-linter` workflow runs these steps in order:
 
-```
+```text
 checkout-source → spectral-lint → build-image → publish-image → generate-workload-cr
 ```
 

--- a/samples/workflows/github-stats-report/README.md
+++ b/samples/workflows/github-stats-report/README.md
@@ -6,7 +6,7 @@ This sample demonstrates a Generic Workflow that fetches repository statistics f
 
 ## Pipeline Overview
 
-```
+```text
 WorkflowRun
     │
     ▼
@@ -70,7 +70,7 @@ spec:
 
 ## Example Output (table format)
 
-```
+```text
 =============================
   GitHub Repository Report
 =============================

--- a/samples/workflows/scm-create-repo/README.md
+++ b/samples/workflows/scm-create-repo/README.md
@@ -19,7 +19,7 @@ The workflows have no dependency on any Component and can be triggered manually.
 
 Both workflows follow the same two-step pattern:
 
-```
+```text
 WorkflowRun
     │
     ▼
@@ -90,7 +90,7 @@ spec:
 
 ### Example Output
 
-```
+```text
 =================================
   GitHub Repository Created
 =================================
@@ -182,7 +182,7 @@ spec:
 
 ### Example Output
 
-```
+```text
 =================================
   CodeCommit Repository Created
 =================================

--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,7 @@ End-to-end and UI tests that run against a real OpenChoreo cluster (local k3d), 
 
 ## Structure
 
-```
+```text
 test/
 ├── e2e/        Go (Ginkgo) end-to-end tests — `make e2e`
 │   ├── e2e_suite_test.go   Suite entry point; requires --e2e.kubecontext

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,7 +4,7 @@ Go (Ginkgo) suites that exercise OpenChoreo features against a real Kubernetes c
 
 ## Structure
 
-```
+```text
 e2e/
 ├── e2e_suite_test.go   Suite entry point; verifies the cluster is reachable (--e2e.kubecontext)
 ├── e2e_test.go         Platform health checks: all control/data plane pods running

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -4,7 +4,7 @@ Playwright tests that drive the Backstage portal end-to-end in Chromium against 
 
 ## Structure
 
-```
+```text
 ui/
 ├── playwright.config.ts   Runner config; maps *.e2e-cp.local hostnames to 127.0.0.1
 │                          via Chromium host-resolver rules (no /etc/hosts edit needed)


### PR DESCRIPTION
Purpose

Improve the readability and consistency of the documentation by adding language identifiers to Markdown fenced code blocks that were missing them.

Approach

Added appropriate language identifiers such as text to fenced code blocks across multiple documentation files. This enables syntax highlighting where applicable and improves the rendering of the documentation without changing any functionality.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

This is a documentation-only change. The updates improve Markdown rendering and consistency by explicitly specifying the language for fenced code blocks.