### PR TITLE
fix: reuse the e2e gate from any successful run at the same commit

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -137,8 +137,28 @@ env:
   YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
 
 jobs:
+  # Pins `inputs.ref` (which may be a branch or tag) to a single commit SHA up
+  # front, so every leg and the final status recording test/reference the
+  # exact same commit even if the ref moves later in the run.
+  resolve-ref:
+    name: Resolve tested commit
+    runs-on: ubuntu-24.04
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Resolve to a commit SHA
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   tier1:
     name: E2E (Tier 1)
+    needs: [resolve-ref]
     # On `schedule` inputs is empty (the nightly runs every leg); dispatch/call honor the toggle.
     if: ${{ github.event_name == 'schedule' || inputs.run_tier1 }}
     runs-on: ubuntu-24.04
@@ -147,7 +167,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
           persist-credentials: false
 
       - name: Clone workflow actions
@@ -203,6 +223,7 @@ jobs:
 
   tier2:
     name: E2E (Tier 2)
+    needs: [resolve-ref]
     if: ${{ github.event_name == 'schedule' || inputs.run_tier2 }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -210,7 +231,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
           persist-credentials: false
 
       - name: Clone workflow actions
@@ -266,6 +287,7 @@ jobs:
 
   tier3:
     name: E2E (Tier 3 — Multi-cluster)
+    needs: [resolve-ref]
     if: ${{ github.event_name == 'schedule' || inputs.run_tier3 }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -273,7 +295,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
           persist-credentials: false
 
       - name: Clone workflow actions
@@ -337,6 +359,7 @@ jobs:
 
   ui:
     name: E2E (UI / Playwright)
+    needs: [resolve-ref]
     if: ${{ github.event_name == 'schedule' || inputs.run_ui }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -359,7 +382,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
           persist-credentials: false
 
       - name: Check UI suite presence
@@ -503,6 +526,7 @@ jobs:
 
   ext-idp:
     name: E2E (External IdP / Dex)
+    needs: [resolve-ref]
     if: ${{ github.event_name == 'schedule' || inputs.run_ext_idp }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -516,7 +540,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
           persist-credentials: false
 
       - name: Check UI suite presence
@@ -654,3 +678,44 @@ jobs:
       # already default it), so the nested quick-start workflow always receives
       # a real chart version.
       helm_chart_version: ${{ inputs.helm_chart_version || '0.0.0-latest-dev' }}
+
+  record-status:
+    name: Record e2e gate status
+    # Stamps `e2e-gate` on the commit resolve-ref pinned (not a re-resolved
+    # ref), so a moving branch that advanced during the run can't get credit
+    # for a pass it never earned.
+    needs: [resolve-ref, tier1, tier2, tier3, ui, ext-idp, quick-start]
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Record gate status on the tested commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BACKSTAGE_IMAGE_TAG: ${{ inputs.backstage_image_tag }}
+          SHA: ${{ needs.resolve-ref.outputs.sha }}
+        run: |
+          if [[ "${{ needs.tier1.result }}" != "success" || "${{ needs.tier2.result }}" != "success" || \
+                "${{ needs.tier3.result }}" != "success" || "${{ needs.ui.result }}" != "success" || \
+                "${{ needs['ext-idp'].result }}" != "success" || "${{ needs['quick-start'].result }}" != "success" ]]; then
+            echo "Not every e2e gate leg succeeded; not recording gate status for ${SHA}."
+            exit 0
+          fi
+          # Encodes the tested artifact versions so reuse checks can match on them.
+          DESCRIPTION="e2e gate passed (helm=${HELM_CHART_VERSION}, backstage=${BACKSTAGE_IMAGE_TAG:-none})"
+          for attempt in 1 2 3; do
+            if gh api --method POST "repos/${{ github.repository }}/statuses/${SHA}" \
+              -f state=success \
+              -f context=e2e-gate \
+              -f description="${DESCRIPTION}" >/dev/null; then
+              echo "Recorded e2e-gate=success on ${SHA}: ${DESCRIPTION}"
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 to record the e2e gate status failed; retrying in $((attempt * 5))s..."
+              sleep $((attempt * 5))
+            fi
+          done
+          echo "::warning::Could not record e2e-gate status on ${SHA} after 3 attempts."

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -386,8 +386,8 @@ jobs:
       - name: Wait for build-and-test workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.resolve-target.outputs.target }}
         run: |
-          TARGET_SHA="${{ steps.resolve-target.outputs.target }}"
           SHORT_SHA=$(git rev-parse --short=8 "${TARGET_SHA}")
           echo "Waiting for build-and-test workflow for commit ${SHORT_SHA}..."
           for i in $(seq 1 30); do
@@ -426,23 +426,29 @@ jobs:
         id: e2e-status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ steps.resolve-target.outputs.target }}
