### PR TITLE
test: create ProjectReleaseBindings in e2e suites

### DIFF
--- a/test/e2e/suites/alerts/alerts_fixtures_test.go
+++ b/test/e2e/suites/alerts/alerts_fixtures_test.go
@@ -115,9 +115,27 @@ func platformResourcesYAML() string {
 			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
+	// ProjectReleaseBinding deploys the project to the development environment,
+	// creating its cell (DP) namespace. spec.projectRelease is left unset; the
+	// Project controller seeds it once the first ProjectRelease is cut.
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName + "-" + envDev,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     projectName,
+				"openchoreo.dev/environment": envDev,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+			Environment: envDev,
+		},
+	}
 	docs := []any{pipeline}
 	docs = append(docs, envs...)
-	docs = append(docs, proj)
+	docs = append(docs, proj, binding)
 	return mustYAMLDocs(docs...)
 }
 

--- a/test/e2e/suites/build/build_fixtures_test.go
+++ b/test/e2e/suites/build/build_fixtures_test.go
@@ -139,9 +139,27 @@ func platformResourcesYAML() string {
 			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
+	// ProjectReleaseBinding deploys the project to the development environment,
+	// creating its cell (DP) namespace. spec.projectRelease is left unset; the
+	// Project controller seeds it once the first ProjectRelease is cut.
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName + "-" + envDev,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     projectName,
+				"openchoreo.dev/environment": envDev,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+			Environment: envDev,
+		},
+	}
 	docs := []any{pipeline}
 	docs = append(docs, envs...)
-	docs = append(docs, proj)
+	docs = append(docs, proj, binding)
 	return mustYAMLDocs(docs...)
 }
 

--- a/test/e2e/suites/connections/connections_fixtures_test.go
+++ b/test/e2e/suites/connections/connections_fixtures_test.go
@@ -112,6 +112,15 @@ func platformResourcesYAML(cpNamespace string, environments, projects []string) 
 		})
 	}
 
+	// deployEnv is the root environment components are deployed into (the first
+	// environment in the promotion chain). Each project gets an unpinned
+	// ProjectReleaseBinding for it so the Project's cell (DP) namespace is
+	// created; the Project controller no longer auto-creates these bindings.
+	deployEnv := "development"
+	if len(environments) > 0 {
+		deployEnv = environments[0]
+	}
+
 	for _, proj := range projects {
 		docs = append(docs, &openchoreov1alpha1.Project{
 			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Project"},
@@ -125,6 +134,25 @@ func platformResourcesYAML(cpNamespace string, environments, projects []string) 
 			Spec: openchoreov1alpha1.ProjectSpec{
 				DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "default"},
 				Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
+			},
+		})
+
+		// ProjectReleaseBinding deploys the project to the root environment,
+		// creating its cell (DP) namespace. spec.projectRelease is left unset;
+		// the Project controller seeds it once the first ProjectRelease is cut.
+		docs = append(docs, &openchoreov1alpha1.ProjectReleaseBinding{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      proj + "-" + deployEnv,
+				Namespace: cpNamespace,
+				Labels: map[string]string{
+					"openchoreo.dev/project":     proj,
+					"openchoreo.dev/environment": deployEnv,
+				},
+			},
+			Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+				Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: proj},
+				Environment: deployEnv,
 			},
 		})
 	}

--- a/test/e2e/suites/gateway/gateway_fixtures_test.go
+++ b/test/e2e/suites/gateway/gateway_fixtures_test.go
@@ -147,7 +147,29 @@ func platformResourcesYAML() string {
 		},
 	}
 
