### PR TITLE
feat(helm): add global image registry and pull secrets overrides

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -252,3 +252,34 @@ Validate that placeholder .invalid hostnames have been replaced with real domain
   {{- fail (printf "Placeholder domains found. Set real hostnames for:\n  - %s" (join "\n  - " $errors)) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Container image reference for a component.
+
+Renders "<repository>:<tag>", with the tag defaulting to .Chart.AppVersion.
+When global.imageRegistry is set, the registry host of the repository is
+replaced with it so every first-party image resolves from a single private
+or mirror registry. A leading path segment counts as a registry host only
+if it contains "." or ":" or equals "localhost", the same rule Docker and
+containerd use to parse image references. The override may itself carry a
+path (e.g. "registry.example.com/ghcr.io") for path-preserving mirrors.
+
+Usage:
+  {{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.controllerManager.image) }}
+
+Parameters:
+  - context: The current Helm context (usually .)
+  - image: The component image block (repository, tag)
+*/}}
+{{- define "openchoreo-control-plane.image" -}}
+{{- $repo := .image.repository -}}
+{{- with .context.Values.global.imageRegistry -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $first := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $first) (contains ":" $first) (eq $first "localhost")) -}}
+{{- $repo = join "/" (rest $parts) -}}
+{{- end -}}
+{{- $repo = printf "%s/%s" . $repo -}}
+{{- end -}}
+{{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.backstage.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.backstage.priorityClass.create }}
       priorityClassName: {{ .Values.backstage.priorityClass.name }}
       {{- end }}
@@ -47,7 +51,7 @@ spec:
       {{- end }}
       containers:
       - name: backstage
-        image: "{{ .Values.backstage.image.repository }}:{{ .Values.backstage.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.backstage.image) }}"
         imagePullPolicy: {{ .Values.backstage.image.pullPolicy }}
         args:
         - "node"

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.clusterGateway.priorityClass.create }}
       priorityClassName: {{ .Values.clusterGateway.priorityClass.name }}
       {{- end }}
@@ -44,7 +48,7 @@ spec:
       {{- end }}
       containers:
       - name: cluster-gateway
-        image: "{{ .Values.clusterGateway.image.repository }}:{{ .Values.clusterGateway.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.clusterGateway.image) }}"
         imagePullPolicy: {{ .Values.clusterGateway.image.pullPolicy }}
         args:
         - --port={{ .Values.clusterGateway.port }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         kubectl.kubernetes.io/default-container: manager
     spec:
       serviceAccountName: {{ .Values.controllerManager.name }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.controllerManager.priorityClass.create }}
       priorityClassName: {{ .Values.controllerManager.priorityClass.name }}
       {{- end }}
@@ -52,7 +56,7 @@ spec:
       {{- /* No init container needed - Secret is created directly by cert-manager */}}
       containers:
       - name: manager
-        image: {{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}
+        image: {{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.controllerManager.image) }}
         imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
         command:
         - /manager

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
@@ -29,13 +29,17 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/event-forwarder/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.event-forwarder.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.eventForwarder.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: event-forwarder
-        image: "{{ .Values.eventForwarder.image.repository }}:{{ .Values.eventForwarder.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.eventForwarder.image) }}"
         imagePullPolicy: {{ .Values.eventForwarder.image.pullPolicy }}
         args:
           - --config=/etc/openchoreo/config.yaml

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/openchoreo-api/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.openchoreoApi.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.openchoreoApi.priorityClass.create }}
       priorityClassName: {{ .Values.openchoreoApi.priorityClass.name }}
       {{- end }}
@@ -53,7 +57,7 @@ spec:
       {{- end }}
       containers:
       - name: api-server
-        image: "{{ .Values.openchoreoApi.image.repository }}:{{ .Values.openchoreoApi.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.openchoreoApi.image) }}"
         imagePullPolicy: {{ .Values.openchoreoApi.image.pullPolicy }}
         args:
           - --config=/etc/openchoreo/config.yaml

--- a/install/helm/openchoreo-control-plane/templates/portal-assistant/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/portal-assistant/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         app.kubernetes.io/component: portal-assistant
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.portalAssistant.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 12000
@@ -35,7 +39,7 @@ spec:
         fsGroup: 12000
       containers:
       - name: portal-assistant
