### PR TITLE
fix: portal assistant is not picking up lates to verify fixes

### DIFF
--- a/agents/portal-assistant/src/agent/orchestrator.py
+++ b/agents/portal-assistant/src/agent/orchestrator.py
@@ -34,6 +34,7 @@ from src.agent.stream_events import emit as _emit_event
 from src.agent.stream_parser import ChatResponseParser
 from src.config import settings
 from src.logging_config import request_id_context
+from src.models import get_current_utc
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,37 @@ def _get_semaphore() -> asyncio.Semaphore:
     if _semaphore is None:
         _semaphore = asyncio.Semaphore(settings.max_concurrent_chats)
     return _semaphore
+
+
+def _stamp_current_time(messages: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Prefix the latest user turn with the current server time.
+
+    Perch has no clock and must never synthesise timestamps (it hallucinates
+    dates), so the frontend normally pre-computes the log window. But the
+    observer's ``query_component_logs`` requires an explicit ``end_time``, and
+    on an "is it fixed now?" follow-up the frontend window is stale — captured
+    when the drawer opened, before the user's fix. We hand the model a
+    trustworthy "now" here — per turn, from the server clock — so the prompt
+    can anchor a fresh re-fetch on it. Injected into the message rather than the
+    system prompt because the rendered system prompt is cached across turns
+    (see builder._get_or_render_prompt) and would freeze the timestamp at first
+    render.
+
+    The latest user turn is normally the final message, but we scan backward
+    for it so a trailing assistant (or other) turn can't silently suppress the
+    stamp — the contract is "the latest user turn," wherever it sits.
+    """
+    idx = next(
+        (i for i in reversed(range(len(messages))) if messages[i].get("role") == "user"),
+        None,
+    )
+    if idx is None:
+        return messages
+    now = get_current_utc().isoformat()
+    target = messages[idx]
+    stamped = dict(target)
+    stamped["content"] = f"[current server time: {now}]\n{target.get('content', '')}"
+    return [*messages[:idx], stamped, *messages[idx + 1 :]]
 
 
 async def stream_chat(
@@ -67,6 +99,11 @@ async def stream_chat(
     """
     request_id_context.set(f"msg_{uuid.uuid4().hex[:12]}")
 
+    # Stamp the server clock onto the latest user turn ONCE and share it with
+    # both the normal streaming path and the recovery fallback, so they anchor
+    # on the same "now" (see _stamp_current_time).
+    stamped_messages = _stamp_current_time(messages)
+
     async with _get_semaphore():
         try:
             agent, _tools, _tools_by_name = await _build_agent(
@@ -76,7 +113,7 @@ async def stream_chat(
             )
             parser = ChatResponseParser()
 
-            async for ev in _yield_chunks(agent, messages, parser):
+            async for ev in _yield_chunks(agent, stamped_messages, parser):
                 yield ev
 
             # Final delta flush — when the model emits the structured
@@ -140,7 +177,7 @@ async def stream_chat(
             yield _emit_event(done_payload)
 
         except Exception as e:
-            async for err_event in _handle_stream_error(e, messages, scope):
+            async for err_event in _handle_stream_error(e, stamped_messages, scope):
                 yield err_event
 
 

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -71,6 +71,14 @@ The frontend captured the rows below from the user's table. They are authoritati
 ```
 
 {% endif -%}
+### Verifying a fix — "is it fixed now?", "did my change work?", "is it still happening?"
+
+These ask for the **current** state, not the original incident, so the visible window and any prefetched rows are **stale** — captured when the drawer opened, before the user's change. Do NOT answer from `prefetched_logs` or `logs_end_time` on these turns.
+
+The latest user message is prefixed with `[current server time: <RFC3339>]` (authoritative — the server clock, not a value you compute). On a verification turn:
+1. Re-fetch project-wide `query_component_logs` with `end_time` = that current server time, `start_time` = `logs_start_time` if set else current server time − 30 min, plus `log_levels`.
+2. Judge **only** from the freshly-returned rows. Error absent from the fresh window → say it has not recurred since `start_time`. Error still present → quote the fresh line **with its timestamp**. No rows at all → say there's been no activity since the change; do not declare it fixed or broken.
+
 ### Start here — parallel pair on turn 1
 {% if scope.runtime_anchor == 'log' -%}
   {%- if scope.pinned_log_trace_id %}
@@ -184,6 +192,7 @@ Rules for the body of each section:
   - no anchor (deployment-health): `list_release_bindings` + `get_resource_tree` on turn 1; `get_resource_events` / `get_resource_logs` on the unhealthy resource next turn; logs/traces only to complement once a pod is running.
   - **Connection-refused exception** (any of the above): when prefetched or fetched rows contain a connection-refused pattern (see "Connection-refused pattern" above), `list_components` is allowed on the same turn as the log/trace fetch; `get_release_binding` for one candidate sibling is allowed on the follow-up turn.
 - **Never** ask for time ranges / RFC3339 / log windows — `scope.logs_start_time` / `logs_end_time` are authoritative when set; otherwise default to 30 min.
+- **Verification override**: for "is it fixed / resolved / still happening / did my change work" follow-ups, `logs_end_time` and `prefetched_logs` are STALE — ignore them and use the `[current server time]` stamped on the latest user message as `end_time`, re-fetching fresh (see "Verifying a fix").
 - **Never** call `query_workflow_logs` (build-failure case only).
 - On empty logs/traces **with a component + environment in scope**: do NOT stop yet — check the data-plane resources first (`list_release_bindings` → `get_resource_tree` → `get_resource_events` / `get_resource_logs`), since a failed deploy's cause lives there, not in the log pipeline. Only once that is also exhausted: ≤2 sentences — one conclusion, one user action. Do NOT enumerate filters, do NOT list "what I tried", do NOT offer follow-up queries. Stop.
 

--- a/agents/portal-assistant/tests/test_orchestrator.py
+++ b/agents/portal-assistant/tests/test_orchestrator.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for src.agent.orchestrator helpers.
+
+``_stamp_current_time`` hands the model a trustworthy "now" by prefixing the
+latest *user* turn with the server clock. These tests pin the contract: it
+finds the latest user turn wherever it sits (not just the final message),
+leaves later turns untouched, and never mutates the caller's input.
+"""
+import copy
+from datetime import UTC, datetime
+
+import pytest
+
+from src.agent import orchestrator
+from src.agent.orchestrator import _stamp_current_time
+
+_FIXED = datetime(2026, 7, 14, 12, 0, 0, tzinfo=UTC)
+_PREFIX = "[current server time: 2026-07-14T12:00:00+00:00]\n"
+
+
+@pytest.fixture(autouse=True)
+def _freeze_clock(monkeypatch):
+    """Pin the server clock so the stamped prefix is deterministic."""
+    monkeypatch.setattr(orchestrator, "get_current_utc", lambda: _FIXED)
+
+
+def test_empty_input_returns_unchanged():
+    assert _stamp_current_time([]) == []
+
+
+def test_stamps_trailing_user_turn():
+    out = _stamp_current_time([{"role": "user", "content": "is it fixed?"}])
+    assert out == [{"role": "user", "content": f"{_PREFIX}is it fixed?"}]
+
+
+def test_stamps_latest_user_turn_when_assistant_trails():
+    # Latest user turn is "second" (index 1); the trailing assistant turn must
+    # NOT suppress the stamp, and both other turns stay byte-for-byte identical.
+    msgs = [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    assert _stamp_current_time(msgs) == [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": f"{_PREFIX}second"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+
+def test_no_user_turn_returns_unchanged():
+    msgs = [{"role": "assistant", "content": "hi"}]
+    assert _stamp_current_time(msgs) == msgs
+
+
+def test_does_not_mutate_input():
+    # Trailing assistant turn ensures the stamped user turn is not the last
+    # element, exercising the copy-not-mutate path on an interior message.
+    msgs = [
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    before = copy.deepcopy(msgs)
+    _stamp_current_time(msgs)
+    assert msgs == before
+
+
+async def test_recovery_fallback_receives_stamped_user_turn(monkeypatch):
+    """On a recursion-limit failure the fallback must get the SAME stamped
+    "now" anchor as the primary path, not the raw unstamped messages."""
+    captured: dict[str, object] = {}
+
+    async def _fake_build_agent(token, scope, *, user_sub=""):
+        return object(), [], {}
+
+    async def _boom(agent, messages, parser):
+        raise RuntimeError("Recursion limit of 50 reached")
+        yield  # unreachable; makes this an async generator
+
+    class _Recovery:
+        text = "recovered answer"
+        source = "model"  # DoneEvent.recovery is Literal["model", "stub"]
+
+    async def _fake_recover(*, messages, scope):
+        captured["messages"] = messages
+        return _Recovery()
+
+    monkeypatch.setattr(orchestrator, "_build_agent", _fake_build_agent)
+    monkeypatch.setattr(orchestrator, "_yield_chunks", _boom)
+    monkeypatch.setattr(orchestrator, "recover_with_fallback", _fake_recover)
+
+    events = [
+        ev
+        async for ev in orchestrator.stream_chat(
+            messages=[{"role": "user", "content": "is it fixed?"}],
+            token="t",
+            user_sub="u",
+            scope=None,
+        )
+    ]
+
+    # The fallback received the stamped latest user turn — same anchor the
+    # primary streaming path would have used.
+    assert captured["messages"][-1]["content"] == f"{_PREFIX}is it fixed?"
+    # And the recovered answer still reached the client.
+    assert any("recovered answer" in ev for ev in events)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
When a user asked the Portal Assistant to verify a fix — e.g. "is it fixed now?" / "did my change work?" — it confidently reported the issue as *still failing* even after the fix had rolled out. It was reasoning over **stale** logs.

Root cause: on a runtime-debug chat, the frontend captures the visible log window (`logsStartTime`/`logsEndTime`) and a snapshot of rows (`prefetchedLogs`) when the drawer opens, then re-sends that same frozen scope on every turn. The agent has no clock by design, and the observer's `query_component_logs` **requires** an explicit `end_time` (`observer/mcp/server.go` required params; `observer/types/logs.go` `validate:"required"`). So on a follow-up "is it fixed?"
turn, the only end time Perch had was the pre-fix one — it re-read the original rows and described them as "current," i.e. hallucinated the verdict.

## Approach

Give Perch a trustworthy "now" and tell it to use it when the user is verifying a fix. Two changes, portal-assistant only (no frontend change, no observer contract change):

1. **`src/agent/orchestrator.py`** — new `_stamp_current_time()` prefixes the latest user turn with `[current server time: <RFC3339>]` from the server clock, applied per-turn at invocation (`_yield_chunks(agent, _stamp_current_time(messages), …)`). It's injected into the **message**, not the system prompt, because the rendered system prompt is cached across turns (`builder._get_or_render_prompt`) and would otherwise freeze the timestamp at first render.

2. **`src/templates/prompts/perch_prompt.j2`** — added a "Verifying a fix" block plus a hard-rule "Verification override": for "is it fixed / resolved / still happening / did my change work" follow-ups, treat `logs_end_time` and `prefetched_logs` as stale, and re-fetch `query_component_logs` with `end_time` = the stamped current server time, judging only from the fresh rows.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
