### PR TITLE
docs: add AI-assisted contribution policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,8 @@ See: docs/contributors/github_workflow.md#pr-title-convention
 - [ ] Tests added or updated (unit, integration, etc.)
 - [ ] Samples updated (if applicable)
 - [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
+<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
+- [ ] This PR includes AI-generated code or content
 
 ## Remarks
 > Add any additional context, known issues, or TODOs related to this PR.

--- a/docs/contributors/AI-POLICY.md
+++ b/docs/contributors/AI-POLICY.md
@@ -1,0 +1,40 @@
+# OpenChoreo AI Policy
+
+This policy covers the use of AI tools (GitHub Copilot, Claude, ChatGPT,
+and similar) when contributing to OpenChoreo. It applies to code, documentation,
+issues, and review discussion. AI is welcome here, and we use it ourselves,
+including CodeRabbit for first-pass review; the goal is to set clear expectations,
+not to discourage AI use.
+
+## Using AI tools
+
+You can use AI tools anywhere in your contribution: code, tests, docs, or design.
+There's no restriction on the kind or size of the work, as long as you meet these
+conditions:
+
+- You review, understand, and test the output before you submit it.
+- You can explain and justify any change during review.
+- You take full ownership of it, the same as if you had written it by hand,
+  design decisions included.
+- It meets the project's quality and licensing standards.
+- You communicate in your own words, in reviews, issues, and discussion. Using AI
+  to help you express or translate your own thinking is fine; having it speak for
+  you is not.
+
+## Disclosure in pull requests
+
+Check the AI-assistance box in the pull request template if AI generated code or
+content in your change. Smaller help, like autocomplete or asking AI to explain
+code, doesn't need to be disclosed.
+
+This helps reviewers know to watch for the ways AI-generated code tends to go
+wrong, such as incorrect logic, made-up APIs, or missed edge cases,
+and it keeps a clear record of how the change was produced.
+
+## Licensing and the DCO
+
+Every commit must be signed off under the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). AI tools can reproduce code from
+their training data, so by signing off you are certifying that you have the right
+to submit the content under the project's license. If you're unsure where
+something came from, don't submit it. Refer to the Linux Foundation [Guidance
+Regarding Use of Generative AI Tools](https://www.linuxfoundation.org/legal/generative-ai) for additional details.

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -8,6 +8,7 @@ Before you start contributing, check out our guidelines:
 
 - **[Contribution Guide](./contribute.md)** – Learn how to setup the development environment, make changes, and submit pull requests.
 - **[GitHub Workflow](./github_workflow.md)** – Understand our GitHub workflow for submitting pull requests.
+- **[AI Policy](./AI-POLICY.md)** – Expectations for using AI tools (Copilot, Claude, ChatGPT, and similar) when contributing.
 - **[Release Guide](./release.md)** – Guide to releasing a new version of OpenChoreo.
 - **[Resource Kind Reference Guide](./../resource-kind-reference-guide.md)** – Get details about resource kinds in OpenChoreo.
 


### PR DESCRIPTION
## Purpose

Adds a policy for AI-assisted contributions so the human author stays responsible for the quality of anything produced with AI help. The motivation is the growing number of low-effort, unreviewed AI outputs (hallucinated code, template-skipping PRs, vague titles, thin tests) that shift the review burden onto maintainers. The policy is not meant to discourage AI use; it sets clear expectations for it.

The content was proposed and agreed on in discussion openchoreo/openchoreo#3926.

## Approach

- Add `docs/contributors/AI-POLICY.md` covering the conditions for using AI tools, when to disclose AI assistance in PRs, and licensing/DCO expectations.
- Link the policy from the contributor guide index (`docs/contributors/README.md`).
- Add a disclosure checkbox to the pull request template so authors can flag when a PR includes AI-generated code or content.

## Related Issues

Related openchoreo/openchoreo#3926.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content