### PR TITLE
feat(cli): add resource to occ config context scope

### DIFF
--- a/internal/occ/cmd/config/cmd.go
+++ b/internal/occ/cmd/config/cmd.go
@@ -56,6 +56,7 @@ func newContextAddCmd() *cobra.Command {
 				Namespace:    flags.GetNamespace(cmd),
 				Project:      flags.GetProject(cmd),
 				Component:    flags.GetComponent(cmd),
+				Resource:     flags.GetResource(cmd),
 			})
 		},
 	}
@@ -64,6 +65,7 @@ func newContextAddCmd() *cobra.Command {
 	flags.AddNamespace(cmd)
 	flags.AddProject(cmd)
 	flags.AddComponent(cmd)
+	flags.AddResource(cmd)
 	_ = cmd.MarkFlagRequired("controlplane")
 	_ = cmd.MarkFlagRequired("credentials")
 	return cmd
@@ -102,6 +104,7 @@ func newContextUpdateCmd() *cobra.Command {
 				Namespace:    flags.GetNamespace(cmd),
 				Project:      flags.GetProject(cmd),
 				Component:    flags.GetComponent(cmd),
+				Resource:     flags.GetResource(cmd),
 				ControlPlane: flags.GetControlPlane(cmd),
 				Credentials:  flags.GetCredentials(cmd),
 			})
@@ -110,6 +113,7 @@ func newContextUpdateCmd() *cobra.Command {
 	flags.AddNamespace(cmd)
 	flags.AddProject(cmd)
 	flags.AddComponent(cmd)
+	flags.AddResource(cmd)
 	flags.AddControlPlane(cmd)
 	flags.AddCredentials(cmd)
 	return cmd

--- a/internal/occ/cmd/config/config.go
+++ b/internal/occ/cmd/config/config.go
@@ -97,7 +97,7 @@ func (c *Config) ListContexts() error {
 	}
 
 	// First empty column for current context marker
-	headers := []string{"", "NAME", "CONTROLPLANE", "CREDENTIALS", "NAMESPACE", "PROJECT", "COMPONENT"}
+	headers := []string{"", "NAME", "CONTROLPLANE", "CREDENTIALS", "NAMESPACE", "PROJECT", "COMPONENT", "RESOURCE"}
 	rows := make([][]string, 0, len(cfg.Contexts))
 
 	for _, ctx := range cfg.Contexts {
@@ -114,6 +114,7 @@ func (c *Config) ListContexts() error {
 			formatValueOrPlaceholder(ctx.Namespace),
 			formatValueOrPlaceholder(ctx.Project),
 			formatValueOrPlaceholder(ctx.Component),
+			formatValueOrPlaceholder(ctx.Resource),
 		})
 	}
 
@@ -200,6 +201,9 @@ func (c *Config) UpdateContext(params UpdateContextParams) error {
 			if params.Component != "" {
 				cfg.Contexts[i].Component = params.Component
 			}
+			if params.Resource != "" {
+				cfg.Contexts[i].Resource = params.Resource
+			}
 			if params.ControlPlane != "" {
 				cfg.Contexts[i].ControlPlane = params.ControlPlane
 			}
@@ -284,6 +288,7 @@ func ApplyContextDefaults(cmd *cobra.Command) error {
 	applyIfNotSet(cmd, "namespace", curCtx.Namespace)
 	applyIfNotSet(cmd, "project", curCtx.Project)
 	applyIfNotSet(cmd, "component", curCtx.Component)
+	applyIfNotSet(cmd, "resource", curCtx.Resource)
 
 	return nil
 }

--- a/internal/occ/cmd/config/config_test.go
+++ b/internal/occ/cmd/config/config_test.go
@@ -322,7 +322,7 @@ func TestListContexts(t *testing.T) {
 		seedConfig(t, &StoredConfig{
 			CurrentContext: "ctx1",
 			Contexts: []Context{
-				{Name: "ctx1", ControlPlane: "cp1", Credentials: "cred1", Namespace: "ns1", Project: "proj1", Component: "comp1"},
+				{Name: "ctx1", ControlPlane: "cp1", Credentials: "cred1", Namespace: "ns1", Project: "proj1", Component: "comp1", Resource: "res1"},
 				{Name: "ctx2", ControlPlane: "cp2", Credentials: "cred2"},
 			},
 		})
@@ -333,10 +333,12 @@ func TestListContexts(t *testing.T) {
 		assert.Contains(t, out, "NAME")
 		assert.Contains(t, out, "CONTROLPLANE")
 		assert.Contains(t, out, "CREDENTIALS")
+		assert.Contains(t, out, "RESOURCE")
 		assert.Contains(t, out, "ctx1")
 		assert.Contains(t, out, "ctx2")
 		assert.Contains(t, out, "cp1")
 		assert.Contains(t, out, "ns1")
+		assert.Contains(t, out, "res1")
 	})
 
 	t.Run("marks current context with asterisk", func(t *testing.T) {
@@ -453,6 +455,7 @@ func TestAddContext(t *testing.T) {
 				Credentials:  "cred1",
 				Namespace:    "ns1",
 				Project:      "proj1",
+				Resource:     "analytics-db",
 			})
 			require.NoError(t, err)
 		})
