### PR TITLE
test: fix flaky e2e override locator in ui tests

### DIFF
--- a/test/e2e/suites/connections/connections_test.go
+++ b/test/e2e/suites/connections/connections_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -39,7 +40,9 @@ var _ = Describe("Connection Resolution", Ordered, Label("tier1"), func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(reason).To(Equal(expectedReason),
 				"expected condition %s reason=%s on ReleaseBinding %s", condType, expectedReason, rbName)
-		}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		}, 3*time.Minute, 2*time.Second).Should(Succeed(), func() string {
+			return releaseBindingDiagnostics(namespace, rbName)
+		})
 	}
 
 	// assertRBCondition checks a ReleaseBinding condition in cpNs via jsonpath.
@@ -57,7 +60,9 @@ var _ = Describe("Connection Resolution", Ordered, Label("tier1"), func() {
 			g.Expect(err).NotTo(HaveOccurred(), "failed to get condition %s on ReleaseBinding %s", condType, rbName)
 			g.Expect(status).To(Equal(expectedStatus),
 				"expected condition %s status=%s on ReleaseBinding %s", condType, expectedStatus, rbName)
-		}, 3*time.Minute, 2*time.Second).Should(Succeed())
+		}, 3*time.Minute, 2*time.Second).Should(Succeed(), func() string {
+			return releaseBindingDiagnostics(cpNs, rbName)
+		})
 	}
 
 	// assertRBEndpointServiceURL checks that a ReleaseBinding endpoint has a serviceURL.
@@ -404,4 +409,41 @@ func getReleaseBindingStatusInNs(g Gomega, namespace, rbName string) openchoreov
 	var rb openchoreov1alpha1.ReleaseBinding
 	g.Expect(json.Unmarshal([]byte(output), &rb)).To(Succeed(), "failed to unmarshal ReleaseBinding %s", rbName)
 	return rb.Status
+}
+
+// releaseBindingDiagnostics returns a human-readable dump of every condition on a
+// ReleaseBinding (type/status/reason/message) plus its recent events. It is meant
+// to be passed as the lazily-evaluated failure description of a condition
+// assertion so that a timeout reports the full picture — not just the single
+// condition that was being polled (e.g. Ready=False with no reason).
+func releaseBindingDiagnostics(namespace, rbName string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n--- diagnostics for releasebinding %s/%s ---\n", namespace, rbName)
+
+	conditions, err := framework.Kubectl(
+		kubeContext,
+		"get", "releasebinding", rbName,
+		"-n", namespace,
+		"-o", `jsonpath={range .status.conditions[*]}{.type}={.status} (reason={.reason}, message={.message}){"\n"}{end}`,
+	)
+	if err != nil {
+		fmt.Fprintf(&b, "failed to read conditions: %v\n", err)
+	} else {
+		fmt.Fprintf(&b, "conditions:\n%s\n", conditions)
+	}
+
+	events, err := framework.Kubectl(
+		kubeContext,
+		"get", "events",
+		"-n", namespace,
+		"--field-selector", "involvedObject.name="+rbName,
+		"--sort-by", ".lastTimestamp",
+	)
+	if err != nil {
+		fmt.Fprintf(&b, "failed to read events: %v\n", err)
+	} else {
+		fmt.Fprintf(&b, "events:\n%s\n", events)
+	}
+
+	return b.String()
 }