-        image: "{{ .Values.portalAssistant.image.repository }}:{{ .Values.portalAssistant.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-control-plane.image" (dict "context" . "image" .Values.portalAssistant.image) }}"
         imagePullPolicy: {{ .Values.portalAssistant.image.pullPolicy }}
         ports:
         - name: http

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2759,6 +2759,22 @@
           "required": [],
           "title": "commonLabels",
           "type": "object"
+        },
+        "imagePullSecrets": {
+          "default": [],
+          "description": "Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "imageRegistry": {
+          "default": "",
+          "description": "Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.",
+          "title": "imageRegistry",
+          "type": "string"
         }
       },
       "required": [],
@@ -4548,21 +4564,6 @@
       },
       "required": [],
       "title": "security",
-      "type": "object"
-    },
-    "waitJob": {
-      "additionalProperties": false,
-      "description": "Wait job configuration for Helm hooks",
-      "properties": {
-        "image": {
-          "default": "rancher/kubectl:v1.36.0",
-          "description": "Container image for wait jobs",
-          "title": "image",
-          "type": "string"
-        }
-      },
-      "required": [],
-      "title": "waitJob",
       "type": "object"
     },
     "webhookService": {

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -19,6 +19,22 @@ global:
   # @schema
   commonLabels: {}
 
+  # @schema
+  # type: string
+  # description: Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.
+  # default: ""
+  # @schema
+  imageRegistry: ""
+
+  # @schema
+  # type: array
+  # description: Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  imagePullSecrets: []
+
 # @schema
 # type: string
 # description: Override the full name of the chart release
@@ -853,18 +869,6 @@ webhookService:
   # default: ClusterIP
   # @schema
   type: ClusterIP
-
-# @schema
-# type: object
-# description: Wait job configuration for Helm hooks
-# @schema
-waitJob:
-  # @schema
-  # type: string
-  # description: Container image for wait jobs
-  # default: rancher/kubectl:v1.36.0
-  # @schema
-  image: rancher/kubectl:v1.36.0
 
 # @schema
 # type: object

--- a/install/helm/openchoreo-data-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-data-plane/templates/_helpers.tpl
@@ -168,3 +168,34 @@ Validate that placeholder .invalid hostnames have been replaced with real domain
 {{- end -}}
 {{- end -}}
 
+{{/*
+Container image reference for a component.
+
+Renders "<repository>:<tag>", with the tag defaulting to .Chart.AppVersion.
+When global.imageRegistry is set, the registry host of the repository is
+replaced with it so every first-party image resolves from a single private
+or mirror registry. A leading path segment counts as a registry host only
+if it contains "." or ":" or equals "localhost", the same rule Docker and
+containerd use to parse image references. The override may itself carry a
+path (e.g. "registry.example.com/ghcr.io") for path-preserving mirrors.
+
+Usage:
+  {{ include "openchoreo-data-plane.image" (dict "context" . "image" .Values.clusterAgent.image) }}
+
+Parameters:
+  - context: The current Helm context (usually .)
+  - image: The component image block (repository, tag)
+*/}}
+{{- define "openchoreo-data-plane.image" -}}
+{{- $repo := .image.repository -}}
+{{- with .context.Values.global.imageRegistry -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $first := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $first) (contains ":" $first) (eq $first "localhost")) -}}
+{{- $repo = join "/" (rest $parts) -}}
+{{- end -}}
+{{- $repo = printf "%s/%s" . $repo -}}
+{{- end -}}
+{{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
+{{- end }}
+

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.clusterAgent.priorityClass.create }}
       priorityClassName: {{ .Values.clusterAgent.priorityClass.name }}
       {{- end }}
@@ -47,7 +51,7 @@ spec:
       {{- end }}
       containers:
       - name: agent
