### PR TITLE
feat: support tls certicate from a defined header in cluster gateway

### DIFF
--- a/cmd/cluster-gateway/main.go
+++ b/cmd/cluster-gateway/main.go
@@ -41,18 +41,20 @@ func init() {
 
 func main() {
 	var (
-		port                 int
-		internalPort         int
-		serverCertPath       string
-		serverKeyPath        string
-		skipClientCertVerify bool
-		readTimeout          time.Duration
-		writeTimeout         time.Duration
-		idleTimeout          time.Duration
-		shutdownTimeout      time.Duration
-		heartbeatInterval    time.Duration
-		heartbeatTimeout     time.Duration
-		logLevel             string
+		port                  int
+		internalPort          int
+		serverCertPath        string
+		serverKeyPath         string
+		skipClientCertVerify  bool
+		readTimeout           time.Duration
+		writeTimeout          time.Duration
+		idleTimeout           time.Duration
+		shutdownTimeout       time.Duration
+		heartbeatInterval     time.Duration
+		heartbeatTimeout      time.Duration
+		logLevel              string
+		trustClientCertHeader bool
+		clientCertHeaderName  string
 	)
 
 	flag.IntVar(&port, "port", cmdutil.GetEnvInt("AGENT_SERVER_PORT", defaultPort),
@@ -76,6 +78,14 @@ func main() {
 	flag.DurationVar(&heartbeatInterval, "heartbeat-interval", defaultHeartbeatInterval, "Heartbeat ping interval")
 	flag.DurationVar(&heartbeatTimeout, "heartbeat-timeout", defaultHeartbeatTimeout, "Heartbeat timeout duration")
 	flag.StringVar(&logLevel, "log-level", cmdutil.GetEnv("LOG_LEVEL", "info"), "Log level (debug, info, warn, error)")
+	flag.BoolVar(&trustClientCertHeader, "trust-client-cert-header",
+		cmdutil.GetEnvBool("TRUST_CLIENT_CERT_HEADER", false),
+		"Fall back to a header for the agent client certificate when the TLS handshake carries none "+
+			"(for deployments behind a TLS-terminating L7 load balancer). Only enable this when the public "+
+			"listener is unreachable except through that load balancer.")
+	flag.StringVar(&clientCertHeaderName, "client-cert-header-name",
+		cmdutil.GetEnv("CLIENT_CERT_HEADER_NAME", "X-Client-Cert"),
+		"HTTP header carrying the base64-encoded PEM client certificate, used when -trust-client-cert-header is set")
 	flag.Parse()
 
 	logger := cmdutil.SetupLogger(logLevel)
@@ -89,6 +99,14 @@ func main() {
 		"heartbeatTimeout", heartbeatTimeout,
 		"note", "Client CA certificates are loaded dynamically from DataPlane/WorkflowPlane/ObservabilityPlane CRs",
 	)
+
+	if trustClientCertHeader {
+		logger.Warn("trust-client-cert-header is enabled: the public listener will accept a client "+
+			"certificate from an HTTP header when the TLS handshake carries none. Ensure the public "+
+			"listener is unreachable except through the trusted load balancer that sets this header.",
+			"header", clientCertHeaderName,
+		)
+	}
 
 	// Create Kubernetes client for querying DataPlane/WorkflowPlane/ObservabilityPlane CRs
 	k8sConfig, err := ctrl.GetConfig()
@@ -106,17 +124,19 @@ func main() {
 	logger.Info("Kubernetes client created successfully")
 
 	config := &clustergateway.Config{
-		Port:                 port,
-		InternalPort:         internalPort,
-		ServerCertPath:       serverCertPath,
-		ServerKeyPath:        serverKeyPath,
-		SkipClientCertVerify: skipClientCertVerify,
-		ReadTimeout:          readTimeout,
-		WriteTimeout:         writeTimeout,
-		IdleTimeout:          idleTimeout,
-		ShutdownTimeout:      shutdownTimeout,
-		HeartbeatInterval:    heartbeatInterval,
-		HeartbeatTimeout:     heartbeatTimeout,
+		Port:                  port,
+		InternalPort:          internalPort,
+		ServerCertPath:        serverCertPath,
+		ServerKeyPath:         serverKeyPath,
+		SkipClientCertVerify:  skipClientCertVerify,
+		ReadTimeout:           readTimeout,
+		WriteTimeout:          writeTimeout,
+		IdleTimeout:           idleTimeout,
+		ShutdownTimeout:       shutdownTimeout,
+		HeartbeatInterval:     heartbeatInterval,
+		HeartbeatTimeout:      heartbeatTimeout,
+		TrustClientCertHeader: trustClientCertHeader,
+		ClientCertHeaderName:  clientCertHeaderName,
 	}
 
 	srv := clustergateway.New(config, k8sClient, logger)

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -62,6 +62,8 @@ spec:
         - --heartbeat-interval={{ .Values.clusterGateway.heartbeatInterval }}
         - --heartbeat-timeout={{ .Values.clusterGateway.heartbeatTimeout }}
         - --skip-client-cert-verify={{ .Values.clusterGateway.tls.skipClientCertVerify }}
+        - --trust-client-cert-header={{ .Values.clusterGateway.tls.trustClientCertHeader }}
+        - --client-cert-header-name={{ .Values.clusterGateway.tls.clientCertHeaderName }}
         - --log-level={{ .Values.clusterGateway.logLevel }}
         ports:
         - name: websocket

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1439,6 +1439,12 @@
           "additionalProperties": true,
           "description": "TLS configuration using cert-manager",
           "properties": {
+            "clientCertHeaderName": {
+              "default": "X-Client-Cert",
+              "description": "HTTP header carrying the base64-encoded PEM client certificate, used when trustClientCertHeader is true",
+              "title": "clientCertHeaderName",
+              "type": "string"
+            },
             "dnsNames": {
               "description": "DNS names for the certificate",
               "items": {
@@ -1500,6 +1506,12 @@
               "default": false,
               "description": "Skip client certificate verification for agent connections (for single-cluster setups without mTLS)",
               "title": "skipClientCertVerify",
+              "type": "boolean"
+            },
+            "trustClientCertHeader": {
+              "default": false,
+              "description": "Trust a header for the agent's client certificate when the TLS handshake carries none, for deployments where a TLS-terminating L7 load balancer sits in front of the public listener. Only enable this when that listener is unreachable except through the trusted load balancer, since the header is trusted verbatim.",
+              "title": "trustClientCertHeader",
               "type": "boolean"
             }
           },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3579,6 +3579,21 @@ clusterGateway:
     # default: false
     # @schema
     skipClientCertVerify: false
+    # @schema
+    # type: boolean
+    # description: Trust a header for the agent's client certificate when the TLS handshake carries none, for
+    #   deployments where a TLS-terminating L7 load balancer sits in front of the public listener. Only enable
+    #   this when that listener is unreachable except through the trusted load balancer, since the header is
+    #   trusted verbatim.
+    # default: false
+    # @schema
+    trustClientCertHeader: false
+    # @schema
+    # type: string
+    # description: HTTP header carrying the base64-encoded PEM client certificate, used when trustClientCertHeader is true
+    # default: X-Client-Cert
+    # @schema
+    clientCertHeaderName: X-Client-Cert
     # type: object
     # description: cert-manager issuer reference
     # @schema

--- a/internal/cluster-gateway/config.go
+++ b/internal/cluster-gateway/config.go
@@ -18,6 +18,24 @@ type Config struct {
 	ShutdownTimeout      time.Duration
 	HeartbeatInterval    time.Duration
 	HeartbeatTimeout     time.Duration
+
+	// TrustClientCertHeader enables falling back to a caller-supplied HTTP header for the
+	// agent's client certificate when the TLS handshake itself carries none. This is for
+	// deployments where a TLS-terminating L7 load balancer sits in front of the public
+	// listener and forwards the certificate it received from the agent as a header instead
+	// of passing the TLS session through untouched.
+	//
+	// This is a network-trust decision, not an application-layer one: the header is trusted
+	// verbatim, so it MUST only be enabled when the gateway's public listener is unreachable
+	// except through the load balancer (e.g. via NetworkPolicy or security group rules).
+	// Anyone who can reach the listener directly can set this header to impersonate any agent.
+	TrustClientCertHeader bool
+
+	// ClientCertHeaderName is the HTTP header the load balancer is expected to populate with
+	// the client certificate when TrustClientCertHeader is enabled. The value must be the
+	// standard base64 encoding of one or more concatenated PEM-encoded certificates (leaf
+	// first, followed by any intermediates).
+	ClientCertHeaderName string
 }
 
 // RemoteServerClientConfig holds configuration for RemoteServerClient

--- a/internal/cluster-gateway/header_cert.go
+++ b/internal/cluster-gateway/header_cert.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustergateway
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+)
+
+// extractClientCertFromHeader parses the agent's client certificate out of an HTTP header
+// instead of the TLS handshake. It is used when a TLS-terminating load balancer sits in
+// front of the public listener and forwards the certificate it received from the agent.
+//
+// The header value must be the standard base64 encoding of one or more concatenated
+// PEM-encoded certificates: the leaf certificate first, followed by any intermediates.
+func extractClientCertFromHeader(r *http.Request, headerName string) (*x509.Certificate, []*x509.Certificate, error) {
+	headerValue := r.Header.Get(headerName)
+	if headerValue == "" {
+		return nil, nil, fmt.Errorf("header %q is empty", headerName)
+	}
+
+	pemData, err := base64.StdEncoding.DecodeString(headerValue)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to base64-decode header %q: %w", headerName, err)
+	}
+
+	var certs []*x509.Certificate
+	rest := pemData
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse certificate from header %q: %w", headerName, err)
+		}
+		certs = append(certs, cert)
+	}
+
+	if len(certs) == 0 {
+		return nil, nil, fmt.Errorf("no PEM-encoded certificate found in header %q", headerName)
+	}
+
+	return certs[0], certs[1:], nil
+}

--- a/internal/cluster-gateway/header_cert_test.go
+++ b/internal/cluster-gateway/header_cert_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustergateway
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractClientCertFromHeader_Success(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	clientCert := generateTestClientCert(t, caCert, caKey)
+	headerValue := base64.StdEncoding.EncodeToString(encodeCertToPEM(t, clientCert))
+
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("X-Client-Cert", headerValue)
+
+	leaf, intermediates, err := extractClientCertFromHeader(r, "X-Client-Cert")
+	require.NoError(t, err)
+	assert.Equal(t, clientCert.Raw, leaf.Raw)
+	assert.Empty(t, intermediates)
+}
+
+func TestExtractClientCertFromHeader_LeafAndIntermediate(t *testing.T) {
+	rootCA, rootKey := generateTestCA(t)
+	clientCert := generateTestClientCert(t, rootCA, rootKey)
+
+	headerValue := base64.StdEncoding.EncodeToString(
+		append(encodeCertToPEM(t, clientCert), encodeCertToPEM(t, rootCA)...),
+	)
+
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("X-Client-Cert", headerValue)
+
+	leaf, intermediates, err := extractClientCertFromHeader(r, "X-Client-Cert")
+	require.NoError(t, err)
+	assert.Equal(t, clientCert.Raw, leaf.Raw)
+	require.Len(t, intermediates, 1)
+	assert.Equal(t, rootCA.Raw, intermediates[0].Raw)
+}
+
+func TestExtractClientCertFromHeader_MissingHeader(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+
+	_, _, err := extractClientCertFromHeader(r, "X-Client-Cert")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestExtractClientCertFromHeader_InvalidBase64(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("X-Client-Cert", "not-valid-base64!!!")
+
+	_, _, err := extractClientCertFromHeader(r, "X-Client-Cert")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base64-decode")
+}
+
+func TestExtractClientCertFromHeader_NoCertInPEM(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("X-Client-Cert", base64.StdEncoding.EncodeToString([]byte("not a pem block")))
+
+	_, _, err := extractClientCertFromHeader(r, "X-Client-Cert")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PEM-encoded certificate")
+}

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -275,8 +275,34 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract client certificate for per-CR validation
-	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+	// Extract client certificate for per-CR validation. Ordinarily this comes from the TLS
+	// handshake. If the public listener sits behind a TLS-terminating L7 load balancer, the
+	// handshake the gateway sees is between it and the load balancer, not the agent, so
+	// r.TLS.PeerCertificates will be empty; in that case fall back to a header the load
+	// balancer is configured to forward the agent's certificate in.
+	var clientCert *x509.Certificate
+	var intermediates []*x509.Certificate
+
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		peerCerts := r.TLS.PeerCertificates
+		clientCert = peerCerts[0]
+		intermediates = peerCerts[1:]
+	} else if s.config.TrustClientCertHeader {
+		var err error
+		clientCert, intermediates, err = extractClientCertFromHeader(r, s.config.ClientCertHeaderName)
+		if err != nil {
+			s.logger.Warn("connection rejected: failed to extract client certificate from header",
+				"planeType", planeType,
+				"planeID", planeID,
+				"header", s.config.ClientCertHeaderName,
+				"error", err,
+			)
+			http.Error(w, "no valid client certificate presented", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	if clientCert == nil {
 		s.logger.Warn("connection rejected: no client certificate presented",
 			"planeType", planeType,
 			"planeID", planeID,
@@ -284,10 +310,6 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no client certificate presented", http.StatusUnauthorized)
 		return
 	}
-
-	peerCerts := r.TLS.PeerCertificates
-	clientCert := peerCerts[0]
-	intermediates := peerCerts[1:]
 
 	// Per-CR certificate validation enforces security boundaries
 	// Each CR is validated independently to prevent cross-tenant access

--- a/internal/cluster-gateway/server_test.go
+++ b/internal/cluster-gateway/server_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -553,6 +554,104 @@ func TestVerifyClientCertificatePerCR_WithIntermediates(t *testing.T) {
 	validCRs, err := s.verifyClientCertificatePerCR(clientCert, []*x509.Certificate{intermediateCert}, "dataplane", "prod")
 	require.NoError(t, err)
 	assert.Contains(t, validCRs, "ns/dp1")
+}
+
+// --- handleWebSocket header-fallback tests ---
+
+func TestHandleWebSocket_HeaderFallback_DisabledByDefault(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	clientCert := generateTestClientCert(t, caCert, caKey)
+	headerValue := base64.StdEncoding.EncodeToString(encodeCertToPEM(t, clientCert))
+
+	scheme := testScheme()
+	dp := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp1", Namespace: "ns"},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			PlaneID: "prod",
+			ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+				ClientCA: openchoreov1alpha1.ValueFrom{Value: string(encodeCertToPEM(t, caCert))},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dp).Build()
+
+	// TrustClientCertHeader left unset (false): the header must be ignored even though it
+	// carries a certificate that would otherwise validate against the DataPlane's CA.
+	s := New(&Config{ClientCertHeaderName: "X-Client-Cert"}, fakeClient, testLogger())
+
+	r := httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil)
+	r.Header.Set("X-Client-Cert", headerValue)
+	w := httptest.NewRecorder()
+
+	s.handleWebSocket(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "no client certificate presented")
+}
+
+func TestHandleWebSocket_HeaderFallback_EnabledButNoHeader(t *testing.T) {
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := New(&Config{TrustClientCertHeader: true, ClientCertHeaderName: "X-Client-Cert"}, fakeClient, testLogger())
+
+	r := httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil)
+	w := httptest.NewRecorder()
+
+	s.handleWebSocket(w, r)
+
+	// With TrustClientCertHeader enabled, an absent header is treated as an invalid header
+	// value (extractClientCertFromHeader errors on the empty header), not as "no cert at all".
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "no valid client certificate presented")
+}
+
+func TestHandleWebSocket_HeaderFallback_EnabledWithInvalidHeader(t *testing.T) {
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := New(&Config{TrustClientCertHeader: true, ClientCertHeaderName: "X-Client-Cert"}, fakeClient, testLogger())
+
+	r := httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil)
+	r.Header.Set("X-Client-Cert", "not-valid-base64!!!")
+	w := httptest.NewRecorder()
+
+	s.handleWebSocket(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "no valid client certificate presented")
+}
+
+func TestHandleWebSocket_HeaderFallback_EnabledWithValidHeaderPassesCertGate(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	clientCert := generateTestClientCert(t, caCert, caKey)
+	headerValue := base64.StdEncoding.EncodeToString(encodeCertToPEM(t, clientCert))
+
+	scheme := testScheme()
+	dp := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp1", Namespace: "ns"},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			PlaneID: "prod",
+			ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+				ClientCA: openchoreov1alpha1.ValueFrom{Value: string(encodeCertToPEM(t, caCert))},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dp).Build()
+	s := New(&Config{TrustClientCertHeader: true, ClientCertHeaderName: "X-Client-Cert"}, fakeClient, testLogger())
+
+	r := httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil)
+	r.Header.Set("X-Client-Cert", headerValue)
+	w := httptest.NewRecorder()
+
+	s.handleWebSocket(w, r)
+
+	// httptest.ResponseRecorder doesn't support hijacking, so the WebSocket upgrade itself
+	// cannot succeed here. What this asserts is that the certificate gate was passed and
+	// per-CR validation matched the DataPlane's CA — i.e. the request got past the
+	// "no client certificate presented" / "no valid client certificate presented" rejections
+	// that the two tests above cover.
+	require.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotContains(t, w.Body.String(), "no client certificate presented")
+	assert.NotContains(t, w.Body.String(), "no valid client certificate presented")
 }
 
 // --- handleHTTPProxy expanded tests ---


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Currently cluster gateway need to get the TLS certificate directly without termination. 

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
