### PR TITLE
fix: prevent shell injection and isolate privileged pods

### DIFF
--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -22,11 +22,23 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{workflow.parameters.build-env}}'
         command:
           - sh
           - -c
@@ -36,9 +48,7 @@ spec:
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{workflow.parameters.build-env}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -69,12 +79,23 @@ spec:
             BUILDER="docker.io/paketobuildpacks/builder-jammy-full:0.3.603"
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full:0.1.130"
 
-            # Build --env flags from the buildEnv JSON array (e.g. [{"name":"BP_NODE_RUN_SCRIPTS","value":"build"}])
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
             echo ">> Building image with Paketo buildpacks"
@@ -84,7 +105,7 @@ spec:
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
               --pull-policy always \
-              $ENV_ARGS
+              "$@"
 
             echo ">> Image built successfully"
             echo ">> Saving image"
@@ -103,11 +124,23 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{workflow.parameters.build-env}}'
         command:
           - sh
           - -c
@@ -117,9 +150,7 @@ spec:
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{workflow.parameters.build-env}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -150,12 +181,23 @@ spec:
             BUILDER="gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1"
             RUN_IMG="gcr.io/buildpacks/google-22/run:latest"
 
-            # Build --env flags from the buildEnv JSON array (e.g. [{"name":"GOOGLE_RUNTIME_VERSION","value":"21"}])
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
             echo ">> Building image with GCP buildpacks"
@@ -165,7 +207,7 @@ spec:
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
               --pull-policy always \
-              $ENV_ARGS
+              "$@"
 
             echo ">> Image built successfully"
             echo ">> Saving image"
@@ -184,12 +226,24 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
           - name: build-env
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{inputs.parameters.build-env}}'
         command:
           - sh
           - -c
@@ -199,9 +253,7 @@ spec:
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{inputs.parameters.build-env}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -232,12 +284,23 @@ spec:
             BUILDER="ghcr.io/openchoreo/buildpack/ballerina:18"
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina:18-run"
 
-            # Build --env flags from the buildEnv JSON array
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
             echo ">> Building image with Ballerina buildpack"
@@ -248,7 +311,7 @@ spec:
               --path "$WORKDIR/$APP_PATH" \
               --volume "/mnt/vol:/app/generated-artifacts:rw" \
               --pull-policy always \
-              $ENV_ARGS
+              "$@"
 
             echo ">> Image built successfully"
             echo ">> Saving image"
@@ -267,13 +330,29 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
           - name: build-env
           - name: build-args
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: DOCKER_CONTEXT
+            value: '{{workflow.parameters.docker-context}}'
+          - name: DOCKERFILE_PATH
+            value: '{{workflow.parameters.dockerfile-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{inputs.parameters.build-env}}'
+          - name: BUILD_ARGS_JSON
+            value: '{{inputs.parameters.build-args}}'
         command:
           - sh
           - -c
@@ -282,11 +361,7 @@ spec:
             set -e
 
             WORKDIR="/mnt/vol/source"
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            DOCKER_CONTEXT="{{workflow.parameters.docker-context}}"
-            DOCKERFILE_PATH="{{workflow.parameters.dockerfile-path}}"
-            BUILD_ENV_JSON='{{inputs.parameters.build-env}}'
-            BUILD_ARGS_JSON='{{inputs.parameters.build-args}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -319,27 +394,46 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
-            # Build --env flags
-            ENV_ARGS=""
+            # Build --env and --build-arg flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
-            # Build --build-arg flags
-            BUILD_ARG_ARGS=""
             if [ -n "$BUILD_ARGS_JSON" ] && [ "$BUILD_ARGS_JSON" != "[]" ]; then
-              BUILD_ARG_ARGS=$(echo "$BUILD_ARGS_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--build-arg \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_build_arg_entries=$(printf '%s' "$BUILD_ARGS_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --build-arg "$kv"
+              done <<EOF
+            $encoded_build_arg_entries
+            EOF
             fi
 
             echo ">> Building image"
-            podman build -t $IMAGE -f $WORKDIR/$DOCKERFILE_PATH $ENV_ARGS $BUILD_ARG_ARGS $WORKDIR/$DOCKER_CONTEXT
+            podman build -t "$IMAGE" -f "$WORKDIR/$DOCKERFILE_PATH" "$@" -- "$WORKDIR/$DOCKER_CONTEXT"
             echo ">> Image built successfully"
             echo ">> Saving image"
-            podman save -o /mnt/vol/app-image.tar $IMAGE
+            podman save -o /mnt/vol/app-image.tar "$IMAGE"
         securityContext:
           privileged: true
         volumeMounts:

--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -72,9 +72,22 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            cat > /etc/containers/containers.conf <<EOF
+            [containers]
+            netns = "host"
+            cgroups = "disabled"
+            log_driver = "k8s-file"
+            [engine]
+            cgroup_manager = "cgroupfs"
+            events_logger = "file"
+            runtime = "crun"
+            EOF
+
             echo ">> Initializing build environment"
-            podman system service --time=0 &
+            mkdir -p /run/podman
+            podman system service --time=0 unix:///run/podman/podman.sock &
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
+            export DOCKER_HOST=unix:///run/podman/podman.sock
 
             BUILDER="docker.io/paketobuildpacks/builder-jammy-full:0.3.603"
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full:0.1.130"
@@ -174,9 +187,22 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            cat > /etc/containers/containers.conf <<EOF
+            [containers]
+            netns = "host"
+            cgroups = "disabled"
+            log_driver = "k8s-file"
+            [engine]
+            cgroup_manager = "cgroupfs"
+            events_logger = "file"
+            runtime = "crun"
+            EOF
+
             echo ">> Initializing build environment"
-            podman system service --time=0 &
+            mkdir -p /run/podman
+            podman system service --time=0 unix:///run/podman/podman.sock &
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
+            export DOCKER_HOST=unix:///run/podman/podman.sock
 
             BUILDER="gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1"
             RUN_IMG="gcr.io/buildpacks/google-22/run:latest"
@@ -277,9 +303,22 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            cat > /etc/containers/containers.conf <<EOF
+            [containers]
+            netns = "host"
+            cgroups = "disabled"
+            log_driver = "k8s-file"
+            [engine]
+            cgroup_manager = "cgroupfs"
+            events_logger = "file"
+            runtime = "crun"
+            EOF
+
             echo ">> Initializing build environment"
-            podman system service --time=0 &
+            mkdir -p /run/podman
+            podman system service --time=0 unix:///run/podman/podman.sock &
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
+            export DOCKER_HOST=unix:///run/podman/podman.sock
 
             BUILDER="ghcr.io/openchoreo/buildpack/ballerina:18"
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina:18-run"

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -5,12 +5,24 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
           - name: build-env
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{inputs.parameters.build-env}}'
         command:
           - sh
           - -c