@@ -463,6 +466,7 @@ func TestAddContext(t *testing.T) {
 		require.Len(t, cfg.Contexts, 1)
 		assert.Equal(t, "ctx1", cfg.Contexts[0].Name)
 		assert.Equal(t, "ns1", cfg.Contexts[0].Namespace)
+		assert.Equal(t, "analytics-db", cfg.Contexts[0].Resource)
 		// CP and credential should be auto-created
 		require.Len(t, cfg.ControlPlanes, 1)
 		assert.Equal(t, "cp1", cfg.ControlPlanes[0].Name)
@@ -1002,6 +1006,7 @@ func TestApplyContextDefaults(t *testing.T) {
 		cmd.Flags().String("namespace", "", "")
 		cmd.Flags().String("project", "", "")
 		cmd.Flags().String("component", "", "")
+		cmd.Flags().String("resource", "", "")
 		return cmd
 	}
 
@@ -1039,6 +1044,7 @@ func TestApplyContextDefaults(t *testing.T) {
 				Namespace: "ns1",
 				Project:   "proj1",
 				Component: "comp1",
+				Resource:  "res1",
 			}},
 		})
 		cmd := newCmd()
@@ -1046,19 +1052,21 @@ func TestApplyContextDefaults(t *testing.T) {
 		assert.Equal(t, "ns1", cmd.Flags().Lookup("namespace").Value.String())
 		assert.Equal(t, "proj1", cmd.Flags().Lookup("project").Value.String())
 		assert.Equal(t, "comp1", cmd.Flags().Lookup("component").Value.String())
+		assert.Equal(t, "res1", cmd.Flags().Lookup("resource").Value.String())
 	})
 
 	t.Run("does not override explicitly set flags", func(t *testing.T) {
 		setupTestHome(t)
 		seedConfig(t, &StoredConfig{
 			CurrentContext: "ctx1",
-			Contexts:       []Context{{Name: "ctx1", Namespace: "from-config", Project: "from-config"}},
+			Contexts:       []Context{{Name: "ctx1", Namespace: "from-config", Project: "from-config", Resource: "from-config"}},
 		})
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("namespace", "explicit"))
 		require.NoError(t, ApplyContextDefaults(cmd))
 		assert.Equal(t, "explicit", cmd.Flags().Lookup("namespace").Value.String())
 		assert.Equal(t, "from-config", cmd.Flags().Lookup("project").Value.String())
+		assert.Equal(t, "from-config", cmd.Flags().Lookup("resource").Value.String())
 	})
 }
 
@@ -1078,6 +1086,25 @@ func TestUpdateContext_ComponentField(t *testing.T) {
 		cfg, err := LoadStoredConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "new-comp", cfg.Contexts[0].Component)