-	return mustYAMLDocs(pipeline, envDevObj, envStgObj, proj)
+	// Binding creation is client-driven: create an unpinned ProjectReleaseBinding
+	// for each environment so the data-plane cell namespaces get created.
+	docs := []any{pipeline, envDevObj, envStgObj, proj}
+	for _, envName := range []string{envDev, envStaging} {
+		binding := &openchoreov1alpha1.ProjectReleaseBinding{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      projectName + "-" + envName,
+				Namespace: cpNs,
+				Labels: map[string]string{
+					"openchoreo.dev/project":     projectName,
+					"openchoreo.dev/environment": envName,
+				},
+			},
+			Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+				Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+				Environment: envName,
+			},
+		}
+		docs = append(docs, binding)
+	}
+
+	return mustYAMLDocs(docs...)
 }
 
 func componentYAML(name, image string, args []string, endpoints map[string]endpointDef, traits []openchoreov1alpha1.ComponentTrait) string {

--- a/test/e2e/suites/gitops/gitops_fixtures_test.go
+++ b/test/e2e/suites/gitops/gitops_fixtures_test.go
@@ -119,9 +119,27 @@ func platformResourcesYAML() string {
 			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
+	// ProjectReleaseBinding deploys the project to the development environment,
+	// creating its cell (DP) namespace. spec.projectRelease is left unset; the
+	// Project controller seeds it once the first ProjectRelease is cut.
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName + "-" + envDev,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     projectName,
+				"openchoreo.dev/environment": envDev,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+			Environment: envDev,
+		},
+	}
 	docs := []any{pipeline}
 	docs = append(docs, envs...)
-	docs = append(docs, proj)
+	docs = append(docs, proj, binding)
 	return mustYAMLDocs(docs...)
 }
 

--- a/test/e2e/suites/mcp/mcp_fixtures_test.go
+++ b/test/e2e/suites/mcp/mcp_fixtures_test.go
@@ -124,3 +124,27 @@ func platformResourcesYAML(cpNamespace string, environments []string, projects [
 
 	return mustYAMLDocs(docs...)
 }
+
+// projectReleaseBindingYAML renders an unpinned ProjectReleaseBinding that
+// deploys the given project to the given environment, creating its cell (DP)
+// namespace. The MCP create_project tool does not author bindings, so the
+// suite applies this after the project is created. spec.projectRelease is left
+// unset; the Project controller seeds it once the first ProjectRelease is cut.
+func projectReleaseBindingYAML(cpNamespace, project, environment string) string {
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      project + "-" + environment,
+			Namespace: cpNamespace,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     project,
+				"openchoreo.dev/environment": environment,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: project},
+			Environment: environment,
+		},
+	}
+	return mustYAMLDocs(binding)
+}

