### PR TITLE
feat: add mtls to cluster gateway communication from internal components

### DIFF
--- a/cmd/cluster-gateway/main.go
+++ b/cmd/cluster-gateway/main.go
@@ -46,6 +46,8 @@ func main() {
 		serverCertPath       string
 		serverKeyPath        string
 		skipClientCertVerify bool
+		internalMTLS         bool
+		internalClientCAPath string
 		readTimeout          time.Duration
 		writeTimeout         time.Duration
 		idleTimeout          time.Duration
@@ -68,7 +70,14 @@ func main() {
 		"Path to server private key")
 	flag.BoolVar(&skipClientCertVerify, "skip-client-cert-verify",
 		cmdutil.GetEnvBool("SKIP_CLIENT_CERT_VERIFY", false),
-		"Skip client certificate verification (for single-cluster setups without mTLS)")
+		"Deprecated: has no effect. Agent certificates are always verified per plane CR; "+
+			"use --internal-mtls to control internal API verification")
+	flag.BoolVar(&internalMTLS, "internal-mtls",
+		cmdutil.GetEnvBool("INTERNAL_MTLS_ENABLED", false),
+		"Require and verify client certificates on the internal API listener (/api/*)")
+	flag.StringVar(&internalClientCAPath, "internal-client-ca-cert",
+		cmdutil.GetEnv("INTERNAL_CLIENT_CA_PATH", ""),
+		"Path to the CA bundle used to verify internal API clients (required when --internal-mtls is enabled)")
 	flag.DurationVar(&readTimeout, "read-timeout", defaultReadTimeout, "HTTP read timeout")
 	flag.DurationVar(&writeTimeout, "write-timeout", defaultWriteTimeout, "HTTP write timeout")
 	flag.DurationVar(&idleTimeout, "idle-timeout", defaultIdleTimeout, "HTTP idle timeout")
@@ -85,10 +94,19 @@ func main() {
 		"internalPort", internalPort,
 		"serverCert", serverCertPath,
 		"serverKey", serverKeyPath,
+		"internalMTLS", internalMTLS,
+		"internalClientCA", internalClientCAPath,
 		"heartbeatInterval", heartbeatInterval,
 		"heartbeatTimeout", heartbeatTimeout,
 		"note", "Client CA certificates are loaded dynamically from DataPlane/WorkflowPlane/ObservabilityPlane CRs",
 	)
+
+	if skipClientCertVerify {
+		logger.Warn("--skip-client-cert-verify is deprecated and has no effect",
+			"note", "agent certificates are always verified per plane CR; "+
+				"use --internal-mtls=false to disable internal API verification",
+		)
+	}
 
 	// Create Kubernetes client for querying DataPlane/WorkflowPlane/ObservabilityPlane CRs
 	k8sConfig, err := ctrl.GetConfig()
