### PR TITLE
feat: add per-env labels and annotations to default project type

### DIFF
--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -18,12 +18,28 @@ metadata:
     openchoreo.dev/display-name: Default Project Type
     openchoreo.dev/description: >-
       Minimal project type that provisions only the cell namespace per
-      environment. Use as the starting template when no additional
-      shared infrastructure (NetworkPolicies, ResourceQuotas, baseline
-      RBAC) is needed.
+      environment. Per-environment labels and annotations can be added
+      to the namespace via ProjectReleaseBinding.spec.environmentConfigs
+      (namespaceLabels, namespaceAnnotations). Use as the starting
+      template when no additional shared infrastructure (NetworkPolicies,
+      ResourceQuotas, baseline RBAC) is needed.
   labels:
     openchoreo.dev/name: default
 spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        namespaceLabels:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+        namespaceAnnotations:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
   resources:
     - id: cell-namespace
       template:
@@ -31,7 +47,8 @@ spec:
         kind: Namespace
         metadata:
           name: ${metadata.namespace}
-          labels: ${metadata.labels}
+          labels: ${oc_merge(metadata.labels, environmentConfigs.namespaceLabels)}
+          annotations: ${environmentConfigs.namespaceAnnotations}
 
 ---
 apiVersion: openchoreo.dev/v1alpha1

--- a/samples/getting-started/cluster-project-types/default.yaml
+++ b/samples/getting-started/cluster-project-types/default.yaml
@@ -6,12 +6,28 @@ metadata:
     openchoreo.dev/display-name: Default Project Type
     openchoreo.dev/description: >-
       Minimal project type that provisions only the cell namespace per
-      environment. Use as the starting template when no additional
-      shared infrastructure (NetworkPolicies, ResourceQuotas, baseline
-      RBAC) is needed.
+      environment. Per-environment labels and annotations can be added
+      to the namespace via ProjectReleaseBinding.spec.environmentConfigs
+      (namespaceLabels, namespaceAnnotations). Use as the starting
+      template when no additional shared infrastructure (NetworkPolicies,
+      ResourceQuotas, baseline RBAC) is needed.
   labels:
     openchoreo.dev/name: default
 spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        namespaceLabels:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+        namespaceAnnotations:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
   resources:
     - id: cell-namespace
       template:
@@ -19,4 +35,5 @@ spec:
         kind: Namespace
         metadata:
           name: ${metadata.namespace}
-          labels: ${metadata.labels}
+          labels: ${oc_merge(metadata.labels, environmentConfigs.namespaceLabels)}
+          annotations: ${environmentConfigs.namespaceAnnotations}


### PR DESCRIPTION
## Purpose

The default ClusterProjectType renders the cell namespace with fixed labels and no annotations. There is no way to add environment-specific labels or annotations (e.g. `istio-injection`, scheduling annotations) to the namespace.

## Approach

- Add an `environmentConfigs` schema to the default ClusterProjectType with `namespaceLabels` and `namespaceAnnotations` map properties (both default to `{}`)
- Template the cell namespace with `labels: ${oc_merge(metadata.labels, environmentConfigs.namespaceLabels)}` and `annotations: ${environmentConfigs.namespaceAnnotations}`, so per-environment values supplied via `ProjectReleaseBinding.spec.environmentConfigs` are applied on top of the platform-injected labels
- Regenerate `samples/getting-started/all.yaml`

## Related Issues

https://github.com/openchoreo/openchoreo/issues/3736

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content