### PR TITLE
fix(api): pin exec/wirelogs authz to the component's owning project

### DIFF
--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -66,7 +66,7 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	componentName := parts[1]
 
 	query := r.URL.Query()
-	project := query.Get("project")
+	requestedProject := query.Get("project")
 	envName := query.Get("env")
 	container := query.Get("container")
 	podName := query.Get("pod")
@@ -77,6 +77,31 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := h.logger.With("namespace", namespace, "component", componentName)
 	logger.Info("Exec request received", "env", envName, "pod", podName, "container", container)
+
+	// Authorize: check that the caller has component:exec permission for this environment.
+	if h.authzChecker == nil {
+		logger.Error("Authorization checker not configured")
+		http.Error(w, "authorization not configured", http.StatusInternalServerError)
+		return
+	}
+
+	// Pin authorization and pod resolution to the component's real owning project
+	// rather than the caller-supplied `project`.
+	project, err := h.resolveComponentProject(ctx, namespace, componentName)
+	if err != nil {
+		status := http.StatusBadRequest
+		var infraErr *execInfraError
+		if errors.As(err, &infraErr) {
+			status = http.StatusServiceUnavailable
+		}
+		logger.Warn("Failed to resolve component for exec", "error", err)
+		http.Error(w, fmt.Sprintf("failed to resolve component: %v", err), status)
+		return
+	}
+	if requestedProject != "" && requestedProject != project {
+		logger.Warn("requested project does not own the target component; authorizing against the component's owner",
+			"requestedProject", requestedProject, "ownerProject", project)
+	}
 
 	// Resolve the target environment before authorizing so per-environment exec
 	// conditions are evaluated against it (`env` may be omitted by the client).
@@ -92,12 +117,6 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Authorize: check that the caller has component:exec permission for this environment.
-	if h.authzChecker == nil {
-		logger.Error("Authorization checker not configured")
-		http.Error(w, "authorization not configured", http.StatusInternalServerError)
-		return
-	}
 	if err := h.authzChecker.Check(ctx, svcpkg.CheckRequest{
 		Action:       authz.ActionExecComponent,
 		ResourceType: "component",
@@ -105,6 +124,7 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Hierarchy: authz.ResourceHierarchy{
 			Namespace: namespace,
 			Project:   project,
+			Component: componentName,
 		},
 		Context: authz.Context{
 			Resource: authz.ResourceAttribute{
@@ -257,6 +277,21 @@ func (h *ExecHandler) resolveEnvName(ctx context.Context, namespace, project, en
 		return "", fmt.Errorf("--project or --env is required")
 	}
 	return h.resolveLowestEnvironment(ctx, namespace, project)
+}
+
+// resolveComponentProject returns the owning project of the named component.
+func (h *ExecHandler) resolveComponentProject(ctx context.Context, namespace, componentName string) (string, error) {
+	comp := &openchoreov1alpha1.Component{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: componentName}, comp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("component %q not found in namespace %q", componentName, namespace)
+		}
+		return "", infraErrorf("failed to look up component %q: %w", componentName, err)
+	}
+	if comp.Spec.Owner.ProjectName == "" {
+		return "", fmt.Errorf("component %q has no owning project", componentName)
+	}
+	return comp.Spec.Owner.ProjectName, nil
 }
 
 // resolvePod resolves the target pod for exec by traversing:

--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -98,9 +98,13 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to resolve component: %v", err), status)
 		return
 	}
+	// Fail closed if the caller named a project that does not own the component.
+	// The generic forbidden message avoids disclosing the component's real owner.
 	if requestedProject != "" && requestedProject != project {
-		logger.Warn("requested project does not own the target component; authorizing against the component's owner",
+		logger.Warn("requested project does not own the target component; denying exec",
 			"requestedProject", requestedProject, "ownerProject", project)
+		http.Error(w, "you do not have permission to exec into this component", http.StatusForbidden)
+		return
 	}
 
 	// Resolve the target environment before authorizing so per-environment exec

--- a/internal/openchoreo-api/api/handlers/exec_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_test.go
@@ -98,10 +98,11 @@ func TestExecHandler_AuthzEnvironmentContext_DerivedEnv(t *testing.T) {
 		"pipeline-derived environment must reach the ABAC context when env is omitted")
 }
 
