### PR TITLE
fix(controller): requeue observability Release on transient ObservabilityPlane lookup

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -870,9 +870,15 @@ func (r *Reconciler) reconcileObservabilityRelease(
 	if len(observabilityPlaneReleaseResources) == 0 {
 		skipReason = "no observability resources to deploy"
 	} else {
-		// Try to resolve the ObservabilityPlane - this will use "default" if not explicitly specified
+		// Resolve the ObservabilityPlane (falls back to the default when not explicitly specified).
+		// Only a genuine not-found means there is nothing to attach to, so skipping is correct. A
+		// transient lookup failure must requeue instead: skipping it would tear down an already-deployed
+		// observability Release (see the cleanup below) and leave it absent until an unrelated reconcile.
 		if _, err := dataPlaneResult.GetObservabilityPlane(ctx, r.Client); err != nil {
-			skipReason = fmt.Sprintf("failed to resolve ObservabilityPlane: %v", err)
+			if !apierrors.IsNotFound(err) {
+				return observabilityReleaseResult{}, fmt.Errorf("failed to resolve ObservabilityPlane: %w", err)
+			}
+			skipReason = fmt.Sprintf("ObservabilityPlane not found: %v", err)
 			logger.Info("Skipping observability Release reconciliation", "reason", skipReason)
 		} else {
 			shouldManage = true

--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -973,7 +973,11 @@ func (r *Reconciler) reconcileObservabilityRelease(
 	case apierrors.IsNotFound(err):
 		// Nothing to clean up.
 	case err != nil:
-		// A transient read failure must requeue rather than silently leave a stale Release behind.
+		// A transient read failure must requeue rather than silently leave a stale Release behind,
+		// and it is surfaced on the status the same way the resolution path above is.
+		msg := fmt.Sprintf("Failed to get observability Release for cleanup: %v", err)
+		controller.MarkFalseCondition(releaseBinding, ConditionReleaseSynced,
+			ReasonReleaseUpdateFailed, msg)
 		return result, fmt.Errorf("failed to get observability Release %q for cleanup: %w", releaseName, err)
 	default:
 		// Only delete a Release this ReleaseBinding owns.

--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -876,6 +876,11 @@ func (r *Reconciler) reconcileObservabilityRelease(
 		// observability Release (see the cleanup below) and leave it absent until an unrelated reconcile.
 		if _, err := dataPlaneResult.GetObservabilityPlane(ctx, r.Client); err != nil {
 			if !apierrors.IsNotFound(err) {
+				// Surface the transient failure on the status the same way the create/update path
+				// below does, then return so the item requeues with backoff.
+				msg := fmt.Sprintf("Failed to resolve ObservabilityPlane: %v", err)
+				controller.MarkFalseCondition(releaseBinding, ConditionReleaseSynced,
+					ReasonReleaseUpdateFailed, msg)
 				return observabilityReleaseResult{}, fmt.Errorf("failed to resolve ObservabilityPlane: %w", err)
 			}
 			skipReason = fmt.Sprintf("ObservabilityPlane not found: %v", err)
@@ -961,20 +966,27 @@ func (r *Reconciler) reconcileObservabilityRelease(
 	// Clean up existing observability Release if it exists but we no longer need it
 	// (e.g., ObservabilityPlaneRef was removed or no more observability resources)
 	existingObsRelease := &openchoreov1alpha1.RenderedRelease{}
-	if err := r.Get(ctx, types.NamespacedName{
+	switch err := r.Get(ctx, types.NamespacedName{
 		Name:      releaseName,
 		Namespace: releaseBinding.Namespace,
-	}, existingObsRelease); err == nil {
-		// Check if we own this release before deleting
+	}, existingObsRelease); {
+	case apierrors.IsNotFound(err):
+		// Nothing to clean up.
+	case err != nil:
+		// A transient read failure must requeue rather than silently leave a stale Release behind.
+		return result, fmt.Errorf("failed to get observability Release %q for cleanup: %w", releaseName, err)
+	default:
+		// Only delete a Release this ReleaseBinding owns.
 		hasOwner, ownerErr := controllerutil.HasOwnerReference(existingObsRelease.GetOwnerReferences(), releaseBinding, r.Scheme)
-		if ownerErr == nil && hasOwner {
+		if ownerErr != nil {
+			return result, fmt.Errorf("failed to check owner reference for observability Release %q: %w", releaseName, ownerErr)
+		}
+		if hasOwner {
 			if deleteErr := r.Delete(ctx, existingObsRelease); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 				logger.Error(deleteErr, "Failed to delete stale observability Release", "release", releaseName)
 				return result, deleteErr
 			}
-			logger.Info("Deleted stale observability Release",
-				"release", releaseName,
-				"reason", "no ObservabilityPlaneRef configured or no observability resources")
+			logger.Info("Deleted stale observability Release", "release", releaseName, "reason", skipReason)
 		}
 	}
 

--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -983,12 +983,16 @@ func (r *Reconciler) reconcileObservabilityRelease(
 		// Only delete a Release this ReleaseBinding owns.
 		hasOwner, ownerErr := controllerutil.HasOwnerReference(existingObsRelease.GetOwnerReferences(), releaseBinding, r.Scheme)
 		if ownerErr != nil {
+			msg := fmt.Sprintf("Failed to check owner reference for observability Release %q: %v", releaseName, ownerErr)
+			controller.MarkFalseCondition(releaseBinding, ConditionReleaseSynced, ReasonReleaseUpdateFailed, msg)
 			return result, fmt.Errorf("failed to check owner reference for observability Release %q: %w", releaseName, ownerErr)
 		}
 		if hasOwner {
 			if deleteErr := r.Delete(ctx, existingObsRelease); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				msg := fmt.Sprintf("Failed to delete stale observability Release %q: %v", releaseName, deleteErr)
+				controller.MarkFalseCondition(releaseBinding, ConditionReleaseSynced, ReasonReleaseUpdateFailed, msg)
 				logger.Error(deleteErr, "Failed to delete stale observability Release", "release", releaseName)
-				return result, deleteErr
+				return result, fmt.Errorf("failed to delete stale observability Release %q: %w", releaseName, deleteErr)
 			}
 			logger.Info("Deleted stale observability Release", "release", releaseName, "reason", skipReason)
 		}

--- a/internal/controller/releasebinding/controller_observability_test.go
+++ b/internal/controller/releasebinding/controller_observability_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -102,6 +103,13 @@ func TestReconcileObservabilityRelease_transientFailureRequeuesAndKeepsRelease(t
 	require.NoError(t,
 		c.Get(context.Background(), types.NamespacedName{Name: releaseName, Namespace: rb.Namespace}, got),
 		"an existing observability Release must survive a transient lookup failure")
+
+	// The transient failure must be surfaced on the status so Ready does not stay stale-True,
+	// matching the create/update error path in the same reconcile.
+	cond := apimeta.FindStatusCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
+	require.NotNil(t, cond, "ReleaseSynced condition must be set on a transient failure")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, string(ReasonReleaseUpdateFailed), cond.Reason)
 }
 
 // A genuinely absent ObservabilityPlane is a real skip, not a transient failure, so the reconcile
@@ -119,4 +127,33 @@ func TestReconcileObservabilityRelease_notFoundSkipsWithoutRequeue(t *testing.T)
 	require.NoError(t, err, "a genuinely absent ObservabilityPlane is a skip, not a retry")
 	assert.False(t, res.managed)
 	assert.NotEmpty(t, res.skipReason)
+}
+
+// A transient failure reading the existing observability Release during cleanup must requeue,
+// otherwise a stale Release could be left behind with no retry.
+func TestReconcileObservabilityRelease_cleanupGetFailureRequeues(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, _ := obsFixtures()
+
+	transientErr := errors.New("etcd unavailable")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*openchoreov1alpha1.RenderedRelease); ok {
+					return transientErr
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	// No observability resources routes into the cleanup path, where the Release lookup fails.
+	_, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
+
+	require.Error(t, err, "a transient failure reading the existing Release for cleanup must requeue")
+	assert.ErrorIs(t, err, transientErr)
 }

--- a/internal/controller/releasebinding/controller_observability_test.go
+++ b/internal/controller/releasebinding/controller_observability_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
+)
+
+func obsSchemeForTest(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, openchoreov1alpha1.AddToScheme(s))
+	return s
+}
+
+func obsFixtures() (
+	*openchoreov1alpha1.ReleaseBinding,
+	*openchoreov1alpha1.ComponentRelease,
+	*openchoreov1alpha1.DataPlane,
+	[]openchoreov1alpha1.RenderedManifest,
+) {
+	rb := &openchoreov1alpha1.ReleaseBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", UID: "rb-uid"},
+		Spec: openchoreov1alpha1.ReleaseBindingSpec{
+			Owner:       openchoreov1alpha1.ReleaseBindingOwner{ProjectName: "proj", ComponentName: "comp"},
+			Environment: "dev",
+		},
+	}
+	cr := &openchoreov1alpha1.ComponentRelease{
+		Spec: openchoreov1alpha1.ComponentReleaseSpec{
+			Owner: openchoreov1alpha1.ComponentReleaseOwner{ComponentName: "comp"},
+		},
+	}
+	dp := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp", Namespace: "ns"},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			ObservabilityPlaneRef: &openchoreov1alpha1.ObservabilityPlaneRef{
+				Kind: openchoreov1alpha1.ObservabilityPlaneRefKindObservabilityPlane,
+				Name: "obs",
+			},
+		},
+	}
+	obsResources := []openchoreov1alpha1.RenderedManifest{
+		{ID: "res-1", Object: &runtime.RawExtension{Raw: []byte(`{}`)}},
+	}
+	return rb, cr, dp, obsResources
+}
+
+// A transient ObservabilityPlane lookup failure must requeue (return an error) rather than
+// silently skipping, and it must not tear down an already-managed observability Release.
+func TestReconcileObservabilityRelease_transientFailureRequeuesAndKeepsRelease(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, obsResources := obsFixtures()
+	releaseName := makeObservabilityReleaseName(cr, rb)
+
+	existing := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: releaseName, Namespace: rb.Namespace},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(rb, existing, scheme))
+
+	transientErr := errors.New("etcd unavailable")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*openchoreov1alpha1.ObservabilityPlane); ok {
+					return transientErr
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	_, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, obsResources)
+
+	// assert (not require) so the release-survival check below still runs on the buggy code path,
+	// where a missing requeue is exactly what leads to the existing release being torn down.
+	assert.Error(t, err, "a transient ObservabilityPlane lookup failure must requeue, not skip")
+	assert.ErrorIs(t, err, transientErr)
+
+	got := &openchoreov1alpha1.RenderedRelease{}
+	require.NoError(t,
+		c.Get(context.Background(), types.NamespacedName{Name: releaseName, Namespace: rb.Namespace}, got),
+		"an existing observability Release must survive a transient lookup failure")
+}
+
+// A genuinely absent ObservabilityPlane is a real skip, not a transient failure, so the reconcile
+// must not requeue. This also proves not-found is distinguished from transient errors.
+func TestReconcileObservabilityRelease_notFoundSkipsWithoutRequeue(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, obsResources := obsFixtures()
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	res, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, obsResources)
+
+	require.NoError(t, err, "a genuinely absent ObservabilityPlane is a skip, not a retry")
+	assert.False(t, res.managed)
+	assert.NotEmpty(t, res.skipReason)
+}