-        image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-data-plane.image" (dict "context" . "image" .Values.clusterAgent.image) }}"
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         args:
         - --server-url={{ .Values.clusterAgent.serverUrl }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -844,6 +844,22 @@
           "required": [],
           "title": "commonLabels",
           "type": "object"
+        },
+        "imagePullSecrets": {
+          "default": [],
+          "description": "Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "imageRegistry": {
+          "default": "",
+          "description": "Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.",
+          "title": "imageRegistry",
+          "type": "string"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -20,6 +20,22 @@ global:
   # @schema
   commonLabels: {}
 
+  # @schema
+  # type: string
+  # description: Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.
+  # default: ""
+  # @schema
+  imageRegistry: ""
+
+  # @schema
+  # type: array
+  # description: Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  imagePullSecrets: []
+
 # @schema
 # type: string
 # description: Kubernetes cluster DNS domain used for service discovery and certificate generation

--- a/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
@@ -168,3 +168,34 @@ explicitly per deployment. k3d overlays supply real values.
   {{- fail (printf "Placeholder domains found. Set real URLs for:\n  - %s" (join "\n  - " $errors)) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Container image reference for a component.
+
+Renders "<repository>:<tag>", with the tag defaulting to .Chart.AppVersion.
+When global.imageRegistry is set, the registry host of the repository is
+replaced with it so every first-party image resolves from a single private
+or mirror registry. A leading path segment counts as a registry host only
+if it contains "." or ":" or equals "localhost", the same rule Docker and
+containerd use to parse image references. The override may itself carry a
+path (e.g. "registry.example.com/ghcr.io") for path-preserving mirrors.
+
+Usage:
+  {{ include "openchoreo-observability-plane.image" (dict "context" . "image" .Values.controllerManager.image) }}
+
+Parameters:
+  - context: The current Helm context (usually .)
+  - image: The component image block (repository, tag)
+*/}}
+{{- define "openchoreo-observability-plane.image" -}}
+{{- $repo := .image.repository -}}
+{{- with .context.Values.global.imageRegistry -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $first := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $first) (contains ":" $first) (eq $first "localhost")) -}}
+{{- $repo = join "/" (rest $parts) -}}
+{{- end -}}
+{{- $repo = printf "%s/%s" . $repo -}}
+{{- end -}}
+{{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "openchoreo-observability-plane.clusterAgent.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.clusterAgent.priorityClass.create }}
       priorityClassName: {{ .Values.clusterAgent.priorityClass.name }}
       {{- end }}
@@ -47,7 +51,7 @@ spec:
       {{- end }}
       containers:
       - name: agent
-        image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-observability-plane.image" (dict "context" . "image" .Values.clusterAgent.image) }}"
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         args:
         - --server-url={{ .Values.clusterAgent.serverUrl }}

--- a/install/helm/openchoreo-observability-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/controller-manager/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.controllerManager.name }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controllerManager.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -40,7 +44,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: manager
-        image: {{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}
+        image: {{ include "openchoreo-observability-plane.image" (dict "context" . "image" .Values.controllerManager.image) }}
         imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
         command:
         - /manager

--- a/install/helm/openchoreo-observability-plane/templates/finops-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/finops-agent/deployment.yaml
@@ -36,6 +36,10 @@ spec:
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" "finops-agent") | nindent 8 }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 12000
@@ -43,7 +47,7 @@ spec:
         fsGroup: 12000
       containers:
       - name: finops-agent
-        image: "{{ .Values.finOpsAgent.image.repository }}:{{ .Values.finOpsAgent.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-observability-plane.image" (dict "context" . "image" .Values.finOpsAgent.image) }}"
         imagePullPolicy: {{ .Values.finOpsAgent.image.pullPolicy }}
         ports:
         - name: http

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -26,14 +26,22 @@ spec:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" "observer") | nindent 8 }}
     spec:
       serviceAccountName: observer
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65532
         fsGroup: 65532
       containers:
+      {{- $observerImage := dict "repository" "ghcr.io/openchoreo/observer" }}
+      {{- if .Values.observer.image }}
+      {{- $observerImage = dict "repository" (.Values.observer.image.repository | default "ghcr.io/openchoreo/observer") "tag" (.Values.observer.image.tag | default "") }}
+      {{- end }}
       - name: observer
