### PR TITLE
fix: cap OpenSearch cluster-mode resources in tier3

### DIFF
--- a/test/e2e/k3d/multi-cluster/values-op-modules.yaml
+++ b/test/e2e/k3d/multi-cluster/values-op-modules.yaml
@@ -15,6 +15,38 @@ openSearch:
     limits:
       memory: "1.5Gi"
 
+# ---- observability-logs-opensearch (OP cluster — cluster mode) ----
+# Trims the default 3-master + 2-data cluster to fit the runner; unconstrained
+# it overcommits the node's CPU and causes it to flap NotReady.
+openSearchCluster:
+  bootstrap:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1000Mi
+      requests:
+        cpu: 100m
+        memory: 1000Mi
+  nodePools:
+    data:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 500m
+          memory: 1000Mi
+        requests:
+          cpu: 100m
+          memory: 1000Mi
+    master:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 500m
+          memory: 900Mi
+        requests:
+          cpu: 100m
+          memory: 900Mi
+
 # ---- observability-metrics-prometheus ----
 kube-prometheus-stack:
   prometheus:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Tier3 e2e was flaky/failing because `_e2e.mc.install-op` runs OpenSearch in cluster mode (3 master + 2 data pods, 1 CPU limit each) uncapped, overcommitting the shared 4-core runner and causing the node to flap `NotReady`, which cascaded into `helm --wait` timeouts on whichever release was installing at the time.

## Approach
Add resource/replica caps for `openSearchCluster` in `values-op-modules.yaml` (1 master + 1 data node, 500m CPU / ~1Gi memory each), mirroring the existing standalone-mode caps in the same file.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content