--- a/internal/controller/releasebinding/controller_observability_test.go
+++ b/internal/controller/releasebinding/controller_observability_test.go
@@ -156,4 +156,10 @@ func TestReconcileObservabilityRelease_cleanupGetFailureRequeues(t *testing.T) {
 
 	require.Error(t, err, "a transient failure reading the existing Release for cleanup must requeue")
 	assert.ErrorIs(t, err, transientErr)
+
+	// The cleanup failure is surfaced on the status too, so Ready does not stay stale-True.
+	cond := apimeta.FindStatusCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
+	require.NotNil(t, cond, "ReleaseSynced condition must be set on a cleanup lookup failure")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, string(ReasonReleaseUpdateFailed), cond.Reason)
 }

--- a/internal/controller/releasebinding/controller_observability_test.go
+++ b/internal/controller/releasebinding/controller_observability_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -162,4 +163,90 @@ func TestReconcileObservabilityRelease_cleanupGetFailureRequeues(t *testing.T) {
 	require.NotNil(t, cond, "ReleaseSynced condition must be set on a cleanup lookup failure")
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
 	assert.Equal(t, string(ReasonReleaseUpdateFailed), cond.Reason)
+}
+
+// When observability is no longer needed, an existing Release this ReleaseBinding owns is deleted.
+func TestReconcileObservabilityRelease_cleanupDeletesOwnedStaleRelease(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, _ := obsFixtures()
+	releaseName := makeObservabilityReleaseName(cr, rb)
+
+	existing := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: releaseName, Namespace: rb.Namespace},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(rb, existing, scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	// No observability resources means the owned Release is now stale and must be removed.
+	res, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
+	require.NoError(t, err)
+	assert.False(t, res.managed)
+
+	got := &openchoreov1alpha1.RenderedRelease{}
+	err = c.Get(context.Background(), types.NamespacedName{Name: releaseName, Namespace: rb.Namespace}, got)
+	assert.True(t, apierrors.IsNotFound(err), "an owned stale observability Release must be deleted")
+}
+
+// A Release with the same name but owned by another resource must be left untouched.
+func TestReconcileObservabilityRelease_cleanupLeavesUnownedRelease(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, _ := obsFixtures()
+	releaseName := makeObservabilityReleaseName(cr, rb)
+
+	existing := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: releaseName, Namespace: rb.Namespace},
+	}
+	otherOwner := &openchoreov1alpha1.ReleaseBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: rb.Namespace, UID: "other-uid"},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(otherOwner, existing, scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	res, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
+	require.NoError(t, err)
+	assert.False(t, res.managed)
+
+	got := &openchoreov1alpha1.RenderedRelease{}
+	require.NoError(t,
+		c.Get(context.Background(), types.NamespacedName{Name: releaseName, Namespace: rb.Namespace}, got),
+		"a Release owned by another resource must be left in place")
+}
+
+// A transient failure deleting a stale owned Release must requeue, not silently succeed.
+func TestReconcileObservabilityRelease_cleanupDeleteFailureRequeues(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, _ := obsFixtures()
+	releaseName := makeObservabilityReleaseName(cr, rb)
+
+	existing := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: releaseName, Namespace: rb.Namespace},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(rb, existing, scheme))
+
+	transientErr := errors.New("etcd unavailable")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*openchoreov1alpha1.RenderedRelease); ok {
+					return transientErr
+				}
+				return cl.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	_, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
+	require.Error(t, err, "a failed delete of a stale owned Release must requeue")
+	assert.ErrorIs(t, err, transientErr)
 }