--- a/test/ui/po/overrides.ts
+++ b/test/ui/po/overrides.ts
@@ -65,6 +65,7 @@ export class OverridesPO {
   // envNameField(). The action is matched by its exact accessible name so the
   // click can never resolve to another row's button.
   async startOverrideInheritedEnv(name: string): Promise<void> {
+    await this.cancelAnyOpenEditor();
     await this.envCard(name)
       .getByRole('button', {
         name: 'Override environment variable',

--- a/test/ui/po/overrides.ts
+++ b/test/ui/po/overrides.ts
@@ -60,34 +60,58 @@ export class OverridesPO {
 
   // ── Override inherited entries ──────────────────────────────────────
 
+  // Begin overriding an inherited env var without filling anything. Splitting
+  // this out lets callers assert on the resulting (locked) editor fields — see
+  // envNameField(). The action is matched by its exact accessible name so the
+  // click can never resolve to another row's button.
+  async startOverrideInheritedEnv(name: string): Promise<void> {
+    await this.envCard(name)
+      .getByRole('button', {
+        name: 'Override environment variable',
+        exact: true,
+      })
+      .click();
+  }
+
   async overrideInheritedEnv(
     name: string,
     newValue: string,
   ): Promise<void> {
-    const card = this.envCard(name);
-    await card
-      .getByRole('button', { name: 'Override' })
-      .click();
+    await this.startOverrideInheritedEnv(name);
     const valueField = this.page.getByLabel('Value', { exact: true }).last();
     await valueField.clear();
     await valueField.fill(newValue);
     await this.clickApply();
   }
 
+  // Begin overriding an inherited file mount without filling anything.
+  async startOverrideInheritedFile(fileName: string): Promise<void> {
+    await this.cancelAnyOpenEditor();
+    await this.fileCard(fileName)
+      .getByRole('button', { name: 'Override file mount', exact: true })
+      .click();
+  }
+
   async overrideInheritedFile(
     fileName: string,
     newContent: string,
   ): Promise<void> {
-    await this.cancelAnyOpenEditor();
-    const card = this.fileCard(fileName);
-    await card
-      .getByRole('button', { name: 'Override' })
-      .click();
+    await this.startOverrideInheritedFile(fileName);
     const content = this.page.getByLabel(/^(Edit )?Content$/).last();
     await content.scrollIntoViewIfNeeded();
     await content.clear();
     await content.fill(newContent);
     await this.clickApply();
+  }
+
+  // The locked Name/File Name fields of the currently open editor. Only one row
+  // is ever editable at a time, so these resolve to a single field.
+  envNameField(): Locator {
+    return this.page.getByLabel('Name', { exact: true });
+  }
+
+  fileNameField(): Locator {
+    return this.page.getByLabel('File Name', { exact: true });
   }
 
   // ── Add new override entries ───────────────────────────────────────
@@ -155,8 +179,7 @@ export class OverridesPO {
     await this.cancelAnyOpenEditor();
     const card = this.envCard(name);
     await card
-      .getByRole('button', { name: 'Edit' })
-      .first()
+      .getByRole('button', { name: 'Edit environment variable', exact: true })
       .click();
     const valueField = this.page.getByLabel('Value', { exact: true }).last();
     await valueField.clear();
@@ -172,8 +195,7 @@ export class OverridesPO {
     const card = this.fileCard(fileName);
     await card.scrollIntoViewIfNeeded();
     await card
-      .getByRole('button', { name: 'Edit' })
-      .first()
+      .getByRole('button', { name: 'Edit file mount', exact: true })
       .click();
     await this.page
       .getByRole('button', { name: 'Save changes' })
@@ -241,28 +263,25 @@ export class OverridesPO {
 
   // ── Private helpers ────────────────────────────────────────────────
 
+  // The row card for a single entry, identified by its exact name/key.
+  //
+  // The row's action buttons (Override/Edit/Delete) live in a sibling of the
+  // element that renders the name, so the tightest container holding both is the
+  // *nearest* ancestor <div> that contains a button. `[1]` on the reverse-order
+  // XPath ancestor axis selects exactly that nearest ancestor — one row, no
+  // filtering and no `.last()` climbing to an outer container that wraps
+  // multiple rows (which previously matched several action buttons at once and
+  // tripped Playwright strict mode).
   private envCard(name: string): Locator {
     return this.page
       .getByText(name, { exact: true })
-      .locator('xpath=ancestor::div[.//button]')
-      .filter({
-        has: this.page.getByRole('button', {
-          name: /^(edit|override|remove environment variable)$/i,
-        }),
-      })
-      .last();
+      .locator('xpath=ancestor::div[.//button][1]');
   }
 
   private fileCard(fileName: string): Locator {
     return this.page
       .getByText(fileName, { exact: true })
-      .locator('xpath=ancestor::div[.//button]')
-      .filter({
-        has: this.page.getByRole('button', {
-          name: /^(edit|override|remove file mount)$/i,
-        }),
-      })
-      .last();
+      .locator('xpath=ancestor::div[.//button][1]');
   }
 
   async cancelAnyOpenEditor(): Promise<void> {

--- a/test/ui/specs/config/component-config-edits.spec.ts
+++ b/test/ui/specs/config/component-config-edits.spec.ts
@@ -489,20 +489,8 @@ test.describe('component config edits through Backstage UI', () => {
     await overrides.openWorkloadTab();
 
     // Override inherited env var — Name must be disabled.
-    const envCard = page
-      .getByText('GREETING_PREFIX', { exact: true })
-      .locator('xpath=ancestor::div[.//button]')
-      .filter({
-        has: page.getByRole('button', {
-          name: /^(edit|override|remove environment variable)$/i,
-        }),
-      })
-      .last();
-    await envCard
-      .getByRole('button', { name: 'Override' })
-      .click();
-    const envNameField = page.getByLabel('Name', { exact: true }).last();
-    await expect(envNameField).toBeDisabled();
+    await overrides.startOverrideInheritedEnv('GREETING_PREFIX');
+    await expect(overrides.envNameField()).toBeDisabled();
 
     const envValueField = page.getByLabel('Value', { exact: true }).last();
     await envValueField.clear();
@@ -510,23 +498,8 @@ test.describe('component config edits through Backstage UI', () => {
     await overrides.clickApply();
 
     // Override inherited file mount — File Name must be disabled.
-    await overrides.cancelAnyOpenEditor();
-    const fileCard = page
-      .getByText('app.properties', { exact: true })
-      .locator('xpath=ancestor::div[.//button]')
-      .filter({
-        has: page.getByRole('button', {
-          name: /^(edit|override|remove file mount)$/i,
-        }),
-      })
-      .last();
-    await fileCard
-      .getByRole('button', { name: 'Override' })
-      .click();
-    const fileNameField = page
-      .getByLabel('File Name', { exact: true })
-      .last();
-    await expect(fileNameField).toBeDisabled();
+    await overrides.startOverrideInheritedFile('app.properties');
+    await expect(overrides.fileNameField()).toBeDisabled();
 
     const expandBtn = page.getByRole('button', { name: /expand content/i });
     if (await expandBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

## Approach
Root cause: OverridesPO.envCard/fileCard selected the row via
`ancestor::div[.//button]` + a `filter({ has: /^(edit|override|remove …)$/ })`
+ `.last()`. An inherited row's action carries the accessible name
"Override environment variable" (the aria-label, not the visible "Override"),
which the anchored filter never matches, and inherited rows render with no
Delete button. With nothing on the row itself matching, the locator climbed to
a shared ancestor wrapping every inherited row, so `Override` resolved to
multiple buttons whenever ≥2 inherited vars existed. The merge logic guarantees
one row per key, so this is a test-locator defect, not a duplicate-row bug.

Fixes:
- overrides.ts: scope rows to the nearest button-bearing ancestor
  (`ancestor::div[.//button][1]`) — exactly one row, no filter/.last(). Match
  actions by exact accessible name (Override/Edit environment variable, file
  mount). Add startOverrideInherited{Env,File} + {env,file}NameField accessors.
- component-config-edits.spec.ts: use the page object instead of a duplicated
  inline XPath chain; behavioral assertions unchanged.
- connections_test.go: on a ReleaseBinding condition timeout, lazily dump all
  conditions (reason+message) and events so a future tier-1 failure reports the
  full state instead of only Ready=False. No timeout/retry changes.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4043

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