@@ -111,6 +129,8 @@ func main() {
 		ServerCertPath:       serverCertPath,
 		ServerKeyPath:        serverKeyPath,
 		SkipClientCertVerify: skipClientCertVerify,
+		InternalMTLSEnabled:  internalMTLS,
+		InternalClientCAPath: internalClientCAPath,
 		ReadTimeout:          readTimeout,
 		WriteTimeout:         writeTimeout,
 		IdleTimeout:          idleTimeout,

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -52,7 +52,12 @@ spec:
         - --server-key=/certs/tls.key
         - --heartbeat-interval={{ .Values.clusterGateway.heartbeatInterval }}
         - --heartbeat-timeout={{ .Values.clusterGateway.heartbeatTimeout }}
-        - --skip-client-cert-verify={{ .Values.clusterGateway.tls.skipClientCertVerify }}
+        {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+        - --internal-mtls=true
+        - --internal-client-ca-cert=/internal-ca/ca.crt
+        {{- else }}
+        - --internal-mtls=false
+        {{- end }}
         - --log-level={{ .Values.clusterGateway.logLevel }}
         ports:
         - name: websocket
@@ -86,7 +91,21 @@ spec:
         - name: server-certs
           mountPath: /certs
           readOnly: true
+        {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+        - name: internal-client-ca
+          mountPath: /internal-ca
+          readOnly: true
+        {{- end }}
       volumes:
       - name: server-certs
         secret:
           secretName: {{ .Values.clusterGateway.tls.secretName }}
+      {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+      # Only ca.crt is mounted; the internal CA private key stays out of the pod
+      - name: internal-client-ca
+        secret:
+          secretName: {{ .Values.clusterGateway.internalMtls.caSecretName }}
+          items:
+          - key: ca.crt
+            path: ca.crt
+      {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/internal-ca.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/internal-ca.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+---
+# CA Certificate for signing internal API client certificates (openchoreo-api,
+# controller-manager). Deliberately separate from the agent CA (cluster-gateway-ca)
+# so data-plane agent certificates cannot authenticate to the internal API.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-internal-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+spec:
+  isCA: true
+  commonName: openchoreo-cluster-gateway-internal-ca
+  subject:
+    organizations:
+      - OpenChoreo
+  secretName: {{ .Values.clusterGateway.internalMtls.caSecretName }}
+  duration: 87600h # 10 years
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    size: 4096
+    # Keep the same CA key across renewals. There is no staged trust rollout, and
+    # the gateway trusts only the current CA bundle, so rotating the key would
+    # orphan already-issued internal client certs (controller-manager, openchoreo-api)
+    # until they are reissued and the gateway reloads the CA. Deliberate CA key
+    # rotation must be coordinated with client reissuance out of band.
+    rotationPolicy: Never
+  issuerRef:
+    name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-ca-issuer
+    kind: Issuer
+---
+# Issuer backed by the internal CA, used to sign internal API client certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-internal-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-gateway
+spec:
+  ca:
+    secretName: {{ .Values.clusterGateway.internalMtls.caSecretName }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/cluster-gateway-client-certificate.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/cluster-gateway-client-certificate.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+# Client certificate for controller-manager to authenticate to the cluster
+# gateway internal API (mTLS). Signed by the gateway internal CA.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.controllerManager.name }}-cluster-gateway-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.componentLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 4 }}
+spec:
+  secretName: {{ .Values.controllerManager.clusterGateway.tls.clientSecret }}
+  commonName: openchoreo-controller-manager
+  subject:
+    organizations:
+      - OpenChoreo
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  usages:
+    - client auth
+  issuerRef:
+    kind: Issuer
+    name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-internal-ca-issuer
+  {{- with .Values.clusterGateway.internalMtls.clientCertDuration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.clusterGateway.internalMtls.clientCertRenewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -54,6 +54,10 @@ spec:
         {{- if .Values.clusterGateway.tls.enabled }}
         - --cluster-gateway-ca-cert={{ .Values.controllerManager.clusterGateway.tls.caPath }}
         {{- end }}
+        {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+        - --cluster-gateway-client-cert={{ .Values.controllerManager.clusterGateway.tls.clientCertPath }}
+        - --cluster-gateway-client-key={{ .Values.controllerManager.clusterGateway.tls.clientKeyPath }}
+        {{- end }}
         {{- if .Values.controllerManager.clusterGateway.tls.insecure }}
         - --cluster-gateway-insecure
         {{- end }}
@@ -106,6 +110,11 @@ spec:
           name: cluster-gateway-ca
           readOnly: true
         {{- end }}
+        {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+        - mountPath: /etc/cluster-gateway-client
+          name: cluster-gateway-client-tls
+          readOnly: true
+        {{- end }}
       volumes:
       {{- if eq (toString .Values.controllerManager.manager.env.enableWebhooks) "true" }}
       - name: cert
@@ -117,4 +126,9 @@ spec:
       - name: cluster-gateway-ca
         secret:
           secretName: {{ .Values.controllerManager.clusterGateway.tls.caSecret }}
+      {{- end }}
+      {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+      - name: cluster-gateway-client-tls
+        secret:
+          secretName: {{ .Values.controllerManager.clusterGateway.tls.clientSecret }}
       {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/cluster-gateway-client-certificate.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/cluster-gateway-client-certificate.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+# Client certificate for openchoreo-api to authenticate to the cluster gateway
+# internal API (mTLS). Signed by the gateway internal CA.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "openchoreo-control-plane.openchoreoApi.name" . }}-cluster-gateway-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-control-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openchoreo-api
+spec:
+  secretName: {{ .Values.openchoreoApi.clusterGateway.tls.clientSecret }}
+  commonName: openchoreo-api
+  subject:
+    organizations:
+      - OpenChoreo
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  usages:
+    - client auth
+  issuerRef:
+    kind: Issuer
+    name: {{ include "openchoreo-control-plane.clusterGateway.name" . }}-internal-ca-issuer
+  {{- with .Values.clusterGateway.internalMtls.clientCertDuration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.clusterGateway.internalMtls.clientCertRenewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+{{- end }}

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -70,6 +70,10 @@ data:
         {{- if .Values.clusterGateway.tls.enabled }}
         ca_cert_path: {{ .Values.openchoreoApi.clusterGateway.tls.caPath | quote }}
         {{- end }}
+        {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+        client_cert_path: {{ .Values.openchoreoApi.clusterGateway.tls.clientCertPath | quote }}
+        client_key_path: {{ .Values.openchoreoApi.clusterGateway.tls.clientKeyPath | quote }}
+        {{- end }}
         insecure: {{ .Values.openchoreoApi.clusterGateway.tls.insecure }}
 
     logging:

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -70,6 +70,11 @@ spec:
           mountPath: /etc/cluster-gateway
           readOnly: true
         {{- end }}
+        {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+        - name: cluster-gateway-client-tls
+          mountPath: /etc/cluster-gateway-client
+          readOnly: true
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health
@@ -98,5 +103,10 @@ spec:
       - name: cluster-gateway-ca
         secret:
           secretName: {{ .Values.openchoreoApi.clusterGateway.tls.caSecret }}
+      {{- end }}
+      {{- if and .Values.clusterGateway.tls.enabled .Values.clusterGateway.internalMtls.enabled }}
+      - name: cluster-gateway-client-tls
+        secret:
+          secretName: {{ .Values.openchoreoApi.clusterGateway.tls.clientSecret }}
       {{- end }}
 {{- end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1096,6 +1096,39 @@
           "title": "image",
           "type": "object"
         },
+        "internalMtls": {
+          "additionalProperties": false,
+          "description": "mTLS enforcement for the cluster gateway internal API (port 8444). When enabled, a dedicated internal CA is created via cert-manager, client certificates are issued for openchoreo-api and controller-manager, and the gateway requires and verifies client certificates on all internal /api/* endpoints.",
+          "properties": {
+            "caSecretName": {
+              "default": "cluster-gateway-internal-ca",
+              "description": "Name of the secret holding the internal CA used to sign and verify internal API client certificates",
+              "title": "caSecretName",
+              "type": "string"
+            },
+            "clientCertDuration": {
+              "default": "2160h",
+              "description": "Internal API client certificate validity duration (90 days)",
+              "title": "clientCertDuration",
+              "type": "string"
+            },
+            "clientCertRenewBefore": {
+              "default": "360h",
+              "description": "Internal API client certificate renewal threshold (15 days before expiry)",
+              "title": "clientCertRenewBefore",
+              "type": "string"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Require and verify client certificates on the cluster gateway internal API. Disabled by default on this release branch to preserve upgrade compatibility; enable it to close unauthenticated access to the internal API.",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "internalMtls",
+          "type": "object"
+        },
         "logLevel": {
           "default": "info",
           "description": "Log level",
@@ -1430,7 +1463,7 @@
             },
             "skipClientCertVerify": {
               "default": false,
-              "description": "Skip client certificate verification for agent connections (for single-cluster setups without mTLS)",
+              "description": "Deprecated: has no effect. Agent certificates are always verified per plane CR; use clusterGateway.internalMtls.enabled to control internal API verification. Will be removed in a future release.",
               "title": "skipClientCertVerify",
               "type": "boolean"
             }
@@ -1652,6 +1685,24 @@
                   "default": "cluster-gateway-ca",
                   "description": "Name of the secret containing the CA certificate",
                   "title": "caSecret",
+                  "type": "string"
+                },
+                "clientCertPath": {
+                  "default": "/etc/cluster-gateway-client/tls.crt",
+                  "description": "Path to the client certificate used for mTLS to the cluster gateway internal API",
+                  "title": "clientCertPath",
+                  "type": "string"
+                },
+                "clientKeyPath": {
+                  "default": "/etc/cluster-gateway-client/tls.key",
+                  "description": "Path to the client private key used for mTLS to the cluster gateway internal API",
+                  "title": "clientKeyPath",
+                  "type": "string"
+                },
+                "clientSecret": {
+                  "default": "controller-manager-cluster-gateway-client-tls",
+                  "description": "Name of the secret containing the controller-manager client certificate for the cluster gateway internal API",
+                  "title": "clientSecret",
                   "type": "string"
                 },
                 "insecure": {
@@ -2846,6 +2897,24 @@
                   "default": "cluster-gateway-ca",
                   "description": "Name of the secret holding the cluster gateway CA certificate",
                   "title": "caSecret",
+                  "type": "string"
+                },
+                "clientCertPath": {
+                  "default": "/etc/cluster-gateway-client/tls.crt",
+                  "description": "Path inside the pod where the client certificate for the cluster gateway internal API is mounted",
+                  "title": "clientCertPath",
+                  "type": "string"
+                },
+                "clientKeyPath": {
+                  "default": "/etc/cluster-gateway-client/tls.key",
+                  "description": "Path inside the pod where the client private key for the cluster gateway internal API is mounted",
+                  "title": "clientKeyPath",
+                  "type": "string"
+                },
+                "clientSecret": {
+                  "default": "openchoreo-api-cluster-gateway-client-tls",
+                  "description": "Name of the secret containing the openchoreo-api client certificate for the cluster gateway internal API",
+                  "title": "clientSecret",
                   "type": "string"
                 },
                 "insecure": {

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -734,6 +734,24 @@ controllerManager:
       # @schema
       caSecret: cluster-gateway-ca
       # @schema
+      # type: string
+      # description: Path to the client certificate used for mTLS to the cluster gateway internal API
+      # default: /etc/cluster-gateway-client/tls.crt
+      # @schema
+      clientCertPath: /etc/cluster-gateway-client/tls.crt
+      # @schema
+      # type: string
+      # description: Path to the client private key used for mTLS to the cluster gateway internal API
+      # default: /etc/cluster-gateway-client/tls.key
+      # @schema
+      clientKeyPath: /etc/cluster-gateway-client/tls.key
+      # @schema
+      # type: string
+      # description: Name of the secret containing the controller-manager client certificate for the cluster gateway internal API
+      # default: controller-manager-cluster-gateway-client-tls
+      # @schema
+      clientSecret: controller-manager-cluster-gateway-client-tls
+      # @schema
       # type: boolean
       # description: Skip TLS verification of the cluster gateway. For development only.
       # default: false
@@ -905,6 +923,24 @@ openchoreoApi:
       # default: cluster-gateway-ca
       # @schema
       caSecret: cluster-gateway-ca
+      # @schema
+      # type: string
+      # description: Path inside the pod where the client certificate for the cluster gateway internal API is mounted
+      # default: /etc/cluster-gateway-client/tls.crt
+      # @schema
+      clientCertPath: /etc/cluster-gateway-client/tls.crt
+      # @schema
+      # type: string
+      # description: Path inside the pod where the client private key for the cluster gateway internal API is mounted
+      # default: /etc/cluster-gateway-client/tls.key
+      # @schema
+      clientKeyPath: /etc/cluster-gateway-client/tls.key
+      # @schema
+      # type: string
+      # description: Name of the secret containing the openchoreo-api client certificate for the cluster gateway internal API
+      # default: openchoreo-api-cluster-gateway-client-tls
+      # @schema
+      clientSecret: openchoreo-api-cluster-gateway-client-tls
       # @schema
       # type: boolean
       # description: Skip TLS verification of the cluster gateway. For development only.
@@ -3426,7 +3462,7 @@ clusterGateway:
     secretName: cluster-gateway-tls
     # @schema
     # type: boolean
-    # description: Skip client certificate verification for agent connections (for single-cluster setups without mTLS)
+    # description: "Deprecated: has no effect. Agent certificates are always verified per plane CR; use clusterGateway.internalMtls.enabled to control internal API verification. Will be removed in a future release."
     # default: false
     # @schema
     skipClientCertVerify: false
@@ -3487,6 +3523,36 @@ clusterGateway:
     # default: 360h
     # @schema
     renewBefore: 360h
+
+  # @schema
+  # type: object
+  # description: mTLS enforcement for the cluster gateway internal API (port 8444). When enabled, a dedicated internal CA is created via cert-manager, client certificates are issued for openchoreo-api and controller-manager, and the gateway requires and verifies client certificates on all internal /api/* endpoints.
+  # @schema
+  internalMtls:
+    # @schema
+    # type: boolean
+    # description: Require and verify client certificates on the cluster gateway internal API. Disabled by default on this release branch to preserve upgrade compatibility; enable it to close unauthenticated access to the internal API.
+    # default: false
+    # @schema
+    enabled: false
+    # @schema
+    # type: string
+    # description: Name of the secret holding the internal CA used to sign and verify internal API client certificates
+    # default: cluster-gateway-internal-ca
+    # @schema
+    caSecretName: cluster-gateway-internal-ca
+    # @schema
+    # type: string
+    # description: Internal API client certificate validity duration (90 days)
+    # default: 2160h
+    # @schema
+    clientCertDuration: 2160h
+    # @schema
+    # type: string
+    # description: Internal API client certificate renewal threshold (15 days before expiry)
+    # default: 360h
+    # @schema
+    clientCertRenewBefore: 360h
 
   # type: object
   # description: Pod security context

--- a/internal/cluster-gateway/config.go
+++ b/internal/cluster-gateway/config.go
@@ -7,11 +7,22 @@ import "time"
 
 // Config holds configuration for the agent server
 type Config struct {
-	Port                 int
-	InternalPort         int
-	ServerCertPath       string
-	ServerKeyPath        string
+	Port           int
+	InternalPort   int
+	ServerCertPath string
+	ServerKeyPath  string
+	// SkipClientCertVerify has no effect: agent client certificates are always
+	// verified per plane CR on the public listener, and internal listener
+	// verification is controlled by InternalMTLSEnabled.
+	//
+	// Deprecated: will be removed in a future release.
 	SkipClientCertVerify bool
+	// InternalMTLSEnabled requires and verifies client certificates on the
+	// internal API listener (/api/*) against InternalClientCAPath.
+	InternalMTLSEnabled bool
+	// InternalClientCAPath is the path to the CA bundle used to verify
+	// internal API clients. Required when InternalMTLSEnabled is true.
+	InternalClientCAPath string
 	ReadTimeout          time.Duration
 	WriteTimeout         time.Duration
 	IdleTimeout          time.Duration

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -115,6 +115,21 @@ func (s *Server) Start() error {
 		"note", "Client certificate verification performed at application level per DataPlane/WorkflowPlane CR",
 	)
 
+	internalTLSConfig, err := buildInternalTLSConfig(tlsConfig, s.config)
+	if err != nil {
+		return fmt.Errorf("failed to configure internal listener TLS: %w", err)
+	}
+	if s.config.InternalMTLSEnabled {
+		s.logger.Info("internal API mTLS enabled",
+			"clientAuth", "RequireAndVerifyClientCert",
+			"clientCA", s.config.InternalClientCAPath,
+		)
+	} else {
+		s.logger.Warn("internal API mTLS disabled",
+			"note", "internal /api/* endpoints accept unauthenticated callers; enable with --internal-mtls",
+		)
+	}
+
 	// Public listener: agent WebSocket only (reached by remote data planes).
 	publicMux := http.NewServeMux()
 	publicMux.HandleFunc("/ws", s.handleWebSocket)
@@ -148,7 +163,7 @@ func (s *Server) Start() error {
 	s.internalServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", s.config.InternalPort),
 		Handler:      internalMux,
-		TLSConfig:    tlsConfig.Clone(),
+		TLSConfig:    internalTLSConfig,
 		ReadTimeout:  s.config.ReadTimeout,
 		WriteTimeout: s.config.WriteTimeout,
 		IdleTimeout:  s.config.IdleTimeout,
@@ -239,6 +254,38 @@ func (s *Server) Start() error {
 		s.logger.Info("server shutdown completed")
 		return nil
 	}
+}
+
+// buildInternalTLSConfig derives the TLS configuration for the internal API
+// listener from the shared base config. When internal mTLS is enabled, callers
+// must present a certificate signed by the internal client CA
+// (RequireAndVerifyClientCert); the internal CA is distinct from the per-plane
+// agent CAs verified on the public listener, so agent certificates cannot
+// authenticate to the internal API.
+func buildInternalTLSConfig(base *tls.Config, cfg *Config) (*tls.Config, error) {
+	tlsConfig := base.Clone()
+	if !cfg.InternalMTLSEnabled {
+		return tlsConfig, nil
+	}
+
+	if cfg.InternalClientCAPath == "" {
+		return nil, fmt.Errorf("internal mTLS is enabled but no client CA is configured: " +
+			"set --internal-client-ca-cert (helm: clusterGateway.internalMtls) or disable with --internal-mtls=false")
+	}
+
+	caData, err := os.ReadFile(cfg.InternalClientCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read internal client CA %s: %w", cfg.InternalClientCAPath, err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caData) {
+		return nil, fmt.Errorf("failed to parse internal client CA %s: no valid certificates found", cfg.InternalClientCAPath)
+	}
+
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	tlsConfig.ClientCAs = caPool
+	return tlsConfig, nil
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/cluster-gateway/server_test.go
+++ b/internal/cluster-gateway/server_test.go
@@ -7,15 +7,21 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -872,4 +878,366 @@ func TestHandleConnection_NormalClose(t *testing.T) {
 
 	// Should log "agent disconnected" and return
 	s.handleConnection("dataplane/prod", connID, mock)
+}
+
+// generateTestClientKeyPair creates a client certificate signed by the given CA
+// and returns it as a tls.Certificate usable in a handshake.
+func generateTestClientKeyPair(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) tls.Certificate {
+	t.Helper()
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "Test Internal Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	leaf, err := x509.ParseCertificate(clientDER)
+	require.NoError(t, err)
+
+	return tls.Certificate{
+		Certificate: [][]byte{clientDER},
+		PrivateKey:  clientKey,
+		Leaf:        leaf,
+	}
+}
+
+// writeTestCAFile writes the CA certificate PEM to a temp file and returns its path.
+func writeTestCAFile(t *testing.T, caCert *x509.Certificate) string {
+	t.Helper()
+	caPath := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, encodeCertToPEM(t, caCert), 0o600))
+	return caPath
+}
+
+func baseTestTLSConfig() *tls.Config {
+	return &tls.Config{
+		ClientAuth: tls.RequestClientCert,
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+// --- buildInternalTLSConfig tests ---
+
+func TestBuildInternalTLSConfig_Disabled(t *testing.T) {
+	cfg := &Config{InternalMTLSEnabled: false}
+
+	tlsConfig, err := buildInternalTLSConfig(baseTestTLSConfig(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, tls.RequestClientCert, tlsConfig.ClientAuth)
+	assert.Nil(t, tlsConfig.ClientCAs)
+}
+
+func TestBuildInternalTLSConfig_EnabledWithValidCA(t *testing.T) {
+	caCert, _ := generateTestCA(t)
+	cfg := &Config{
+		InternalMTLSEnabled:  true,
+		InternalClientCAPath: writeTestCAFile(t, caCert),
+	}
+
+	tlsConfig, err := buildInternalTLSConfig(baseTestTLSConfig(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+	assert.NotNil(t, tlsConfig.ClientCAs)
+}
+
+func TestBuildInternalTLSConfig_EnabledWithoutCAPath(t *testing.T) {
+	cfg := &Config{InternalMTLSEnabled: true}
+
+	_, err := buildInternalTLSConfig(baseTestTLSConfig(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "internal-client-ca-cert")
+}
+
+func TestBuildInternalTLSConfig_EnabledWithMissingFile(t *testing.T) {
+	cfg := &Config{
+		InternalMTLSEnabled:  true,
+		InternalClientCAPath: filepath.Join(t.TempDir(), "does-not-exist.crt"),
+	}
+
+	_, err := buildInternalTLSConfig(baseTestTLSConfig(), cfg)
+	require.Error(t, err)
+}
+
+func TestBuildInternalTLSConfig_EnabledWithInvalidPEM(t *testing.T) {
+	caPath := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, []byte("not a certificate"), 0o600))
+	cfg := &Config{
+		InternalMTLSEnabled:  true,
+		InternalClientCAPath: caPath,
+	}
+
+	_, err := buildInternalTLSConfig(baseTestTLSConfig(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid certificates")
+}
+
+// --- handshake-level enforcement tests ---
+
+// startInternalTestServer starts an HTTPS server using the internal listener's
+// TLS configuration derived from cfg, serving a trivial 200 handler.
+func startInternalTestServer(t *testing.T, cfg *Config) *httptest.Server {
+	t.Helper()
+	tlsConfig, err := buildInternalTLSConfig(baseTestTLSConfig(), cfg)
+	require.NoError(t, err)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	srv.TLS = tlsConfig
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newTestHTTPSClient(serverCertPool *x509.CertPool, clientCerts ...tls.Certificate) *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      serverCertPool,
+				Certificates: clientCerts,
+				MinVersion:   tls.VersionTLS12,
+			},
+		},
+	}
+}
+
+func serverCertPool(t *testing.T, srv *httptest.Server) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	return pool
+}
+
+func TestInternalListener_MTLSEnabled_AcceptsInternalCACert(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	srv := startInternalTestServer(t, &Config{
+		InternalMTLSEnabled:  true,
+		InternalClientCAPath: writeTestCAFile(t, caCert),
+	})
+
+	client := newTestHTTPSClient(serverCertPool(t, srv), generateTestClientKeyPair(t, caCert, caKey))
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ok", string(body))
+}
+
+func TestInternalListener_MTLSEnabled_RejectsNoClientCert(t *testing.T) {
+	caCert, _ := generateTestCA(t)
+	srv := startInternalTestServer(t, &Config{
+		InternalMTLSEnabled:  true,
+		InternalClientCAPath: writeTestCAFile(t, caCert),
+	})
+
+	client := newTestHTTPSClient(serverCertPool(t, srv))
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		resp.Body.Close()
+	}
+	require.Error(t, err, "request without a client certificate must be rejected")
+}
+
+func TestInternalListener_MTLSEnabled_RejectsCertFromOtherCA(t *testing.T) {
+	internalCACert, _ := generateTestCA(t)
+	// Simulates an agent certificate signed by a different (agent) CA.
+	otherCACert, otherCAKey := generateTestCA(t)
+
+	srv := startInternalTestServer(t, &Config{
+		InternalMTLSEnabled:  true,
+		InternalClientCAPath: writeTestCAFile(t, internalCACert),
+	})
+
+	client := newTestHTTPSClient(serverCertPool(t, srv), generateTestClientKeyPair(t, otherCACert, otherCAKey))
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		resp.Body.Close()
+	}
+	require.Error(t, err, "certificate signed by a different CA must be rejected")
+}
+
+func TestInternalListener_MTLSDisabled_AcceptsNoClientCert(t *testing.T) {
+	srv := startInternalTestServer(t, &Config{InternalMTLSEnabled: false})
+
+	client := newTestHTTPSClient(serverCertPool(t, srv))
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// --- Server.Start tests ---
+
+// writeServerKeyPairFiles generates a self-signed server certificate and its EC
+// private key, writes both to PEM files, and returns their paths. The pair is
+// valid for tls.LoadX509KeyPair used in Server.Start.
+func writeServerKeyPairFiles(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(100),
+		Subject:      pkix.Name{CommonName: "test-server"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "server.crt")
+	keyPath = filepath.Join(dir, "server.key")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	return certPath, keyPath
+}
+
+func TestStart_ServerCertLoadError(t *testing.T) {
+	s := New(&Config{
+		ServerCertPath: filepath.Join(t.TempDir(), "missing.crt"),
+		ServerKeyPath:  filepath.Join(t.TempDir(), "missing.key"),
+	}, nil, testLogger())
+
+	err := s.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load server certificate")
+}
+
+// TestStart_InternalTLSConfigError verifies that a failure while building the
+// internal listener TLS config is wrapped and returned from Start before any
+// port is bound. mTLS is enabled with no client CA, which buildInternalTLSConfig
+// rejects.
+func TestStart_InternalTLSConfigError(t *testing.T) {
+	certPath, keyPath := writeServerKeyPairFiles(t)
+
+	s := New(&Config{
+		ServerCertPath:      certPath,
+		ServerKeyPath:       keyPath,
+		InternalMTLSEnabled: true,
+		// InternalClientCAPath deliberately empty.
+	}, nil, testLogger())
+
+	err := s.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to configure internal listener TLS")
+}
+
+// waitForHealth polls the fixed health endpoint until it returns 200. It returns
+// true once healthy. If Start returns early (e.g. the fixed :8080 health port is
+// already bound), the test is skipped rather than failed, since that is an
+// environment conflict and not a code defect.
+func waitForHealth(t *testing.T, startErr <-chan error) bool {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-startErr:
+			skipOrFailOnStartErr(t, err)
+			return false
+		default:
+		}
+
+		resp, err := http.Get("http://127.0.0.1:8080/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	select {
+	case err := <-startErr:
+		skipOrFailOnStartErr(t, err)
+	default:
+		t.Skip("health server did not become ready on :8080 (port likely in use)")
+	}
+	return false
+}
+
+func skipOrFailOnStartErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("Start returned nil before becoming healthy")
+		return
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "address already in use") || strings.Contains(msg, "bind:") {
+		t.Skipf("health/server port unavailable in this environment: %v", err)
+		return
+	}
+	t.Fatalf("Start returned an unexpected error before becoming healthy: %v", err)
+}
+
+// TestStart_Lifecycle brings the server fully up on ephemeral ports and asserts
+// that a SIGTERM triggers a graceful shutdown returning nil. It exercises both
+// the internal-mTLS-enabled and disabled logging/config branches in Start.
+func TestStart_Lifecycle(t *testing.T) {
+	tests := []struct {
+		name string
+		mtls bool
+	}{
+		{name: "internal mTLS enabled", mtls: true},
+		{name: "internal mTLS disabled", mtls: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certPath, keyPath := writeServerKeyPairFiles(t)
+			cfg := &Config{
+				Port:            0, // ephemeral
+				InternalPort:    0, // ephemeral
+				ServerCertPath:  certPath,
+				ServerKeyPath:   keyPath,
+				ShutdownTimeout: 5 * time.Second,
+			}
+			if tt.mtls {
+				caCert, _ := generateTestCA(t)
+				cfg.InternalMTLSEnabled = true
+				cfg.InternalClientCAPath = writeTestCAFile(t, caCert)
+			}
+
+			s := New(cfg, nil, testLogger())
+
+			startErr := make(chan error, 1)
+			go func() { startErr <- s.Start() }()
+
+			if !waitForHealth(t, startErr) {
+				return // skipped or failed inside helper
+			}
+
+			// Trigger graceful shutdown; Start installs a SIGTERM handler via
+			// signal.NotifyContext, so this is absorbed rather than killing the
+			// test process.
+			p, err := os.FindProcess(os.Getpid())
+			require.NoError(t, err)
+			require.NoError(t, p.Signal(syscall.SIGTERM))
+
+			select {
+			case err := <-startErr:
+				require.NoError(t, err, "Start should return nil after graceful shutdown")
+			case <-time.After(10 * time.Second):
+				t.Fatal("Start did not return after SIGTERM")
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Currently the openchoreo controller and openchoreo api calls clustergateway without any authorization and need to enable authorization because if the cluster is compromised or malcious pod deployed they can easily get resources from different planes. 

## Approach
Add mTLS communication between cluster gateway and clients

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4168

## Checklist
- [x]Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
