### PR TITLE
feat(controller): expose dataplane and gateway context to the project pipeline

### DIFF
--- a/api/v1alpha1/projecttype_types.go
+++ b/api/v1alpha1/projecttype_types.go
@@ -29,7 +29,8 @@ type ProjectTypeSpec struct {
 	// ProjectReleaseBinding of this type. Each entry has a unique id;
 	// includeWhen and forEach control conditional and iterative rendering;
 	// CEL expressions in the template body are evaluated against
-	// ${parameters.*}, ${environmentConfigs.*}, and ${metadata.*}.
+	// ${parameters.*}, ${environmentConfigs.*}, ${metadata.*},
+	// ${dataplane.*}, ${environment.*}, and the effective ${gateway.*}.
 	// +kubebuilder:validation:MinItems=1
 	// +listType=map
 	// +listMapKey=id

--- a/config/crd/bases/openchoreo.dev_projectreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_projectreleases.yaml
@@ -129,7 +129,8 @@ spec:
                           ProjectReleaseBinding of this type. Each entry has a unique id;
                           includeWhen and forEach control conditional and iterative rendering;
                           CEL expressions in the template body are evaluated against
-                          ${parameters.*}, ${environmentConfigs.*}, and ${metadata.*}.
+                          ${parameters.*}, ${environmentConfigs.*}, ${metadata.*},
+                          ${dataplane.*}, ${environment.*}, and the effective ${gateway.*}.
                         items:
                           description: ResourceTemplate defines a template for generating
                             Kubernetes resources

--- a/config/crd/bases/openchoreo.dev_projecttypes.yaml
+++ b/config/crd/bases/openchoreo.dev_projecttypes.yaml
@@ -78,7 +78,8 @@ spec:
                   ProjectReleaseBinding of this type. Each entry has a unique id;
                   includeWhen and forEach control conditional and iterative rendering;
                   CEL expressions in the template body are evaluated against
-                  ${parameters.*}, ${environmentConfigs.*}, and ${metadata.*}.
+                  ${parameters.*}, ${environmentConfigs.*}, ${metadata.*},
+                  ${dataplane.*}, ${environment.*}, and the effective ${gateway.*}.
                 items:
                   description: ResourceTemplate defines a template for generating
                     Kubernetes resources

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_projectreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_projectreleases.yaml
@@ -128,7 +128,8 @@ spec:
                           ProjectReleaseBinding of this type. Each entry has a unique id;
                           includeWhen and forEach control conditional and iterative rendering;
                           CEL expressions in the template body are evaluated against
-                          ${parameters.*}, ${environmentConfigs.*}, and ${metadata.*}.
+                          ${parameters.*}, ${environmentConfigs.*}, ${metadata.*},
+                          ${dataplane.*}, ${environment.*}, and the effective ${gateway.*}.
                         items:
                           description: ResourceTemplate defines a template for generating
                             Kubernetes resources

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_projecttypes.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_projecttypes.yaml
@@ -77,7 +77,8 @@ spec:
                   ProjectReleaseBinding of this type. Each entry has a unique id;
                   includeWhen and forEach control conditional and iterative rendering;
                   CEL expressions in the template body are evaluated against
-                  ${parameters.*}, ${environmentConfigs.*}, and ${metadata.*}.
+                  ${parameters.*}, ${environmentConfigs.*}, ${metadata.*},
+                  ${dataplane.*}, ${environment.*}, and the effective ${gateway.*}.
                 items:
                   description: ResourceTemplate defines a template for generating
                     Kubernetes resources

--- a/internal/controller/projectreleasebinding/controller_render.go
+++ b/internal/controller/projectreleasebinding/controller_render.go
@@ -48,6 +48,8 @@ func (r *Reconciler) renderAndEmit(
 		ProjectParameters:  release.Spec.Parameters,
 		EnvironmentConfigs: binding.Spec.EnvironmentConfigs,
 		Metadata:           metadataCtx,
+		DataPlane:          projectpipeline.BuildDataPlaneContext(dataPlane),
+		Environment:        projectpipeline.BuildEnvironmentContext(environment, dataPlane),
 	}
 
 	output, err := r.Pipeline.Render(input)

--- a/internal/pipeline/project/gateway.go
+++ b/internal/pipeline/project/gateway.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package projectpipeline
+
+import "github.com/openchoreo/openchoreo/api/v1alpha1"
+
+// BuildDataPlaneContext extracts the dataplane CEL surface from a
+// v1alpha1.DataPlane CR. Pure function, no controller-runtime imports.
+// Returns a zero-valued context when dataPlane is nil so callers don't have to
+// guard.
+func BuildDataPlaneContext(dataPlane *v1alpha1.DataPlane) DataPlaneContext {
+	if dataPlane == nil {
+		return DataPlaneContext{}
+	}
+	dpCtx := DataPlaneContext{}
+	if dataPlane.Spec.SecretStoreRef != nil {
+		dpCtx.SecretStore = dataPlane.Spec.SecretStoreRef.Name
+	}
+	if dataPlane.Spec.ObservabilityPlaneRef != nil {
+		dpCtx.ObservabilityPlaneRef = &ObservabilityPlaneRefContext{
+			Kind: string(dataPlane.Spec.ObservabilityPlaneRef.Kind),
+			Name: dataPlane.Spec.ObservabilityPlaneRef.Name,
+		}
+	}
+	dpCtx.Gateway = toGatewayData(&dataPlane.Spec.Gateway)
+	return dpCtx
+}
+
+// BuildEnvironmentContext extracts the per-environment CEL surface, merging
+// environment-level gateway overrides with dataplane-level fallbacks at each
+// leaf. Mirrors the component pipeline's mergeGatewayData semantics: ingress
+// and egress merge independently; within each, external and internal endpoints
+// fall back independently. Returns a zero-valued context (no gateway) when
+// both inputs are nil.
+func BuildEnvironmentContext(env *v1alpha1.Environment, dataPlane *v1alpha1.DataPlane) EnvironmentContext {
+	var envGW, dpGW *v1alpha1.GatewaySpec
+	if env != nil {
+		envGW = &env.Spec.Gateway
+	}
+	if dataPlane != nil {
+		dpGW = &dataPlane.Spec.Gateway
+	}
+	return EnvironmentContext{
+		Gateway: mergeGatewayData(envGW, dpGW),
+	}
+}
+
+// toGatewayData converts a v1alpha1.GatewaySpec into the GatewayData shape used
+// in CEL templates. Returns nil when neither ingress nor egress is set so
+// templates can use has(...) guards.
+func toGatewayData(gw *v1alpha1.GatewaySpec) *GatewayData {
+	if gw == nil {
+		return nil
+	}
+	data := &GatewayData{}
+	if gw.Ingress != nil {
+		data.Ingress = toGatewayNetworkData(gw.Ingress)
+	}
+	if gw.Egress != nil {
+		data.Egress = toGatewayNetworkData(gw.Egress)
+	}
+	if data.Ingress == nil && data.Egress == nil {
+		return nil
+	}
+	return data
+}
+
+func toGatewayNetworkData(t *v1alpha1.GatewayNetworkSpec) *GatewayNetworkData {
+	if t == nil {
+		return nil
+	}
+	data := &GatewayNetworkData{}
+	if t.External != nil {
+		data.External = toGatewayEndpointData(t.External)
+	}
+	if t.Internal != nil {
+		data.Internal = toGatewayEndpointData(t.Internal)
+	}
+	if data.External == nil && data.Internal == nil {
+		return nil
+	}
+	return data
+}
+
+func toGatewayEndpointData(e *v1alpha1.GatewayEndpointSpec) *GatewayEndpointData {
+	if e == nil {
+		return nil
+	}
+	data := &GatewayEndpointData{
+		Name:      e.Name,
+		Namespace: e.Namespace,
+	}
+	if e.HTTP != nil {
+		data.HTTP = toGatewayListenerData(e.HTTP)
+	}
+	if e.HTTPS != nil {
+		data.HTTPS = toGatewayListenerData(e.HTTPS)
+	}
+	if e.TLS != nil {
+		data.TLS = toGatewayListenerData(e.TLS)
+	}
+	return data
+}
+
+func toGatewayListenerData(l *v1alpha1.GatewayListenerSpec) *GatewayListenerData {
+	if l == nil {
+		return nil
+	}
+	return &GatewayListenerData{
+		ListenerName: l.ListenerName,
+		Port:         l.Port,
+		Host:         l.Host,
+	}
+}
+
+// mergeGatewayData merges environment-level and dataplane-level gateway specs.
+// Ingress and egress are merged independently, so specifying only one at the
+// environment level still falls back to the dataplane value for the other.
+func mergeGatewayData(envGW, dpGW *v1alpha1.GatewaySpec) *GatewayData {
+	var envIngress, dpIngress *v1alpha1.GatewayNetworkSpec
+	var envEgress, dpEgress *v1alpha1.GatewayNetworkSpec
+
+	if envGW != nil {
+		envIngress = envGW.Ingress
+		envEgress = envGW.Egress
+	}
+	if dpGW != nil {
+		dpIngress = dpGW.Ingress
+		dpEgress = dpGW.Egress
+	}
+
+	data := &GatewayData{
+		Ingress: mergeGatewayNetworkData(envIngress, dpIngress),
+		Egress:  mergeGatewayNetworkData(envEgress, dpEgress),
+	}
+	if data.Ingress == nil && data.Egress == nil {
+		return nil
+	}
+	return data
+}
+
+// mergeGatewayNetworkData merges environment-level and dataplane-level gateway
+// network specs. External and internal endpoints are merged independently,
+// preferring environment values and falling back to dataplane values for any
+// unspecified endpoint.
+func mergeGatewayNetworkData(envNetwork, dpNetwork *v1alpha1.GatewayNetworkSpec) *GatewayNetworkData {
+	if envNetwork == nil && dpNetwork == nil {
+		return nil
+	}
+
+	var envExternal, dpExternal *v1alpha1.GatewayEndpointSpec
+	var envInternal, dpInternal *v1alpha1.GatewayEndpointSpec
+
+	if envNetwork != nil {
+		envExternal = envNetwork.External
+		envInternal = envNetwork.Internal
+	}
+	if dpNetwork != nil {
+		dpExternal = dpNetwork.External
+		dpInternal = dpNetwork.Internal
+	}
+
+	external := envExternal
+	if external == nil {
+		external = dpExternal
+	}
+	internal := envInternal
+	if internal == nil {
+		internal = dpInternal
+	}
+
+	data := &GatewayNetworkData{
+		External: toGatewayEndpointData(external),
+		Internal: toGatewayEndpointData(internal),
+	}
+	if data.External == nil && data.Internal == nil {
+		return nil
+	}
+	return data
+}

--- a/internal/pipeline/project/pipeline.go
+++ b/internal/pipeline/project/pipeline.go
@@ -12,7 +12,8 @@
 //   - Render walks ProjectTypeSpec.Resources[] and returns the rendered
 //     entries. ForEach templates contribute one entry per iteration with
 //     ID suffixed by the iteration index. CEL context exposes ${metadata.*}
-//     (including namespace), ${parameters.*}, and ${environmentConfigs.*}.
+//     (including namespace), ${parameters.*}, ${environmentConfigs.*},
+//     ${dataplane.*}, ${environment.*}, and the effective ${gateway.*}.
 package projectpipeline
 
 import (
@@ -44,6 +45,9 @@ func NewPipeline() *Pipeline {
 //   - ${metadata.*} (namespace, projectName/UID, environmentName/UID, ...)
 //   - ${parameters.*} (Project.spec.parameters with schema defaults applied)
 //   - ${environmentConfigs.*} (binding overrides with schema defaults applied)
+//   - ${dataplane.*} (secretStore, gateway, observabilityPlaneRef)
+//   - ${environment.*} (env-or-dataplane merged gateway)
+//   - ${gateway.*} (top-level alias of the effective environment gateway)
 //
 // ProjectTypeSpec.Validations are evaluated against the same context before
 // rendering begins; any rule that returns false aborts the call.
@@ -212,6 +216,9 @@ func buildBaseContext(input *RenderInput) (map[string]any, error) {
 		Metadata:           md,
 		Parameters:         parameters,
 		EnvironmentConfigs: envConfigs,
+		DataPlane:          input.DataPlane,
+		Environment:        input.Environment,
+		Gateway:            input.Environment.Gateway,
 	})
 }
 

--- a/internal/pipeline/project/pipeline_test.go
+++ b/internal/pipeline/project/pipeline_test.go
@@ -196,3 +196,170 @@ func TestRender_MissingNamespaceRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Namespace is empty")
 }