-// A caller that names a component owned by another project must be authorized
-// against the component's real owner, not the project supplied in the query
-func TestExecHandler_AuthzPinsComponentOwnerProject(t *testing.T) {
-	pdp := testutil.DenyPDP()
+// A caller that names a component owned by another project must be denied before
+// authorization runs — even under an allowing policy (GHSA-52gf-6rpq-fgmx).
+// victim-svc is owned by team-b; the caller claims team-a.
+func TestExecHandler_DeniesComponentProjectMismatch(t *testing.T) {
+	pdp := testutil.AllowPDP()
 	h := newExecHandler(t, pdp, execComponent("default", "victim-svc", "team-b"))
 
 	req := httptest.NewRequest(http.MethodGet,
@@ -111,10 +112,7 @@ func TestExecHandler_AuthzPinsComponentOwnerProject(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusForbidden, rec.Code)
-	require.Len(t, pdp.Captured, 1)
-	testutil.RequireEvalRequest(t, pdp.Captured[0],
-		authz.ActionExecComponent, "component", "victim-svc",
-		authz.ResourceHierarchy{Namespace: "default", Project: "team-b", Component: "victim-svc"})
+	require.Empty(t, pdp.Captured, "authz must not run when the requested project does not own the component")
 }
 
 // Exec must fail before authorization when the target component does not exist,

--- a/internal/openchoreo-api/api/handlers/exec_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_test.go
@@ -30,13 +30,25 @@ func newExecHandler(t *testing.T, pdp *testutil.CapturingPDP, objs ...client.Obj
 	}
 }
 
+// execComponent builds a minimal Component owned by the given project, enough for
+// the handler to resolve the component's owning project before authorizing.
+func execComponent(namespace, name, project string) *openchoreov1alpha1.Component {
+	return &openchoreov1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: project},
+		},
+	}
+}
+
 // These tests assert the exec authz check carries the target environment in its
-// ABAC context. The fake client has no Component, so the request fails right
-// after the check — but by then the PDP has captured the evaluate request.
+// ABAC context. The component is owned by project "default"; after the authz
+// check the request fails during pod resolution (no Environment/DataPlane
+// seeded) — but by then the PDP has captured the evaluate request.
 
 func TestExecHandler_AuthzEnvironmentContext_ExplicitEnv(t *testing.T) {
 	pdp := testutil.AllowPDP()
-	h := newExecHandler(t, pdp)
+	h := newExecHandler(t, pdp, execComponent("default", "greeter-service", "default"))
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/exec/namespaces/default/components/greeter-service?env=development&project=default",
@@ -46,7 +58,7 @@ func TestExecHandler_AuthzEnvironmentContext_ExplicitEnv(t *testing.T) {
 	require.Len(t, pdp.Captured, 1, "authz check should run before pod resolution")
 	testutil.RequireEvalRequest(t, pdp.Captured[0],
 		authz.ActionExecComponent, "component", "greeter-service",
-		authz.ResourceHierarchy{Namespace: "default", Project: "default"})
+		authz.ResourceHierarchy{Namespace: "default", Project: "default", Component: "greeter-service"})
 	require.Equal(t,
 		services.FormatDualScopedResourceName("default", "development", false),
 		pdp.Captured[0].Context.Resource.Environment)
@@ -72,7 +84,7 @@ func TestExecHandler_AuthzEnvironmentContext_DerivedEnv(t *testing.T) {
 			}},
 		},
 	}
-	h := newExecHandler(t, pdp, proj, pipeline)
+	h := newExecHandler(t, pdp, proj, pipeline, execComponent("default", "greeter-service", "default"))
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/exec/namespaces/default/components/greeter-service?project=default",
@@ -84,4 +96,40 @@ func TestExecHandler_AuthzEnvironmentContext_DerivedEnv(t *testing.T) {
 		services.FormatDualScopedResourceName("default", "development", false),
 		pdp.Captured[0].Context.Resource.Environment,
 		"pipeline-derived environment must reach the ABAC context when env is omitted")
