### PR TITLE
feat(helm): enable gateway websocket upgrades for component exec

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/gateway/httplistenerpolicy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/httplistenerpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: enable-websocket
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-default
+  upgradeConfig:
+    enabledUpgrades:
+      - websocket
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/gateway/httplistenerpolicy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/httplistenerpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.enabled }}
+{{- if and .Values.gateway.enabled (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") }}
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: HTTPListenerPolicy
 metadata:


### PR DESCRIPTION
## Purpose
`occ component exec` and the Backstage component terminal need WebSocket upgrade support on the control-plane gateway. Today this requires **manually** applying an `HTTPListenerPolicy` (documented in the CLI reference). This ships it with the chart so exec works out of the box.

## Approach
Add a kgateway `HTTPListenerPolicy` (`enable-websocket`) targeting the default gateway, gated on `gateway.enabled` and rendered in the gateway's namespace (kgateway requires the policy to be in the same namespace as its `targetRef`).

- `templates/gateway/httplistenerpolicy.yaml` (new) — `spec.upgradeConfig.enabledUpgrades: [websocket]` on `gateway-default`.
- No new values / `values.schema.json` changes.

## Related Issues
_N/A_ — companion docs change (removing the manual step) tracked in a separate openchoreo.github.io PR.

## Checklist
- [ ] Tests added or updated (chart change — validated via `helm lint` + `helm template`)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported

## Remarks
- Validated: `helm template` renders the policy when `gateway.enabled=true` and omits it when `false`; `helm lint` passes.
- kgateway v2.3.1 CRD `gateway.kgateway.dev/v1alpha1 HTTPListenerPolicy`; the same policy is already `ACCEPTED/ATTACHED` on a running k3d cluster.