+          HELM_CHART_VERSION: ${{ steps.resolve-target.outputs.helm-chart-version }}
+          BACKSTAGE_IMAGE_TAG: ${{ steps.backstage-tag.outputs.backstage-image-tag }}
         run: |
-          TARGET="${{ steps.resolve-target.outputs.target }}"
-          # The tag run reuses a green gate when the commit is unchanged since
-          # branching: record-e2e stamps the gated commit with a
-          # release-e2e-gate commit status, which we look up here. The combined
-          # status endpoint returns the latest status per context, so this is
-          # deterministic regardless of how many other statuses the commit has.
-          # Fall back to "none" on any gh api error so a transient lookup
-          # failure runs the gate (safe default) instead of aborting the release.
-          if ! STATE=$(gh api "repos/${{ github.repository }}/commits/${TARGET}/status" \
-            --jq '.statuses | map(select(.context == "release-e2e-gate"))[0].state // "none"'); then
+          # e2e-gate.yml stamps `e2e-gate` on its tested commit regardless of
+          # trigger, so this reuses any prior passing gate at this commit —
+          # only if it also tested the same Helm/Backstage versions (encoded
+          # in the description, since backstage_image_tag can drift between
+          # runs at the same commit).
+          EXPECTED_DESC="e2e gate passed (helm=${HELM_CHART_VERSION}, backstage=${BACKSTAGE_IMAGE_TAG:-none})"
+          if ! STATUS_JSON=$(gh api "repos/${{ github.repository }}/commits/${TARGET}/status" \
+            --jq '.statuses | map(select(.context == "e2e-gate"))[0] // {}'); then
             echo "::warning::Failed to query commit status for ${TARGET}; assuming no prior e2e gate."
-            STATE="none"
+            STATUS_JSON="{}"
           fi
-          if [ "$STATE" = "success" ]; then
-            echo "e2e gate already passed at ${TARGET}; it will be reused."
+          STATE=$(echo "$STATUS_JSON" | jq -r '.state // "none"')
+          DESCRIPTION=$(echo "$STATUS_JSON" | jq -r '.description // ""')
+          if [ "$STATE" = "success" ] && [ "$DESCRIPTION" = "$EXPECTED_DESC" ]; then
+            echo "e2e gate already passed at ${TARGET} for ${EXPECTED_DESC}; it will be reused."
             echo "e2e-already-passed=true" >> $GITHUB_OUTPUT
+          elif [ "$STATE" = "success" ]; then
+            echo "e2e gate passed at ${TARGET} but for different artifacts ('${DESCRIPTION}' vs expected '${EXPECTED_DESC}'); the gate will run again."
+            echo "e2e-already-passed=false" >> $GITHUB_OUTPUT
           else
             echo "No passing e2e gate at ${TARGET} (state: ${STATE}); the gate will run."
             echo "e2e-already-passed=false" >> $GITHUB_OUTPUT
@@ -453,14 +459,15 @@ jobs:
   # at the exact commit being released before the tag is created. Also
   # runs on branch creation so the new release tip is gated up front.
   # Legs run in parallel, one k3d cluster each. Skipped when the target
