### PR TITLE
feat: add X-Forwarded-Client-Cert support for cluster gateway agent authentication

### DIFF
--- a/cmd/cluster-gateway/main.go
+++ b/cmd/cluster-gateway/main.go
@@ -41,20 +41,22 @@ func init() {
 
 func main() {
 	var (
-		port                 int
-		internalPort         int
-		serverCertPath       string
-		serverKeyPath        string
-		skipClientCertVerify bool
-		internalMTLS         bool
-		internalClientCAPath string
-		readTimeout          time.Duration
-		writeTimeout         time.Duration
-		idleTimeout          time.Duration
-		shutdownTimeout      time.Duration
-		heartbeatInterval    time.Duration
-		heartbeatTimeout     time.Duration
-		logLevel             string
+		port                     int
+		internalPort             int
+		serverCertPath           string
+		serverKeyPath            string
+		skipClientCertVerify     bool
+		internalMTLS             bool
+		internalClientCAPath     string
+		agentAuthMode            string
+		agentAuthForwardedHeader string
+		readTimeout              time.Duration
+		writeTimeout             time.Duration
+		idleTimeout              time.Duration
+		shutdownTimeout          time.Duration
+		heartbeatInterval        time.Duration
+		heartbeatTimeout         time.Duration
+		logLevel                 string
 	)
 
 	flag.IntVar(&port, "port", cmdutil.GetEnvInt("AGENT_SERVER_PORT", defaultPort),
@@ -78,6 +80,16 @@ func main() {
 	flag.StringVar(&internalClientCAPath, "internal-client-ca-cert",
 		cmdutil.GetEnv("INTERNAL_CLIENT_CA_PATH", ""),
 		"Path to the CA bundle used to verify internal API clients (required when --internal-mtls is enabled)")
+	flag.StringVar(&agentAuthMode, "agent-auth-mode",
+		cmdutil.GetEnv("AGENT_AUTH_MODE", string(clustergateway.AgentAuthModeMTLS)),
+		"How the public listener obtains the agent client certificate: "+
+			"'mtls' (from the TLS handshake) or 'forwarded-header' (from a header set by a trusted TLS-terminating proxy)")
+	flag.StringVar(&agentAuthForwardedHeader, "agent-auth-forwarded-header",
+		cmdutil.GetEnv("AGENT_AUTH_FORWARDED_HEADER", clustergateway.DefaultForwardedHeaderName),
+		"Request header carrying the URL-encoded client certificate chain when --agent-auth-mode=forwarded-header "+
+			"(e.g. X-Amzn-Mtls-Clientcert for AWS ALB in mTLS passthrough mode — "+
+			"ALB verify mode sends certificate-attribute headers instead, "+
+			"X-Forwarded-Client-Cert for Envoy/Istio)")
 	flag.DurationVar(&readTimeout, "read-timeout", defaultReadTimeout, "HTTP read timeout")
 	flag.DurationVar(&writeTimeout, "write-timeout", defaultWriteTimeout, "HTTP write timeout")
 	flag.DurationVar(&idleTimeout, "idle-timeout", defaultIdleTimeout, "HTTP idle timeout")
@@ -96,6 +108,7 @@ func main() {
 		"serverKey", serverKeyPath,
 		"internalMTLS", internalMTLS,
 		"internalClientCA", internalClientCAPath,
+		"agentAuthMode", agentAuthMode,
 		"heartbeatInterval", heartbeatInterval,
 		"heartbeatTimeout", heartbeatTimeout,
 		"note", "Client CA certificates are loaded dynamically from DataPlane/WorkflowPlane/ObservabilityPlane CRs",
@@ -124,19 +137,21 @@ func main() {
 	logger.Info("Kubernetes client created successfully")
 
 	config := &clustergateway.Config{
-		Port:                 port,
-		InternalPort:         internalPort,
-		ServerCertPath:       serverCertPath,
-		ServerKeyPath:        serverKeyPath,
-		SkipClientCertVerify: skipClientCertVerify,
-		InternalMTLSEnabled:  internalMTLS,
-		InternalClientCAPath: internalClientCAPath,
-		ReadTimeout:          readTimeout,
-		WriteTimeout:         writeTimeout,
-		IdleTimeout:          idleTimeout,
-		ShutdownTimeout:      shutdownTimeout,
-		HeartbeatInterval:    heartbeatInterval,
-		HeartbeatTimeout:     heartbeatTimeout,
+		Port:                     port,
+		InternalPort:             internalPort,
+		ServerCertPath:           serverCertPath,
+		ServerKeyPath:            serverKeyPath,
+		SkipClientCertVerify:     skipClientCertVerify,
+		InternalMTLSEnabled:      internalMTLS,
+		InternalClientCAPath:     internalClientCAPath,
+		AgentAuthMode:            clustergateway.AgentAuthMode(agentAuthMode),
+		AgentAuthForwardedHeader: agentAuthForwardedHeader,
+		ReadTimeout:              readTimeout,
+		WriteTimeout:             writeTimeout,
+		IdleTimeout:              idleTimeout,
+		ShutdownTimeout:          shutdownTimeout,
+		HeartbeatInterval:        heartbeatInterval,
+		HeartbeatTimeout:         heartbeatTimeout,
 	}
 
 	srv := clustergateway.New(config, k8sClient, logger)

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -67,6 +67,10 @@ spec:
         {{- else }}
         - --internal-mtls=false
         {{- end }}
+        - --agent-auth-mode={{ .Values.clusterGateway.agentAuth.mode }}
+        {{- if eq .Values.clusterGateway.agentAuth.mode "forwarded-header" }}
+        - --agent-auth-forwarded-header={{ .Values.clusterGateway.agentAuth.forwardedHeaderName }}
+        {{- end }}
         - --log-level={{ .Values.clusterGateway.logLevel }}
         ports:
         - name: websocket

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1119,6 +1119,31 @@
           "title": "affinity",
           "type": "object"
         },
+        "agentAuth": {
+          "additionalProperties": false,
+          "description": "Agent client-certificate authentication for the public listener (port 8443). Controls where the gateway reads the agent's client certificate that is then verified per plane CR. Defaults to end-to-end mTLS; switch to forwarded-header only when a trusted L7 proxy (e.g. AWS ALB, Envoy/Istio) terminates the agent's TLS and forwards the certificate in a header.",
+          "properties": {
+            "forwardedHeaderName": {
+              "default": "X-Forwarded-Client-Cert",
+              "description": "Request header carrying the URL-encoded client certificate chain when mode is forwarded-header. Use X-Amzn-Mtls-Clientcert for AWS ALB mTLS passthrough, or X-Forwarded-Client-Cert for Envoy/Istio XFCC.",
+              "title": "forwardedHeaderName",
+              "type": "string"
+            },
+            "mode": {
+              "default": "mtls",
+              "description": "Where the gateway reads the agent client certificate. 'mtls' takes it from the TLS handshake (requires TLS passthrough / L4 exposure to the gateway). 'forwarded-header' takes it from a header set by a trusted TLS-terminating proxy - only safe when the public listener is reachable exclusively from that proxy.",
+              "enum": [
+                "mtls",
+                "forwarded-header"
+              ],
+              "required": [],
+              "title": "mode"
+            }
+          },
+          "required": [],
+          "title": "agentAuth",
+          "type": "object"
+        },
         "heartbeatInterval": {
           "default": "30s",
           "description": "Heartbeat interval for agent connections",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -3703,6 +3703,24 @@ clusterGateway:
     # @schema
     clientCertRenewBefore: 360h
 
+  # @schema
+  # type: object
+  # description: Agent client-certificate authentication for the public listener (port 8443). Controls where the gateway reads the agent's client certificate that is then verified per plane CR. Defaults to end-to-end mTLS; switch to forwarded-header only when a trusted L7 proxy (e.g. AWS ALB, Envoy/Istio) terminates the agent's TLS and forwards the certificate in a header.
+  # @schema
+  agentAuth:
+    # @schema
+    # description: Where the gateway reads the agent client certificate. 'mtls' takes it from the TLS handshake (requires TLS passthrough / L4 exposure to the gateway). 'forwarded-header' takes it from a header set by a trusted TLS-terminating proxy - only safe when the public listener is reachable exclusively from that proxy.
+    # enum: [mtls, forwarded-header]
+    # default: mtls
+    # @schema
+    mode: mtls
+    # @schema
+    # type: string
+    # description: Request header carrying the URL-encoded client certificate chain when mode is forwarded-header. Use X-Amzn-Mtls-Clientcert for AWS ALB mTLS passthrough, or X-Forwarded-Client-Cert for Envoy/Istio XFCC.
+    # default: X-Forwarded-Client-Cert
+    # @schema
+    forwardedHeaderName: X-Forwarded-Client-Cert
+
   # type: object
   # description: Pod security context
   # @schema

--- a/internal/cluster-gateway/agent_auth.go
+++ b/internal/cluster-gateway/agent_auth.go
@@ -1,0 +1,196 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustergateway
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// errNoClientCertificate is returned by every AgentAuthenticator when the
+// request carries no usable client certificate. A missing certificate is always
+// treated as unauthenticated, regardless of mode.
+var errNoClientCertificate = errors.New("no client certificate presented")
+
+// agentCredentials is the input to per-CR certificate verification: the leaf
+// client certificate and any intermediates presented alongside it. It is the
+// common output of every AgentAuthenticator, so the rest of the gateway is
+// unaware of how the certificate was obtained. The ordering matches
+// tls.ConnectionState.PeerCertificates (leaf first).
+type agentCredentials struct {
+	clientCert    *x509.Certificate
+	intermediates []*x509.Certificate
+}
+
+// AgentAuthenticator extracts the agent's client certificate chain from an
+// inbound WebSocket request. Implementations differ only in WHERE the chain
+// comes from (TLS handshake vs a forwarded header); the trust anchors and the
+// per-CR verification performed afterwards are identical in every mode.
+type AgentAuthenticator interface {
+	// Authenticate returns the client certificate chain for the request, or an
+	// error if no usable certificate is present.
+	Authenticate(r *http.Request) (*agentCredentials, error)
+}
+
+// mtlsAuthenticator reads the client certificate from the TLS handshake. This
+// is the default and preserves the gateway's original behavior.
+type mtlsAuthenticator struct{}
+
+func (mtlsAuthenticator) Authenticate(r *http.Request) (*agentCredentials, error) {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return nil, errNoClientCertificate
+	}
+	return &agentCredentials{
+		clientCert:    r.TLS.PeerCertificates[0],
+		intermediates: r.TLS.PeerCertificates[1:],
+	}, nil
+}
+
+// forwardedHeaderAuthenticator reads the client certificate chain from a header
+// set by a trusted TLS-terminating proxy. This is only safe when the public
+// listener is reachable exclusively from that proxy (see Server.Start warning).
+type forwardedHeaderAuthenticator struct {
+	header string
+}
+
+func (a forwardedHeaderAuthenticator) Authenticate(r *http.Request) (*agentCredentials, error) {
+	raw := strings.TrimSpace(r.Header.Get(a.header))
+	if raw == "" {
+		// A trusted proxy omits the header entirely when the client presents no
+		// certificate, so an absent header is unauthenticated, not an error state.
+		return nil, errNoClientCertificate
+	}
+
+	// parseForwardedCertChain returns at least one certificate on success.
+	certs, err := parseForwardedCertChain(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &agentCredentials{
+		clientCert:    certs[0],
+		intermediates: certs[1:],
+	}, nil
+}
+
+// buildAgentAuthenticator resolves the configured agent authentication mode into
+// an AgentAuthenticator, returning an error for an unrecognized mode so it is
+// surfaced at startup rather than silently defaulting.
+func buildAgentAuthenticator(cfg *Config) (AgentAuthenticator, error) {
+	switch cfg.AgentAuthMode {
+	case "", AgentAuthModeMTLS:
+		return mtlsAuthenticator{}, nil
+	case AgentAuthModeForwardedHeader:
+		header := cfg.AgentAuthForwardedHeader
+		if header == "" {
+			header = DefaultForwardedHeaderName
+		}
+		return forwardedHeaderAuthenticator{header: header}, nil
+	default:
+		return nil, fmt.Errorf("invalid agent auth mode %q: must be %q or %q",
+			cfg.AgentAuthMode, AgentAuthModeMTLS, AgentAuthModeForwardedHeader)
+	}
+}
+
+// parseForwardedCertChain parses a client certificate chain from a forwarded
+// header value. It supports the two encodings emitted by TLS-terminating proxies:
+//
+//   - AWS ALB (X-Amzn-Mtls-Clientcert): the whole value is a URL-encoded,
+//     concatenated PEM chain, leaf first.
+//   - Envoy/Istio XFCC (X-Forwarded-Client-Cert): a comma-separated list of
+//     semicolon-delimited key=value elements. The first element is the
+//     client-facing hop; its Chain (preferred) or Cert holds URL-encoded PEM.
+//
+// The leaf certificate is returned first, followed by any intermediates.
+func parseForwardedCertChain(raw string) ([]*x509.Certificate, error) {
+	// URL-encoded PEM begins with literal "-----BEGIN" (dashes are not
+	// percent-encoded); XFCC begins with a "key=" token instead.
+	if strings.HasPrefix(raw, "-----BEGIN") {
+		return decodeURLEncodedPEM(raw)
+	}
+	return parseXFCCChain(raw)
+}
+
+// parseXFCCChain parses the Envoy/Istio X-Forwarded-Client-Cert format. Only the
+// first (client-facing) element is used; its Chain value is preferred because it
+// includes the leaf and issuers, falling back to Cert (leaf only).
+func parseXFCCChain(raw string) ([]*x509.Certificate, error) {
+	// The first element is the client-facing hop; drop any subsequent proxy
+	// hops. Both delimiters must be quote-aware: Envoy quotes values that
+	// contain delimiters (e.g. Subject="CN=Test, OU=Eng"), and Subject content
+	// is client-controlled, so a naive split could let a crafted Subject inject
+	// a bogus Cert pair.
+	element := splitUnquoted(raw, ',')[0]
+
+	var leafPEM, chainPEM string
+	for _, pair := range splitUnquoted(element, ';') {
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		// URL-encoded PEM values are wrapped in double quotes by Envoy.
+		value = strings.Trim(strings.TrimSpace(value), `"`)
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "cert":
+			leafPEM = value
+		case "chain":
+			chainPEM = value
+		}
+	}
+
+	source := chainPEM
+	if source == "" {
+		source = leafPEM
+	}
+	if source == "" {
+		return nil, fmt.Errorf("forwarded certificate: XFCC header has no Cert or Chain element")
+	}
+
+	return decodeURLEncodedPEM(source)
+}
+
+// splitUnquoted splits s at each occurrence of sep that is not inside a
+// double-quoted section, honoring backslash escapes within quotes. It always
+// returns at least one element.
+func splitUnquoted(s string, sep byte) []string {
+	var parts []string
+	start := 0
+	inQuotes := false
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if inQuotes && i+1 < len(s) {
+				i++ // skip the escaped character
+			}
+		case '"':
+			inQuotes = !inQuotes
+		case sep:
+			if !inQuotes {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	return append(parts, s[start:])
+}
+
+// decodeURLEncodedPEM percent-decodes a URL-encoded PEM chain and parses every
+// CERTIFICATE block within it. url.PathUnescape is used rather than
+// QueryUnescape so that literal '+' characters in base64 bodies are preserved.
+// Values that are already plain PEM (no percent-escapes) pass through unchanged.
+func decodeURLEncodedPEM(encoded string) ([]*x509.Certificate, error) {
+	decoded, err := url.PathUnescape(encoded)
+	if err != nil {
+		decoded = encoded
+	}
+	certs, err := parseCACertificates([]byte(decoded))
+	if err != nil {
+		return nil, fmt.Errorf("forwarded certificate: %w", err)
+	}
+	return certs, nil
+}

--- a/internal/cluster-gateway/agent_auth_test.go
+++ b/internal/cluster-gateway/agent_auth_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clustergateway
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// pemChain concatenates the PEM encodings of the given certificates, leaf first,
+// matching the on-the-wire form a proxy forwards.
+func pemChain(t *testing.T, certs ...*x509.Certificate) string {
+	t.Helper()
+	var b strings.Builder
+	for _, c := range certs {
+		b.Write(encodeCertToPEM(t, c))
+	}
+	return b.String()
+}
+
+// albHeaderValue mimics the AWS ALB X-Amzn-Mtls-Clientcert value: a URL-encoded,
+// concatenated PEM chain.
+func albHeaderValue(t *testing.T, certs ...*x509.Certificate) string {
+	t.Helper()
+	return url.PathEscape(pemChain(t, certs...))
+}
+
+// xfccHeaderValue mimics an Envoy/Istio X-Forwarded-Client-Cert element. cert is
+// the leaf; chain, when non-empty, is included as the (preferred) Chain value.
+func xfccHeaderValue(t *testing.T, cert *x509.Certificate, chain ...*x509.Certificate) string {
+	t.Helper()
+	el := fmt.Sprintf(`Hash=0123abcd;Cert=%q`, url.PathEscape(pemChain(t, cert)))
+	if len(chain) > 0 {
+		el += fmt.Sprintf(`;Chain=%q`, url.PathEscape(pemChain(t, chain...)))
+	}
+	el += `;Subject="CN=Test Client"`
+	return el
+}
+
+func TestMTLSAuthenticator_Authenticate(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	leaf := generateTestClientCert(t, caCert, caKey)
+
+	t.Run("extracts leaf and intermediates from handshake", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+		req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf, caCert}}
+
+		creds, err := mtlsAuthenticator{}.Authenticate(req)
+		require.NoError(t, err)
+		assert.Equal(t, leaf, creds.clientCert)
+		require.Len(t, creds.intermediates, 1)
+		assert.Equal(t, caCert, creds.intermediates[0])
+	})
+
+	t.Run("no TLS connection is unauthenticated", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+		req.TLS = nil
+
+		_, err := mtlsAuthenticator{}.Authenticate(req)
+		assert.ErrorIs(t, err, errNoClientCertificate)
+	})
+
+	t.Run("no peer certificates is unauthenticated", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+		req.TLS = &tls.ConnectionState{PeerCertificates: nil}
+
+		_, err := mtlsAuthenticator{}.Authenticate(req)
+		assert.ErrorIs(t, err, errNoClientCertificate)
+	})
+}
+
+func TestForwardedHeaderAuthenticator_Authenticate(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	leaf := generateTestClientCert(t, caCert, caKey)
+
+	const header = "X-Amzn-Mtls-Clientcert"
+	auth := forwardedHeaderAuthenticator{header: header}
+
+	newReq := func(headerName, value string) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+		if value != "" {
+			req.Header.Set(headerName, value)
+		}
+		return req
+	}
+
+	t.Run("ALB url-encoded PEM, leaf only", func(t *testing.T) {
+		creds, err := auth.Authenticate(newReq(header, albHeaderValue(t, leaf)))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+		assert.Empty(t, creds.intermediates)
+	})
+
+	t.Run("ALB url-encoded PEM with intermediate", func(t *testing.T) {
+		creds, err := auth.Authenticate(newReq(header, albHeaderValue(t, leaf, caCert)))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+		require.Len(t, creds.intermediates, 1)
+		assert.Equal(t, caCert.Raw, creds.intermediates[0].Raw)
+	})
+
+	t.Run("already-decoded raw PEM passes through", func(t *testing.T) {
+		creds, err := auth.Authenticate(newReq(header, pemChain(t, leaf)))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("XFCC Cert element", func(t *testing.T) {
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", xfccHeaderValue(t, leaf)))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("XFCC prefers Chain over Cert", func(t *testing.T) {
+		// Distinct cert in Chain proves Chain wins when both are present.
+		chainLeaf := generateTestClientCert(t, caCert, caKey)
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", xfccHeaderValue(t, leaf, chainLeaf, caCert)))
+		require.NoError(t, err)
+		assert.Equal(t, chainLeaf.Raw, creds.clientCert.Raw)
+		require.Len(t, creds.intermediates, 1)
+		assert.Equal(t, caCert.Raw, creds.intermediates[0].Raw)
+	})
+
+	t.Run("XFCC multiple hops uses the first (client-facing) element", func(t *testing.T) {
+		hopLeaf := generateTestClientCert(t, caCert, caKey)
+		value := xfccHeaderValue(t, leaf) + "," + xfccHeaderValue(t, hopLeaf)
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", value))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("missing header is unauthenticated", func(t *testing.T) {
+		_, err := auth.Authenticate(newReq(header, ""))
+		assert.ErrorIs(t, err, errNoClientCertificate)
+	})
+
+	t.Run("whitespace-only header is unauthenticated", func(t *testing.T) {
+		_, err := auth.Authenticate(newReq(header, "   "))
+		assert.ErrorIs(t, err, errNoClientCertificate)
+	})
+
+	t.Run("malformed PEM is rejected", func(t *testing.T) {
+		_, err := auth.Authenticate(newReq(header, "-----BEGIN CERTIFICATE-----\nnot-base64\n-----END CERTIFICATE-----"))
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errNoClientCertificate)
+	})
+
+	t.Run("XFCC quoted comma before Cert does not truncate the element", func(t *testing.T) {
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		value := `Subject="CN=Test, OU=Eng";` + xfccHeaderValue(t, leaf)
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", value))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("XFCC quoted semicolon in Subject cannot inject a Cert pair", func(t *testing.T) {
+		// Subject content is client-controlled and follows Cert in Envoy's
+		// element order; a quoted ";Cert=" inside it must not override the leaf.
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		value := xfccHeaderValue(t, leaf) + `;Subject="CN=evil;Cert=bogus"`
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", value))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("XFCC escaped quote inside a quoted value stays quoted", func(t *testing.T) {
+		// A \" must not toggle the quoted state: without escape handling the
+		// comma after it would be treated as an element boundary, truncating
+		// the element before Cert is reached.
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		value := `Subject="CN=\"a, b\", OU=Eng";` + xfccHeaderValue(t, leaf)
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", value))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("XFCC ignores elements without key=value", func(t *testing.T) {
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		value := "malformed;" + xfccHeaderValue(t, leaf)
+		creds, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", value))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("invalid percent-escape falls back to the raw value", func(t *testing.T) {
+		// A '%' not followed by two hex digits fails PathUnescape; the value is
+		// then treated as plain PEM, so garbage after the certificate block is
+		// ignored by the PEM decoder.
+		creds, err := auth.Authenticate(newReq(header, pemChain(t, leaf)+"%zz"))
+		require.NoError(t, err)
+		assert.Equal(t, leaf.Raw, creds.clientCert.Raw)
+	})
+
+	t.Run("XFCC without Cert or Chain is rejected", func(t *testing.T) {
+		a := forwardedHeaderAuthenticator{header: "X-Forwarded-Client-Cert"}
+		_, err := a.Authenticate(newReq("X-Forwarded-Client-Cert", `Hash=abc;Subject="CN=x"`))
+		require.Error(t, err)
+	})
+}
+
+func TestBuildAgentAuthenticator(t *testing.T) {
+	t.Run("empty mode defaults to mtls", func(t *testing.T) {
+		a, err := buildAgentAuthenticator(&Config{})
+		require.NoError(t, err)
+		assert.IsType(t, mtlsAuthenticator{}, a)
+	})
+
+	t.Run("explicit mtls", func(t *testing.T) {
+		a, err := buildAgentAuthenticator(&Config{AgentAuthMode: AgentAuthModeMTLS})
+		require.NoError(t, err)
+		assert.IsType(t, mtlsAuthenticator{}, a)
+	})
+
+	t.Run("forwarded-header with explicit header", func(t *testing.T) {
+		a, err := buildAgentAuthenticator(&Config{
+			AgentAuthMode:            AgentAuthModeForwardedHeader,
+			AgentAuthForwardedHeader: "X-Forwarded-Client-Cert",
+		})
+		require.NoError(t, err)
+		fh, ok := a.(forwardedHeaderAuthenticator)
+		require.True(t, ok)
+		assert.Equal(t, "X-Forwarded-Client-Cert", fh.header)
+	})
+
+	t.Run("forwarded-header defaults header to ALB", func(t *testing.T) {
+		a, err := buildAgentAuthenticator(&Config{AgentAuthMode: AgentAuthModeForwardedHeader})
+		require.NoError(t, err)
+		fh, ok := a.(forwardedHeaderAuthenticator)
+		require.True(t, ok)
+		assert.Equal(t, DefaultForwardedHeaderName, fh.header)
+	})
+
+	t.Run("invalid mode is an error", func(t *testing.T) {
+		_, err := buildAgentAuthenticator(&Config{AgentAuthMode: "bogus"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid agent auth mode")
+	})
+}
+
+// TestForwardedHeaderMatchesHandshakeVerification encodes the core promise of the
+// feature: forwarded-header extraction feeds byte-identical credentials into the
+// per-CR verifier, so a given client certificate is accepted for exactly the same
+// CRs regardless of how it reached the gateway. If this parity ever breaks, the
+// forwarded-header path would silently diverge from the trusted mtls path.
+func TestForwardedHeaderMatchesHandshakeVerification(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	leaf := generateTestClientCert(t, caCert, caKey)
+	caPEM := encodeCertToPEM(t, caCert)
+
+	dp := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp1", Namespace: "ns"},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			PlaneID: "prod",
+			ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+				ClientCA: openchoreov1alpha1.ValueFrom{Value: string(caPEM)},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(dp).Build()
+	s := &Server{k8sClient: fakeClient, logger: testLogger()}
+
+	// mtls path: certificate from the TLS handshake.
+	mtlsReq := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	mtlsReq.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+	mtlsCreds, err := mtlsAuthenticator{}.Authenticate(mtlsReq)
+	require.NoError(t, err)
+
+	// forwarded-header path: same certificate, forwarded by an ALB-style proxy.
+	fwdReq := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	fwdReq.Header.Set(DefaultForwardedHeaderName, albHeaderValue(t, leaf))
+	fwdCreds, err := forwardedHeaderAuthenticator{header: DefaultForwardedHeaderName}.Authenticate(fwdReq)
+	require.NoError(t, err)
+
+	mtlsValid, err := s.verifyClientCertificatePerCR(mtlsCreds.clientCert, mtlsCreds.intermediates, "dataplane", "prod")
+	require.NoError(t, err)
+	fwdValid, err := s.verifyClientCertificatePerCR(fwdCreds.clientCert, fwdCreds.intermediates, "dataplane", "prod")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"ns/dp1"}, mtlsValid)
+	assert.Equal(t, mtlsValid, fwdValid, "forwarded-header verification must match handshake verification")
+}

--- a/internal/cluster-gateway/config.go
+++ b/internal/cluster-gateway/config.go
@@ -5,12 +5,42 @@ package clustergateway
 
 import "time"
 
+// AgentAuthMode selects how the public agent listener obtains the client
+// certificate chain that is subsequently verified per plane CR.
+type AgentAuthMode string
+
+const (
+	// AgentAuthModeMTLS takes the client certificate from the TLS handshake
+	// (r.TLS.PeerCertificates). This is the default and requires the agent's
+	// TLS to reach the gateway unterminated (TLS passthrough / L4 exposure).
+	AgentAuthModeMTLS AgentAuthMode = "mtls"
+	// AgentAuthModeForwardedHeader takes the client certificate chain from an
+	// HTTP header set by a trusted L7 proxy that terminated the agent's TLS
+	// (e.g. AWS ALB mTLS passthrough, or Envoy/Istio XFCC). Only the extraction
+	// point changes; the trust anchors and per-CR verification are identical to
+	// mtls mode.
+	AgentAuthModeForwardedHeader AgentAuthMode = "forwarded-header"
+
+	// DefaultForwardedHeaderName is the header inspected in forwarded-header
+	// mode when none is configured. It matches Envoy/Istio.
+	DefaultForwardedHeaderName = "X-Forwarded-Client-Cert"
+)
+
 // Config holds configuration for the agent server
 type Config struct {
 	Port           int
 	InternalPort   int
 	ServerCertPath string
 	ServerKeyPath  string
+	// AgentAuthMode selects how the public listener obtains the agent client
+	// certificate: AgentAuthModeMTLS (default, from the TLS handshake) or
+	// AgentAuthModeForwardedHeader (from a header set by a trusted
+	// TLS-terminating proxy). An empty value is treated as mtls.
+	AgentAuthMode AgentAuthMode
+	// AgentAuthForwardedHeader is the request header carrying the URL-encoded
+	// client certificate chain when AgentAuthMode is
+	// AgentAuthModeForwardedHeader. Empty defaults to DefaultForwardedHeaderName.
+	AgentAuthForwardedHeader string
 	// SkipClientCertVerify has no effect: agent client certificates are always
 	// verified per plane CR on the public listener, and internal listener
 	// verification is controlled by InternalMTLSEnabled.

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -59,7 +59,8 @@ type Server struct {
 	streamSessionsMu      sync.RWMutex
 	validator             *RequestValidator
 	logger                *slog.Logger
-	k8sClient             client.Client // Kubernetes client for querying DataPlane/WorkflowPlane CRs
+	k8sClient             client.Client      // Kubernetes client for querying DataPlane/WorkflowPlane CRs
+	agentAuth             AgentAuthenticator // How the public listener extracts the agent client certificate
 }
 
 func New(config *Config, k8sClient client.Client, logger *slog.Logger) *Server {
@@ -76,6 +77,9 @@ func New(config *Config, k8sClient client.Client, logger *slog.Logger) *Server {
 		validator:             NewRequestValidator(),
 		logger:                logger.With("component", "agent-server"),
 		k8sClient:             k8sClient,
+		// Safe default; Start replaces this with the configured mode (and
+		// surfaces an invalid mode as an error).
+		agentAuth: mtlsAuthenticator{},
 	}
 }
 
@@ -115,6 +119,26 @@ func (s *Server) Start() error {
 		"clientAuth", "RequestClientCert",
 		"note", "Client certificate verification performed at application level per DataPlane/WorkflowPlane CR",
 	)
+
+	// Resolve how the public listener obtains the agent client certificate. An
+	// invalid mode fails startup rather than silently falling back.
+	agentAuth, err := buildAgentAuthenticator(s.config)
+	if err != nil {
+		return fmt.Errorf("failed to configure agent authentication: %w", err)
+	}
+	s.agentAuth = agentAuth
+	if fh, ok := agentAuth.(forwardedHeaderAuthenticator); ok {
+		s.logger.Warn("agent authentication using forwarded header",
+			"mode", AgentAuthModeForwardedHeader,
+			"header", fh.header,
+			"note", "the gateway trusts this header for agent identity; the public listener MUST be reachable only from the trusted TLS-terminating proxy, "+
+				"and every other ingress path must strip it",
+		)
+	} else {
+		s.logger.Info("agent authentication using client certificate from TLS handshake",
+			"mode", AgentAuthModeMTLS,
+		)
+	}
 
 	internalTLSConfig, err := buildInternalTLSConfig(tlsConfig, s.config)
 	if err != nil {
@@ -322,19 +346,27 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract client certificate for per-CR validation
-	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+	// Extract the client certificate for per-CR validation. Where the chain
+	// comes from (TLS handshake vs a header set by a trusted TLS-terminating
+	// proxy) depends on the configured agent auth mode; the per-CR verification
+	// below is identical in every mode.
+	authenticator := s.agentAuth
+	if authenticator == nil {
+		authenticator = mtlsAuthenticator{}
+	}
+	creds, err := authenticator.Authenticate(r)
+	if err != nil {
 		s.logger.Warn("connection rejected: no client certificate presented",
 			"planeType", planeType,
 			"planeID", planeID,
+			"error", err,
 		)
 		http.Error(w, "no client certificate presented", http.StatusUnauthorized)
 		return
 	}
 
-	peerCerts := r.TLS.PeerCertificates
-	clientCert := peerCerts[0]
-	intermediates := peerCerts[1:]
+	clientCert := creds.clientCert
+	intermediates := creds.intermediates
 
 	// Per-CR certificate validation enforces security boundaries
 	// Each CR is validated independently to prevent cross-tenant access

--- a/internal/cluster-gateway/server_test.go
+++ b/internal/cluster-gateway/server_test.go
@@ -1079,6 +1079,94 @@ func TestInternalListener_MTLSDisabled_AcceptsNoClientCert(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+// --- handleWebSocket tests ---
+
+func TestHandleWebSocket_ParamValidation(t *testing.T) {
+	s := New(&Config{}, nil, testLogger())
+
+	tests := []struct {
+		name    string
+		target  string
+		wantMsg string
+	}{
+		{name: "missing planeType", target: "/ws?planeID=prod", wantMsg: "missing planeType"},
+		{name: "missing planeID", target: "/ws?planeType=dataplane", wantMsg: "missing planeID"},
+		{name: "invalid planeType", target: "/ws?planeType=bogus&planeID=prod", wantMsg: "invalid planeType"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			s.handleWebSocket(w, httptest.NewRequest(http.MethodGet, tt.target, nil))
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), tt.wantMsg)
+		})
+	}
+}
+
+// TestHandleWebSocket_NoClientCertificate covers the nil-authenticator fallback:
+// a Server constructed without New (agentAuth nil) must still default to mTLS
+// extraction and reject a request that carries no TLS client certificate.
+func TestHandleWebSocket_NoClientCertificate(t *testing.T) {
+	s := &Server{logger: testLogger()}
+
+	w := httptest.NewRecorder()
+	s.handleWebSocket(w, httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "no client certificate presented")
+}
+
+// TestHandleWebSocket_ForwardedHeader_CRVerificationFailed proves the forwarded
+// certificate feeds the same per-CR verification as mTLS mode: a cert extracted
+// from the header is still rejected when no plane CR trusts its CA.
+func TestHandleWebSocket_ForwardedHeader_CRVerificationFailed(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	clientCert := generateTestClientCert(t, caCert, caKey)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	s := New(&Config{}, fakeClient, testLogger())
+	s.agentAuth = forwardedHeaderAuthenticator{header: DefaultForwardedHeaderName}
+
+	req := httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil)
+	req.Header.Set(DefaultForwardedHeaderName, albHeaderValue(t, clientCert))
+
+	w := httptest.NewRecorder()
+	s.handleWebSocket(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "client certificate verification failed")
+}
+
+// TestHandleWebSocket_ForwardedHeader_UpgradeFailed authenticates successfully
+// via the forwarded header against a matching DataPlane CR, then fails only at
+// the WebSocket upgrade because the request is not a websocket handshake.
+func TestHandleWebSocket_ForwardedHeader_UpgradeFailed(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	clientCert := generateTestClientCert(t, caCert, caKey)
+
+	dp := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp1", Namespace: "ns"},
+		Spec: openchoreov1alpha1.DataPlaneSpec{
+			PlaneID: "prod",
+			ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+				ClientCA: openchoreov1alpha1.ValueFrom{Value: string(encodeCertToPEM(t, caCert))},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(dp).Build()
+	s := New(&Config{}, fakeClient, testLogger())
+	s.agentAuth = forwardedHeaderAuthenticator{header: DefaultForwardedHeaderName}
+
+	req := httptest.NewRequest(http.MethodGet, "/ws?planeType=dataplane&planeID=prod", nil)
+	req.Header.Set(DefaultForwardedHeaderName, albHeaderValue(t, clientCert))
+
+	w := httptest.NewRecorder()
+	s.handleWebSocket(w, req)
+	// Auth and per-CR verification passed; the plain HTTP request fails the
+	// websocket handshake, which the upgrader reports as 400.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.NotContains(t, w.Body.String(), "certificate")
+}
+
 // --- Server.Start tests ---
 
 // writeServerKeyPairFiles generates a self-signed server certificate and its EC
@@ -1140,6 +1228,23 @@ func TestStart_InternalTLSConfigError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to configure internal listener TLS")
 }
 
