### PR TITLE
chore: flag CRD field changes needing manual propagation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -90,6 +90,32 @@ reviews:
         - If schema changes: call out upgrade/migration impact and required controller/CRD/OpenAPI updates.
         - Add or update tests to cover new/changed fields or behaviors.
 
+    - path: "api/v1alpha1/**"
+      instructions: |
+        LEVEL: VERY STRICT (CRD types - cross-surface propagation)
+        Codegen is already enforced by CI (`make code.gen-check` covers CRD manifests and
+        openapi.yaml<->generated-code consistency), so do NOT comment about regenerating code
+        or CRDs. Focus only on the hand-maintained hops that have no generator and silently
+        drift when a CRD field is added.
+
+        Trigger ONLY when this PR adds or renames a developer/user-facing spec field (a field
+        on a *Spec type). Then inspect THIS PR's diff and comment ONLY for a surface that
+        plausibly needs the field but has no corresponding change in the PR - as a short
+        checklist the author can confirm or consciously skip:
+        - OpenAPI source: does openapi/openchoreo-api.yaml (hand-authored, NOT generated from
+          the CRD types) need the field to keep the REST contract in sync?
+        - MCP: do the handlers in internal/openchoreo-api/mcphandlers/** surface it?
+        - CLI (occ fsmode): do the field-by-field mappers in internal/occ/fsmode/typed/** and
+          the generator in internal/occ/fsmode/generator/** emit it? These reconstruct specs
+          field by field and have repeatedly dropped new fields (validations, removes,
+          dependency resources).
+        - Service converters in internal/openchoreo-api/services/** if they copy specs by field.
+
+        Stay SILENT - emit no comment - when the field is status-only, internal or
+        controller-only, or clearly not part of these surfaces, or when the PR already updates
+        them. Do not speculate or produce a checklist "just in case"; flag only a concrete,
+        visible gap. The author decides whether each surface truly needs the change.
+
     - path: "openapi/**"
       instructions: |
         LEVEL: VERY STRICT (OpenAPI)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Adds an api/v1alpha1/** path_instruction that, when a PR adds a spec field, flags the hand-maintained surfaces (OpenAPI yaml, MCP, occ fsmode) it may need to propagate to. Scoped to visible gaps; silent on codegen, which CI enforces.

related https://github.com/openchoreo/openchoreo/discussions/4103

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