+}
+
+// A caller that names a component owned by another project must be authorized
+// against the component's real owner, not the project supplied in the query
+func TestExecHandler_AuthzPinsComponentOwnerProject(t *testing.T) {
+	pdp := testutil.DenyPDP()
+	h := newExecHandler(t, pdp, execComponent("default", "victim-svc", "team-b"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/victim-svc?env=development&project=team-a",
+		nil).WithContext(testutil.AuthzContext())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Len(t, pdp.Captured, 1)
+	testutil.RequireEvalRequest(t, pdp.Captured[0],
+		authz.ActionExecComponent, "component", "victim-svc",
+		authz.ResourceHierarchy{Namespace: "default", Project: "team-b", Component: "victim-svc"})
+}
+
+// Exec must fail before authorization when the target component does not exist,
+// so component existence — not a caller-supplied project — drives the decision.
+func TestExecHandler_ComponentNotFound(t *testing.T) {
+	pdp := testutil.AllowPDP()
+	h := newExecHandler(t, pdp) // no component seeded
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/ghost?env=development&project=default",
+		nil).WithContext(testutil.AuthzContext())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), `component "ghost" not found`)
+	require.Empty(t, pdp.Captured, "authz must not run for a non-existent component")
 }

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -120,6 +121,18 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "authorization not configured", http.StatusInternalServerError)
 		return
 	}
+
+	if component != "" {
+		ownerProject, err := h.resolveComponentProject(ctx, logger, namespace, component, project)
+		if err != nil {
+			logger.Warn("Failed to resolve component for wirelogs", "error", err)
+			http.Error(w, fmt.Sprintf("failed to resolve component: %v", err), http.StatusBadRequest)
+			return
+		}
+		project = ownerProject
+		logger = logger.With("project", project)
+	}
+
 	if err := h.authzChecker.Check(ctx, wirelogsCheckRequest(namespace, environment, project, component)); err != nil {
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			http.Error(w, "you do not have permission to view wirelogs for this scope", http.StatusForbidden)
@@ -259,6 +272,26 @@ func wirelogsCheckRequest(namespace, environment, project, component string) svc
 			Context:      authzCtx,
 		}
 	}