+// TestStart_AgentAuthConfigError verifies that an unrecognized agent auth mode is
+// surfaced from Start (fail loud) before any port is bound, rather than silently
+// falling back to a default.
+func TestStart_AgentAuthConfigError(t *testing.T) {
+	certPath, keyPath := writeServerKeyPairFiles(t)
+
+	s := New(&Config{
+		ServerCertPath: certPath,
+		ServerKeyPath:  keyPath,
+		AgentAuthMode:  "not-a-real-mode",
+	}, nil, testLogger())
+
+	err := s.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to configure agent authentication")
+}
+
 // waitForHealth polls the fixed health endpoint until it returns 200. It returns
 // true once healthy. If Start returns early (e.g. the fixed :8080 health port is
 // already bound), the test is skipped rather than failed, since that is an
@@ -1193,11 +1298,13 @@ func skipOrFailOnStartErr(t *testing.T, err error) {
 // the internal-mTLS-enabled and disabled logging/config branches in Start.
 func TestStart_Lifecycle(t *testing.T) {
 	tests := []struct {
-		name string
-		mtls bool
+		name            string
+		mtls            bool
+		forwardedHeader bool
 	}{
 		{name: "internal mTLS enabled", mtls: true},
 		{name: "internal mTLS disabled", mtls: false},
+		{name: "forwarded-header agent auth", forwardedHeader: true},
 	}
 
 	for _, tt := range tests {
@@ -1214,6 +1321,9 @@ func TestStart_Lifecycle(t *testing.T) {
 				caCert, _ := generateTestCA(t)
 				cfg.InternalMTLSEnabled = true
 				cfg.InternalClientCAPath = writeTestCAFile(t, caCert)
+			}
+			if tt.forwardedHeader {
+				cfg.AgentAuthMode = AgentAuthModeForwardedHeader
 			}
 
 			s := New(cfg, nil, testLogger())


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The cluster gateway's public agent listener (port 8443) authenticates connecting plane agents via mTLS, reading the client certificate directly from the TLS handshake (r.TLS.PeerCertificates). This requires the agent's TLS connection to reach the gateway unterminated — i.e., TLS passthrough / L4 exposure.

In deployments where an L7 proxy terminates TLS in front of the gateway (e.g., AWS ALB with mTLS passthrough mode, or an Envoy/Istio ingress), the handshake never reaches the gateway, so the client certificate is unavailable and agents cannot authenticate. This PR adds a forwarded-header authentication mode that reads the agent's client certificate chain from a header set by the trusted TLS-terminating proxy (X-Amzn-Mtls-Clientcert for ALB, X-Forwarded-Client-Cert for Envoy/Istio), enabling gateway deployment behind such proxies. Only the certificate extraction point changes — the trust anchors and per-plane-CR certificate verification remain identical in both modes.

## Approach
- New AgentAuthenticator abstraction (internal/cluster-gateway/agent_auth.go): a small interface that extracts the agent's client certificate chain (leaf + intermediates) from an inbound WebSocket request. Two implementations:
  - mtlsAuthenticator — reads from the TLS handshake (default; preserves existing behavior).
  - forwardedHeaderAuthenticator — reads a URL-encoded PEM chain from a configurable header. Supports both proxy encodings: AWS ALB's raw URL-encoded PEM chain, and Envoy/Istio's XFCC key=value format (preferring Chain over Cert, using only the first client-facing element).
- Fail-loud configuration: buildAgentAuthenticator rejects unrecognized modes at Start() — startup fails rather than silently falling back to a default. Forwarded-header mode logs a prominent Warn documenting the security precondition: the public listener must be reachable only via the trusted proxy, and all other ingress paths must strip the header.
- Handler change (server.go): handleWebSocket now calls s.agentAuth.Authenticate(r) instead of reading r.TLS.PeerCertificates inline; the downstream per-CR validation is untouched.
- Configuration plumbing: new --agent-auth-mode / --agent-auth-forwarded-header flags (env: AGENT_AUTH_MODE, AGENT_AUTH_FORWARDED_HEADER) in cmd/cluster-gateway/main.go, and new Helm values clusterGateway.agentAuth.mode (enum: mtls | forwarded-header, default mtls) and clusterGateway.agentAuth.forwardedHeaderName (default X-Forwarded-Client-Cert) wired through the deployment template and values.schema.json.
- Backward compatible: default mode is mtls; existing deployments are unaffected.

## Related Issues
- https://github.com/openchoreo/openchoreo/issues/4229

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
- Security note: forwarded-header mode trusts the configured header for agent identity. It is only safe when the public listener is reachable exclusively from the TLS-terminating proxy and every other ingress path strips the header. The gateway logs this precondition as a warning at startup.
- Certificate verification (trust anchors, per-plane-CR checks preventing cross-tenant access) is unchanged in both modes — this PR only changes where the chain is read from.
- XFCC parsing uses only the first (client-facing) element of a multi-hop header and prefers Chain (leaf + issuers) over Cert (leaf only).
