### PR TITLE
fix(helm): make authz bootstrap roles and bindings fully configurable

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/authz/_authz-bootstrap.tpl
+++ b/install/helm/openchoreo-control-plane/templates/authz/_authz-bootstrap.tpl
@@ -7,12 +7,6 @@ hook (see bootstrap-configmap.yaml / bootstrap-job.yaml) rather than applied
 as tracked release resources, since a hook Job is always waited on to
 completion (retried via its own backoffLimit) independent of whether the
 caller passes --wait to helm.
-
-All objects, system (hardcoded below, labeled openchoreo.io/system: "true")
-and user-facing (sourced from values), are upserted via kubectl apply on
-every hook run, so they always match the chart version currently installed.
-Hand-edits made directly against these objects in the cluster do not survive
-the next install/upgrade; customize via values instead.
 */}}
 
 {{/*
@@ -149,173 +143,18 @@ spec:
 {{- end }}
 
 {{/*
-Hardcoded system roles. These are platform-owned and always managed by the
-bootstrap hook (upserted), so they are intentionally not exposed in values.
-*/}}
-{{- define "openchoreo-control-plane.authz.systemRoles" -}}
-- name: backstage-catalog-reader
-  system: true
-  actions:
-    - "component:view"
-    - "componenttype:view"
-    - "resource:view"
-    - "resourcerelease:view"
-    - "projectrelease:view"
-    - "resourcereleasebinding:view"
-    - "projectreleasebinding:view"
-    - "resourcetype:view"
-    - "projecttype:view"
-    - "namespace:view"
-    - "project:view"
-    - "dataplane:view"
-    - "environment:view"
-    - "trait:view"
-    - "workload:view"
-    - "workflowplane:view"
-    - "clusterworkflowplane:view"
-    - "workflow:view"
-    - "deploymentpipeline:view"
-    - "observabilityplane:view"
-    - "clusterobservabilityplane:view"
-    - "clusterdataplane:view"
-    - "clustercomponenttype:view"
-    - "clusterresourcetype:view"
-    - "clusterprojecttype:view"
-    - "clustertrait:view"
-    - "clusterworkflow:view"
-    - "observabilityalertsnotificationchannel:view"
-- name: finops-agent
-  system: true
-  actions:
-    - "component:view"
-    - "project:view"
-    - "namespace:view"
-    - "environment:view"
-    - "metrics:view"
-    - "alerts:view"
-- name: rca-agent
-  system: true
-  actions:
-    - "component:view"
-    - "project:view"
-    - "namespace:view"
-    - "componentrelease:view"
-    - "releasebinding:view"
-    - "workflowrun:view"
-    - "environment:view"
-    - "workload:view"
-    - "trait:view"
-    - "logs:view"
-    - "events:view"
-    - "metrics:view"
-    - "alerts:view"
-    - "incidents:view"
-    - "incidents:update"
-    - "traces:view"
-- name: workload-publisher
-  system: true
-  actions:
-    - "workload:create"
-    - "workload:update"
-    - "workload:view"
-    - "workflowrun:view"
-    - "workflowrun:update"
-- name: observer-resource-reader
-  system: true
-  actions:
-    - "component:view"
-    - "project:view"
-    - "namespace:view"
-    - "environment:view"
-{{- end }}
-
-{{/*
-Hardcoded system bindings (see systemRoles).
-*/}}
-{{- define "openchoreo-control-plane.authz.systemMappings" -}}
-- name: backstage-catalog-reader-binding
-  kind: ClusterAuthzRoleBinding
-  system: true
-  roleMappings:
-    - roleRef:
-        name: backstage-catalog-reader
-        kind: ClusterAuthzRole
-  entitlement:
-    claim: sub
-    value: openchoreo-backstage-client
-  effect: allow
-- name: finops-agent-binding
-  kind: ClusterAuthzRoleBinding
-  system: true
-  roleMappings:
-    - roleRef:
-        name: finops-agent
-        kind: ClusterAuthzRole
-  entitlement:
-    claim: sub
-    value: openchoreo-finops-agent
-  effect: allow
-- name: rca-agent-binding
-  kind: ClusterAuthzRoleBinding
-  system: true
-  roleMappings:
-    - roleRef:
-        name: rca-agent
-        kind: ClusterAuthzRole
-  entitlement:
-    claim: sub
-    value: openchoreo-rca-agent
-  effect: allow
-- name: workload-publisher-binding
-  kind: ClusterAuthzRoleBinding
-  system: true
-  roleMappings:
-    - roleRef:
-        name: workload-publisher
-        kind: ClusterAuthzRole
-  entitlement:
-    claim: sub
-    value: openchoreo-workload-publisher-client
-  effect: allow
-- name: observer-resource-reader-binding
-  kind: ClusterAuthzRoleBinding
-  system: true
-  roleMappings:
-    - roleRef:
-        name: observer-resource-reader
-        kind: ClusterAuthzRole
-  entitlement:
-    claim: sub
-    value: openchoreo-observer-resource-reader-client
-  effect: allow
-{{- end }}
-
-{{/*
-Full multi-document YAML for every bootstrap role and binding, system
-(hardcoded) and user-facing (from values), at column 0. All are applied
-uniformly, roles before bindings. Consumed by the bootstrap ConfigMap.
+Full multi-document YAML for every bootstrap role and binding, at column 0.
+Roles before bindings. Consumed by the bootstrap ConfigMap.
 */}}
 {{- define "openchoreo-control-plane.authz.allManifests" -}}
 {{- $root := . -}}
 {{- $bootstrap := .Values.openchoreoApi.config.security.authorization.bootstrap -}}