--- a/test/e2e/suites/mcp/mcp_test.go
+++ b/test/e2e/suites/mcp/mcp_test.go
@@ -237,6 +237,11 @@ var _ = Describe("MCP Server", Ordered, Label("tier2"), func() {
 			Eventually(func(g Gomega) {
 				framework.AssertResourceExists(g, kubeContext, mcpNs, "project", projectName)
 			}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+			By("creating a ProjectReleaseBinding so the development cell namespace is provisioned")
+			output, err := framework.KubectlApplyLiteral(kubeContext,
+				projectReleaseBindingYAML(mcpNs, projectName, "development"))
+			Expect(err).NotTo(HaveOccurred(), "failed to create ProjectReleaseBinding: %s", output)
 		})
 
 		It("creates a component via MCP", func() {

--- a/test/e2e/suites/networkpolicy/networkpolicy_fixtures_test.go
+++ b/test/e2e/suites/networkpolicy/networkpolicy_fixtures_test.go
@@ -342,6 +342,29 @@ func unprotectedPodYAML(namespace, name string) string {
 	return mustYAMLDocs(pod, svc)
 }
 
+// projectReleaseBindingYAML creates an unpinned ProjectReleaseBinding for a
+// (project, environment) pair. This is what triggers creation of the data-plane
+// cell namespace; spec.projectRelease is left unset so the Project controller
+// seeds it once the first ProjectRelease is cut.
+func projectReleaseBindingYAML(cpNamespace, project, environment string) string {
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", project, environment),
+			Namespace: cpNamespace,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     project,
+				"openchoreo.dev/environment": environment,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: project},
+			Environment: environment,
+		},
+	}
+	return mustYAMLDocs(binding)
+}
+
 // releaseBindingYAML creates a ReleaseBinding that deploys an existing ComponentRelease
 // to a specific environment. Used to promote a component to staging without autoDeploy.
 func releaseBindingYAML(cpNamespace, project, component, releaseName, environment string) string {

--- a/test/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/test/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -220,6 +220,22 @@ var _ = Describe("NetworkPolicy Enforcement", Ordered, Label("tier1"), func() {
 		output, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML(cpNsBeta, []string{"development", "staging"}, []string{"proj1"}))
 		Expect(err).NotTo(HaveOccurred(), "failed to apply beta platform resources: %s", output)
 
+		By("creating ProjectReleaseBindings for acme")
+		// Binding creation is client-driven; each (project, environment) we deploy
+		// to needs an unpinned ProjectReleaseBinding for its cell namespace to appear.
+		for _, prb := range []struct{ project, env string }{
+			{"proj1", "development"},
+			{"proj1", "staging"},
+			{"proj2", "development"},
+		} {
+			output, err = framework.KubectlApplyLiteral(kubeContext, projectReleaseBindingYAML(cpNsAcme, prb.project, prb.env))
+			Expect(err).NotTo(HaveOccurred(), "failed to create acme %s/%s ProjectReleaseBinding: %s", prb.project, prb.env, output)
+		}
+
+		By("creating ProjectReleaseBindings for beta")
+		output, err = framework.KubectlApplyLiteral(kubeContext, projectReleaseBindingYAML(cpNsBeta, "proj1", "development"))
+		Expect(err).NotTo(HaveOccurred(), "failed to create beta proj1/development ProjectReleaseBinding: %s", output)
+
 		By("creating Components and Workloads in acme")
 		// comp-a: http-echo with project + namespace + external visibility.
 		output, err = framework.KubectlApplyLiteral(kubeContext, componentYAML(

--- a/test/e2e/suites/observability/observability_fixtures_test.go
+++ b/test/e2e/suites/observability/observability_fixtures_test.go
@@ -121,9 +121,27 @@ func platformResourcesYAML() string {
 			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
+	// ProjectReleaseBinding deploys the project to the development environment,
+	// creating its cell (DP) namespace. spec.projectRelease is left unset; the
+	// Project controller seeds it once the first ProjectRelease is cut.
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName + "-" + envDev,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     projectName,
+				"openchoreo.dev/environment": envDev,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+			Environment: envDev,
+		},
+	}
 	docs := []any{pipeline}
 	docs = append(docs, envs...)
-	docs = append(docs, proj)
+	docs = append(docs, proj, binding)
 	return mustYAMLDocs(docs...)
 }
 

--- a/test/e2e/suites/openchoreoapi/fixtures_test.go
+++ b/test/e2e/suites/openchoreoapi/fixtures_test.go
@@ -90,6 +90,25 @@ func newProject(name string) gen.Project {
 	}
 }
 
+// newProjectReleaseBinding returns an unpinned gen.ProjectReleaseBinding for the
+// given project and environment. Binding creation is client-driven, so the suite
+// must create it explicitly for the project's data-plane cell namespace to exist.
+func newProjectReleaseBinding(projectName, env string) gen.ProjectReleaseBinding {
+	return gen.ProjectReleaseBinding{
+		Metadata: gen.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s", projectName, env),
+		},
+		Spec: &gen.ProjectReleaseBindingSpec{
+			Environment: env,
+			Owner: struct {
+				ProjectName string `json:"projectName"`
+			}{
+				ProjectName: projectName,
+			},
+		},
+	}
+}
+
 // newComponent returns a gen.Component for creation, referencing a ClusterComponentType.
 func newComponent(name, projectName, clusterComponentTypeName string) gen.Component {
 	autoDeploy := true

--- a/test/e2e/suites/openchoreoapi/openchoreoapi_test.go
+++ b/test/e2e/suites/openchoreoapi/openchoreoapi_test.go
@@ -178,6 +178,14 @@ metadata:
 		Expect(getResp.StatusCode()).To(Equal(http.StatusOK))
 		Expect(getResp.JSON200).NotTo(BeNil())
 		Expect(getResp.JSON200.Metadata.Name).To(Equal(projectName))
+
+		By("creating an unpinned ProjectReleaseBinding to provision the cell namespace")
+		prbResp, err := client.CreateProjectReleaseBindingWithResponse(ctx, nsName,
+			newProjectReleaseBinding(projectName, "development"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(prbResp.StatusCode()).To(Equal(http.StatusCreated),
+			"expected 201 for project release binding creation, got %d: %s",
+			prbResp.StatusCode(), string(prbResp.Body))
 	})
 
 	// ── Test 6: ComponentType list + pagination ──────────────────────────

--- a/test/e2e/suites/secrets/secrets_fixtures_test.go
+++ b/test/e2e/suites/secrets/secrets_fixtures_test.go
@@ -121,6 +121,24 @@ func platformResourcesYAML() string {
 				Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 			},
 		},
