### PR TITLE
fix: preserve newlines in build env and args

### DIFF
--- a/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/ballerina-buildpack-build.yaml
@@ -108,12 +108,21 @@ spec:
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 

--- a/install/k3d/build-cache/workflow-templates/containerfile-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/containerfile-build.yaml
@@ -92,20 +92,37 @@ spec:
             STEOF
 
             # Build --env and --build-arg flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 
             if [ -n "$BUILD_ARGS_JSON" ] && [ "$BUILD_ARGS_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --build-arg "$kv"
+              encoded_build_arg_entries=$(printf '%s' "$BUILD_ARGS_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --build-arg "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ARGS_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_build_arg_entries
             EOF
             fi
 

--- a/install/k3d/build-cache/workflow-templates/gcp-buildpacks-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/gcp-buildpacks-build.yaml
@@ -100,12 +100,21 @@ spec:
             RUN_IMG="gcr.io/buildpacks/google-22/run@sha256:a8ccb6641b4d98b0adf6397f954e7194611d1ae61310f0561f1c00fdf7f9ba96"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 

--- a/install/k3d/build-cache/workflow-templates/paketo-buildpacks-build.yaml
+++ b/install/k3d/build-cache/workflow-templates/paketo-buildpacks-build.yaml
@@ -102,12 +102,21 @@ spec:
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 

--- a/samples/getting-started/workflow-templates.yaml
+++ b/samples/getting-started/workflow-templates.yaml
@@ -101,12 +101,21 @@ spec:
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 
@@ -215,12 +224,21 @@ spec:
             RUN_IMG="gcr.io/buildpacks/google-22/run@sha256:a8ccb6641b4d98b0adf6397f954e7194611d1ae61310f0561f1c00fdf7f9ba96"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 
@@ -337,12 +355,21 @@ spec:
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 
@@ -446,20 +473,37 @@ spec:
             EOF
 
             # Build --env and --build-arg flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 
             if [ -n "$BUILD_ARGS_JSON" ] && [ "$BUILD_ARGS_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --build-arg "$kv"
+              encoded_build_arg_entries=$(printf '%s' "$BUILD_ARGS_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --build-arg "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ARGS_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_build_arg_entries
             EOF
             fi
 

--- a/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
+++ b/samples/getting-started/workflow-templates/ballerina-buildpack-build.yaml
@@ -90,12 +90,21 @@ spec:
             RUN_IMAGE="ghcr.io/openchoreo/buildpack/ballerina@sha256:121499416443e19dcb43a22e7acfa246d29427a978a43b29b5b4e7a8385b222c"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 

--- a/samples/getting-started/workflow-templates/containerfile-build.yaml
+++ b/samples/getting-started/workflow-templates/containerfile-build.yaml
@@ -72,20 +72,37 @@ spec:
             EOF
 
             # Build --env and --build-arg flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 
             if [ -n "$BUILD_ARGS_JSON" ] && [ "$BUILD_ARGS_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --build-arg "$kv"
+              encoded_build_arg_entries=$(printf '%s' "$BUILD_ARGS_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --build-arg "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ARGS_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_build_arg_entries
             EOF
             fi
 

--- a/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/gcp-buildpacks-build.yaml
@@ -82,12 +82,21 @@ spec:
             RUN_IMG="gcr.io/buildpacks/google-22/run@sha256:a8ccb6641b4d98b0adf6397f954e7194611d1ae61310f0561f1c00fdf7f9ba96"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 

--- a/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
+++ b/samples/getting-started/workflow-templates/paketo-buildpacks-build.yaml
@@ -84,12 +84,21 @@ spec:
             RUN_IMG="docker.io/paketobuildpacks/run-jammy-full@sha256:84a29ab400de17994da1270742de91718658dfbe4713cae9b765f0c9e1062eac"
 
             # Build --env flags as argv entries, not shell fragments.
+            # Base64 keeps embedded newlines within a single argv entry.
             set --
             if [ -n "$BUILD_ENV_JSON" ] && [ "$BUILD_ENV_JSON" != "[]" ]; then
-              while IFS= read -r kv; do
-                [ -n "$kv" ] && set -- "$@" --env "$kv"
+              encoded_env_entries=$(printf '%s' "$BUILD_ENV_JSON" |
+                jq -r '.[] | "\(.name)=\(.value)" | @base64')
+              while IFS= read -r encoded_kv; do
+                [ -n "$encoded_kv" ] || continue
+                kv_with_sentinel=$(
+                  printf '%s' "$encoded_kv" | base64 -d
+                  printf '.'
+                )
+                kv=${kv_with_sentinel%?}
+                set -- "$@" --env "$kv"
               done <<EOF
-            $(printf '%s' "$BUILD_ENV_JSON" | jq -r '.[] | "\(.name)=\(.value)"')
+            $encoded_env_entries
             EOF
             fi
 

--- a/test/workflowtemplates/build_publish_behavior_test.go
+++ b/test/workflowtemplates/build_publish_behavior_test.go
@@ -16,6 +16,18 @@ import (
 
 const buildPodmanStub = `#!/bin/sh
 echo "podman $*" >> "$CALLS"
+for arg do
+  if [ "$arg" = "MULTILINE_ENV=first
+second
+" ]; then
+    echo "podman-multiline-env-preserved" >> "$CALLS"
+  fi
+  if [ "$arg" = "MULTILINE_ARG=alpha
+beta
+" ]; then
+    echo "podman-multiline-build-arg-preserved" >> "$CALLS"
+  fi
+done
 case "$1" in
   info)
     echo true
@@ -39,6 +51,13 @@ exit 0
 
 const packStub = `#!/bin/sh
 echo "pack $*" >> "$CALLS"
+for arg do
+  if [ "$arg" = "MULTILINE_ENV=first
+second
+" ]; then
+    echo "pack-multiline-env-preserved" >> "$CALLS"
+  fi
+done
 exit 0
 `
 
@@ -46,16 +65,18 @@ const buildJQStub = `#!/bin/sh
 input=$(cat)
 echo "jq $*" >> "$CALLS"
 echo "jq-stdin $input" >> "$CALLS"
-case "$*" in
-  *)
-    case "$input" in
-      *HTTP_PROXY*)
-        printf '%s\n' "HTTP_PROXY=http://proxy"
-        ;;
-      *FOO*)
-        printf '%s\n' "FOO=bar" "HELLO=world"
-        ;;
-    esac
+case "$input" in
+  *MULTILINE_ENV*)
+    printf '%s\n' "TVVMVElMSU5FX0VOVj1maXJzdApzZWNvbmQK"
+    ;;
+  *MULTILINE_ARG*)
+    printf '%s\n' "TVVMVElMSU5FX0FSRz1hbHBoYQpiZXRhCg=="
+    ;;
+  *HTTP_PROXY*)
+    printf '%s\n' "SFRUUF9QUk9YWT1odHRwOi8vcHJveHk="
+    ;;
+  *FOO*)
+    printf '%s\n' "Rk9PPWJhcg==" "SEVMTE89d29ybGQ="
     ;;
 esac
 exit 0
@@ -147,12 +168,27 @@ func buildReplacements(root string) []string {
 		"{{inputs.parameters.build-env}}", `[{"name":"FOO","value":"bar"},{"name":"HELLO","value":"world"}]`,
 		"{{workflow.parameters.build-env}}", `[{"name":"FOO","value":"bar"},{"name":"HELLO","value":"world"}]`,
 		"{{inputs.parameters.build-args}}", `[{"name":"HTTP_PROXY","value":"http://proxy"}]`,
+		"{{inputs.parameters.build-cache}}", "none",
+		"{{inputs.parameters.cache-layers-mode}}", "disabled",
 		"/mnt/vol", vol,
 		"/storage/run", filepath.Join(root, "storage", "run"),
 		"/storage/graph", filepath.Join(root, "storage", "graph"),
 		"/etc/containers", filepath.Join(root, "containers"),
 		"/run/podman", filepath.Join(root, "run", "podman"),
 	}
+}
+
+func multilineBuildReplacements(root string) []string {
+	replacements := buildReplacements(root)
+	for i := 0; i < len(replacements); i += 2 {
+		switch replacements[i] {
+		case "{{inputs.parameters.build-env}}", "{{workflow.parameters.build-env}}":
+			replacements[i+1] = `[{"name":"MULTILINE_ENV","value":"first\nsecond\n"}]`
+		case "{{inputs.parameters.build-args}}":
+			replacements[i+1] = `[{"name":"MULTILINE_ARG","value":"alpha\nbeta\n"}]`
+		}
+	}
+	return replacements
 }
 
 func TestContainerfileBuild_Behavior(t *testing.T) {
@@ -240,6 +276,58 @@ func TestBuildpackBuilds_Behavior(t *testing.T) {
 				"buildpack build must wait until the built image exists before saving")
 			requireCallContains(t, res, "podman save -o", filepath.Join(res.root, "mnt-vol", "app-image.tar"),
 				"buildpack build must save the image tar handoff for publish-image")
+		})
+	}
+}
+
+func TestBuilds_PreserveNewlinesInJSONArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		dir       string
+		file      string
+		buildpack bool
+	}{
+		{name: "sample/containerfile", dir: templatesDir, file: "containerfile-build.yaml"},
+		{name: "sample/ballerina", dir: templatesDir, file: "ballerina-buildpack-build.yaml", buildpack: true},
+		{name: "sample/gcp", dir: templatesDir, file: "gcp-buildpacks-build.yaml", buildpack: true},
+		{name: "sample/paketo", dir: templatesDir, file: "paketo-buildpacks-build.yaml", buildpack: true},
+		{name: "build-cache/containerfile", dir: buildCacheTemplatesDir, file: "containerfile-build.yaml"},
+		{name: "build-cache/ballerina", dir: buildCacheTemplatesDir, file: "ballerina-buildpack-build.yaml", buildpack: true},
+		{name: "build-cache/gcp", dir: buildCacheTemplatesDir, file: "gcp-buildpacks-build.yaml", buildpack: true},
+		{name: "build-cache/paketo", dir: buildCacheTemplatesDir, file: "paketo-buildpacks-build.yaml", buildpack: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := scriptForTemplateFromDir(t, tc.dir, tc.file, "build-image")
+			env := envForTemplateFromDir(t, tc.dir, tc.file, "build-image")
+			stubs := map[string]string{
+				"podman": buildPodmanStub,
+				"jq":     buildJQStub,
+			}
+			if tc.buildpack {
+				stubs["pack"] = packStub
+			}
+
+			res := runScriptWithEnv(t, script, env, stubs, func(root string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "mnt-vol", "source", "service"), 0o755))
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "storage"), 0o755))
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "containers"), 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(root, "mnt-vol", "source", "Dockerfile"),
+					[]byte("FROM scratch\n"),
+					0o644,
+				))
+			}, multilineBuildReplacements)
+
+			requireScriptSuccess(t, res, tc.file+" must accept JSON values containing newlines")
+			if tc.buildpack {
+				requireHasCall(t, res, "pack-multiline-env-preserved",
+					"buildpack build must preserve an embedded and trailing newline in one --env argument")
+			} else {
+				requireHasCall(t, res, "podman-multiline-env-preserved",
+					"containerfile build must preserve an embedded and trailing newline in one --env argument")
+				requireHasCall(t, res, "podman-multiline-build-arg-preserved",
+					"containerfile build must preserve an embedded and trailing newline in one --build-arg argument")
+			}
 		})
 	}
 }

