### PR TITLE
fix(controller): watch observability plane changes

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -104,6 +104,7 @@ func networkPolicyProviderFromDataPlane(dp *controller.DataPlaneResult) networkp
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=environments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=dataplanes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=clusterdataplanes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=openchoreo.dev,resources=observabilityplanes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=clusterobservabilityplanes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=renderedreleases,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=secretreferences,verbs=get;list;watch
@@ -1573,6 +1574,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&openchoreov1alpha1.ClusterDataPlane{},
 			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForClusterDataPlane),
 			builder.WithPredicates(dataPlaneRenderInputsChangedPredicate()),
+		).
+		// Observability plane availability determines whether the observability
+		// RenderedRelease is managed. Reconcile dependent bindings when a plane is
+		// created, deleted, or its spec changes instead of waiting for periodic resync.
+		Watches(
+			&openchoreov1alpha1.ObservabilityPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForObservabilityPlane),
+			builder.WithPredicates(observabilityPlaneChangedPredicate()),
+		).
+		Watches(
+			&openchoreov1alpha1.ClusterObservabilityPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForClusterObservabilityPlane),
+			builder.WithPredicates(observabilityPlaneChangedPredicate()),
 		).
 		Named("releasebinding").
 		Complete(r)

--- a/internal/controller/releasebinding/controller_watch.go
+++ b/internal/controller/releasebinding/controller_watch.go
@@ -395,6 +395,23 @@ func openchoreoAnnotationsChanged(oldAnn, newAnn map[string]string) bool {
 	return !apiequality.Semantic.DeepEqual(pick(oldAnn), pick(newAnn))
 }
 
