### PR TITLE
test: seed ProjectReleaseBindings in UI e2e specs

### DIFF
--- a/test/ui/specs/abac-ui/abac-env-restriction.spec.ts
+++ b/test/ui/specs/abac-ui/abac-env-restriction.spec.ts
@@ -60,6 +60,32 @@ spec:
     name: default
 ---
 apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: ${PROJECT_NAME}-development
+  namespace: default
+  labels:
+    openchoreo.dev/project: ${PROJECT_NAME}
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: ${PROJECT_NAME}
+  environment: development
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: ${PROJECT_NAME}-staging
+  namespace: default
+  labels:
+    openchoreo.dev/project: ${PROJECT_NAME}
+    openchoreo.dev/environment: staging
+spec:
+  owner:
+    projectName: ${PROJECT_NAME}
+  environment: staging
+---
+apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterAuthzRole
 metadata:
   name: ${BINDING_NAME}-rb-role

--- a/test/ui/specs/observability/observability-panels.spec.ts
+++ b/test/ui/specs/observability/observability-panels.spec.ts
@@ -75,6 +75,19 @@ spec:
   type:
     kind: ClusterProjectType
     name: default
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ProjectReleaseBinding
+metadata:
+  name: ${PROJECT_NAME}-development
+  namespace: ${NS}
+  labels:
+    openchoreo.dev/project: ${PROJECT_NAME}
+    openchoreo.dev/environment: development
+spec:
+  owner:
+    projectName: ${PROJECT_NAME}
+  environment: development
 `;
 
 const postgresYAML = `


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Two UI e2e specs create their Project via raw kubectl apply rather than through the Backstage scaffolder, so they never get a ProjectReleaseBinding.
Since ProjectReleaseBinding auto-creation was removed (#4085), the cell (DP) namespace is never created and the deployed/autoDeploy ReleaseBindings hang waiting for Active/Ready — this was causing `abac-env-restriction.spec.ts` and `observability-panels.spec.ts` to time out and fail in CI.

## Approach
Seed an unpinned ProjectReleaseBinding (owner + environment only) for each environment the spec deploys to:
- abac-env-restriction.spec.ts: development, staging
- observability-panels.spec.ts: development

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content