@@ -20,9 +32,7 @@ spec:
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{inputs.parameters.build-env}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -53,12 +63,23 @@ spec:
             BUILDER="ghcr.io/openchoreo/buildpack/ballerina:18"
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina:18-run"
 
-            # Build --env flags from the buildEnv JSON array
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
             echo ">> Building image with Ballerina buildpack"
@@ -69,7 +90,7 @@ spec:
               --path "$WORKDIR/$APP_PATH" \
               --volume "/mnt/vol:/app/generated-artifacts:rw" \
               --pull-policy always \
-              $ENV_ARGS
+              "$@"
 
             echo ">> Image built successfully"
             echo ">> Saving image"

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -56,9 +56,22 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            cat > /etc/containers/containers.conf <<EOF
+            [containers]
+            netns = "host"
+            cgroups = "disabled"
+            log_driver = "k8s-file"
+            [engine]
+            cgroup_manager = "cgroupfs"
+            events_logger = "file"
+            runtime = "crun"
+            EOF
+
             echo ">> Initializing build environment"
-            podman system service --time=0 &
+            mkdir -p /run/podman
+            podman system service --time=0 unix:///run/podman/podman.sock &
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
+            export DOCKER_HOST=unix:///run/podman/podman.sock
 
             BUILDER="ghcr.io/openchoreo/buildpack/ballerina:18"
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina:18-run"

--- a/samples/getting-started/workflow-templates/checkout-source.yaml
+++ b/samples/getting-started/workflow-templates/checkout-source.yaml
@@ -17,6 +17,13 @@ spec:
             optional: true
       container:
         image: alpine/git
+        env:
+          - name: BRANCH
+            value: '{{workflow.parameters.branch}}'
+          - name: REPO
+            value: '{{workflow.parameters.git-repo}}'
+          - name: COMMIT
+            value: '{{workflow.parameters.commit}}'
         command:
           - sh
           - -c
@@ -24,9 +31,6 @@ spec:
           - |-
             set -e
 
-            BRANCH={{workflow.parameters.branch}}
-            REPO={{workflow.parameters.git-repo}}
-            COMMIT={{workflow.parameters.commit}}
             GIT_SECRET_PATH="/etc/secrets/git-secret"
 
             # --- Parameter Validation ---
@@ -135,7 +139,7 @@ spec:
             fi
 
             if [ -n "$COMMIT" ]; then
-                git clone --no-checkout --depth 1 "$REPO" /mnt/vol/source
+                git clone --no-checkout --depth 1 -- "$REPO" /mnt/vol/source
                 cd /mnt/vol/source
                 git config --global advice.detachedHead false
                 git fetch --depth 1 origin "$COMMIT"
@@ -143,7 +147,7 @@ spec:
                 echo -n "$COMMIT" | cut -c1-8 > /tmp/git-revision.txt
                 echo ">> Checked out commit: $COMMIT"
             else
-                git clone --single-branch --branch $BRANCH --depth 1 "$REPO" /mnt/vol/source
+                git clone --single-branch --branch "$BRANCH" --depth 1 -- "$REPO" /mnt/vol/source
                 cd /mnt/vol/source
                 COMMIT_SHA=$(git rev-parse HEAD)
                 echo -n "$COMMIT_SHA" | cut -c1-8 > /tmp/git-revision.txt

--- a/samples/getting-started/workflow-templates/checkout-source.yaml
+++ b/samples/getting-started/workflow-templates/checkout-source.yaml
@@ -50,6 +50,13 @@ spec:
               exit 1
             fi
 
+            case "$COMMIT" in
+              -*)
+                echo ">> Error: Commit must not start with a hyphen."
+                exit 1
+                ;;
+            esac
+
             # Check if git secret exists (for private repositories)
             if [ -d "$GIT_SECRET_PATH" ] && [ "$(ls $GIT_SECRET_PATH 2>/dev/null)" ]; then
                 echo ">> Configuring repository authentication"

--- a/samples/getting-started/workflow-templates/containerfile-build.yaml
+++ b/samples/getting-started/workflow-templates/containerfile-build.yaml
@@ -5,13 +5,29 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
           - name: build-env
           - name: build-args
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: DOCKER_CONTEXT
+            value: '{{workflow.parameters.docker-context}}'
+          - name: DOCKERFILE_PATH
+            value: '{{workflow.parameters.dockerfile-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{inputs.parameters.build-env}}'
+          - name: BUILD_ARGS_JSON
+            value: '{{inputs.parameters.build-args}}'
         command:
           - sh
           - -c