+}
+
+// resolveComponentProject returns the owning project of the named component.
+func (h *WirelogsHandler) resolveComponentProject(ctx context.Context, logger *slog.Logger, namespace, component, requestedProject string) (string, error) {
+	comp := &openchoreov1alpha1.Component{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: component}, comp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("component %q not found in namespace %q", component, namespace)
+		}
+		return "", fmt.Errorf("failed to look up component %q: %w", component, err)
+	}
+	owner := comp.Spec.Owner.ProjectName
+	if owner == "" {
+		return "", fmt.Errorf("component %q has no owning project", component)
+	}
+	if requestedProject != "" && requestedProject != owner {
+		logger.Warn("requested project does not own the target component; authorizing against the component's owner",
+			"requestedProject", requestedProject, "ownerProject", owner)
+	}
+	return owner, nil
 }
 
 // resolvePlane resolves the data plane for an environment.

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -149,6 +149,12 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.proxyWirelogsStream(ctx, w, logger, namespace, environment, project, component)
+}
+
+// proxyWirelogsStream resolves the target data plane and proxies the gateway's
+// SSE stream to the client.
+func (h *WirelogsHandler) proxyWirelogsStream(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, namespace, environment, project, component string) {
 	plane, err := h.resolvePlane(ctx, namespace, environment)
 	if err != nil {
 		logger.Error("Failed to resolve data plane for wirelogs", "error", err)

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -122,15 +122,21 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When a component filter is supplied, require it to be owned by the requested
+	// project and authorize against the component's real owning project.
 	if component != "" {
-		ownerProject, err := h.resolveComponentProject(ctx, logger, namespace, component, project)
+		ownerProject, err := h.resolveComponentProject(ctx, namespace, component)
 		if err != nil {
 			logger.Warn("Failed to resolve component for wirelogs", "error", err)
 			http.Error(w, fmt.Sprintf("failed to resolve component: %v", err), http.StatusBadRequest)
 			return
 		}
-		project = ownerProject
-		logger = logger.With("project", project)
+		if ownerProject != project {
+			logger.Warn("requested project does not own the target component; denying",
+				"requestedProject", project, "ownerProject", ownerProject)
+			http.Error(w, "you do not have permission to view wirelogs for this scope", http.StatusForbidden)
+			return
+		}
 	}
 
 	if err := h.authzChecker.Check(ctx, wirelogsCheckRequest(namespace, environment, project, component)); err != nil {
@@ -275,7 +281,7 @@ func wirelogsCheckRequest(namespace, environment, project, component string) svc
 }
 
 // resolveComponentProject returns the owning project of the named component.
-func (h *WirelogsHandler) resolveComponentProject(ctx context.Context, logger *slog.Logger, namespace, component, requestedProject string) (string, error) {
+func (h *WirelogsHandler) resolveComponentProject(ctx context.Context, namespace, component string) (string, error) {
 	comp := &openchoreov1alpha1.Component{}
 	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: component}, comp); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -283,15 +289,10 @@ func (h *WirelogsHandler) resolveComponentProject(ctx context.Context, logger *s
 		}
 		return "", fmt.Errorf("failed to look up component %q: %w", component, err)
 	}
-	owner := comp.Spec.Owner.ProjectName
-	if owner == "" {
+	if comp.Spec.Owner.ProjectName == "" {
 		return "", fmt.Errorf("component %q has no owning project", component)
 	}
-	if requestedProject != "" && requestedProject != owner {
-		logger.Warn("requested project does not own the target component; authorizing against the component's owner",
-			"requestedProject", requestedProject, "ownerProject", owner)
-	}
-	return owner, nil
+	return comp.Spec.Owner.ProjectName, nil
 }
 
 // resolvePlane resolves the data plane for an environment.

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -103,6 +103,7 @@ func TestWirelogsHandler_Forbidden(t *testing.T) {
 		Return(&authz.Decision{Decision: false, Context: &authz.DecisionContext{Reason: "no wirelogs:view"}}, nil)
 
 	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, wirelogsComponent("ns-a", "checkout", "demo")),
 		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
 		logger:       slog.Default(),
 	}
@@ -113,9 +114,21 @@ func TestWirelogsHandler_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+// wirelogsComponent builds a minimal Component owned by the given project, enough
+// for the handler to resolve the component's owning project before authorizing.
+func wirelogsComponent(namespace, name, project string) *openchoreov1alpha1.Component {
+	return &openchoreov1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: project},
+		},
+	}
+}
+
 // captureAuthzRequest runs ServeHTTP with a PDP that records the EvaluateRequest
 // and denies, so the handler returns 403 before doing any data-plane lookups.
-func captureAuthzRequest(t *testing.T, path string) *authz.EvaluateRequest {
+// Seed any Component objects a component-filtered request needs to resolve.
+func captureAuthzRequest(t *testing.T, path string, objs ...client.Object) *authz.EvaluateRequest {
 	t.Helper()
 
 	var captured *authz.EvaluateRequest
@@ -128,6 +141,7 @@ func captureAuthzRequest(t *testing.T, path string) *authz.EvaluateRequest {
 		})
 
 	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, objs...),
 		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
 		logger:       slog.Default(),
 	}
