### PR TITLE
fix(helm): gate KGateway TrafficPolicies on gatewayClassName

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/traffic-policy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/traffic-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backstage.enabled .Values.backstage.http.enabled .Values.gateway.enabled .Values.backstage.http.hostnames -}}
+{{- if and .Values.backstage.enabled .Values.backstage.http.enabled .Values.gateway.enabled .Values.backstage.http.hostnames (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") -}}
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: TrafficPolicy
 metadata:

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/traffic-policy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/traffic-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.openchoreoApi.enabled .Values.openchoreoApi.http.enabled .Values.gateway.enabled -}}
+{{- if and .Values.openchoreoApi.enabled .Values.openchoreoApi.http.enabled .Values.gateway.enabled (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") -}}
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: TrafficPolicy
 metadata:

--- a/install/helm/openchoreo-control-plane/templates/portal-assistant/traffic-policy.yaml
+++ b/install/helm/openchoreo-control-plane/templates/portal-assistant/traffic-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.portalAssistant.enabled .Values.portalAssistant.http.enabled .Values.gateway.enabled }}
+{{- if and .Values.portalAssistant.enabled .Values.portalAssistant.http.enabled .Values.gateway.enabled (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") }}
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: TrafficPolicy
 metadata:

--- a/install/helm/openchoreo-observability-plane/templates/observer/traffic-policy.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/traffic-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.enabled }}
+{{- if and .Values.gateway.enabled (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") }}
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: TrafficPolicy
 metadata:


### PR DESCRIPTION
## Purpose
The control-plane and observability-plane Helm charts render KGateway-specific `TrafficPolicy` resources (`gateway.kgateway.dev/v1alpha1`) unconditionally, without checking the configured `gateway.gatewayClassName`. 
This causes issues on setups using non-KGateway options (e.g. Istio or Cilium), where the KGateway CRDs are not installed, causing `helm install/upgrade` commands to fail because the `TrafficPolicy` CRD is missing.

This PR gates these templates on `gatewayClassName == "kgateway"` so that KGateway `TrafficPolicy` objects are only generated when KGateway is actually in use.

## Approach
Updated the following Helm templates to add the gating condition `(eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway")`:
1. `install/helm/openchoreo-control-plane/templates/openchoreo-api/traffic-policy.yaml`
2. `install/helm/openchoreo-control-plane/templates/backstage/traffic-policy.yaml`
3. `install/helm/openchoreo-control-plane/templates/portal-assistant/traffic-policy.yaml`
4. `install/helm/openchoreo-observability-plane/templates/observer/traffic-policy.yaml`

## Related Issues
Closes #4068
Refs #3915

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content
