### PR TITLE
ci: fix backport workflow failing on fork PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,11 +26,17 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: github.event.pull_request.merged
+    # Only run for merged PRs that carry a `backport/` label.
+    if: >-
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport/')
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # Check out the base branch, not the PR merge commit: avoids checkout v7's
+          # fork-PR guard under pull_request_target. Backport only needs base history.
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Create backport pull requests
         id: backport


### PR DESCRIPTION
## Purpose

The backport workflow posts a "Backport failed" comment on merged PRs that come from forks, even when the PR has no backport label and nothing was meant to be backported. This showed up on #4045 (an external/fork PR with no `backport/` label).

Two things combine to cause it:

1. The job runs on every merged PR. Its `if` only checks `github.event.pull_request.merged`, with no label check, so `actions/checkout` runs even when there's no backport to do.
2. `actions/checkout` v7 (pulled in by #3949) added a guard that refuses to check out fork PR code under `pull_request_target`. Under that trigger the default checkout resolves to the PR's merge commit (fork-derived), so the guard fires and the checkout step fails. The `Comment on failure` step then posts the misleading "Backport failed" comment, even though the backport action never ran.

## Approach

- Gate the job on a `backport/` label (matching the upstream backport-action example). Merged PRs without the label now skip the job entirely, so forks no longer trip the checkout guard or get a spurious failure comment.
- Check out the base ref (`github.event.pull_request.base.ref`) instead of the default PR merge commit. The backport only needs base history to cherry-pick, and pinning the base ref keeps it clear of the checkout v7 fork-PR guard without using `allow-unsafe-pr-checkout`.

Validated the workflow with `actionlint` (clean).

## Related Issues

N/A. Context: symptom appeared on #4045; the checkout guard came in via #3949.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

N/A