### PR TITLE
fix: derive endpoint schema type from protocol on workload create

### DIFF
--- a/internal/occ/resources/workload/converter.go
+++ b/internal/occ/resources/workload/converter.go
@@ -274,7 +274,10 @@ func addEndpointsFromDescriptor(workload *openchoreov1alpha1.Workload, descripto
 			Visibility:  visibility,
 		}
 
-		// Set schema if provided
+		// Set the schema only when a schema file is provided. The schema type is
+		// derived from the endpoint protocol (e.g. HTTP -> openapi, gRPC -> proto)
+		// rather than copied from the endpoint type verbatim, so it matches the
+		// canonical formats understood by the rendering pipeline's schema extractor.
 		if descriptorEndpoint.SchemaFile != "" {
 			// Resolve schema file path relative to the workload descriptor directory
 			baseDir := filepath.Dir(descriptorPath)
@@ -287,7 +290,7 @@ func addEndpointsFromDescriptor(workload *openchoreov1alpha1.Workload, descripto
 			}
 
 			endpoint.Schema = &openchoreov1alpha1.Schema{
-				Type:    descriptorEndpoint.Type,
+				Type:    schemaFormatByEndpointType[openchoreov1alpha1.EndpointType(descriptorEndpoint.Type)],
 				Content: schemaContent,
 			}
 		}
@@ -295,6 +298,17 @@ func addEndpointsFromDescriptor(workload *openchoreov1alpha1.Workload, descripto
 		workload.Spec.Endpoints[descriptorEndpoint.Name] = endpoint
 	}
 	return nil
+}
+
+// schemaFormatByEndpointType maps an endpoint protocol to the canonical schema
+// format used for its API definition. These values mirror the canonical schema
+// types recognized by internal/pipeline/component/schemaextract. Endpoint types
+// with no API schema format (TCP, UDP, Websocket) are intentionally absent, so a
+// map lookup yields "" and no schema type is emitted for them.
+var schemaFormatByEndpointType = map[openchoreov1alpha1.EndpointType]string{
+	openchoreov1alpha1.EndpointTypeHTTP:    "openapi",
+	openchoreov1alpha1.EndpointTypeGRPC:    "proto",
+	openchoreov1alpha1.EndpointTypeGraphQL: "graphql",
 }
 
 // validEndpointVisibilities is the set of allowed visibility values for endpoints.

--- a/internal/occ/resources/workload/converter_test.go
+++ b/internal/occ/resources/workload/converter_test.go
@@ -773,7 +773,7 @@ info:
 			{
 				Name:       "api",
 				Port:       8080,
-				Type:       "REST",
+				Type:       "HTTP",
 				SchemaFile: "openapi.yaml",
 				Visibility: []string{"external"},
 			},
@@ -784,9 +784,55 @@ info:
 	require.Contains(t, w.Spec.Endpoints, "api")
 	ep := w.Spec.Endpoints["api"]
 	require.NotNil(t, ep.Schema)
-	assert.Equal(t, "REST", ep.Schema.Type)
+	// Schema type is derived from the endpoint protocol (HTTP -> openapi),
+	// not copied from the endpoint type verbatim.
+	assert.Equal(t, "openapi", ep.Schema.Type)
 	assert.Equal(t, schemaContent, ep.Schema.Content)
 }
+
+func TestAddEndpointsFromDescriptorSchemaTypeDerivation(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpointType string
+		wantSchema   string // "" means no schema.Type set
+	}{
+		{name: "HTTP maps to openapi", endpointType: "HTTP", wantSchema: "openapi"},
+		{name: "gRPC maps to proto", endpointType: "gRPC", wantSchema: "proto"},
+		{name: "GraphQL maps to graphql", endpointType: "GraphQL", wantSchema: "graphql"},
+		{name: "TCP has no schema format", endpointType: "TCP", wantSchema: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			descriptorPath := filepath.Join(dir, "workload.yaml")
+			schemaContent := "schema-body"
+			testutil.WriteYAML(t, dir, "schema.txt", schemaContent)
+			w := &openchoreov1alpha1.Workload{
+				Spec: openchoreov1alpha1.WorkloadSpec{
+					WorkloadTemplateSpec: openchoreov1alpha1.WorkloadTemplateSpec{},
+				},
+			}
+			desc := &WorkloadDescriptor{
+				Endpoints: []WorkloadDescriptorEndpoint{
+					{
+						Name:       "api",
+						Port:       8080,
+						Type:       tt.endpointType,
+						SchemaFile: "schema.txt",
+						Visibility: []string{"external"},
+					},
+				},
+			}
+			err := addEndpointsFromDescriptor(w, desc, descriptorPath)
+			require.NoError(t, err)
+			ep := w.Spec.Endpoints["api"]
+			require.NotNil(t, ep.Schema)
+			assert.Equal(t, tt.wantSchema, ep.Schema.Type)
+			assert.Equal(t, schemaContent, ep.Schema.Content)
+		})
+	}
+}
+
 func TestAddEndpointsFromDescriptorSchemaFileMissing(t *testing.T) {
 	dir := t.TempDir()
 	descriptorPath := filepath.Join(dir, "workload.yaml")
@@ -1000,7 +1046,7 @@ metadata:
 endpoints:
   - name: http
     port: 8080
-    type: REST
+    type: HTTP
     basePath: /api
     visibility:
       - external
@@ -1055,10 +1101,10 @@ spec:
   endpoints:
     http:
       port: 8080
-      type: REST
+      type: HTTP
       basePath: /api
       schema:
-        type: REST
+        type: openapi
         content: 'openapi: "3.0.0"'
       visibility:
         - external


### PR DESCRIPTION
## Purpose

The workload descriptor converter copied the endpoint's `type` (e.g. "HTTP") verbatim into `schema.type`. That value is not a canonical schema format, so the rendering pipeline's schemaextract could not match an extractor and silently degraded HTTP endpoints to catch-all routing even when a valid OpenAPI schema was supplied.

## Approach

 Derive `schema.type` from the endpoint protocol instead — HTTP -> openapi, gRPC -> proto, GraphQL -> graphql — and only emit it when a schemaFile is present. Protocols without an API schema format (TCP/UDP/Websocket) get no schema type.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4265

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
