### PR TITLE
fix(api): enable resource mcp toolset by default

### DIFF
--- a/cmd/openchoreo-api/config.yaml
+++ b/cmd/openchoreo-api/config.yaml
@@ -165,6 +165,7 @@ mcp:
     - deployment
     - build
     - pe
+    - resource
 
 logging:
   # Minimum log level: debug, info, warn, error


### PR DESCRIPTION
## Purpose

The `resource` MCP toolset was missing from the shipped `cmd/openchoreo-api/config.yaml` default toolset list. Because the explicit config file overrides the Go-level `MCPDefaults()`, any `openchoreo-api` process started from this config (local dev and other non-Helm runs) had the Resource CRUD MCP tools disabled: `create_resource`, `get_resource`, `list_resources`, `update_resource`, `delete_resource`.

The Helm chart was already fixed in #4092; this brings the standalone config default in line so all deployment paths agree.

## Approach

- Add `resource` to `mcp.toolsets` in `cmd/openchoreo-api/config.yaml`, so the shipped default enables every valid toolset and matches both the Helm chart (#4092) and `MCPDefaults()`.

## Related Issues

Related #4092

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
N/A