### PR TITLE
feat(helm): enable WebSocket upgrades by default on KGateway

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/gateway/httplistenerpolicy.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/httplistenerpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.gateway.enabled (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") .Values.gateway.httpListenerPolicy.enabled }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: default-httplistenerpolicy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-data-plane.componentLabels" (dict "context" . "component" "gateway") | nindent 4 }}
+spec:
+  # Target the default gateway created by this chart
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-default
+  # Enable WebSocket upgrades by default on all listeners of the target Gateway
+  upgradeConfig:
+    enabledUpgrades:
+      - websocket
+{{- end }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -725,6 +725,21 @@
           "title": "gatewayClassName",
           "type": "string"
         },
+        "httpListenerPolicy": {
+          "additionalProperties": false,
+          "description": "HTTPListenerPolicy configuration for KGateway. Configures additional listener-level settings\non the gateway default HTTP/HTTPS listeners (e.g. enabling WebSocket upgrades).",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable HTTPListenerPolicy creation for the gateway",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "httpListenerPolicy",
+          "type": "object"
+        },
         "httpPort": {
           "default": 80,
           "description": "Port for the HTTP listener on the gateway",

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -165,6 +165,21 @@ gateway:
 
   # @schema
   # type: object
+  # additionalProperties: false
+  # description: |
+  #   HTTPListenerPolicy configuration for KGateway. Configures additional listener-level settings
+  #   on the gateway default HTTP/HTTPS listeners (e.g. enabling WebSocket upgrades).
+  # @schema
+  httpListenerPolicy:
+    # @schema
+    # type: boolean
+    # description: Enable HTTPListenerPolicy creation for the gateway
+    # default: true
+    # @schema
+    enabled: true
+
+  # @schema
+  # type: object
   # additionalProperties: true
   # description: KGateway controller configuration for managing Gateway API resources
   # @schema

--- a/samples/from-image/doclet/README.md
+++ b/samples/from-image/doclet/README.md
@@ -40,29 +40,7 @@ A sample application that demonstrates how an OpenChoreo Workload consumes manag
 - An OpenChoreo cluster with the control plane installed
 - `kubectl` access to the cluster
 
-## Step 1: Enable WebSockets at the data-plane gateway
-
-The doclet frontend reverse-proxies a WebSocket sub-path (`/ws/collab-svc`) to the collab service. kgateway disables WebSocket upgrades by default; enable them on the data-plane Gateway with a one-time `HTTPListenerPolicy`:
-
-```bash
-kubectl apply -f - <<EOF
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: HTTPListenerPolicy
-metadata:
-  name: default-httplistenerpolicy
-  namespace: openchoreo-data-plane
-spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: gateway-default
-  upgradeConfig:
-    enabledUpgrades:
-      - websocket
-EOF
-```
-
-## Step 2: Deploy
+## Step 1: Deploy
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/samples/from-image/doclet/project.yaml
@@ -81,7 +59,7 @@ kubectl apply \
 
 Components have `autoDeploy: true` and create their `ReleaseBinding`s automatically. The `ResourceReleaseBinding`s under `bindings/development/` are applied with `spec.resourceRelease` intentionally unset — they will stay pending until promoted in the next step.
 
-## Step 3: Promote each resource to the development environment
+## Step 2: Promote each resource to the development environment
 
 Pin each Resource's binding to its latest release:
 

--- a/samples/from-image/echo-websocket-service/README.md
+++ b/samples/from-image/echo-websocket-service/README.md
@@ -13,29 +13,7 @@ The service is deployed from the pre-built image:
 **Protocol:** WebSocket
 **Functionality:** Echoes back any message sent by the client.
 
-## Step 1: Enable WebSockets at the Ingress Gateway
-
-Before deploying the WebSocket service, you need to enable WebSocket upgrades at the ingress gateway by applying the following HTTPListenerPolicy:
-
-```bash
-kubectl apply -f - <<EOF
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: HTTPListenerPolicy
-metadata:
-  name: default-httplistenerpolicy
-  namespace: openchoreo-data-plane
-spec:
-  targetRefs:
-  - group: gateway.networking.k8s.io
-    kind: Gateway
-    name: gateway-default
-  upgradeConfig:
-    enabledUpgrades:
-    - websocket
-EOF
-```
-
-## Step 2: Deploy the Application
+## Step 1: Deploy the Application
 
 The following command will create the relevant resources in OpenChoreo:
 
@@ -46,7 +24,7 @@ kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/main/sa
 > [!NOTE]
 > Since this uses a pre-built image, the deployment will be faster compared to building from source.
 
-## Step 3: Test the Application
+## Step 2: Test the Application
 
 You can test the WebSocket service using `wscat` (install via `npm install -g wscat`).
 


### PR DESCRIPTION
## Purpose
`Websocket` is a first-class workload endpoint type in OpenChoreo, but connections failed out of the box because KGateway (based on Envoy) disables WebSocket upgrades by default. Enabling upgrades requires an `HTTPListenerPolicy` (`gateway.kgateway.dev/v1alpha1`) on the Gateway listener.

This PR deploys a default `HTTPListenerPolicy` in the data-plane Helm chart so that WebSocket upgrades work out-of-the-box for all users without manual cluster-wide operations.

## Approach
1. Added a new template `install/helm/openchoreo-data-plane/templates/gateway/httplistenerpolicy.yaml` which creates an `HTTPListenerPolicy` targeting the default gateway (`gateway-default`) with WebSocket upgrades enabled.
2. Gated the generation on `gateway.enabled` and `gateway.gatewayClassName == "kgateway"` to align with the KGateway-specific CRD availability and prevent installation failures on non-KGateway configurations.
3. Added the `gateway.httpListenerPolicy` configuration under `gateway` in `values.yaml` and `values.schema.json` to allow users to toggle the policy.
4. Cleaned up the manual step to apply the `HTTPListenerPolicy` from `samples/from-image/doclet/README.md` and `samples/from-image/echo-websocket-service/README.md`.

## Related Issues
Closes #4068
Refs #3915

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content
