### PR TITLE
fix: use multi-arch Ballerina buildpack images

### DIFF
--- a/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
@@ -53,9 +53,10 @@ spec:
             mkdir -p /storage/run /storage/graph
             cat > /etc/containers/storage.conf <<STEOF
             [storage]
-            driver = "vfs"
+            driver = "overlay"
             runroot = "/storage/run"
             graphroot = "/storage/graph"
+            [storage.options.overlay]
             STEOF
 
             cat > /etc/containers/containers.conf <<CEOF

--- a/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
@@ -53,10 +53,9 @@ spec:
             mkdir -p /storage/run /storage/graph
             cat > /etc/containers/storage.conf <<STEOF
             [storage]
-            driver = "overlay"
+            driver = "vfs"
             runroot = "/storage/run"
             graphroot = "/storage/graph"
-            [storage.options.overlay]
             STEOF
 
             cat > /etc/containers/containers.conf <<CEOF
@@ -93,9 +92,9 @@ spec:
             done
 
             # ghcr.io/openchoreo/buildpack/ballerina:18
-            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd"
+            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:4615d47b43885210b2ae9a9b6f327cd8c10165a2d5af8e13dce6fcfefeae8a0d"
             # ghcr.io/openchoreo/buildpack/ballerina:18-run
-            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:cae91b6892095e0215f22208799f432646d74ad0b05f9a764a532dbeccb9f94c"
+            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
             ENV_ARGS=""
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then

--- a/install/k3d/common/push-buildpack-cache-images.yaml
+++ b/install/k3d/common/push-buildpack-cache-images.yaml
@@ -102,8 +102,8 @@ spec:
           push_image "gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1" "buildpacks-cache/google-builder:latest"
           push_image "gcr.io/buildpacks/google-22/run@sha256:a8ccb6641b4d98b0adf6397f954e7194611d1ae61310f0561f1c00fdf7f9ba96" "buildpacks-cache/google-run:latest"
           # ghcr.io/openchoreo/buildpack/ballerina:18
-          push_image "ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd" "buildpacks-cache/ballerina-builder:18"
+          push_image "ghcr.io/openchoreo/buildpack/ballerina@sha256:4615d47b43885210b2ae9a9b6f327cd8c10165a2d5af8e13dce6fcfefeae8a0d" "buildpacks-cache/ballerina-builder:18"
           # ghcr.io/openchoreo/buildpack/ballerina:18-run
-          push_image "ghcr.io/openchoreo/buildpack/ballerina@sha256:cae91b6892095e0215f22208799f432646d74ad0b05f9a764a532dbeccb9f94c" "buildpacks-cache/ballerina-run:18"
+          push_image "ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c" "buildpacks-cache/ballerina-run:18"
 
           echo "All buildpack images cached successfully"

--- a/install/k3d/registry-cache/preload-build-images.yaml
+++ b/install/k3d/registry-cache/preload-build-images.yaml
@@ -70,7 +70,7 @@ spec:
               docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac
               gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1
               gcr.io/buildpacks/google-22/run@sha256:a8ccb6641b4d98b0adf6397f954e7194611d1ae61310f0561f1c00fdf7f9ba96
-              ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd
+              ghcr.io/openchoreo/buildpack/ballerina@sha256:4615d47b43885210b2ae9a9b6f327cd8c10165a2d5af8e13dce6fcfefeae8a0d
               ghcr.io/openchoreo/openchoreo-cli:latest-dev
               "
 

--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -301,9 +301,9 @@ spec:
             export DOCKER_HOST=unix:///run/podman/podman.sock
 
             # ghcr.io/openchoreo/buildpack/ballerina:18
-            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd"
+            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:4615d47b43885210b2ae9a9b6f327cd8c10165a2d5af8e13dce6fcfefeae8a0d"
             # ghcr.io/openchoreo/buildpack/ballerina:18-run
-            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:cae91b6892095e0215f22208799f432646d74ad0b05f9a764a532dbeccb9f94c"
+            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
             # Build --env flags
             ENV_ARGS=""

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -76,9 +76,9 @@ spec:
             export DOCKER_HOST=unix:///run/podman/podman.sock
 
             # ghcr.io/openchoreo/buildpack/ballerina:18
-            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:bd85ed5b6573ba27294f456e22478a5b4d1c36a540526c35e822234aa69ee1bd"
+            BUILDER="ghcr.io/openchoreo/buildpack/ballerina@sha256:4615d47b43885210b2ae9a9b6f327cd8c10165a2d5af8e13dce6fcfefeae8a0d"
             # ghcr.io/openchoreo/buildpack/ballerina:18-run
-            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:cae91b6892095e0215f22208799f432646d74ad0b05f9a764a532dbeccb9f94c"
+            RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
             # Build --env flags
             ENV_ARGS=""


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Ballerina builds could stall during the CNB export phase on Apple Silicon environments because the builder and run images were AMD64-only and executed through QEMU emulation.

This PR updates the workflow references to multi-architecture Ballerina buildpack images, allowing builds to run natively on both AMD64 and ARM64 environments.

## Approach
  - Published multi-architecture Ballerina builder and run images.
  - Updated all Ballerina workflow templates to use the new digest-pinned image indexes.
  - Updated the k3d build-cache and preload configurations with the new digests.
  - Preserved digest pinning for reproducible builds.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4077

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
