### PR TITLE
feat: show console login in the k3d install summary

### DIFF
--- a/install/k3d/k3d-install.sh
+++ b/install/k3d/k3d-install.sh
@@ -518,7 +518,7 @@ EOF
 
 print_summary() {
     step "OpenChoreo installation complete"
-    info "Console:  http://openchoreo.localhost:8080"
+    info "Console:  http://openchoreo.localhost:8080  (log in with admin@openchoreo.dev / Admin@123)"
     info "API:      http://api.openchoreo.localhost:8080"
     info "Planes:   control, data$([[ "$WITH_BUILD" == "true" ]] && echo ", workflow")$([[ "$WITH_OBSERVABILITY" == "true" ]] && echo ", observability")"
     info "Delete:   k3d cluster delete ${CLUSTER_NAME}"


### PR DESCRIPTION
After a one-command install (`k3d-install.sh`), the end-of-run summary printed the console URL but not how to log in. This adds the default console credentials (`admin@openchoreo.dev` / `Admin@123`, as bootstrapped by the thunder values) on the console URL line, so the summary is self-contained for someone running the `curl | bash` one-liner.

```
==> OpenChoreo installation complete
    Console:  http://openchoreo.localhost:8080  (log in with admin@openchoreo.dev / Admin@123)
    API:      http://api.openchoreo.localhost:8080
    ...
```