### PR TITLE
docs: update developer concepts doc with organizational concept

### DIFF
--- a/docs/proposals/0200-openchoreo-developer-concepts.md
+++ b/docs/proposals/0200-openchoreo-developer-concepts.md
@@ -132,6 +132,8 @@ Projects, components and APIs are Kubernetes CRDs. We can make them less complic
 
 This section describes the shape and semantics of these kinds. 
 
+> **Note** This proposal originally described a first-class `Organization` CRD (1:1 mapped to a Kubernetes namespace), as shown in the "Namespaces and Organizations" and "Custom resource (CR) naming scope" sections below. The `Organization` CRD and all `spec.organization` / `organizationName` fields have since been **removed** from OpenChoreo — resources are now grouped directly under Kubernetes namespaces instead. See [openchoreo/openchoreo#1583](https://github.com/openchoreo/openchoreo/pull/1583) ("Use k8s namespaces to group resources and remove Organization") for the removal, and [openchoreo/openchoreo#1468](https://github.com/openchoreo/openchoreo/issues/1468) / [openchoreo/openchoreo#1273](https://github.com/openchoreo/openchoreo/issues/1273) / [openchoreo/openchoreo#1271](https://github.com/openchoreo/openchoreo/issues/1271) for the design discussion and related tasks. The sections below are kept as-is for historical context; treat any `organization` references as superseded by the corresponding Kubernetes namespace.
+
 ### Namespaces and Organizations
 There is a 1:1 mapping between OpenChoreo organizations and Kubernetes namespaces in the OpenChoreo control plane. 
 


### PR DESCRIPTION
## Purpose
OpenChoreo no longer has a separate `Organization` concept/CRD — resources are organized directly under Kubernetes namespaces instead. The `docs/proposals/0200-openchoreo-developer-concepts.md` proposal doc was written before this change and still described `Organization` as a first-class CRD (1:1 mapped to a namespace), which is now outdated and misleading for anyone reading the proposal as current documentation.

## Approach
Removed the "Namespaces and Organizations" section, the `Organization` CRD YAML examples, and all `spec.organization` / `organizationName` field references from example YAML and prose throughout the doc. Updated surrounding sentences (e.g. Project, API, Component descriptions, immutable fields section) so they read correctly without the organization references.

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content

## Remarks
Docs-only change, no code/behavior affected.
