### PR TITLE
docs: add deployment topology comparison to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,65 @@ The diagram below illustrates some of the core concepts of the Platform API and 
 </div>
 </br>
 
+## Deployment Topologies
+
+OpenChoreo supports flexible deployment topologies, from a single development cluster to fully separated production planes.
+
+### Single-Cluster (Development)
+
+All planes run in a single Kubernetes cluster using separate namespaces. Ideal for local development and evaluation.
+
+```text
+┌─────────────────────────────────────────────────┐
+│              Single Kubernetes Cluster           │
+│                                                  │
+│  ┌──────────────────┐  ┌──────────────────┐     │
+│  │  Control Plane   │  │   Data Plane     │     │
+│  │  (namespace)     │  │   (namespace)    │     │
+│  └──────────────────┘  └──────────────────┘     │
+│  ┌──────────────────┐  ┌──────────────────┐     │
+│  │  Workflow Plane  │  │ Observability    │     │
+│  │  (namespace)     │  │ Plane (namespace)│     │
+│  └──────────────────┘  └──────────────────┘     │
+└─────────────────────────────────────────────────┘
+```
+
+### Multi-Cluster (Production)
+
+Each plane runs on its own Kubernetes cluster, connected via the cluster agent over secure WebSocket connections. This provides workload isolation, independent scaling, and clear security boundaries.
+
+```text
+┌──────────────────┐         ┌──────────────────┐
+│  Control Plane   │◄───────►│  Data Plane      │
+│  Cluster         │  agent  │  Cluster (prod)  │
+└──────────────────┘         └──────────────────┘
+        │                    ┌──────────────────┐
+        ├───────────────────►│  Data Plane      │
+        │              agent │  Cluster (staging)│
+        │                    └──────────────────┘
+        │                    ┌──────────────────┐
+        ├───────────────────►│  Workflow Plane  │
+        │              agent │  Cluster         │
+        │                    └──────────────────┘
+        │                    ┌──────────────────┐
+        └───────────────────►│  Observability   │
+                       agent │  Plane Cluster   │
+                             └──────────────────┘
+```
+
+### Topology Comparison
+
+| Aspect | Single-Cluster | Multi-Cluster |
+|--------|---------------|---------------|
+| **Setup complexity** | Low (one `helm install`) | Higher (one install per cluster + agent config) |
+| **Workload isolation** | Namespace-level only | Cluster-level (strongest isolation) |
+| **Scaling** | All planes share resources | Each plane scales independently |
+| **Fault domain** | Shared — control plane failure affects workloads | Isolated — data plane continues serving if control plane is down |
+| **Recommended for** | Development, CI, demos | Staging, production |
+| **Minimum clusters** | 1 | 2 (control + data) — additional planes optional |
+
+> **Note:** The [Quick Start Guide](https://openchoreo.dev/docs/getting-started/quick-start-guide/) uses a single-cluster topology. For production deployment guidance, see the [Installation Guide](https://openchoreo.dev/docs/getting-started/try-it-out/on-k3d-locally/).
+
 ## Getting Started
 
 The easiest way to try OpenChoreo is by following the **[Quick Start Guide](https://openchoreo.dev/docs/getting-started/quick-start-guide/)**. It walks you through setting up Choreo using a Dev Container, so you can start experimenting without affecting your local environment.


### PR DESCRIPTION
## Purpose

Adds a **Deployment Topologies** section to the main README to help users understand the different ways OpenChoreo can be deployed, from a single-cluster development setup to a multi-cluster production environment.

## Approach

- Added an overview of supported deployment topologies
- Documented both single-cluster and multi-cluster deployment models
- Included topology diagrams to illustrate each deployment architecture
- Added a comparison table highlighting differences in complexity, isolation, scaling, and recommended use cases

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

This is a documentation-only change intended to help users choose the deployment topology that best fits their development and production environments.