-{{- range $r := (include "openchoreo-control-plane.authz.systemRoles" . | fromYamlArray) }}
----
-{{ include "openchoreo-control-plane.authz.roleManifest" (dict "role" $r "root" $root) }}
-{{- end }}
 {{- range $r := $bootstrap.roles }}
-{{- if not $r.system }}
 ---
 {{ include "openchoreo-control-plane.authz.roleManifest" (dict "role" $r "root" $root) }}
-{{- end }}
-{{- end }}
-{{- range $m := (include "openchoreo-control-plane.authz.systemMappings" . | fromYamlArray) }}
----
-{{ include "openchoreo-control-plane.authz.bindingManifest" (dict "mapping" $m "root" $root) }}
 {{- end }}
 {{- range $m := $bootstrap.mappings }}
-{{- if not $m.system }}
 ---
 {{ include "openchoreo-control-plane.authz.bindingManifest" (dict "mapping" $m "root" $root) }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1176,6 +1176,90 @@ openchoreoApi:
           # default: []
           # @schema
           roles:
+            # Backstage catalog provider role for reading catalog data from the control plane
+            - name: backstage-catalog-reader
+              system: true
+              actions:
+                - "component:view"
+                - "componenttype:view"
+                - "resource:view"
+                - "resourcerelease:view"
+                - "projectrelease:view"
+                - "resourcereleasebinding:view"
+                - "projectreleasebinding:view"
+                - "resourcetype:view"
+                - "projecttype:view"
+                - "namespace:view"
+                - "project:view"
+                - "dataplane:view"
+                - "environment:view"
+                - "trait:view"
+                - "workload:view"
+                - "workflowplane:view"
+                - "clusterworkflowplane:view"
+                - "workflow:view"
+                - "deploymentpipeline:view"
+                - "observabilityplane:view"
+                - "clusterobservabilityplane:view"
+                - "clusterdataplane:view"
+                - "clustercomponenttype:view"
+                - "clusterresourcetype:view"
+                - "clusterprojecttype:view"
+                - "clustertrait:view"
+                - "clusterworkflow:view"
+                - "observabilityalertsnotificationchannel:view"
+
+            # FinOps agent role for cost analysis and resource overprovisioning assessment
+            - name: finops-agent
+              system: true
+              actions:
+                - "component:view"
+                - "project:view"
+                - "namespace:view"
+                - "environment:view"
+                - "metrics:view"
+                - "alerts:view"
+
+            # Root Cause Analysis (RCA) agent role for troubleshooting and debugging
+            - name: rca-agent
+              system: true
+              actions:
+                - "component:view"
+                - "project:view"
+                - "namespace:view"
+                - "componentrelease:view"
+                - "releasebinding:view"
+                - "workflowrun:view"
+                - "environment:view"
+                - "workload:view"
+                - "trait:view"
+                - "logs:view"
+                - "events:view"
+                - "metrics:view"
+                - "alerts:view"
+                - "incidents:view"
+                - "incidents:update"
+                - "traces:view"
+
+            # Workload publisher role for creating workloads from CI workflows
+            - name: workload-publisher
+              system: true
+              actions:
+                - "workload:create"
+                - "workload:update"
+                - "workload:view"
+                - "workflowrun:view"
+                - "workflowrun:update"
+
+            # Observer service role for resolving resource UIDs
+            - name: observer-resource-reader
+              system: true
+              actions:
+                - "component:view"
+                - "project:view"
+                - "namespace:view"
+                - "environment:view"
+
             # Admin role with full permissions to all resources
             - name: admin
               actions:
@@ -1608,6 +1692,71 @@ openchoreoApi:
               entitlement:
                 claim: sub
                 value: service_mcp_client
+              effect: allow
+
+            # Backstage catalog reader mapping - grants the Backstage catalog provider's service identity read access
+            - name: backstage-catalog-reader-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: backstage-catalog-reader
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-backstage-client
+              effect: allow
+
+            # FinOps agent mapping - grants FinOps service account cost analysis access
+            - name: finops-agent-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: finops-agent
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-finops-agent
+              effect: allow
+
+            # RCA agent mapping - grants RCA service account troubleshooting access
+            - name: rca-agent-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: rca-agent
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-rca-agent
+              effect: allow
+
+            # Workload publisher mapping - grants workload publisher service account workload creation access
+            - name: workload-publisher-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: workload-publisher
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-workload-publisher-client
+              effect: allow
+
+            # Observer mapping - grants observer service account resource UID resolver access
+            - name: observer-resource-reader-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: observer-resource-reader
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-observer-resource-reader-client
               effect: allow
     # identity.oidc and identity.clients come from security.oidc.* and security.oidc.externalClients
     # @schema

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -54,6 +54,17 @@ openchoreoApi:
                 claim: sub
                 value: openchoreo-backstage-client
               effect: allow
+            - name: finops-agent-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: finops-agent
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: openchoreo-finops-agent
+              effect: allow
             - name: rca-agent-binding
               kind: ClusterAuthzRoleBinding
               system: true


### PR DESCRIPTION
Roles and bindings for the built-in integrations (backstage catalog sync, FinOps/RCA agents, workload publisher, observer) were hardcoded in the bootstrap template, and any values override for one of them was silently dropped since the template unconditionally skipped values-sourced entries marked system: true. This broke the ext-idp e2e overlay's attempt to override backstage-catalog-reader-binding's entitlement with Dex's client-credentials sub encoding, so the Backstage catalog provider's calls to the control plane were denied and the catalog never synced.

Move all of it into values.yaml as configurable defaults so per-IdP overrides actually apply, and simplify the template to render everything from values with no hardcoded/filtered duplication.