+
+// fixtureDataPlane returns a DataPlane with a secret store, observability
+// plane ref, and both egress and ingress gateways configured. The egress
+// external HTTPS host differs from fixtureEnvironment so tests can tell the
+// raw dataplane surface apart from the merged effective gateway.
+func fixtureDataPlane() *v1alpha1.DataPlane {
+	dp := &v1alpha1.DataPlane{}
+	dp.Name = "primary"
+	dp.Spec.SecretStoreRef = &v1alpha1.SecretStoreRef{Name: "vault-store"}
+	dp.Spec.ObservabilityPlaneRef = &v1alpha1.ObservabilityPlaneRef{
+		Kind: v1alpha1.ObservabilityPlaneRefKind("ObservabilityPlane"),
+		Name: "obs-default",
+	}
+	dp.Spec.Gateway = v1alpha1.GatewaySpec{
+		Egress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      "egress-gw",
+				Namespace: "gateway-system",
+				HTTPS:     &v1alpha1.GatewayListenerSpec{Port: 443, Host: "egress.dp.example.com"},
+			},
+		},
+		Ingress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      "ingress-gw",
+				Namespace: "gateway-system",
+				HTTPS:     &v1alpha1.GatewayListenerSpec{Port: 443, Host: "ingress.dp.example.com"},
+			},
+		},
+	}
+	return dp
+}
+
+// fixtureEnvironment returns an Environment that overrides only the egress
+// external gateway; ingress is left unset so it falls back to the dataplane.
+func fixtureEnvironment() *v1alpha1.Environment {
+	env := &v1alpha1.Environment{}
+	env.Name = "dev"
+	env.Spec.Gateway = v1alpha1.GatewaySpec{
+		Egress: &v1alpha1.GatewayNetworkSpec{
+			External: &v1alpha1.GatewayEndpointSpec{
+				Name:      "egress-gw",
+				Namespace: "gateway-system",
+				HTTPS:     &v1alpha1.GatewayListenerSpec{Port: 443, Host: "egress.dev.example.com"},
+			},
+		},
+	}
+	return env
+}
+
+func TestRender_ExposesDataPlaneAndGatewayContext(t *testing.T) {
+	p := NewPipeline()
+
+	dp := fixtureDataPlane()
+	env := fixtureEnvironment()
+
+	input := &RenderInput{
+		ProjectTypeSpec: &v1alpha1.ProjectTypeSpec{
+			Resources: []v1alpha1.ResourceTemplate{
+				nsTemplate(t),
+				{
+					ID: "shared-secret",
+					Template: rawExt(t, map[string]any{
+						"apiVersion": "external-secrets.io/v1beta1",
+						"kind":       "ExternalSecret",
+						"metadata": map[string]any{
+							"name":      "shared-secret",
+							"namespace": "${metadata.namespace}",
+						},
+						"spec": map[string]any{
+							"secretStoreRef": map[string]any{
+								"name": "${dataplane.secretStore}",
+								"kind": "ClusterSecretStore",
+							},
+							// Effective (merged) egress gateway — env wins.
+							"effectiveEgressHost": "${gateway.egress.external.https.host}",
+							// Raw dataplane egress gateway — dataplane value.
+							"dpEgressHost": "${dataplane.gateway.egress.external.https.host}",
+							// Ingress not overridden by env → dataplane fallback.
+							"effectiveIngressHost": "${gateway.ingress.external.https.host}",
+						},
+					}),
+				},
+			},
+		},
+		Metadata:    fixtureMetadata(),
+		DataPlane:   BuildDataPlaneContext(dp),
+		Environment: BuildEnvironmentContext(env, dp),
+	}
+
+	out, err := p.Render(input)
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 2)
+
+	spec := out.Entries[1].Object["spec"].(map[string]any)
+	assert.Equal(t, "vault-store", spec["secretStoreRef"].(map[string]any)["name"])
+	assert.Equal(t, "egress.dev.example.com", spec["effectiveEgressHost"], "top-level gateway alias should be the env-merged value")
+	assert.Equal(t, "egress.dp.example.com", spec["dpEgressHost"], "dataplane.gateway should be the raw dataplane value")
+	assert.Equal(t, "ingress.dp.example.com", spec["effectiveIngressHost"], "ingress should fall back to the dataplane when env omits it")
+}
+
+func TestRender_GatewayNilGuardFallsBack(t *testing.T) {
+	p := NewPipeline()
+
+	input := &RenderInput{
+		ProjectTypeSpec: &v1alpha1.ProjectTypeSpec{
+			Resources: []v1alpha1.ResourceTemplate{
+				nsTemplate(t),
+				{
+					ID: "guarded",
+					Template: rawExt(t, map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata":   map[string]any{"name": "guarded"},
+						"data": map[string]any{
+							"egressHost":  "${has(environment.gateway) ? environment.gateway.egress.external.https.host : 'no-gateway'}",
+							"secretStore": "${has(dataplane.secretStore) ? dataplane.secretStore : 'no-store'}",
+						},
+					}),
+				},
+			},
+		},
+		Metadata: fixtureMetadata(),
+		// DataPlane and Environment left zero-valued: no gateway, no secret store.
+	}
+
+	out, err := p.Render(input)
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 2)
+
+	data := out.Entries[1].Object["data"].(map[string]any)
+	assert.Equal(t, "no-gateway", data["egressHost"])
+	assert.Equal(t, "no-store", data["secretStore"])
+}
+
+func TestBuildEnvironmentContext_EnvOverridesDataPlaneByLeaf(t *testing.T) {
+	envCtx := BuildEnvironmentContext(fixtureEnvironment(), fixtureDataPlane())
+
+	require.NotNil(t, envCtx.Gateway)
+	require.NotNil(t, envCtx.Gateway.Egress)
+	require.NotNil(t, envCtx.Gateway.Egress.External)
+	// Environment-level egress external wins over the dataplane.
+	assert.Equal(t, "egress.dev.example.com", envCtx.Gateway.Egress.External.HTTPS.Host)
+
+	require.NotNil(t, envCtx.Gateway.Ingress)
+	require.NotNil(t, envCtx.Gateway.Ingress.External)
+	// Ingress is unset on the environment, so it falls back to the dataplane.
+	assert.Equal(t, "ingress.dp.example.com", envCtx.Gateway.Ingress.External.HTTPS.Host)
+}
+
+func TestBuildDataPlaneContext_ExtractsSecretStoreAndObservability(t *testing.T) {
+	dpCtx := BuildDataPlaneContext(fixtureDataPlane())
+
+	assert.Equal(t, "vault-store", dpCtx.SecretStore)
+	require.NotNil(t, dpCtx.ObservabilityPlaneRef)
+	assert.Equal(t, "ObservabilityPlane", dpCtx.ObservabilityPlaneRef.Kind)
+	assert.Equal(t, "obs-default", dpCtx.ObservabilityPlaneRef.Name)
+	require.NotNil(t, dpCtx.Gateway)
+	require.NotNil(t, dpCtx.Gateway.Egress)
+	assert.Equal(t, "egress.dp.example.com", dpCtx.Gateway.Egress.External.HTTPS.Host)
+}
+
+func TestBuildDataPlaneContext_NilReturnsZero(t *testing.T) {
+	dpCtx := BuildDataPlaneContext(nil)
+	assert.Empty(t, dpCtx.SecretStore)
+	assert.Nil(t, dpCtx.Gateway)
+	assert.Nil(t, dpCtx.ObservabilityPlaneRef)
+}

