### PR TITLE
fix(controller): clean up dp and workflows namespaces on delete

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller/component"
 	"github.com/openchoreo/openchoreo/internal/controller/componentrelease"
 	"github.com/openchoreo/openchoreo/internal/controller/componenttype"
+	"github.com/openchoreo/openchoreo/internal/controller/controlplanenamespace"
 	"github.com/openchoreo/openchoreo/internal/controller/dataplane"
 	"github.com/openchoreo/openchoreo/internal/controller/deploymentpipeline"
 	"github.com/openchoreo/openchoreo/internal/controller/environment"
@@ -154,6 +155,7 @@ func setupControlPlaneControllers(
 		&deploymentpipeline.Reconciler{Client: c, Scheme: s},
 		&workload.Reconciler{Client: c, Scheme: s},
 		&environment.Reconciler{Client: c, PlaneClientProvider: planeClientProvider, Scheme: s},
+		&controlplanenamespace.Reconciler{Client: c, PlaneClientProvider: planeClientProvider, Scheme: s},
 		&dataplane.Reconciler{
 			Client:        c,
 			Scheme:        s,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/controller-manager-role.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/controller-manager-role.yaml
@@ -35,6 +35,7 @@ rules:
     - delete
     - get
     - list
+    - update
     - watch
 - apiGroups:
     - ""

--- a/internal/controller/controlplanenamespace/controller.go
+++ b/internal/controller/controlplanenamespace/controller.go
@@ -1,0 +1,145 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplanenamespace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+const (
+	// CleanupFinalizer blocks control-plane namespace deletion until the
+	// shared workflows-* namespace on the workflow plane is removed.
+	CleanupFinalizer = "openchoreo.dev/control-plane-namespace-cleanup"
+)
+
+// Reconciler manages cleanup of workflow-plane resources owned by an
+// OpenChoreo control-plane namespace (labelled openchoreo.dev/control-plane=true).
+type Reconciler struct {
+	client.Client
+	PlaneClientProvider kubernetesClient.WorkflowPlaneClientProvider
+	Scheme              *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update;delete
+// +kubebuilder:rbac:groups=openchoreo.dev,resources=workflowplanes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=openchoreo.dev,resources=clusterworkflowplanes,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("namespace", req.Name)
+
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, req.NamespacedName, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Predicate should filter these out; belt-and-suspenders for direct Reconcile calls.
+	if ns.Labels[labels.LabelKeyControlPlaneNamespace] != labels.LabelValueTrue {
+		return ctrl.Result{}, nil
+	}
+
+	if !ns.DeletionTimestamp.IsZero() {
+		return r.finalize(ctx, ns)
+	}
+
+	if controllerutil.AddFinalizer(ns, CleanupFinalizer) {
+		logger.Info("Adding control-plane namespace cleanup finalizer")
+		if err := r.Update(ctx, ns); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) finalize(ctx context.Context, ns *corev1.Namespace) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("namespace", ns.Name)
+
+	if !controllerutil.ContainsFinalizer(ns, CleanupFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	pending, err := r.deleteWorkflowsNamespace(ctx, ns.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if pending {
+		logger.Info("Waiting for workflows namespace deletion", "workflowsNamespace", workflowsNamespaceName(ns.Name))
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	if controllerutil.RemoveFinalizer(ns, CleanupFinalizer) {
+		if err := r.Update(ctx, ns); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// deleteWorkflowsNamespace deletes workflows-<orgNS> on the resolved workflow plane.
+// Returns pending=true while the remote namespace still exists.
+func (r *Reconciler) deleteWorkflowsNamespace(ctx context.Context, orgNS string) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	wpResult, err := controller.GetWorkflowPlaneFromRef(ctx, r.Client, orgNS, nil)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// No workflow plane configured — nothing to clean up.
+			logger.Info("No workflow plane found during namespace finalization, skipping workflows cleanup")
+			return false, nil
+		}
+		return false, fmt.Errorf("resolve workflow plane for namespace %s: %w", orgNS, err)
+	}
+
+	wpClient, err := wpResult.GetK8sClient(r.PlaneClientProvider)
+	if err != nil {
+		return false, fmt.Errorf("workflow plane client for namespace %s: %w", orgNS, err)
+	}
+
+	wfNSName := workflowsNamespaceName(orgNS)
+	wfNS := &corev1.Namespace{}
+	if err := wpClient.Get(ctx, client.ObjectKey{Name: wfNSName}, wfNS); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get workflows namespace %s: %w", wfNSName, err)
+	}
+
+	if wfNS.DeletionTimestamp.IsZero() {
+		if err := wpClient.Delete(ctx, wfNS); err != nil && !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("delete workflows namespace %s: %w", wfNSName, err)
+		}
+	}
+	return true, nil
+}
+
+func workflowsNamespaceName(orgNS string) string {
+	return "workflows-" + orgNS
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			return obj.GetLabels()[labels.LabelKeyControlPlaneNamespace] == labels.LabelValueTrue
+		})).
+		Named("controlplanenamespace").
+		Complete(r)
+}

