### PR TITLE
feat(helm): add affinity and topology spread constraint support

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.clusterGateway.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clusterGateway.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
@@ -45,6 +45,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.eventForwarder.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.eventForwarder.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
@@ -33,6 +33,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.eventForwarder.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventForwarder.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventForwarder.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.eventForwarder.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-control-plane/templates/portal-assistant/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/portal-assistant/deployment.yaml
@@ -32,6 +32,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.portalAssistant.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.portalAssistant.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.portalAssistant.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.portalAssistant.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 12000

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -7,7 +7,7 @@
       "description": "Backstage UI configuration",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "default": {},
           "description": "Affinity rules",
           "required": [],
@@ -1541,6 +1541,16 @@
           },
           "title": "tolerations",
           "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [],
@@ -1552,7 +1562,7 @@
       "description": "Controller Manager configuration - the main controller for OpenChoreo CRDs",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "default": {},
           "description": "Affinity rules for pod scheduling",
           "required": [],
@@ -2366,6 +2376,14 @@
       "additionalProperties": false,
       "description": "Event-forwarder configuration — watches OpenChoreo Kubernetes resources via informers and forwards change-notification webhooks to subscribers (typically Backstage's events plugin) for near-real-time catalog updates.",
       "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Affinity rules for pod scheduling",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "config": {
           "additionalProperties": false,
           "properties": {
@@ -2513,6 +2531,16 @@
           "title": "name",
           "type": "string"
         },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Node selector for pod scheduling",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
+        },
         "podSecurityContext": {
           "additionalProperties": false,
           "properties": {
@@ -2617,6 +2645,16 @@
           ],
           "title": "serviceAccount",
           "type": "object"
+        },
+        "tolerations": {
+          "default": [],
+          "description": "Tolerations for pod scheduling",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tolerations",
+          "type": "array"
         }
       },
       "required": [
@@ -2839,7 +2877,7 @@
       "description": "OpenChoreo API server configuration",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "default": {},
           "description": "Affinity rules",
           "required": [],
@@ -4116,6 +4154,14 @@
       "additionalProperties": false,
       "description": "Optional Portal Assistant chat agent. Disabled by default; enable to opt in.",
       "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Affinity rules for pod scheduling",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "authConfigConfigMap": {
           "default": "",
           "title": "authConfigConfigMap",
@@ -4300,6 +4346,16 @@
           "title": "name",
           "type": "string"
         },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Node selector for pod scheduling",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
+        },
         "replicas": {
           "default": 1,
           "title": "replicas",
@@ -4383,6 +4439,26 @@
           ],
           "title": "service",
           "type": "object"
+        },
+        "tolerations": {
+          "default": [],
+          "description": "Tolerations for pod scheduling",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2655,6 +2655,16 @@
           },
           "title": "tolerations",
           "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3984,6 +3984,15 @@ eventForwarder:
   # @schema
   affinity: {}
 
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []
+
 # @schema
 # type: object
 # description: Optional Portal Assistant chat agent. Disabled by default; enable to opt in.

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -641,6 +641,7 @@ controllerManager:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # description: Affinity rules for pod scheduling
   # default: {}
   # @schema
@@ -2204,6 +2205,7 @@ openchoreoApi:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # description: Affinity rules
   # default: {}
   # @schema
@@ -3060,6 +3062,7 @@ backstage:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # description: Affinity rules
   # default: {}
   # @schema
@@ -3756,6 +3759,15 @@ clusterGateway:
   # @schema
   affinity: {}
 
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []
+
 # @schema
 # type: object
 # additionalProperties: true
@@ -3946,6 +3958,32 @@ eventForwarder:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
 
+  # @schema
+  # type: object
+  # description: Node selector for pod scheduling
+  # additionalProperties:
+  #   type: string
+  # default: {}
+  # @schema
+  nodeSelector: {}
+
+  # @schema
+  # type: array
+  # description: Tolerations for pod scheduling
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  tolerations: []
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Affinity rules for pod scheduling
+  # default: {}
+  # @schema
+  affinity: {}
+
 # @schema
 # type: object
 # description: Optional Portal Assistant chat agent. Disabled by default; enable to opt in.
@@ -4051,3 +4089,38 @@ portalAssistant:
     requests:
       cpu: 100m
       memory: 256Mi
