### PR TITLE
test: cover target plane, and dp-resource-hash annotation

### DIFF
--- a/internal/pipeline/component/pipeline_test.go
+++ b/internal/pipeline/component/pipeline_test.go
@@ -40,6 +40,16 @@ func loadTestDataFile(t *testing.T, path string) string {
 	return string(data)
 }
 
+// resourceKindName returns a "Kind/name" label for a rendered resource, for test messages.
+func resourceKindName(resource map[string]any) string {
+	kind, _ := resource["kind"].(string)
+	name := ""
+	if meta, ok := resource["metadata"].(map[string]any); ok {
+		name, _ = meta["name"].(string)
+	}
+	return fmt.Sprintf("%s/%s", kind, name)
+}
+
 func TestPipeline_Render(t *testing.T) {
 	devEnvironmentYAML := `
     apiVersion: openchoreo.dev/v1alpha1
@@ -104,9 +114,12 @@ func TestPipeline_Render(t *testing.T) {
 		environmentYAML      string
 		dataplaneYAML        string
 		secretReferencesYAML string
+		wantMetadata         *RenderMetadata
+		wantTargetPlanes     []string
 	}{
 		{
-			name: "simple component without traits",
+			name:         "simple component without traits",
+			wantMetadata: &RenderMetadata{ResourceCount: 1, BaseResourceCount: 1, TraitCount: 0, TraitResourceCount: 0, Warnings: []string{}},
 			snapshotYAML: `
 apiVersion: core.choreo.dev/v1alpha1
 kind: ComponentEnvSnapshot
@@ -291,7 +304,9 @@ spec:
 			wantErr: false,
 		},
 		{
-			name: "component with trait creates",
+			name:             "component with trait creates",
+			wantMetadata:     &RenderMetadata{ResourceCount: 2, BaseResourceCount: 1, TraitCount: 1, TraitResourceCount: 1, Warnings: []string{}},
+			wantTargetPlanes: []string{v1alpha1.TargetPlaneDataPlane, v1alpha1.TargetPlaneObservabilityPlane},
 			snapshotYAML: `
 apiVersion: core.choreo.dev/v1alpha1
 kind: ComponentEnvSnapshot
@@ -328,7 +343,8 @@ spec:
               database:
                 type: string
         creates:
-          - template:
+          - targetPlane: observabilityplane
+            template:
               apiVersion: v1
               kind: Secret
               metadata:
@@ -370,7 +386,8 @@ spec:
 			wantErr: false,
 		},
 		{
-			name: "component with trait patches",
+			name:         "component with trait patches",
+			wantMetadata: &RenderMetadata{ResourceCount: 1, BaseResourceCount: 1, TraitCount: 1, TraitResourceCount: 0, Warnings: []string{}},
 			snapshotYAML: `
 apiVersion: core.choreo.dev/v1alpha1
 kind: ComponentEnvSnapshot
@@ -815,7 +832,13 @@ spec:
 			wantErr: false,
 		},
 		{
-			name:                 "component with configurations and secrets",
+			name:         "component with configurations and secrets",
+			wantMetadata: &RenderMetadata{ResourceCount: 7, BaseResourceCount: 7, TraitCount: 0, TraitResourceCount: 0, Warnings: []string{}},
+			wantTargetPlanes: []string{
+				v1alpha1.TargetPlaneDataPlane, v1alpha1.TargetPlaneDataPlane, v1alpha1.TargetPlaneDataPlane,
+				v1alpha1.TargetPlaneDataPlane,
+				v1alpha1.TargetPlaneDataPlane, v1alpha1.TargetPlaneDataPlane, v1alpha1.TargetPlaneDataPlane,
+			},
 			snapshotYAML:         loadTestDataFile(t, "configurations-and-secrets/snapshot.yaml"),
 			settingsYAML:         loadTestDataFile(t, "configurations-and-secrets/settings.yaml"),
 			environmentYAML:      devEnvironmentYAML,
@@ -937,7 +960,33 @@ spec:
 				return
 			}
 