@@ -141,7 +155,9 @@ func captureAuthzRequest(t *testing.T, path string) *authz.EvaluateRequest {
 }
 
 func TestWirelogsHandler_AuthzScope_Component(t *testing.T) {
-	req := captureAuthzRequest(t, "/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout")
+	req := captureAuthzRequest(t,
+		"/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo&component=checkout",
+		wirelogsComponent("ns-a", "checkout", "demo"))
 
 	assert.Equal(t, authz.ActionViewWirelogs, req.Action, "wirelogs must check its own action, not logs:view")
 	assert.Equal(t, "component", req.Resource.Type)
@@ -151,6 +167,39 @@ func TestWirelogsHandler_AuthzScope_Component(t *testing.T) {
 	assert.Equal(t, "checkout", req.Resource.Hierarchy.Component)
 	assert.Equal(t, "ns-a/development", req.Context.Resource.Environment,
 		"resource.environment must always be set so CEL conditions can scope per env")
+}
+
+// A component filter must be authorized against the component's real owning
+// project, not the caller-supplied `project`.
+func TestWirelogsHandler_AuthzPinsComponentOwnerProject(t *testing.T) {
+	req := captureAuthzRequest(t,
+		"/api/v1/namespaces/ns-a/environments/development/wirelogs?project=team-a&component=checkout",
+		wirelogsComponent("ns-a", "checkout", "team-b"))
+
+	assert.Equal(t, authz.ActionViewWirelogs, req.Action)
+	assert.Equal(t, "component", req.Resource.Type)
+	assert.Equal(t, "checkout", req.Resource.ID)
+	assert.Equal(t, "ns-a", req.Resource.Hierarchy.Namespace)
+	assert.Equal(t, "team-b", req.Resource.Hierarchy.Project,
+		"authz must be scoped to the component's real owner, not the caller-supplied project")
+	assert.Equal(t, "checkout", req.Resource.Hierarchy.Component)
+}
+
+// A component filter naming a non-existent component must fail before authz.
+func TestWirelogsHandler_ComponentNotFound(t *testing.T) {
+	pdp := authzmocks.NewMockPDP(t)
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t),
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t,
+		"/api/v1/namespaces/ns-a/environments/development/wirelogs?project=demo&component=ghost"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `component "ghost" not found`)
 }
 
 func TestWirelogsHandler_AuthzScope_ProjectOnly(t *testing.T) {

--- a/internal/openchoreo-api/api/handlers/wirelogs_test.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs_test.go
@@ -169,20 +169,24 @@ func TestWirelogsHandler_AuthzScope_Component(t *testing.T) {
 		"resource.environment must always be set so CEL conditions can scope per env")
 }
 
-// A component filter must be authorized against the component's real owning
-// project, not the caller-supplied `project`.
-func TestWirelogsHandler_AuthzPinsComponentOwnerProject(t *testing.T) {
-	req := captureAuthzRequest(t,
-		"/api/v1/namespaces/ns-a/environments/development/wirelogs?project=team-a&component=checkout",
-		wirelogsComponent("ns-a", "checkout", "team-b"))
+// A component filter naming a project that does not own the component must be
+// denied before authorization runs (GHSA-52gf-6rpq-fgmx). checkout is owned by
+// team-b; the caller claims team-a.
+func TestWirelogsHandler_DeniesComponentProjectMismatch(t *testing.T) {
+	// No Evaluate expectation → the mock fails the test if authz is reached.
+	pdp := authzmocks.NewMockPDP(t)
+	h := &WirelogsHandler{
+		k8sClient:    newWirelogsK8sClient(t, wirelogsComponent("ns-a", "checkout", "team-b")),
+		authzChecker: svcpkg.NewAuthzChecker(pdp, slog.Default()),
+		logger:       slog.Default(),
+	}
 
-	assert.Equal(t, authz.ActionViewWirelogs, req.Action)
-	assert.Equal(t, "component", req.Resource.Type)
-	assert.Equal(t, "checkout", req.Resource.ID)
-	assert.Equal(t, "ns-a", req.Resource.Hierarchy.Namespace)
-	assert.Equal(t, "team-b", req.Resource.Hierarchy.Project,
-		"authz must be scoped to the component's real owner, not the caller-supplied project")
-	assert.Equal(t, "checkout", req.Resource.Hierarchy.Component)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, wirelogsRequest(t,
+		"/api/v1/namespaces/ns-a/environments/development/wirelogs?project=team-a&component=checkout"))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "you do not have permission")
 }
 
 // A component filter naming a non-existent component must fail before authz.


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The exec and wirelogs handlers authorized requests against the caller-supplied project query parameter while resolving the target component by name only. Because the Casbin PDP decides purely from the resource hierarchy and ignores the resource ID, a caller holding a project-scoped grant on one project could exec into — and read the wirelogs of — components owned by other projects in the same namespace.

Both handlers now resolve the component first and derive the owning project from comp.Spec.Owner.ProjectName, using it for the authorization check (and for the Hubble flow filter / pod resolution) instead of trusting caller input. This matches the established fetch-then-authorize pattern in services/component. A caller-supplied project that differs from the real owner is logged for audit but does not change the decision.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