@@ -20,11 +36,7 @@ spec:
             set -e
 
             WORKDIR="/mnt/vol/source"
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            DOCKER_CONTEXT="{{workflow.parameters.docker-context}}"
-            DOCKERFILE_PATH="{{workflow.parameters.dockerfile-path}}"
-            BUILD_ENV_JSON='{{inputs.parameters.build-env}}'
-            BUILD_ARGS_JSON='{{inputs.parameters.build-args}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -57,27 +69,46 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
-            # Build --env flags
-            ENV_ARGS=""
+            # Build --env and --build-arg flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
-            # Build --build-arg flags
-            BUILD_ARG_ARGS=""
             if [ -n "$BUILD_ARGS_JSON" ] && [ "$BUILD_ARGS_JSON" != "[]" ]; then
-              BUILD_ARG_ARGS=$(echo "$BUILD_ARGS_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--build-arg \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_build_arg_entries=$(printf '%s' "$BUILD_ARGS_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --build-arg "$kv"
+              done <<EOF
+            $encoded_build_arg_entries
+            EOF
             fi
 
             echo ">> Building image"
-            podman build -t $IMAGE -f $WORKDIR/$DOCKERFILE_PATH $ENV_ARGS $BUILD_ARG_ARGS $WORKDIR/$DOCKER_CONTEXT
+            podman build -t "$IMAGE" -f "$WORKDIR/$DOCKERFILE_PATH" "$@" -- "$WORKDIR/$DOCKER_CONTEXT"
             echo ">> Image built successfully"
             echo ">> Saving image"
-            podman save -o /mnt/vol/app-image.tar $IMAGE
+            podman save -o /mnt/vol/app-image.tar "$IMAGE"
         securityContext:
           privileged: true
         volumeMounts:

--- a/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
@@ -5,11 +5,23 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{workflow.parameters.build-env}}'
         command:
           - sh
           - -c
@@ -19,9 +31,7 @@ spec:
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{workflow.parameters.build-env}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -52,12 +62,23 @@ spec:
             BUILDER="gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1"
             RUN_IMG="gcr.io/buildpacks/google-22/run:latest"
 
-            # Build --env flags from the buildEnv JSON array (e.g. [{"name":"GOOGLE_RUNTIME_VERSION","value":"21"}])
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
             echo ">> Building image with GCP buildpacks"
@@ -67,7 +88,7 @@ spec:
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
               --pull-policy always \
-              $ENV_ARGS
+              "$@"
 
             echo ">> Image built successfully"
             echo ">> Saving image"

--- a/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
@@ -55,9 +55,22 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            cat > /etc/containers/containers.conf <<EOF
+            [containers]
+            netns = "host"
+            cgroups = "disabled"
+            log_driver = "k8s-file"
+            [engine]
+            cgroup_manager = "cgroupfs"
+            events_logger = "file"
+            runtime = "crun"
+            EOF
+
             echo ">> Initializing build environment"
-            podman system service --time=0 &
+            mkdir -p /run/podman
+            podman system service --time=0 unix:///run/podman/podman.sock &
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
+            export DOCKER_HOST=unix:///run/podman/podman.sock
 
             BUILDER="gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1"
             RUN_IMG="gcr.io/buildpacks/google-22/run:latest"

--- a/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload-k3d.yaml
@@ -28,8 +28,49 @@ spec:
             default: "http://host.k3d.internal:8080"
           - name: api-server-host-header
             default: "api.openchoreo.localhost"
+      volumes:
+        - name: tools
+          emptyDir: {}
+      initContainers:
+        - name: copy-occ
+          image: ghcr.io/openchoreo/openchoreo-cli:v1.0.0
+          command: [sh, -c, "mkdir -p /tools/bin && cp /usr/local/bin/occ /tools/bin/occ"]
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE
+            value: '{{inputs.parameters.image}}'
+          - name: RUN_NAME
+            value: '{{inputs.parameters.run-name}}'
+          - name: PROJECT_NAME
+            value: '{{workflow.parameters.project-name}}'
+          - name: COMPONENT_NAME
+            value: '{{workflow.parameters.component-name}}'
+          - name: NAMESPACE_NAME
+            value: '{{workflow.parameters.namespace-name}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: OAUTH_URL
+            value: '{{inputs.parameters.oauth-token-url}}'
+          - name: OAUTH_HOST
+            value: '{{inputs.parameters.oauth-host-header}}'
+          - name: CLIENT_ID
+            value: '{{inputs.parameters.oauth-client-id}}'
+          - name: CLIENT_SECRET
+            value: '{{inputs.parameters.oauth-client-secret}}'
+          - name: OAUTH_SCOPE
+            value: '{{inputs.parameters.oauth-scope}}'
+          - name: API_URL
+            value: '{{inputs.parameters.api-server-url}}'
+          - name: API_HOST
+            value: '{{inputs.parameters.api-server-host-header}}'
         command:
           - sh
           - -c
@@ -37,17 +78,16 @@ spec:
           - |-
             set -e
 
-            IMAGE={{inputs.parameters.image}}
-            RUN_NAME={{inputs.parameters.run-name}}
-            PROJECT_NAME={{workflow.parameters.project-name}}
-            COMPONENT_NAME={{workflow.parameters.component-name}}
-            NAMESPACE_NAME={{workflow.parameters.namespace-name}}
-            APP_PATH="{{workflow.parameters.app-path}}"
+            export PATH="/tools/bin:${PATH}"
+            export HOME="/tmp/openchoreo"
+            mkdir -p "${HOME}"
 
             DESCRIPTOR_PATH="/mnt/vol/source${APP_PATH:+/${APP_PATH#/}}"
             OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+            WORKLOAD_JSON="/mnt/vol/workload-cr.json"
 
             echo ">> Image: ${IMAGE}"
