### PR TITLE
chore: add ProjectReleaseBindings to samples

### DIFF
--- a/samples/from-image/doclet/project.yaml
+++ b/samples/from-image/doclet/project.yaml
@@ -14,3 +14,46 @@ spec:
   type:
     kind: ClusterProjectType
     name: default
+
+# ProjectReleaseBindings deploy the project to each pipeline environment and
+# own its cell namespaces. spec.projectRelease is left unset; the Project
+# controller seeds it once with the latest ProjectRelease.
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: doclet-development
+  namespace: default
+  labels:
+    openchoreo.dev/project: doclet
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: doclet
+  environment: development
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: doclet-staging
+  namespace: default
+  labels:
+    openchoreo.dev/project: doclet
+    openchoreo.dev/environment: staging
+spec:
+  owner:
+    projectName: doclet
+  environment: staging
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: doclet-production
+  namespace: default
+  labels:
+    openchoreo.dev/project: doclet
+    openchoreo.dev/environment: production
+spec:
+  owner:
+    projectName: doclet
+  environment: production

--- a/samples/from-image/url-shortener/project.yaml
+++ b/samples/from-image/url-shortener/project.yaml
@@ -14,3 +14,46 @@ spec:
   type:
     kind: ClusterProjectType
     name: default
+
+# ProjectReleaseBindings deploy the project to each pipeline environment and
+# own its cell namespaces. spec.projectRelease is left unset; the Project
+# controller seeds it once with the latest ProjectRelease.
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: url-shortener-development
+  namespace: default
+  labels:
+    openchoreo.dev/project: url-shortener
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: url-shortener
+  environment: development
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: url-shortener-staging
+  namespace: default
+  labels:
+    openchoreo.dev/project: url-shortener
+    openchoreo.dev/environment: staging
+spec:
+  owner:
+    projectName: url-shortener
+  environment: staging
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: url-shortener-production
+  namespace: default
+  labels:
+    openchoreo.dev/project: url-shortener
+    openchoreo.dev/environment: production
+spec:
+  owner:
+    projectName: url-shortener
+  environment: production

--- a/samples/from-source/projects/latency-lab/project.yaml
+++ b/samples/from-source/projects/latency-lab/project.yaml
@@ -14,3 +14,46 @@ spec:
   type:
     kind: ClusterProjectType
     name: default
+
+# ProjectReleaseBindings deploy the project to each pipeline environment and
+# own its cell namespaces. spec.projectRelease is left unset; the Project
+# controller seeds it once with the latest ProjectRelease.
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: latency-lab-development
+  namespace: default
+  labels:
+    openchoreo.dev/project: latency-lab
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: latency-lab
+  environment: development
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: latency-lab-staging
+  namespace: default
+  labels:
+    openchoreo.dev/project: latency-lab
+    openchoreo.dev/environment: staging
+spec:
+  owner:
+    projectName: latency-lab
+  environment: staging
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: latency-lab-production
+  namespace: default
+  labels:
+    openchoreo.dev/project: latency-lab
+    openchoreo.dev/environment: production
+spec:
+  owner:
+    projectName: latency-lab
+  environment: production

--- a/samples/from-source/projects/url-shortener/project.yaml
+++ b/samples/from-source/projects/url-shortener/project.yaml
@@ -14,3 +14,46 @@ spec:
   type:
     kind: ClusterProjectType
     name: default
+
+# ProjectReleaseBindings deploy the project to each pipeline environment and
+# own its cell namespaces. spec.projectRelease is left unset; the Project
+# controller seeds it once with the latest ProjectRelease.
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: url-shortener-development
+  namespace: default
+  labels:
+    openchoreo.dev/project: url-shortener
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: url-shortener
+  environment: development
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: url-shortener-staging
+  namespace: default
+  labels:
+    openchoreo.dev/project: url-shortener
+    openchoreo.dev/environment: staging
+spec:
+  owner:
+    projectName: url-shortener
+  environment: staging
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: url-shortener-production
+  namespace: default
+  labels:
+    openchoreo.dev/project: url-shortener
+    openchoreo.dev/environment: production
+spec:
+  owner:
+    projectName: url-shortener
+  environment: production

--- a/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
+++ b/samples/gcp-microservices-demo/gcp-microservice-demo-project.yaml
@@ -14,3 +14,46 @@ spec:
   type:
     kind: ClusterProjectType
     name: default
+
+# ProjectReleaseBindings deploy the project to each pipeline environment and
+# own its cell namespaces. spec.projectRelease is left unset; the Project
+# controller seeds it once with the latest ProjectRelease.
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: gcp-microservice-demo-development
+  namespace: default
+  labels:
+    openchoreo.dev/project: gcp-microservice-demo
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: gcp-microservice-demo
+  environment: development
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: gcp-microservice-demo-staging
+  namespace: default
+  labels:
+    openchoreo.dev/project: gcp-microservice-demo
+    openchoreo.dev/environment: staging
+spec:
+  owner:
+    projectName: gcp-microservice-demo
+  environment: staging
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: gcp-microservice-demo-production
+  namespace: default
+  labels:
+    openchoreo.dev/project: gcp-microservice-demo
+    openchoreo.dev/environment: production
+spec:
+  owner:
+    projectName: gcp-microservice-demo
+  environment: production


### PR DESCRIPTION
## Purpose
The Project controller no longer auto-creates ProjectReleaseBindings, so sample projects that relied on it never get cell namespaces and fail to deploy.

## Approach
Add explicit per-environment (development, staging, production) ProjectReleaseBindings to the affected sample projects.

## Related Issues

- #3736 
- Discussion: https://github.com/openchoreo/openchoreo/discussions/3347#discussioncomment-17546491

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
N/A
