### PR TITLE
fix(controller): cascade Resource deletions and surface precise finalize statuses (backport to release-v1.1)

### DIFF
--- a/internal/controller/project/controller_finalize.go
+++ b/internal/controller/project/controller_finalize.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -51,8 +52,11 @@ func (r *Reconciler) finalize(ctx context.Context, old, project *openchoreov1alp
 
 	// Mark the project condition as finalizing and return so that the project will indicate that it is being finalized.
 	// The actual finalization will be done in the next reconcile loop triggered by the status update.
-	if meta.SetStatusCondition(&project.Status.Conditions, NewProjectFinalizingCondition(project.Generation)) {
-		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, project)
+	cond := meta.FindStatusCondition(project.Status.Conditions, string(ConditionFinalizing))
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		if meta.SetStatusCondition(&project.Status.Conditions, NewProjectFinalizingCondition(project.Generation)) {
+			return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, project)
+		}
 	}
 
 	// Perform cleanup logic for deployment tracks
@@ -66,6 +70,9 @@ func (r *Reconciler) finalize(ctx context.Context, old, project *openchoreov1alp
 	// If deletion is still in progress, check in next cycle
 	if !artifactsDeleted {
 		logger.Info("Child resources are still being deleted", "name", project.Name)
+		if controller.MarkTrueCondition(project, ConditionFinalizing, ReasonProjectFinalizing, "Waiting for child resources to be deleted") {
+			return controller.UpdateStatusConditionsAndRequeueAfter(ctx, r.Client, old, project, time.Second*5)
+		}
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
@@ -89,8 +96,16 @@ func (r *Reconciler) deleteChildAndLinkedResources(ctx context.Context, project 
 		logger.Error(err, "Failed to delete components")
 		return false, err
 	}
-	if !componentsDeleted {
-		logger.Info("Components are still being deleted", "name", project.Name)
+
+	// Clean up resources
+	resourcesDeleted, err := r.deleteResourcesAndWait(ctx, project)
+	if err != nil {
+		logger.Error(err, "Failed to delete resources")
+		return false, err
+	}
+
+	if !componentsDeleted || !resourcesDeleted {
+		logger.Info("Children are still being deleted", "name", project.Name)
 		return false, nil
 	}
 
@@ -135,6 +150,36 @@ func (r *Reconciler) deleteComponentsAndWait(ctx context.Context, project *openc
 		component := &componentsList.Items[i]
 		if err := client.IgnoreNotFound(r.Delete(ctx, component)); err != nil {
 			return false, fmt.Errorf("failed to delete component %s: %w", component.Name, err)
+		}
+	}
+
+	return false, nil
+}
+
+// deleteResourcesAndWait checks if any Resources owned by this Project still exist,
+// and deletes them if they exist.
+func (r *Reconciler) deleteResourcesAndWait(ctx context.Context, project *openchoreov1alpha1.Project) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("project", project.Name)
+
+	// List Resources owned by this Project using shared field index
+	resourcesList := &openchoreov1alpha1.ResourceList{}
+	if err := r.List(ctx, resourcesList,
+		client.InNamespace(project.Namespace),
+		client.MatchingFields{controller.IndexKeyResourceOwnerProjectName: project.Name}); err != nil {
+		return false, fmt.Errorf("failed to list resources: %w", err)
+	}
+
+	if len(resourcesList.Items) == 0 {
+		logger.Info("All resources are deleted")
+		return true, nil
+	}
+
+	// Delete all Resources owned by this Project
+	logger.Info("Deleting owned Resources", "count", len(resourcesList.Items))
+	for i := range resourcesList.Items {
+		resource := &resourcesList.Items[i]
+		if err := client.IgnoreNotFound(r.Delete(ctx, resource)); err != nil {
+			return false, fmt.Errorf("failed to delete resource %s: %w", resource.Name, err)
 		}
 	}
 

--- a/internal/controller/project/controller_integration_test.go
+++ b/internal/controller/project/controller_integration_test.go
@@ -693,9 +693,6 @@ var _ = Describe("Project Controller", func() {
 					DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{
 						Name: pipName,
 					},
-					Type: openchoreov1alpha1.ProjectTypeRef{
-						Name: "default",
-					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, project)).To(Succeed())

--- a/internal/controller/project/controller_integration_test.go
+++ b/internal/controller/project/controller_integration_test.go
@@ -578,6 +578,24 @@ var _ = Describe("Project Controller", func() {
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 
+			By("Creating an owned Resource")
+			resource := &openchoreov1alpha1.Resource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "it-lifecycle-res",
+					Namespace: nsName,
+				},
+				Spec: openchoreov1alpha1.ResourceSpec{
+					Owner: openchoreov1alpha1.ResourceOwner{
+						ProjectName: projName,
+					},
+					Type: openchoreov1alpha1.ResourceTypeRef{
+						Kind: openchoreov1alpha1.ResourceTypeRefKindResourceType,
+						Name: "some-type",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
 			By("Deleting project")
 			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
 
@@ -593,12 +611,9 @@ var _ = Describe("Project Controller", func() {
 			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Reconcile again: completes finalization")
-			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
-			Expect(err).NotTo(HaveOccurred())
-
 			By("Verifying project is fully deleted")
 			Eventually(func() bool {
+				_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 				return errors.IsNotFound(k8sClient.Get(ctx, nn, &openchoreov1alpha1.Project{}))
 			}, itTimeout, itInterval).Should(BeTrue())
 		})
@@ -652,4 +667,91 @@ var _ = Describe("Project Controller", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 	})
+
+	Context("Finalization with owned Resources", func() {
+		const (
+			nsName   = "it-finalize-res-ns"
+			dpName   = "it-finalize-res-dp"
+			envName  = "it-finalize-res-env"
+			pipName  = "it-finalize-res-pip"
+			projName = "it-finalize-res-proj"
+		)
+
+		nn := types.NamespacedName{Name: projName, Namespace: nsName}
+
+		BeforeEach(func() {
+			setupDependencies(nsName, dpName, envName, pipName)
+		})
+
+		It("should delete owned Resources when Project is deleted", func() {
+			project := &openchoreov1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      projName,
+					Namespace: nsName,
+				},
+				Spec: openchoreov1alpha1.ProjectSpec{
+					DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{
+						Name: pipName,
+					},
+					Type: openchoreov1alpha1.ProjectTypeRef{
+						Name: "default",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+
+			r := itReconciler()
+
+			// Reconcile project to add finalizer
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile project to set Created condition
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create owned Resource
+			resource := &openchoreov1alpha1.Resource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "it-finalize-res-resource",
+					Namespace: nsName,
+				},
+				Spec: openchoreov1alpha1.ResourceSpec{
+					Owner: openchoreov1alpha1.ResourceOwner{
+						ProjectName: projName,
+					},
+					Type: openchoreov1alpha1.ResourceTypeRef{
+						Kind: openchoreov1alpha1.ResourceTypeRefKindResourceType,
+						Name: "some-type",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			// Wait for resource to be visible in cache/client
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: "it-finalize-res-resource", Namespace: nsName}, &openchoreov1alpha1.Resource{})
+			}, itTimeout, itInterval).Should(Succeed())
+
+			// Delete the Project
+			updated := &openchoreov1alpha1.Project{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, updated)).To(Succeed())
+
+			// Verify the owned Resource is deleted
+			Eventually(func() bool {
+				_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "it-finalize-res-resource", Namespace: nsName}, &openchoreov1alpha1.Resource{})
+				return errors.IsNotFound(err)
+			}, itTimeout, itInterval).Should(BeTrue())
+
+			// Verify the project is deleted
+			Eventually(func() bool {
+				_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				err := k8sClient.Get(ctx, nn, &openchoreov1alpha1.Project{})
+				return errors.IsNotFound(err)
+			}, itTimeout, itInterval).Should(BeTrue())
+		})
+	})
+
 })