-			if !tt.wantErr && tt.wantResourceYAML != "" {
+			if tt.wantErr {
+				return
+			}
+			if output == nil {
+				t.Fatalf("Render() returned nil output without an error")
+			}
+
+			if tt.wantMetadata != nil {
+				if diff := cmp.Diff(tt.wantMetadata, output.Metadata); diff != "" {
+					t.Errorf("Metadata mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if tt.wantTargetPlanes != nil {
+				if len(tt.wantTargetPlanes) != len(output.Resources) {
+					t.Fatalf("wantTargetPlanes length %d != rendered resource count %d",
+						len(tt.wantTargetPlanes), len(output.Resources))
+				}
+				for i, rr := range output.Resources {
+					if rr.TargetPlane != tt.wantTargetPlanes[i] {
+						t.Errorf("resource[%d] (%s) targetPlane = %q, want %q",
+							i, resourceKindName(rr.Resource), rr.TargetPlane, tt.wantTargetPlanes[i])
+					}
+				}
+			}
+
+			if tt.wantResourceYAML != "" {
 				// Parse expected resources
 				var wantResources []map[string]any
 				if err := yaml.Unmarshal([]byte(tt.wantResourceYAML), &wantResources); err != nil {

--- a/internal/pipeline/component/testdata/configurations-and-secrets/expected-resources-with-config-helpers.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/expected-resources-with-config-helpers.yaml
@@ -67,6 +67,11 @@
   spec:
     replicas: 3
     template:
+      metadata:
+        annotations:
+          # Pinned: part of the upgrade contract - a change rolls all existing
+          # workloads' pods on upgrade. Update only when intended.
+          openchoreo.dev/dp-resource-hash: "696979b485"
       spec:
         containers:
           - name: main

--- a/internal/pipeline/component/testdata/configurations-and-secrets/expected-resources.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/expected-resources.yaml
@@ -67,6 +67,11 @@
   spec:
     replicas: 3
     template:
+      metadata:
+        annotations:
+          # Pinned: part of the upgrade contract - a change rolls all existing
+          # workloads' pods on upgrade. Update only when intended.
+          openchoreo.dev/dp-resource-hash: "66789f766"
       spec:
         containers:
           - name: main

--- a/internal/pipeline/component/testdata/configurations-and-secrets/snapshot-with-config-helpers.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/snapshot-with-config-helpers.yaml
@@ -10,6 +10,7 @@ spec:
         replicas: 2
   componentType:
     spec:
+      workloadType: deployment
       environmentConfigs:
         openAPIV3Schema:
           type: object

--- a/internal/pipeline/component/testdata/configurations-and-secrets/snapshot.yaml
+++ b/internal/pipeline/component/testdata/configurations-and-secrets/snapshot.yaml
@@ -10,6 +10,7 @@ spec:
         replicas: 2
   componentType:
     spec:
+      workloadType: deployment
       environmentConfigs:
         openAPIV3Schema:
           type: object


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
TestPipeline_Render stripped each rendered resource to its Resource map before cmp.Diff, so RenderedResource.TargetPlane was never compared. Separately, the configurations-and-secrets snapshots omitted componentType.spec.workloadType, so addDPResourceHashAnnotation returned early and the dp-resource-hash annotation was never exercised on the realistic render path.

- Assert RenderMetadata (resource/base/trait counts, warnings) and per-resource TargetPlane via new opt-in wantMetadata/wantTargetPlanes table fields.
- Set workloadType: deployment on both config snapshots so addDPResourceHashAnnotation runs on the realistic render path, and pin the resulting dp-resource-hash values in the golden files. The hash is part of the upgrade contract (a change rolls all existing workloads' pods on upgrade), so an unintended hash change should fail the test.
- Cover a non-dataplane target plane by marking the trait-created Secret observabilityplane.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