-  # commit already has a passing gate (reused via record-e2e), and
-  # skip_e2e bypasses the gate for declared emergencies only.
+  # commit already has a passing gate (see resolve-target), and skip_e2e
+  # bypasses the gate for declared emergencies only.
   # ----------------------------------------------------------------
   e2e:
     needs: [validate, resolve-target]
     if: ${{ always() && !failure() && !cancelled() && (github.event.inputs.action == 'full' || github.event.inputs.action == 'tag' || github.event.inputs.action == 'branch') && !inputs.skip_e2e && needs.resolve-target.outputs.e2e-already-passed != 'true' }}
     permissions:
       contents: read
+      statuses: write
     uses: ./.github/workflows/e2e-gate.yml
     with:
       ref: ${{ needs.resolve-target.outputs.target }}
@@ -468,42 +475,6 @@ jobs:
       backstage_image_tag: ${{ needs.resolve-target.outputs.backstage-image-tag }}
     secrets:
       E2E_GITHUB_PAT: ${{ secrets.E2E_GITHUB_PAT }}
-
-  # ----------------------------------------------------------------
-  # Record e2e pass: stamp the gated commit with a release-e2e-gate
-  # commit status so a later tag run at the same commit reuses the green
-  # gate (see resolve-target) instead of re-running the full suite.
-  # Side-effect only — tag does not depend on it, so a recording hiccup
-  # never blocks a release whose e2e already passed.
-  # ----------------------------------------------------------------
-  record-e2e:
-    needs: [validate, resolve-target, e2e]
-    if: ${{ needs.e2e.result == 'success' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      statuses: write
-    steps:
-      - name: Record passing e2e gate on target commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TARGET="${{ needs.resolve-target.outputs.target }}"
-          # Recording is a side-effect for future reuse; a failure must not fail
-          # the release. Retry a few times, then warn and succeed if it never lands.
-          for attempt in 1 2 3; do
-            if gh api --method POST "repos/${{ github.repository }}/statuses/${TARGET}" \
-              -f state=success \
-              -f context=release-e2e-gate \
-              -f description="Release e2e gate passed" >/dev/null; then
-              echo "Recorded release-e2e-gate=success on ${TARGET}"
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "Attempt ${attempt}/3 to record the e2e gate status failed; retrying in $((attempt * 5))s..."
-              sleep $((attempt * 5))
-            fi
-          done
-          echo "::warning::Could not record release-e2e-gate status on ${TARGET} after 3 attempts; a later tag run at this commit will re-run the gate instead of reusing it."
 
   # ----------------------------------------------------------------
   # Tag: create and push the annotated release tag at the gated commit.

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -32,10 +32,22 @@ The gate runs at two points, both keyed to the exact commit:
   branch creation), in which case the earlier green gate is reused instead of
   re-run.
 
-Reuse is tracked by a `release-e2e-gate` commit status, so it applies only when
-the tag points at the identical commit. Any new commit on the branch — a fix or
-a backported patch — is gated afresh, and only passing gates are recorded, so a
+Reuse is tracked by an `e2e-gate` commit status, which `e2e-gate.yml` stamps on
+its own tested commit whenever every leg passes — regardless of what triggered
+that run. So it also picks up a manual pre-flight dispatch or a nightly
+schedule run, not just ones run by the orchestrator itself, as long as it
+lands on the identical commit. Any new commit on the branch — a fix or a
+backported patch — is gated afresh, and only passing gates are recorded, so a
 failed gate is never reused.
+
+Reuse also requires the same Helm chart version and Backstage image tag, not
+just the same commit: the status description encodes both, and the
+orchestrator only reuses a prior gate when that description matches the
+versions it just resolved for the current run. This matters because the
+Backstage image tag tracks the `backstage-plugins` release branch tip rather
+than anything in this repo's history, so it can change between two gate
+checks at the same openchoreo commit. When the description doesn't match, the
+gate is re-run even though the commit already has a passing status.
 
 The gate shards the suite into five parallel legs, each on its own runner
 and k3d cluster:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Currently, successful e2e gate run gets reused only when a prior release ochestrator has triggered it.

This PR updates the e2e gate to record the successful run and updates the release ochestrator to refer from the recorded successful e2e gate runs. Record status is not independant from the e2e gate run trigger (scheduled, manual, release orchestrator)

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content