### PR TITLE
fix(controller): allow project finalization with empty deployment pipeline

### DIFF
--- a/internal/controller/project/controller_integration_test.go
+++ b/internal/controller/project/controller_integration_test.go
@@ -467,6 +467,100 @@ var _ = Describe("Project Controller", func() {
 		})
 	})
 
+	Context("Finalization with empty DeploymentPipeline", func() {
+		const (
+			nsName   = "it-empty-pip-ns"
+			pipName  = "it-empty-pip"
+			projName = "it-empty-pip-proj"
+		)
+
+		nn := types.NamespacedName{Name: projName, Namespace: nsName}
+
+		BeforeEach(func() {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: nsName},
+			}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: nsName}, ns)
+			if err != nil && errors.IsNotFound(err) {
+				Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			}
+
+			depPip := &openchoreov1alpha1.DeploymentPipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pipName,
+					Namespace: nsName,
+				},
+				Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+					PromotionPaths: []openchoreov1alpha1.PromotionPath{},
+				},
+			}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: pipName, Namespace: nsName}, &openchoreov1alpha1.DeploymentPipeline{})
+			if err != nil && errors.IsNotFound(err) {
+				Expect(k8sClient.Create(ctx, depPip)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			forceDeleteProject(nn)
+		})
+
+		It("should finalize and delete project when pipeline has no environments", func() {
+			project := &openchoreov1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      projName,
+					Namespace: nsName,
+					Labels:    map[string]string{},
+				},
+				Spec: openchoreov1alpha1.ProjectSpec{
+					DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{
+						Name: pipName,
+					},
+					Type: openchoreov1alpha1.ProjectTypeRef{
+						Name: "default",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+
+			r := itReconciler()
+
+			// First reconcile: adds finalizer
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: sets Created condition
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Delete the project
+			updated := &openchoreov1alpha1.Project{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				p := &openchoreov1alpha1.Project{}
+				if err := k8sClient.Get(ctx, nn, p); err != nil {
+					return false
+				}
+				return !p.DeletionTimestamp.IsZero()
+			}, itTimeout, itInterval).Should(BeTrue())
+
+			// Reconcile to set Finalizing condition
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile again to complete finalization
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify project is deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, nn, &openchoreov1alpha1.Project{})
+				return errors.IsNotFound(err)
+			}, itTimeout, itInterval).Should(BeTrue())
+		})
+	})
+
 	Context("Finalization without finalizer", func() {
 		It("should return no error when project has no finalizer and is being deleted", func() {
 			const (

--- a/internal/controller/project/controller_unit_test.go
+++ b/internal/controller/project/controller_unit_test.go
@@ -304,6 +304,95 @@ func TestFindEnvironmentNamesFromDeploymentPipeline(t *testing.T) {
 	}
 }
 
+// ── makeProjectContext ───────────────────────────────────────────────────────
+
+func TestMakeProjectContext_EmptyDeploymentPipeline(t *testing.T) {
+	s := newSeedTestScheme(t)
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-pipeline", Namespace: "test-ns"},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: []openchoreov1alpha1.PromotionPath{},
+		},
+	}
+	project := &openchoreov1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-project", Namespace: "test-ns"},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "empty-pipeline"},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline, project).Build()
+	r := &Reconciler{Client: cli, Scheme: s}
+
+	projectCtx, err := r.makeProjectContext(context.Background(), project)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if projectCtx == nil {
+		t.Fatal("expected non-nil project context")
+	}
+	if projectCtx.Project == nil || projectCtx.Project.Name != "my-project" {
+		t.Errorf("expected project my-project, got %#v", projectCtx.Project)
+	}
+	if projectCtx.DeploymentPipeline == nil || projectCtx.DeploymentPipeline.Name != "empty-pipeline" {
+		t.Errorf("expected pipeline empty-pipeline, got %#v", projectCtx.DeploymentPipeline)
+	}
+	if len(projectCtx.EnvironmentNames) != 0 {
+		t.Errorf("expected no environment names, got %v", projectCtx.EnvironmentNames)
+	}
+	if len(projectCtx.NamespaceNames) != 0 {
+		t.Errorf("expected no namespace names, got %v", projectCtx.NamespaceNames)
+	}
+}
+
+func TestMakeProjectContext_MissingDeploymentPipeline(t *testing.T) {
+	s := newSeedTestScheme(t)
+	project := &openchoreov1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-project", Namespace: "test-ns"},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "already-gone"},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(project).Build()
+	r := &Reconciler{Client: cli, Scheme: s}
+
+	projectCtx, err := r.makeProjectContext(context.Background(), project)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if projectCtx == nil || projectCtx.Project == nil {
+		t.Fatal("expected project context with project set")
+	}
+	if projectCtx.DeploymentPipeline != nil {
+		t.Errorf("expected nil pipeline when not found, got %#v", projectCtx.DeploymentPipeline)
+	}
+}
+
+func TestDeleteExternalResourcesAndWait_EmptyPipeline(t *testing.T) {
+	s := newSeedTestScheme(t)
+	pipeline := &openchoreov1alpha1.DeploymentPipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-pipeline", Namespace: "test-ns"},
+		Spec: openchoreov1alpha1.DeploymentPipelineSpec{
+			PromotionPaths: nil,
+		},
+	}
+	project := &openchoreov1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-project", Namespace: "test-ns"},
+		Spec: openchoreov1alpha1.ProjectSpec{
+			DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{Name: "empty-pipeline"},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline, project).Build()
+	r := &Reconciler{Client: cli, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	done, err := r.deleteExternalResourcesAndWait(context.Background(), project)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected cleanup to complete for empty pipeline")
+	}
+}
+
 // ── makeExternalResourceHandlers ─────────────────────────────────────────────
 
 func TestMakeExternalResourceHandlers(t *testing.T) {

--- a/internal/controller/project/project_context.go
+++ b/internal/controller/project/project_context.go
@@ -31,8 +31,13 @@ func (r *Reconciler) makeProjectContext(ctx context.Context, project *openchoreo
 	}
 
 	environmentNames := r.findEnvironmentNamesFromDeploymentPipeline(deploymentPipeline)
+	// If the pipeline has no environments, return a context without namespace names.
+	// This allows finalization to proceed when the pipeline is empty.
 	if len(environmentNames) == 0 {
-		return nil, fmt.Errorf("no environments found for deployment pipeline %s", project.Spec.DeploymentPipelineRef.Name)
+		return &dataplane.ProjectContext{
+			DeploymentPipeline: deploymentPipeline,
+			Project:            project,
+		}, nil
 	}
 
 	namespaceNames := k8sintegrations.MakeNamespaceNames(environmentNames, *project)


### PR DESCRIPTION
## Purpose
Deleting a Project that points at a DeploymentPipeline with no environments (empty promotion paths) leaves the Project stuck in `Finalizing`. The finalizer calls `makeProjectContext`, which returned an error when the pipeline had zero environments, so cleanup never finished and the finalizer was never removed.

Fixes https://github.com/openchoreo/openchoreo/issues/4067

## Approach
`makeProjectContext` already returns an empty context when the DeploymentPipeline is missing so finalization can continue. Do the same when the pipeline exists but has no environments: return a context with the project (and pipeline) but no namespace names, so external resource cleanup is a no-op and the finalizer can complete.

## Related Issues
- Fixes #4067

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
Admission validation for "at least one environment" is intentionally not in this PR. Discussion on #4067 notes empty pipelines may still be useful when removing the last environment from a pipeline before deleting that environment.