--- a/internal/controller/controlplanenamespace/controller.go
+++ b/internal/controller/controlplanenamespace/controller.go
@@ -26,10 +26,14 @@ const (
 	// CleanupFinalizer blocks control-plane namespace deletion until the
 	// shared workflows-* namespace on the workflow plane is removed.
 	CleanupFinalizer = "openchoreo.dev/control-plane-namespace-cleanup"
+
+	// workflowPlaneClientTimeout bounds remote Get/Delete during finalization so a
+	// stalled plane cannot pin a reconcile worker indefinitely.
+	workflowPlaneClientTimeout = 30 * time.Second
 )
 
 // Reconciler manages cleanup of workflow-plane resources owned by an
-// OpenChoreo control-plane namespace (labelled openchoreo.dev/control-plane=true).
+// OpenChoreo control-plane namespace (labeled openchoreo.dev/control-plane=true).
 type Reconciler struct {
 	client.Client
 	PlaneClientProvider kubernetesClient.WorkflowPlaneClientProvider
@@ -48,22 +52,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("get namespace %s: %w", req.Name, err)
 	}
 
-	// Predicate should filter these out; belt-and-suspenders for direct Reconcile calls.
-	if ns.Labels[labels.LabelKeyControlPlaneNamespace] != labels.LabelValueTrue {
-		return ctrl.Result{}, nil
-	}
-
+	// Finalize even if the control-plane label was removed after the finalizer
+	// was added, so deletion cannot strand forever.
 	if !ns.DeletionTimestamp.IsZero() {
 		return r.finalize(ctx, ns)
+	}
+
+	if ns.Labels[labels.LabelKeyControlPlaneNamespace] != labels.LabelValueTrue {
+		return ctrl.Result{}, nil
 	}
 
 	if controllerutil.AddFinalizer(ns, CleanupFinalizer) {
 		logger.Info("Adding control-plane namespace cleanup finalizer")
 		if err := r.Update(ctx, ns); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("add cleanup finalizer on namespace %s: %w", ns.Name, err)
 		}
 	}
 	return ctrl.Result{}, nil
@@ -87,7 +92,7 @@ func (r *Reconciler) finalize(ctx context.Context, ns *corev1.Namespace) (ctrl.R
 
 	if controllerutil.RemoveFinalizer(ns, CleanupFinalizer) {
 		if err := r.Update(ctx, ns); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("remove cleanup finalizer on namespace %s: %w", ns.Name, err)
 		}
 	}
 	return ctrl.Result{}, nil
@@ -113,9 +118,12 @@ func (r *Reconciler) deleteWorkflowsNamespace(ctx context.Context, orgNS string)
 		return false, fmt.Errorf("workflow plane client for namespace %s: %w", orgNS, err)
 	}
 
+	remoteCtx, cancel := context.WithTimeout(ctx, workflowPlaneClientTimeout)
+	defer cancel()
+
 	wfNSName := workflowsNamespaceName(orgNS)
 	wfNS := &corev1.Namespace{}
-	if err := wpClient.Get(ctx, client.ObjectKey{Name: wfNSName}, wfNS); err != nil {
+	if err := wpClient.Get(remoteCtx, client.ObjectKey{Name: wfNSName}, wfNS); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -123,7 +131,7 @@ func (r *Reconciler) deleteWorkflowsNamespace(ctx context.Context, orgNS string)
 	}
 
 	if wfNS.DeletionTimestamp.IsZero() {
-		if err := wpClient.Delete(ctx, wfNS); err != nil && !apierrors.IsNotFound(err) {
+		if err := wpClient.Delete(remoteCtx, wfNS); err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("delete workflows namespace %s: %w", wfNSName, err)
 		}
 	}
