### PR TITLE
fix: add notification channel view permission to backstage-catalog-reader

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1192,6 +1192,7 @@ openchoreoApi:
                 - "clusterprojecttype:view"
                 - "clustertrait:view"
                 - "clusterworkflow:view"
+                - "observabilityalertsnotificationchannel:view"
 
             # FinOps agent role for cost analysis and resource overprovisioning assessment
             - name: finops-agent


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The backstage-catalog-reader role (bound to the Backstage backend's service identity) is missing observabilityalertsnotificationchannel:view even though it has :view for every other namespace-scoped listable resource (environment, dataplane, workflow, deploymentpipeline, etc).

Backstage's periodic catalog sync runs a full resync as this identity; without this action the list call is denied and gets silently dropped, which wipes any previously-synced notification channel entities from the Backstage catalog on the next sync cycle.


## Approach
Adds notification channel view permission to backstage-catalog-reader role

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4032

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