+
+  # @schema
+  # type: object
+  # description: Node selector for pod scheduling
+  # additionalProperties:
+  #   type: string
+  # default: {}
+  # @schema
+  nodeSelector: {}
+
+  # @schema
+  # type: array
+  # description: Tolerations for pod scheduling
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  tolerations: []
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Affinity rules for pod scheduling
+  # default: {}
+  # @schema
+  affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -45,6 +45,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.clusterAgent.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clusterAgent.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -7,7 +7,7 @@
       "description": "Cluster Agent configuration for WebSocket connection to control plane cluster gateway",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "default": {},
           "description": "Affinity rules for pod scheduling",
           "required": [],
@@ -506,6 +506,16 @@
             "type": "object"
           },
           "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
           "type": "array"
         }
       },

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -781,7 +781,17 @@ clusterAgent:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # description: Affinity rules for pod scheduling
   # default: {}
   # @schema
   affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/deployment.yaml
@@ -45,6 +45,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.clusterAgent.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clusterAgent.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-observability-plane/templates/finops-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/finops-agent/deployment.yaml
@@ -40,6 +40,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.finOpsAgent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.finOpsAgent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.finOpsAgent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.finOpsAgent.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 12000

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -30,6 +30,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.observer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.observer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.observer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.observer.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/install/helm/openchoreo-observability-plane/templates/sre-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/sre-agent/deployment.yaml
@@ -34,6 +34,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.rca.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rca.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rca.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rca.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 12000

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -7,7 +7,7 @@
       "description": "Cluster Agent configuration for WebSocket-based communication with the control plane's cluster gateway",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "default": {},
           "description": "Affinity rules for pod scheduling",
           "required": [],
@@ -441,6 +441,16 @@
           },
           "title": "tolerations",
           "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [],
@@ -452,7 +462,7 @@
       "description": "Configuration for the observability plane controller manager that reconciles ObservabilityAlertRules and other CRDs",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "default": {},
           "description": "Affinity rules for pod scheduling",
           "required": [],
@@ -788,6 +798,14 @@
       "additionalProperties": false,
       "description": "FinOps Agent Configuration",
       "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Affinity rules for pod scheduling",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "analysisTimeoutSeconds": {
           "default": 600,
           "description": "Analysis timeout in seconds",
@@ -931,6 +949,16 @@
           "minimum": 1,
           "title": "maxConcurrentAnalyses",
           "type": "integer"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Node selector for pod scheduling",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
         },
         "oauth": {
           "additionalProperties": false,
@@ -1090,6 +1118,26 @@
           "description": "Skip TLS certificate verification for MCP server connections (use for self-signed certs)",
           "title": "tlsInsecureSkipVerify",
           "type": "boolean"
+        },
+        "tolerations": {
+          "default": [],
+          "description": "Tolerations for pod scheduling",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [],
@@ -1265,6 +1313,14 @@
       "additionalProperties": true,
       "description": "OpenChoreo Observer service configuration - REST API that abstracts observability backends for logging, metrics, and tracing via adapters",
       "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Affinity rules for pod scheduling",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "alertStoreBackend": {
           "default": "sqlite",
           "description": "Alert entry storage backend for fired alerts",
@@ -1440,6 +1496,16 @@
           "title": "logsAdapter",
           "type": "object"
         },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Node selector for pod scheduling",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
+        },
         "oauthClientId": {
           "default": "openchoreo-observer-resource-reader-client",
           "description": "OAuth2 client ID used by the Observer when calling the control plane API",
@@ -1603,6 +1669,26 @@
           "title": "service",
           "type": "object"
         },
