### PR TITLE
docs: fix stale MCP tool file references

### DIFF
--- a/docs/contributors/adding-new-mcp-tools.md
+++ b/docs/contributors/adding-new-mcp-tools.md
@@ -8,7 +8,7 @@ This guide explains how to add new tools to the OpenChoreo MCP server implementa
   - Toolset handler interfaces and `Toolsets` struct: `pkg/mcp/tools/types.go`
   - Tool registration lists and `Toolsets.Register(...)`: `pkg/mcp/tools/register.go`
   - Schema/result helpers: `pkg/mcp/tools/helpers.go`
-  - Tool implementations are grouped by domain in files like `namespace.go`, `project.go`, `component.go`, `deployment.go`, `build.go`, `pe.go`
+  - Tool implementations are grouped by domain in files like `namespace.go`, `project.go`, `component.go`, `resource.go`, `resource_release.go`, `pe.go`
 - **Tool implementations (handlers)**: `internal/openchoreo-api/mcphandlers/`
   - A single handler type implements one or more toolset handler interfaces (e.g. `NamespaceToolsetHandler`, `ComponentToolsetHandler`, `PEToolsetHandler`).
 - **Wiring enabled toolsets**: `cmd/openchoreo-api/main.go` (`buildMCPToolsets`)


### PR DESCRIPTION
Purpose

Update stale file references in the MCP tools contributor guide to reflect the current repository structure.

Approach

Replaced references to non-existent files (deployment.go and build.go) with the current implementation files (resource.go and resource_release.go).

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

This is a documentation-only change that updates outdated file references to match the current codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP server structure guide with refreshed example tool filenames to better reflect the current layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->