@@ -138,7 +146,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Namespace{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			return obj.GetLabels()[labels.LabelKeyControlPlaneNamespace] == labels.LabelValueTrue
+			if obj.GetLabels()[labels.LabelKeyControlPlaneNamespace] == labels.LabelValueTrue {
+				return true
+			}
+			// Keep reconciling while our finalizer is present even if the label was removed.
+			return controllerutil.ContainsFinalizer(obj, CleanupFinalizer)
 		})).
 		Named("controlplanenamespace").
 		Complete(r)

--- a/internal/controller/controlplanenamespace/controller_test.go
+++ b/internal/controller/controlplanenamespace/controller_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplanenamespace
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("core scheme: %v", err)
+	}
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("openchoreo scheme: %v", err)
+	}
+	return s
+}
+
+type staticWPProvider struct {
+	cli client.Client
+	err error
+}
+
+func (p *staticWPProvider) WorkflowPlaneClient(*openchoreov1alpha1.WorkflowPlane) (client.Client, error) {
+	return p.cli, p.err
+}
+
+func (p *staticWPProvider) ClusterWorkflowPlaneClient(*openchoreov1alpha1.ClusterWorkflowPlane) (client.Client, error) {
+	return p.cli, p.err
+}
+
+func controlPlaneNS(name string, finalizers ...string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Labels:     map[string]string{labels.LabelKeyControlPlaneNamespace: labels.LabelValueTrue},
+			Finalizers: finalizers,
+		},
+	}
+}
+
+func TestReconcile_AddsFinalizer(t *testing.T) {
+	s := testScheme(t)
+	ns := controlPlaneNS("acme")
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+	r := &Reconciler{Client: cli, Scheme: s, PlaneClientProvider: &staticWPProvider{cli: cli}}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "acme"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got := &corev1.Namespace{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: "acme"}, got); err != nil {
+		t.Fatalf("get ns: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatal("expected cleanup finalizer")
+	}
+}
+
+func TestReconcile_IgnoresUnlabeledNamespace(t *testing.T) {
+	s := testScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+	r := &Reconciler{Client: cli, Scheme: s}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "kube-system"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got := &corev1.Namespace{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: "kube-system"}, got); err != nil {
+		t.Fatalf("get ns: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatal("should not add finalizer to unlabeled namespace")
+	}
+}
+
+func TestFinalize_DeletesWorkflowsNamespace(t *testing.T) {
+	s := testScheme(t)
+	ctx := context.Background()
+
+	// Control-plane ns being deleted
+	cpNS := controlPlaneNS("acme", CleanupFinalizer)
+	now := metav1.Now()
+	cpNS.DeletionTimestamp = &now
+
+	// Default ClusterWorkflowPlane so resolution succeeds
+	cwp := &openchoreov1alpha1.ClusterWorkflowPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+
+	// Workflow-plane side: the shared workflows namespace
+	wfNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "workflows-acme"}}
+
+	cpClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cpNS, cwp).Build()
+	wpClient := fake.NewClientBuilder().WithScheme(s).WithObjects(wfNS).Build()
+
+	r := &Reconciler{
+		Client:              cpClient,
+		Scheme:              s,
+		PlaneClientProvider: &staticWPProvider{cli: wpClient},
+	}
+
+	// First pass: issues delete, requeues
+	result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "acme"}})
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while workflows namespace is terminating")
+	}
+
+	// Simulate workflows namespace gone
+	if err := wpClient.Delete(ctx, wfNS); err != nil && !apierrors.IsNotFound(err) {
+		// fake client may have already marked it; force remove if needed
+		_ = wpClient.Delete(ctx, wfNS)
+	}
+	// Fake client keeps deleting objects with finalizers; our wfNS has none so it should be gone.
+	// If still present (DeletionTimestamp set), remove it from the store by creating a fresh client.
+	if err := wpClient.Get(ctx, types.NamespacedName{Name: "workflows-acme"}, &corev1.Namespace{}); err == nil {
+		// Still there — build a new wp client without it
+		wpClient = fake.NewClientBuilder().WithScheme(s).Build()
+		r.PlaneClientProvider = &staticWPProvider{cli: wpClient}
+	}
+
+	// Second pass: removes finalizer
+	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "acme"}})
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	got := &corev1.Namespace{}
+	err = cpClient.Get(ctx, types.NamespacedName{Name: "acme"}, got)
+	if apierrors.IsNotFound(err) {
+		// finalizer removed and object GC'd — fine for fake client with deletionTimestamp
+		return
+	}
+	if err != nil {
+		t.Fatalf("get cp ns: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatal("expected cleanup finalizer removed")
+	}
+}
+
+func TestFinalize_SkipsWhenNoWorkflowPlane(t *testing.T) {
+	s := testScheme(t)
+	ctx := context.Background()
+
+	cpNS := controlPlaneNS("acme", CleanupFinalizer)
+	now := metav1.Now()
+	cpNS.DeletionTimestamp = &now
+
+	cpClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cpNS).Build()
+	r := &Reconciler{
+		Client:              cpClient,
+		Scheme:              s,
+		PlaneClientProvider: &staticWPProvider{cli: fake.NewClientBuilder().WithScheme(s).Build()},
+	}
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "acme"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got := &corev1.Namespace{}
+	err = cpClient.Get(ctx, types.NamespacedName{Name: "acme"}, got)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatal("expected finalizer removed when no workflow plane exists")
+	}
+}
+
+func TestWorkflowsNamespaceName(t *testing.T) {
+	if got := workflowsNamespaceName("acme"); got != "workflows-acme" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/controller/controlplanenamespace/controller_test.go
+++ b/internal/controller/controlplanenamespace/controller_test.go
@@ -202,3 +202,61 @@ func TestWorkflowsNamespaceName(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+// Label can be stripped after the finalizer is set (mislabel / operator edit).
+// Finalization must still run so deletion does not hang forever.
+func TestFinalize_AfterControlPlaneLabelRemoved(t *testing.T) {
+	s := testScheme(t)
+	ctx := context.Background()
+
+	now := metav1.Now()
+	cpNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "acme",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{CleanupFinalizer},
+			// No control-plane label — only the finalizer remains.
+		},
+	}
+	cwp := &openchoreov1alpha1.ClusterWorkflowPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	wfNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "workflows-acme"}}
+
+	cpClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cpNS, cwp).Build()
+	wpClient := fake.NewClientBuilder().WithScheme(s).WithObjects(wfNS).Build()
+	r := &Reconciler{
+		Client:              cpClient,
+		Scheme:              s,
+		PlaneClientProvider: &staticWPProvider{cli: wpClient},
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "acme"}})
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while workflows namespace is terminating")
+	}
+
+	// Workflows ns gone
+	wpClient = fake.NewClientBuilder().WithScheme(s).Build()
+	r.PlaneClientProvider = &staticWPProvider{cli: wpClient}
+
+	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "acme"}})
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	got := &corev1.Namespace{}
+	err = cpClient.Get(ctx, types.NamespacedName{Name: "acme"}, got)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatal("expected finalizer removed after unlabeled finalize")
+	}
+}

