### PR TITLE
docs: disallow AI co-authors and assisted-by commit trailers

### DIFF
--- a/docs/contributors/AI-POLICY.md
+++ b/docs/contributors/AI-POLICY.md
@@ -38,3 +38,6 @@ their training data, so by signing off you are certifying that you have the righ
 to submit the content under the project's license. If you're unsure where
 something came from, don't submit it. Refer to the Linux Foundation [Guidance
 Regarding Use of Generative AI Tools](https://www.linuxfoundation.org/legal/generative-ai) for additional details.
+
+Listing AI tooling as a co-author, co-signing commits using an AI tool, or using
+the assisted-by, co-developed or similar commit trailer is not allowed.


### PR DESCRIPTION
## Purpose

The AI policy covers disclosure and DCO sign-off, but it doesn't say anything about commit metadata. Some AI tools add themselves as a co-author or attach trailers like `Assisted-by` by default, which muddies who actually signed off on a commit. This spells out that it isn't allowed.

## Approach

- Add a line to the "Licensing and the DCO" section of `docs/contributors/AI-POLICY.md` stating that listing AI tooling as a co-author, co-signing commits with an AI tool, or using assisted-by / co-developed style trailers is not allowed.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content