### PR TITLE
fix: stop racing the auto-created ReleaseBinding in workloadtypes suite

### DIFF
--- a/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_fixtures_test.go
@@ -192,9 +192,9 @@ func componentWithImageYAML(name, componentType, image string, port int, args []
 	return mustYAMLDocs(comp, workload)
 }
 
-// scheduledTaskComponentYAML returns a Component + Workload + ReleaseBinding for
-// the cronjob/scheduled-task ClusterComponentType. The ReleaseBinding sets a
-// minute-frequency schedule so the test can observe a scheduled Job within ~60s.
+// scheduledTaskComponentYAML returns a Component + Workload for the
+// cronjob/scheduled-task ClusterComponentType. AutoDeploy creates the
+// ReleaseBinding; its schedule is patched in separately (scheduleOverridePatch).
 func scheduledTaskComponentYAML(name, image string) string {
 	comp := &openchoreov1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{APIVersion: openChoreoAPIVer, Kind: "Component"},
@@ -231,28 +231,11 @@ func scheduledTaskComponentYAML(name, image string) string {
 			},
 		},
 	}
-	// ReleaseBinding override forces a 1-minute schedule so the test does not
-	// have to wait the sample's default 5 minutes for `lastScheduleTime`.
-	rb := map[string]any{
-		"apiVersion": openChoreoAPIVer,
-		"kind":       "ReleaseBinding",
-		"metadata": map[string]any{
-			"name":      name + releaseBindingSuffix,
-			"namespace": cpNs,
-		},
-		"spec": map[string]any{
-			"owner": map[string]any{
-				"projectName":   projectName,
-				"componentName": name,
-			},
-			"environment": envDev,
-			"componentTypeEnvironmentConfigs": map[string]any{
-				"schedule": "* * * * *",
-			},
-		},
-	}
-	return mustYAMLDocs(comp, workload, rb)
+	return mustYAMLDocs(comp, workload)
 }
+
+// scheduleOverridePatch forces a 1-minute schedule on the ReleaseBinding.
+const scheduleOverridePatch = `{"spec":{"componentTypeEnvironmentConfigs":{"schedule":"* * * * *"}}}`
 
 // testerPodYAML returns a busybox pod that sleeps forever, used as the source
 // of in-cluster wget probes against project-visibility workloads. Deployed in

--- a/test/e2e/suites/workloadtypes/workloadtypes_test.go
+++ b/test/e2e/suites/workloadtypes/workloadtypes_test.go
@@ -62,6 +62,19 @@ var _ = Describe("Workload Type Matrix", Ordered, Label("tier1"), func() {
 			scheduledTaskComponentYAML(componentScheduled, imageScheduled))
 		Expect(err).NotTo(HaveOccurred(), "failed to create scheduled-task component: %s", output)
 
+		// Wait for AutoDeploy's ReleaseBinding before patching its schedule.
+		By("waiting for auto-created scheduled-task ReleaseBinding")
+		scheduledRBName := componentScheduled + releaseBindingSuffix
+		Eventually(func() error {
+			_, err := framework.KubectlGet(kubeContext, cpNs, "releasebinding", scheduledRBName)
+			return err
+		}, framework.DefaultTimeout, framework.DefaultPolling).Should(Succeed())
+
+		By("patching scheduled-task ReleaseBinding for a 1-minute schedule")
+		output, err = framework.Kubectl(kubeContext, "patch", "releasebinding", scheduledRBName,
+			"-n", cpNs, "--type=merge", "-p", scheduleOverridePatch)
+		Expect(err).NotTo(HaveOccurred(), "failed to patch schedule on ReleaseBinding %s: %s", scheduledRBName, output)
+
 		By("waiting for data plane namespace discovery")
 		Eventually(func() error {
 			var discoverErr error


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
$subject to fix the intermittent e2e failure

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content