--- a/internal/controller/project/suite_test.go
+++ b/internal/controller/project/suite_test.go
@@ -67,9 +67,10 @@ var _ = BeforeSuite(func() {
 			BindAddress: "0", // Disable metrics server in tests
 		},
 		Cache: cache.Options{
-			// Only cache Component type (required for field index queries)
+			// Only cache Component and Resource type (required for field index queries)
 			ByObject: map[client.Object]cache.ByObject{
 				&openchoreov1alpha1.Component{}: {},
+				&openchoreov1alpha1.Resource{}:  {},
 			},
 			DefaultNamespaces: map[string]cache.Config{},
 		},
@@ -95,6 +96,16 @@ var _ = BeforeSuite(func() {
 				return nil
 			}
 			return []string{component.Spec.Owner.ProjectName}
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Resource{},
+		controller.IndexKeyResourceOwnerProjectName, func(obj client.Object) []string {
+			resource := obj.(*openchoreov1alpha1.Resource)
+			if resource.Spec.Owner.ProjectName == "" {
+				return nil
+			}
+			return []string{resource.Spec.Owner.ProjectName}
 		})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/resource/controller_finalize.go
+++ b/internal/controller/resource/controller_finalize.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -65,16 +68,25 @@ func (r *Reconciler) finalize(ctx context.Context, old, res *openchoreov1alpha1.
 	// deferred whole-status writer used by reconcile: every exit path either
 	// sets exactly one condition (Finalizing) and persists immediately, or
 	// sets nothing.
-	if meta.SetStatusCondition(&res.Status.Conditions, NewFinalizingCondition(res.Generation)) {
-		return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, res)
+	cond := meta.FindStatusCondition(res.Status.Conditions, string(ConditionFinalizing))
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		if meta.SetStatusCondition(&res.Status.Conditions, NewFinalizingCondition(res.Generation)) {
+			return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, res)
+		}
 	}
 
