### PR TITLE
docs: fix grammar in contributor guide

### DIFF
--- a/docs/contributors/contribute.md
+++ b/docs/contributors/contribute.md
@@ -151,7 +151,7 @@ You can directly run the `manager` or `occ` binary this location to try out.
 
 ### Incremental Development
 
-Rather using build and run the binaries every time, you can use the go run make targets to run the binaries directly.
+Rather than using build and run the binaries every time, you can use the go run make targets to run the binaries directly.
 
 - Running the `manager` binary:
   ```sh


### PR DESCRIPTION
Purpose

Fix a minor grammar issue in the contributor guide to improve readability.

Approach

Updated the sentence from “Rather using” to “Rather than using” in docs/contributors/contribute.md.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

This is a documentation-only change and does not affect functionality.