### PR TITLE
fix: re-trigger acknowledged alerts

### DIFF
--- a/internal/observer/service/alerts.go
+++ b/internal/observer/service/alerts.go
@@ -296,25 +296,39 @@ func (s *AlertService) checkAlertSuppression(ctx context.Context, ruleName, rule
 		return false, nil
 	}
 
-	isDuplicate, err := s.alertEntryStore.HasRecentAlert(ctx, ruleName, ruleNamespace, componentUID, since)
+	recentAlert, err := s.alertEntryStore.GetRecentAlert(ctx, ruleName, ruleNamespace, componentUID, since)
 	if err != nil {
 		s.logger.Warn("Failed to check alert suppression", "error", err, "ruleName", ruleName)
 		return false, nil
 	}
 
-	if isDuplicate {
-		s.logger.Info("Alert suppressed (duplicate within suppression window)",
-			"ruleName", ruleName, "ruleNamespace", ruleNamespace,
-			"suppressionWindow", s.config.Alerting.AlertSuppressionWindow)
-		suppressedStatus := gen.AlertWebhookResponseStatusSuccess
-		msg := "alert suppressed: duplicate within suppression window"
-		return true, &gen.AlertWebhookResponse{
-			Status:  &suppressedStatus,
-			Message: &msg,
+	if recentAlert == nil {
+		return false, nil
+	}
+
+	// An acknowledged or resolved incident represents a completed alert occurrence.
+	// A later webhook must create a new occurrence even if it arrives within the
+	// suppression window. If the incident has not been persisted yet, keep
+	// suppressing to avoid a race creating duplicate incidents.
+	if recentAlert.IncidentEnabled && s.incidentEntryStore != nil {
+		status, found, statusErr := s.incidentEntryStore.GetIncidentStatusByAlertID(ctx, recentAlert.ID)
+		if statusErr != nil {
+			s.logger.Warn("Failed to check incident status for alert suppression",
+				"error", statusErr, "alertID", recentAlert.ID, "ruleName", ruleName)
+		} else if found && status != incidententry.StatusActive {
+			return false, nil
 		}
 	}
 
-	return false, nil
+	s.logger.Info("Alert suppressed (duplicate within suppression window)",
+		"ruleName", ruleName, "ruleNamespace", ruleNamespace,
+		"suppressionWindow", s.config.Alerting.AlertSuppressionWindow)
+	suppressedStatus := gen.AlertWebhookResponseStatusSuccess
+	msg := "alert suppressed: duplicate within suppression window"
+	return true, &gen.AlertWebhookResponse{
+		Status:  &suppressedStatus,
+		Message: &msg,
+	}
 }
 
 // buildAlertDetails enriches alert details from the webhook request and alert rule CR.

--- a/internal/observer/service/alerts_query_test.go
+++ b/internal/observer/service/alerts_query_test.go
@@ -313,8 +313,8 @@ func (f *fakeAlertEntryStore) QueryAlertEntries(_ context.Context, params alerte
 	f.lastQueryParams = params
 	return f.entries, f.total, nil
 }
-func (f *fakeAlertEntryStore) HasRecentAlert(context.Context, string, string, string, time.Time) (bool, error) {
-	return false, nil
+func (f *fakeAlertEntryStore) GetRecentAlert(context.Context, string, string, string, time.Time) (*alertentry.AlertEntry, error) {
+	return nil, nil
 }
 func (f *fakeAlertEntryStore) Close() error { return nil }
 
@@ -337,6 +337,9 @@ func (f *fakeIncidentEntryStore) WriteIncidentEntry(context.Context, *incidenten
 func (f *fakeIncidentEntryStore) QueryIncidentEntries(_ context.Context, params incidententry.QueryParams) ([]incidententry.IncidentEntry, int, error) {
 	f.lastQueryParams = params
 	return f.entries, f.total, nil
+}
+func (f *fakeIncidentEntryStore) GetIncidentStatusByAlertID(context.Context, string) (string, bool, error) {
+	return "", false, nil
 }
 func (f *fakeIncidentEntryStore) UpdateIncidentEntry(_ context.Context, id string, status string, notes, description *string, _ time.Time) (incidententry.IncidentEntry, error) {
 	f.lastUpdateID = id

--- a/internal/observer/service/alerts_webhook_test.go
+++ b/internal/observer/service/alerts_webhook_test.go
@@ -253,6 +253,22 @@ func TestWebhook_DuplicateWithinWindow_Suppressed(t *testing.T) {
 	assert.Equal(t, int32(1), f.rcaCallCount.Load(), "suppressed alert should not trigger RCA")
 }
 
+func TestWebhook_IncidentStatusStoreError_RemainsSuppressed(t *testing.T) {
+	rule := testAlertRule("rule-cr-1", true, false)
+	f := newWebhookTestFixture(t, time.Hour, rule, false)
+
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+	assert.Eventually(t, func() bool { return f.incidentCount(t) == 1 }, 2*time.Second, 50*time.Millisecond)
+
+	require.NoError(t, f.incidentStore.Close())
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "suppressed",
+		"incident status lookup errors should preserve duplicate suppression")
+}
+
 func TestWebhook_AcknowledgedIncident_RetriggersWithinSuppressionWindow(t *testing.T) {
 	rule := testAlertRule("rule-cr-1", true, false)
 	f := newWebhookTestFixture(t, time.Hour, rule, false)

--- a/internal/observer/service/alerts_webhook_test.go
+++ b/internal/observer/service/alerts_webhook_test.go
@@ -253,6 +253,34 @@ func TestWebhook_DuplicateWithinWindow_Suppressed(t *testing.T) {
 	assert.Equal(t, int32(1), f.rcaCallCount.Load(), "suppressed alert should not trigger RCA")
 }
 
+func TestWebhook_AcknowledgedIncident_RetriggersWithinSuppressionWindow(t *testing.T) {
+	rule := testAlertRule("rule-cr-1", true, false)
+	f := newWebhookTestFixture(t, time.Hour, rule, false)
+
+	resp, err := f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+	assert.Eventually(t, func() bool { return f.incidentCount(t) == 1 }, 2*time.Second, 50*time.Millisecond)
+
+	incidents, _, err := f.incidentStore.QueryIncidentEntries(context.Background(), incidententry.QueryParams{
+		StartTime: "2000-01-01T00:00:00Z",
+		EndTime:   "2099-01-01T00:00:00Z",
+		Limit:     100,
+	})
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+	_, err = f.incidentStore.UpdateIncidentEntry(
+		context.Background(), incidents[0].ID, incidententry.StatusAcknowledged, nil, nil, time.Now().UTC(),
+	)
+	require.NoError(t, err)
+
+	resp, err = f.svc.HandleAlertWebhook(context.Background(), webhookReq("rule-cr-1"))
+	require.NoError(t, err)
+	assert.Contains(t, *resp.Message, "alert acknowledged")
+	assert.Equal(t, 2, f.alertCount(t), "acknowledgement should end suppression for the prior occurrence")
+	assert.Eventually(t, func() bool { return f.incidentCount(t) == 2 }, 2*time.Second, 50*time.Millisecond)
+}
+
 func TestWebhook_DifferentRule_NotSuppressed(t *testing.T) {
 	rule1 := testAlertRule("rule-cr-1", false, false)
 	rule2 := testAlertRule("rule-cr-2", false, false)

--- a/internal/observer/store/alertentry/sql.go
+++ b/internal/observer/store/alertentry/sql.go
@@ -6,6 +6,7 @@ package alertentry
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -317,19 +318,23 @@ func (s *sqlStore) QueryAlertEntries(ctx context.Context, params QueryParams) ([
 	return entries, total, nil
 }
 
-func (s *sqlStore) HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace, componentUID string, since time.Time) (bool, error) {
+func (s *sqlStore) GetRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace, componentUID string, since time.Time) (*AlertEntry, error) {
 	sinceNS := since.UnixNano()
 	var query string
 	if s.backend == BackendPostgreSQL {
-		query = hasRecentAlertPostgresQuery
+		query = getRecentAlertPostgresQuery
 	} else {
-		query = hasRecentAlertSQLiteQuery
+		query = getRecentAlertSQLiteQuery
 	}
-	var exists bool
-	if err := s.db.QueryRowContext(ctx, query, alertRuleCRName, alertRuleCRNamespace, componentUID, sinceNS).Scan(&exists); err != nil {
-		return false, fmt.Errorf("failed to check recent alert: %w", err)
+	var entry AlertEntry
+	if err := s.db.QueryRowContext(ctx, query, alertRuleCRName, alertRuleCRNamespace, componentUID, sinceNS).
+		Scan(&entry.ID, &entry.IncidentEnabled); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get recent alert: %w", err)
 	}
-	return exists, nil
+	return &entry, nil
 }
 
 func normalizeTimestamp(value string) (string, error) {
@@ -416,15 +421,15 @@ const createAlertRuleCRTimestampIndexQuery = `
 CREATE INDEX IF NOT EXISTS idx_alert_entries_cr_ts
 ON alert_entries(alert_rule_cr_name, alert_rule_cr_namespace, component_id, timestamp_ns);`
 
-const hasRecentAlertSQLiteQuery = `
-SELECT EXISTS(SELECT 1 FROM alert_entries
+const getRecentAlertSQLiteQuery = `
+SELECT id, incident_enabled FROM alert_entries
 WHERE alert_rule_cr_name = ? AND alert_rule_cr_namespace = ? AND component_id = ? AND timestamp_ns >= ?
-LIMIT 1);`
+ORDER BY timestamp_ns DESC LIMIT 1;`
 
-const hasRecentAlertPostgresQuery = `
-SELECT EXISTS(SELECT 1 FROM alert_entries
+const getRecentAlertPostgresQuery = `
+SELECT id, incident_enabled FROM alert_entries
 WHERE alert_rule_cr_name = $1 AND alert_rule_cr_namespace = $2 AND component_id = $3 AND timestamp_ns >= $4
-LIMIT 1);`
+ORDER BY timestamp_ns DESC LIMIT 1;`
 
 const insertAlertEntryPostgresQuery = `
 INSERT INTO alert_entries (

--- a/internal/observer/store/alertentry/sql_test.go
+++ b/internal/observer/store/alertentry/sql_test.go
@@ -243,3 +243,17 @@ func TestGetRecentAlert(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRecentAlert_StoreError(t *testing.T) {
+	t.Parallel()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	store, err := New(BackendSQLite, dsn, slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, store.Initialize(context.Background()))
+	require.NoError(t, store.Close())
+
+	_, err = store.GetRecentAlert(context.Background(), "rule-cr-1", "obs-plane", "comp-uid-1", time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get recent alert")
+}

--- a/internal/observer/store/alertentry/sql_test.go
+++ b/internal/observer/store/alertentry/sql_test.go
@@ -142,7 +142,7 @@ func TestQueryAlertEntries(t *testing.T) {
 	assert.Equal(t, "rule-b", got[0].AlertRuleName)
 }
 
-func TestHasRecentAlert(t *testing.T) {
+func TestGetRecentAlert(t *testing.T) {
 	t.Parallel()
 
 	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
@@ -219,9 +219,9 @@ func TestHasRecentAlert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := store.HasRecentAlert(ctx, tt.crName, tt.crNamespace, tt.componentUID, tt.since)
+			got, err := store.GetRecentAlert(ctx, tt.crName, tt.crNamespace, tt.componentUID, tt.since)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, got != nil)
 		})
 	}
 }

--- a/internal/observer/store/alertentry/sql_test.go
+++ b/internal/observer/store/alertentry/sql_test.go
@@ -166,6 +166,24 @@ func TestGetRecentAlert(t *testing.T) {
 		ComponentID:          "comp-uid-1",
 	})
 	require.NoError(t, err)
+	latestID, err := store.WriteAlertEntry(ctx, &AlertEntry{
+		Timestamp:            now.Add(-20 * time.Minute).Format(time.RFC3339Nano),
+		AlertRuleName:        "high-error-rate",
+		AlertRuleCRName:      "rule-cr-1",
+		AlertRuleCRNamespace: "obs-plane",
+		AlertValue:           "84",
+		NamespaceName:        "ns-1",
+		ComponentName:        "payments",
+		ComponentID:          "comp-uid-1",
+		IncidentEnabled:      true,
+	})
+	require.NoError(t, err)
+
+	latest, err := store.GetRecentAlert(ctx, "rule-cr-1", "obs-plane", "comp-uid-1", now.Add(-time.Hour))
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, latestID, latest.ID)
+	assert.True(t, latest.IncidentEnabled)
 
 	tests := []struct {
 		name         string

--- a/internal/observer/store/alertentry/store.go
+++ b/internal/observer/store/alertentry/store.go
@@ -61,7 +61,7 @@ type AlertEntryStore interface {
 	Initialize(ctx context.Context) error
 	WriteAlertEntry(ctx context.Context, entry *AlertEntry) (id string, err error)
 	QueryAlertEntries(ctx context.Context, params QueryParams) ([]AlertEntry, int, error)
-	HasRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace, componentUID string, since time.Time) (bool, error)
+	GetRecentAlert(ctx context.Context, alertRuleCRName, alertRuleCRNamespace, componentUID string, since time.Time) (*AlertEntry, error)
 	Close() error
 }
 

--- a/internal/observer/store/incidententry/sql.go
+++ b/internal/observer/store/incidententry/sql.go
@@ -427,6 +427,27 @@ func (s *sqlStore) QueryIncidentEntries(ctx context.Context, params QueryParams)
 	return entries, total, nil
 }
 
+func (s *sqlStore) GetIncidentStatusByAlertID(ctx context.Context, alertID string) (string, bool, error) {
+	alertID = strings.TrimSpace(alertID)
+	if alertID == "" {
+		return "", false, fmt.Errorf("alert id is required")
+	}
+
+	var status string
+	query := `SELECT status FROM incident_entries WHERE alert_id = ? ORDER BY timestamp_ns DESC LIMIT 1`
+	if s.backend == BackendPostgreSQL {
+		query = `SELECT status FROM incident_entries WHERE alert_id = $1 ORDER BY timestamp_ns DESC LIMIT 1`
+	}
+	err := s.db.QueryRowContext(ctx, query, alertID).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get incident status for alert %q: %w", alertID, err)
+	}
+	return status, true, nil
+}
+
 func (s *sqlStore) UpdateIncidentEntry(ctx context.Context, id string, status string, notes, description *string, now time.Time) (IncidentEntry, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {

--- a/internal/observer/store/incidententry/sql.go
+++ b/internal/observer/store/incidententry/sql.go
@@ -70,6 +70,9 @@ func (s *sqlStore) Initialize(ctx context.Context) error {
 	if _, err := s.db.ExecContext(initCtx, createProjectEnvTimestampIndexQuery); err != nil {
 		return fmt.Errorf("failed to create incident_entries index: %w", err)
 	}
+	if _, err := s.db.ExecContext(initCtx, createAlertTimestampIndexQuery); err != nil {
+		return fmt.Errorf("failed to create incident_entries alert index: %w", err)
+	}
 
 	// Run schema migrations
 	if err := s.runSchemaMigrations(initCtx); err != nil {
@@ -770,6 +773,10 @@ CREATE TABLE IF NOT EXISTS incident_entries (
 const createProjectEnvTimestampIndexQuery = `
 CREATE INDEX IF NOT EXISTS idx_incident_entries_project_env_ts
 ON incident_entries(project_id, environment_id, timestamp_ns);`
+
+const createAlertTimestampIndexQuery = `
+CREATE INDEX IF NOT EXISTS idx_incident_entries_alert_ts
+ON incident_entries(alert_id, timestamp_ns);`
 
 const insertIncidentEntrySQLiteQuery = `
 INSERT INTO incident_entries (

--- a/internal/observer/store/incidententry/sql_test.go
+++ b/internal/observer/store/incidententry/sql_test.go
@@ -89,6 +89,31 @@ func TestWriteIncidentEntryWithMissingAlertID(t *testing.T) {
 	require.Error(t, err, "expected error for missing alert id")
 }
 
+func TestGetIncidentStatusByAlertID(t *testing.T) {
+	t.Parallel()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	store, err := New(BackendSQLite, dsn, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(context.Background()))
+
+	_, err = store.WriteIncidentEntry(context.Background(), &IncidentEntry{
+		AlertID: "alert-1",
+		Status:  StatusAcknowledged,
+	})
+	require.NoError(t, err)
+
+	status, found, err := store.GetIncidentStatusByAlertID(context.Background(), "alert-1")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, StatusAcknowledged, status)
+
+	_, found, err = store.GetIncidentStatusByAlertID(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
 func TestQueryIncidentEntries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observer/store/incidententry/sql_test.go
+++ b/internal/observer/store/incidententry/sql_test.go
@@ -121,6 +121,24 @@ func TestGetIncidentStatusByAlertID(t *testing.T) {
 	_, found, err = store.GetIncidentStatusByAlertID(ctx, "missing")
 	require.NoError(t, err)
 	assert.False(t, found)
+
+	_, _, err = store.GetIncidentStatusByAlertID(ctx, "  ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alert id is required")
+}
+
+func TestGetIncidentStatusByAlertID_StoreError(t *testing.T) {
+	t.Parallel()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	store, err := New(BackendSQLite, dsn, slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, store.Initialize(context.Background()))
+	require.NoError(t, store.Close())
+
+	_, _, err = store.GetIncidentStatusByAlertID(context.Background(), "alert-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get incident status")
 }
 
 func TestQueryIncidentEntries(t *testing.T) {

--- a/internal/observer/store/incidententry/sql_test.go
+++ b/internal/observer/store/incidententry/sql_test.go
@@ -98,18 +98,27 @@ func TestGetIncidentStatusByAlertID(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, store.Close()) })
 	require.NoError(t, store.Initialize(context.Background()))
 
-	_, err = store.WriteIncidentEntry(context.Background(), &IncidentEntry{
-		AlertID: "alert-1",
-		Status:  StatusAcknowledged,
+	ctx := context.Background()
+	now := time.Now().UTC()
+	_, err = store.WriteIncidentEntry(ctx, &IncidentEntry{
+		AlertID:   "alert-1",
+		Timestamp: now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
+		Status:    StatusActive,
+	})
+	require.NoError(t, err)
+	_, err = store.WriteIncidentEntry(ctx, &IncidentEntry{
+		AlertID:   "alert-1",
+		Timestamp: now.Add(-time.Minute).Format(time.RFC3339Nano),
+		Status:    StatusAcknowledged,
 	})
 	require.NoError(t, err)
 
-	status, found, err := store.GetIncidentStatusByAlertID(context.Background(), "alert-1")
+	status, found, err := store.GetIncidentStatusByAlertID(ctx, "alert-1")
 	require.NoError(t, err)
 	assert.True(t, found)
 	assert.Equal(t, StatusAcknowledged, status)
 
-	_, found, err = store.GetIncidentStatusByAlertID(context.Background(), "missing")
+	_, found, err = store.GetIncidentStatusByAlertID(ctx, "missing")
 	require.NoError(t, err)
 	assert.False(t, found)
 }

--- a/internal/observer/store/incidententry/store.go
+++ b/internal/observer/store/incidententry/store.go
@@ -68,6 +68,7 @@ type IncidentEntryStore interface {
 	Initialize(ctx context.Context) error
 	WriteIncidentEntry(ctx context.Context, entry *IncidentEntry) (id string, err error)
 	QueryIncidentEntries(ctx context.Context, params QueryParams) ([]IncidentEntry, int, error)
+	GetIncidentStatusByAlertID(ctx context.Context, alertID string) (status string, found bool, err error)
 	UpdateIncidentEntry(ctx context.Context, id string, status string, notes, description *string, now time.Time) (IncidentEntry, error)
 	Close() error
 }


### PR DESCRIPTION
## Purpose

Fix alert suppression so a new occurrence can trigger after the previous incident has been acknowledged or resolved.

Previously, suppression considered any recent matching alert a duplicate without checking its incident lifecycle state. This prevented subsequent occurrences from triggering within the suppression window.

## Approach

- Retrieve the latest matching alert during duplicate suppression.
- Check the incident associated with that alert.
- Continue suppressing alerts while the incident is active or still being persisted.
- Allow a new alert when the previous incident is acknowledged or resolved.
- Add regression coverage for re-triggering after acknowledgement.
- Add store-level coverage for retrieving alert and incident state.

## Related Issues

Closes #4201

## Checklist

- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (not applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported
- [x] This PR includes AI-generated code or content

## Remarks

Focused validation passed:

- `go test ./internal/observer/store/alertentry`
- `go test ./internal/observer/store/incidententry`
- `go test ./internal/observer/service`

The full lint gate could not complete locally because the machine ran out of disk space while compiling the repository-pinned linter.