### PR TITLE
test: add integration tests for post-render CEL validations

### DIFF
--- a/internal/controller/releasebinding/controller_integration_test.go
+++ b/internal/controller/releasebinding/controller_integration_test.go
@@ -1675,6 +1675,162 @@ var _ = Describe("ReleaseBinding Controller", func() {
 		})
 	})
 
+	Context("when a previously successful deploy fails a post-render validation after envConfig update", func() {
+		const (
+			project  = "postrender-proj"
+			compName = "postrender-comp"
+			envName  = "postrender-env"
+			dpName   = "postrender-dp"
+			rbName   = "rb-postrender"
+			crName   = "cr-postrender"
+		)
+		req := reconcileRequest(rbName)
+		expectedReleaseName := compName + "-" + envName
+
+		// Deployment whose .spec.replicas is driven by parameters.replicas. The CEL
+		// placeholder occupies the whole field, so replicas renders as a native int,
+		// which the post-render rule can compare against environmentConfigs.maxReplicas.
+		replicaDeployment := &runtime.RawExtension{
+			Raw: []byte(`{` +
+				`"apiVersion":"apps/v1",` +
+				`"kind":"Deployment",` +
+				`"metadata":{"name":"postrender-deployment"},` +
+				`"spec":{` +
+				`"replicas":"${parameters.replicas}",` +
+				`"selector":{"matchLabels":{"app":"postrender"}},` +
+				`"template":{` +
+				`"metadata":{"labels":{"app":"postrender"}},` +
+				`"spec":{"containers":[{"name":"app","image":"nginx:latest"}]}` +
+				`}}}`,
+			),
+		}
+
+		AfterEach(func() {
+			forceDelete(rbName)
+			forceDeleteRelease(expectedReleaseName)
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.ComponentRelease{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: crName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: envName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: dpName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: compName},
+			})
+			_ = k8sClient.Delete(ctx, &openchoreov1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: project},
+			})
+		})
+
+		It("flips conditions to RenderingFailed but preserves the existing RenderedRelease", func() {
+			r := testReconcilerWithPipeline()
+
+			By("Creating a ComponentRelease with a post-render validation against the rendered Deployment")
+			cr := crFixture(crName, project, compName)
+			cr.Spec.ComponentType.Spec.Resources = []openchoreov1alpha1.ResourceTemplate{
+				{ID: "deployment", Template: replicaDeployment},
+			}
+			cr.Spec.ComponentType.Spec.Parameters = &openchoreov1alpha1.SchemaSection{
+				OpenAPIV3Schema: &runtime.RawExtension{
+					Raw: []byte(`{"type":"object","properties":{"replicas":{"type":"integer","default":1}}}`),
+				},
+			}
+			cr.Spec.ComponentType.Spec.EnvironmentConfigs = &openchoreov1alpha1.SchemaSection{
+				OpenAPIV3Schema: &runtime.RawExtension{
+					Raw: []byte(`{"type":"object","properties":{"maxReplicas":{"type":"integer","default":10}}}`),
+				},
+			}
+			cr.Spec.ComponentType.Spec.PostRenderValidations = []openchoreov1alpha1.PostRenderValidation{
+				{
+					Target: openchoreov1alpha1.PostRenderTarget{
+						PatchTarget: openchoreov1alpha1.PatchTarget{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+					},
+					Rule:    "${int(resource.spec.replicas) <= int(environmentConfigs.maxReplicas)}",
+					Message: "post-render: replicas exceed maxReplicas",
+				},
+			}
+			cr.Spec.ComponentProfile = &openchoreov1alpha1.ComponentProfile{
+				Parameters: &runtime.RawExtension{
+					Raw: []byte(`{"replicas":3}`),
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			By("Creating remaining dependencies")
+			Expect(k8sClient.Create(ctx, dpFixture(dpName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, envFixture(envName, dpName))).To(Succeed())
+			Expect(k8sClient.Create(ctx, componentFixture(compName, project))).To(Succeed())
+			Expect(k8sClient.Create(ctx, projectFixture(project))).To(Succeed())
+
+			By("Creating the ReleaseBinding with envConfig that satisfies the rule (maxReplicas=10 >= replicas=3)")
+			rb := rbFixture(rbName, project, compName, envName, crName, true)
+			rb.Spec.ComponentTypeEnvironmentConfigs = &runtime.RawExtension{
+				Raw: []byte(`{"maxReplicas":10}`),
+			}
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+
+			By("First reconcile: renders successfully and creates the RenderedRelease")
+			result := mustReconcile(r, req)
+			Expect(result.Requeue).To(BeTrue())
+
+			By("Verifying ReleaseSynced=True after initial deploy")
+			rb = fetchRB(rbName)
+			cond := conditionFor(rb, string(ConditionReleaseSynced))
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+			By("Verifying the RenderedRelease was created")
+			createdRelease := &openchoreov1alpha1.RenderedRelease{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: ns, Name: expectedReleaseName},
+				createdRelease,
+			)).To(Succeed())
+			originalReleaseUID := createdRelease.UID
+
+			By("Updating the ReleaseBinding envConfig to break the post-render rule (maxReplicas=1 < replicas=3)")
+			rb = fetchRB(rbName)
+			rb.Spec.ComponentTypeEnvironmentConfigs = &runtime.RawExtension{
+				Raw: []byte(`{"maxReplicas":1}`),
+			}
+			Expect(k8sClient.Update(ctx, rb)).To(Succeed())
+
+			By("Re-reconciling — expects a rendering failure from the post-render validation")
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to render resources"))
+
+			By("Verifying ReleaseSynced flipped to False/RenderingFailed with the post-render message")
+			rb = fetchRB(rbName)
+			cond = conditionFor(rb, string(ConditionReleaseSynced))
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(string(ReasonRenderingFailed)))
+			Expect(cond.Message).To(ContainSubstring("post-render: replicas exceed maxReplicas"))
+
+			By("Verifying Ready=False mirrors the RenderingFailed reason")
+			readyCond := conditionFor(rb, string(ConditionReady))
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCond.Reason).To(Equal(string(ReasonRenderingFailed)))
+
+			By("Verifying the existing RenderedRelease still exists and is unchanged")
+			survivingRelease := &openchoreov1alpha1.RenderedRelease{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: ns, Name: expectedReleaseName},
+				survivingRelease,
+			)).To(Succeed(), "RenderedRelease should survive a render failure")
+			Expect(survivingRelease.UID).To(Equal(originalReleaseUID),
+				"RenderedRelease should be the same object, not recreated")
+		})
+	})
+
 	Context("when environment-level configs are supplied via the ReleaseBinding", func() {
 		const (
 			project  = "envcfg-proj"

--- a/internal/webhook/componentrelease/webhook_test.go
+++ b/internal/webhook/componentrelease/webhook_test.go
@@ -1188,4 +1188,70 @@ var _ = Describe("ComponentRelease Webhook", func() {
 		})
 	})
 
+	Context("Post-Render Validation in Embedded Resources", func() {
+		It("should admit valid postRenderValidations in frozen ComponentType", func() {
+			obj = validComponentRelease()
+			obj.Spec.ComponentType.Spec.PostRenderValidations = []openchoreodevv1alpha1.PostRenderValidation{
+				{
+					Target: openchoreodevv1alpha1.PostRenderTarget{
+						PatchTarget: openchoreodevv1alpha1.PatchTarget{Group: "apps", Version: "v1", Kind: "Deployment"},
+					},
+					Rule:    "${resource.spec.replicas == 1}",
+					Message: "single replica",
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject malformed postRenderValidations rule in frozen ComponentType", func() {
+			obj = validComponentRelease()
+			obj.Spec.ComponentType.Spec.PostRenderValidations = []openchoreodevv1alpha1.PostRenderValidation{
+				{
+					Target: openchoreodevv1alpha1.PostRenderTarget{
+						PatchTarget: openchoreodevv1alpha1.PatchTarget{Group: "apps", Version: "v1", Kind: "Deployment"},
+					},
+					Rule:    "${resource.spec.replicas ==}",
+					Message: "single replica",
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			// Assert the componentType field path so the failure is attributable to the
+			// frozen ComponentType spec, not the trait path.
+			Expect(err.Error()).To(ContainSubstring("spec.componentType.spec.postRenderValidations"))
+			Expect(err.Error()).To(ContainSubstring("rule must return boolean"))
+		})
+
+		It("should reject malformed postRenderValidations rule in frozen Trait spec", func() {
+			obj = validComponentRelease()
+			obj.Spec.Traits = []openchoreodevv1alpha1.ComponentReleaseTrait{
+				{
+					Kind: openchoreodevv1alpha1.TraitRefKindTrait,
+					Name: "storage",
+					Spec: openchoreodevv1alpha1.TraitSpec{
+						PostRenderValidations: []openchoreodevv1alpha1.PostRenderValidation{
+							{
+								Target: openchoreodevv1alpha1.PostRenderTarget{
+									PatchTarget: openchoreodevv1alpha1.PatchTarget{Group: "apps", Version: "v1", Kind: "Deployment"},
+								},
+								Rule:    "${resource.spec.replicas ==}",
+								Message: "single replica",
+							},
+						},
+					},
+				},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			// Assert the traits field path so the failure is attributable to the frozen
+			// trait spec (ValidateTraitSpec).
+			Expect(err.Error()).To(ContainSubstring("spec.traits[0].spec.postRenderValidations"))
+			Expect(err.Error()).To(ContainSubstring("rule must return boolean"))
+		})
+	})
+
 })

--- a/internal/webhook/componenttype/webhook_test.go
+++ b/internal/webhook/componenttype/webhook_test.go
@@ -1395,5 +1395,50 @@ var _ = Describe("ComponentType Webhook", func() {
 			Expect(created.Spec.PostRenderValidations[0].Target.MustMatch).ToNot(BeNil())
 			Expect(*created.Spec.PostRenderValidations[0].Target.MustMatch).To(BeTrue())
 		})
+
+		It("rejects a ComponentType with a malformed post-render CEL rule (webhook CEL compile check)", func() {
+			if k8sClient == nil {
+				Skip("envtest apiserver not available")
+			}
+			spec := validSpec()
+			spec.PostRenderValidations = []openchoreodevv1alpha1.PostRenderValidation{{
+				Target: openchoreodevv1alpha1.PostRenderTarget{
+					PatchTarget: openchoreodevv1alpha1.PatchTarget{Group: "apps", Version: "v1", Kind: "Deployment"},
+				},
+				Rule:    "${resource.spec.replicas +}",
+				Message: "malformed rule",
+			}}
+			ct := &openchoreodevv1alpha1.ComponentType{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "postr-bad-", Namespace: "default"},
+				Spec:       spec,
+			}
+			err := k8sClient.Create(ctx, ct)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("postRenderValidations"))
+			Expect(err.Error()).To(ContainSubstring("rule must return boolean"))
+		})
+
+		It("rejects a ComponentType postRenderValidation that sets forEach without var", func() {
+			if k8sClient == nil {
+				Skip("envtest apiserver not available")
+			}
+			spec := validSpec()
+			spec.PostRenderValidations = []openchoreodevv1alpha1.PostRenderValidation{{
+				ForEach: "${parameters.routes}",
+				Target: openchoreodevv1alpha1.PostRenderTarget{
+					PatchTarget: openchoreodevv1alpha1.PatchTarget{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"},
+				},
+				Rule:    "${resource.spec.rules.size() > 0}",
+				Message: "route lost its rules",
+			}}
+			ct := &openchoreodevv1alpha1.ComponentType{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "postr-foreach-", Namespace: "default"},
+				Spec:       spec,
+			}
+			err := k8sClient.Create(ctx, ct)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("postRenderValidations"))
+			Expect(err.Error()).To(ContainSubstring("var is required when forEach is specified"))
+		})
 	})
 })


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Cover three gaps in postRenderValidations coverage:
- releasebinding controller envtest: a post-render failure flips ReleaseSynced to False/RenderingFailed with the validation message and preserves the existing RenderedRelease
- componentrelease webhook: admission accepts a valid frozen post-render rule and rejects malformed rules on both the componentType and trait paths
- componenttype webhook: rejects a malformed post-render rule and forEach without var

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