-	hasBindings, err := r.hasOwnedResourceReleaseBindings(ctx, res)
+	hasBindings, err := r.deleteOwnedResourceReleaseBindingsAndWait(ctx, res)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if hasBindings {
 		logger.Info("Waiting for ResourceReleaseBindings to be deleted")
+		controller.MarkTrueCondition(res, ConditionFinalizing, ReasonFinalizing, "Waiting for ResourceReleaseBindings to be deleted")
+		if !equality.Semantic.DeepEqual(old.Status.Conditions, res.Status.Conditions) {
+			if err := controller.UpdateStatusConditions(ctx, r.Client, old, res); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{RequeueAfter: requeueWaitForChildren}, nil
 	}
 
@@ -83,6 +95,13 @@ func (r *Reconciler) finalize(ctx context.Context, old, res *openchoreov1alpha1.
 		return ctrl.Result{}, err
 	}
 	if deleted {
+		logger.Info("Waiting for ResourceReleases to be deleted")
+		controller.MarkTrueCondition(res, ConditionFinalizing, ReasonFinalizing, "Waiting for ResourceReleases to be deleted")
+		if !equality.Semantic.DeepEqual(old.Status.Conditions, res.Status.Conditions) {
+			if err := controller.UpdateStatusConditions(ctx, r.Client, old, res); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{RequeueAfter: requeueWaitForChildren}, nil
 	}
 
@@ -95,16 +114,62 @@ func (r *Reconciler) finalize(ctx context.Context, old, res *openchoreov1alpha1.
 	return ctrl.Result{}, nil
 }
 
-// hasOwnedResourceReleaseBindings returns true if any ResourceReleaseBinding in
-// the same namespace still references the given Resource.
-func (r *Reconciler) hasOwnedResourceReleaseBindings(ctx context.Context, res *openchoreov1alpha1.Resource) (bool, error) {
+// deleteOwnedResourceReleaseBindingsAndWait triggers deletion of every ResourceReleaseBinding
+// owned by the given Resource depending on its retention policy. Returns true if any
+// bindings still exist; the caller should requeue to wait for them to be deleted.
+func (r *Reconciler) deleteOwnedResourceReleaseBindingsAndWait(ctx context.Context, res *openchoreov1alpha1.Resource) (bool, error) {
 	bindings := &openchoreov1alpha1.ResourceReleaseBindingList{}
 	if err := r.List(ctx, bindings,
 		client.InNamespace(res.Namespace),
 		client.MatchingFields{controller.IndexKeyResourceReleaseBindingOwnerResourceName: res.Name}); err != nil {
 		return false, fmt.Errorf("list ResourceReleaseBindings: %w", err)
 	}
-	return len(bindings.Items) > 0, nil
+	if len(bindings.Items) == 0 {
+		return false, nil
+	}
+	for i := range bindings.Items {
+		binding := &bindings.Items[i]
+		if !binding.DeletionTimestamp.IsZero() {
+			continue
+		}
+		retain, err := r.effectiveRetainPolicy(ctx, binding)
+		if err != nil {
+			return false, fmt.Errorf("resolve effective retainPolicy for binding %s: %w", binding.Name, err)
+		}
+		if retain == openchoreov1alpha1.ResourceRetainPolicyRetain {
+			continue
+		}
+		if err := r.Delete(ctx, binding); err != nil {
+			return false, fmt.Errorf("delete ResourceReleaseBinding %s: %w", binding.Name, err)
+		}
+	}
+	return true, nil
+}
+
+// effectiveRetainPolicy resolves the policy in priority order:
+//  1. binding override (spec.retainPolicy)
+//  2. snapshot default (ResourceRelease.spec.resourceType.spec.retainPolicy)
+//  3. universal default (Delete)
+func (r *Reconciler) effectiveRetainPolicy(ctx context.Context, binding *openchoreov1alpha1.ResourceReleaseBinding) (openchoreov1alpha1.ResourceRetainPolicy, error) {
+	if binding.Spec.RetainPolicy != "" {
+		return binding.Spec.RetainPolicy, nil
+	}
+	if binding.Spec.ResourceRelease == "" {
+		return openchoreov1alpha1.ResourceRetainPolicyDelete, nil
+	}
+	rr := &openchoreov1alpha1.ResourceRelease{}
+	err := r.Get(ctx, client.ObjectKey{Name: binding.Spec.ResourceRelease, Namespace: binding.Namespace}, rr)
+	switch {
+	case err == nil:
+		if rr.Spec.ResourceType.Spec.RetainPolicy != "" {
+			return rr.Spec.ResourceType.Spec.RetainPolicy, nil
+		}
+		return openchoreov1alpha1.ResourceRetainPolicyDelete, nil
+	case apierrors.IsNotFound(err):
+		return openchoreov1alpha1.ResourceRetainPolicyDelete, nil
+	default:
+		return "", fmt.Errorf("get ResourceRelease %q: %w", binding.Spec.ResourceRelease, err)
+	}
 }
 
 // deleteOwnedResourceReleases triggers deletion of every ResourceRelease owned

--- a/internal/controller/resource/controller_finalize_test.go
+++ b/internal/controller/resource/controller_finalize_test.go
@@ -67,9 +67,13 @@ var _ = Describe("Finalizer", func() {
 		}
 	}
 
-	newBinding := func(name, ownerResource string) *openchoreov1alpha1.ResourceReleaseBinding {
+	newBinding := func(name, ownerResource string, withFinalizer bool) *openchoreov1alpha1.ResourceReleaseBinding {
+		om := metav1.ObjectMeta{Name: name, Namespace: "default"}
+		if withFinalizer {
+			om.Finalizers = []string{"test-keep"}
+		}
 		return &openchoreov1alpha1.ResourceReleaseBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			ObjectMeta: om,
 			Spec: openchoreov1alpha1.ResourceReleaseBindingSpec{
 				Owner: openchoreov1alpha1.ResourceReleaseBindingOwner{
 					ProjectName:  "p",
@@ -109,7 +113,7 @@ var _ = Describe("Finalizer", func() {
 
 	It("holds the finalizer while ResourceReleaseBindings reference the Resource", func() {
 		res := newRes("fin-block", true)
-		binding := newBinding("fin-block-binding", res.Name)
+		binding := newBinding("fin-block-binding", res.Name, true)
 		cli := buildClient(res, binding)
 		r := &Reconciler{Client: cli, Scheme: scheme.Scheme}
 
@@ -133,6 +137,10 @@ var _ = Describe("Finalizer", func() {
 		cond := meta.FindStatusCondition(updated.Status.Conditions, "Finalizing")
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+		updatedBinding := &openchoreov1alpha1.ResourceReleaseBinding{}
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(binding), updatedBinding)).To(Succeed())
+		Expect(updatedBinding.DeletionTimestamp).NotTo(BeNil())
 	})
 
 	It("is a no-op when the resource-cleanup finalizer is not present (already removed elsewhere)", func() {
@@ -178,5 +186,33 @@ var _ = Describe("Finalizer", func() {
 
 		err = cli.Get(finCtx, client.ObjectKeyFromObject(release), &openchoreov1alpha1.ResourceRelease{})
 		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "owned ResourceRelease should be deleted")
+	})
+
+	It("does not delete bindings and blocks when retainPolicy is Retain", func() {
+		res := newRes("fin-retain", true)
+		binding := newBinding("fin-retain-binding", res.Name, true)
+		binding.Spec.RetainPolicy = openchoreov1alpha1.ResourceRetainPolicyRetain
+		cli := buildClient(res, binding)
+		r := &Reconciler{Client: cli, Scheme: scheme.Scheme}
+
+		Expect(cli.Delete(finCtx, res)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(res)}
+
+		// 1st reconcile: finalize branch, sets Finalizing condition, returns.
+		_, err := r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		// 2nd reconcile: binding is Retain, should NOT call delete on it, and requeue.
+		result, err := r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+		updatedBinding := &openchoreov1alpha1.ResourceReleaseBinding{}
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(binding), updatedBinding)).To(Succeed())
+		Expect(updatedBinding.DeletionTimestamp).To(BeNil(), "binding should NOT have been deleted automatically under Retain policy")
+
+		updated := &openchoreov1alpha1.Resource{}
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(res), updated)).To(Succeed())
+		Expect(updated.Finalizers).To(ContainElement(ResourceFinalizer), "resource finalizer should still be blocked")
 	})
 })

--- a/internal/controller/watch.go
+++ b/internal/controller/watch.go
@@ -27,6 +27,9 @@ const (
 	// IndexKeyComponentOwnerProjectName indexes Component by owner project name.
 	IndexKeyComponentOwnerProjectName = "component.spec.owner.projectName"
 
+	// IndexKeyResourceOwnerProjectName indexes Resource by owner project name.
+	IndexKeyResourceOwnerProjectName = "resource.spec.owner.projectName"
+
 	// IndexKeyProjectDeploymentPipelineRef indexes Project by deploymentPipelineRef.
 	IndexKeyProjectDeploymentPipelineRef = "project.spec.deploymentPipelineRef"
 
@@ -97,6 +100,17 @@ func SetupSharedIndexes(ctx context.Context, mgr ctrl.Manager) error {
 			return []string{component.Spec.Owner.ProjectName}
 		}); err != nil {
 		return fmt.Errorf("failed to setup Component owner project index: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Resource{},
+		IndexKeyResourceOwnerProjectName, func(obj client.Object) []string {
+			resource := obj.(*openchoreov1alpha1.Resource)
+			if resource.Spec.Owner.ProjectName == "" {
+				return nil
+			}
+			return []string{resource.Spec.Owner.ProjectName}
+		}); err != nil {
+		return fmt.Errorf("failed to setup Resource owner project index: %w", err)
 	}
 
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.Project{},

--- a/internal/controller/watch_test.go
+++ b/internal/controller/watch_test.go
@@ -4,13 +4,81 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 )
+
+type mockIndexer struct {
+	client.FieldIndexer
+	indexFuncs map[string]client.IndexerFunc
+}
+
+func (m *mockIndexer) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	if m.indexFuncs == nil {
+		m.indexFuncs = make(map[string]client.IndexerFunc)
+	}
+	m.indexFuncs[field] = extractValue
+	return nil
+}
+
+type mockManager struct {
+	manager.Manager
+	indexer *mockIndexer
+}
+
+func (m *mockManager) GetFieldIndexer() client.FieldIndexer {
+	return m.indexer
+}
+
+func TestResourceOwnerProjectNameIndexer(t *testing.T) {
+	mgr := &mockManager{indexer: &mockIndexer{}}
+	err := SetupSharedIndexes(context.Background(), mgr)
+	require.NoError(t, err)
+
+	idxFunc := mgr.indexer.indexFuncs[IndexKeyResourceOwnerProjectName]
+	require.NotNil(t, idxFunc)
+
+	tests := []struct {
+		name     string
+		resource *openchoreov1alpha1.Resource
+		expected []string
+	}{
+		{
+			name: "with project name",
+			resource: &openchoreov1alpha1.Resource{
+				Spec: openchoreov1alpha1.ResourceSpec{
+					Owner: openchoreov1alpha1.ResourceOwner{
+						ProjectName: "test-project",
+					},
+				},
+			},
+			expected: []string{"test-project"},
+		},
+		{
+			name: "without project name",
+			resource: &openchoreov1alpha1.Resource{
+				Spec: openchoreov1alpha1.ResourceSpec{
+					Owner: openchoreov1alpha1.ResourceOwner{},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := idxFunc(tt.resource)
+			assert.Equal(t, tt.expected, res)
+		})
+	}
+}
 
 func TestIndexResourceReleaseBindingOwnerEnv(t *testing.T) {
 	t.Run("returns_composite_key_when_all_fields_set", func(t *testing.T) {


### PR DESCRIPTION
Backport of #3917 to `release-v1.1`.

## Original description

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

Currently, deleting a `Resource` with `retainPolicy: Delete` hangs in the `Terminating` state, as its finalizer fails to cascade the deletion to its `ResourceReleaseBinding`s. Additionally, deleting a `Project` does not cascade to its `Resource` objects, leaving them orphaned. This PR fixes the finalizer logic for both controllers to correctly trigger cleanup of dependent artifacts and prevents infinite loops when updating block statuses.

## Approach
> Summarize the solution and implementation details.
- **Resource Controller:** Replaced `hasOwnedResourceReleaseBindings` with `deleteOwnedResourceReleaseBindingsAndWait` to explicitly issue `Delete` calls on child bindings during finalization.
- **Project Controller:** Introduced a shared index (`IndexKeyResourceOwnerProjectName`) in the watch logic to enable rapid lookup of `Resource` objects owned by a `Project`. Added `deleteResourcesAndWait` to initiate deletion for all owned Resources alongside Components.
- **Status Conditions Fix:** Updated `Resource` and `Project` finalizers to ensure specific blocked statuses (e.g., `"Waiting for child resources to be deleted"`) are persisted correctly without being continuously overwritten by generic finalizing statuses, avoiding an infinite requeue loop.
- **Testing:** Updated `internal/controller/resource/controller_finalize_test.go` and `internal/controller/project/suite_test.go` to support the new cascades and test environments.

## Related Issues
> Include any related issues that are resolved by this PR.
Closes #3909

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
N/A

