### PR TITLE
fix(controller): poll autoscaled workloads more frequently

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,6 +42,35 @@ const (
 	tlsRouteKind    = "TLSRoute"
 	gatewayAPIGroup = "gateway.networking.k8s.io"
 )
+
+// autoscaledStableInterval is the reconcile interval used for releases whose
+// workload is driven by an external autoscaler (KEDA/HPA). Those workloads
+// change replica count in the data plane without any control-plane event, and
+// the data plane can't be watched, so the reported status is only as fresh as
+// the poll. A short interval keeps the UI roughly in sync with scale up/down
+// instead of lagging by the default stable interval (5m).
+const autoscaledStableInterval = 30 * time.Second
+
+// autoscalerKinds are the resource kinds whose presence in a release means an
+// external autoscaler owns the workload's replica count.
+var autoscalerKinds = map[string]struct{}{
+	"ScaledObject":            {}, // keda.sh
+	"HTTPScaledObject":        {}, // http.keda.sh
+	"HorizontalPodAutoscaler": {}, // autoscaling
+}
+
+// hasAutoscaledWorkload reports whether any rendered resource is an autoscaler,
+// so the release can be polled more frequently to track replica changes.
+func hasAutoscaledWorkload(resources []map[string]any) bool {
+	for _, res := range resources {
+		if kind, ok := res["kind"].(string); ok {
+			if _, isAutoscaler := autoscalerKinds[kind]; isAutoscaler {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // routeKindCompat lists which workload endpoint types each Gateway API route kind
 // may expose. HTTPRoute/GRPCRoute attach to the http and https gateway listeners
@@ -644,6 +674,12 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 			EnvironmentName: releaseBinding.Spec.Environment,
 			TargetPlane:     openchoreov1alpha1.TargetPlaneDataPlane,
 			Resources:       dataPlaneReleaseResources,
+		}
+
+		// Poll autoscaled workloads more frequently so the reported status tracks
+		// KEDA/HPA scale up/down (the data plane can't be watched cross-plane).
+		if hasAutoscaledWorkload(dataPlaneResources) {
+			dataPlaneRelease.Spec.Interval = &metav1.Duration{Duration: autoscaledStableInterval}
 		}
 
 		return controllerutil.SetControllerReference(releaseBinding, dataPlaneRelease, r.Scheme)

--- a/internal/controller/releasebinding/controller_unit_test.go
+++ b/internal/controller/releasebinding/controller_unit_test.go
@@ -231,6 +231,66 @@ func TestMakeObservabilityReleaseName_Format(t *testing.T) {
 	}
 }
 
+func TestHasAutoscaledWorkload(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []map[string]any
+		want      bool
+	}{
+		{
+			name:      "no resources",
+			resources: nil,
+			want:      false,
+		},
+		{
+			name: "plain deployment only",
+			resources: []map[string]any{
+				{"kind": "Deployment"},
+				{"kind": "Service"},
+			},
+			want: false,
+		},
+		{
+			name: "KEDA ScaledObject present",
+			resources: []map[string]any{
+				{"kind": "Deployment"},
+				{"kind": "ScaledObject"},
+			},
+			want: true,
+		},
+		{
+			name: "KEDA HTTPScaledObject present",
+			resources: []map[string]any{
+				{"kind": "HTTPScaledObject"},
+			},
+			want: true,
+		},
+		{
+			name: "HorizontalPodAutoscaler present",
+			resources: []map[string]any{
+				{"kind": "HorizontalPodAutoscaler"},
+			},
+			want: true,
+		},
+		{
+			name: "resource without a string kind is ignored",
+			resources: []map[string]any{
+				{"kind": 123},
+				{"notkind": "ScaledObject"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasAutoscaledWorkload(tt.resources); got != tt.want {
+				t.Errorf("hasAutoscaledWorkload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // ---- generateResourceID tests ----
 
 func TestGenerateResourceID_KindAndName(t *testing.T) {


### PR DESCRIPTION
## Purpose

A component using KEDA (or an HPA) scales its data-plane Deployment up and down without any control-plane event, and the data plane cannot be watched cross-plane (the gateway proxy has no watch verb). The `renderedrelease` controller therefore only observes replica changes on its periodic requeue, and a scaled-to-zero workload is treated as "stable" so it polls on the default 5-minute interval. The result: after KEDA brings pods up (or takes them down), the reported status — and the portal — lags by up to ~5 minutes, so a workload that is actually running keeps showing as "Suspended".

This makes the reported status track scale up/down within tens of seconds instead of minutes, without introducing any cross-plane watch infrastructure.

## Approach

When the `releasebinding` controller renders the data-plane resources, detect whether they include an autoscaler (`ScaledObject`, `HTTPScaledObject`, or `HorizontalPodAutoscaler`). If so, set the rendered `RenderedRelease.Spec.Interval` to 30s. That field already exists and is the sole input to the stable requeue interval, so no changes to the `renderedrelease` controller logic are needed. Non-autoscaled releases are unchanged and keep the 5-minute default.

Detection is by resource `kind` only, so core stays decoupled from KEDA (no new dependency; core has no KEDA references today). The interval applies whether the workload is currently up or scaled to zero, so both scale-up and scale-down are reflected quickly.

Verified end-to-end on a local k3d cluster with a live KEDA HTTP scale-to-zero component: on wake, the ReleaseBinding `ResourcesReady` condition flipped from `ReadyWithSuspendedResources` to `Ready` within ~30s (previously up to 5m).

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

A true event-driven watch of data-plane workloads was considered and rejected as out of scope: the control plane reaches the data plane only through a one-shot HTTP proxy tunnel that returns `501` for `watch=true`, so a real watch would be a new cross-plane streaming project. A 30s poll is the minimal near-live approach; the cost is periodic proxy calls scoped to only the components that opted into autoscaling.

The portal also needs a one-line change so an environment card keeps polling while its deployment is suspended (today it only polls while `NotReady`); that lives in the backstage-plugins repo and will be a separate PR.
