### PR TITLE
docs: fix duplicate step number in CRD contributor guide

### DIFF
--- a/docs/contributors/adding-new-crd.md
+++ b/docs/contributors/adding-new-crd.md
@@ -120,7 +120,7 @@ if err := (&component.Reconciler{
 }
 ```
 
-### 4. **Test the Refactored Controller**
+### 6. **Test the Refactored Controller**
 
 Run the following to verify that your changes are working as expected:
 


### PR DESCRIPTION
Purpose

Fix a duplicate step number in the CRD contributor guide to improve the document’s structure and readability.

Approach

Updated the duplicated step heading by changing the final “### 4. Test the Refactored Controller” to “### 6. Test the Refactored Controller”, keeping the numbering sequence consistent.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

This is a documentation-only change with no functional impact.