### PR TITLE
chore: remove unused configs from observability plane chart values

### DIFF
--- a/install/helm/openchoreo-observability-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/controller-manager/deployment.yaml
@@ -50,12 +50,6 @@ spec:
           value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        {{- if .Values.controllerManager.clusterGateway.enabled }}
-        - name: CLUSTER_GATEWAY_URL
-          value: {{ quote .Values.controllerManager.clusterGateway.url }}
-        - name: CLUSTER_GATEWAY_CA_CERT
-          value: {{ quote .Values.controllerManager.clusterGateway.tls.caPath }}
-        {{- end }}
         ports:
         - name: metrics
           containerPort: 8080
@@ -81,10 +75,4 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- if .Values.controllerManager.clusterGateway.enabled }}
-      volumes:
-      - name: cluster-gateway-ca
-        configMap:
-          name: {{ .Values.controllerManager.clusterGateway.tls.caConfigMap }}
-      {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -459,48 +459,6 @@
           "title": "affinity",
           "type": "object"
         },
-        "clusterGateway": {
-          "additionalProperties": false,
-          "description": "Cluster gateway configuration for multi-cluster communication",
-          "properties": {
-            "enabled": {
-              "default": false,
-              "description": "Enable cluster gateway integration for multi-cluster setups",
-              "title": "enabled",
-              "type": "boolean"
-            },
-            "tls": {
-              "additionalProperties": false,
-              "description": "TLS configuration for cluster gateway communication",
-              "properties": {
-                "caConfigMap": {
-                  "default": "cluster-gateway-ca",
-                  "description": "Name of the ConfigMap containing the gateway CA certificate",
-                  "title": "caConfigMap",
-                  "type": "string"
-                },
-                "caPath": {
-                  "default": "/etc/cluster-gateway/ca.crt",
-                  "description": "Path to the CA certificate file for gateway verification",
-                  "title": "caPath",
-                  "type": "string"
-                }
-              },
-              "required": [],
-              "title": "tls",
-              "type": "object"
-            },
-            "url": {
-              "default": "https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443",
-              "description": "URL of the cluster gateway service in the control plane",
-              "title": "url",
-              "type": "string"
-            }
-          },
-          "required": [],
-          "title": "clusterGateway",
-          "type": "object"
-        },
         "containerSecurityContext": {
           "additionalProperties": false,
           "description": "Container-level security context settings",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -327,41 +327,6 @@ controllerManager:
       # @schema
       enableWebhooks: "false"
 
-  # @schema
-  # type: object
-  # description: Cluster gateway configuration for multi-cluster communication
-  # @schema
-  clusterGateway:
-    # @schema
-    # type: boolean
-    # description: Enable cluster gateway integration for multi-cluster setups
-    # default: false
-    # @schema
-    enabled: false
-    # @schema
-    # type: string
-    # description: URL of the cluster gateway service in the control plane
-    # default: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443
-    # @schema
-    url: https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8443
-    # @schema
-    # type: object
-    # description: TLS configuration for cluster gateway communication
-    # @schema
-    tls:
-      # @schema
-      # type: string
-      # description: Path to the CA certificate file for gateway verification
-      # default: /etc/cluster-gateway/ca.crt
-      # @schema
-      caPath: /etc/cluster-gateway/ca.crt
-      # @schema
-      # type: string
-      # description: Name of the ConfigMap containing the gateway CA certificate
-      # default: cluster-gateway-ca
-      # @schema
-      caConfigMap: cluster-gateway-ca
-
 ## Values for dependent charts
 
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request removes all configuration and deployment logic related to the `clusterGateway` integration to the controller-manager deployment in the OpenChoreo Observability Plane Helm chart. Controller manager deployment in the observability plane reconciles only the ObservabilityAlertRule CRs and no need to communicate through a cluster gateway.

Configuration and schema cleanup:

* Removed the entire `clusterGateway` configuration block (including `enabled`, `url`, and `tls` settings) from `controllerManager` in `values.yaml`, along with all associated schema comments.
* Deleted the `clusterGateway` schema definition from `values.schema.json`, removing validation and documentation for these settings.

Deployment template simplification:

* Removed conditional environment variables (`CLUSTER_GATEWAY_URL`, `CLUSTER_GATEWAY_CA_CERT`) from the `controller-manager` deployment template, as well as their dependency on the `clusterGateway.enabled` value.
* Deleted the conditional `volumes` definition for mounting the cluster gateway CA certificate in the deployment template.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