+            echo ">> occ version: $(occ version 2>/dev/null || echo 'unknown')"
             echo ">> Descriptor path: ${DESCRIPTOR_PATH}"
             echo ">> Namespace: ${NAMESPACE_NAME}, Project: ${PROJECT_NAME}, Component: ${COMPONENT_NAME}"
             if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
@@ -64,66 +104,39 @@ spec:
               exit 1
             fi
 
-            mkdir -p /etc/containers
-            cat <<EOF > /etc/containers/storage.conf
-            [storage]
-            driver = "overlay"
-            runroot = "/run/containers/storage"
-            graphroot = "/var/lib/containers/storage"
-            [storage.options.overlay]
-            mount_program = "/usr/bin/fuse-overlayfs"
-            EOF
-
             # --- Step 1: Generate workload CR using occ ---
             WORKLOAD_FROM_SOURCE="false"
             if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
               WORKLOAD_FROM_SOURCE="true"
               echo ">> Generating workload CR from workload descriptor"
-              podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:v1.0.0 \
-                workload create \
+              cd "${DESCRIPTOR_PATH}"
+              occ workload create \
                 --namespace "${NAMESPACE_NAME}" \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \
                 --image "${IMAGE}" \
                 --descriptor "workload.yaml" \
-                -o "workload-cr.yaml"
+                -o "${OUTPUT_PATH}"
             else
               echo ">> Generating default workload CR"
-              podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:v1.0.0 \
-                workload create \
+              cd "${DESCRIPTOR_PATH}"
+              occ workload create \
                 --namespace "${NAMESPACE_NAME}" \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \
                 --image "${IMAGE}" \
-                -o "workload-cr.yaml"
+                -o "${OUTPUT_PATH}"
             fi
 
-            cp -f "${DESCRIPTOR_PATH}/workload-cr.yaml" "${OUTPUT_PATH}"
-
             # --- Step 2: Convert workload CR YAML to JSON (strip apiVersion and kind) ---
-            # Use yq to convert YAML to JSON, then jq -c to produce valid compact single-line JSON
-             podman run --rm \
-               -v /mnt/vol:/data:rw \
-               mikefarah/yq -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
-               > /mnt/vol/workload-cr-raw.json
-             podman run --rm \
-               -v /mnt/vol:/data:rw \
-               ghcr.io/jqlang/jq:1.7.1 -c '.' /data/workload-cr-raw.json \
-               > /mnt/vol/workload-cr.json
+            yq -o=json 'del(.apiVersion) | del(.kind)' "${OUTPUT_PATH}" \
+              > /mnt/vol/workload-cr-raw.json
+            jq -c '.' /mnt/vol/workload-cr-raw.json \
+              > "${WORKLOAD_JSON}"
             echo ">> Generated workload JSON payload:"
-            cat /mnt/vol/workload-cr.json
+            cat "${WORKLOAD_JSON}"
 
             # --- Step 3: Get OAuth token ---
-            OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
-            OAUTH_HOST="{{inputs.parameters.oauth-host-header}}"
-            CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
-            CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
-            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
-
             echo ">> Requesting OAuth token from ${OAUTH_URL}"
             if [ -n "${OAUTH_SCOPE}" ]; then
               TOKEN_RESPONSE=$(curl -s --fail-with-body \
@@ -152,11 +165,8 @@ spec:
             echo ">> Successfully obtained access token"
 
             # --- Step 4: Create or update workload via API server ---
-            API_URL="{{inputs.parameters.api-server-url}}"
-            API_HOST="{{inputs.parameters.api-server-host-header}}"
-
             # Extract workload name from the JSON payload for potential update
-            WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq -r '.metadata.name' /data/workload-cr.json)
+            WORKLOAD_NAME=$(yq -r '.metadata.name' "${WORKLOAD_JSON}")
 
             echo ">> Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads"
             RESPONSE=$(curl -s -w "\n%{http_code}" \
@@ -164,7 +174,7 @@ spec:
               -H "Host: ${API_HOST}" \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-              -d @/mnt/vol/workload-cr.json)
+              -d @"${WORKLOAD_JSON}")
 
             HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
             BODY=$(echo "${RESPONSE}" | sed '$d')
@@ -179,7 +189,7 @@ spec:
                   -H "Host: ${API_HOST}" \
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-                  -d @/mnt/vol/workload-cr.json)
+                  -d @"${WORKLOAD_JSON}")
               else
                 echo ">> Workload already exists, updating only container image (auto-generated)"
                 # GET the existing workload
@@ -198,17 +208,13 @@ spec:
 
                 # Extract the new image from the generated workload and merge into existing
                 echo "${GET_BODY}" > /mnt/vol/workload-existing.json
-                NEW_IMAGE=$(podman run --rm \
-                  -v /mnt/vol:/data:ro \
-                  ghcr.io/jqlang/jq:1.7.1 -r '.spec.container.image' /data/workload-cr.json)
+                NEW_IMAGE=$(jq -r '.spec.container.image' "${WORKLOAD_JSON}")
 
                 echo ">> Updating container image to: ${NEW_IMAGE}"
-                podman run --rm \
-                  -v /mnt/vol:/data:rw \
-                  ghcr.io/jqlang/jq:1.7.1 \
+                jq \
                   --arg img "${NEW_IMAGE}" \
                   '.spec.container.image = $img' \
