### PR TITLE
feat(controller): poll scaled-to-zero workloads faster to detect scale-up

### DIFF
--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -33,7 +33,9 @@ const (
 	targetPlaneDataPlane          = "dataplane"
 	targetPlaneObservabilityPlane = "observabilityplane"
 
-	appsAPIGroup = "apps"
+	appsAPIGroup    = "apps"
+	deploymentKind  = "Deployment"
+	statefulSetKind = "StatefulSet"
 
 	// ConditionResourcesApplied indicates whether resources were successfully applied to the target plane.
 	// When False, it contains the error message from the failed apply operation.
@@ -201,6 +203,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
+	// Poll workloads scaled to zero faster so an autoscaler-driven scale-up is noticed promptly.
+	if hasResurrectableWorkload(desiredResources, liveResources) {
+		requeueAfter := getResurrectableRequeueInterval()
+		logger.Info("Workload is scaled to zero, requeuing to detect autoscaler-driven scale-up",
+			"requeueAfter", requeueAfter)
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+
 	requeueAfter := getStableRequeueInterval(release)
 	logger.Info("Successfully applied the Release resources to the target plane",
 		"targetPlane", targetPlane, "requeueAfter", requeueAfter)
@@ -312,7 +322,7 @@ func (r *Reconciler) makeDesiredResources(release *openchoreov1alpha1.RenderedRe
 // can surface it instead of silently dropping the restart trigger.
 func injectRestartedAt(obj *unstructured.Unstructured, value string) error {
 	gvk := obj.GroupVersionKind()
-	if gvk.Group != appsAPIGroup || gvk.Kind != "Deployment" {
+	if gvk.Group != appsAPIGroup || gvk.Kind != deploymentKind {
 		return nil
 	}
 	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
@@ -449,8 +459,8 @@ var wellKnownDataPlaneGVKs = []schema.GroupVersionKind{
 	{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
 
 	// Apps
-	{Group: "apps", Version: "v1", Kind: "Deployment"},
-	{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+	{Group: appsAPIGroup, Version: "v1", Kind: deploymentKind},
+	{Group: appsAPIGroup, Version: "v1", Kind: statefulSetKind},
 
 	// Batch
 	{Group: "batch", Version: "v1", Kind: "Job"},
@@ -608,6 +618,15 @@ func getStableRequeueInterval(release *openchoreov1alpha1.RenderedRelease) time.
 	}
 
 	// Add 20% jitter
+	jitterMax := time.Duration(float64(baseInterval) * 0.2)
+	return addJitter(baseInterval, jitterMax)
+}
+
+// getResurrectableRequeueInterval returns the requeue interval for workloads scaled to zero
+// that an autoscaler may resurrect: faster than the stable cadence so a scale-up is noticed
+// promptly, but slow enough not to hammer the plane agent when many workloads sit idle.
+func getResurrectableRequeueInterval() time.Duration {
+	baseInterval := 1 * time.Minute
 	jitterMax := time.Duration(float64(baseInterval) * 0.2)
 	return addJitter(baseInterval, jitterMax)
 }

--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -168,11 +168,44 @@ func (r *Reconciler) hasTransitioningResources(resources []openchoreov1alpha1.Re
 	return false
 }
 
+// hasResurrectableWorkload reports whether any managed Deployment or StatefulSet is scaled to
+// zero without being paused, so an autoscaler (HPA/KEDA scale-from-zero) could bring it back
+// up at any time. Replicas are read from the live object, not the rendered spec: the control
+// plane strips spec.replicas from autoscaled workloads, so only the live object reflects what
+// the autoscaler set. Live items carry no GVK, so workloads are matched by the desired GVK and
+// paired to the live object by resource ID.
+func hasResurrectableWorkload(desiredResources, liveResources []*unstructured.Unstructured) bool {
+	liveByID := make(map[string]*unstructured.Unstructured, len(liveResources))
+	for _, live := range liveResources {
+		if id := live.GetLabels()[labels.LabelKeyRenderedReleaseResourceID]; id != "" {
+			liveByID[id] = live
+		}
+	}
+
+	for _, desired := range desiredResources {
+		gvk := desired.GroupVersionKind()
+		if gvk.Group != appsAPIGroup || (gvk.Kind != deploymentKind && gvk.Kind != statefulSetKind) {
+			continue
+		}
+		live, ok := liveByID[desired.GetLabels()[labels.LabelKeyRenderedReleaseResourceID]]
+		if !ok {
+			continue
+		}
+		if paused, _, _ := unstructured.NestedBool(live.Object, "spec", "paused"); paused {
+			continue
+		}
+		if replicas, found, err := unstructured.NestedInt64(live.Object, "spec", "replicas"); err == nil && found && replicas == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func GetHealthCheckFunc(gvk schema.GroupVersionKind) func(obj *unstructured.Unstructured) (openchoreov1alpha1.HealthStatus, error) {
 	switch {
-	case gvk.Group == "apps" && gvk.Kind == "Deployment":
+	case gvk.Group == appsAPIGroup && gvk.Kind == deploymentKind:
 		return getDeploymentHealth
-	case gvk.Group == "apps" && gvk.Kind == "StatefulSet":
+	case gvk.Group == appsAPIGroup && gvk.Kind == statefulSetKind:
 		return getStatefulSetHealth
 	case gvk.Group == "" && gvk.Kind == "Pod":
 		return getPodHealth

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -389,6 +389,103 @@ func TestHasTransitioningResources(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────
+// hasResurrectableWorkload
+// ─────────────────────────────────────────────────────────────
+
+func TestHasResurrectableWorkload(t *testing.T) {
+	// desired is a rendered manifest carrying its GVK + resource-ID label; live is the object
+	// fetched back from the plane (no GVK on list items) sharing the same resource-ID label.
+	desired := func(resID string, gvk schema.GroupVersionKind) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		u.SetLabels(map[string]string{labels.LabelKeyRenderedReleaseResourceID: resID})
+		return u
+	}
+	deploymentGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	statefulSetGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
+	liveDeployment := func(resID string, replicas *int32, paused bool) *unstructured.Unstructured {
+		u := toUnstructured(t, &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: replicas, Paused: paused}})
+		u.SetLabels(map[string]string{labels.LabelKeyRenderedReleaseResourceID: resID})
+		return u
+	}
+	liveStatefulSet := func(resID string, replicas *int32) *unstructured.Unstructured {
+		u := toUnstructured(t, &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Replicas: replicas}})
+		u.SetLabels(map[string]string{labels.LabelKeyRenderedReleaseResourceID: resID})
+		return u
+	}
+	serviceGVK := schema.GroupVersionKind{Version: "v1", Kind: "Service"}
+
+	tests := []struct {
+		name    string
+		desired []*unstructured.Unstructured
+		live    []*unstructured.Unstructured
+		want    bool
+	}{
+		{
+			name: "empty resources returns false",
+			want: false,
+		},
+		{
+			name:    "deployment scaled to zero returns true",
+			desired: []*unstructured.Unstructured{desired("d1", deploymentGVK)},
+			live:    []*unstructured.Unstructured{liveDeployment("d1", int32Ptr(0), false)},
+			want:    true,
+		},
+		{
+			name:    "paused deployment at zero returns false",
+			desired: []*unstructured.Unstructured{desired("d1", deploymentGVK)},
+			live:    []*unstructured.Unstructured{liveDeployment("d1", int32Ptr(0), true)},
+			want:    false,
+		},
+		{
+			name:    "deployment with replicas returns false",
+			desired: []*unstructured.Unstructured{desired("d1", deploymentGVK)},
+			live:    []*unstructured.Unstructured{liveDeployment("d1", int32Ptr(2), false)},
+			want:    false,
+		},
+		{
+			name:    "deployment without replicas field returns false",
+			desired: []*unstructured.Unstructured{desired("d1", deploymentGVK)},
+			live:    []*unstructured.Unstructured{liveDeployment("d1", nil, false)},
+			want:    false,
+		},
+		{
+			name:    "statefulset scaled to zero returns true",
+			desired: []*unstructured.Unstructured{desired("s1", statefulSetGVK)},
+			live:    []*unstructured.Unstructured{liveStatefulSet("s1", int32Ptr(0))},
+			want:    true,
+		},
+		{
+			name:    "non-workload kind at zero returns false",
+			desired: []*unstructured.Unstructured{desired("svc", serviceGVK)},
+			live:    nil,
+			want:    false,
+		},
+		{
+			name:    "no matching live resource returns false",
+			desired: []*unstructured.Unstructured{desired("d1", deploymentGVK)},
+			live:    nil,
+			want:    false,
+		},
+		{
+			name:    "mix with a scaled-to-zero deployment returns true",
+			desired: []*unstructured.Unstructured{desired("d1", deploymentGVK), desired("d2", deploymentGVK)},
+			live:    []*unstructured.Unstructured{liveDeployment("d1", int32Ptr(1), false), liveDeployment("d2", int32Ptr(0), false)},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasResurrectableWorkload(tt.desired, tt.live)
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
 // GetHealthCheckFunc
 // ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Purpose
A `RenderedRelease` whose Deployment or StatefulSet is scaled to zero is treated as "stable" and gets the slow (5m) requeue cadence. But an autoscaler (HPA / KEDA scale-from-zero) can bring that workload back up at any moment, and the control plane would not observe the `0 -> N` transition until the next stable poll — up to 5 minutes of staleness in the reported status.

## Approach
Add a middle requeue tier between the progressing (10s) and stable (5m) cadences for releases that own a Deployment or StatefulSet currently at zero replicas and not deliberately paused:

- New `hasResurrectableWorkload` check and `getResurrectableRequeueInterval()` (1m, with the same 20% jitter as the existing helpers). Wired into `Reconcile` after the transitioning check and before the stable path.
- Replica state is read from the **live** object fetched from the target plane, not the rendered desired spec. For autoscaled workloads the control plane strips `spec.replicas` from what it applies, so only the live object reflects what the autoscaler actually set on the cluster.
- Workloads are identified by the **desired** object's GVK and paired to the live object by resource-ID label, because live list items returned over the proxy do not carry their own GVK (the API server sets it only on the list envelope) — the same pairing `buildResourceStatus` uses.
- Deliberately paused rollouts are excluded: nothing external will resurrect them, so they stay on the slow cadence and a cluster full of paused workloads does not hammer the plane agent.

The interval is hardcoded (not spec-configurable) to keep the change contained. Cutting the per-poll cost for idle workloads (apply only when the spec changed) is a separate, larger optimization tracked by the existing TODO in the controller.

## Related Issues
_None._

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
Unit tests cover the scaled-to-zero (Deployment and StatefulSet), paused-at-zero, replicas>0, missing-replicas-field, non-workload-kind, no-matching-live, and mixed cases. Verified locally: `make lint` (scoped to the package), `go test`, `gofmt`, and `go vet` are clean.