--- a/internal/pipeline/project/types.go
+++ b/internal/pipeline/project/types.go
@@ -45,6 +45,17 @@ type RenderInput struct {
 	// ${metadata.*}. Must include Namespace; the mandated Namespace template
 	// renders against it as metadata.name = ${metadata.namespace}.
 	Metadata MetadataContext
+
+	// DataPlane is the controller-computed dataplane surface exposed to CEL
+	// as ${dataplane.*}. Built from the DataPlane the binding resolves via
+	// BuildDataPlaneContext.
+	DataPlane DataPlaneContext
+
+	// Environment is the controller-computed per-environment surface exposed
+	// to CEL as ${environment.*}. Gateway carries the merged effective
+	// gateway (environment-or-dataplane fallback at each leaf) for templates
+	// that emit cell egress NetworkPolicies / routing against the gateway.
+	Environment EnvironmentContext
 }
 
 // RenderOutput carries the rendered manifests in spec order. ForEach
@@ -106,7 +117,85 @@ type MetadataContext struct {
 // BaseContext is the top-level CEL surface produced by buildBaseContext and
 // fed into the template engine.
 type BaseContext struct {
-	Metadata           MetadataContext `json:"metadata"`
-	Parameters         map[string]any  `json:"parameters"`
-	EnvironmentConfigs map[string]any  `json:"environmentConfigs"`
+	Metadata           MetadataContext    `json:"metadata"`
+	Parameters         map[string]any     `json:"parameters"`
+	EnvironmentConfigs map[string]any     `json:"environmentConfigs"`
+	DataPlane          DataPlaneContext   `json:"dataplane"`
+	Environment        EnvironmentContext `json:"environment"`
+	// Gateway is the effective gateway (Environment.Gateway, which itself is
+	// env-or-dp merged) exposed at the top level for terseness:
+	// ${gateway.egress.external.https.host} is identical to
+	// ${environment.gateway.egress.external.https.host}.
+	//
+	// Templates that may evaluate against a missing gateway must guard via
+	// has(environment.gateway) — has(gateway) is invalid CEL because the
+	// top-level alias is omitted from the marshaled map when nil.
+	Gateway *GatewayData `json:"gateway,omitempty"`
+}
+
+// DataPlaneContext is the dataplane surface exposed to CEL templates as
+// ${dataplane.*}. Optional fields use omitempty so templates can guard with
+// has(...) — mirrors the resource pipeline's contract.
+type DataPlaneContext struct {
+	// SecretStore is the name of the ESO ClusterSecretStore configured on the
+	// DataPlane. ProjectTypes emitting a shared-cell ExternalSecret reference
+	// this.
+	SecretStore string `json:"secretStore,omitempty"`
+
+	// Gateway is the raw DataPlane-level gateway configuration. Nil when the
+	// DataPlane has no gateway configured. The effective gateway used by most
+	// templates is the merged Environment-or-DataPlane value exposed at the
+	// top-level ${gateway.*} and on ${environment.gateway.*}.
+	Gateway *GatewayData `json:"gateway,omitempty"`
+
+	// ObservabilityPlaneRef is the observability plane reference for
+	// ProjectTypes that emit observability-plane-side resources. Optional; nil
+	// when the DataPlane has no observability plane configured. Templates that
+	// reference ${dataplane.observabilityPlaneRef.*} must guard with
+	// has(dataplane.observabilityPlaneRef).
+	ObservabilityPlaneRef *ObservabilityPlaneRefContext `json:"observabilityPlaneRef,omitempty"`
+}
+
+// EnvironmentContext is the per-environment surface exposed to CEL templates
+// as ${environment.*}. Gateway carries the merged effective gateway:
+// environment-level overrides take precedence, falling back to dataplane-level
+// values at each leaf. Mirrors the resource pipeline's EnvironmentContext.
+type EnvironmentContext struct {
+	Gateway *GatewayData `json:"gateway,omitempty"`
+}
+
+// GatewayData provides gateway configuration in templates.
+type GatewayData struct {
+	Ingress *GatewayNetworkData `json:"ingress,omitempty"`
+	Egress  *GatewayNetworkData `json:"egress,omitempty"`
+}
+
+// GatewayNetworkData provides traffic gateway data for ingress/egress in
+// templates.
+type GatewayNetworkData struct {
+	External *GatewayEndpointData `json:"external,omitempty"`
+	Internal *GatewayEndpointData `json:"internal,omitempty"`
+}
+
+// GatewayEndpointData provides endpoint data for a gateway in templates.
+type GatewayEndpointData struct {
+	Name      string               `json:"name,omitempty"`
+	Namespace string               `json:"namespace,omitempty"`
+	HTTP      *GatewayListenerData `json:"http,omitempty"`
+	HTTPS     *GatewayListenerData `json:"https,omitempty"`
+	TLS       *GatewayListenerData `json:"tls,omitempty"`
+}
+
+// GatewayListenerData provides listener data for a gateway in templates.
+type GatewayListenerData struct {
+	ListenerName string `json:"listenerName,omitempty"`
+	Port         int32  `json:"port,omitempty"`
+	Host         string `json:"host,omitempty"`
+}
+
+// ObservabilityPlaneRefContext is the {kind, name} reference exposed under
+// ${dataplane.observabilityPlaneRef.*}.
+type ObservabilityPlaneRefContext struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
 }


