### PR TITLE
fix: namespace-qualify occ filesystem-mode resource indexes

### DIFF
--- a/internal/occ/cmd/componentrelease/resolver.go
+++ b/internal/occ/cmd/componentrelease/resolver.go
@@ -20,7 +20,7 @@ import (
 func buildOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.OutputDirResolverFunc {
 	return func(projectName, componentName string) string {
 		// Priority 1: Use directory of existing releases
-		releases := ocIndex.ListReleasesForComponent(projectName, componentName)
+		releases := ocIndex.ListReleasesForComponent(namespace, projectName, componentName)
 		if len(releases) > 0 {
 			return filepath.Dir(releases[0].FilePath)
 		}

--- a/internal/occ/cmd/componentrelease/resolver_test.go
+++ b/internal/occ/cmd/componentrelease/resolver_test.go
@@ -73,6 +73,28 @@ func TestBuildOutputDirResolver(t *testing.T) {
 
 		assert.Empty(t, resolver("nonexistent-proj", "nonexistent-comp"))
 	})
+
+	// Regression test for issue #4148: a duplicate owner (same project/component) exists in two
+	// namespaces with releases in distinct directories. The resolver must return the ACTIVE
+	// namespace's release directory. Both namespaces are populated so the namespace-scoped release
+	// lookup cannot pass by Go map-iteration order.
+	t.Run("namespace isolation: resolves active namespace's releases dir", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		addComponent(t, idx, "team-a", "dup-comp", "dup-proj",
+			"/repo/team-a/projects/dup-proj/components/dup-comp/component.yaml")
+		addRelease(t, idx, "team-a", "dup-comp-a", "dup-proj", "dup-comp",
+			"/repo/team-a/projects/dup-proj/components/dup-comp/releases/dup-comp-a.yaml")
+		addComponent(t, idx, "team-b", "dup-comp", "dup-proj",
+			"/repo/team-b/projects/dup-proj/components/dup-comp/component.yaml")
+		addRelease(t, idx, "team-b", "dup-comp-b", "dup-proj", "dup-comp",
+			"/repo/team-b/projects/dup-proj/components/dup-comp/releases/dup-comp-b.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildOutputDirResolver(ocIndex, "team-a")
+
+		assert.Equal(t, "/repo/team-a/projects/dup-proj/components/dup-comp/releases", resolver("dup-proj", "dup-comp"))
+	})
 }
 
 // addComponent adds a Component resource entry to the index.

--- a/internal/occ/cmd/releasebinding/releasebinding.go
+++ b/internal/occ/cmd/releasebinding/releasebinding.go
@@ -151,7 +151,7 @@ func (r *ReleaseBinding) Generate(params GenerateParams) error {
 	}
 
 	// Get and validate deployment pipeline
-	pipelineEntry, ok := ocIndex.GetDeploymentPipeline(params.UsePipeline)
+	pipelineEntry, ok := ocIndex.GetDeploymentPipeline(namespace, params.UsePipeline)
 	if !ok {
 		return fmt.Errorf("deployment pipeline %q not found", params.UsePipeline)
 	}

--- a/internal/occ/cmd/releasebinding/resolver.go
+++ b/internal/occ/cmd/releasebinding/resolver.go
@@ -19,9 +19,12 @@ import (
 //  2. Otherwise, use a "release-bindings/" directory alongside the component file.
 func buildBindingOutputDirResolver(ocIndex *fsmode.Index, namespace string) output.OutputDirResolverFunc {
 	return func(projectName, componentName string) string {
-		// Priority 1: Use directory of existing bindings
+		// Priority 1: Use directory of existing bindings in the active namespace
 		allBindings := ocIndex.ListReleaseBindings()
 		for _, entry := range allBindings {
+			if entry.Namespace() != namespace {
+				continue
+			}
 			owner := fsmode.ExtractOwnerRef(entry)
 			if owner != nil && owner.ProjectName == projectName && owner.ComponentName == componentName {
 				return filepath.Dir(entry.FilePath)

--- a/internal/occ/cmd/releasebinding/resolver_test.go
+++ b/internal/occ/cmd/releasebinding/resolver_test.go
@@ -73,6 +73,28 @@ func TestBuildBindingOutputDirResolver(t *testing.T) {
 
 		assert.Empty(t, resolver("nonexistent-proj", "nonexistent-comp"))
 	})
+
+	// Regression test for issue #4148: a duplicate owner (same project/component) exists in two
+	// namespaces with bindings in distinct directories. The resolver must return the ACTIVE
+	// namespace's binding directory. Both namespaces are populated so the namespace-filtered
+	// binding lookup cannot pass by Go map-iteration order.
+	t.Run("namespace isolation: resolves active namespace's bindings dir", func(t *testing.T) {
+		idx := index.New("/repo")
+
+		addComponent(t, idx, "team-a", "dup-comp", "dup-proj",
+			"/repo/team-a/projects/dup-proj/components/dup-comp/component.yaml")
+		addBinding(t, idx, "team-a", "dup-comp-dev", "dup-proj", "dup-comp", "dev",
+			"/repo/team-a/projects/dup-proj/components/dup-comp/release-bindings/dup-comp-dev.yaml")
+		addComponent(t, idx, "team-b", "dup-comp", "dup-proj",
+			"/repo/team-b/projects/dup-proj/components/dup-comp/component.yaml")
+		addBinding(t, idx, "team-b", "dup-comp-dev", "dup-proj", "dup-comp", "dev",
+			"/repo/team-b/projects/dup-proj/components/dup-comp/release-bindings/dup-comp-dev.yaml")
+
+		ocIndex := fsmode.WrapIndex(idx)
+		resolver := buildBindingOutputDirResolver(ocIndex, "team-a")
+
+		assert.Equal(t, "/repo/team-a/projects/dup-proj/components/dup-comp/release-bindings", resolver("dup-proj", "dup-comp"))
+	})
 }
 
 // addComponent adds a Component resource entry to the index.

--- a/internal/occ/cmd/workload/workload.go
+++ b/internal/occ/cmd/workload/workload.go
@@ -103,7 +103,7 @@ func (w *Workload) createFileSystemMode(params CreateParams, synthParams synth.C
 	var workloadCR *openchoreov1alpha1.Workload
 
 	if params.FilePath == "" {
-		if entry, ok := idx.GetWorkloadForComponent(params.ProjectName, params.ComponentName); ok {
+		if entry, ok := idx.GetWorkloadForComponent(params.NamespaceName, params.ProjectName, params.ComponentName); ok {
 			typedWorkload, err := typed.NewWorkload(entry)
 			if err != nil {
 				return fmt.Errorf("failed to read existing workload: %w", err)

--- a/internal/occ/fsmode/generator/bulk_component_release.go
+++ b/internal/occ/fsmode/generator/bulk_component_release.go
@@ -101,13 +101,20 @@ func (g *ReleaseGenerator) GenerateBulkReleases(opts BulkReleaseOptions) (*BulkR
 // discoverComponents discovers which components to process based on options
 func (g *ReleaseGenerator) discoverComponents(opts BulkReleaseOptions) ([]*index.ResourceEntry, error) {
 	if opts.All {
-		// Return all components in the repository
-		return g.index.ListComponents(), nil
+		// Return all components in the active namespace
+		var components []*index.ResourceEntry
+		for _, comp := range g.index.ListComponents() {
+			if comp.Namespace() != opts.Namespace {
+				continue
+			}
+			components = append(components, comp)
+		}
+		return components, nil
 	}
 
 	if opts.ProjectName != "" {
 		// Return all components in the specified project
-		components := g.index.ListComponentsForProject(opts.ProjectName)
+		components := g.index.ListComponentsForProject(opts.Namespace, opts.ProjectName)
 		if len(components) == 0 {
 			return nil, fmt.Errorf("no components found for project %q", opts.ProjectName)
 		}

--- a/internal/occ/fsmode/generator/bulk_component_release_test.go
+++ b/internal/occ/fsmode/generator/bulk_component_release_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode"
 	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
@@ -23,20 +24,20 @@ func TestDiscoverComponents(t *testing.T) {
 	ocIndex := fsmode.WrapIndex(idx)
 	gen := NewReleaseGenerator(ocIndex)
 
-	t.Run("all flag returns all components", func(t *testing.T) {
-		components, err := gen.discoverComponents(BulkReleaseOptions{All: true})
+	t.Run("all flag returns all components in namespace", func(t *testing.T) {
+		components, err := gen.discoverComponents(BulkReleaseOptions{All: true, Namespace: "default"})
 		require.NoError(t, err)
 		assert.Len(t, components, 3)
 	})
 
 	t.Run("project filter returns matching components", func(t *testing.T) {
-		components, err := gen.discoverComponents(BulkReleaseOptions{ProjectName: "proj-1"})
+		components, err := gen.discoverComponents(BulkReleaseOptions{ProjectName: "proj-1", Namespace: "default"})
 		require.NoError(t, err)
 		assert.Len(t, components, 2)
 	})
 
 	t.Run("project with no components returns error", func(t *testing.T) {
-		_, err := gen.discoverComponents(BulkReleaseOptions{ProjectName: "nonexistent"})
+		_, err := gen.discoverComponents(BulkReleaseOptions{ProjectName: "nonexistent", Namespace: "default"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no components found")
 	})
@@ -48,6 +49,49 @@ func TestDiscoverComponents(t *testing.T) {
 	})
 }
 
+// TestDiscoverComponents_NamespaceFilter verifies that the --all discovery path only
+// returns components in the active namespace (issue #4148).
+func TestDiscoverComponents_NamespaceFilter(t *testing.T) {
+	idx := index.New("/repo")
+
+	addComponentNS(t, idx, "team-a", "web-app", "proj", "deployment/service", "/repo/team-a/web-app.yaml")
+	addComponentNS(t, idx, "team-a", "api", "proj", "deployment/service", "/repo/team-a/api.yaml")
+	addComponentNS(t, idx, "team-b", "web-app", "proj", "deployment/service", "/repo/team-b/web-app.yaml")
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewReleaseGenerator(ocIndex)
+
+	components, err := gen.discoverComponents(BulkReleaseOptions{All: true, Namespace: "team-a"})
+	require.NoError(t, err)
+	require.Len(t, components, 2)
+	for _, comp := range components {
+		assert.Equal(t, "team-a", comp.Namespace())
+	}
+}
+
+// addComponentNS adds a Component resource entry to the index in a specific namespace.
+func addComponentNS(t *testing.T, idx *index.Index, namespace, name, project, componentTypeName, filePath string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner":         map[string]any{"projectName": project},
+					"componentType": map[string]any{"name": componentTypeName, "kind": "ComponentType"},
+				},
+			},
+		},
+		FilePath: filePath,
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
 func TestGenerateBulkReleases(t *testing.T) {
 	t.Run("generates releases for all components in a project", func(t *testing.T) {
 		idx := index.New("/repo")
@@ -55,7 +99,7 @@ func TestGenerateBulkReleases(t *testing.T) {
 		addComponent(t, idx, "svc-a", "myproj", "deployment/service", "/repo/svc-a.yaml")
 		addComponent(t, idx, "svc-b", "myproj", "deployment/service", "/repo/svc-b.yaml")
 
-		addComponentType(t, idx, "service", "deployment", "/repo/ct-service.yaml")
+		addComponentType(t, idx, "default", "service", "deployment", "/repo/ct-service.yaml")
 
 		addWorkload(t, idx, "default", "svc-a-workload", "myproj", "svc-a",
 			map[string]any{"container": map[string]any{"image": "img-a:v1"}},
@@ -94,7 +138,7 @@ func TestGenerateBulkReleases(t *testing.T) {
 		addComponent(t, idx, "svc-good", "myproj", "deployment/service", "/repo/svc-good.yaml")
 		addComponent(t, idx, "svc-bad", "myproj", "deployment/service", "/repo/svc-bad.yaml")
 
-		addComponentType(t, idx, "service", "deployment", "/repo/ct-service.yaml")
+		addComponentType(t, idx, "default", "service", "deployment", "/repo/ct-service.yaml")
 
 		addWorkload(t, idx, "default", "svc-good-workload", "myproj", "svc-good",
 			map[string]any{"container": map[string]any{"image": "img:v1"}},

--- a/internal/occ/fsmode/generator/component_release.go
+++ b/internal/occ/fsmode/generator/component_release.go
@@ -68,7 +68,7 @@ func (g *ReleaseGenerator) GenerateRelease(opts ReleaseOptions) (*unstructured.U
 	var ctSpec v1alpha1.ComponentTypeSpec
 	switch ctKind {
 	case string(v1alpha1.ComponentTypeRefKindComponentType):
-		ct, err := g.index.GetTypedComponentType(typeName)
+		ct, err := g.index.GetTypedComponentType(opts.Namespace, typeName)
 		if err != nil {
 			return nil, fmt.Errorf("component type %q not found (referenced by component %q): %w",
 				typeName, opts.ComponentName, err)
@@ -104,13 +104,13 @@ func (g *ReleaseGenerator) GenerateRelease(opts ReleaseOptions) (*unstructured.U
 
 	// Gather every Trait/ClusterTrait referenced by both the embedded ComponentType traits
 	// and the component-level traits so BuildSpec can freeze their specs.
-	traits, clusterTraits, err := g.gatherTraits(&ctSpec, comp.Component)
+	traits, clusterTraits, err := g.gatherTraits(&ctSpec, comp.Component, opts.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	// Fetch the workload that carries the built container image.
-	wl, err := g.index.GetTypedWorkloadForComponent(comp.ProjectName(), comp.Name)
+	wl, err := g.index.GetTypedWorkloadForComponent(opts.Namespace, comp.ProjectName(), comp.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (g *ReleaseGenerator) GenerateRelease(opts ReleaseOptions) (*unstructured.U
 	// Determine release name.
 	releaseName := opts.ReleaseName
 	if releaseName == "" {
-		releaseName, err = GenerateReleaseName(comp.Name, opts.Date, opts.Version, g.index)
+		releaseName, err = GenerateReleaseName(comp.Name, opts.Date, opts.Version, opts.Namespace, comp.ProjectName(), g.index)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate release name: %w", err)
 		}
@@ -187,6 +187,7 @@ func defaultTraitKinds(ctSpec *v1alpha1.ComponentTypeSpec, comp *v1alpha1.Compon
 func (g *ReleaseGenerator) gatherTraits(
 	ctSpec *v1alpha1.ComponentTypeSpec,
 	comp *v1alpha1.Component,
+	namespace string,
 ) (map[string]v1alpha1.TraitSpec, map[string]v1alpha1.ClusterTraitSpec, error) {
 	traits := make(map[string]v1alpha1.TraitSpec)
 	clusterTraits := make(map[string]v1alpha1.ClusterTraitSpec)
@@ -206,7 +207,7 @@ func (g *ReleaseGenerator) gatherTraits(
 			if _, exists := traits[name]; exists {
 				return nil
 			}
-			t, err := g.index.GetTypedTrait(name)
+			t, err := g.index.GetTypedTrait(namespace, name)
 			if err != nil {
 				return err
 			}

--- a/internal/occ/fsmode/generator/component_release_test.go
+++ b/internal/occ/fsmode/generator/component_release_test.go
@@ -44,7 +44,7 @@ func addComponent(t *testing.T, idx *index.Index, name, project, componentTypeNa
 }
 
 // addComponentType adds a ComponentType resource entry to the index.
-func addComponentType(t *testing.T, idx *index.Index, name, workloadType string, filePath string) {
+func addComponentType(t *testing.T, idx *index.Index, namespace, name, workloadType string, filePath string) {
 	t.Helper()
 	entry := &index.ResourceEntry{
 		Resource: &unstructured.Unstructured{
@@ -53,7 +53,7 @@ func addComponentType(t *testing.T, idx *index.Index, name, workloadType string,
 				"kind":       "ComponentType",
 				"metadata": map[string]any{
 					"name":      name,
-					"namespace": "default",
+					"namespace": namespace,
 				},
 				"spec": map[string]any{
 					"workloadType": workloadType,
@@ -97,7 +97,7 @@ func addWorkload(t *testing.T, idx *index.Index, namespace, name, project, compo
 }
 
 // addTrait adds a Trait resource entry to the index.
-func addTrait(t *testing.T, idx *index.Index, name string, spec map[string]any, filePath string) {
+func addTrait(t *testing.T, idx *index.Index, namespace, name string, spec map[string]any, filePath string) {
 	t.Helper()
 	entry := &index.ResourceEntry{
 		Resource: &unstructured.Unstructured{
@@ -106,7 +106,7 @@ func addTrait(t *testing.T, idx *index.Index, name string, spec map[string]any, 
 				"kind":       "Trait",
 				"metadata": map[string]any{
 					"name":      name,
-					"namespace": "default",
+					"namespace": namespace,
 				},
 				"spec": spec,
 			},
@@ -116,9 +116,12 @@ func addTrait(t *testing.T, idx *index.Index, name string, spec map[string]any, 
 	require.NoError(t, idx.Add(entry))
 }
 
-// addComponentWithTraits adds a Component with trait references to the index.
-func addComponentWithTraits(t *testing.T, idx *index.Index, namespace string, traits []map[string]any, filePath string) {
+// addComponentWithTraits adds a Component with trait references to the index. The component is
+// always seeded into the "default" namespace to match addComponentTypeWithSpec, since
+// namespace-scoped ComponentType lookup requires the component to share the ComponentType's namespace.
+func addComponentWithTraits(t *testing.T, idx *index.Index, traits []map[string]any, filePath string) {
 	t.Helper()
+	const namespace = "default"
 	const name = "my-svc"
 	const project = "myproj"
 	const componentTypeName = "deployment/service"
@@ -161,7 +164,7 @@ func TestGenerateRelease_ManifestShape(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace,
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-1"},
 			{"name": "logging", "instanceName": "logging-1"},
@@ -187,11 +190,11 @@ func TestGenerateRelease_ManifestShape(t *testing.T) {
 		},
 		"/repo/projects/myproj/components/my-svc/workload.yaml")
 
-	addTrait(t, idx, "ingress",
+	addTrait(t, idx, "default", "ingress",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "networking.k8s.io/v1", "kind": "Ingress"}}}},
 		"/repo/platform/traits/ingress.yaml")
 
-	addTrait(t, idx, "logging",
+	addTrait(t, idx, "default", "logging",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}}}},
 		"/repo/platform/traits/logging.yaml")
 
@@ -281,7 +284,7 @@ func TestGenerateRelease_AllowedTraitKindDefaulted(t *testing.T) {
 	idx := index.New("/repo")
 
 	// Component spells the trait kind out explicitly; the ComponentType's allowedTraits omits it.
-	addComponentWithTraits(t, idx, namespace,
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "Trait", "name": "logging", "instanceName": "logging-1"},
 		},
@@ -302,7 +305,7 @@ func TestGenerateRelease_AllowedTraitKindDefaulted(t *testing.T) {
 		map[string]any{"container": map[string]any{"image": "reg/my-svc:v1"}},
 		"/repo/projects/myproj/components/my-svc/workload.yaml")
 
-	addTrait(t, idx, "logging",
+	addTrait(t, idx, "default", "logging",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}}}},
 		"/repo/platform/traits/logging.yaml")
 
@@ -340,7 +343,7 @@ func TestGenerateRelease_DeterministicTraitOrder(t *testing.T) {
 	newGen := func() *ReleaseGenerator {
 		idx := index.New("/repo")
 
-		addComponentWithTraits(t, idx, namespace,
+		addComponentWithTraits(t, idx,
 			[]map[string]any{
 				{"kind": "Trait", "name": "zebra", "instanceName": "zebra-1"},
 				{"kind": "Trait", "name": "alpha", "instanceName": "alpha-1"},
@@ -363,8 +366,8 @@ func TestGenerateRelease_DeterministicTraitOrder(t *testing.T) {
 			},
 			"/repo/platform/component-types/service.yaml")
 
-		addTrait(t, idx, "zebra", map[string]any{}, "/repo/platform/traits/zebra.yaml")
-		addTrait(t, idx, "alpha", map[string]any{}, "/repo/platform/traits/alpha.yaml")
+		addTrait(t, idx, "default", "zebra", map[string]any{}, "/repo/platform/traits/zebra.yaml")
+		addTrait(t, idx, "default", "alpha", map[string]any{}, "/repo/platform/traits/alpha.yaml")
 		addClusterTrait(t, idx, "yak", map[string]any{}, "/repo/platform/cluster-traits/yak.yaml")
 		addClusterTrait(t, idx, "beta", map[string]any{}, "/repo/platform/cluster-traits/beta.yaml")
 
@@ -479,7 +482,7 @@ func TestGenerateRelease_ComponentTypeEmbeddedTraitOmittedKind(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace, nil,
+	addComponentWithTraits(t, idx, nil,
 		"/repo/projects/myproj/components/my-svc/component.yaml")
 
 	// Embedded trait entry omits "kind"; the file is a ComponentType, so it must default to Trait.
@@ -493,7 +496,7 @@ func TestGenerateRelease_ComponentTypeEmbeddedTraitOmittedKind(t *testing.T) {
 		},
 		"/repo/platform/component-types/service.yaml")
 
-	addTrait(t, idx, "sidecar",
+	addTrait(t, idx, "default", "sidecar",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}}}},
 		"/repo/platform/traits/sidecar.yaml")
 
@@ -725,7 +728,7 @@ func TestGenerateRelease_ClusterTrait(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace,
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "ClusterTrait", "name": "global-ingress", "instanceName": "gi-1"},
 		},
@@ -788,14 +791,16 @@ func TestGenerateRelease_ClusterTrait(t *testing.T) {
 
 func TestGenerateRelease_MissingClusterTraitErrors(t *testing.T) {
 	const (
-		namespace     = "staging"
+		// The ComponentType helper (addComponentTypeWithSpec) seeds into the "default" namespace,
+		// and namespace-scoped ComponentType lookup now requires the component to share it.
+		namespace     = "default"
 		projectName   = "myproj"
 		componentName = "my-svc"
 	)
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace,
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "ClusterTrait", "name": "global-ingress", "instanceName": "gi-1"},
 		},
@@ -914,7 +919,7 @@ func TestGenerateRelease_WorkloadEndpointsIncluded(t *testing.T) {
 	addComponent(t, idx, componentName, projectName, "deployment/service",
 		"/repo/projects/doclet/components/document-svc/component.yaml")
 
-	addComponentType(t, idx, "service", "deployment",
+	addComponentType(t, idx, "default", "service", "deployment",
 		"/repo/platform/component-types/service.yaml")
 
 	addWorkload(t, idx, namespace, "document-svc-workload", projectName, componentName,
@@ -981,7 +986,7 @@ func TestGenerateRelease_WorkloadConnectionsIncluded(t *testing.T) {
 	addComponent(t, idx, componentName, projectName, "deployment/service",
 		"/repo/projects/doclet/components/document-svc/component.yaml")
 
-	addComponentType(t, idx, "service", "deployment",
+	addComponentType(t, idx, "default", "service", "deployment",
 		"/repo/platform/component-types/service.yaml")
 
 	addWorkload(t, idx, namespace, "document-svc-workload", projectName, componentName,
@@ -1056,7 +1061,7 @@ func TestGenerateRelease_ProjectNameMismatch(t *testing.T) {
 
 	addComponent(t, idx, "my-svc", "actual-project", "deployment/service",
 		"/repo/projects/actual-project/components/my-svc/component.yaml")
-	addComponentType(t, idx, "service", "deployment",
+	addComponentType(t, idx, "default", "service", "deployment",
 		"/repo/platform/component-types/service.yaml")
 	addWorkload(t, idx, "default", "my-svc-workload", "actual-project", "my-svc",
 		map[string]any{"container": map[string]any{"image": "img:v1"}},
@@ -1078,7 +1083,7 @@ func TestGenerateRelease_ProjectNameMismatch(t *testing.T) {
 func TestGenerateRelease_UnsupportedTraitKindErrors(t *testing.T) {
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, "default",
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "UnknownTraitKind", "name": "my-trait", "instanceName": "t-1"},
 		},
@@ -1134,7 +1139,7 @@ func TestGenerateRelease_WithComponentParameters(t *testing.T) {
 	}
 	require.NoError(t, idx.Add(entry))
 
-	addComponentType(t, idx, "service", "deployment",
+	addComponentType(t, idx, "default", "service", "deployment",
 		"/repo/platform/component-types/service.yaml")
 	addWorkload(t, idx, "default", "my-svc-workload", "myproj", "my-svc",
 		map[string]any{"container": map[string]any{"image": "img:v1"}},
@@ -1164,7 +1169,7 @@ func TestGenerateRelease_DuplicateTraitsDeduped(t *testing.T) {
 	idx := index.New("/repo")
 
 	// Component references the same trait twice with different instance names
-	addComponentWithTraits(t, idx, "default",
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-a"},
 			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-b"},
@@ -1181,7 +1186,7 @@ func TestGenerateRelease_DuplicateTraitsDeduped(t *testing.T) {
 			},
 		},
 		"/repo/ct.yaml")
-	addTrait(t, idx, "ingress", map[string]any{}, "/repo/traits/ingress.yaml")
+	addTrait(t, idx, "default", "ingress", map[string]any{}, "/repo/traits/ingress.yaml")
 	addWorkload(t, idx, "default", "my-svc-workload", "myproj", "my-svc",
 		map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
 
@@ -1220,7 +1225,7 @@ func TestGenerateRelease_WorkloadWithoutEndpoints(t *testing.T) {
 	addComponent(t, idx, componentName, projectName, "deployment/worker",
 		"/repo/projects/doclet/components/worker-svc/component.yaml")
 
-	addComponentType(t, idx, "worker", "statefulset",
+	addComponentType(t, idx, "default", "worker", "statefulset",
 		"/repo/platform/component-types/worker.yaml")
 
 	addWorkload(t, idx, namespace, "worker-svc-workload", projectName, componentName,
@@ -1281,7 +1286,7 @@ func TestGenerateRelease_FullComponentTypeSpecPreserved(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace, nil,
+	addComponentWithTraits(t, idx, nil,
 		"/repo/projects/myproj/components/my-svc/component.yaml")
 
 	addComponentTypeWithSpec(t, idx,
@@ -1308,7 +1313,7 @@ func TestGenerateRelease_FullComponentTypeSpecPreserved(t *testing.T) {
 		},
 		"/repo/platform/component-types/service.yaml")
 
-	addTrait(t, idx, "sidecar",
+	addTrait(t, idx, "default", "sidecar",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}}}},
 		"/repo/platform/traits/sidecar.yaml")
 
@@ -1365,7 +1370,7 @@ func TestGenerateRelease_TraitNotInAllowedTraitsErrors(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace,
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "Trait", "name": "ingress", "instanceName": "ingress-1"},
 		},
@@ -1383,7 +1388,7 @@ func TestGenerateRelease_TraitNotInAllowedTraitsErrors(t *testing.T) {
 		"/repo/platform/component-types/service.yaml")
 
 	// The trait exists in the index so that, absent validation, the release would build cleanly.
-	addTrait(t, idx, "ingress", map[string]any{}, "/repo/platform/traits/ingress.yaml")
+	addTrait(t, idx, "default", "ingress", map[string]any{}, "/repo/platform/traits/ingress.yaml")
 
 	addWorkload(t, idx, namespace, "my-svc-workload", projectName, componentName,
 		map[string]any{"container": map[string]any{"image": "reg/my-svc:v1"}},
@@ -1414,7 +1419,7 @@ func TestGenerateRelease_DuplicateTraitInstanceNameErrors(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace,
+	addComponentWithTraits(t, idx,
 		[]map[string]any{
 			{"kind": "Trait", "name": "ingress", "instanceName": "shared-1"},
 		},
@@ -1435,8 +1440,8 @@ func TestGenerateRelease_DuplicateTraitInstanceNameErrors(t *testing.T) {
 		"/repo/platform/component-types/service.yaml")
 
 	// Both traits exist so that, absent validation, the release would build cleanly.
-	addTrait(t, idx, "ingress", map[string]any{}, "/repo/platform/traits/ingress.yaml")
-	addTrait(t, idx, "sidecar", map[string]any{}, "/repo/platform/traits/sidecar.yaml")
+	addTrait(t, idx, "default", "ingress", map[string]any{}, "/repo/platform/traits/ingress.yaml")
+	addTrait(t, idx, "default", "sidecar", map[string]any{}, "/repo/platform/traits/sidecar.yaml")
 
 	addWorkload(t, idx, namespace, "my-svc-workload", projectName, componentName,
 		map[string]any{"container": map[string]any{"image": "reg/my-svc:v1"}},
@@ -1467,7 +1472,7 @@ func TestGenerateRelease_MissingEmbeddedTraitErrors(t *testing.T) {
 
 	idx := index.New("/repo")
 
-	addComponentWithTraits(t, idx, namespace, nil,
+	addComponentWithTraits(t, idx, nil,
 		"/repo/projects/myproj/components/my-svc/component.yaml")
 
 	addComponentTypeWithSpec(t, idx,
@@ -1516,7 +1521,7 @@ func TestGenerateRelease_WorkloadDependencyResourcesPreserved(t *testing.T) {
 	addComponent(t, idx, componentName, projectName, "deployment/service",
 		"/repo/projects/doclet/components/document-svc/component.yaml")
 
-	addComponentType(t, idx, "service", "deployment",
+	addComponentType(t, idx, "default", "service", "deployment",
 		"/repo/platform/component-types/service.yaml")
 
 	addWorkload(t, idx, namespace, "document-svc-workload", projectName, componentName,
@@ -1682,4 +1687,135 @@ func TestGenerateRelease_ByteCompatCommonCase(t *testing.T) {
 	equal, err := output.CompareReleaseSpecs(release, oldFormat)
 	require.NoError(t, err)
 	assert.True(t, equal, "new BuildSpec output must spec-match the old-format release for the common case")
+}
+
+// seedNamespaceComponentGraph adds a full component graph (Component + ComponentType + Trait +
+// Workload) into a single namespace. The same-named ComponentType and Trait are given
+// namespace-distinct specs — the ComponentType via its workloadType and the Trait via the kind of
+// the resource it creates — so a release can be asserted to embed its own namespace's specs.
+func seedNamespaceComponentGraph(t *testing.T, idx *index.Index, namespace, ctWorkloadType, traitTemplateKind string) {
+	t.Helper()
+
+	const (
+		componentName     = "web-app"
+		projectName       = "proj"
+		componentTypeName = "svc"
+		traitName         = "logging"
+	)
+
+	comp := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Component",
+				"metadata":   map[string]any{"name": componentName, "namespace": namespace},
+				"spec": map[string]any{
+					"owner":         map[string]any{"projectName": projectName},
+					"componentType": map[string]any{"name": componentTypeName, "kind": "ComponentType"},
+					"traits": []any{
+						map[string]any{"kind": "Trait", "name": traitName, "instanceName": "logging-1"},
+					},
+				},
+			},
+		},
+		FilePath: "/repo/" + namespace + "/components/web-app/component.yaml",
+	}
+	require.NoError(t, idx.Add(comp))
+
+	ct := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentType",
+				"metadata":   map[string]any{"name": componentTypeName, "namespace": namespace},
+				"spec": map[string]any{
+					"workloadType": ctWorkloadType,
+					"resources":    []any{},
+					"schema":       map[string]any{},
+					"allowedTraits": []any{
+						map[string]any{"kind": "Trait", "name": traitName},
+					},
+				},
+			},
+		},
+		FilePath: "/repo/" + namespace + "/component-types/svc.yaml",
+	}
+	require.NoError(t, idx.Add(ct))
+
+	trait := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Trait",
+				"metadata":   map[string]any{"name": traitName, "namespace": namespace},
+				"spec": map[string]any{
+					"creates": []any{
+						map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": traitTemplateKind}},
+					},
+				},
+			},
+		},
+		FilePath: "/repo/" + namespace + "/traits/logging.yaml",
+	}
+	require.NoError(t, idx.Add(trait))
+
+	addWorkload(t, idx, namespace, "web-app-workload", projectName, componentName,
+		map[string]any{"container": map[string]any{"image": "reg/web-app:v1"}},
+		"/repo/"+namespace+"/components/web-app/workload.yaml")
+}
+
+// TestGenerateRelease_NamespaceCollisionIsolation is a generator-level regression test for
+// issue #4148: two namespaces each hold a full component graph whose ComponentType and Trait
+// share names across namespaces but carry distinct specs. Generating a release for both
+// components in the same test asserts each release embeds ITS OWN namespace's ComponentType and
+// Trait specs, never the other namespace's. Both namespaces are generated together because a
+// single-namespace assertion could pass or fail on Go map-iteration order — resolving both is the
+// deterministic oracle.
+func TestGenerateRelease_NamespaceCollisionIsolation(t *testing.T) {
+	idx := index.New("/repo")
+
+	// team-a: ComponentType workloadType "deployment", logging Trait creates a ConfigMap.
+	seedNamespaceComponentGraph(t, idx, "team-a", "deployment", "ConfigMap")
+	// team-b: same-named ComponentType/Trait, distinct specs (statefulset / Secret).
+	seedNamespaceComponentGraph(t, idx, "team-b", "statefulset", "Secret")
+
+	gen := NewReleaseGenerator(fsmode.WrapIndex(idx))
+
+	generate := func(namespace string) *unstructured.Unstructured {
+		release, err := gen.GenerateRelease(ReleaseOptions{
+			ComponentName: "web-app",
+			ProjectName:   "proj",
+			Namespace:     namespace,
+			ReleaseName:   "web-app-release-1",
+		})
+		require.NoError(t, err)
+		return release
+	}
+
+	// loggingTraitTemplateKind returns the kind of the resource the frozen "logging" trait creates.
+	loggingTraitTemplateKind := func(release *unstructured.Unstructured) string {
+		traitsSlice, ok, _ := unstructured.NestedSlice(release.Object, "spec", "traits")
+		require.True(t, ok, "expected spec.traits")
+		require.Len(t, traitsSlice, 1)
+		trait := traitsSlice[0].(map[string]interface{})
+		assert.Equal(t, "logging", trait["name"])
+		creates, ok, _ := unstructured.NestedSlice(trait, "spec", "creates")
+		require.True(t, ok, "expected trait spec.creates")
+		require.Len(t, creates, 1)
+		kind, ok, _ := unstructured.NestedString(creates[0].(map[string]interface{}), "template", "kind")
+		require.True(t, ok, "expected trait creates[0].template.kind")
+		return kind
+	}
+
+	releaseA := generate("team-a")
+	releaseB := generate("team-b")
+
+	ctWorkloadTypeA, _, _ := unstructured.NestedString(releaseA.Object, "spec", "componentType", "spec", "workloadType")
+	ctWorkloadTypeB, _, _ := unstructured.NestedString(releaseB.Object, "spec", "componentType", "spec", "workloadType")
+
+	assert.Equal(t, "deployment", ctWorkloadTypeA, "team-a release must embed team-a's ComponentType spec")
+	assert.Equal(t, "statefulset", ctWorkloadTypeB, "team-b release must embed team-b's ComponentType spec")
+
+	assert.Equal(t, "ConfigMap", loggingTraitTemplateKind(releaseA), "team-a release must embed team-a's Trait spec")
+	assert.Equal(t, "Secret", loggingTraitTemplateKind(releaseB), "team-b release must embed team-b's Trait spec")
 }

--- a/internal/occ/fsmode/generator/namer.go
+++ b/internal/occ/fsmode/generator/namer.go
@@ -15,7 +15,7 @@ import (
 
 // GenerateReleaseName generates a release name following the naming convention
 // Format: <component-name>-<YYYYMMDD>-<version>
-func GenerateReleaseName(componentName string, date time.Time, version string, index *fsmode.Index) (string, error) {
+func GenerateReleaseName(componentName string, date time.Time, version, namespace, projectName string, index *fsmode.Index) (string, error) {
 	if date.IsZero() {
 		date = time.Now()
 	}
@@ -23,7 +23,7 @@ func GenerateReleaseName(componentName string, date time.Time, version string, i
 
 	if version == "" {
 		// Auto-detect version
-		latestVersion := getLatestVersionForDate(componentName, dateStr, index)
+		latestVersion := getLatestVersionForDate(componentName, dateStr, namespace, projectName, index)
 		version = IncrementVersion(latestVersion)
 	}
 
@@ -31,15 +31,21 @@ func GenerateReleaseName(componentName string, date time.Time, version string, i
 }
 
 // getLatestVersionForDate finds the latest version number for a component on a specific date.
-// It returns "0" if no releases are found for that day.
-func getLatestVersionForDate(componentName, dateStr string, index *fsmode.Index) string {
-	// 1. Get all releases from the index
-	releases := index.ListReleases()
+// It returns "0" if no releases are found for that day. Releases are scoped to the
+// component's namespace and project via ownership, so releases with the same component
+// name in another namespace do not affect version increment.
+func getLatestVersionForDate(componentName, dateStr, namespace, projectName string, index *fsmode.Index) string {
+	// Get releases owned by this namespace/project/component from the index
+	releases := index.ListReleasesForComponent(namespace, projectName, componentName)
 	if len(releases) == 0 {
 		return "0" // No releases found, start with version 0
 	}
 
-	// 2. Filter releases for the target component and date, then collect versions
+	// Filter releases for the target component and date, then collect versions.
+	// Only conventionally-named <component>-<date>-<version> releases participate in
+	// auto-numbering. Off-convention releases (e.g. hand-authored hotfixes) that are
+	// owned by this component but named differently are ignored, so they do not perturb
+	// the generated version sequence.
 	var versionsOnDate []int
 	for _, releaseEntry := range releases {
 		relCompName, relDateStr, relVersion, err := ParseReleaseName(releaseEntry.Name())
@@ -60,7 +66,7 @@ func getLatestVersionForDate(componentName, dateStr string, index *fsmode.Index)
 		return "0" // No releases for this specific component and day
 	}
 
-	// 3. Find the highest version number
+	// Find the highest version number
 	sort.Ints(versionsOnDate)
 	latestVersion := versionsOnDate[len(versionsOnDate)-1]
 

--- a/internal/occ/fsmode/generator/namer_test.go
+++ b/internal/occ/fsmode/generator/namer_test.go
@@ -71,24 +71,83 @@ func TestParseReleaseName(t *testing.T) {
 	}
 }
 
-// makeTestIndex builds an in-memory fsmode.Index with ComponentRelease entries.
+const (
+	testNamespace = "team-a"
+	testProject   = "proj"
+)
+
+// makeTestIndex builds an in-memory fsmode.Index with ComponentRelease entries in
+// the default test namespace/project. Each release is owned by the component parsed
+// from its release name (falling back to the full name when unparseable) so it is
+// indexed for owner-scoped lookups.
 func makeTestIndex(t *testing.T, releaseNames []string) *fsmode.Index {
 	t.Helper()
+	return makeTestIndexNS(t, testNamespace, testProject, releaseNames)
+}
+
+// makeTestIndexNS is like makeTestIndex but places releases in a specific namespace/project.
+func makeTestIndexNS(t *testing.T, namespace, projectName string, releaseNames []string) *fsmode.Index {
+	t.Helper()
 	idx := index.New("/test")
+	addReleasesNS(t, idx, namespace, projectName, releaseNames)
+	return fsmode.WrapIndex(idx)
+}
+
+func addReleasesNS(t *testing.T, idx *index.Index, namespace, projectName string, releaseNames []string) {
+	t.Helper()
 	for _, name := range releaseNames {
+		componentName := name
+		if comp, _, _, err := ParseReleaseName(name); err == nil {
+			componentName = comp
+		}
 		entry := &index.ResourceEntry{
 			Resource: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "openchoreo.dev/v1alpha1",
 					"kind":       "ComponentRelease",
-					"metadata":   map[string]interface{}{"name": name},
+					"metadata": map[string]interface{}{
+						"name":      name,
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"owner": map[string]interface{}{
+							"projectName":   projectName,
+							"componentName": componentName,
+						},
+					},
 				},
 			},
-			FilePath: "/test/" + name + ".yaml",
+			FilePath: "/test/" + namespace + "/" + name + ".yaml",
 		}
 		require.NoError(t, idx.Add(entry), "failed to add entry %q", name)
 	}
-	return fsmode.WrapIndex(idx)
+}
+
+// addReleaseWithOwner adds a single ComponentRelease whose metadata.name and owning
+// component intentionally differ, so tests can exercise release names that do not follow
+// the <component>-<date>-<version> convention (e.g. hand-authored hotfixes).
+func addReleaseWithOwner(t *testing.T, idx *index.Index, namespace, projectName, releaseName, ownerComponent string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentRelease",
+				"metadata": map[string]any{
+					"name":      releaseName,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"owner": map[string]any{
+						"projectName":   projectName,
+						"componentName": ownerComponent,
+					},
+				},
+			},
+		},
+		FilePath: "/test/" + namespace + "/" + releaseName + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry), "failed to add entry %q", releaseName)
 }
 
 func TestGenerateReleaseName(t *testing.T) {
@@ -96,14 +155,14 @@ func TestGenerateReleaseName(t *testing.T) {
 
 	t.Run("explicit version skips auto-detect", func(t *testing.T) {
 		idx := makeTestIndex(t, nil)
-		name, err := GenerateReleaseName("my-comp", date, "5", idx)
+		name, err := GenerateReleaseName("my-comp", date, "5", testNamespace, testProject, idx)
 		require.NoError(t, err)
 		assert.Equal(t, "my-comp-20250315-5", name)
 	})
 
 	t.Run("auto-detect version with no existing releases", func(t *testing.T) {
 		idx := makeTestIndex(t, nil)
-		name, err := GenerateReleaseName("my-comp", date, "", idx)
+		name, err := GenerateReleaseName("my-comp", date, "", testNamespace, testProject, idx)
 		require.NoError(t, err)
 		assert.Equal(t, "my-comp-20250315-1", name)
 	})
@@ -114,7 +173,7 @@ func TestGenerateReleaseName(t *testing.T) {
 			"my-comp-20250315-3",
 			"my-comp-20250315-2",
 		})
-		name, err := GenerateReleaseName("my-comp", date, "", idx)
+		name, err := GenerateReleaseName("my-comp", date, "", testNamespace, testProject, idx)
 		require.NoError(t, err)
 		assert.Equal(t, "my-comp-20250315-4", name)
 	})
@@ -123,7 +182,7 @@ func TestGenerateReleaseName(t *testing.T) {
 		idx := makeTestIndex(t, []string{
 			"other-comp-20250315-10",
 		})
-		name, err := GenerateReleaseName("my-comp", date, "", idx)
+		name, err := GenerateReleaseName("my-comp", date, "", testNamespace, testProject, idx)
 		require.NoError(t, err)
 		assert.Equal(t, "my-comp-20250315-1", name)
 	})
@@ -132,15 +191,39 @@ func TestGenerateReleaseName(t *testing.T) {
 		idx := makeTestIndex(t, []string{
 			"my-comp-20250314-5",
 		})
-		name, err := GenerateReleaseName("my-comp", date, "", idx)
+		name, err := GenerateReleaseName("my-comp", date, "", testNamespace, testProject, idx)
 		require.NoError(t, err)
 		assert.Equal(t, "my-comp-20250315-1", name)
+	})
+
+	t.Run("auto-detect ignores off-convention releases owned by the component", func(t *testing.T) {
+		// A hand-authored hotfix owned by my-comp but named differently must not pull
+		// the auto-generated version up to 10.
+		idx := index.New("/test")
+		addReleaseWithOwner(t, idx, testNamespace, testProject, "hotfix-20250315-9", "my-comp")
+		ocIndex := fsmode.WrapIndex(idx)
+		name, err := GenerateReleaseName("my-comp", date, "", testNamespace, testProject, ocIndex)
+		require.NoError(t, err)
+		assert.Equal(t, "my-comp-20250315-1", name)
+	})
+
+	t.Run("auto-detect ignores same-named component in another namespace", func(t *testing.T) {
+		idx := index.New("/test")
+		addReleasesNS(t, idx, "team-a", testProject, []string{"my-comp-20250315-1"})
+		addReleasesNS(t, idx, "team-b", testProject, []string{
+			"my-comp-20250315-7",
+			"my-comp-20250315-8",
+		})
+		ocIndex := fsmode.WrapIndex(idx)
+		name, err := GenerateReleaseName("my-comp", date, "", "team-a", testProject, ocIndex)
+		require.NoError(t, err)
+		assert.Equal(t, "my-comp-20250315-2", name, "team-a version must not be affected by team-b releases")
 	})
 
 	t.Run("zero date uses current date", func(t *testing.T) {
 		idx := makeTestIndex(t, nil)
 		before := time.Now().Format("20060102")
-		name, err := GenerateReleaseName("my-comp", time.Time{}, "1", idx)
+		name, err := GenerateReleaseName("my-comp", time.Time{}, "1", testNamespace, testProject, idx)
 		require.NoError(t, err)
 		after := time.Now().Format("20060102")
 		valid := name == "my-comp-"+before+"-1" || name == "my-comp-"+after+"-1"
@@ -151,7 +234,7 @@ func TestGenerateReleaseName(t *testing.T) {
 func TestGetLatestVersionForDate(t *testing.T) {
 	t.Run("no releases returns 0", func(t *testing.T) {
 		idx := makeTestIndex(t, nil)
-		assert.Equal(t, "0", getLatestVersionForDate("comp", "20250315", idx))
+		assert.Equal(t, "0", getLatestVersionForDate("comp", "20250315", testNamespace, testProject, idx))
 	})
 
 	t.Run("finds highest version for matching component and date", func(t *testing.T) {
@@ -160,21 +243,21 @@ func TestGetLatestVersionForDate(t *testing.T) {
 			"comp-20250315-3",
 			"comp-20250315-2",
 		})
-		assert.Equal(t, "3", getLatestVersionForDate("comp", "20250315", idx))
+		assert.Equal(t, "3", getLatestVersionForDate("comp", "20250315", testNamespace, testProject, idx))
 	})
 
 	t.Run("ignores different component", func(t *testing.T) {
 		idx := makeTestIndex(t, []string{
 			"other-20250315-10",
 		})
-		assert.Equal(t, "0", getLatestVersionForDate("comp", "20250315", idx))
+		assert.Equal(t, "0", getLatestVersionForDate("comp", "20250315", testNamespace, testProject, idx))
 	})
 
 	t.Run("ignores different date", func(t *testing.T) {
 		idx := makeTestIndex(t, []string{
 			"comp-20250314-5",
 		})
-		assert.Equal(t, "0", getLatestVersionForDate("comp", "20250315", idx))
+		assert.Equal(t, "0", getLatestVersionForDate("comp", "20250315", testNamespace, testProject, idx))
 	})
 
 	t.Run("ignores malformed release names", func(t *testing.T) {
@@ -182,7 +265,25 @@ func TestGetLatestVersionForDate(t *testing.T) {
 			"not-a-valid-release",
 			"comp-20250315-2",
 		})
-		assert.Equal(t, "2", getLatestVersionForDate("comp", "20250315", idx))
+		assert.Equal(t, "2", getLatestVersionForDate("comp", "20250315", testNamespace, testProject, idx))
+	})
+
+	t.Run("scopes version to namespace", func(t *testing.T) {
+		idx := index.New("/test")
+		addReleasesNS(t, idx, "team-a", testProject, []string{"comp-20250315-2"})
+		addReleasesNS(t, idx, "team-b", testProject, []string{"comp-20250315-9"})
+		ocIndex := fsmode.WrapIndex(idx)
+		assert.Equal(t, "2", getLatestVersionForDate("comp", "20250315", "team-a", testProject, ocIndex))
+		assert.Equal(t, "9", getLatestVersionForDate("comp", "20250315", "team-b", testProject, ocIndex))
+	})
+
+	t.Run("ignores off-convention release names owned by the component", func(t *testing.T) {
+		// Owned by "comp" but named "hotfix-...": must not count toward comp's versioning.
+		idx := index.New("/test")
+		addReleaseWithOwner(t, idx, testNamespace, testProject, "hotfix-20250315-9", "comp")
+		addReleasesNS(t, idx, testNamespace, testProject, []string{"comp-20250315-2"})
+		ocIndex := fsmode.WrapIndex(idx)
+		assert.Equal(t, "2", getLatestVersionForDate("comp", "20250315", testNamespace, testProject, ocIndex))
 	})
 }
 

--- a/internal/occ/fsmode/generator/release_binding.go
+++ b/internal/occ/fsmode/generator/release_binding.go
@@ -102,7 +102,7 @@ func (g *BindingGenerator) GenerateBinding(opts BindingOptions) (*unstructured.U
 	}
 
 	// 4. Check if binding already exists
-	existingBinding, exists := g.index.GetReleaseBindingForEnv(opts.ProjectName, opts.ComponentName, opts.TargetEnv)
+	existingBinding, exists := g.index.GetReleaseBindingForEnv(opts.Namespace, opts.ProjectName, opts.ComponentName, opts.TargetEnv)
 
 	if exists {
 		// UPDATE mode: Read the original file from disk to preserve all fields,
@@ -142,7 +142,7 @@ func (g *BindingGenerator) GenerateBindingWithInfo(opts BindingOptions) (*Bindin
 	}
 
 	// Check if this is an update and capture existing file path
-	entry, exists := g.index.GetReleaseBindingForEnv(opts.ProjectName, opts.ComponentName, opts.TargetEnv)
+	entry, exists := g.index.GetReleaseBindingForEnv(opts.Namespace, opts.ProjectName, opts.ComponentName, opts.TargetEnv)
 	if exists {
 		info.IsUpdate = true
 		info.ExistingFilePath = entry.FilePath
@@ -158,10 +158,13 @@ func (g *BindingGenerator) GenerateBindingWithInfo(opts BindingOptions) (*Bindin
 func (g *BindingGenerator) selectComponentRelease(opts BindingOptions) (string, error) {
 	// If explicit release provided, validate it exists
 	if opts.ComponentRelease != "" {
-		// Validate release exists in index
+		// Validate release exists in index, scoped to the active namespace
 		releases := g.index.ListReleases()
 		found := false
 		for _, release := range releases {
+			if release.Namespace() != opts.Namespace {
+				continue
+			}
 			if release.Name() == opts.ComponentRelease {
 				// Verify it belongs to the specified component
 				owner := fsmode.ExtractOwnerRef(release)
@@ -194,7 +197,7 @@ func (g *BindingGenerator) selectComponentRelease(opts BindingOptions) (string, 
 		}
 
 		// Find the existing release whose spec matches the current component state
-		releases := g.index.ListReleasesForComponent(opts.ProjectName, opts.ComponentName)
+		releases := g.index.ListReleasesForComponent(opts.Namespace, opts.ProjectName, opts.ComponentName)
 		if len(releases) == 0 {
 			return "", fmt.Errorf("no releases found for component %s/%s",
 				opts.ProjectName, opts.ComponentName)
@@ -247,7 +250,7 @@ func (g *BindingGenerator) selectComponentRelease(opts BindingOptions) (string, 
 	}
 
 	// Find binding in previous environment
-	prevBinding, ok := g.index.GetReleaseBindingForEnv(opts.ProjectName, opts.ComponentName, prevEnv)
+	prevBinding, ok := g.index.GetReleaseBindingForEnv(opts.Namespace, opts.ProjectName, opts.ComponentName, prevEnv)
 	if !ok {
 		return "", fmt.Errorf("no ReleaseBinding found in previous environment %q for component %s/%s; "+
 			"create binding in %q first or specify --component-release explicitly",
@@ -316,9 +319,12 @@ func (g *BindingGenerator) GenerateBulkBindings(opts BulkBindingOptions) (*BulkB
 	var components []*fsmode.OwnerRef
 
 	if opts.All {
-		// Process all components in the repository
+		// Process all components in the active namespace
 		allComponents := g.index.ListComponents()
 		for _, comp := range allComponents {
+			if comp.Namespace() != opts.Namespace {
+				continue
+			}
 			owner := fsmode.ExtractOwnerRef(comp)
 			if owner != nil {
 				components = append(components, owner)
@@ -326,7 +332,7 @@ func (g *BindingGenerator) GenerateBulkBindings(opts BulkBindingOptions) (*BulkB
 		}
 	} else if opts.ProjectName != "" {
 		// Process all components in the specified project
-		projectComponents := g.index.ListComponentsForProject(opts.ProjectName)
+		projectComponents := g.index.ListComponentsForProject(opts.Namespace, opts.ProjectName)
 		for _, comp := range projectComponents {
 			owner := fsmode.ExtractOwnerRef(comp)
 			if owner != nil {
@@ -359,7 +365,7 @@ func (g *BindingGenerator) GenerateBulkBindings(opts BulkBindingOptions) (*BulkB
 		}
 
 		// Check if this is an update or create
-		entry, exists := g.index.GetReleaseBindingForEnv(owner.ProjectName, owner.ComponentName, opts.TargetEnv)
+		entry, exists := g.index.GetReleaseBindingForEnv(opts.Namespace, owner.ProjectName, owner.ComponentName, opts.TargetEnv)
 
 		bindingName := binding.GetName()
 		releaseName := getNestedString(binding.Object, "spec", "releaseName")

--- a/internal/occ/fsmode/generator/release_binding_test.go
+++ b/internal/occ/fsmode/generator/release_binding_test.go
@@ -31,9 +31,8 @@ func newTestPipelineInfo() *pipeline.PipelineInfo {
 // generateMatchingRelease generates a ComponentRelease whose spec matches the
 // current component state, using the ReleaseGenerator. This ensures the release
 // spec is exactly what the hash-based comparison expects.
-func generateMatchingRelease(t *testing.T, idx *index.Index, releaseName, projectName, componentName string) *unstructured.Unstructured {
+func generateMatchingRelease(t *testing.T, idx *index.Index, namespace, releaseName, projectName, componentName string) *unstructured.Unstructured {
 	t.Helper()
-	const namespace = "test-ns"
 	tmpIndex := fsmode.WrapIndex(idx)
 	gen := NewReleaseGenerator(tmpIndex)
 	release, err := gen.GenerateRelease(ReleaseOptions{
@@ -64,14 +63,14 @@ func TestGenerateBindingWithInfo_Create(t *testing.T) {
 	addComponentWithKind(t, idx, namespace, componentName, projectName, componentTypeName,
 		"ComponentType",
 		"/repo/projects/my-proj/components/my-comp.yaml")
-	addComponentType(t, idx, componentTypeName, workloadType,
+	addComponentType(t, idx, namespace, componentTypeName, workloadType,
 		"/repo/component-types/my-type.yaml")
 	addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
 		map[string]any{"container": map[string]any{"image": image}},
 		"/repo/projects/my-proj/components/my-comp/workload.yaml")
 
 	// Generate a ComponentRelease whose spec matches the current component state
-	release := generateMatchingRelease(t, idx, releaseName, projectName, componentName)
+	release := generateMatchingRelease(t, idx, namespace, releaseName, projectName, componentName)
 
 	// Add the matching release to the index
 	releaseEntry := &index.ResourceEntry{
@@ -145,14 +144,14 @@ spec:
 	addComponentWithKind(t, idx, namespace, componentName, projectName, componentTypeName,
 		"ComponentType",
 		filepath.Join(tmpDir, "projects", projectName, "components", componentName+".yaml"))
-	addComponentType(t, idx, componentTypeName, workloadType,
+	addComponentType(t, idx, namespace, componentTypeName, workloadType,
 		filepath.Join(tmpDir, "component-types", componentTypeName+".yaml"))
 	addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
 		map[string]any{"container": map[string]any{"image": image}},
 		filepath.Join(tmpDir, "projects", projectName, "components", componentName, "workload.yaml"))
 
 	// Generate a ComponentRelease whose spec matches the current component state
-	release := generateMatchingRelease(t, idx, newRelease, projectName, componentName)
+	release := generateMatchingRelease(t, idx, namespace, newRelease, projectName, componentName)
 
 	// Add the matching release to the index
 	releaseEntry := &index.ResourceEntry{
@@ -231,7 +230,7 @@ func TestSelectComponentRelease_NoReleasesFound(t *testing.T) {
 	addComponentWithKind(t, idx, "test-ns", "my-comp", "my-proj", "my-type",
 		"ComponentType",
 		"/repo/projects/my-proj/components/my-comp.yaml")
-	addComponentType(t, idx, "my-type", "Deployment",
+	addComponentType(t, idx, "test-ns", "my-type", "Deployment",
 		"/repo/component-types/my-type.yaml")
 	addWorkload(t, idx, "test-ns", "my-comp-workload", "my-proj", "my-comp",
 		map[string]any{"container": map[string]any{"image": "img:v1"}},
@@ -258,7 +257,7 @@ func TestSelectComponentRelease_NoMatchingRelease(t *testing.T) {
 	addComponentWithKind(t, idx, "test-ns", "my-comp", "my-proj", "my-type",
 		"ComponentType",
 		"/repo/projects/my-proj/components/my-comp.yaml")
-	addComponentType(t, idx, "my-type", "Deployment",
+	addComponentType(t, idx, "test-ns", "my-type", "Deployment",
 		"/repo/component-types/my-type.yaml")
 	addWorkload(t, idx, "test-ns", "my-comp-workload", "my-proj", "my-comp",
 		map[string]any{"container": map[string]any{"image": "img:v2"}},
@@ -310,7 +309,7 @@ func TestSelectComponentRelease_CompareSpecsError(t *testing.T) {
 	addComponentWithKind(t, idx, "test-ns", "my-comp", "my-proj", "my-type",
 		"ComponentType",
 		"/repo/projects/my-proj/components/my-comp.yaml")
-	addComponentType(t, idx, "my-type", "Deployment",
+	addComponentType(t, idx, "test-ns", "my-type", "Deployment",
 		"/repo/component-types/my-type.yaml")
 	addWorkload(t, idx, "test-ns", "my-comp-workload", "my-proj", "my-comp",
 		map[string]any{"container": map[string]any{"image": "img:v1"}},
@@ -423,7 +422,7 @@ func TestSelectComponentRelease_ExplicitRelease(t *testing.T) {
 	addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
 		"ComponentType",
 		"/repo/projects/my-proj/components/my-comp.yaml")
-	addComponentType(t, idx, "my-type", "Deployment",
+	addComponentType(t, idx, "test-ns", "my-type", "Deployment",
 		"/repo/component-types/my-type.yaml")
 	addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
 		map[string]any{"container": map[string]any{"image": "img:v1"}},
@@ -500,7 +499,7 @@ func TestSelectComponentRelease_NonRootEnvPromotion(t *testing.T) {
 		idx := index.New("/repo")
 		addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
 			"ComponentType", "/repo/comp.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
 
@@ -527,7 +526,7 @@ func TestSelectComponentRelease_NonRootEnvPromotion(t *testing.T) {
 		idx := index.New("/repo")
 		addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
 			"ComponentType", "/repo/comp.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
 
@@ -549,7 +548,7 @@ func TestSelectComponentRelease_NonRootEnvPromotion(t *testing.T) {
 		idx := index.New("/repo")
 		addComponentWithKind(t, idx, namespace, componentName, projectName, "my-type",
 			"ComponentType", "/repo/comp.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl.yaml")
 
@@ -608,7 +607,7 @@ func TestGenerateBulkBindings(t *testing.T) {
 		// Add two components in different projects
 		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
 		addComponentWithKind(t, idx, namespace, "comp-b", "proj-b", "my-type", "ComponentType", "/repo/comp-b.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
 		addWorkload(t, idx, namespace, "comp-b-workload", "proj-b", "comp-b",
@@ -619,7 +618,7 @@ func TestGenerateBulkBindings(t *testing.T) {
 			{"proj-a", "comp-a", "comp-a-20260101-0"},
 			{"proj-b", "comp-b", "comp-b-20260101-0"},
 		} {
-			release := generateMatchingRelease(t, idx, info.release, info.proj, info.comp)
+			release := generateMatchingRelease(t, idx, namespace, info.release, info.proj, info.comp)
 			require.NoError(t, idx.Add(&index.ResourceEntry{
 				Resource: release,
 				FilePath: "/repo/releases/" + info.release + ".yaml",
@@ -645,7 +644,7 @@ func TestGenerateBulkBindings(t *testing.T) {
 
 		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
 		addComponentWithKind(t, idx, namespace, "comp-b", "proj-a", "my-type", "ComponentType", "/repo/comp-b.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
 		addWorkload(t, idx, namespace, "comp-b-workload", "proj-a", "comp-b",
@@ -655,7 +654,7 @@ func TestGenerateBulkBindings(t *testing.T) {
 			{"comp-a", "comp-a-20260101-0"},
 			{"comp-b", "comp-b-20260101-0"},
 		} {
-			release := generateMatchingRelease(t, idx, info.release, "proj-a", info.comp)
+			release := generateMatchingRelease(t, idx, namespace, info.release, "proj-a", info.comp)
 			require.NoError(t, idx.Add(&index.ResourceEntry{
 				Resource: release,
 				FilePath: "/repo/releases/" + info.release + ".yaml",
@@ -683,7 +682,7 @@ func TestGenerateBulkBindings(t *testing.T) {
 		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
 		addComponentWithKind(t, idx, namespace, "comp-b", "proj-a", "my-type", "ComponentType", "/repo/comp-b.yaml")
 		addComponentWithKind(t, idx, namespace, "comp-c", "proj-b", "my-type", "ComponentType", "/repo/comp-c.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
 		addWorkload(t, idx, namespace, "comp-b-workload", "proj-a", "comp-b",
@@ -696,7 +695,7 @@ func TestGenerateBulkBindings(t *testing.T) {
 			{"proj-a", "comp-b", "comp-b-20260101-0"},
 			{"proj-b", "comp-c", "comp-c-20260101-0"},
 		} {
-			release := generateMatchingRelease(t, idx, info.release, info.proj, info.comp)
+			release := generateMatchingRelease(t, idx, namespace, info.release, info.proj, info.comp)
 			require.NoError(t, idx.Add(&index.ResourceEntry{
 				Resource: release,
 				FilePath: "/repo/releases/" + info.release + ".yaml",
@@ -731,14 +730,14 @@ func TestGenerateBulkBindings(t *testing.T) {
 		// comp-a is valid, comp-b has no releases -> will error
 		addComponentWithKind(t, idx, namespace, "comp-a", "proj-a", "my-type", "ComponentType", "/repo/comp-a.yaml")
 		addComponentWithKind(t, idx, namespace, "comp-b", "proj-a", "my-type", "ComponentType", "/repo/comp-b.yaml")
-		addComponentType(t, idx, "my-type", "Deployment", "/repo/ct.yaml")
+		addComponentType(t, idx, "test-ns", "my-type", "Deployment", "/repo/ct.yaml")
 		addWorkload(t, idx, namespace, "comp-a-workload", "proj-a", "comp-a",
 			map[string]any{"container": map[string]any{"image": "img:v1"}}, "/repo/wl-a.yaml")
 		addWorkload(t, idx, namespace, "comp-b-workload", "proj-a", "comp-b",
 			map[string]any{"container": map[string]any{"image": "img:v2"}}, "/repo/wl-b.yaml")
 
 		// Only add release for comp-a
-		release := generateMatchingRelease(t, idx, "comp-a-20260101-0", "proj-a", "comp-a")
+		release := generateMatchingRelease(t, idx, namespace, "comp-a-20260101-0", "proj-a", "comp-a")
 		require.NoError(t, idx.Add(&index.ResourceEntry{
 			Resource: release,
 			FilePath: "/repo/releases/comp-a-20260101-0.yaml",
@@ -821,10 +820,10 @@ func addTraitUsingComponent(t *testing.T, idx *index.Index, namespace, projectNa
 	}
 	require.NoError(t, idx.Add(ctEntry))
 
-	addTrait(t, idx, "logging",
+	addTrait(t, idx, namespace, "logging",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}}}},
 		"/repo/traits/logging.yaml")
-	addTrait(t, idx, "sidecar",
+	addTrait(t, idx, namespace, "sidecar",
 		map[string]any{"creates": []any{map[string]any{"template": map[string]any{"apiVersion": "v1", "kind": "Service"}}}},
 		"/repo/traits/sidecar.yaml")
 	addWorkload(t, idx, namespace, componentName+"-workload", projectName, componentName,
@@ -881,7 +880,7 @@ func TestSelectComponentRelease_LegacyFormatRelease(t *testing.T) {
 	addTraitUsingComponent(t, idx, namespace, projectName, componentName, componentTypeName, image)
 
 	// Generate the full-spec expected release, then reduce it to the old on-disk shape.
-	expected := generateMatchingRelease(t, idx, releaseName, projectName, componentName)
+	expected := generateMatchingRelease(t, idx, namespace, releaseName, projectName, componentName)
 	legacy := stripToLegacyShape(t, expected, "sidecar")
 	require.NoError(t, idx.Add(&index.ResourceEntry{
 		Resource: legacy,
@@ -921,7 +920,7 @@ func TestSelectComponentRelease_DifferentReleaseNotLegacy(t *testing.T) {
 
 	// Build an old-shape release, then genuinely diverge it by changing the workload image
 	// so it must NOT be treated as a legacy match.
-	expected := generateMatchingRelease(t, idx, releaseName, projectName, componentName)
+	expected := generateMatchingRelease(t, idx, namespace, releaseName, projectName, componentName)
 	legacy := stripToLegacyShape(t, expected, "sidecar")
 	require.NoError(t, unstructured.SetNestedField(legacy.Object, "reg/my-comp:OTHER",
 		"spec", "workload", "container", "image"))
@@ -944,6 +943,132 @@ func TestSelectComponentRelease_DifferentReleaseNotLegacy(t *testing.T) {
 	assert.Contains(t, err.Error(), "no matching release found for current component state")
 	assert.NotContains(t, err.Error(), "older occ version",
 		"a genuinely different release must not be reported as a legacy match")
+}
+
+// TestGenerateBulkBindings_NamespaceIsolation is a regression test for issue #4148: bulk --all
+// discovery must process only components in the active namespace. Two namespaces hold identically
+// named component/project graphs with distinct workload images (and thus distinct matching
+// releases). A bulk run scoped to team-a must bind exactly team-a's component against team-a's
+// release, never team-b's. Both namespaces are populated so the ListComponents map-order path
+// cannot pass by chance: without the namespace filter the run would emit two bindings.
+func TestGenerateBulkBindings_NamespaceIsolation(t *testing.T) {
+	const (
+		projectName   = "shared-proj"
+		componentName = "web-app"
+		releaseA      = "web-app-20260101-a"
+		releaseB      = "web-app-20260101-b"
+	)
+
+	idx := index.New("/repo")
+
+	// team-a graph plus its matching release (image :a).
+	addComponentWithKind(t, idx, "team-a", componentName, projectName, "my-type",
+		"ComponentType", "/repo/team-a/projects/shared-proj/components/web-app.yaml")
+	addComponentType(t, idx, "team-a", "my-type", "Deployment", "/repo/team-a/component-types/my-type.yaml")
+	addWorkload(t, idx, "team-a", componentName+"-workload", projectName, componentName,
+		map[string]any{"container": map[string]any{"image": "reg/web-app:a"}},
+		"/repo/team-a/projects/shared-proj/components/web-app/workload.yaml")
+	relA := generateMatchingRelease(t, idx, "team-a", releaseA, projectName, componentName)
+	require.NoError(t, idx.Add(&index.ResourceEntry{
+		Resource: relA,
+		FilePath: "/repo/team-a/projects/shared-proj/components/web-app/releases/" + releaseA + ".yaml",
+	}))
+
+	// team-b graph with the same project/component names but a distinct image + release (image :b).
+	addComponentWithKind(t, idx, "team-b", componentName, projectName, "my-type",
+		"ComponentType", "/repo/team-b/projects/shared-proj/components/web-app.yaml")
+	addComponentType(t, idx, "team-b", "my-type", "Deployment", "/repo/team-b/component-types/my-type.yaml")
+	addWorkload(t, idx, "team-b", componentName+"-workload", projectName, componentName,
+		map[string]any{"container": map[string]any{"image": "reg/web-app:b"}},
+		"/repo/team-b/projects/shared-proj/components/web-app/workload.yaml")
+	relB := generateMatchingRelease(t, idx, "team-b", releaseB, projectName, componentName)
+	require.NoError(t, idx.Add(&index.ResourceEntry{
+		Resource: relB,
+		FilePath: "/repo/team-b/projects/shared-proj/components/web-app/releases/" + releaseB + ".yaml",
+	}))
+
+	ocIndex := fsmode.WrapIndex(idx)
+	gen := NewBindingGenerator(ocIndex)
+
+	result, err := gen.GenerateBulkBindings(BulkBindingOptions{
+		All:          true,
+		TargetEnv:    "dev",
+		PipelineInfo: newTestPipelineInfo(),
+		Namespace:    "team-a",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Errors)
+	require.Len(t, result.Bindings, 1, "bulk --all must bind only the active namespace's component")
+	assert.Equal(t, projectName, result.Bindings[0].ProjectName)
+	assert.Equal(t, componentName, result.Bindings[0].ComponentName)
+	assert.Equal(t, releaseA, result.Bindings[0].ReleaseName, "must select team-a's release, not team-b's")
+}
+
+// TestSelectComponentRelease_ExplicitReleaseNamespaceIsolation is a regression test for issue
+// #4148: an explicitly named ComponentRelease must be resolved only within the active namespace.
+// Two namespaces hold a same-named release owned by the same project/component; a binding request
+// in team-a resolves and stamps the team-a namespace, while a request in a namespace that has no
+// such release must fail rather than borrow another namespace's identically named release (the
+// cross-namespace leak that existed before the namespace filter on ListReleases).
+func TestSelectComponentRelease_ExplicitReleaseNamespaceIsolation(t *testing.T) {
+	const (
+		releaseName   = "web-app-20260101-0"
+		projectName   = "shared-proj"
+		componentName = "web-app"
+	)
+
+	idx := index.New("/repo")
+
+	// Same-named release owned by the same project/component, present in two namespaces.
+	addOwnedRelease := func(namespace, filePath string) {
+		t.Helper()
+		require.NoError(t, idx.Add(&index.ResourceEntry{
+			Resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "openchoreo.dev/v1alpha1",
+					"kind":       "ComponentRelease",
+					"metadata":   map[string]any{"name": releaseName, "namespace": namespace},
+					"spec": map[string]any{
+						"owner": map[string]any{
+							"projectName":   projectName,
+							"componentName": componentName,
+						},
+					},
+				},
+			},
+			FilePath: filePath,
+		}))
+	}
+	addOwnedRelease("team-a", "/repo/team-a/releases/"+releaseName+".yaml")
+	addOwnedRelease("team-b", "/repo/team-b/releases/"+releaseName+".yaml")
+
+	gen := NewBindingGenerator(fsmode.WrapIndex(idx))
+
+	// A request in team-a resolves against team-a's release and stamps the team-a namespace.
+	binding, err := gen.GenerateBinding(BindingOptions{
+		ProjectName:      projectName,
+		ComponentName:    componentName,
+		ComponentRelease: releaseName,
+		TargetEnv:        "dev",
+		PipelineInfo:     newTestPipelineInfo(),
+		Namespace:        "team-a",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, releaseName, getNestedString(binding.Object, "spec", "releaseName"))
+	assert.Equal(t, "team-a", binding.GetNamespace())
+
+	// A namespace with no matching release must not borrow team-a/team-b's identically named
+	// release; before the namespace filter this cross-namespace lookup resolved successfully.
+	_, err = gen.GenerateBinding(BindingOptions{
+		ProjectName:      projectName,
+		ComponentName:    componentName,
+		ComponentRelease: releaseName,
+		TargetEnv:        "dev",
+		PipelineInfo:     newTestPipelineInfo(),
+		Namespace:        "team-c",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or does not belong")
 }
 
 // addReleaseBinding adds a ReleaseBinding resource entry to the index.

--- a/internal/occ/fsmode/index.go
+++ b/internal/occ/fsmode/index.go
@@ -5,11 +5,22 @@ package fsmode
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/openchoreo/openchoreo/internal/occ/fsmode/typed"
 	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
 )
+
+// nsKey builds a lookup key by joining namespace-qualified parts with "/".
+// fsmode is GitOps-only and requires every namespace-scoped resource to set
+// metadata.namespace explicitly, so callers always pass a concrete namespace as
+// the leading part. A resource that omits its namespace keys under a leading
+// "/" and simply never matches a real lookup, which is the intended outcome for
+// such invalid input.
+func nsKey(parts ...string) string {
+	return strings.Join(parts, "/")
+}
 
 // OwnerRef represents OpenChoreo-specific owner reference information
 type OwnerRef struct {
@@ -55,16 +66,18 @@ type Index struct {
 	*index.Index
 	mu sync.RWMutex
 
-	// OpenChoreo-specific indexes
-	componentsByProject   map[string][]*index.ResourceEntry // projectName -> components
-	workloadsByComponent  map[string]*index.ResourceEntry   // "project/component" -> workload
-	componentTypes        map[string]*index.ResourceEntry   // typeName -> componentType
-	traits                map[string]*index.ResourceEntry   // traitName -> trait
-	clusterComponentTypes map[string]*index.ResourceEntry   // typeName -> clusterComponentType
-	clusterTraits         map[string]*index.ResourceEntry   // traitName -> clusterTrait
-	releasesByComponent   map[string][]*index.ResourceEntry // "project/component" -> releases
-	releaseBindingsByEnv  map[string][]*index.ResourceEntry // "project/component/env" -> bindings
-	deploymentPipelines   map[string]*index.ResourceEntry   // pipelineName -> pipeline
+	// OpenChoreo-specific indexes.
+	// Namespace-scoped indexes are keyed with a leading namespace segment so that
+	// resources sharing a name across namespaces do not collide.
+	componentsByProject   map[string][]*index.ResourceEntry // "namespace/project" -> components
+	workloadsByComponent  map[string]*index.ResourceEntry   // "namespace/project/component" -> workload
+	componentTypes        map[string]*index.ResourceEntry   // "namespace/typeName" -> componentType
+	traits                map[string]*index.ResourceEntry   // "namespace/traitName" -> trait
+	clusterComponentTypes map[string]*index.ResourceEntry   // typeName -> clusterComponentType (cluster-scoped)
+	clusterTraits         map[string]*index.ResourceEntry   // traitName -> clusterTrait (cluster-scoped)
+	releasesByComponent   map[string][]*index.ResourceEntry // "namespace/project/component" -> releases
+	releaseBindingsByEnv  map[string][]*index.ResourceEntry // "namespace/project/component/env" -> bindings
+	deploymentPipelines   map[string]*index.ResourceEntry   // "namespace/pipelineName" -> pipeline
 }
 
 // WrapIndex wraps an existing generic index with OpenChoreo-specific functionality
@@ -94,32 +107,33 @@ func (idx *Index) addToSpecializedIndexesUnsafe(entry *index.ResourceEntry) {
 
 	switch gvk {
 	case ComponentGVK:
-		// Index by project
+		// Index by namespace and project
 		projectName := entry.GetNestedString("spec", "owner", "projectName")
 		if projectName != "" {
-			idx.componentsByProject[projectName] = append(idx.componentsByProject[projectName], entry)
+			key := nsKey(entry.Namespace(), projectName)
+			idx.componentsByProject[key] = append(idx.componentsByProject[key], entry)
 		}
 
 	case WorkloadGVK:
-		// Index by component
+		// Index by namespace and component
 		owner := ExtractOwnerRef(entry)
 		if owner != nil && owner.ProjectName != "" && owner.ComponentName != "" {
-			key := fmt.Sprintf("%s/%s", owner.ProjectName, owner.ComponentName)
+			key := nsKey(entry.Namespace(), owner.ProjectName, owner.ComponentName)
 			idx.workloadsByComponent[key] = entry
 		}
 
 	case ComponentTypeGVK:
-		// Index by type name
+		// Index by namespace and type name
 		name := entry.Name()
 		if name != "" {
-			idx.componentTypes[name] = entry
+			idx.componentTypes[nsKey(entry.Namespace(), name)] = entry
 		}
 
 	case TraitGVK:
-		// Index by trait name
+		// Index by namespace and trait name
 		name := entry.Name()
 		if name != "" {
-			idx.traits[name] = entry
+			idx.traits[nsKey(entry.Namespace(), name)] = entry
 		}
 
 	case ClusterComponentTypeGVK:
@@ -137,27 +151,27 @@ func (idx *Index) addToSpecializedIndexesUnsafe(entry *index.ResourceEntry) {
 		}
 
 	case ComponentReleaseGVK:
-		// Index by component
+		// Index by namespace and component
 		owner := ExtractOwnerRef(entry)
 		if owner != nil && owner.ProjectName != "" && owner.ComponentName != "" {
-			key := fmt.Sprintf("%s/%s", owner.ProjectName, owner.ComponentName)
+			key := nsKey(entry.Namespace(), owner.ProjectName, owner.ComponentName)
 			idx.releasesByComponent[key] = append(idx.releasesByComponent[key], entry)
 		}
 
 	case ReleaseBindingGVK:
-		// Index by component and environment
+		// Index by namespace, component, and environment
 		owner := ExtractOwnerRef(entry)
 		envName := entry.GetNestedString("spec", "environment")
 		if owner != nil && owner.ProjectName != "" && owner.ComponentName != "" && envName != "" {
-			key := fmt.Sprintf("%s/%s/%s", owner.ProjectName, owner.ComponentName, envName)
+			key := nsKey(entry.Namespace(), owner.ProjectName, owner.ComponentName, envName)
 			idx.releaseBindingsByEnv[key] = append(idx.releaseBindingsByEnv[key], entry)
 		}
 
 	case DeploymentPipelineGVK:
-		// Index by pipeline name
+		// Index by namespace and pipeline name
 		name := entry.Name()
 		if name != "" {
-			idx.deploymentPipelines[name] = entry
+			idx.deploymentPipelines[nsKey(entry.Namespace(), name)] = entry
 		}
 	}
 }
@@ -189,21 +203,21 @@ func (idx *Index) GetComponent(namespace, name string) (*index.ResourceEntry, bo
 	return idx.Index.Get(ComponentGVK, namespace, name)
 }
 
-// GetComponentType retrieves a component type by name
-func (idx *Index) GetComponentType(name string) (*index.ResourceEntry, bool) {
+// GetComponentType retrieves a component type by namespace and name
+func (idx *Index) GetComponentType(namespace, name string) (*index.ResourceEntry, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	entry, ok := idx.componentTypes[name]
+	entry, ok := idx.componentTypes[nsKey(namespace, name)]
 	return entry, ok
 }
 
-// GetTrait retrieves a trait by name
-func (idx *Index) GetTrait(name string) (*index.ResourceEntry, bool) {
+// GetTrait retrieves a trait by namespace and name
+func (idx *Index) GetTrait(namespace, name string) (*index.ResourceEntry, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	entry, ok := idx.traits[name]
+	entry, ok := idx.traits[nsKey(namespace, name)]
 	return entry, ok
 }
 
@@ -244,11 +258,11 @@ func (idx *Index) GetTypedClusterTrait(name string) (*typed.ClusterTrait, error)
 }
 
 // GetWorkloadForComponent retrieves the workload for a specific component
-func (idx *Index) GetWorkloadForComponent(projectName, componentName string) (*index.ResourceEntry, bool) {
+func (idx *Index) GetWorkloadForComponent(namespace, projectName, componentName string) (*index.ResourceEntry, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	key := fmt.Sprintf("%s/%s", projectName, componentName)
+	key := nsKey(namespace, projectName, componentName)
 	entry, ok := idx.workloadsByComponent[key]
 	return entry, ok
 }
@@ -259,11 +273,11 @@ func (idx *Index) ListComponents() []*index.ResourceEntry {
 }
 
 // ListComponentsForProject returns all components for a specific project
-func (idx *Index) ListComponentsForProject(projectName string) []*index.ResourceEntry {
+func (idx *Index) ListComponentsForProject(namespace, projectName string) []*index.ResourceEntry {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	return idx.componentsByProject[projectName]
+	return idx.componentsByProject[nsKey(namespace, projectName)]
 }
 
 // ListReleases returns all component releases
@@ -280,18 +294,18 @@ func (idx *Index) GetTypedComponent(namespace, name string) (*typed.Component, e
 	return typed.NewComponent(entry)
 }
 
-// GetTypedComponentType retrieves a component type by name and returns a typed wrapper
-func (idx *Index) GetTypedComponentType(name string) (*typed.ComponentType, error) {
-	entry, ok := idx.GetComponentType(name)
+// GetTypedComponentType retrieves a component type by namespace and name and returns a typed wrapper
+func (idx *Index) GetTypedComponentType(namespace, name string) (*typed.ComponentType, error) {
+	entry, ok := idx.GetComponentType(namespace, name)
 	if !ok {
 		return nil, fmt.Errorf("component type %q not found", name)
 	}
 	return typed.NewComponentType(entry)
 }
 
-// GetTypedTrait retrieves a trait by name and returns a typed wrapper
-func (idx *Index) GetTypedTrait(name string) (*typed.Trait, error) {
-	entry, ok := idx.GetTrait(name)
+// GetTypedTrait retrieves a trait by namespace and name and returns a typed wrapper
+func (idx *Index) GetTypedTrait(namespace, name string) (*typed.Trait, error) {
+	entry, ok := idx.GetTrait(namespace, name)
 	if !ok {
 		return nil, fmt.Errorf("trait %q not found", name)
 	}
@@ -299,8 +313,8 @@ func (idx *Index) GetTypedTrait(name string) (*typed.Trait, error) {
 }
 
 // GetTypedWorkloadForComponent retrieves the workload for a specific component and returns a typed wrapper
-func (idx *Index) GetTypedWorkloadForComponent(projectName, componentName string) (*typed.Workload, error) {
-	entry, ok := idx.GetWorkloadForComponent(projectName, componentName)
+func (idx *Index) GetTypedWorkloadForComponent(namespace, projectName, componentName string) (*typed.Workload, error) {
+	entry, ok := idx.GetWorkloadForComponent(namespace, projectName, componentName)
 	if !ok {
 		return nil, fmt.Errorf("workload for component %q (project: %q) not found", componentName, projectName)
 	}
@@ -308,11 +322,11 @@ func (idx *Index) GetTypedWorkloadForComponent(projectName, componentName string
 }
 
 // ListReleasesForComponent returns all component releases for a specific component
-func (idx *Index) ListReleasesForComponent(projectName, componentName string) []*index.ResourceEntry {
+func (idx *Index) ListReleasesForComponent(namespace, projectName, componentName string) []*index.ResourceEntry {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	key := fmt.Sprintf("%s/%s", projectName, componentName)
+	key := nsKey(namespace, projectName, componentName)
 	return idx.releasesByComponent[key]
 }
 
@@ -321,12 +335,12 @@ func (idx *Index) GetProject(namespace, name string) (*index.ResourceEntry, bool
 	return idx.Index.Get(ProjectGVK, namespace, name)
 }
 
-// GetDeploymentPipeline retrieves a deployment pipeline by name
-func (idx *Index) GetDeploymentPipeline(name string) (*index.ResourceEntry, bool) {
+// GetDeploymentPipeline retrieves a deployment pipeline by namespace and name
+func (idx *Index) GetDeploymentPipeline(namespace, name string) (*index.ResourceEntry, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	entry, ok := idx.deploymentPipelines[name]
+	entry, ok := idx.deploymentPipelines[nsKey(namespace, name)]
 	return entry, ok
 }
 
@@ -337,11 +351,11 @@ func (idx *Index) ListReleaseBindings() []*index.ResourceEntry {
 
 // GetReleaseBindingForEnv retrieves a release binding for a specific component and environment
 // Returns the first binding found for the given component and environment
-func (idx *Index) GetReleaseBindingForEnv(projectName, componentName, envName string) (*index.ResourceEntry, bool) {
+func (idx *Index) GetReleaseBindingForEnv(namespace, projectName, componentName, envName string) (*index.ResourceEntry, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	key := fmt.Sprintf("%s/%s/%s", projectName, componentName, envName)
+	key := nsKey(namespace, projectName, componentName, envName)
 	bindings := idx.releaseBindingsByEnv[key]
 	if len(bindings) == 0 {
 		return nil, false

--- a/internal/occ/fsmode/index_test.go
+++ b/internal/occ/fsmode/index_test.go
@@ -100,8 +100,11 @@ func TestExtractOwnerRef(t *testing.T) {
 	}
 }
 
-func addClusterComponentTypeEntry(t *testing.T, idx *index.Index, name string) {
+// addClusterComponentTypeEntry adds a cluster-scoped ComponentType named "service". Cluster
+// resources resolve by bare name, so the name has no reason to vary across the callers.
+func addClusterComponentTypeEntry(t *testing.T, idx *index.Index) {
 	t.Helper()
+	const name = "service"
 	entry := &index.ResourceEntry{
 		Resource: &unstructured.Unstructured{
 			Object: map[string]any{
@@ -119,8 +122,11 @@ func addClusterComponentTypeEntry(t *testing.T, idx *index.Index, name string) {
 	require.NoError(t, idx.Add(entry))
 }
 
-func addClusterTraitEntry(t *testing.T, idx *index.Index, name string) {
+// addClusterTraitEntry adds a cluster-scoped Trait named "global-ingress". Cluster resources
+// resolve by bare name, so the name has no reason to vary across the callers.
+func addClusterTraitEntry(t *testing.T, idx *index.Index) {
 	t.Helper()
+	const name = "global-ingress"
 	entry := &index.ResourceEntry{
 		Resource: &unstructured.Unstructured{
 			Object: map[string]any{
@@ -137,7 +143,7 @@ func addClusterTraitEntry(t *testing.T, idx *index.Index, name string) {
 
 func TestGetClusterComponentType(t *testing.T) {
 	idx := index.New("/repo")
-	addClusterComponentTypeEntry(t, idx, "service")
+	addClusterComponentTypeEntry(t, idx)
 	ocIndex := WrapIndex(idx)
 
 	t.Run("found", func(t *testing.T) {
@@ -154,7 +160,7 @@ func TestGetClusterComponentType(t *testing.T) {
 
 func TestGetClusterTrait(t *testing.T) {
 	idx := index.New("/repo")
-	addClusterTraitEntry(t, idx, "global-ingress")
+	addClusterTraitEntry(t, idx)
 	ocIndex := WrapIndex(idx)
 
 	t.Run("found", func(t *testing.T) {
@@ -171,7 +177,7 @@ func TestGetClusterTrait(t *testing.T) {
 
 func TestGetTypedClusterComponentType(t *testing.T) {
 	idx := index.New("/repo")
-	addClusterComponentTypeEntry(t, idx, "service")
+	addClusterComponentTypeEntry(t, idx)
 	ocIndex := WrapIndex(idx)
 
 	t.Run("found", func(t *testing.T) {
@@ -190,7 +196,7 @@ func TestGetTypedClusterComponentType(t *testing.T) {
 
 func TestGetTypedClusterTrait(t *testing.T) {
 	idx := index.New("/repo")
-	addClusterTraitEntry(t, idx, "global-ingress")
+	addClusterTraitEntry(t, idx)
 	ocIndex := WrapIndex(idx)
 
 	t.Run("found", func(t *testing.T) {
@@ -303,8 +309,11 @@ func addWorkloadEntry(t *testing.T, idx *index.Index, namespace, name, projectNa
 	require.NoError(t, idx.Add(entry))
 }
 
-func addComponentReleaseEntry(t *testing.T, idx *index.Index, namespace, name, projectName, componentName string) {
+// addComponentReleaseEntry adds a ComponentRelease owned by component "web-app". Every caller
+// exercises the same owning component across projects/namespaces, so componentName is fixed here.
+func addComponentReleaseEntry(t *testing.T, idx *index.Index, namespace, name, projectName string) {
 	t.Helper()
+	const componentName = "web-app"
 	entry := &index.ResourceEntry{
 		Resource: &unstructured.Unstructured{
 			Object: map[string]any{
@@ -327,8 +336,11 @@ func addComponentReleaseEntry(t *testing.T, idx *index.Index, namespace, name, p
 	require.NoError(t, idx.Add(entry))
 }
 
-func addReleaseBindingEntry(t *testing.T, idx *index.Index, namespace, name, projectName, componentName, envName string) {
+// addReleaseBindingEntry adds a ReleaseBinding owned by component "web-app". Every caller
+// exercises the same owning component across projects/namespaces, so componentName is fixed here.
+func addReleaseBindingEntry(t *testing.T, idx *index.Index, namespace, name, projectName, envName string) {
 	t.Helper()
+	const componentName = "web-app"
 	entry := &index.ResourceEntry{
 		Resource: &unstructured.Unstructured{
 			Object: map[string]any{
@@ -414,19 +426,19 @@ func buildFullIndex(t *testing.T) *Index {
 	addTraitEntry(t, idx, "ns1", "autoscaler")
 
 	// ClusterComponentTypes & ClusterTraits (already have helpers)
-	addClusterComponentTypeEntry(t, idx, "service")
-	addClusterTraitEntry(t, idx, "global-ingress")
+	addClusterComponentTypeEntry(t, idx)
+	addClusterTraitEntry(t, idx)
 
 	// Workloads
 	addWorkloadEntry(t, idx, "ns1", "web-app-workload", "proj-a", "web-app")
 
 	// ComponentReleases
-	addComponentReleaseEntry(t, idx, "ns1", "web-app-20260401-v1", "proj-a", "web-app")
-	addComponentReleaseEntry(t, idx, "ns1", "web-app-20260401-v2", "proj-a", "web-app")
+	addComponentReleaseEntry(t, idx, "ns1", "web-app-20260401-v1", "proj-a")
+	addComponentReleaseEntry(t, idx, "ns1", "web-app-20260401-v2", "proj-a")
 
 	// ReleaseBindings
-	addReleaseBindingEntry(t, idx, "ns1", "web-app-dev-binding", "proj-a", "web-app", "dev")
-	addReleaseBindingEntry(t, idx, "ns1", "web-app-staging-binding", "proj-a", "web-app", "staging")
+	addReleaseBindingEntry(t, idx, "ns1", "web-app-dev-binding", "proj-a", "dev")
+	addReleaseBindingEntry(t, idx, "ns1", "web-app-staging-binding", "proj-a", "staging")
 
 	// Projects
 	addProjectEntry(t, idx, "ns1", "proj-a")
@@ -456,13 +468,13 @@ func TestGetComponentType(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		entry, ok := ocIndex.GetComponentType("http-service")
+		entry, ok := ocIndex.GetComponentType("ns1", "http-service")
 		require.True(t, ok)
 		assert.Equal(t, "http-service", entry.Name())
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, ok := ocIndex.GetComponentType("nonexistent")
+		_, ok := ocIndex.GetComponentType("ns1", "nonexistent")
 		assert.False(t, ok)
 	})
 }
@@ -471,13 +483,13 @@ func TestGetTrait(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		entry, ok := ocIndex.GetTrait("autoscaler")
+		entry, ok := ocIndex.GetTrait("ns1", "autoscaler")
 		require.True(t, ok)
 		assert.Equal(t, "autoscaler", entry.Name())
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, ok := ocIndex.GetTrait("nonexistent")
+		_, ok := ocIndex.GetTrait("ns1", "nonexistent")
 		assert.False(t, ok)
 	})
 }
@@ -486,13 +498,13 @@ func TestGetWorkloadForComponent(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		entry, ok := ocIndex.GetWorkloadForComponent("proj-a", "web-app")
+		entry, ok := ocIndex.GetWorkloadForComponent("ns1", "proj-a", "web-app")
 		require.True(t, ok)
 		assert.Equal(t, "web-app-workload", entry.Name())
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, ok := ocIndex.GetWorkloadForComponent("proj-a", "nonexistent")
+		_, ok := ocIndex.GetWorkloadForComponent("ns1", "proj-a", "nonexistent")
 		assert.False(t, ok)
 	})
 }
@@ -501,13 +513,13 @@ func TestGetTypedWorkloadForComponent(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		wl, err := ocIndex.GetTypedWorkloadForComponent("proj-a", "web-app")
+		wl, err := ocIndex.GetTypedWorkloadForComponent("ns1", "proj-a", "web-app")
 		require.NoError(t, err)
 		require.NotNil(t, wl)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := ocIndex.GetTypedWorkloadForComponent("proj-a", "nonexistent")
+		_, err := ocIndex.GetTypedWorkloadForComponent("ns1", "proj-a", "nonexistent")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent")
 	})
@@ -523,12 +535,12 @@ func TestListComponentsForProject(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("project with components", func(t *testing.T) {
-		components := ocIndex.ListComponentsForProject("proj-a")
+		components := ocIndex.ListComponentsForProject("ns1", "proj-a")
 		assert.Len(t, components, 2)
 	})
 
 	t.Run("project with no components", func(t *testing.T) {
-		components := ocIndex.ListComponentsForProject("nonexistent")
+		components := ocIndex.ListComponentsForProject("ns1", "nonexistent")
 		assert.Empty(t, components)
 	})
 }
@@ -543,12 +555,12 @@ func TestListReleasesForComponent(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("component with releases", func(t *testing.T) {
-		releases := ocIndex.ListReleasesForComponent("proj-a", "web-app")
+		releases := ocIndex.ListReleasesForComponent("ns1", "proj-a", "web-app")
 		assert.Len(t, releases, 2)
 	})
 
 	t.Run("component with no releases", func(t *testing.T) {
-		releases := ocIndex.ListReleasesForComponent("proj-b", "worker")
+		releases := ocIndex.ListReleasesForComponent("ns2", "proj-b", "worker")
 		assert.Empty(t, releases)
 	})
 }
@@ -573,13 +585,13 @@ func TestGetTypedComponentType(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		ct, err := ocIndex.GetTypedComponentType("http-service")
+		ct, err := ocIndex.GetTypedComponentType("ns1", "http-service")
 		require.NoError(t, err)
 		assert.Equal(t, "deployment", ct.Spec.WorkloadType)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := ocIndex.GetTypedComponentType("nonexistent")
+		_, err := ocIndex.GetTypedComponentType("ns1", "nonexistent")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent")
 	})
@@ -589,13 +601,13 @@ func TestGetTypedTrait(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		trait, err := ocIndex.GetTypedTrait("autoscaler")
+		trait, err := ocIndex.GetTypedTrait("ns1", "autoscaler")
 		require.NoError(t, err)
 		require.NotNil(t, trait)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := ocIndex.GetTypedTrait("nonexistent")
+		_, err := ocIndex.GetTypedTrait("ns1", "nonexistent")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent")
 	})
@@ -620,13 +632,13 @@ func TestGetDeploymentPipeline(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		entry, ok := ocIndex.GetDeploymentPipeline("default-pipeline")
+		entry, ok := ocIndex.GetDeploymentPipeline("ns1", "default-pipeline")
 		require.True(t, ok)
 		assert.Equal(t, "default-pipeline", entry.Name())
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, ok := ocIndex.GetDeploymentPipeline("nonexistent")
+		_, ok := ocIndex.GetDeploymentPipeline("ns1", "nonexistent")
 		assert.False(t, ok)
 	})
 }
@@ -641,20 +653,193 @@ func TestGetReleaseBindingForEnv(t *testing.T) {
 	ocIndex := buildFullIndex(t)
 
 	t.Run("found", func(t *testing.T) {
-		entry, ok := ocIndex.GetReleaseBindingForEnv("proj-a", "web-app", "dev")
+		entry, ok := ocIndex.GetReleaseBindingForEnv("ns1", "proj-a", "web-app", "dev")
 		require.True(t, ok)
 		assert.Equal(t, "web-app-dev-binding", entry.Name())
 	})
 
 	t.Run("different environment", func(t *testing.T) {
-		entry, ok := ocIndex.GetReleaseBindingForEnv("proj-a", "web-app", "staging")
+		entry, ok := ocIndex.GetReleaseBindingForEnv("ns1", "proj-a", "web-app", "staging")
 		require.True(t, ok)
 		assert.Equal(t, "web-app-staging-binding", entry.Name())
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, ok := ocIndex.GetReleaseBindingForEnv("proj-a", "web-app", "prod")
+		_, ok := ocIndex.GetReleaseBindingForEnv("ns1", "proj-a", "web-app", "prod")
 		assert.False(t, ok)
+	})
+}
+
+// addComponentTypeEntryWithMarker adds a ComponentType whose spec carries a marker
+// value so tests can assert which namespace's resource was resolved.
+func addComponentTypeEntryWithMarker(t *testing.T, idx *index.Index, namespace, name, marker string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentType",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"workloadType": marker,
+					"resources":    []any{},
+				},
+			},
+		},
+		FilePath: "/repo/" + namespace + "/component-types/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addTraitEntryWithMarker(t *testing.T, idx *index.Index, namespace, name, marker string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "Trait",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"marker": marker,
+				},
+			},
+		},
+		FilePath: "/repo/" + namespace + "/traits/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+func addDeploymentPipelineEntryWithMarker(t *testing.T, idx *index.Index, namespace, name, marker string) {
+	t.Helper()
+	entry := &index.ResourceEntry{
+		Resource: &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "DeploymentPipeline",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"marker": marker,
+				},
+			},
+		},
+		FilePath: "/repo/" + namespace + "/pipelines/" + name + ".yaml",
+	}
+	require.NoError(t, idx.Add(entry))
+}
+
+// TestNamespaceCollisionIsolation verifies that namespace-scoped specialized
+// lookups isolate resources that share a name across namespaces (issue #4148).
+func TestNamespaceCollisionIsolation(t *testing.T) {
+	idx := index.New("/repo")
+
+	// Same-named namespace-scoped resources with distinct specs in two namespaces.
+	addComponentTypeEntryWithMarker(t, idx, "team-a", "http-service", "deployment")
+	addComponentTypeEntryWithMarker(t, idx, "team-b", "http-service", "statefulset")
+	addTraitEntryWithMarker(t, idx, "team-a", "logging", "marker-a")
+	addTraitEntryWithMarker(t, idx, "team-b", "logging", "marker-b")
+	addDeploymentPipelineEntryWithMarker(t, idx, "team-a", "pipe", "pipe-a")
+	addDeploymentPipelineEntryWithMarker(t, idx, "team-b", "pipe", "pipe-b")
+
+	// Cluster-scoped resources resolve by bare name.
+	addClusterComponentTypeEntry(t, idx)
+	addClusterTraitEntry(t, idx)
+
+	// Same project/component owners across namespaces.
+	addWorkloadEntry(t, idx, "team-a", "web-app-wl", "proj", "web-app")
+	addWorkloadEntry(t, idx, "team-b", "web-app-wl", "proj", "web-app")
+	addComponentEntry(t, idx, "team-a", "web-app", "proj")
+	addComponentEntry(t, idx, "team-b", "web-app", "proj")
+	addComponentReleaseEntry(t, idx, "team-a", "web-app-20260401-1", "proj")
+	addComponentReleaseEntry(t, idx, "team-b", "web-app-20260401-9", "proj")
+	addReleaseBindingEntry(t, idx, "team-a", "web-app-dev-a", "proj", "dev")
+	addReleaseBindingEntry(t, idx, "team-b", "web-app-dev-b", "proj", "dev")
+
+	ocIndex := WrapIndex(idx)
+
+	t.Run("component type isolated by namespace", func(t *testing.T) {
+		ctA, err := ocIndex.GetTypedComponentType("team-a", "http-service")
+		require.NoError(t, err)
+		assert.Equal(t, "deployment", ctA.Spec.WorkloadType)
+
+		ctB, err := ocIndex.GetTypedComponentType("team-b", "http-service")
+		require.NoError(t, err)
+		assert.Equal(t, "statefulset", ctB.Spec.WorkloadType)
+	})
+
+	t.Run("trait isolated by namespace", func(t *testing.T) {
+		entryA, ok := ocIndex.GetTrait("team-a", "logging")
+		require.True(t, ok)
+		assert.Equal(t, "marker-a", entryA.GetNestedString("spec", "marker"))
+
+		entryB, ok := ocIndex.GetTrait("team-b", "logging")
+		require.True(t, ok)
+		assert.Equal(t, "marker-b", entryB.GetNestedString("spec", "marker"))
+	})
+
+	t.Run("deployment pipeline isolated by namespace", func(t *testing.T) {
+		entryA, ok := ocIndex.GetDeploymentPipeline("team-a", "pipe")
+		require.True(t, ok)
+		assert.Equal(t, "pipe-a", entryA.GetNestedString("spec", "marker"))
+
+		entryB, ok := ocIndex.GetDeploymentPipeline("team-b", "pipe")
+		require.True(t, ok)
+		assert.Equal(t, "pipe-b", entryB.GetNestedString("spec", "marker"))
+	})
+
+	t.Run("cluster-scoped still resolve by bare name", func(t *testing.T) {
+		_, ok := ocIndex.GetClusterComponentType("service")
+		assert.True(t, ok)
+		_, ok = ocIndex.GetClusterTrait("global-ingress")
+		assert.True(t, ok)
+	})
+
+	t.Run("owner-based workload isolated by namespace", func(t *testing.T) {
+		entryA, ok := ocIndex.GetWorkloadForComponent("team-a", "proj", "web-app")
+		require.True(t, ok)
+		assert.Equal(t, "team-a", entryA.Namespace())
+
+		entryB, ok := ocIndex.GetWorkloadForComponent("team-b", "proj", "web-app")
+		require.True(t, ok)
+		assert.Equal(t, "team-b", entryB.Namespace())
+	})
+
+	t.Run("owner-based releases isolated by namespace", func(t *testing.T) {
+		relA := ocIndex.ListReleasesForComponent("team-a", "proj", "web-app")
+		require.Len(t, relA, 1)
+		assert.Equal(t, "web-app-20260401-1", relA[0].Name())
+
+		relB := ocIndex.ListReleasesForComponent("team-b", "proj", "web-app")
+		require.Len(t, relB, 1)
+		assert.Equal(t, "web-app-20260401-9", relB[0].Name())
+	})
+
+	t.Run("owner-based bindings isolated by namespace", func(t *testing.T) {
+		bindA, ok := ocIndex.GetReleaseBindingForEnv("team-a", "proj", "web-app", "dev")
+		require.True(t, ok)
+		assert.Equal(t, "web-app-dev-a", bindA.Name())
+
+		bindB, ok := ocIndex.GetReleaseBindingForEnv("team-b", "proj", "web-app", "dev")
+		require.True(t, ok)
+		assert.Equal(t, "web-app-dev-b", bindB.Name())
+	})
+
+	t.Run("components listed per namespace", func(t *testing.T) {
+		compsA := ocIndex.ListComponentsForProject("team-a", "proj")
+		require.Len(t, compsA, 1)
+		assert.Equal(t, "team-a", compsA[0].Namespace())
+
+		compsB := ocIndex.ListComponentsForProject("team-b", "proj")
+		require.Len(t, compsB, 1)
+		assert.Equal(t, "team-b", compsB[0].Namespace())
 	})
 }
 
@@ -681,7 +866,7 @@ func TestAddToSpecializedIndexesUnsafe(t *testing.T) {
 		}
 		require.NoError(t, idx.Add(entry))
 		ocIndex.rebuildSpecializedIndexes()
-		comps := ocIndex.ListComponentsForProject("proj-x")
+		comps := ocIndex.ListComponentsForProject("ns1", "proj-x")
 		assert.Len(t, comps, 1)
 	})
 
@@ -699,7 +884,7 @@ func TestAddToSpecializedIndexesUnsafe(t *testing.T) {
 		}
 		require.NoError(t, idx.Add(entry))
 		ocIndex.rebuildSpecializedIndexes()
-		_, ok := ocIndex.GetDeploymentPipeline("my-pipeline")
+		_, ok := ocIndex.GetDeploymentPipeline("ns1", "my-pipeline")
 		assert.True(t, ok)
 	})
 }

--- a/internal/occ/fsmode/output/workload_writer.go
+++ b/internal/occ/fsmode/output/workload_writer.go
@@ -76,7 +76,7 @@ func (w *WorkloadWriter) resolveOutputPath(params WorkloadWriteParams) string {
 	}
 
 	// Priority 2: Check if workload already exists for this component
-	existingWorkload, ok := w.index.GetWorkloadForComponent(params.ProjectName, params.ComponentName)
+	existingWorkload, ok := w.index.GetWorkloadForComponent(params.Namespace, params.ProjectName, params.ComponentName)
 	if ok && existingWorkload != nil {
 		// Replace existing workload file
 		return existingWorkload.FilePath


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
occ file-system mode built specialized lookup maps keyed by bare metadata.name for namespace-scoped resources (ComponentType, Trait, DeploymentPipeline, and the owner-based component/workload/release/ binding indexes). Two same-named resources in different namespaces collided: only one survived the map rebuild (Go map iteration order, non-deterministic) and lookups could not disambiguate by namespace, so `occ componentrelease generate` and `occ releasebinding generate` for a component in one namespace could silently embed another namespace's spec.

## Approach

Key every namespace-scoped specialized index by namespace/name (via an nsKey helper matching the generic index's empty-namespace semantics), add a namespace parameter to the corresponding lookups, and thread the active namespace through ComponentRelease and ReleaseBinding generation and the command callers. Namespace-filter the --all discovery and output-directory resolver paths that previously iterated every namespace. Cluster-scoped ClusterComponentType and ClusterTrait continue to use bare-name keys.

Add cross-namespace regression tests (two-namespace oracles) at the index, generator, bulk-binding, explicit-release, and output-resolver layers.

## Related Issues
> Fixes #4148

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
