### PR TITLE
fix(api): expose resource dependencies in workload schema

### DIFF
--- a/internal/openchoreo-api/services/workload/service.go
+++ b/internal/openchoreo-api/services/workload/service.go
@@ -426,6 +426,28 @@ func workloadSpecSchema() *extv1.JSONSchemaProps {
 		},
 	}
 
+	resourceDependencySchema := extv1.JSONSchemaProps{
+		Type:        objectType,
+		Description: "Dependency on a project-bound Resource. Named outputs of the resolved ResourceReleaseBinding are wired into the container.",
+		Required:    []string{"ref"},
+		Properties: map[string]extv1.JSONSchemaProps{
+			"ref": {
+				Type:        stringType,
+				Description: "Name of the Resource to consume. Must be in the same project as the consuming component.",
+			},
+			"envBindings": {
+				Type:                 objectType,
+				Description:          "Maps ResourceType output names to container environment variable names.",
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{Schema: &extv1.JSONSchemaProps{Type: stringType}},
+			},
+			"fileBindings": {
+				Type:                 objectType,
+				Description:          "Maps ResourceType output names to container mount paths.",
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{Schema: &extv1.JSONSchemaProps{Type: stringType}},
+			},
+		},
+	}
+
 	return &extv1.JSONSchemaProps{
 		Type:        objectType,
 		Description: "Workload specification defining the runtime configuration for a component.",
@@ -469,12 +491,17 @@ func workloadSpecSchema() *extv1.JSONSchemaProps {
 			},
 			"dependencies": {
 				Type:        objectType,
-				Description: "Dependencies on other components' endpoints.",
+				Description: "Dependencies on other components' endpoints and on project-bound Resources.",
 				Properties: map[string]extv1.JSONSchemaProps{
 					"endpoints": {
 						Type:        "array",
 						Description: "Endpoint connections to other components.",
 						Items:       &extv1.JSONSchemaPropsOrArray{Schema: &connectionSchema},
+					},
+					"resources": {
+						Type:        "array",
+						Description: "Resource dependencies on project-bound Resources.",
+						Items:       &extv1.JSONSchemaPropsOrArray{Schema: &resourceDependencySchema},
 					},
 				},
 			},

--- a/internal/openchoreo-api/services/workload/service_test.go
+++ b/internal/openchoreo-api/services/workload/service_test.go
@@ -272,4 +272,46 @@ func TestGetWorkloadSchema(t *testing.T) {
 		require.True(t, ok)
 		assert.Contains(t, container.Required, "image")
 	})
+
+	t.Run("exposes endpoint and resource dependencies", func(t *testing.T) {
+		svc := newService(t)
+
+		schema, err := svc.GetWorkloadSchema(ctx)
+		require.NoError(t, err)
+
+		deps, ok := schema.Properties["dependencies"]
+		require.True(t, ok, "schema must define dependencies")
+		assert.Equal(t, "object", deps.Type)
+
+		// Endpoint dependencies on other components.
+		endpoints, ok := deps.Properties["endpoints"]
+		require.True(t, ok, "dependencies must define endpoints")
+		assert.Equal(t, "array", endpoints.Type)
+
+		// Resource dependencies on project-bound Resources.
+		resources, ok := deps.Properties["resources"]
+		require.True(t, ok, "dependencies must define resources")
+		assert.Equal(t, "array", resources.Type)
+		require.NotNil(t, resources.Items)
+		require.NotNil(t, resources.Items.Schema)
+
+		item := resources.Items.Schema
+		assert.Equal(t, "object", item.Type)
+		assert.Contains(t, item.Required, "ref")
+
+		ref, ok := item.Properties["ref"]
+		require.True(t, ok, "resource dependency must define ref")
+		assert.Equal(t, "string", ref.Type)
+
+		// envBindings and fileBindings are maps of output name -> target, so
+		// they use additionalProperties (string), not fixed properties.
+		for _, name := range []string{"envBindings", "fileBindings"} {
+			binding, ok := item.Properties[name]
+			require.True(t, ok, "resource dependency must define %s", name)
+			assert.Equal(t, "object", binding.Type)
+			require.NotNil(t, binding.AdditionalProperties, "%s must set additionalProperties", name)
+			require.NotNil(t, binding.AdditionalProperties.Schema, "%s additionalProperties must have a schema", name)
+			assert.Equal(t, "string", binding.AdditionalProperties.Schema.Type)
+		}
+	})
 }


### PR DESCRIPTION
## Purpose

`get_workload_schema` returns a JSON schema that did not advertise `dependencies.resources[]`. As a result, MCP clients using the schema to author a workload could not discover how to wire a project-bound Resource into a container (`ref`, `envBindings`, `fileBindings`).

The Workload CRD type `WorkloadDependencies` has had a `Resources []WorkloadResourceDependency` field since #3404, but the hand-written schema in `workloadSpecSchema()` was never updated to match, so it only exposed `dependencies.endpoints`.

## Approach

- Add a `resourceDependencySchema` (`ref`, `envBindings`, `fileBindings`) to `workloadSpecSchema()`, mirroring the existing `connectionSchema` used for endpoints. `envBindings`/`fileBindings` are maps of output name to target, so they use `additionalProperties: {type: string}`.
- Wire `resources` into the `dependencies` object alongside `endpoints`.
- Add a schema test covering both `dependencies.endpoints` and the new `dependencies.resources` shape.

## Related Issues

Closes #4099

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

N/A