--- a/internal/controller/environment/integrations/kubernetes/namespaces_handler.go
+++ b/internal/controller/environment/integrations/kubernetes/namespaces_handler.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openchoreo/openchoreo/internal/dataplane"
-	k8s "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
 type namespacesHandler struct {
@@ -35,16 +35,18 @@ func (h *namespacesHandler) IsRequired(envCtx *dataplane.EnvironmentContext) boo
 	return true
 }
 
-func (h *namespacesHandler) GetCurrentState(ctx context.Context, envCtx *dataplane.EnvironmentContext) (interface{}, error) {
-	// this should list the namespaces which has the following labels:
-	//	environment-name: <environment_name>
-	//	namespace-name: <namespace_name>
-	namespaceList := &corev1.NamespaceList{}
-	labelSelector := client.MatchingLabels{
-		k8s.LabelKeyEnvironmentName: envCtx.Environment.Name,
-		k8s.LabelKeyNamespaceName:   envCtx.Environment.Namespace,
+// environmentNamespaceLabels matches data-plane namespaces owned by this environment.
+// Keys must match those set when the namespace is created (see renderedrelease.makeDesiredNamespaces).
+func environmentNamespaceLabels(envCtx *dataplane.EnvironmentContext) client.MatchingLabels {
+	return client.MatchingLabels{
+		labels.LabelKeyEnvironmentName: envCtx.Environment.Name,
+		labels.LabelKeyNamespaceName:   envCtx.Environment.Namespace,
 	}
-	if err := h.kubernetesClient.List(ctx, namespaceList, labelSelector); err != nil {
+}
+
+func (h *namespacesHandler) GetCurrentState(ctx context.Context, envCtx *dataplane.EnvironmentContext) (interface{}, error) {
+	namespaceList := &corev1.NamespaceList{}
+	if err := h.kubernetesClient.List(ctx, namespaceList, environmentNamespaceLabels(envCtx)); err != nil {
 		if k8sapierrors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -65,26 +67,14 @@ func (h *namespacesHandler) Update(ctx context.Context, envCtx *dataplane.Enviro
 }
 
 func (h *namespacesHandler) Delete(ctx context.Context, envCtx *dataplane.EnvironmentContext) error {
-	// this should delete the namespaces which has the following labels:
-	//	environment-name: <environment_name>
-	//	namespace-name: <namespace_name>
 	namespaceList := &corev1.NamespaceList{}
-	labelSelector := client.MatchingLabels{
-		k8s.LabelKeyEnvironmentName: envCtx.Environment.Name,
-		k8s.LabelKeyNamespaceName:   envCtx.Environment.Namespace,
-	}
-
-	if err := h.kubernetesClient.List(ctx, namespaceList, labelSelector); err != nil {
+	if err := h.kubernetesClient.List(ctx, namespaceList, environmentNamespaceLabels(envCtx)); err != nil {
 		return fmt.Errorf("error listing namespaces: %w", err)
 	}
 
-	if len(namespaceList.Items) == 0 {
-		return nil
-	}
-
-	// Deleting each namespace
-	for _, ns := range namespaceList.Items {
-		if err := h.kubernetesClient.Delete(ctx, &ns); err != nil {
+	for i := range namespaceList.Items {
+		ns := &namespaceList.Items[i]
+		if err := h.kubernetesClient.Delete(ctx, ns); err != nil {
 			if k8sapierrors.IsNotFound(err) {
 				continue
 			}

--- a/internal/controller/environment/integrations/kubernetes/namespaces_handler_test.go
+++ b/internal/controller/environment/integrations/kubernetes/namespaces_handler_test.go
@@ -57,6 +57,8 @@ func TestNamespacesHandler_GetCurrentState(t *testing.T) {
 		cli := fake.NewClientBuilder().WithScheme(s).WithObjects(
 			dpNS("dp-acme-my-project-development-abc", "development", "acme"),
 			dpNS("dp-acme-other-staging-xyz", "staging", "acme"),
+			// Same env name under a different org namespace must not match.
+			dpNS("dp-other-my-project-development-zzz", "development", "other-org"),
 		).Build()
 		h := NewNamespacesHandler(cli)
 

--- a/internal/controller/environment/integrations/kubernetes/namespaces_handler_test.go
+++ b/internal/controller/environment/integrations/kubernetes/namespaces_handler_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/dataplane"
+	"github.com/openchoreo/openchoreo/internal/labels"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return s
+}
+
+func envCtx(envName, orgNS string) *dataplane.EnvironmentContext {
+	return &dataplane.EnvironmentContext{
+		Environment: &openchoreov1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: envName, Namespace: orgNS},
+		},
+	}
+}
+
+func dpNS(name, env, orgNS string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				labels.LabelKeyEnvironmentName: env,
+				labels.LabelKeyNamespaceName:   orgNS,
+				labels.LabelKeyProjectName:     "my-project",
+			},
+		},
+	}
+}
+
+func TestNamespacesHandler_GetCurrentState(t *testing.T) {
+	s := testScheme(t)
+	ctx := context.Background()
+	ec := envCtx("development", "acme")
+
+	t.Run("finds namespaces labeled with openchoreo.dev keys", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			dpNS("dp-acme-my-project-development-abc", "development", "acme"),
+			dpNS("dp-acme-other-staging-xyz", "staging", "acme"),
+		).Build()
+		h := NewNamespacesHandler(cli)
+
+		got, err := h.GetCurrentState(ctx, ec)
+		if err != nil {
+			t.Fatalf("GetCurrentState: %v", err)
+		}
+		list, ok := got.(*corev1.NamespaceList)
+		if !ok || list == nil {
+			t.Fatalf("expected NamespaceList, got %T", got)
+		}
+		if len(list.Items) != 1 {
+			t.Fatalf("expected 1 namespace, got %d", len(list.Items))
+		}
+		if list.Items[0].Name != "dp-acme-my-project-development-abc" {
+			t.Fatalf("unexpected namespace %q", list.Items[0].Name)
+		}
+	})
+
+	t.Run("ignores legacy unprefixed label keys", func(t *testing.T) {
+		// Namespaces created by the current pipeline use openchoreo.dev/* labels.
+		// Matching only the old keys would miss them and leave orphans on env delete.
+		legacy := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dp-legacy",
+				Labels: map[string]string{
+					"environment-name": "development",
+					"namespace-name":   "acme",
+				},
+			},
+		}
+		cli := fake.NewClientBuilder().WithScheme(s).WithObjects(legacy).Build()
+		h := NewNamespacesHandler(cli)
+
+		got, err := h.GetCurrentState(ctx, ec)
+		if err != nil {
+			t.Fatalf("GetCurrentState: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil for legacy labels, got %#v", got)
+		}
+	})
+
+	t.Run("returns nil when no matching namespaces", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(s).Build()
+		h := NewNamespacesHandler(cli)
+		got, err := h.GetCurrentState(ctx, ec)
+		if err != nil {
+			t.Fatalf("GetCurrentState: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+}
+
+func TestNamespacesHandler_Delete(t *testing.T) {
+	s := testScheme(t)
+	ctx := context.Background()
+	ec := envCtx("development", "acme")
+
+	match := dpNS("dp-acme-my-project-development-abc", "development", "acme")
+	otherEnv := dpNS("dp-acme-my-project-staging-def", "staging", "acme")
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(match, otherEnv).Build()
+	h := NewNamespacesHandler(cli)
+
+	if err := h.Delete(ctx, ec); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Matching namespace deleted
+	err := cli.Get(ctx, client.ObjectKey{Name: match.Name}, &corev1.Namespace{})
+	if err == nil {
+		t.Fatal("expected matching namespace to be deleted")
+	}
+
+	// Other environment's namespace kept
+	if err := cli.Get(ctx, client.ObjectKey{Name: otherEnv.Name}, &corev1.Namespace{}); err != nil {
+		t.Fatalf("other env namespace should remain: %v", err)
+	}
+}


### PR DESCRIPTION
## Purpose
When an Environment is deleted, the finalizer is supposed to remove the associated data-plane (`dp-*`) namespaces. That cleanup never matched real namespaces: the handler listed with legacy labels (`environment-name` / `namespace-name`) while `RenderedRelease` creates them with `openchoreo.dev/environment` and `openchoreo.dev/namespace`. The finalizer completed without deleting anything and left empty `dp-*` namespaces behind.

The shared `workflows-<org-namespace>` namespace on the workflow plane also had no owner, so deleting a control-plane org namespace left it orphaned.

Fixes #2921

## Approach
Point the environment namespace handler at the same label keys used at creation (`internal/labels`). List/delete still scope by environment name and control-plane namespace so only that env's data-plane namespaces are removed.

Add a small control-plane Namespace controller that only watches namespaces labelled `openchoreo.dev/control-plane=true`, adds a finalizer, and on delete removes `workflows-<ns>` via the resolved default workflow plane client. If no workflow plane exists, cleanup is skipped and the finalizer is removed.

Manager RBAC gains `update` on namespaces so the new finalizer can be written.

## Related Issues
- Fixes #2921

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
Matches the split called out on #2921: environment finalizer owns `dp-*` cleanup; workflows namespace is org-scoped and handled from the control-plane namespace lifecycle, not from Environment.