--- a/test/workflowtemplates/helper_test.go
+++ b/test/workflowtemplates/helper_test.go
@@ -16,6 +16,8 @@ import (
 // test package.
 const templatesDir = "../../samples/getting-started/workflow-templates"
 
+const buildCacheTemplatesDir = "../../install/k3d/build-cache/workflow-templates"
+
 const ciWorkflowsDir = "../../samples/getting-started/ci-workflows"
 
 // workflowTemplate is a minimal view of an Argo ClusterWorkflowTemplate — just
@@ -150,7 +152,12 @@ type argoStep struct {
 // loadTemplate parses a template YAML by file name (e.g. "checkout-source.yaml").
 func loadTemplate(t *testing.T, filename string) workflowTemplate {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join(templatesDir, filename))
+	return loadTemplateFromDir(t, templatesDir, filename)
+}
+
+func loadTemplateFromDir(t *testing.T, dir, filename string) workflowTemplate {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, filename))
 	require.NoError(t, err, "reading template %s", filename)
 
 	var wt workflowTemplate
@@ -171,7 +178,12 @@ func loadCIWorkflow(t *testing.T, filename string) clusterWorkflow {
 // scriptForTemplate returns container.args[0] for the named Argo template.
 func scriptForTemplate(t *testing.T, filename, templateName string) string {
 	t.Helper()
-	tmpl := workflowTemplateByName(t, filename, templateName)
+	return scriptForTemplateFromDir(t, templatesDir, filename, templateName)
+}
+
+func scriptForTemplateFromDir(t *testing.T, dir, filename, templateName string) string {
+	t.Helper()
+	tmpl := workflowTemplateByNameFromDir(t, dir, filename, templateName)
 	args := tmpl.Container.Args
 	require.NotEmpty(t, args, "template %s/%s has no container.args", filename, templateName)
 	return args[0]
@@ -179,13 +191,23 @@ func scriptForTemplate(t *testing.T, filename, templateName string) string {
 
 func envForTemplate(t *testing.T, filename, templateName string) []envVar {
 	t.Helper()
-	tmpl := workflowTemplateByName(t, filename, templateName)
+	return envForTemplateFromDir(t, templatesDir, filename, templateName)
+}
+
+func envForTemplateFromDir(t *testing.T, dir, filename, templateName string) []envVar {
+	t.Helper()
+	tmpl := workflowTemplateByNameFromDir(t, dir, filename, templateName)
 	return tmpl.Container.Env
 }
 
 func workflowTemplateByName(t *testing.T, filename, templateName string) workflowTemplateStep {
 	t.Helper()
-	wt := loadTemplate(t, filename)
+	return workflowTemplateByNameFromDir(t, templatesDir, filename, templateName)
+}
+
+func workflowTemplateByNameFromDir(t *testing.T, dir, filename, templateName string) workflowTemplateStep {
+	t.Helper()
+	wt := loadTemplateFromDir(t, dir, filename)
 	for _, tmpl := range wt.Spec.Templates {
 		if tmpl.Name != templateName {
 			continue


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose

Build environment and build-argument JSON values containing newlines were incorrectly split into multiple CLI arguments. This change preserves multiline values as single --env or --build-arg arguments across standard and build-cache workflow templates.

  ## Approach

Encode each name=value entry with Base64 before line-based iteration, then decode it when constructing the argument list. A sentinel preserves trailing newlines during shell command substitution, with regression tests covering all standard and cache-aware build templates.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
