### PR TITLE
fix: wrap long internal-port flag usage string

### DIFF
--- a/cmd/cluster-gateway/main.go
+++ b/cmd/cluster-gateway/main.go
@@ -58,7 +58,8 @@ func main() {
 	flag.IntVar(&port, "port", cmdutil.GetEnvInt("AGENT_SERVER_PORT", defaultPort),
 		"Public server port serving the agent WebSocket endpoint (/ws)")
 	flag.IntVar(&internalPort, "internal-port", cmdutil.GetEnvInt("AGENT_INTERNAL_PORT", defaultInternalPort),
-		"Internal server port serving the caller-facing /api/* endpoints (in-cluster callers only; not exposed outside the cluster)")
+		"Internal server port serving the caller-facing /api/* endpoints "+
+			"(in-cluster callers only; not exposed outside the cluster)")
 	flag.StringVar(&serverCertPath, "server-cert",
 		cmdutil.GetEnv("SERVER_CERT_PATH", "/certs/tls.crt"),
 		"Path to server certificate")


### PR DESCRIPTION
## Purpose

`make lint` fails on `release-v1.1` because `cmd/cluster-gateway/main.go:61` exceeds the 120-character line limit (`lll`). The long usage string for the `-internal-port` flag was introduced by the merged cluster-gateway port-split change.

## Approach

- Split the `-internal-port` flag usage string across two lines using string concatenation. No behavior change; the message text is identical.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)