-        image: "{{ if .Values.observer.image }}{{ .Values.observer.image.repository | default "ghcr.io/openchoreo/observer" }}:{{ .Values.observer.image.tag | default .Chart.AppVersion }}{{ else }}ghcr.io/openchoreo/observer:{{ .Chart.AppVersion }}{{ end }}"
+        image: "{{ include "openchoreo-observability-plane.image" (dict "context" . "image" $observerImage) }}"
         imagePullPolicy: {{ if .Values.observer.image }}{{ .Values.observer.image.pullPolicy | default "IfNotPresent" }}{{ else }}IfNotPresent{{ end }}
         ports:
         - name: http

--- a/install/helm/openchoreo-observability-plane/templates/sre-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/sre-agent/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" .Values.rca.name) | nindent 8 }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 12000
@@ -37,7 +41,7 @@ spec:
         fsGroup: 12000
       containers:
       - name: {{ .Values.rca.name }}
-        image: "{{ .Values.rca.image.repository }}:{{ .Values.rca.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-observability-plane.image" (dict "context" . "image" .Values.rca.image) }}"
         imagePullPolicy: {{ .Values.rca.image.pullPolicy }}
         ports:
         - name: http

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1223,6 +1223,22 @@
           "title": "commonLabels",
           "type": "object"
         },
+        "imagePullSecrets": {
+          "default": [],
+          "description": "Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "imageRegistry": {
+          "default": "",
+          "description": "Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.",
+          "title": "imageRegistry",
+          "type": "string"
+        },
         "installationMode": {
           "default": "singleCluster",
           "description": "Installation mode of OpenChoreo",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -27,6 +27,22 @@ global:
   commonLabels: {}
 
   # @schema
+  # type: string
+  # description: Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.
+  # default: ""
+  # @schema
+  imageRegistry: ""
+
+  # @schema
+  # type: array
+  # description: Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  imagePullSecrets: []
+
+  # @schema
   # description: Installation mode of OpenChoreo
   # enum: [singleCluster, multiCluster, quickStart]
   # default: singleCluster

--- a/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
@@ -140,3 +140,37 @@ Cluster Agent service account name
 {{- end }}
 {{- end }}
 
+{{/*
+Container image reference for a component.
+
+Renders "<repository>:<tag>", with the tag defaulting to .Chart.AppVersion.
+When global.imageRegistry is set, the registry host of the repository is
+replaced with it so every first-party image resolves from a single private
+or mirror registry. A leading path segment counts as a registry host only
+if it contains "." or ":" or equals "localhost", the same rule Docker and
+containerd use to parse image references. The override may itself carry a
+path (e.g. "registry.example.com/ghcr.io") for path-preserving mirrors.
+
+Note: images of the argo-workflows subchart are not covered by this value;
+override them via argo-workflows.{controller,executor,server}.image.registry.
+
+Usage:
+  {{ include "openchoreo-workflow-plane.image" (dict "context" . "image" .Values.clusterAgent.image) }}
+
+Parameters:
+  - context: The current Helm context (usually .)
+  - image: The component image block (repository, tag)
+*/}}
+{{- define "openchoreo-workflow-plane.image" -}}
+{{- $repo := .image.repository -}}
+{{- with .context.Values.global.imageRegistry -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $first := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $first) (contains ":" $first) (eq $first "localhost")) -}}
+{{- $repo = join "/" (rest $parts) -}}
+{{- end -}}
+{{- $repo = printf "%s/%s" . $repo -}}
+{{- end -}}
+{{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
+{{- end }}
+

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "openchoreo-workflow-plane.clusterAgent.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.clusterAgent.priorityClass.create }}
       priorityClassName: {{ .Values.clusterAgent.priorityClass.name }}
       {{- end }}
@@ -47,7 +51,7 @@ spec:
       {{- end }}
       containers:
       - name: agent
-        image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "openchoreo-workflow-plane.image" (dict "context" . "image" .Values.clusterAgent.image) }}"
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         args:
         - --server-url={{ .Values.clusterAgent.serverUrl }}

--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -567,25 +567,26 @@
           "required": [],
           "title": "commonLabels",
           "type": "object"