-                  /data/workload-existing.json \
+                  /mnt/vol/workload-existing.json \
                   > /mnt/vol/workload-merged.json
 
                 RESPONSE=$(curl -s -w "\n%{http_code}" \
@@ -254,20 +260,14 @@ spec:
             # If workload is source-defined, also add the workload-from-source annotation
             echo "${WF_RUN_BODY}" > /mnt/vol/workflowrun-get.json
             if [ "${WORKLOAD_FROM_SOURCE}" = "true" ]; then
-              podman run --rm \
-                -v /mnt/vol:/data:rw \
-                ghcr.io/jqlang/jq:1.7.1 \
-                --rawfile wl /data/workload-cr.json \
+              jq --rawfile wl "${WORKLOAD_JSON}" \
                 '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "true"' \
-                /data/workflowrun-get.json \
+                /mnt/vol/workflowrun-get.json \
                 > /mnt/vol/workflowrun-updated.json
             else
-              podman run --rm \
-                -v /mnt/vol:/data:rw \
-                ghcr.io/jqlang/jq:1.7.1 \
-                --rawfile wl /data/workload-cr.json \
+              jq --rawfile wl "${WORKLOAD_JSON}" \
                 '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "false"' \
-                /data/workflowrun-get.json \
+                /mnt/vol/workflowrun-get.json \
                 > /mnt/vol/workflowrun-updated.json
             fi
 
@@ -291,5 +291,5 @@ spec:
         volumeMounts:
           - name: workspace
             mountPath: /mnt/vol
-        securityContext:
-          privileged: true
+          - name: tools
+            mountPath: /tools

--- a/samples/getting-started/workflow-templates/generate-workload.yaml
+++ b/samples/getting-started/workflow-templates/generate-workload.yaml
@@ -24,8 +24,45 @@ spec:
           # Update these when the API server URL or host changes.
           - name: api-server-url
             default: "http://host.k3d.internal:8080"
+      volumes:
+        - name: tools
+          emptyDir: {}
+      initContainers:
+        - name: copy-occ
+          image: ghcr.io/openchoreo/openchoreo-cli:v1.0.0
+          command: [sh, -c, "mkdir -p /tools/bin && cp /usr/local/bin/occ /tools/bin/occ"]
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE
+            value: '{{inputs.parameters.image}}'
+          - name: RUN_NAME
+            value: '{{inputs.parameters.run-name}}'
+          - name: PROJECT_NAME
+            value: '{{workflow.parameters.project-name}}'
+          - name: COMPONENT_NAME
+            value: '{{workflow.parameters.component-name}}'
+          - name: NAMESPACE_NAME
+            value: '{{workflow.parameters.namespace-name}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: OAUTH_URL
+            value: '{{inputs.parameters.oauth-token-url}}'
+          - name: CLIENT_ID
+            value: '{{inputs.parameters.oauth-client-id}}'
+          - name: CLIENT_SECRET
+            value: '{{inputs.parameters.oauth-client-secret}}'
+          - name: OAUTH_SCOPE
+            value: '{{inputs.parameters.oauth-scope}}'
+          - name: API_URL
+            value: '{{inputs.parameters.api-server-url}}'
         command:
           - sh
           - -c
@@ -33,17 +70,16 @@ spec:
           - |-
             set -e
 
-            IMAGE={{inputs.parameters.image}}
-            RUN_NAME={{inputs.parameters.run-name}}
-            PROJECT_NAME={{workflow.parameters.project-name}}
-            COMPONENT_NAME={{workflow.parameters.component-name}}
-            NAMESPACE_NAME={{workflow.parameters.namespace-name}}
-            APP_PATH="{{workflow.parameters.app-path}}"
+            export PATH="/tools/bin:${PATH}"
+            export HOME="/tmp/openchoreo"
+            mkdir -p "${HOME}"
 
             DESCRIPTOR_PATH="/mnt/vol/source${APP_PATH:+/${APP_PATH#/}}"
             OUTPUT_PATH="/mnt/vol/workload-cr.yaml"
+            WORKLOAD_JSON="/mnt/vol/workload-cr.json"
 
             echo ">> Image: ${IMAGE}"
+            echo ">> occ version: $(occ version 2>/dev/null || echo 'unknown')"
             echo ">> Descriptor path: ${DESCRIPTOR_PATH}"
             echo ">> Namespace: ${NAMESPACE_NAME}, Project: ${PROJECT_NAME}, Component: ${COMPONENT_NAME}"
             if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
@@ -60,65 +96,39 @@ spec:
               exit 1
             fi
 
-            mkdir -p /etc/containers
-            cat <<EOF > /etc/containers/storage.conf
-            [storage]
-            driver = "overlay"
-            runroot = "/run/containers/storage"
-            graphroot = "/var/lib/containers/storage"
-            [storage.options.overlay]
-            mount_program = "/usr/bin/fuse-overlayfs"
-            EOF
-
             # --- Step 1: Generate workload CR using occ ---
             WORKLOAD_FROM_SOURCE="false"
             if [ -f "${DESCRIPTOR_PATH}/workload.yaml" ]; then
               WORKLOAD_FROM_SOURCE="true"
               echo ">> Generating workload CR from descriptor"
-              podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:v1.0.0 \
-                workload create \
+              cd "${DESCRIPTOR_PATH}"
+              occ workload create \
                 --namespace "${NAMESPACE_NAME}" \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \
                 --image "${IMAGE}" \
                 --descriptor "workload.yaml" \
-                -o "workload-cr.yaml"
+                -o "${OUTPUT_PATH}"
             else
               echo ">> Generating default workload CR"
-              podman run --rm --network=none \
-              -v $DESCRIPTOR_PATH:/app:rw -w /app \
-              ghcr.io/openchoreo/openchoreo-cli:v1.0.0 \
-                workload create \
+              cd "${DESCRIPTOR_PATH}"
+              occ workload create \
                 --namespace "${NAMESPACE_NAME}" \
                 --project "${PROJECT_NAME}" \
                 --component "${COMPONENT_NAME}" \
                 --image "${IMAGE}" \
-                -o "workload-cr.yaml"
+                -o "${OUTPUT_PATH}"
             fi
 
-            cp -f "${DESCRIPTOR_PATH}/workload-cr.yaml" "${OUTPUT_PATH}"
-
             # --- Step 2: Convert workload CR YAML to JSON (strip apiVersion and kind) ---
-            # Use yq to convert YAML to JSON, then jq -c to produce valid compact single-line JSON
-             podman run --rm \
-               -v /mnt/vol:/data:rw \
-               mikefarah/yq -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
-               > /mnt/vol/workload-cr-raw.json
-             podman run --rm \
-               -v /mnt/vol:/data:rw \
-               ghcr.io/jqlang/jq:1.7.1 -c '.' /data/workload-cr-raw.json \
-               > /mnt/vol/workload-cr.json
+            yq -o=json 'del(.apiVersion) | del(.kind)' "${OUTPUT_PATH}" \
+              > /mnt/vol/workload-cr-raw.json
+            jq -c '.' /mnt/vol/workload-cr-raw.json \
+              > "${WORKLOAD_JSON}"
             echo ">> Generated workload JSON payload:"
-            cat /mnt/vol/workload-cr.json
+            cat "${WORKLOAD_JSON}"
 
             # --- Step 3: Get OAuth token ---
-            OAUTH_URL="{{inputs.parameters.oauth-token-url}}"
-            CLIENT_ID="{{inputs.parameters.oauth-client-id}}"
-            CLIENT_SECRET="{{inputs.parameters.oauth-client-secret}}"
-            OAUTH_SCOPE="{{inputs.parameters.oauth-scope}}"
-
             echo ">> Requesting OAuth token from ${OAUTH_URL}"
             if [ -n "${OAUTH_SCOPE}" ]; then
               TOKEN_RESPONSE=$(curl -sk --fail-with-body \
@@ -145,17 +155,15 @@ spec:
             echo ">> Successfully obtained access token"
 
             # --- Step 4: Create or update workload via API server ---
-            API_URL="{{inputs.parameters.api-server-url}}"
-
             # Extract workload name from the JSON payload for potential update
-            WORKLOAD_NAME=$(podman run --rm -v /mnt/vol:/data:ro mikefarah/yq -r '.metadata.name' /data/workload-cr.json)
+            WORKLOAD_NAME=$(yq -r '.metadata.name' "${WORKLOAD_JSON}")
 
             echo ">> Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads"
             RESPONSE=$(curl -sk -w "\n%{http_code}" \
               -X POST "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads" \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-              -d @/mnt/vol/workload-cr.json)
+              -d @"${WORKLOAD_JSON}")
 
             HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
             BODY=$(echo "${RESPONSE}" | sed '$d')
@@ -169,7 +177,7 @@ spec:
                   -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE_NAME}/workloads/${WORKLOAD_NAME}" \
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-                  -d @/mnt/vol/workload-cr.json)
+                  -d @"${WORKLOAD_JSON}")
               else
                 echo ">> Workload already exists, updating only container image (auto-generated)"
                 # GET the existing workload
