### PR TITLE
chore(deps): bump codecov/codecov-action from 6.0.1 to 7.0.0 (#3747)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
           make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./cover.out
           fail_ci_if_error: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Purpose

Backport #3747 to `release-v1.1`. The release branch still pins `codecov/codecov-action` at an older version, so coverage uploads run on an outdated action. This bumps it to v7.0.0 to match `main`.

## Approach

- Cherry-pick 14b87b86 (#3747), bumping `codecov/codecov-action` from 6.0.1 to 7.0.0 in `.github/workflows/build-and-test.yml`.
- Resolved a conflict against the release branch (pinned at v6.0.0) by taking the v7.0.0 pin, which is the intent of the backport.

## Related Issues

Backport of #3747

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)