-        }
-      },
-      "required": [],
-      "title": "global",
-      "type": "object"
-    },
-    "waitJob": {
-      "additionalProperties": false,
-      "description": "Wait job configuration for post-install hooks",
-      "properties": {
-        "image": {
-          "default": "rancher/kubectl:v1.36.0",
-          "description": "Container image used for wait jobs (must contain kubectl)",
-          "title": "image",
+        },
+        "imagePullSecrets": {
+          "default": [],
+          "description": "Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "imageRegistry": {
+          "default": "",
+          "description": "Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.",
+          "title": "imageRegistry",
           "type": "string"
         }
       },
       "required": [],
-      "title": "waitJob",
+      "title": "global",
       "type": "object"
     }
   },

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -15,6 +15,22 @@ global:
   # @schema
   commonLabels: {}
 
+  # @schema
+  # type: string
+  # description: Registry override for all first-party container images. When set, it replaces the registry host of each image repository. May include a path (e.g. registry.example.com/ghcr.io) for path-preserving mirrors. Empty uses each image's default registry.
+  # default: ""
+  # @schema
+  imageRegistry: ""
+
+  # @schema
+  # type: array
+  # description: Image pull secrets applied to all first-party pods, for pulling images from authenticated private registries. Entries are LocalObjectReferences (name only).
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  imagePullSecrets: []
+
 # @schema
 # type: object
 # additionalProperties: true
@@ -130,19 +146,6 @@ argo-workflows:
   # @schema
   workflowNamespaces:
     - argo-build
-
-# @schema
-# type: object
-# additionalProperties: false
-# description: Wait job configuration for post-install hooks
-# @schema
-waitJob:
-  # @schema
-  # type: string
-  # description: Container image used for wait jobs (must contain kubectl)
-  # default: rancher/kubectl:v1.36.0
-  # @schema
-  image: rancher/kubectl:v1.36.0
 
 # @schema
 # type: object


### PR DESCRIPTION
## Purpose

There is currently no way to point an OpenChoreo install at a private or mirror registry. Every chart bakes the registry host into each image `repository`, so redirecting images means overriding every repository value by hand, and none of the charts render `imagePullSecrets`, so authenticated registries cannot be used at all. This blocks air-gapped installs and the common enterprise setup where images must come from an internal registry even with internet access.

This PR adds a single registry override and pull-secret support to all four plane charts. It is the chart-side groundwork for air-gapped installation support (#3577, proposal in #3855), and per the maintainer discussion on that proposal it is useful on its own, independent of air-gap work.

## Approach

- Add `global.imageRegistry` to the control, data, workflow, and observability plane charts. An `image` helper in each chart's `_helpers.tpl` builds the image reference: when the value is set, it replaces the registry host of the repository (a leading path segment counts as a host only if it contains `.` or `:` or equals `localhost`, the same rule Docker and containerd use to parse references). The value may carry a path (e.g. `registry.example.com/ghcr.io`) for path-preserving mirror layouts.
- Add `global.imagePullSecrets`, rendered into every first-party Deployment (13 across the four charts) for authenticated registries.
- Route the observer image through the helper; its previous hardcoded `{{ else }}ghcr.io/openchoreo/observer{{ end }}` fallback ignored image overrides.
- Remove the orphaned `waitJob` values from the control and workflow plane charts: no template consumes them (verified repo-wide), they were dead config.
- Regenerate `values.schema.json` for all four charts.

Both new values default to empty, and with them unset the rendered manifests are byte-identical to the previous chart version, so existing installs are unaffected.

## Verification

- Default renders diffed byte-for-byte against pre-change renders for all four charts: identical.
- Live `helm upgrade` of running control and data plane releases with unchanged values: zero churn (same deployment generations, same pod UIDs, no restarts).
- Full offline validation on an isolated k3d cluster (internal network, no egress): control + data planes installed with `global.imageRegistry` pointing at a local mirror, all 22 pods running, every application image served from the mirror including the runtime-spawned kgateway `envoy-wrapper`, and a negative test confirming pulls from public registries fail.
- `helm lint` passes for all four charts.

## Related Issues

Related #3577
Related #3855 (proposal discussion)

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

Follow-ups tracked separately: the air-gapped installation guide for the docs site, per-dependency-chart override documentation (cert-manager, external-secrets, kgateway, OpenBao, thunder), and registry parameterization for community module charts.