### PR TITLE
feat: add opt-in mTLS to the cluster-gateway internal listener

### DIFF
--- a/cmd/cluster-gateway/main.go
+++ b/cmd/cluster-gateway/main.go
@@ -46,6 +46,7 @@ func main() {
 		serverCertPath       string
 		serverKeyPath        string
 		skipClientCertVerify bool
+		internalClientCAPath string
 		readTimeout          time.Duration
 		writeTimeout         time.Duration
 		idleTimeout          time.Duration
@@ -69,6 +70,10 @@ func main() {
 	flag.BoolVar(&skipClientCertVerify, "skip-client-cert-verify",
 		cmdutil.GetEnvBool("SKIP_CLIENT_CERT_VERIFY", false),
 		"Skip client certificate verification (for single-cluster setups without mTLS)")
+	flag.StringVar(&internalClientCAPath, "internal-client-ca",
+		cmdutil.GetEnv("INTERNAL_CLIENT_CA_PATH", ""),
+		"Path to a CA bundle for verifying client certificates on the internal listener "+
+			"(env: INTERNAL_CLIENT_CA_PATH). Empty (default) disables internal mTLS.")
 	flag.DurationVar(&readTimeout, "read-timeout", defaultReadTimeout, "HTTP read timeout")
 	flag.DurationVar(&writeTimeout, "write-timeout", defaultWriteTimeout, "HTTP write timeout")
 	flag.DurationVar(&idleTimeout, "idle-timeout", defaultIdleTimeout, "HTTP idle timeout")
@@ -83,6 +88,7 @@ func main() {
 	logger.Info("starting OpenChoreo Cluster Gateway",
 		"port", port,
 		"internalPort", internalPort,
+		"internalMTLS", internalClientCAPath != "",
 		"serverCert", serverCertPath,
 		"serverKey", serverKeyPath,
 		"heartbeatInterval", heartbeatInterval,
@@ -111,6 +117,7 @@ func main() {
 		ServerCertPath:       serverCertPath,
 		ServerKeyPath:        serverKeyPath,
 		SkipClientCertVerify: skipClientCertVerify,
+		InternalClientCAPath: internalClientCAPath,
 		ReadTimeout:          readTimeout,
 		WriteTimeout:         writeTimeout,
 		IdleTimeout:          idleTimeout,

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -54,6 +54,9 @@ spec:
         - --heartbeat-interval={{ .Values.clusterGateway.heartbeatInterval }}
         - --heartbeat-timeout={{ .Values.clusterGateway.heartbeatTimeout }}
         - --skip-client-cert-verify={{ .Values.clusterGateway.tls.skipClientCertVerify }}
+        {{- if .Values.clusterGateway.internalMtls.enabled }}
+        - --internal-client-ca=/certs/ca.crt
+        {{- end }}
         - --log-level={{ .Values.clusterGateway.logLevel }}
         ports:
         - name: websocket

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/internal-client-certificates.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/internal-client-certificates.yaml
@@ -1,0 +1,58 @@
+# Client certificates for in-cluster callers of the cluster gateway's
+# internal listener (:8444). Issued by the same CA as the gateway's server
+# certificate so the gateway can verify callers against /certs/ca.crt.
+{{- if .Values.clusterGateway.internalMtls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: controller-manager-gateway-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller-manager
+spec:
+  secretName: controller-manager-gateway-client-tls
+  commonName: controller-manager.openchoreo.internal
+  usages:
+    - client auth
+  issuerRef:
+    {{- if .Values.clusterGateway.tls.issuerRef.kind }}
+    kind: {{ .Values.clusterGateway.tls.issuerRef.kind }}
+    {{- else }}
+    kind: Issuer
+    {{- end }}
+    name: {{ .Values.clusterGateway.tls.issuerRef.name }}
+  {{- with .Values.clusterGateway.internalMtls.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.clusterGateway.internalMtls.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-api-gateway-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api-server
+spec:
+  secretName: openchoreo-api-gateway-client-tls
+  commonName: openchoreo-api.openchoreo.internal
+  usages:
+    - client auth
+  issuerRef:
+    {{- if .Values.clusterGateway.tls.issuerRef.kind }}
+    kind: {{ .Values.clusterGateway.tls.issuerRef.kind }}
+    {{- else }}
+    kind: Issuer
+    {{- end }}
+    name: {{ .Values.clusterGateway.tls.issuerRef.name }}
+  {{- with .Values.clusterGateway.internalMtls.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.clusterGateway.internalMtls.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -64,6 +64,10 @@ spec:
         {{- if .Values.controllerManager.clusterGateway.tls.insecure }}
         - --cluster-gateway-insecure
         {{- end }}
+        {{- if .Values.clusterGateway.internalMtls.enabled }}
+        - --cluster-gateway-client-cert=/etc/cluster-gateway-client/tls.crt
+        - --cluster-gateway-client-key=/etc/cluster-gateway-client/tls.key
+        {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
           value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}
@@ -119,6 +123,11 @@ spec:
           name: cluster-gateway-ca
           readOnly: true
         {{- end }}
+        {{- if .Values.clusterGateway.internalMtls.enabled }}
+        - mountPath: /etc/cluster-gateway-client
+          name: cluster-gateway-client-cert
+          readOnly: true
+        {{- end }}
       volumes:
       {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
       - name: cert
@@ -130,4 +139,14 @@ spec:
       - name: cluster-gateway-ca
         secret:
           secretName: {{ .Values.controllerManager.clusterGateway.tls.caSecret }}
+          # Only the CA certificate is needed for server verification; do not
+          # expose the CA private key to this pod.
+          items:
+          - key: ca.crt
+            path: ca.crt
+      {{- end }}
+      {{- if .Values.clusterGateway.internalMtls.enabled }}
+      - name: cluster-gateway-client-cert
+        secret:
+          secretName: controller-manager-gateway-client-tls
       {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -72,6 +72,10 @@ data:
         {{- if .Values.clusterGateway.tls.enabled }}
         ca_cert_path: {{ .Values.openchoreoApi.clusterGateway.tls.caPath | quote }}
         {{- end }}
+        {{- if .Values.clusterGateway.internalMtls.enabled }}
+        client_cert_path: /etc/cluster-gateway-client/tls.crt
+        client_key_path: /etc/cluster-gateway-client/tls.key
+        {{- end }}
         insecure: {{ .Values.openchoreoApi.clusterGateway.tls.insecure }}
 
     logging:

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -72,6 +72,11 @@ spec:
           mountPath: /etc/cluster-gateway
           readOnly: true
         {{- end }}
+        {{- if .Values.clusterGateway.internalMtls.enabled }}
+        - name: cluster-gateway-client-cert
+          mountPath: /etc/cluster-gateway-client
+          readOnly: true
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health
@@ -100,5 +105,15 @@ spec:
       - name: cluster-gateway-ca
         secret:
           secretName: {{ .Values.openchoreoApi.clusterGateway.tls.caSecret }}
+          # Only the CA certificate is needed for server verification; do not
+          # expose the CA private key to this pod.
+          items:
+          - key: ca.crt
+            path: ca.crt
+      {{- end }}
+      {{- if .Values.clusterGateway.internalMtls.enabled }}
+      - name: cluster-gateway-client-cert
+        secret:
+          secretName: openchoreo-api-gateway-client-tls
       {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1163,6 +1163,33 @@
           "title": "image",
           "type": "object"
         },
+        "internalMtls": {
+          "additionalProperties": true,
+          "description": "Mutual TLS for the internal listener (:8444). When enabled, the gateway requires in-cluster callers (controller manager, API server) to present a client certificate issued by the cluster-gateway CA. Client certificates are created automatically via cert-manager. Requires clusterGateway.tls.enabled with a server-cert secret containing ca.crt (the default cert-manager setup).",
+          "properties": {
+            "duration": {
+              "default": "2160h",
+              "description": "Client certificate validity duration (90 days)",
+              "title": "duration",
+              "type": "string"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Enable mTLS on the internal listener",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "renewBefore": {
+              "default": "720h",
+              "description": "Client certificate renewal threshold (30 days before expiry)",
+              "title": "renewBefore",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "internalMtls",
+          "type": "object"
+        },
         "logLevel": {
           "default": "info",
           "description": "Log level",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3625,6 +3625,33 @@ clusterGateway:
     renewBefore: 360h
 
   # type: object
+  # description: Mutual TLS for the internal listener (:8444)
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Mutual TLS for the internal listener (:8444). When enabled, the gateway requires in-cluster callers (controller manager, API server) to present a client certificate issued by the cluster-gateway CA. Client certificates are created automatically via cert-manager. Requires clusterGateway.tls.enabled with a server-cert secret containing ca.crt (the default cert-manager setup).
+  # @schema
+  internalMtls:
+    # @schema
+    # type: boolean
+    # description: Enable mTLS on the internal listener
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: string
+    # description: Client certificate validity duration (90 days)
+    # default: 2160h
+    # @schema
+    duration: 2160h
+    # @schema
+    # type: string
+    # description: Client certificate renewal threshold (30 days before expiry)
+    # default: 720h
+    # @schema
+    renewBefore: 720h
+
+  # type: object
   # description: Pod security context
   # @schema
   # type: object

--- a/install/k3d/k3d-install.sh
+++ b/install/k3d/k3d-install.sh
@@ -34,6 +34,7 @@ OPENCHOREO_VERSION="${OPENCHOREO_VERSION:-}"
 
 WITH_BUILD=false
 WITH_OBSERVABILITY=false
+WITH_INTERNAL_MTLS=false
 
 usage() {
     cat <<EOF
@@ -42,6 +43,7 @@ Usage: k3d-install.sh [OPTIONS]
 Options:
   --with-build             Also install the workflow plane (Argo Workflows + registry)
   --with-observability     Also install the observability plane (OpenSearch logs/traces + metrics)
+  --with-internal-mtls     Require client certificates (mTLS) on the cluster-gateway internal listener
   --version VER            OpenChoreo version to install, e.g. 1.1.1 or latest-dev
                            (required when not running from a checkout)
   --cluster-name NAME     k3d cluster name (default: openchoreo)
@@ -55,6 +57,7 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --with-build) WITH_BUILD=true; shift ;;
         --with-observability) WITH_OBSERVABILITY=true; shift ;;
+        --with-internal-mtls) WITH_INTERNAL_MTLS=true; shift ;;
         --version) need_arg "$@"; OPENCHOREO_VERSION="$2"; shift 2 ;;
         --cluster-name) need_arg "$@"; CLUSTER_NAME="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
@@ -257,11 +260,16 @@ EOF
         --for=condition=Ready externalsecret/backstage-secrets --timeout=120s
 
     step "Installing the control plane"
-    # shellcheck disable=SC2046
+    local internal_mtls_args=""
+    if [[ "$WITH_INTERNAL_MTLS" == true ]]; then
+        internal_mtls_args="--set clusterGateway.internalMtls.enabled=true"
+    fi
+    # shellcheck disable=SC2046,SC2086
     $HELM upgrade --install openchoreo-control-plane "$HELM_REPO/openchoreo-control-plane" \
         $(chart_version_args) \
         --namespace "$CONTROL_PLANE_NS" --create-namespace \
-        --values "$(asset install/k3d/single-cluster/values-cp.yaml)"
+        --values "$(asset install/k3d/single-cluster/values-cp.yaml)" \
+        $internal_mtls_args
     $KUBECTL wait -n "$CONTROL_PLANE_NS" \
         --for=condition=available --timeout=300s deployment --all
 

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -113,6 +113,51 @@ kubectl --context k3d-openchoreo-cp wait -n openchoreo-control-plane \
   --for=condition=available --timeout=300s deployment --all
 ```
 
+### (Optional) Enable mTLS on the Cluster Gateway Internal Listener
+
+By default, the cluster-gateway's internal listener (`:8444`, serving `/api/proxy/`,
+`/api/exec/`, `/api/wirelogs/`, and `/api/v1/planes/*`) is ClusterIP-only and relies on
+network reachability. For defence-in-depth against in-cluster lateral movement, enable
+mTLS so callers (controller-manager and openchoreo-api) must present a client
+certificate issued by the cluster-gateway CA. Client certificates are created and
+renewed automatically via cert-manager — no manual cert handling.
+
+Add `--set clusterGateway.internalMtls.enabled=true` to the install command above, or
+enable it on an existing install:
+
+```bash
+helm upgrade openchoreo-control-plane install/helm/openchoreo-control-plane \
+  --kube-context k3d-openchoreo-cp \
+  --namespace openchoreo-control-plane \
+  --values install/k3d/multi-cluster/values-cp.yaml \
+  --set clusterGateway.internalMtls.enabled=true
+
+kubectl --context k3d-openchoreo-cp wait -n openchoreo-control-plane \
+  --for=condition=available --timeout=300s deployment --all
+```
+
+> [!NOTE]
+> Enabling this rolls the cluster-gateway, controller-manager, and openchoreo-api
+> deployments together. Brief handshake failures during the rollout self-heal —
+> callers retry transient connection errors. Cluster agents are unaffected: they
+> connect to the external listener (`:8443`), whose authentication is unchanged.
+
+Verify the gateway is enforcing client certificates:
+
+```bash
+# Gateway log confirms enforcement
+kubectl --context k3d-openchoreo-cp logs deployment/cluster-gateway \
+  -n openchoreo-control-plane | grep "internal listener mTLS enabled"
+
+# A caller without a client certificate must be rejected at the TLS handshake
+kubectl --context k3d-openchoreo-cp run mtls-check --rm -i --restart=Never \
+  --image=curlimages/curl -n openchoreo-control-plane -- \
+  curl -sk https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8444/api/v1/planes/status
+# expected: request fails with a TLS alert about the missing/required client certificate
+```
+
+To disable, set `clusterGateway.internalMtls.enabled=false` and upgrade again.
+
 ## 2. Install Default Resources
 
 ```bash

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -137,6 +137,50 @@ kubectl wait -n openchoreo-control-plane \
   --for=condition=available --timeout=300s deployment --all
 ```
 
+### (Optional) Enable mTLS on the Cluster Gateway Internal Listener
+
+By default, the cluster-gateway's internal listener (`:8444`, serving `/api/proxy/`,
+`/api/exec/`, `/api/wirelogs/`, and `/api/v1/planes/*`) is ClusterIP-only and relies on
+network reachability. For defence-in-depth against in-cluster lateral movement, enable
+mTLS so callers (controller-manager and openchoreo-api) must present a client
+certificate issued by the cluster-gateway CA. Client certificates are created and
+renewed automatically via cert-manager — no manual cert handling.
+
+Add `--set clusterGateway.internalMtls.enabled=true` to the install command above, or
+enable it on an existing install:
+
+```bash
+helm upgrade openchoreo-control-plane install/helm/openchoreo-control-plane \
+  --namespace openchoreo-control-plane \
+  --values install/k3d/single-cluster/values-cp.yaml \
+  --set clusterGateway.internalMtls.enabled=true
+
+kubectl wait -n openchoreo-control-plane \
+  --for=condition=available --timeout=300s deployment --all
+```
+
+> [!NOTE]
+> Enabling this rolls the cluster-gateway, controller-manager, and openchoreo-api
+> deployments together. Brief handshake failures during the rollout self-heal —
+> callers retry transient connection errors. Cluster agents are unaffected: they
+> connect to the external listener (`:8443`), whose authentication is unchanged.
+
+Verify the gateway is enforcing client certificates:
+
+```bash
+# Gateway log confirms enforcement
+kubectl logs deployment/cluster-gateway -n openchoreo-control-plane \
+  | grep "internal listener mTLS enabled"
+
+# A caller without a client certificate must be rejected at the TLS handshake
+kubectl run mtls-check --rm -i --restart=Never \
+  --image=curlimages/curl -n openchoreo-control-plane -- \
+  curl -sk https://cluster-gateway.openchoreo-control-plane.svc.cluster.local:8444/api/v1/planes/status
+# expected: curl: (55) ... alert certificate required
+```
+
+To disable, set `clusterGateway.internalMtls.enabled=false` and upgrade again.
+
 ### Extract Cluster Gateway CA
 
 Wait for cert-manager to issue the cluster-gateway CA certificate, then populate the ConfigMap that the controller-manager and cluster-agents use to verify the gateway server.

--- a/internal/clients/gateway/client.go
+++ b/internal/clients/gateway/client.go
@@ -238,11 +238,20 @@ func BuildTLSConfig(config *TLSConfig) (*tls.Config, error) {
 		if config.ClientCertFile == "" || config.ClientKeyFile == "" {
 			return nil, fmt.Errorf("both ClientCertFile and ClientKeyFile must be set for mTLS")
 		}
-		cert, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile)
-		if err != nil {
+		// Eagerly load once to fail fast on misconfiguration.
+		if _, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile); err != nil {
 			return nil, fmt.Errorf("failed to load client key pair: %w", err)
 		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
+		certFile, keyFile := config.ClientCertFile, config.ClientKeyFile
+		// Reload from disk on each handshake so cert-manager renewals are
+		// picked up without restarting the pod.
+		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load client key pair: %w", err)
+			}
+			return &cert, nil
+		}
 	}
 
 	return tlsConfig, nil

--- a/internal/clients/gateway/client_test.go
+++ b/internal/clients/gateway/client_test.go
@@ -824,7 +824,10 @@ func TestBuildTLSConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.True(t, cfg.InsecureSkipVerify)
-		assert.Len(t, cfg.Certificates, 1)
+		require.NotNil(t, cfg.GetClientCertificate)
+		cert, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, cert.Certificate)
 	})
 
 	t.Run("ServerName is propagated", func(t *testing.T) {
@@ -868,7 +871,60 @@ func TestBuildTLSConfig(t *testing.T) {
 			ClientKeyFile:  keyFile,
 		})
 		require.NoError(t, err)
-		assert.Len(t, cfg.Certificates, 1)
+		require.NotNil(t, cfg.GetClientCertificate)
+		cert, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, cert.Certificate)
+	})
+
+	t.Run("client cert renewed on disk is picked up without rebuilding the config", func(t *testing.T) {
+		certPEM, keyPEM := mustGenerateKeyPairPEM(t)
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "client.crt")
+		keyFile := filepath.Join(dir, "client.key")
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := BuildTLSConfig(&TLSConfig{
+			ClientCertFile: certFile,
+			ClientKeyFile:  keyFile,
+		})
+		require.NoError(t, err)
+
+		first, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+
+		// Simulate cert-manager renewal: overwrite the keypair on disk.
+		renewedCertPEM, renewedKeyPEM := mustGenerateKeyPairPEM(t)
+		require.NoError(t, os.WriteFile(certFile, renewedCertPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, renewedKeyPEM, 0o600))
+
+		second, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+		assert.NotEqual(t, first.Certificate, second.Certificate,
+			"handshake must present the renewed certificate, not the startup-time one")
+	})
+
+	t.Run("client cert removed from disk surfaces a handshake-time error", func(t *testing.T) {
+		certPEM, keyPEM := mustGenerateKeyPairPEM(t)
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "client.crt")
+		keyFile := filepath.Join(dir, "client.key")
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := BuildTLSConfig(&TLSConfig{
+			ClientCertFile: certFile,
+			ClientKeyFile:  keyFile,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, os.Remove(certFile))
+		require.NoError(t, os.Remove(keyFile))
+
+		_, err = cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client key pair")
 	})
 
 	t.Run("only ClientCertFile set returns asymmetric-config error", func(t *testing.T) {

--- a/internal/clients/kubernetes/proxy_client.go
+++ b/internal/clients/kubernetes/proxy_client.go
@@ -817,11 +817,20 @@ func buildProxyTLSConfig(tlsConfig *ProxyTLSConfig) (*tls.Config, error) {
 		if tlsConfig.ClientCertPath == "" || tlsConfig.ClientKeyPath == "" {
 			return nil, fmt.Errorf("both ClientCertPath and ClientKeyPath must be set for mTLS")
 		}
-		clientCert, err := tls.LoadX509KeyPair(tlsConfig.ClientCertPath, tlsConfig.ClientKeyPath)
-		if err != nil {
+		// Eagerly load once to fail fast on misconfiguration.
+		if _, err := tls.LoadX509KeyPair(tlsConfig.ClientCertPath, tlsConfig.ClientKeyPath); err != nil {
 			return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
 		}
-		cfg.Certificates = []tls.Certificate{clientCert}
+		certPath, keyPath := tlsConfig.ClientCertPath, tlsConfig.ClientKeyPath
+		// Reload from disk on each handshake so cert-manager renewals are
+		// picked up without restarting the pod.
+		cfg.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
+			}
+			return &clientCert, nil
+		}
 	}
 
 	return cfg, nil

--- a/internal/clients/kubernetes/proxy_client_test.go
+++ b/internal/clients/kubernetes/proxy_client_test.go
@@ -287,7 +287,60 @@ func TestBuildProxyTLSConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.True(t, cfg.InsecureSkipVerify)
-		assert.Len(t, cfg.Certificates, 1)
+		require.NotNil(t, cfg.GetClientCertificate)
+		cert, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, cert.Certificate)
+	})
+
+	t.Run("client cert renewed on disk is picked up without rebuilding the config", func(t *testing.T) {
+		certPEM, keyPEM := mustCreateSelfSignedCertAndKeyPEM(t)
+		dir := t.TempDir()
+		certFile := dir + "/client.crt"
+		keyFile := dir + "/client.key"
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{
+			ClientCertPath: certFile,
+			ClientKeyPath:  keyFile,
+		})
+		require.NoError(t, err)
+
+		first, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+
+		// Simulate cert-manager renewal: overwrite the keypair on disk.
+		renewedCertPEM, renewedKeyPEM := mustCreateSelfSignedCertAndKeyPEM(t)
+		require.NoError(t, os.WriteFile(certFile, renewedCertPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, renewedKeyPEM, 0o600))
+
+		second, err := cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.NoError(t, err)
+		assert.NotEqual(t, first.Certificate, second.Certificate,
+			"handshake must present the renewed certificate, not the startup-time one")
+	})
+
+	t.Run("client cert removed from disk surfaces a handshake-time error", func(t *testing.T) {
+		certPEM, keyPEM := mustCreateSelfSignedCertAndKeyPEM(t)
+		dir := t.TempDir()
+		certFile := dir + "/client.crt"
+		keyFile := dir + "/client.key"
+		require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+		require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+
+		cfg, err := buildProxyTLSConfig(&ProxyTLSConfig{
+			ClientCertPath: certFile,
+			ClientKeyPath:  keyFile,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, os.Remove(certFile))
+		require.NoError(t, os.Remove(keyFile))
+
+		_, err = cfg.GetClientCertificate(&tls.CertificateRequestInfo{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client certificate and key")
 	})
 
 	t.Run("only ClientCertPath set returns asymmetric-config error", func(t *testing.T) {

--- a/internal/cluster-gateway/config.go
+++ b/internal/cluster-gateway/config.go
@@ -12,6 +12,9 @@ type Config struct {
 	ServerCertPath       string
 	ServerKeyPath        string
 	SkipClientCertVerify bool
+	// InternalClientCAPath, when non-empty, enables mTLS on the internal
+	// listener: callers must present a certificate signed by this CA.
+	InternalClientCAPath string
 	ReadTimeout          time.Duration
 	WriteTimeout         time.Duration
 	IdleTimeout          time.Duration

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -96,6 +96,28 @@ func getOrGenerateRequestID(r *http.Request) string {
 	return requestID
 }
 
+// buildInternalTLSConfig derives the internal listener's TLS config from the
+// base config. When caPath is non-empty, callers must present a client
+// certificate signed by that CA (mTLS); when empty, the base TLS behavior is
+// kept unchanged.
+func buildInternalTLSConfig(base *tls.Config, caPath string) (*tls.Config, error) {
+	cfg := base.Clone()
+	if caPath == "" {
+		return cfg, nil
+	}
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read internal client CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("no certificates parsed from internal client CA %q", caPath)
+	}
+	cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	cfg.ClientCAs = pool
+	return cfg, nil
+}
+
 func (s *Server) Start() error {
 	cert, err := tls.LoadX509KeyPair(s.config.ServerCertPath, s.config.ServerKeyPath)
 	if err != nil {
@@ -115,6 +137,17 @@ func (s *Server) Start() error {
 		"clientAuth", "RequestClientCert",
 		"note", "Client certificate verification performed at application level per DataPlane/WorkflowPlane CR",
 	)
+
+	internalTLSConfig, err := buildInternalTLSConfig(tlsConfig, s.config.InternalClientCAPath)
+	if err != nil {
+		return err
+	}
+	if s.config.InternalClientCAPath != "" {
+		s.logger.Info("internal listener mTLS enabled",
+			"clientAuth", "RequireAndVerifyClientCert",
+			"clientCA", s.config.InternalClientCAPath,
+		)
+	}
 
 	// Public listener: agent WebSocket only (reached by remote data planes).
 	publicMux := http.NewServeMux()
@@ -150,7 +183,7 @@ func (s *Server) Start() error {
 	s.internalServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", s.config.InternalPort),
 		Handler:      internalMux,
-		TLSConfig:    tlsConfig.Clone(),
+		TLSConfig:    internalTLSConfig,
 		ReadTimeout:  s.config.ReadTimeout,
 		WriteTimeout: s.config.WriteTimeout,
 		IdleTimeout:  s.config.IdleTimeout,

--- a/internal/cluster-gateway/server_test.go
+++ b/internal/cluster-gateway/server_test.go
@@ -7,13 +7,18 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -872,4 +877,240 @@ func TestHandleConnection_NormalClose(t *testing.T) {
 
 	// Should log "agent disconnected" and return
 	s.handleConnection("dataplane/prod", connID, mock)
+}
+
+// --- Internal listener mTLS tests ---
+
+// writeTestCAFile writes the given CA certificate as PEM to a temp file.
+func writeTestCAFile(t *testing.T, caCert *x509.Certificate) string {
+	t.Helper()
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caFile, encodeCertToPEM(t, caCert), 0o600))
+	return caFile
+}
+
+// generateTestClientKeyPair creates a tls.Certificate (cert + key) signed by the given CA.
+func generateTestClientKeyPair(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) tls.Certificate {
+	t.Helper()
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "Test Internal Caller"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	return tls.Certificate{
+		Certificate: [][]byte{clientDER},
+		PrivateKey:  clientKey,
+	}
+}
+
+func TestBuildInternalTLSConfig(t *testing.T) {
+	base := &tls.Config{
+		ClientAuth: tls.RequestClientCert,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	t.Run("empty CA path keeps base TLS behavior unchanged", func(t *testing.T) {
+		// Default-off contract: without a CA, the internal listener must behave
+		// exactly like today so enabling the feature is strictly opt-in.
+		cfg, err := buildInternalTLSConfig(base, "")
+		require.NoError(t, err)
+		assert.Equal(t, tls.RequestClientCert, cfg.ClientAuth)
+		assert.Nil(t, cfg.ClientCAs)
+	})
+
+	t.Run("valid CA requires and verifies client certificates", func(t *testing.T) {
+		caCert, _ := generateTestCA(t)
+		cfg, err := buildInternalTLSConfig(base, writeTestCAFile(t, caCert))
+		require.NoError(t, err)
+		assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+		assert.NotNil(t, cfg.ClientCAs)
+		// The base config must not be mutated: the public listener keeps
+		// serving agents without TLS-level verification.
+		assert.Equal(t, tls.RequestClientCert, base.ClientAuth)
+		assert.Nil(t, base.ClientCAs)
+	})
+
+	t.Run("missing CA file is a fatal configuration error", func(t *testing.T) {
+		_, err := buildInternalTLSConfig(base, "/path/does/not/exist/ca.crt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read internal client CA")
+	})
+
+	t.Run("garbage PEM is a fatal configuration error", func(t *testing.T) {
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte("not-a-cert"), 0o600))
+		_, err := buildInternalTLSConfig(base, caFile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no certificates parsed")
+	})
+}
+
+// TestInternalListenerMTLS_Handshake exercises real TLS handshakes against a
+// listener using the internal TLS config, proving the mTLS boundary holds:
+// callers without a certificate (or with one from a different CA) must be
+// rejected before any handler runs, and callers with a certificate from the
+// configured CA must get through.
+func TestInternalListenerMTLS_Handshake(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	base := &tls.Config{
+		ClientAuth: tls.RequestClientCert,
+		MinVersion: tls.VersionTLS12,
+	}
+	cfg, err := buildInternalTLSConfig(base, writeTestCAFile(t, caCert))
+	require.NoError(t, err)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = cfg
+	srv.StartTLS()
+	defer srv.Close()
+
+	t.Run("caller without a client certificate is rejected", func(t *testing.T) {
+		// srv.Client() trusts the server certificate but presents none itself.
+		_, err := srv.Client().Get(srv.URL + "/api/v1/planes/status")
+		require.Error(t, err, "certificate-less handshake must be refused")
+	})
+
+	t.Run("caller with a certificate from the configured CA is accepted", func(t *testing.T) {
+		client := srv.Client()
+		transport := client.Transport.(*http.Transport).Clone()
+		transport.TLSClientConfig.Certificates = []tls.Certificate{generateTestClientKeyPair(t, caCert, caKey)}
+		client.Transport = transport
+
+		resp, err := client.Get(srv.URL + "/api/v1/planes/status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("caller with a certificate from a different CA is rejected", func(t *testing.T) {
+		otherCACert, otherCAKey := generateTestCA(t)
+		client := srv.Client()
+		transport := client.Transport.(*http.Transport).Clone()
+		transport.TLSClientConfig.Certificates = []tls.Certificate{generateTestClientKeyPair(t, otherCACert, otherCAKey)}
+		client.Transport = transport
+
+		_, err := client.Get(srv.URL + "/api/v1/planes/status")
+		require.Error(t, err, "certificate from an unknown CA must be refused")
+	})
+
+	t.Run("with no CA configured, certificate-less callers still succeed", func(t *testing.T) {
+		// Regression guard for the non-breaking default: this failing means the
+		// default-off contract broke and existing installs would lose gateway access.
+		plainCfg, err := buildInternalTLSConfig(base, "")
+		require.NoError(t, err)
+
+		plainSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		plainSrv.TLS = plainCfg
+		plainSrv.StartTLS()
+		defer plainSrv.Close()
+
+		resp, err := plainSrv.Client().Get(plainSrv.URL + "/api/v1/planes/status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// --- Server.Start tests ---
+
+// writeTestServerKeyPairFiles writes a self-signed server certificate and key
+// to temp files and returns their paths.
+func writeTestServerKeyPairFiles(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	caCert, caKey := generateTestCA(t)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+
+	keyDER, err := x509.MarshalECPrivateKey(caKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	require.NoError(t, os.WriteFile(certPath, encodeCertToPEM(t, caCert), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+	return certPath, keyPath
+}
+
+func TestStart_InvalidServerCertIsFatal(t *testing.T) {
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := New(&Config{
+		ServerCertPath: "/path/does/not/exist/tls.crt",
+		ServerKeyPath:  "/path/does/not/exist/tls.key",
+	}, fakeClient, testLogger())
+
+	err := s.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load server certificate")
+}
+
+func TestStart_InvalidInternalClientCAIsFatal(t *testing.T) {
+	certPath, keyPath := writeTestServerKeyPairFiles(t)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := New(&Config{
+		ServerCertPath:       certPath,
+		ServerKeyPath:        keyPath,
+		InternalClientCAPath: "/path/does/not/exist/ca.crt",
+	}, fakeClient, testLogger())
+
+	// Start must fail before binding any listener: a gateway configured for
+	// internal mTLS that cannot verify callers must not come up without it.
+	err := s.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read internal client CA")
+}
+
+func TestStart_ReturnsServerErrorWhenPublicPortBusy(t *testing.T) {
+	// Occupy a port so the public listener fails fast; Start must surface the
+	// error through the serverErrors channel. Internal mTLS is enabled so the
+	// full listener-setup path (including the mTLS log branch) is exercised.
+	// The server binds with a wildcard address (":<port>"), so the occupying
+	// listener must use a wildcard address too — a loopback-only listener
+	// (e.g. "127.0.0.1:0") doesn't conflict with a wildcard bind on the same
+	// port and would leave Start() hanging forever instead of erroring.
+	ln, err := net.Listen("tcp", ":0") //nolint:gosec // G102: wildcard bind is required to conflict with the server's wildcard listener
+	require.NoError(t, err)
+	defer ln.Close()
+	busyPort := ln.Addr().(*net.TCPAddr).Port
+
+	certPath, keyPath := writeTestServerKeyPairFiles(t)
+	caCert, _ := generateTestCA(t)
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := New(&Config{
+		Port:                 busyPort,
+		InternalPort:         0, // ephemeral
+		ServerCertPath:       certPath,
+		ServerKeyPath:        keyPath,
+		InternalClientCAPath: writeTestCAFile(t, caCert),
+		ShutdownTimeout:      time.Second,
+	}, fakeClient, testLogger())
+	defer func() {
+		for _, srv := range []*http.Server{s.httpServer, s.internalServer, s.healthServer} {
+			if srv != nil {
+				srv.Close()
+			}
+		}
+	}()
+
+	err = s.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server error")
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The cluster gateway's internal listener (`:8444`, serving `/api/proxy/`, `/api/exec/`, `/api/wirelogs/`, and `/api/v1/planes/*`) is ClusterIP-only and performs no caller authentication — any workload running inside the control-plane cluster can proxy into any connected plane's Kubernetes API, exec into plane pods, stream network flows, or disrupt agent connectivity. This PR adds opt-in mTLS to the internal listener so callers must present a client certificate issued by the cluster-gateway CA. It is **default disabled** and strictly non-breaking: with the toggle off, rendered manifests and runtime TLS behavior are unchanged.

## Approach
**Gateway (verify side)**
- New `--internal-client-ca` flag / `INTERNAL_CLIENT_CA_PATH` env on the cluster-gateway (`cmd/cluster-gateway/main.go`, `internal/cluster-gateway/config.go`). When set, the internal listener's TLS config gets `ClientAuth: RequireAndVerifyClientCert` with the configured CA pool (`buildInternalTLSConfig` in `internal/cluster-gateway/server.go`); when unset, the config is an untouched clone of today's. An unreadable/invalid CA is a fatal startup error. The external agent listener (`:8443`, `/ws`) and its per-CR mTLS model are untouched — cluster agents require no change.

**Callers (present side)**
- All caller paths (gateway client, K8s proxy client, exec/wirelogs WebSocket dialers) already supported client certificates via existing-but-unused flags/config; this PR only activates them via Helm.
- Client keypairs are now loaded per-handshake via `GetClientCertificate` (`internal/clients/gateway/client.go`, `internal/clients/kubernetes/proxy_client.go`) instead of once at startup, so cert-manager renewals are picked up without pod restarts. Startup still eagerly loads once to fail fast on misconfiguration.

**Helm (single toggle: `clusterGateway.internalMtls.enabled`, default `false`)**
- Two client `Certificate`s (`usages: [client auth]`) issued from the chart's existing cluster-gateway CA `Issuer` for controller-manager and openchoreo-api, with distinct `commonName`s to enable SAN/CN-based authorization later.
- Gateway gains `--internal-client-ca=/certs/ca.crt` (no new mount — `ca.crt` is already in the server-cert secret); callers gain cert mounts wired into the existing flags/config keys. `values.schema.json` updated.
- Hardening (applies regardless of the toggle): the `cluster-gateway-ca` secret mounts in caller deployments are restricted to `ca.crt` via `items:`, so the CA private key is no longer exposed to caller pods.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4168

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
