### PR TITLE
fix: scope workflow executor role to least privilege

### DIFF
--- a/internal/controller/workflowrun/controller_unit_test.go
+++ b/internal/controller/workflowrun/controller_unit_test.go
@@ -957,6 +957,16 @@ func TestMakeRole(t *testing.T) {
 	if len(rule.Resources) != 1 || rule.Resources[0] != "workflowtaskresults" {
 		t.Errorf("expected resource 'workflowtaskresults', got %v", rule.Resources)
 	}
+	wantVerbs := []string{"create", "patch"}
+	if len(rule.Verbs) != len(wantVerbs) {
+		t.Fatalf("expected verbs %v, got %v", wantVerbs, rule.Verbs)
+	}
+	for i, v := range wantVerbs {
+		if rule.Verbs[i] != v {
+			t.Errorf("expected verbs %v, got %v", wantVerbs, rule.Verbs)
+			break
+		}
+	}
 }
 
 func TestMakeRoleBinding(t *testing.T) {

--- a/internal/controller/workflowrun/run_engine.go
+++ b/internal/controller/workflowrun/run_engine.go
@@ -89,7 +89,7 @@ func makeRole(namespace, roleName string) *rbacv1.Role {
 			{
 				APIGroups: []string{"argoproj.io"},
 				Resources: []string{"workflowtaskresults"},
-				Verbs:     []string{"create", "get", "list", "watch", "update", "patch"},
+				Verbs:     []string{"create", "patch"},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

### Purpose

The Role provisioned for workflow build pods granted overly broad RBAC (create, get, list, watch, update, patch) on argoproj.io/workflowtaskresults, violating least privilege. The workflow pod's Argo emissary executor only ever writes its own task result, so the read verbs and update were unnecessary attack surface.

### Approach

Reduced the executor Role in run_engine.go to just create and patch, matching Argo's official executor RBAC. The read verbs (get/list/watch) are consumed by the Argo controller under its own service account, not the workflow pod, so trimming them has no functional impact on build execution.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
