### PR TITLE
docs: add context and prerequisites to MCP server configuration

### DIFF
--- a/docs/configure-controlplane-mcp-server.md
+++ b/docs/configure-controlplane-mcp-server.md
@@ -2,6 +2,31 @@
 
 > **DEPRECATED:** This document describes the legacy MCP server (`pkg/mcp/legacytools/`). The toolset code has been moved to `pkg/mcp/legacytools/` and the config key renamed from `mcp` to `legacy_mcp`. A new MCP server implementation is being developed.
 
+## Before You Begin
+
+### What is the MCP Server?
+
+The OpenChoreo MCP (Model Context Protocol) server allows AI assistants (such as Claude, Cursor, and VS Code Copilot) to interact with your OpenChoreo control plane programmatically. Through MCP, AI assistants can list projects, create components, trigger builds, check deployment status, and more — all using natural language.
+
+### Legacy vs. New MCP Server
+
+> **Important:** This document describes the **legacy** MCP server. OpenChoreo is transitioning to a new MCP server implementation with improved toolset organization and handler separation.
+
+| | Legacy MCP Server | New MCP Server |
+|---|---|---|
+| **Code location** | `pkg/mcp/legacytools/` | `pkg/mcp/tools/` |
+| **Config key** | `legacy_mcp` | `mcp` |
+| **Status** | Deprecated (still functional) | Active development |
+| **Documentation** | This document | [Adding New MCP Tools](./contributors/adding-new-mcp-tools.md) |
+
+If you are setting up MCP for the first time, refer to the [MCP samples](../samples/mcp/) for getting started with the current implementation.
+
+### Prerequisites
+
+- A running OpenChoreo control plane with the `openchoreo-api` server deployed
+- `kubectl` access to the control plane cluster
+- Helm (if configuring via Helm values)
+
 This guide explains the OpenChoreo MCP (Model Context Protocol) server concepts, implementation and configuration.
 
 ## Architecture Overview
@@ -70,3 +95,41 @@ openchoreoApi:
     # Or enable specific toolsets based on your requirements
     # toolsets: "namespace,project,component"
 ```
+
+## Troubleshooting
+
+### MCP tools not responding
+
+If AI assistants cannot reach the MCP server:
+
+1. Verify the `openchoreo-api` pod is running:
+   ```bash
+   kubectl get pods -n openchoreo-control-plane -l app.kubernetes.io/component=openchoreo-api
+   ```
+
+2. Check the MCP server logs for errors:
+   ```bash
+   kubectl logs -n openchoreo-control-plane -l app.kubernetes.io/component=openchoreo-api --tail=50
+   ```
+
+3. Verify the `MCP_TOOLSETS` environment variable is set correctly:
+   ```bash
+   kubectl get deployment -n openchoreo-control-plane openchoreo-api -o jsonpath='{.spec.template.spec.containers[0].env}' | jq .
+   ```
+
+### Only some toolsets are available
+
+If certain MCP tools are missing, check which toolsets are enabled:
+
+```bash
+kubectl get deployment -n openchoreo-control-plane openchoreo-api \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="MCP_TOOLSETS")].value}'
+```
+
+Ensure the desired toolsets are included in the comma-separated list.
+
+## Next Steps
+
+- **Try MCP with AI assistants**: See the [MCP samples](../samples/mcp/) for guided walkthroughs
+- **Add new MCP tools**: See [Adding New MCP Tools](./contributors/adding-new-mcp-tools.md) for the new server implementation
+- **Understand resource types**: See the [Resource Kind Reference Guide](./resource-kind-reference-guide.md) for what MCP tools operate on


### PR DESCRIPTION
## Purpose

Adds introductory context and troubleshooting guidance to the MCP server configuration documentation to help users understand when to use it, the prerequisites, and where to go next.

## Approach

- Added a **Before You Begin** section explaining the purpose of the MCP server and the difference between the legacy and current implementations
- Documented the required prerequisites before configuring the MCP server
- Added a troubleshooting section covering common configuration issues
- Added a **Next Steps** section with links to related documentation

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

This is a documentation-only change intended to improve the usability of the MCP server configuration guide by providing additional context, troubleshooting guidance, and references to related documentation.