### PR TITLE
fix: retry node-ready wait to tolerate transient k3s API unavailability

### DIFF
--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -276,6 +276,18 @@ define e2e_mc_op_settle
 	done
 endef
 
+# Retries kubectl wait for node-Ready, since a just-created k3s API server can
+# briefly return ServiceUnavailable and kubectl wait won't retry that itself.
+# Usage: $(call e2e_mc_wait_nodes_ready,<kubectl-context-flags>,<cluster-label>)
+define e2e_mc_wait_nodes_ready
+	@for i in $$(seq 1 $(E2E_SETTLE_STABLE_HITS)); do \
+		if kubectl $(1) wait --for=condition=Ready nodes --all --timeout=120s; then exit 0; fi; \
+		if [ $$i -eq $(E2E_SETTLE_STABLE_HITS) ]; then echo "$(2) API server did not become ready in time"; exit 1; fi; \
+		$(call log_info, $(2) API server not ready yet, retrying node-ready wait); \
+		sleep $(E2E_SETTLE_INTERVAL); \
+	done
+endef
+
 ##@ E2E Testing
 
 # ---------------------------------------------------------------------------
@@ -734,16 +746,16 @@ e2e.multi.setup: ## All setup: clusters + prerequisites + install + configure
 e2e.multi.setup-clusters: ## Create all four k3d clusters (CP, DP, WP, OP)
 	@$(call log_info, Creating CP cluster '$(E2E_MC_CP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-cp.yaml
-	$(E2E_MC_CP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_CP_KUBECONTEXT),CP)
 	@$(call log_info, Creating DP cluster '$(E2E_MC_DP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-dp.yaml
-	$(E2E_MC_DP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_DP_KUBECONTEXT),DP)
 	@$(call log_info, Creating WP cluster '$(E2E_MC_WP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-wp.yaml
-	$(E2E_MC_WP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_WP_KUBECONTEXT),WP)
 	@$(call log_info, Creating OP cluster '$(E2E_MC_OP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-op.yaml
-	$(E2E_MC_OP_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_OP_KUBECONTEXT),OP)
 	@$(call log_info, Applying CoreDNS rewrites)
 	$(E2E_MC_CP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-cp.yaml
 	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-dp.yaml


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Tier3 e2e test runs fail intermittently due to k3s API unavailability.
Ref: https://github.com/openchoreo/openchoreo/actions/runs/28835417245/job/85518068221

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content