+	})
+}
+
+func TestUpdateContext_ResourceField(t *testing.T) {
+	c := New()
+
+	t.Run("updates resource field", func(t *testing.T) {
+		setupTestHome(t)
+		seedConfig(t, &StoredConfig{
+			Contexts:      []Context{{Name: "ctx1", ControlPlane: "cp1", Credentials: "cred1", Resource: "old-res"}},
+			ControlPlanes: []ControlPlane{{Name: "cp1"}},
+			Credentials:   []Credential{{Name: "cred1"}},
+		})
+
+		require.NoError(t, c.UpdateContext(UpdateContextParams{Name: "ctx1", Resource: "new-res"}))
+
+		cfg, err := LoadStoredConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "new-res", cfg.Contexts[0].Resource)
 	})
 }
 

--- a/internal/occ/cmd/config/params.go
+++ b/internal/occ/cmd/config/params.go
@@ -11,6 +11,7 @@ type AddContextParams struct {
 	Namespace    string
 	Project      string
 	Component    string
+	Resource     string
 }
 
 // GetControlPlane returns the control plane name.
@@ -30,6 +31,7 @@ type UpdateContextParams struct {
 	Namespace    string
 	Project      string
 	Component    string
+	Resource     string
 	ControlPlane string
 	Credentials  string
 }

--- a/internal/occ/cmd/config/types.go
+++ b/internal/occ/cmd/config/types.go
@@ -36,4 +36,5 @@ type Context struct {
 	Namespace    string `yaml:"namespace,omitempty"`
 	Project      string `yaml:"project,omitempty"`
 	Component    string `yaml:"component,omitempty"`
+	Resource     string `yaml:"resource,omitempty"`
 }

--- a/test/e2e/suites/occ/occ_config_test.go
+++ b/test/e2e/suites/occ/occ_config_test.go
@@ -55,15 +55,17 @@ func describeConfigCommands() {
 				_, _, err := occ.Run("config", "context", "use", "test-ctx")
 				Expect(err).NotTo(HaveOccurred())
 			})
-			It("updates the context", func() {
+			It("updates the context with namespace, project, and resource", func() {
 				_, _, err := occ.Run("config", "context", "update", "test-ctx",
-					"--namespace", "default", "--project", "default")
+					"--namespace", "default", "--project", "default", "--resource", "analytics-db")
 				Expect(err).NotTo(HaveOccurred())
 
 				stdout, _, err := occ.Run("config", "context", "list")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(stdout).To(ContainSubstring("default"),
 					"expected updated namespace/project in context list")
+				Expect(stdout).To(ContainSubstring("analytics-db"),
+					"expected updated resource in context list")
 			})
 			It("switches back to original context and deletes test context", func() {
 				_, _, err := occ.Run("config", "context", "use", "e2e")


### PR DESCRIPTION
## Purpose
Add `resource` as a first-class dimension of the `occ` CLI context, achieving parity with `namespace`, `project`, and `component`.

Currently, `--resource` is a transient flag that users must re-type on every invocation of resource-scoped commands (e.g. `occ resourcerelease list --resource analytics-db`). This is inconsistent with how the sibling `--component` flag is handled — component can be stored in a context and auto-defaulted. This PR brings the same ergonomics to `resource`.

## Approach

The change mirrors exactly how `component` is implemented throughout the codebase — small, additive, and fully backward-compatible (`omitempty` YAML tag means existing config files load cleanly).

**Changes:**
- `types.go`: Add `Resource string` field to `Context` struct (`yaml:"resource,omitempty"`)
- `params.go`: Add `Resource` to `AddContextParams` and `UpdateContextParams`
- `config.go`: Wire `Resource` through `ListContexts` (new RESOURCE column), `UpdateContext`, and `ApplyContextDefaults`
- `cmd.go`: Register `--resource` flag on `occ config context add` and `occ config context update`
- `config_test.go`: Extend existing tests + add `TestUpdateContext_ResourceField`
- `occ_config_test.go`: Extend e2e context CRUD block to cover `--resource`

**Usage after this change:**
```sh
# Store once
occ config context update myctx --resource analytics-db

# Run without repeating --resource
occ resourcerelease list
occ resourcereleasebinding list

# Explicit flag still wins
occ resourcerelease list --resource other-db
```

## Related Issues

Fixes #4126

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content