@@ -187,17 +195,13 @@ spec:
 
                 # Extract the new image from the generated workload and merge into existing
                 echo "${GET_BODY}" > /mnt/vol/workload-existing.json
-                NEW_IMAGE=$(podman run --rm \
-                  -v /mnt/vol:/data:ro \
-                  ghcr.io/jqlang/jq:1.7.1 -r '.spec.container.image' /data/workload-cr.json)
+                NEW_IMAGE=$(jq -r '.spec.container.image' "${WORKLOAD_JSON}")
 
                 echo ">> Updating container image to: ${NEW_IMAGE}"
-                podman run --rm \
-                  -v /mnt/vol:/data:rw \
-                  ghcr.io/jqlang/jq:1.7.1 \
+                jq \
                   --arg img "${NEW_IMAGE}" \
                   '.spec.container.image = $img' \
-                  /data/workload-existing.json \
+                  /mnt/vol/workload-existing.json \
                   > /mnt/vol/workload-merged.json
 
                 RESPONSE=$(curl -sk -w "\n%{http_code}" \
@@ -241,20 +245,14 @@ spec:
             # If workload is source-defined, also add the workload-from-source annotation
             echo "${WF_RUN_BODY}" > /mnt/vol/workflowrun-get.json
             if [ "${WORKLOAD_FROM_SOURCE}" = "true" ]; then
-              podman run --rm \
-                -v /mnt/vol:/data:rw \
-                ghcr.io/jqlang/jq:1.7.1 \
-                --rawfile wl /data/workload-cr.json \
+              jq --rawfile wl "${WORKLOAD_JSON}" \
                 '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "true"' \
-                /data/workflowrun-get.json \
+                /mnt/vol/workflowrun-get.json \
                 > /mnt/vol/workflowrun-updated.json
             else
-              podman run --rm \
-                -v /mnt/vol:/data:rw \
-                ghcr.io/jqlang/jq:1.7.1 \
-                --rawfile wl /data/workload-cr.json \
+              jq --rawfile wl "${WORKLOAD_JSON}" \
                 '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n")) | .metadata.annotations["openchoreo.dev/workload-from-source"] = "false"' \
-                /data/workflowrun-get.json \
+                /mnt/vol/workflowrun-get.json \
                 > /mnt/vol/workflowrun-updated.json
             fi
 
@@ -277,5 +275,5 @@ spec:
         volumeMounts:
           - name: workspace
             mountPath: /mnt/vol
-        securityContext:
-          privileged: true
+          - name: tools
+            mountPath: /tools

--- a/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
@@ -5,11 +5,23 @@ metadata:
 spec:
   templates:
     - name: build-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: APP_PATH
+            value: '{{workflow.parameters.app-path}}'
+          - name: BUILD_ENV_JSON
+            value: '{{workflow.parameters.build-env}}'
         command:
           - sh
           - -c
@@ -19,9 +31,7 @@ spec:
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{workflow.parameters.image-name}}:{{workflow.parameters.image-tag}}-{{inputs.parameters.git-revision}}"
-            APP_PATH="{{workflow.parameters.app-path}}"
-            BUILD_ENV_JSON='{{workflow.parameters.build-env}}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             # --- Parameter Validation ---
             echo ">> Image: $IMAGE"
