### PR TITLE
feat(helm): add Backstage cookie session affinity for exec across replicas

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/httproute.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/httproute.yaml
@@ -49,6 +49,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.backstage.http.sessionPersistence.enabled }}
+      # Pin each browser to one Backstage replica so the two-request exec
+      # handshake (POST /exec/init then WS /exec/ws) lands on the same pod when
+      # the Deployment is scaled out (the exec session is held in-process).
+      sessionPersistence:
+        type: Cookie
+        sessionName: {{ .Values.backstage.http.sessionPersistence.sessionName | quote }}
+        cookieConfig:
+          lifetimeType: Session
+      {{- end }}
       backendRefs:
         - name: {{ include "openchoreo-control-plane.backstage.name" . }}
           port: {{ .Values.backstage.service.port }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -636,6 +636,26 @@
               },
               "title": "hostnames",
               "type": "array"
+            },
+            "sessionPersistence": {
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Pin each browser to one Backstage replica via cookie session persistence on the catch-all route, so the exec terminal's init+ws handshake lands on the same pod when scaled out",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "sessionName": {
+                  "default": "openchoreo-backstage-session",
+                  "description": "Name of the session-persistence cookie",
+                  "title": "sessionName",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "sessionPersistence",
+              "type": "object"
             }
           },
           "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2997,6 +2997,23 @@ backstage:
     # @schema
     hostnames:
       - openchoreo.invalid
+    # @schema
+    # type: object
+    # required: false
+    # @schema
+    sessionPersistence:
+      # @schema
+      # type: boolean
+      # description: Pin each browser to one Backstage replica via cookie session persistence on the catch-all route, so the exec terminal's init+ws handshake lands on the same pod when scaled out
+      # default: true
+      # @schema
+      enabled: true
+      # @schema
+      # type: string
+      # description: Name of the session-persistence cookie
+      # default: openchoreo-backstage-session
+      # @schema
+      sessionName: openchoreo-backstage-session
   # @schema
   # type: array
   # description: Topology spread constraints


### PR DESCRIPTION
## Purpose
The component exec terminal authenticates over two requests: `POST /api/openchoreo/exec/init` (mints a short-lived session, held in-process) followed by a `WS /api/openchoreo/exec/ws?sessionId=` upgrade that consumes it. The Backstage Deployment ships with an HPA (+ PDB), so under scale-out the two requests can land on **different replicas** — the upgrade then misses the in-process session and the terminal fails intermittently (`Invalid or expired session`).

## Approach
Add Gateway-API cookie **session persistence** (`type: Cookie`, `lifetimeType: Session`) to the catch-all `/` rule of the Backstage `HTTPRoute`, so a browser sticks to one Backstage replica and the `init` + `ws` handshake lands on the same pod. kgateway (the configured gateway class) supports the native `httproutes.spec.rules.sessionPersistence` field.

- `templates/backstage/httproute.yaml`: `sessionPersistence` on the `/` rule, gated by a value.
- `values.yaml`: new `backstage.http.sessionPersistence` (`enabled: true`, `sessionName`).
- `values.schema.json`: regenerated via `helm-schema`.

Service-level `sessionAffinity: ClientIP` was intentionally **not** used — traffic goes through the gateway, so it would key on the gateway's source IP, not the browser's. This makes the current in-process session store correct under scale-out with no new infra (a shared store remains a possible future hardening).

## Related Issues
_N/A_

## Checklist
- [ ] Tests added or updated (helm chart change — validated via `helm lint` + `helm template`)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
- Validated: `helm lint` passes; `helm template` renders `sessionPersistence` on the `/` rule when enabled and omits it when disabled.
- Runtime verification still pending: with `backstage` scaled to ≥2 replicas, confirm exec is consistent and `init`/`ws` hit the same pod (`Set-Cookie` present).
- Fallback if a cluster's kgateway build doesn't honor `sessionPersistence`: a kgateway `BackendConfigPolicy` with `ringHash` consistent hashing.
- Opened as **draft** pending my own review.
