### PR TITLE
feat: add cors config for default service component type

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -450,6 +450,18 @@ spec:
                   path:
                     type: ReplacePrefixMatch
                     replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
+              # Allow browsers to call this endpoint cross-origin (e.g. the portal's
+              # OpenAPI "Try Out" console). The wildcard origin suits a dev IDP; tighten
+              # to the portal origin(s) for production. No credentials are used, so "*"
+              # is valid. The prefix match above serves all methods, so OPTIONS preflight
+              # requests reach this filter.
+              - type: CORS
+                cors:
+                  allowOrigins: ["*"]
+                  allowMethods: [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD]
+                  allowHeaders: ["*"]
+                  exposeHeaders: ["*"]
+                  allowCredentials: false
             backendRefs:
             - name: ${metadata.componentName}
               port: ${endpoint.value.port}

--- a/samples/getting-started/component-types/service.yaml
+++ b/samples/getting-started/component-types/service.yaml
@@ -151,6 +151,18 @@ spec:
                   path:
                     type: ReplacePrefixMatch
                     replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
+              # Allow browsers to call this endpoint cross-origin (e.g. the portal's
+              # OpenAPI "Try Out" console). The wildcard origin suits a dev IDP; tighten
+              # to the portal origin(s) for production. No credentials are used, so "*"
+              # is valid. The prefix match above serves all methods, so OPTIONS preflight
+              # requests reach this filter.
+              - type: CORS
+                cors:
+                  allowOrigins: ["*"]
+                  allowMethods: [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD]
+                  allowHeaders: ["*"]
+                  exposeHeaders: ["*"]
+                  allowCredentials: false
             backendRefs:
             - name: ${metadata.componentName}
               port: ${endpoint.value.port}


### PR DESCRIPTION
## Purpose

This PR adds CORS configuration for default service component type. This is required for the new API Try Out console to work in https://github.com/openchoreo/backstage-plugins/pull/670.

## Approach
Use the Kubernetes Gateway API HTTPRoute supported CORS configuration.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4118

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
