### PR TITLE
feat: divide cluster gateway service to internal and external services

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/service.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/service.yaml
@@ -1,7 +1,39 @@
+# Internal service: in-cluster clients only. Always ClusterIP so the internal API
+# (8444) can never be exposed outside the cluster.
+#   - websocket   (8443): cluster-agents running in this cluster (single-cluster installs)
+#   - internal-api(8444): openchoreo-api / controller-manager (/api/* proxy, exec, wirelogs, plane lifecycle)
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+    app: cluster-gateway
+spec:
+  type: ClusterIP
+  ports:
+  - name: websocket
+    port: {{ .Values.clusterGateway.service.port }}
+    targetPort: {{ .Values.clusterGateway.port }}
+    protocol: TCP
+  - name: internal-api
+    port: 8444
+    targetPort: 8444
+    protocol: TCP
+  selector:
+    app: cluster-gateway
+    app.kubernetes.io/component: cluster-gateway
+    {{- include "openchoreo-control-plane.selectorLabels" . | nindent 4 }}
+---
+# External service: agent WebSocket (8443) only. Target of the TLSRoute / LoadBalancer.
+# The internal API (8444) is deliberately NOT published here, so it cannot be exposed
+# outside the cluster even when service.type is LoadBalancer or NodePort.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-external
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
@@ -23,10 +55,6 @@ spec:
     {{- if and (eq .Values.clusterGateway.service.type "NodePort") .Values.clusterGateway.service.nodePort }}
     nodePort: {{ .Values.clusterGateway.service.nodePort }}
     {{- end }}
-  - name: internal-api
-    port: 8444
-    targetPort: 8444
-    protocol: TCP
   selector:
     app: cluster-gateway
     app.kubernetes.io/component: cluster-gateway

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/tlsroute.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/tlsroute.yaml
@@ -21,6 +21,6 @@ spec:
     {{- end }}
   rules:
     - backendRefs:
-        - name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}
+        - name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-external
           port: {{ .Values.clusterGateway.service.port }}
 {{- end }}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Previously, we have a single service exposed the cluster gateway service which exposes internal and external port both. Hence we decided to expose exteernal port seperately and internal port seperatly. Note that internal service expose internal port and external port both to provide backword compatibility.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
