### PR TITLE
feat(helm): enable resource mcp toolset by default

### DIFF
--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -3048,9 +3048,11 @@
                     "project",
                     "component",
                     "deployment",
-                    "build"
+                    "build",
+                    "pe",
+                    "resource"
                   ],
-                  "description": "List of enabled MCP toolsets. Each toolset exposes a group of related operations. Allowed toolsets: namespace, project, component, deployment, build, pe",
+                  "description": "List of enabled MCP toolsets. Each toolset exposes a group of related operations. Allowed toolsets: namespace, project, component, deployment, build, pe, resource",
                   "items": {
                     "type": "string"
                   },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1757,10 +1757,10 @@ openchoreoApi:
       enabled: true
       # @schema
       # type: array
-      # description: "List of enabled MCP toolsets. Each toolset exposes a group of related operations. Allowed toolsets: namespace, project, component, deployment, build, pe"
+      # description: "List of enabled MCP toolsets. Each toolset exposes a group of related operations. Allowed toolsets: namespace, project, component, deployment, build, pe, resource"
       # items:
       #   type: string
-      # default: ["namespace", "project", "component", "deployment", "build"]
+      # default: ["namespace", "project", "component", "deployment", "build", "pe", "resource"]
       # @schema
       toolsets:
         - "namespace"
@@ -1769,6 +1769,7 @@ openchoreoApi:
         - "deployment"
         - "build"
         - "pe"
+        - "resource"
     # @schema
     # type: object
     # description: Logging configuration


### PR DESCRIPTION
Enables the `resource` MCP toolset in the control-plane Helm chart's default `openchoreoApi.config.mcp.toolsets` list.

The `resource` toolset (dev-facing Resource CRUD) is registered in `pkg/mcp/tools` but was the only toolset absent from the chart default, leaving it off out of the box. Also aligns the `# @schema` description/default comment (and regenerated `values.schema.json`) with the shipped list, which had drifted (missing `pe`).