### PR TITLE
docs: add component type decision guide to getting-started

### DIFF
--- a/samples/getting-started/README.md
+++ b/samples/getting-started/README.md
@@ -80,6 +80,30 @@ clustertrait.openchoreo.dev/observability-alert-rule      10s
 | web-application | Deployment | react, docker | HTTP endpoint required |
 | scheduled-task | CronJob | docker, google-cloud-buildpacks | - |
 
+#### Choosing a Component Type
+
+Use this flowchart to determine which component type fits your workload:
+
+```mermaid
+flowchart TD
+    A["Does your app serve HTTP traffic?"] -->|Yes| B["Is it a frontend/UI?"]
+    A -->|No| C["Does it run on a schedule?"]
+    B -->|Yes| D["web-application"]
+    B -->|No| E["service"]
+    C -->|Yes| F["scheduled-task"]
+    C -->|No| G["worker"]
+```
+
+| Criteria | service | web-application | worker | scheduled-task |
+|----------|---------|-----------------|--------|----------------|
+| **Kubernetes workload** | Deployment | Deployment | Deployment | CronJob |
+| **Exposes endpoints?** | ✅ Required (≥1) | ✅ Required (HTTP) | ❌ Forbidden | N/A |
+| **Long-running?** | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No (runs to completion) |
+| **Use case** | APIs, microservices, gRPC backends | React/Angular/Vue frontends, static sites | Queue consumers, event processors, background jobs | Periodic reports, cleanup jobs, batch processing |
+| **Example** | REST API, GraphQL server | Dashboard UI, marketing site | Email sender, log aggregator | Daily report generator, DB cleanup |
+
+> **Tip:** If none of these fit your workload (e.g., you need a StatefulSet or DaemonSet), you can define a custom ComponentType. See the [Component Types samples](../component-types/) for examples.
+
 ### Cluster Resource Types
 
 | Name | Description |


### PR DESCRIPTION
## Purpose

Adds a component type decision guide to the getting-started documentation to help users choose the most appropriate component type for their workloads.

## Approach

- Added a decision flowchart for selecting a component type
- Added a comparison table covering service, web-application, worker, and scheduled-task
- Included common use cases and key behavioral differences
- Added guidance for users who need custom ComponentTypes

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

This is a documentation-only change intended to improve the getting-started experience by helping users quickly identify the most suitable component type for their applications.