### PR TITLE
fix(controller): report deployment health from observed pods when scaled to zero

### DIFF
--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -190,23 +190,29 @@ func getDeploymentHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.Hea
 		return openchoreov1alpha1.HealthStatusUnknown, fmt.Errorf("failed to convert to deployment: %w", err)
 	}
 
-	// Check if deployment is paused (or deliberately scaled to zero) -> Suspended
+	// Check if deployment is paused -> Suspended
 	if deployment.Spec.Paused {
 		return openchoreov1alpha1.HealthStatusSuspended, nil
 	}
-	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
-		return openchoreov1alpha1.HealthStatusSuspended, nil
+	// Extract replica details
+	desiredReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desiredReplicas = *deployment.Spec.Replicas
+	}
+	// A workload scaled to zero is Suspended only once no pods remain. An autoscaler
+	// (e.g. KEDA/HPA) writes spec.replicas=0 to scale down before its pods are gone,
+	// so while pods still exist, judge readiness against the observed count rather
+	// than report Suspended or progress toward a stale desired count of 0.
+	if desiredReplicas == 0 {
+		if deployment.Status.Replicas == 0 {
+			return openchoreov1alpha1.HealthStatusSuspended, nil
+		}
+		desiredReplicas = deployment.Status.Replicas
 	}
 
 	// New spec not yet observed -> Progressing
 	if deployment.Status.ObservedGeneration == 0 || deployment.Generation > deployment.Status.ObservedGeneration {
 		return openchoreov1alpha1.HealthStatusProgressing, nil
-	}
-
-	// Extract replica details
-	desiredReplicas := int32(1)
-	if deployment.Spec.Replicas != nil {
-		desiredReplicas = *deployment.Spec.Replicas
 	}
 	updatedReplicas := deployment.Status.UpdatedReplicas
 	readyReplicas := deployment.Status.ReadyReplicas

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -481,11 +481,83 @@ func TestGetDeploymentHealth(t *testing.T) {
 			want: openchoreov1alpha1.HealthStatusSuspended,
 		},
 		{
-			name: "zero replicas is Suspended",
+			name: "zero replicas with no running pods is Suspended",
 			deployment: appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(0)},
 				Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
+			},
+			want: openchoreov1alpha1.HealthStatusSuspended,
+		},
+		{
+			// When an autoscaler scales to zero, spec.replicas reads 0 before the pods
+			// are actually gone (scale-down in flight). Pods that still exist and are
+			// ready must not be reported as Suspended.
+			name: "zero desired replicas but pods running and ready is Healthy",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(0)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration:  1,
+					Replicas:            2,
+					UpdatedReplicas:     2,
+					ReadyReplicas:       2,
+					AvailableReplicas:   2,
+					UnavailableReplicas: 0,
+				},
+			},
+			want: openchoreov1alpha1.HealthStatusHealthy,
+		},
+		{
+			name: "zero desired replicas with pods partially ready is Progressing",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(0)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration:  1,
+					Replicas:            2,
+					UpdatedReplicas:     2,
+					ReadyReplicas:       1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 1,
+				},
+			},
+			want: openchoreov1alpha1.HealthStatusProgressing,
+		},
+		{
+			// The observed-count fallback must not hide a genuinely broken rollout:
+			// spec scaled to zero, pods present but none available and progressing
+			// stalled -> Degraded, not Healthy/Suspended.
+			name: "zero desired replicas with pods present but none available is Degraded",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(0)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  0,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			want: openchoreov1alpha1.HealthStatusDegraded,
+		},
+		{
+			// Paused halts rollouts while pods keep serving; it is deliberately
+			// suspended regardless of running, ready pods.
+			name: "paused deployment with running pods is Suspended",
+			deployment: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Paused: true, Replicas: int32Ptr(2)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					ReadyReplicas:      2,
+					AvailableReplicas:  2,
+				},
 			},
 			want: openchoreov1alpha1.HealthStatusSuspended,
 		},


### PR DESCRIPTION
## What

`getDeploymentHealth` decided a Deployment was `Suspended` from the desired `spec.replicas` alone. When an autoscaler (KEDA/HPA) scales to zero it writes `spec.replicas=0` during scale-down *before* the pods are actually gone, so a workload with running pods was classified `Suspended`. That health becomes the `ReadyWithSuspendedResources` reason on the ReleaseBinding, which the portal renders as "Suspended" — so users saw "Suspended" while pods were serving.

This makes the decision observed-pod-aware:

- A zero-scaled workload is `Suspended` only once `status.Replicas == 0`.
- While pods still exist (scale-down in flight), readiness is judged against the observed replica count instead of the stale desired count of 0, so a running autoscaled workload reports `Healthy` rather than perpetually `Progressing`.

`spec.Paused` still maps to `Suspended` regardless of pods — paused halts rollouts while pods keep serving, which matches the enum's documented meaning and Argo CD gitops-engine semantics.

## Why

The KEDA trait already removes `/spec/replicas` from the Deployment manifest, so core never owns the field and there is no server-side-apply fight. The bug was purely in the health evaluator reading desired instead of observed state.

## Verified

- `go test ./internal/controller/renderedrelease/...` and `.../releasebinding/...` pass.
- `golangci-lint` (repo-pinned v2.8.0) reports 0 issues.
- New unit cases cover: zero-scaled with no pods → Suspended; zero-scaled with ready pods → Healthy; zero-scaled partially ready → Progressing; zero-scaled with pods present but none available → Degraded (fallback does not mask a broken rollout); paused with running pods → Suspended.
- No CRD types changed, so no codegen.

## Not yet done / follow-ups

- Not yet exercised end-to-end on a k3d cluster with a live KEDA scale-to-zero cycle; verified via unit tests and tracing only.
- `getStatefulSetHealth` has no `Suspended` concept, so a KEDA-idle StatefulSet reads `Healthy` while an equivalent Deployment reads `Suspended`. Out of scope here (the two functions key off different signals); worth a separate pass.