--- a/internal/controller/releasebinding/controller_observability_test.go
+++ b/internal/controller/releasebinding/controller_observability_test.go
@@ -218,6 +218,22 @@ func TestReconcileObservabilityRelease_cleanupLeavesUnownedRelease(t *testing.T)
 		"a Release owned by another resource must be left in place")
 }
 
+func seedReleaseSyncedTrue(rb *openchoreov1alpha1.ReleaseBinding) {
+	apimeta.SetStatusCondition(&rb.Status.Conditions, metav1.Condition{
+		Type:    string(ConditionReleaseSynced),
+		Status:  metav1.ConditionTrue,
+		Reason:  "Seeded",
+		Message: "stale True from a prior successful reconcile",
+	})
+}
+
+func assertReleaseSyncedFalse(t *testing.T, rb *openchoreov1alpha1.ReleaseBinding) {
+	t.Helper()
+	cond := apimeta.FindStatusCondition(rb.Status.Conditions, string(ConditionReleaseSynced))
+	require.NotNil(t, cond, "ReleaseSynced condition must be set")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status, "a cleanup error must clear a stale Ready-True")
+}
+
 // A transient failure deleting a stale owned Release must requeue, not silently succeed.
 func TestReconcileObservabilityRelease_cleanupDeleteFailureRequeues(t *testing.T) {
 	scheme := obsSchemeForTest(t)
@@ -246,9 +262,12 @@ func TestReconcileObservabilityRelease_cleanupDeleteFailureRequeues(t *testing.T
 	r := &Reconciler{Client: c, Scheme: scheme}
 	dpResult := &controller.DataPlaneResult{DataPlane: dp}
 
+	seedReleaseSyncedTrue(rb)
 	_, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
 	require.Error(t, err, "a failed delete of a stale owned Release must requeue")
 	assert.ErrorIs(t, err, transientErr)
+	assert.Contains(t, err.Error(), "failed to delete stale observability Release", "the delete error should carry context")
+	assertReleaseSyncedFalse(t, rb)
 }
 
 // If the owner's GVK cannot be resolved, cleanup surfaces the error rather than guessing ownership.
@@ -267,7 +286,9 @@ func TestReconcileObservabilityRelease_cleanupOwnerCheckError(t *testing.T) {
 	r := &Reconciler{Client: c, Scheme: runtime.NewScheme()}
 	dpResult := &controller.DataPlaneResult{DataPlane: dp}
 
+	seedReleaseSyncedTrue(rb)
 	_, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
 	require.Error(t, err, "an unresolvable owner reference must surface as an error, not a silent skip")
 	assert.Contains(t, err.Error(), "failed to check owner reference")
+	assertReleaseSyncedFalse(t, rb)
 }

--- a/internal/controller/releasebinding/controller_observability_test.go
+++ b/internal/controller/releasebinding/controller_observability_test.go
@@ -250,3 +250,24 @@ func TestReconcileObservabilityRelease_cleanupDeleteFailureRequeues(t *testing.T
 	require.Error(t, err, "a failed delete of a stale owned Release must requeue")
 	assert.ErrorIs(t, err, transientErr)
 }
+
+// If the owner's GVK cannot be resolved, cleanup surfaces the error rather than guessing ownership.
+func TestReconcileObservabilityRelease_cleanupOwnerCheckError(t *testing.T) {
+	scheme := obsSchemeForTest(t)
+	rb, cr, dp, _ := obsFixtures()
+	releaseName := makeObservabilityReleaseName(cr, rb)
+
+	existing := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: releaseName, Namespace: rb.Namespace},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(rb, existing, scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	// A Scheme without ReleaseBinding registered makes HasOwnerReference fail to resolve the owner GVK.
+	r := &Reconciler{Client: c, Scheme: runtime.NewScheme()}
+	dpResult := &controller.DataPlaneResult{DataPlane: dp}
+
+	_, err := r.reconcileObservabilityRelease(context.Background(), rb, cr, dpResult, nil)
+	require.Error(t, err, "an unresolvable owner reference must surface as an error, not a silent skip")
+	assert.Contains(t, err.Error(), "failed to check owner reference")
+}


### PR DESCRIPTION
## Purpose
`reconcileObservabilityRelease` treats every `GetObservabilityPlane` error as "don't manage this Release". A transient lookup failure (an API server blip or a throttled request) therefore skips the observability Release and, if one already exists, deletes it, then returns without requeuing. The Release stays gone until some unrelated event triggers another reconcile. Fixes #2764.

## Approach
The resolver already separates the two cases at the error level: genuine absence (an explicit ref that does not exist, or no default plane) is wrapped with `apierrors.NewNotFound`, while a failed lookup keeps the underlying client error. So the reconcile can branch on `apierrors.IsNotFound`: a real not-found still skips, since there is nothing to attach to, and anything else returns the error so the item requeues with backoff and the existing Release is left alone.

Two smaller consistency fixes in the same function came out of review. The transient path now marks `ReleaseSynced=False` before requeuing, the same as the create/update error path in the same reconcile, so `Ready` does not stay stale-`True` while the reconcile keeps failing. And the cleanup that removes a no-longer-needed Release now distinguishes not-found from other errors on its own lookup (requeue instead of swallow) and logs the actual skip reason instead of a fixed string.

To be sure `IsNotFound` was the right predicate, I checked every not-found path in `GetObservabilityPlane`, `GetObservabilityPlaneFromRef`, and `getDefaultObservabilityPlane` and confirmed they all wrap `NewNotFound`. The two remaining plain-error paths are an unsupported ref kind, which the CRD enum already rejects, and "no data plane set"; both are genuine errors where requeuing is the safer behavior anyway.

## Related Issues
Fixes #2764

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
`controller_observability_test.go` covers the behavior with the fake client's interceptor: a transient resolution failure requeues, keeps an existing Release, and marks `ReleaseSynced=False`; a genuinely absent ObservabilityPlane skips without requeuing; and a transient failure on the cleanup lookup requeues rather than being swallowed. Verified fail-before / pass-after, and the full `releasebinding` package (unit plus envtest) stays green.

One integration note: re-triggering a skipped observability reconcile once the plane later appears depends on the ObservabilityPlane / ClusterObservabilityPlane watches from #4223 (issue #2765). This PR keeps the reconcile-level behavior correct (a genuine absence is a skip, not a hot loop) and does not duplicate that watch work.