+        "tolerations": {
+          "default": [],
+          "description": "Tolerations for pod scheduling",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
+        },
         "tracingAdapter": {
           "additionalProperties": false,
           "description": "Configurations for tracing adapter connectivity",
@@ -1633,6 +1719,14 @@
       "additionalProperties": false,
       "description": "AI-powered Root Cause Analysis agent configuration",
       "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Affinity rules for pod scheduling",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "authz": {
           "additionalProperties": false,
           "description": "Authorization configuration for RCA agent",
@@ -1777,6 +1871,16 @@
           "description": "Name of the RCA agent deployment",
           "title": "name",
           "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Node selector for pod scheduling",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
         },
         "oauth": {
           "additionalProperties": false,
@@ -1924,6 +2028,26 @@
           "description": "PVC storage size for SQLite (only used when reportBackend is sqlite)",
           "title": "sqliteStorageSize",
           "type": "string"
+        },
+        "tolerations": {
+          "default": [],
+          "description": "Tolerations for pod scheduling",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "default": [],
+          "description": "Topology spread constraints for pod distribution across failure domains",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -226,6 +226,7 @@ controllerManager:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # description: Affinity rules for pod scheduling
   # default: {}
   # @schema
@@ -661,6 +662,41 @@ observer:
     # @schema
     hostnames: []
 
+  # @schema
+  # type: object
+  # description: Node selector for pod scheduling
+  # additionalProperties:
+  #   type: string
+  # default: {}
+  # @schema
+  nodeSelector: {}
+
+  # @schema
+  # type: array
+  # description: Tolerations for pod scheduling
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  tolerations: []
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Affinity rules for pod scheduling
+  # default: {}
+  # @schema
+  affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []
+
 
 ## Values for local templates
 
@@ -1046,10 +1082,20 @@ clusterAgent:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # description: Affinity rules for pod scheduling
   # default: {}
   # @schema
   affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []
 
 
 # @schema
@@ -1512,6 +1558,41 @@ rca:
   # @schema
   extraEnvs: []
 
+  # @schema
+  # type: object
+  # description: Node selector for pod scheduling
+  # additionalProperties:
+  #   type: string
+  # default: {}
+  # @schema
+  nodeSelector: {}
+
+  # @schema
+  # type: array
+  # description: Tolerations for pod scheduling
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  tolerations: []
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Affinity rules for pod scheduling
+  # default: {}
+  # @schema
+  affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []
+
 # FinOps Agent Configuration
 finOpsAgent:
   # @schema
@@ -1782,3 +1863,38 @@ finOpsAgent:
   #       description: Environment variable value
   # @schema
   extraEnvs: []
+
+  # @schema
+  # type: object
+  # description: Node selector for pod scheduling
+  # additionalProperties:
+  #   type: string
+  # default: {}
+  # @schema
+  nodeSelector: {}
+
+  # @schema
+  # type: array
+  # description: Tolerations for pod scheduling
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  tolerations: []
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # description: Affinity rules for pod scheduling
+  # default: {}
+  # @schema
+  affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for pod distribution across failure domains
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  topologySpreadConstraints: []

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/deployment.yaml
@@ -45,6 +45,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.clusterAgent.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clusterAgent.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -551,6 +551,16 @@
           },
           "title": "tolerations",
           "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for cluster agent pods",
+          "items": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [],

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -464,3 +464,12 @@ clusterAgent:
   # description: Affinity rules for cluster agent pods
   # @schema
   affinity: {}
+
+  # @schema
+  # type: array
+  # description: Topology spread constraints for cluster agent pods
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # @schema
+  topologySpreadConstraints: []


### PR DESCRIPTION
## Purpose

Scheduling controls across the plane Helm charts were uneven. Some deployments (cluster-gateway, cluster-agents) exposed `affinity` but not `topologySpreadConstraints`, and several (observer, sre-agent, finops-agent, portal-assistant, event-forwarder) exposed no scheduling knobs at all. On top of that, most existing `affinity` values were unusable in practice: the generated `values.schema.json` marked them with `additionalProperties: false`, so helm rejected any real affinity rule (e.g. `nodeAffinity`) at install time.

This PR makes `nodeSelector`, `affinity`, `tolerations`, and `topologySpreadConstraints` configurable on all first-party deployments in the control, data, observability, and workflow plane charts, and fixes the schema so affinity values are actually accepted.

## Approach

- Add `topologySpreadConstraints` support to cluster-gateway (control plane) and the cluster-agent deployments in the data, observability, and workflow plane charts
- Add the full scheduling block (`nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`) to observer, sre-agent, finops-agent, and portal-assistant
- Add `nodeSelector`, `affinity`, and `tolerations` to event-forwarder (`topologySpreadConstraints` omitted since its replicas are hardcoded to 1)
- Add `# additionalProperties: true` to all `affinity` schema annotations so the generated schema accepts real affinity rules, matching what cluster-gateway and the workflow-plane agent already declared
- Regenerate `values.schema.json` for all four charts with helm-schema
- All new values default to empty, so existing installs are unaffected unless the values are set

Verified by rendering each chart with `helm template` with node affinity, tolerations, node selectors, and zone/hostname spread constraints set on every touched component, and confirming the fields land on the correct Deployment specs. `helm lint` passes on all four charts.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content