### PR TITLE
test: fix UI row-editor selectors and harden cluster setup against openapi race

### DIFF
--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -358,6 +358,12 @@ _e2e.prepare-backstage-secret:
 e2e.setup-cluster: ## Create k3d cluster
 	@$(call log_info, Creating k3d cluster '$(E2E_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_K3D_DIR)/config.yaml
+	@# Gate on node readiness before the first apply: k3d returns once the
+	@# cluster is "created", but the API server may still be bringing up its
+	@# OpenAPI/aggregation layer, which a client-side `apply` needs ("failed
+	@# to download openapi: the server is currently unable to handle the
+	@# request"). Mirrors the multi-cluster setup.
+	$(E2E_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
 	@$(call log_info, Applying CoreDNS rewrite for e2e domains)
 	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/coredns-custom.yaml
 	@$(call log_success, k3d cluster '$(E2E_CLUSTER_NAME)' created)

--- a/test/ui/po/component.ts
+++ b/test/ui/po/component.ts
@@ -9,8 +9,8 @@ export interface CreateComponentInput {
   project: string; // project metadata name to select in the form's Project picker
   // Template card label on the "Browse component templates" page. Restricted
   // to the endpoint-bearing templates: create() drives the endpoint sub-form
-  // ("Add Endpoint" / "Save") unconditionally, which non-HTTP templates
-  // (e.g. "Worker") don't render. Defaults to "Web Application".
+  // ("Add Endpoint" / "Save changes") unconditionally, which non-HTTP
+  // templates (e.g. "Worker") don't render. Defaults to "Web Application".
   template?: 'Web Application' | 'Service';
   image: string; // container image reference (Container Image deployment source)
   // Web Application / Service component types require at least one HTTP
@@ -123,9 +123,11 @@ export class ComponentPO {
     await portField.fill(String(port));
     // Commit the endpoint item — the wizard refuses to advance to Review while
     // an endpoint is still in edit mode ("Save or cancel the item you are
-    // currently editing before proceeding.").
+    // currently editing before proceeding."). The button reads "Save" but
+    // carries aria-label="Save changes", so the accessible name (what
+    // getByRole matches) is "Save changes", not the visible "Save".
     await this.page
-      .getByRole('button', { name: 'Save', exact: true })
+      .getByRole('button', { name: 'Save changes', exact: true })
       .click();
   }
 

--- a/test/ui/po/overrides.ts
+++ b/test/ui/po/overrides.ts
@@ -66,7 +66,7 @@ export class OverridesPO {
   ): Promise<void> {
     const card = this.envCard(name);
     await card
-      .getByRole('button', { name: 'Override', exact: true })
+      .getByRole('button', { name: 'Override' })
       .click();
     const valueField = this.page.getByLabel('Value', { exact: true }).last();
     await valueField.clear();
@@ -81,7 +81,7 @@ export class OverridesPO {
     await this.cancelAnyOpenEditor();
     const card = this.fileCard(fileName);
     await card
-      .getByRole('button', { name: 'Override', exact: true })
+      .getByRole('button', { name: 'Override' })
       .click();
     const content = this.page.getByLabel(/^(Edit )?Content$/).last();
     await content.scrollIntoViewIfNeeded();
@@ -155,7 +155,7 @@ export class OverridesPO {
     await this.cancelAnyOpenEditor();
     const card = this.envCard(name);
     await card
-      .getByRole('button', { name: 'Edit', exact: true })
+      .getByRole('button', { name: 'Edit' })
       .first()
       .click();
     const valueField = this.page.getByLabel('Value', { exact: true }).last();
@@ -172,11 +172,11 @@ export class OverridesPO {
     const card = this.fileCard(fileName);
     await card.scrollIntoViewIfNeeded();
     await card
-      .getByRole('button', { name: 'Edit', exact: true })
+      .getByRole('button', { name: 'Edit' })
       .first()
       .click();
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .waitFor({ state: 'visible', timeout: 5_000 });
     const expandBtn = this.page.getByRole('button', {
       name: /expand content/i,
@@ -229,7 +229,7 @@ export class OverridesPO {
 
   async expectApplyDisabled(): Promise<void> {
     await expect(
-      this.page.getByRole('button', { name: 'Apply changes' }),
+      this.page.getByRole('button', { name: 'Save changes' }),
     ).toBeDisabled();
   }
 
@@ -279,7 +279,7 @@ export class OverridesPO {
       .getByRole('button', { name: 'Add Environment Variable', exact: true })
       .click();
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .first()
       .waitFor({ state: 'visible', timeout: 10_000 });
   }
@@ -289,14 +289,14 @@ export class OverridesPO {
       .getByRole('button', { name: 'Add File Mount', exact: true })
       .click();
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .last()
       .waitFor({ state: 'visible', timeout: 10_000 });
   }
 
   async clickApply(): Promise<void> {
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .click();
   }
 

--- a/test/ui/po/workloadConfig.ts
+++ b/test/ui/po/workloadConfig.ts
@@ -162,7 +162,7 @@ export class WorkloadConfigPO {
 
   async expectApplyDisabled(): Promise<void> {
     await expect(
-      this.page.getByRole('button', { name: 'Apply changes' }),
+      this.page.getByRole('button', { name: 'Save changes' }),
     ).toBeDisabled();
   }
 
@@ -355,16 +355,16 @@ export class WorkloadConfigPO {
   private async clickEditOnEnvRow(name: string): Promise<void> {
     await this.cancelAnyOpenEditor();
     const card = this.envCard(name);
-    await card.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    await card.getByRole('button', { name: 'Edit' }).first().click();
   }
 
   private async clickEditOnFileRow(fileName: string): Promise<void> {
     await this.cancelAnyOpenEditor();
     const card = this.fileCard(fileName);
     await card.scrollIntoViewIfNeeded();
-    await card.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    await card.getByRole('button', { name: 'Edit' }).first().click();
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .waitFor({ state: 'visible', timeout: 5_000 });
   }
 
@@ -382,7 +382,7 @@ export class WorkloadConfigPO {
       .getByRole('button', { name: 'Add Environment Variable', exact: true })
       .click();
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .first()
       .waitFor({ state: 'visible', timeout: 10_000 });
   }
@@ -392,14 +392,14 @@ export class WorkloadConfigPO {
       .getByRole('button', { name: 'Add File Mount', exact: true })
       .click();
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .last()
       .waitFor({ state: 'visible', timeout: 10_000 });
   }
 
   private async clickApply(): Promise<void> {
     await this.page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .click();
   }
 

--- a/test/ui/specs/config/component-config-edits.spec.ts
+++ b/test/ui/specs/config/component-config-edits.spec.ts
@@ -296,7 +296,7 @@ test.describe('component config edits through Backstage UI', () => {
       .getByRole('button', { name: 'Add Environment Variable', exact: true })
       .click();
     await page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .waitFor({ state: 'visible', timeout: 10_000 });
     // Fill only the Value field, leave Name empty.
     await page.getByLabel('Value', { exact: true }).last().fill('some-value');
@@ -453,7 +453,7 @@ test.describe('component config edits through Backstage UI', () => {
       .getByRole('button', { name: 'Add Environment Variable', exact: true })
       .click();
     await page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .waitFor({ state: 'visible', timeout: 10_000 });
     await page.getByLabel('Value', { exact: true }).last().fill('orphan-val');
 
@@ -465,7 +465,7 @@ test.describe('component config edits through Backstage UI', () => {
       .getByRole('button', { name: 'Add File Mount', exact: true })
       .click();
     await page
-      .getByRole('button', { name: 'Apply changes' })
+      .getByRole('button', { name: 'Save changes' })
       .waitFor({ state: 'visible', timeout: 10_000 });
     await page
       .getByLabel('Mount Path', { exact: true })
@@ -499,7 +499,7 @@ test.describe('component config edits through Backstage UI', () => {
       })
       .last();
     await envCard
-      .getByRole('button', { name: 'Override', exact: true })
+      .getByRole('button', { name: 'Override' })
       .click();
     const envNameField = page.getByLabel('Name', { exact: true }).last();
     await expect(envNameField).toBeDisabled();
@@ -521,7 +521,7 @@ test.describe('component config edits through Backstage UI', () => {
       })
       .last();
     await fileCard
-      .getByRole('button', { name: 'Override', exact: true })
+      .getByRole('button', { name: 'Override' })
       .click();
     const fileNameField = page
       .getByLabel('File Name', { exact: true })


### PR DESCRIPTION
## Purpose

The scheduled **main E2E Gate** is red on two jobs:

- **E2E (UI / Playwright)** — 5 specs (`abac-ui/abac-env-restriction`, `config/component-config-edits`, `dev-ops/dev-ops-component`, `lifecycle/full-lifecycle`, `pe-ops/pe-ops-trait-attach` BYOI) fail on all retries in `ComponentPO.create → fillDetails`, timing out waiting for the endpoint editor's commit button. Reproduced on runs [28211977445](https://github.com/openchoreo/openchoreo/actions/runs/28211977445) and [28216299408](https://github.com/openchoreo/openchoreo/actions/runs/28216299408).
- **E2E (External IdP / Dex)** — `e2e.setup-cluster` fails at the first `kubectl apply` with `failed to download openapi: the server is currently unable to handle the request`.

## Approach

Two independent root causes, both in the e2e suite:

**1. UI selectors stale after the `EditRowActions` rename.** The `backstage-plugins` *"prominent save/discard actions"* change consolidated all workload row editors (endpoints, env vars, file mounts, dependencies) into a shared `EditRowActions` component and relabeled its buttons: Save → `aria-label="Save changes"` (visible text "Save"), Cancel → `"Cancel editing"`, Delete → `"Remove <item>"`, Edit → `"<label> <item>"`. Playwright's `getByRole({ name })` matches the **accessible name** (an `aria-label` overrides visible text), so the old `'Apply changes'` and the interim `'Save'` (#3994) no longer match, and the `exact: true` `'Edit'`/`'Override'` row selectors broke once their names gained the item suffix. The POs were only partially migrated (`'Cancel editing'` / `'Remove …'` were updated); this finishes it:

- `po/component.ts`: endpoint commit `'Save'` → `'Save changes'`.
- `po/overrides.ts`, `po/workloadConfig.ts`, `specs/config/component-config-edits.spec.ts`: `'Apply changes'` → `'Save changes'`; drop `exact: true` on the card-scoped `'Edit'`/`'Override'` row buttons so the substring match tolerates the new `"<label> environment variable"` / `"… file mount"` names (mirrors how the UI's own `EnvVarEditor.test.tsx` matches them with `/edit/i`, `/override/i`).
- Left unchanged: the standalone About-card `'Edit'` icon in `po/definitionTab.ts` (genuinely named "Edit", not a row editor) and the card-finder regexes (still resolve via their `remove <item>` alternative).

**2. Cluster-setup openapi race.** `e2e.setup-cluster` ran its first `kubectl apply -f coredns-custom.yaml` immediately after `k3d cluster create`, before the API server's OpenAPI/aggregation layer was serving — a client-side `apply` needs it. Added a `kubectl wait --for=condition=Ready nodes --all --timeout=120s` gate before the apply, matching the existing multi-cluster `e2e.multi.setup-clusters` path.

## Related Issues

None — fixes the main E2E gate directly. Corrects the selector introduced in #3994.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

- Selector values verified against the live `openchoreo/backstage-plugins` source (`EditRowActions.tsx` + `EnvVarEditor.test.tsx`); the failing run's Playwright trace confirmed the rendered button carries `aria-label="Save changes"`.
- Not yet validated end-to-end against a live cluster — recommend the UI e2e gate run on this PR to confirm green.
