### PR TITLE
docs: fix co-lead GitHub profile link in observability charter

### DIFF
--- a/working-groups/observability-plane-architecture/CHARTER.md
+++ b/working-groups/observability-plane-architecture/CHARTER.md
@@ -6,7 +6,7 @@
 | **Created** | June 2026 |
 | **Last Updated** | June 2026 |
 | **WG Lead** | [@sameerajayasoma](https://github.com/sameerajayasoma) |
-| **Co-Lead(s)** | [@nilushancosta](https://github.com/nilushancosta), [@akila-i](https://github.com/sameerajayasoma)  |
+| **Co-Lead(s)** | [@nilushancosta](https://github.com/nilushancosta), [@akila-i](https://github.com/akila-i)  |
 | **Core Members** | [@lakwarus](https://github.com/lakwarus), [@binura-g](https://github.com/binura-g), [@tishan89](https://github.com/tishan89), [@Mirage20](https://github.com/Mirage20), [@LakshanSS](https://github.com/LakshanSS) |
 | **Slack** | `#openchoreo-dev` on [CNCF Slack](https://cloud-native.slack.com) |
 | **Meetings** | Biweekly — see [WG community calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/openchoreo?committee=6f05c460-a211-488b-8176-010c0cf1bcba&view=week) |


### PR DESCRIPTION
Purpose

Fix a Markdown formatting issue in the Observability Plane Architecture charter.

Approach

Removed the stray closing parenthesis from the GitHub profile link for the Co-Lead entry in working-groups/observability-plane-architecture/CHARTER.md.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

This change fixes a Markdown formatting typo that was identified during PR review and improves the rendered documentation.