### PR TITLE
fix(controller): block core secrets and serviceaccounts on k8s proxy

### DIFF
--- a/internal/cluster-gateway/validator.go
+++ b/internal/cluster-gateway/validator.go
@@ -12,8 +12,11 @@ import (
 type RequestValidator struct {
 	maxRequestBodySize int64
 	allowedMethods     map[string]bool
-	blockedPaths       []string
-	allowedTargets     map[string]bool
+	// blockedPaths are optional extra substrings blocked by BlockPath.
+	// Sensitive core resources (secrets, serviceaccounts) are blocked via
+	// pathTouchesSensitiveCoreResource so real /api/v1 paths are matched.
+	blockedPaths   []string
+	allowedTargets map[string]bool
 }
 
 type ValidationError struct {
@@ -23,6 +26,13 @@ type ValidationError struct {
 
 func (e *ValidationError) Error() string {
 	return e.Message
+}
+
+// sensitiveCoreResources are core/v1 resource names that must not be reachable
+// through the k8s HTTP proxy (any namespace, including subresources like token).
+var sensitiveCoreResources = map[string]struct{}{
+	"secrets":         {},
+	"serviceaccounts": {},
 }
 
 func NewRequestValidator() *RequestValidator {
@@ -37,10 +47,7 @@ func NewRequestValidator() *RequestValidator {
 			http.MethodHead:    true,
 			http.MethodOptions: true,
 		},
-		blockedPaths: []string{
-			"/api/v1/namespaces/kube-system/secrets",
-			"/apis/v1/serviceaccounts", // Cluster-wide service accounts
-		},
+		blockedPaths: nil,
 		allowedTargets: map[string]bool{
 			"k8s":        true,
 			"monitoring": true,
@@ -61,6 +68,13 @@ func (v *RequestValidator) ValidateRequest(r *http.Request, target, path string)
 		return &ValidationError{
 			Code:    http.StatusForbidden,
 			Message: fmt.Sprintf("Target not allowed: %s", target),
+		}
+	}
+
+	if pathTouchesSensitiveCoreResource(path) {
+		return &ValidationError{
+			Code:    http.StatusForbidden,
+			Message: fmt.Sprintf("Access to path is blocked: %s", path),
 		}
 	}
 
@@ -95,6 +109,34 @@ func (v *RequestValidator) ValidateRequest(r *http.Request, target, path string)
 	}
 
 	return nil
+}
+
+// pathTouchesSensitiveCoreResource reports whether path is a core/v1 request for
+// secrets or serviceaccounts (cluster or namespaced, including subresources).
+// Only /api/v1/... is matched so CRDs under /apis/... are not false-positive blocked.
+func pathTouchesSensitiveCoreResource(path string) bool {
+	parts := strings.Split(path, "/")
+	for i := 0; i < len(parts); i++ {
+		if parts[i] != "api" {
+			continue
+		}
+		if i+1 >= len(parts) || parts[i+1] != "v1" {
+			continue
+		}
+		// /api/v1/<resource>/...
+		if i+2 < len(parts) {
+			if _, ok := sensitiveCoreResources[parts[i+2]]; ok {
+				return true
+			}
+		}
+		// /api/v1/namespaces/<ns>/<resource>/...
+		if i+4 < len(parts) && parts[i+2] == "namespaces" {
+			if _, ok := sensitiveCoreResources[parts[i+4]]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (v *RequestValidator) AllowTarget(target string) {

--- a/internal/cluster-gateway/validator.go
+++ b/internal/cluster-gateway/validator.go
@@ -6,6 +6,7 @@ package clustergateway
 import (
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 )
 
@@ -111,11 +112,14 @@ func (v *RequestValidator) ValidateRequest(r *http.Request, target, path string)
 	return nil
 }
 
-// pathTouchesSensitiveCoreResource reports whether path is a core/v1 request for
+// pathTouchesSensitiveCoreResource reports whether rawPath is a core/v1 request for
 // secrets or serviceaccounts (cluster or namespaced, including subresources).
 // Only /api/v1/... is matched so CRDs under /apis/... are not false-positive blocked.
-func pathTouchesSensitiveCoreResource(path string) bool {
-	parts := strings.Split(path, "/")
+//
+// path.Clean collapses //, /./, and trailing slashes. An optional "watch" segment
+// after /api/v1 is skipped so /api/v1/watch/... is handled the same as list/get.
+func pathTouchesSensitiveCoreResource(rawPath string) bool {
+	parts := strings.Split(path.Clean(rawPath), "/")
 	for i := 0; i < len(parts); i++ {
 		if parts[i] != "api" {
 			continue
@@ -123,15 +127,20 @@ func pathTouchesSensitiveCoreResource(path string) bool {
 		if i+1 >= len(parts) || parts[i+1] != "v1" {
 			continue
 		}
-		// /api/v1/<resource>/...
-		if i+2 < len(parts) {
-			if _, ok := sensitiveCoreResources[parts[i+2]]; ok {
+		// Resource index is right after /api/v1, or after optional /api/v1/watch.
+		resourceIdx := i + 2
+		if resourceIdx < len(parts) && parts[resourceIdx] == "watch" {
+			resourceIdx++
+		}
+		// /api/v1/[watch/]<resource>/...
+		if resourceIdx < len(parts) {
+			if _, ok := sensitiveCoreResources[parts[resourceIdx]]; ok {
 				return true
 			}
 		}
-		// /api/v1/namespaces/<ns>/<resource>/...
-		if i+4 < len(parts) && parts[i+2] == "namespaces" {
-			if _, ok := sensitiveCoreResources[parts[i+4]]; ok {
+		// /api/v1/[watch/]namespaces/<ns>/<resource>/...
+		if resourceIdx+2 < len(parts) && parts[resourceIdx] == "namespaces" {
+			if _, ok := sensitiveCoreResources[parts[resourceIdx+2]]; ok {
 				return true
 			}
 		}

--- a/internal/cluster-gateway/validator_test.go
+++ b/internal/cluster-gateway/validator_test.go
@@ -75,6 +75,15 @@ func TestValidateRequest_SensitiveCoreResources(t *testing.T) {
 		{"namespaced serviceaccounts list", "/api/v1/namespaces/default/serviceaccounts"},
 		{"serviceaccount get", "/api/v1/namespaces/default/serviceaccounts/default"},
 		{"serviceaccount token subresource", "/api/v1/namespaces/default/serviceaccounts/default/token"},
+		// watch form (Kubernetes legacy watch path)
+		{"watch namespaced secrets", "/api/v1/watch/namespaces/default/secrets"},
+		{"watch cluster secrets", "/api/v1/watch/secrets"},
+		{"watch serviceaccounts", "/api/v1/watch/namespaces/default/serviceaccounts"},
+		// path.Clean must collapse these before matching
+		{"double slash secrets", "/api//v1/namespaces/default/secrets"},
+		{"dot segment secrets", "/api/./v1/namespaces/default/secrets"},
+		{"trailing slash secrets", "/api/v1/namespaces/default/secrets/"},
+		{"double slash after api", "//api/v1/namespaces/default/secrets"},
 	}
 
 	for _, tt := range blocked {
@@ -95,6 +104,7 @@ func TestValidateRequest_SensitiveCoreResources(t *testing.T) {
 	}{
 		{"pods", "/api/v1/namespaces/default/pods"},
 		{"events", "/api/v1/namespaces/default/events"},
+		{"watch pods", "/api/v1/watch/namespaces/default/pods"},
 		{"external secrets crd", "/apis/external-secrets.io/v1beta1/namespaces/default/externalsecrets"},
 		{"wrong legacy sa path string still not core api", "/apis/v1/serviceaccounts"},
 	}
@@ -109,11 +119,30 @@ func TestValidateRequest_SensitiveCoreResources(t *testing.T) {
 }
 
 func TestPathTouchesSensitiveCoreResource(t *testing.T) {
-	assert.True(t, pathTouchesSensitiveCoreResource("/api/v1/namespaces/ns/secrets"))
-	assert.True(t, pathTouchesSensitiveCoreResource("/api/v1/serviceaccounts"))
-	assert.False(t, pathTouchesSensitiveCoreResource("/api/v1/namespaces/ns/pods"))
-	assert.False(t, pathTouchesSensitiveCoreResource("/apis/v1/serviceaccounts"))
-	assert.False(t, pathTouchesSensitiveCoreResource("/apis/external-secrets.io/v1/namespaces/ns/externalsecrets"))
+	blocked := []string{
+		"/api/v1/namespaces/ns/secrets",
+		"/api/v1/serviceaccounts",
+		"/api/v1/watch/namespaces/ns/secrets",
+		"/api/v1/watch/secrets",
+		"/api/v1/watch/serviceaccounts",
+		"/api//v1/namespaces/ns/secrets",
+		"/api/./v1/namespaces/ns/secrets",
+		"/api/v1/namespaces/ns/secrets/",
+		"//api/v1/namespaces/ns/secrets",
+	}
+	for _, p := range blocked {
+		assert.Truef(t, pathTouchesSensitiveCoreResource(p), "expected blocked: %s", p)
+	}
+
+	allowed := []string{
+		"/api/v1/namespaces/ns/pods",
+		"/api/v1/watch/namespaces/ns/pods",
+		"/apis/v1/serviceaccounts",
+		"/apis/external-secrets.io/v1/namespaces/ns/externalsecrets",
+	}
+	for _, p := range allowed {
+		assert.Falsef(t, pathTouchesSensitiveCoreResource(p), "expected allowed: %s", p)
+	}
 }
 
 func TestValidateRequest_AllowedTargets(t *testing.T) {

--- a/internal/cluster-gateway/validator_test.go
+++ b/internal/cluster-gateway/validator_test.go
@@ -30,7 +30,7 @@ func TestNewRequestValidator(t *testing.T) {
 		assert.True(t, v.allowedTargets[tgt], "target %s should be allowed", tgt)
 	}
 
-	assert.Len(t, v.blockedPaths, 2)
+	assert.Empty(t, v.blockedPaths)
 }
 
 func TestValidateRequest_AllowedMethods(t *testing.T) {
@@ -61,20 +61,24 @@ func TestValidateRequest_AllowedMethods(t *testing.T) {
 	}
 }
 
-func TestValidateRequest_BlockedPaths(t *testing.T) {
+func TestValidateRequest_SensitiveCoreResources(t *testing.T) {
 	v := NewRequestValidator()
 
-	tests := []struct {
+	blocked := []struct {
 		name string
 		path string
 	}{
+		{"namespaced secrets list", "/api/v1/namespaces/default/secrets"},
+		{"namespaced secret get", "/api/v1/namespaces/openchoreo-control-plane/secrets/my-secret"},
 		{"kube-system secrets", "/api/v1/namespaces/kube-system/secrets"},
-		{"cluster-wide service accounts", "/apis/v1/serviceaccounts"},
-		{"kube-system secrets subpath", "/api/v1/namespaces/kube-system/secrets/my-secret"},
+		{"cluster serviceaccounts list", "/api/v1/serviceaccounts"},
+		{"namespaced serviceaccounts list", "/api/v1/namespaces/default/serviceaccounts"},
+		{"serviceaccount get", "/api/v1/namespaces/default/serviceaccounts/default"},
+		{"serviceaccount token subresource", "/api/v1/namespaces/default/serviceaccounts/default/token"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tt := range blocked {
+		t.Run("blocked_"+tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			err := v.ValidateRequest(req, "k8s", tt.path)
 			require.Error(t, err)
@@ -83,6 +87,33 @@ func TestValidateRequest_BlockedPaths(t *testing.T) {
 			assert.Equal(t, http.StatusForbidden, valErr.Code)
 		})
 	}
+
+	// CRDs under /apis/ must not be blocked by the core secrets/SA check.
+	allowed := []struct {
+		name string
+		path string
+	}{
+		{"pods", "/api/v1/namespaces/default/pods"},
+		{"events", "/api/v1/namespaces/default/events"},
+		{"external secrets crd", "/apis/external-secrets.io/v1beta1/namespaces/default/externalsecrets"},
+		{"wrong legacy sa path string still not core api", "/apis/v1/serviceaccounts"},
+	}
+
+	for _, tt := range allowed {
+		t.Run("allowed_"+tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			err := v.ValidateRequest(req, "k8s", tt.path)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestPathTouchesSensitiveCoreResource(t *testing.T) {
+	assert.True(t, pathTouchesSensitiveCoreResource("/api/v1/namespaces/ns/secrets"))
+	assert.True(t, pathTouchesSensitiveCoreResource("/api/v1/serviceaccounts"))
+	assert.False(t, pathTouchesSensitiveCoreResource("/api/v1/namespaces/ns/pods"))
+	assert.False(t, pathTouchesSensitiveCoreResource("/apis/v1/serviceaccounts"))
+	assert.False(t, pathTouchesSensitiveCoreResource("/apis/external-secrets.io/v1/namespaces/ns/externalsecrets"))
 }
 
 func TestValidateRequest_AllowedTargets(t *testing.T) {


### PR DESCRIPTION
## Purpose
The cluster-gateway k8s proxy denylist was not effective for the sensitive resources it was meant to protect.

ServiceAccount blocking used `/apis/v1/serviceaccounts`, which is not a core API path. Real requests use `/api/v1/serviceaccounts` and `/api/v1/namespaces/{ns}/serviceaccounts`.

Secret blocking only covered the kube-system namespace prefix, so secrets in other namespaces passed validation.

Fixes #4237

## Approach
Replace the brittle substring list for those two resources with a path segment check limited to core `/api/v1` routes. That covers:

- secrets in any namespace (list and get)
- cluster and namespaced serviceaccounts
- the serviceaccount token subresource

CRDs under `/apis/...` are not matched, so things like ExternalSecret CRD paths are not false-positive blocked. The existing `BlockPath` helper still adds extra substring blocks when needed.

Unit tests now use real API paths for blocked cases and assert that non-sensitive core paths and `/apis/...` CRDs still pass.

## Related Issues
- Fixes #4237
- Related: #4168 (internal listener mTLS is complementary; this change hardens path policy)

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
Did not change allowed HTTP methods in this PR. Path policy only.