+		// ProjectReleaseBinding deploys the project to the development environment,
+		// creating its cell (DP) namespace. spec.projectRelease is left unset; the
+		// Project controller seeds it once the first ProjectRelease is cut.
+		&openchoreov1alpha1.ProjectReleaseBinding{
+			TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      projectName + "-" + environmentName,
+				Namespace: cpNs,
+				Labels: map[string]string{
+					"openchoreo.dev/project":     projectName,
+					"openchoreo.dev/environment": environmentName,
+				},
+			},
+			Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+				Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+				Environment: environmentName,
+			},
+		},
 	}
 	return mustYAMLDocs(docs...)
 }

--- a/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
@@ -115,9 +115,27 @@ func platformResourcesYAML() string {
 			Type:                  openchoreov1alpha1.ProjectTypeRef{Kind: openchoreov1alpha1.ProjectTypeRefKindClusterProjectType, Name: "default"},
 		},
 	}
+	// ProjectReleaseBinding deploys the project to the development environment,
+	// creating its cell (DP) namespace. spec.projectRelease is left unset; the
+	// Project controller seeds it once the first ProjectRelease is cut.
+	binding := &openchoreov1alpha1.ProjectReleaseBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "ProjectReleaseBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName + releaseBindingSuffix,
+			Namespace: cpNs,
+			Labels: map[string]string{
+				"openchoreo.dev/project":     projectName,
+				"openchoreo.dev/environment": envDev,
+			},
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ProjectReleaseBindingOwner{ProjectName: projectName},
+			Environment: envDev,
+		},
+	}
 	docs := []any{pipeline}
 	docs = append(docs, envs...)
-	docs = append(docs, proj)
+	docs = append(docs, proj, binding)
 	return mustYAMLDocs(docs...)
 }
 

--- a/test/e2e/suites/workloadtypes/workloadtypes_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_test.go
@@ -40,8 +40,9 @@ var _ = Describe("Workload Type Matrix", Ordered, Label("tier1"), func() {
 		output, err = framework.KubectlApplyLiteral(kubeContext, platformResourcesYAML())
 		Expect(err).NotTo(HaveOccurred(), "failed to apply platform resources: %s", output)
 
-		// The DP namespace is created lazily by the controller on the first
-		// Component reconcile, so deploy components first then poll for it.
+		// The DP namespace is created by the ProjectReleaseBinding applied
+		// above once the project's first release is cut, so deploy components
+		// then poll for it.
 		By("deploying service component (greeter)")
 		output, err = framework.KubectlApplyLiteral(kubeContext, componentWithImageYAML(
 			componentService, "deployment/service", imageService, servicePort,


### PR DESCRIPTION
## Purpose
E2e suites time out in setup with `dp namespace for <proj>/<env> not found`. Since ProjectReleaseBinding auto-creation was removed (#4085), a project's cell (data-plane) namespace is no longer created automatically, so every suite that deploys a project and waits for its DP namespace (or a ReleaseBinding to become Ready) hangs. This spans suites across all tiers (tier1/tier2/tier3), surfaced first by the Tier 1 gate.

## Approach
Have each affected suite author the binding explicitly — an unpinned ProjectReleaseBinding (owner + environment only; the controller seeds the pin) for every `(project, environment)` it actually deploys to:

- Inline struct appended to the suite's platform-resources YAML: workloadtypes, secrets, observability, alerts, build, gateway (dev+staging), connections, gitops (Git-synced).
- Applied per control-plane namespace in the test body: networkpolicy (acme proj1 dev/staging, proj2 dev; beta proj1 dev).
- Created via the MCP-created project's kubectl path: mcp.
- Created via the REST API client: openchoreoapi.

Not touched: microservicesdemo (applies the `samples/gcp-microservices-demo` dir, already carries bindings); authz and occ (pure RBAC / CLI round-trip suites that never depend on a cell namespace).

## Related Issues
N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
All 11 modified suites compile (`go test -c`) and pass `go vet`.