@@ -52,12 +62,23 @@ spec:
             BUILDER="docker.io/paketobuildpacks/builder-jammy-full:0.3.603"
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full:0.1.130"
 
-            # Build --env flags from the buildEnv JSON array (e.g. [{"name":"BP_NODE_RUN_SCRIPTS","value":"build"}])
-            ENV_ARGS=""
+            # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
+            set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              ENV_ARGS=$(echo "$BUILD_ENV_JSON" | \
-                podman run --rm -i ghcr.io/jqlang/jq:1.7.1 -r '.[] | "--env \(.name)=\(.value)"' | \
-                tr '\n' ' ')
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
+              done <<EOF
+            $encoded_env_entries
+            EOF
             fi
 
             echo ">> Building image with Paketo buildpacks"
@@ -67,7 +88,7 @@ spec:
               --docker-host inherit \
               --path "$WORKDIR/$APP_PATH" \
               --pull-policy always \
-              $ENV_ARGS
+              "$@"
 
             echo ">> Image built successfully"
             echo ">> Saving image"

--- a/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
@@ -55,9 +55,22 @@ spec:
             mount_program = "/usr/bin/fuse-overlayfs"
             EOF
 
+            cat > /etc/containers/containers.conf <<EOF
+            [containers]
+            netns = "host"
+            cgroups = "disabled"
+            log_driver = "k8s-file"
+            [engine]
+            cgroup_manager = "cgroupfs"
+            events_logger = "file"
+            runtime = "crun"
+            EOF
+
             echo ">> Initializing build environment"
-            podman system service --time=0 &
+            mkdir -p /run/podman
+            podman system service --time=0 unix:///run/podman/podman.sock &
             until podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null | grep -q true; do sleep 1; done
+            export DOCKER_HOST=unix:///run/podman/podman.sock
 
             BUILDER="docker.io/paketobuildpacks/builder-jammy-full:0.3.603"
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full:0.1.130"

--- a/samples/getting-started/workflow-templates/publish-image-k3d.yaml
+++ b/samples/getting-started/workflow-templates/publish-image-k3d.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   templates:
     - name: publish-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
@@ -19,7 +20,14 @@ spec:
             optional: true
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
         command:
           - sh
           - -c
@@ -27,9 +35,6 @@ spec:
           - |-
             set -e
 
-            GIT_REVISION={{inputs.parameters.git-revision}}
-            IMAGE_NAME={{workflow.parameters.image-name}}
-            IMAGE_TAG={{workflow.parameters.image-tag}}
             SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             REGISTRY_ENDPOINT="host.k3d.internal:10082"
@@ -58,13 +63,13 @@ spec:
 
             podman load -i /mnt/vol/app-image.tar
 
-            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+            podman tag "$SRC_IMAGE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
 
             echo ">> Pushing image to registry"
             if [ -f "$AUTH_FILE" ]; then
-              podman push --tls-verify=false --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=false --authfile "$AUTH_FILE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             else
-              podman push --tls-verify=false $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=false "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             fi
 
             echo ">> Image published successfully: $REGISTRY_ENDPOINT/$SRC_IMAGE"

--- a/samples/getting-started/workflow-templates/publish-image.yaml
+++ b/samples/getting-started/workflow-templates/publish-image.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   templates:
     - name: publish-image
+      podSpecPatch: '{"hostUsers": false}'
       inputs:
         parameters:
           - name: git-revision
@@ -19,7 +20,14 @@ spec:
             optional: true
             secretName: '{{workflow.parameters.registry-push-secret}}'
       container:
-        image: ghcr.io/openchoreo/podman-runner:v1.0
+        image: ghcr.io/openchoreo/podman-runner:v1.2
+        env:
+          - name: GIT_REVISION
+            value: '{{inputs.parameters.git-revision}}'
+          - name: IMAGE_NAME
+            value: '{{workflow.parameters.image-name}}'
+          - name: IMAGE_TAG
+            value: '{{workflow.parameters.image-tag}}'
         command:
           - sh
           - -c
@@ -27,9 +35,6 @@ spec:
           - |-
             set -e
 
-            GIT_REVISION={{inputs.parameters.git-revision}}
-            IMAGE_NAME={{workflow.parameters.image-name}}
-            IMAGE_TAG={{workflow.parameters.image-tag}}
             SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             REGISTRY_ENDPOINT="ttl.sh/openchoreo-builds"
@@ -58,13 +63,13 @@ spec:
 
             podman load -i /mnt/vol/app-image.tar
 
-            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+            podman tag "$SRC_IMAGE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
 
             echo ">> Pushing image to registry"
             if [ -f "$AUTH_FILE" ]; then