+// observabilityPlaneChangedPredicate passes lifecycle events and spec changes while
+// ignoring status-only updates. ReleaseBinding only depends on plane availability and
+// desired configuration; status churn must not fan out reconciles to every workload.
+func observabilityPlaneChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(_ event.CreateEvent) bool { return true },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		},
+	}
+}
+
 // findReleaseBindingsForDataPlane enqueues every ReleaseBinding whose target Environment
 // references the changed namespace-scoped DataPlane.
 func (r *Reconciler) findReleaseBindingsForDataPlane(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -414,6 +431,110 @@ func (r *Reconciler) findReleaseBindingsForClusterDataPlane(ctx context.Context,
 		return nil
 	}
 	return r.releaseBindingsForDataPlaneRef(ctx, "", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, cdp.Name)
+}
+
+// findReleaseBindingsForObservabilityPlane enqueues bindings whose namespaced
+// DataPlane references the changed namespaced ObservabilityPlane.
+func (r *Reconciler) findReleaseBindingsForObservabilityPlane(ctx context.Context, obj client.Object) []reconcile.Request {
+	op, ok := obj.(*openchoreov1alpha1.ObservabilityPlane)
+	if !ok {
+		return nil
+	}
+	return r.releaseBindingsForObservabilityPlaneRef(
+		ctx, op.Namespace, openchoreov1alpha1.ObservabilityPlaneRefKindObservabilityPlane, op.Name)
+}
+
+// findReleaseBindingsForClusterObservabilityPlane enqueues bindings whose namespaced
+// DataPlane or cluster-scoped ClusterDataPlane references the changed plane.
+func (r *Reconciler) findReleaseBindingsForClusterObservabilityPlane(
+	ctx context.Context, obj client.Object,
+) []reconcile.Request {
+	cop, ok := obj.(*openchoreov1alpha1.ClusterObservabilityPlane)
+	if !ok {
+		return nil
+	}
+	return r.releaseBindingsForObservabilityPlaneRef(
+		ctx, "", openchoreov1alpha1.ObservabilityPlaneRefKindClusterObservabilityPlane, cop.Name)
+}
+
+// releaseBindingsForObservabilityPlaneRef resolves the data planes that reference an
+// observability plane, then reuses the data-plane mapper to find their ReleaseBindings.
+func (r *Reconciler) releaseBindingsForObservabilityPlaneRef(
+	ctx context.Context, namespace string, kind openchoreov1alpha1.ObservabilityPlaneRefKind, name string,
+) []reconcile.Request {
+	logger := log.FromContext(ctx)
+
+	var dataPlanes openchoreov1alpha1.DataPlaneList
+	var listOpts []client.ListOption
+	if kind == openchoreov1alpha1.ObservabilityPlaneRefKindObservabilityPlane {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+	if err := r.List(ctx, &dataPlanes, listOpts...); err != nil {
+		logger.Error(err, "Failed to list DataPlanes for observability plane change",
+			"kind", kind, "observabilityPlane", name)
+		return nil
+	}
+
+	seen := make(map[types.NamespacedName]struct{})
+	requests := make([]reconcile.Request, 0)
+	appendUnique := func(items []reconcile.Request) {
+		for _, item := range items {
+			if _, exists := seen[item.NamespacedName]; exists {
+				continue
+			}
+			seen[item.NamespacedName] = struct{}{}
+			requests = append(requests, item)
+		}
+	}
+
+	for i := range dataPlanes.Items {
+		dp := &dataPlanes.Items[i]
+		if !observabilityPlaneRefMatches(dp.Spec.ObservabilityPlaneRef, kind, name) {
+			continue
+		}
+		appendUnique(r.releaseBindingsForDataPlaneRef(
+			ctx, dp.Namespace, openchoreov1alpha1.DataPlaneRefKindDataPlane, dp.Name))
+	}
+
+	if kind != openchoreov1alpha1.ObservabilityPlaneRefKindClusterObservabilityPlane {
+		return requests
+	}
+
+	var clusterDataPlanes openchoreov1alpha1.ClusterDataPlaneList
+	if err := r.List(ctx, &clusterDataPlanes); err != nil {
+		logger.Error(err, "Failed to list ClusterDataPlanes for observability plane change",
+			"observabilityPlane", name)
+		return requests
+	}
+	for i := range clusterDataPlanes.Items {
+		cdp := &clusterDataPlanes.Items[i]
+		if !clusterObservabilityPlaneRefMatches(cdp.Spec.ObservabilityPlaneRef, name) {
+			continue
+		}
+		appendUnique(r.releaseBindingsForDataPlaneRef(
+			ctx, "", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, cdp.Name))
+	}
+	return requests
+}
+
+func observabilityPlaneRefMatches(
+	ref *openchoreov1alpha1.ObservabilityPlaneRef,
+	kind openchoreov1alpha1.ObservabilityPlaneRefKind,
+	name string,
+) bool {
+	if ref == nil {
+		// A DataPlane with no explicit reference can resolve to either a namespaced
+		// or cluster-scoped default. Enqueueing for both avoids missing precedence changes.
+		return name == controller.DefaultPlaneName
+	}
+	return ref.Kind == kind && ref.Name == name
+}
+
+func clusterObservabilityPlaneRefMatches(ref *openchoreov1alpha1.ClusterObservabilityPlaneRef, name string) bool {
+	if ref == nil {
+		return name == controller.DefaultPlaneName
+	}
+	return ref.Kind == openchoreov1alpha1.ClusterObservabilityPlaneRefKindClusterObservabilityPlane && ref.Name == name
 }
 
 // releaseBindingsForDataPlaneRef returns reconcile requests for the ReleaseBindings whose target

--- a/internal/controller/releasebinding/controller_watch_observabilityplane_test.go
+++ b/internal/controller/releasebinding/controller_watch_observabilityplane_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+func observabilityPlaneObj(generation int64) *openchoreov1alpha1.ObservabilityPlane {
+	return &openchoreov1alpha1.ObservabilityPlane{
+		ObjectMeta: metav1.ObjectMeta{Generation: generation},
+	}
+}
+
+func TestObservabilityPlaneChangedPredicate(t *testing.T) {
+	p := observabilityPlaneChangedPredicate()
+
+	assert.True(t, p.Create(event.CreateEvent{Object: observabilityPlaneObj(1)}), "create should pass")
+	assert.True(t, p.Delete(event.DeleteEvent{Object: observabilityPlaneObj(1)}), "delete should pass")
+	assert.False(t, p.Generic(event.GenericEvent{Object: observabilityPlaneObj(1)}), "generic should be ignored")
+	assert.True(t, p.Update(event.UpdateEvent{
+		ObjectOld: observabilityPlaneObj(1),
+		ObjectNew: observabilityPlaneObj(2),
+	}), "spec generation change should pass")
+	assert.False(t, p.Update(event.UpdateEvent{
+		ObjectOld: observabilityPlaneObj(1),
+		ObjectNew: observabilityPlaneObj(1),
+	}), "status-only update should be ignored")
+}
+
+func dataPlaneWithObservabilityRef(
+	namespace, name string,
+	ref *openchoreov1alpha1.ObservabilityPlaneRef,
+) *openchoreov1alpha1.DataPlane {
+	return &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			ObservabilityPlaneRef: ref,
+		},
+	}
+}
+
+func clusterDataPlaneWithObservabilityRef(
+	name string,
+	ref *openchoreov1alpha1.ClusterObservabilityPlaneRef,
+) *openchoreov1alpha1.ClusterDataPlane {
+	return &openchoreov1alpha1.ClusterDataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: openchoreov1alpha1.ClusterDataPlaneSpec{
+			ObservabilityPlaneRef: ref,
+		},
+	}
+}
+
+func TestFindReleaseBindingsForObservabilityPlane(t *testing.T) {
+	ctx := context.Background()
+	r := newReconcilerWith(t,
+		dataPlaneWithObservabilityRef("org", "dp-a", &openchoreov1alpha1.ObservabilityPlaneRef{
+			Kind: openchoreov1alpha1.ObservabilityPlaneRefKindObservabilityPlane,
+			Name: "obs-a",
+		}),
+		dataPlaneWithObservabilityRef("org", "dp-b", &openchoreov1alpha1.ObservabilityPlaneRef{
+			Kind: openchoreov1alpha1.ObservabilityPlaneRefKindObservabilityPlane,
+			Name: "obs-b",
+		}),
+		dataPlaneWithObservabilityRef("org", "dp-cluster", &openchoreov1alpha1.ObservabilityPlaneRef{
+			Kind: openchoreov1alpha1.ObservabilityPlaneRefKindClusterObservabilityPlane,
+			Name: "obs-a",
+		}),
+		dataPlaneWithObservabilityRef("org", "dp-default", nil),
+		envRef("org", "env-a", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-a"),
+		envRef("org", "env-b", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-b"),
+		envRef("org", "env-cluster", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-cluster"),
+		envRef("org", "env-default", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-default"),
+		bindingFor("org", "rb-a", "env-a"),
+		bindingFor("org", "rb-b", "env-b"),
+		bindingFor("org", "rb-cluster", "env-cluster"),
+		bindingFor("org", "rb-default", "env-default"),
+	)
+
+	t.Run("matches namespaced references by kind and name", func(t *testing.T) {
+		reqs := r.findReleaseBindingsForObservabilityPlane(ctx, &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "org", Name: "obs-a"},
+		})
+		assert.ElementsMatch(t, []string{"rb-a"}, requestNames(reqs))
+	})
+
+	t.Run("matches implicit default references", func(t *testing.T) {
+		reqs := r.findReleaseBindingsForObservabilityPlane(ctx, &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "org", Name: "default"},
+		})
+		assert.ElementsMatch(t, []string{"rb-default"}, requestNames(reqs))
+	})
+}
+
+func TestFindReleaseBindingsForClusterObservabilityPlane(t *testing.T) {
+	ctx := context.Background()
+	r := newReconcilerWith(t,
+		dataPlaneWithObservabilityRef("org-a", "dp-shared", &openchoreov1alpha1.ObservabilityPlaneRef{
+			Kind: openchoreov1alpha1.ObservabilityPlaneRefKindClusterObservabilityPlane,
+			Name: "shared",
+		}),
+		dataPlaneWithObservabilityRef("org-a", "dp-local", &openchoreov1alpha1.ObservabilityPlaneRef{
+			Kind: openchoreov1alpha1.ObservabilityPlaneRefKindObservabilityPlane,
+			Name: "shared",
+		}),
+		dataPlaneWithObservabilityRef("org-a", "dp-default", nil),
+		clusterDataPlaneWithObservabilityRef("cdp-shared", &openchoreov1alpha1.ClusterObservabilityPlaneRef{
+			Kind: openchoreov1alpha1.ClusterObservabilityPlaneRefKindClusterObservabilityPlane,
+			Name: "shared",
+		}),
+		clusterDataPlaneWithObservabilityRef("cdp-default", nil),
+		envRef("org-a", "env-shared", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-shared"),
+		envRef("org-a", "env-local", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-local"),
+		envRef("org-a", "env-default", openchoreov1alpha1.DataPlaneRefKindDataPlane, "dp-default"),
+		envRef("org-b", "env-cdp", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, "cdp-shared"),
+		envRef("org-b", "env-cdp-default", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, "cdp-default"),
+		bindingFor("org-a", "rb-shared", "env-shared"),
+		bindingFor("org-a", "rb-local", "env-local"),
+		bindingFor("org-a", "rb-default", "env-default"),
+		bindingFor("org-b", "rb-cdp", "env-cdp"),
+		bindingFor("org-b", "rb-cdp-default", "env-cdp-default"),
+	)
+
+	t.Run("matches namespaced and cluster data plane references", func(t *testing.T) {
+		reqs := r.findReleaseBindingsForClusterObservabilityPlane(ctx,
+			&openchoreov1alpha1.ClusterObservabilityPlane{ObjectMeta: metav1.ObjectMeta{Name: "shared"}})
+		assert.ElementsMatch(t, []string{"rb-shared", "rb-cdp"}, requestNames(reqs))
+	})
+
+	t.Run("matches implicit default references", func(t *testing.T) {
+		reqs := r.findReleaseBindingsForClusterObservabilityPlane(ctx,
+			&openchoreov1alpha1.ClusterObservabilityPlane{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
+		assert.ElementsMatch(t, []string{"rb-default", "rb-cdp-default"}, requestNames(reqs))
+	})
+}


### PR DESCRIPTION
## Purpose
ReleaseBindings that initially skipped observability resources were not requeued when their ObservabilityPlane or ClusterObservabilityPlane became available, changed, or was removed. This left the observability RenderedRelease stale until the periodic resync.

## Approach
- Watch ObservabilityPlane and ClusterObservabilityPlane lifecycle and spec-generation changes.
- Resolve affected DataPlanes and ClusterDataPlanes, then enqueue the ReleaseBindings targeting their Environments.
- Cover explicit references, default-plane fallback behavior, cross-namespace cluster references, request de-duplication, and the required RBAC marker.
- Add focused unit tests for event filtering and both mapping paths.

## Related Issues
Fixes #2765

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (not applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
Validation completed:
- `make go.test`
- `make code.gen-check`
- `./bin/tools/golangci-lint run --timeout 15m`
- `make license-check newline-check`
- `go test -race ./internal/controller/releasebinding -run ObservabilityPlane -count=1`