### PR DESCRIPTION
## Purpose

The project release-lifecycle CEL pipeline (`ProjectType` → `Project` → `ProjectReleaseBinding` → `RenderedRelease`) only exposed `${metadata.*}`, `${parameters.*}`, and `${environmentConfigs.*}` to `(Cluster)ProjectType.spec.resources` templates. The component and resource pipelines already expose the richer `dataplane` and `gateway` surfaces, and the project binding controller already resolves the `DataPlane` and `Environment` — it just discarded their specs after harvesting names/UIDs.

This blocks project-scoped (cell) templates that need:
- the ESO secret store for a shared-cell `ExternalSecret` (`${dataplane.secretStore}`)
- the egress gateway location for cell egress NetworkPolicies / routing (`${gateway.egress.*}`)
- the observability plane ref for project-scoped alert/dashboard resources

## Approach

Mirror the resource pipeline (the closest sibling) rather than sharing a package — component and resource already each carry their own copy of these types, so this follows the established convention with zero blast radius on shipped pipelines.

- Add `DataPlaneContext` / `EnvironmentContext` (+ gateway data types) to `internal/pipeline/project/types.go` and a new `gateway.go` with pure `BuildDataPlaneContext` / `BuildEnvironmentContext` conversions (copied from `internal/pipeline/resource/gateway.go`).
- Thread them through `RenderInput` → `buildBaseContext`, exposing:
  - `${dataplane.secretStore}`, `${dataplane.observabilityPlaneRef.*}`, `${dataplane.gateway.*}`
  - `${environment.gateway.*}` (env-over-dataplane merged at each leaf)
  - `${gateway.*}` — top-level alias of the effective environment gateway (guard with `has(environment.gateway)`)
- Wire it in at `renderAndEmit` from the already-fetched CRDs — no new API calls, no signature changes.
- Update the `ProjectType.spec.resources` doc comment and regenerate the `projecttypes` / `projectreleases` CRD descriptions.

## Related Issues

_None._

## Checklist
- [x] Tests added or updated (unit, integration, etc.) — new cases for dataplane/secretStore, raw vs. effective gateway, env-over-dataplane merge precedence, and the nil-gateway `has()` guard
- [ ] Samples updated (if applicable) — intentionally deferred; an egress/secretStore example in the sample `ClusterProjectType` will land in a follow-up
- [ ] Added `backport/<release-branch>` label if this should be backported