-              podman push --tls-verify=true --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=true --authfile "$AUTH_FILE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             else
-              podman push --tls-verify=true $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify=true "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             fi
 
             echo ">> Image published successfully: $REGISTRY_ENDPOINT/$SRC_IMAGE"

--- a/samples/workflows/aws-rds-postgres/aws-rds-postgres-create.yaml
+++ b/samples/workflows/aws-rds-postgres/aws-rds-postgres-create.yaml
@@ -249,6 +249,9 @@ spec:
     - name: report-step
       container:
         image: alpine:3
+        env:
+          - name: CREDENTIALS_SECRET
+            value: '{{workflow.parameters.credentials-secret}}'
         command: [sh, -c]
         args:
           - |
@@ -280,10 +283,10 @@ spec:
             echo "Connection String (template):"
             echo "  ${CONN_STRING_TEMPLATE}"
             echo ""
-            echo "NOTE: Password is stored in the '{{workflow.parameters.credentials-secret}}'"
+            echo "NOTE: Password is stored in the '${CREDENTIALS_SECRET}'"
             echo "      Kubernetes Secret under the 'dbPassword' key."
             echo "      Retrieve it with:"
-            echo "      kubectl get secret {{workflow.parameters.credentials-secret}} \\"
+            echo "      kubectl get secret ${CREDENTIALS_SECRET} \\"
             echo "        -o jsonpath='{.data.dbPassword}' | base64 -d"
             echo "================================================="
             echo ""

--- a/samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml
+++ b/samples/workflows/github-stats-report/cluster-workflow-template-github-stats-report.yaml
@@ -22,13 +22,15 @@ spec:
     - name: fetch-step
       container:
         image: curlimages/curl:8.8.0
+        env:
+          - name: ORG
+            value: '{{workflow.parameters.org}}'
+          - name: REPO
+            value: '{{workflow.parameters.repo}}'
         command: [sh, -c]
         args:
           - |
             set -e
-            ORG="{{workflow.parameters.org}}"
-            REPO="{{workflow.parameters.repo}}"
-
             echo "Fetching stats for ${ORG}/${REPO} ..."
             curl -sf \
               -H "Accept: application/vnd.github+json" \
@@ -76,12 +78,14 @@ spec:
           - name: output-format
       container:
         image: alpine:3
+        env:
+          - name: FORMAT
+            value: '{{inputs.parameters.output-format}}'
         command: [sh, -c]
         args:
           - |
             set -e
             apk add --no-cache jq -q
-            FORMAT="{{inputs.parameters.output-format}}"
 
             if [ "$FORMAT" = "json" ]; then
               cat /mnt/data/stats.json

--- a/samples/workflows/scm-create-repo/codecommit-create-repo.yaml
+++ b/samples/workflows/scm-create-repo/codecommit-create-repo.yaml
@@ -24,10 +24,6 @@ spec:
         args:
           - |
             set -e
-            REPO_NAME="{{workflow.parameters.repo-name}}"
-            DESCRIPTION="{{workflow.parameters.description}}"
-            REGION="{{workflow.parameters.region}}"
-
             echo "Creating CodeCommit repository ${REPO_NAME} in region ${REGION} ..."
             aws codecommit create-repository \
               --repository-name "$REPO_NAME" \
@@ -37,6 +33,12 @@ spec:
 
             echo "Repository creation request complete."
         env:
+          - name: REPO_NAME
+            value: '{{workflow.parameters.repo-name}}'
+          - name: DESCRIPTION
+            value: '{{workflow.parameters.description}}'
+          - name: REGION
+            value: '{{workflow.parameters.region}}'
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/samples/workflows/scm-create-repo/github-create-repo.yaml
+++ b/samples/workflows/scm-create-repo/github-create-repo.yaml
@@ -24,13 +24,6 @@ spec:
         args:
           - |
             set -e
-            OWNER="{{workflow.parameters.owner}}"
-            REPO_NAME="{{workflow.parameters.repo-name}}"
-            DESCRIPTION="{{workflow.parameters.description}}"
-            VISIBILITY="{{workflow.parameters.visibility}}"
-            AUTO_INIT="{{workflow.parameters.auto-init}}"
-            GITIGNORE_TEMPLATE="{{workflow.parameters.gitignore-template}}"
-            LICENSE_TEMPLATE="{{workflow.parameters.license-template}}"
 
             IS_PRIVATE="false"
             if [ "$VISIBILITY" = "private" ]; then
@@ -60,6 +53,20 @@ spec:
 
             echo "Repository creation request complete."
         env:
+          - name: OWNER
+            value: '{{workflow.parameters.owner}}'
+          - name: REPO_NAME
+            value: '{{workflow.parameters.repo-name}}'
+          - name: DESCRIPTION
+            value: '{{workflow.parameters.description}}'
+          - name: VISIBILITY
+            value: '{{workflow.parameters.visibility}}'
+          - name: AUTO_INIT
+            value: '{{workflow.parameters.auto-init}}'
+          - name: GITIGNORE_TEMPLATE
+            value: '{{workflow.parameters.gitignore-template}}'
+          - name: LICENSE_TEMPLATE
+            value: '{{workflow.parameters.license-template}}'
           - name: GITHUB_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

Workflow parameters were interpolated directly into shell scripts, allowing crafted values to alter command execution. Privileged Podman workflow pods also ran without user-namespace isolation. This PR prevents parameter-based shell injection and reduces the host impact of privileged workflow execution.

## Approach

Argo parameters are passed through container environment variables and consumed as quoted shell values. Build environment variables and build arguments are encoded and reconstructed as distinct argv entries, preserving spaces, quotes, glob characters, and newlines.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
