### PR TITLE
fix: require E2E_WITH_UI for ext-idp Backstage overlay in e2e setup

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -523,7 +523,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
+      E2E_WITH_UI: "true"
       E2E_WITH_EXT_IDP: "true"
+      E2E_BACKSTAGE_IMAGE_TAG: ${{ inputs.backstage_image_tag }}
       E2E_KUBECONTEXT: k3d-openchoreo-e2e
       UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
     steps:
@@ -618,7 +620,9 @@ jobs:
           make e2e.setup \
             E2E_HELM_SOURCE=oci \
             HELM_CHART_VERSION="${HELM_CHART_VERSION}" \
+            E2E_WITH_UI="${E2E_WITH_UI}" \
             E2E_WITH_EXT_IDP="${E2E_WITH_EXT_IDP}" \
+            E2E_BACKSTAGE_IMAGE_TAG="${E2E_BACKSTAGE_IMAGE_TAG}" \
             E2E_SETUP_TIMEOUT=10m
 
       - name: Run ext-idp Playwright tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
+      E2E_WITH_UI: "true"
       E2E_WITH_EXT_IDP: "true"
       E2E_KUBECONTEXT: k3d-openchoreo-e2e
       UI_BASE_URL: http://openchoreo.e2e-cp.local:28080
@@ -279,6 +280,7 @@ jobs:
           make e2e.setup \
             E2E_HELM_SOURCE=oci \
             HELM_CHART_VERSION="${{ steps.helm-version.outputs.version }}" \
+            E2E_WITH_UI=true \
             E2E_WITH_EXT_IDP=true \
             E2E_SETUP_TIMEOUT=10m
 

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -22,7 +22,6 @@ E2E_WITH_UI            ?= false
 E2E_BACKSTAGE_IMAGE_TAG ?=
 # Set to "true" to replace Thunder with Dex as the OIDC provider and run the
 # external-IdP Playwright suite (test/ui/specs/external-idp/).
-# Implies Backstage — no need to also set E2E_WITH_UI=true.
 E2E_WITH_EXT_IDP       ?= false
 # Go duration for the test suite (go test -timeout)
 E2E_TEST_TIMEOUT       ?= 20m
@@ -62,25 +61,23 @@ UI_DIR                 := $(PROJECT_DIR)/test/ui
 UI_K3D_DIR             := $(UI_DIR)/k3d
 
 # When the UI suite is enabled, layer the cp-ui overlay on top of the default
-# control-plane values so Backstage gets switched on. When a Backstage image tag
-# is supplied, pin it so the install does not fall back to the chart AppVersion
-# (the openchoreo SHA), which has no matching openchoreo-ui image.
+# control-plane values so Backstage gets switched on. External-IdP mode layers
+# a second overlay on top that swaps Thunder for Dex as the OIDC provider (the
+# ext-idp overlay overrides security.oidc.* and adds the groups scope) — it
+# requires E2E_WITH_UI=true too, since Backstage is what the ext-idp suite
+# drives. When a Backstage image tag is supplied, pin it so the install does
+# not fall back to the chart AppVersion (the openchoreo SHA), which has no
+# matching openchoreo-ui image.
 ifeq ($(E2E_WITH_UI),true)
   E2E_CP_EXTRA_VALUES := --values $(UI_K3D_DIR)/values-cp-ui.yaml
+  ifeq ($(E2E_WITH_EXT_IDP),true)
+    E2E_CP_EXTRA_VALUES += --values $(UI_K3D_DIR)/values-cp-ext-idp.yaml
+  endif
   ifneq ($(strip $(E2E_BACKSTAGE_IMAGE_TAG)),)
     E2E_CP_EXTRA_VALUES += --set-string backstage.image.tag=$(E2E_BACKSTAGE_IMAGE_TAG)
   endif
 else
   E2E_CP_EXTRA_VALUES :=
-endif
-
-# External-IdP mode: enable Backstage AND swap Thunder for Dex as the OIDC provider.
-# The ext-idp overlay overrides security.oidc.* and adds the groups scope.
-ifeq ($(E2E_WITH_EXT_IDP),true)
-  E2E_CP_EXTRA_VALUES := --values $(UI_K3D_DIR)/values-cp-ui.yaml --values $(UI_K3D_DIR)/values-cp-ext-idp.yaml
-  ifneq ($(strip $(E2E_BACKSTAGE_IMAGE_TAG)),)
-    E2E_CP_EXTRA_VALUES += --set-string backstage.image.tag=$(E2E_BACKSTAGE_IMAGE_TAG)
-  endif
 endif
 
 # Namespaces


### PR DESCRIPTION
The ext-idp e2e leg relied on E2E_WITH_EXT_IDP alone to switch on the Backstage/UI Helm overlay, bypassing E2E_WITH_UI and never forwarding backstage_image_tag. Make E2E_WITH_UI the single flag controlling the UI overlay, layer the ext-idp overlay on top of it when both are set, and forward E2E_WITH_UI/E2E_BACKSTAGE_IMAGE_TAG from the ext-idp jobs in e2e-gate.yml and release.yml.