### PR TITLE
fix(controller): add container ports so workloads can be targeted by name

### DIFF
--- a/internal/pipeline/component/context/cel_extensions.go
+++ b/internal/pipeline/component/context/cel_extensions.go
@@ -15,6 +15,7 @@ const (
 	configurationsIdentifier = "configurations"
 	dependenciesIdentifier   = "dependencies"
 	derivedIdentifier        = "derived"
+	workloadIdentifier       = "workload"
 )
 
 // CELExtensions returns CEL environment options for configuration, workload,
@@ -31,6 +32,7 @@ func CELExtensions() []cel.EnvOption {
 			toConfigEnvsByContainerMacro,
 			toSecretEnvsByContainerMacro,
 			toServicePortsMacro,
+			toContainerPortsMacro,
 			toContainerEnvsMacro,
 			toEndpointResourcesMacro,
 		),
@@ -111,8 +113,16 @@ var toSecretEnvsByContainerMacro = cel.ReceiverMacro("toSecretEnvsByContainer", 
 
 var toServicePortsMacro = cel.ReceiverMacro("toServicePorts", 0,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
-		if target.Kind() == ast.IdentKind && target.AsIdent() == "workload" {
+		if target.Kind() == ast.IdentKind && target.AsIdent() == workloadIdentifier {
 			return derivedField(eh, "servicePorts"), nil
+		}
+		return nil, nil
+	})
+
+var toContainerPortsMacro = cel.ReceiverMacro("toContainerPorts", 0,
+	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
+		if target.Kind() == ast.IdentKind && target.AsIdent() == workloadIdentifier {
+			return derivedField(eh, "containerPorts"), nil
 		}
 		return nil, nil
 	})
@@ -133,7 +143,7 @@ var toContainerEnvsMacro = cel.ReceiverMacro("toContainerEnvs", 0,
 // avoided unless a template opts in.
 var toEndpointResourcesMacro = cel.ReceiverMacro("toEndpointResources", 1,
 	func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
-		if target.Kind() == ast.IdentKind && target.AsIdent() == "workload" {
+		if target.Kind() == ast.IdentKind && target.AsIdent() == workloadIdentifier {
 			return eh.NewCall(operators.OptIndex, derivedField(eh, "endpointResources"), args[0]), nil
 		}
 		return nil, nil

--- a/internal/pipeline/component/context/cel_extensions_test.go
+++ b/internal/pipeline/component/context/cel_extensions_test.go
@@ -611,7 +611,7 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 				},
 			}),
 			want: []any{
-				map[string]any{"name": "http", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
+				map[string]any{"name": "http", "port": float64(8080), "targetPort": "http", "protocol": "TCP"},
 			},
 		},
 		{
@@ -623,8 +623,8 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 				},
 			}),
 			want: []any{
-				map[string]any{"name": "admin", "port": float64(9091), "targetPort": float64(9091), "protocol": "TCP"},
-				map[string]any{"name": "grpc", "port": float64(9090), "targetPort": float64(9090), "protocol": "TCP"},
+				map[string]any{"name": "admin", "port": float64(9091), "targetPort": "admin", "protocol": "TCP"},
+				map[string]any{"name": "grpc", "port": float64(9090), "targetPort": "grpc", "protocol": "TCP"},
 			},
 		},
 		{
@@ -635,7 +635,7 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 				},
 			}),
 			want: []any{
-				map[string]any{"name": "dns", "port": float64(53), "targetPort": float64(53), "protocol": "UDP"},
+				map[string]any{"name": "dns", "port": float64(53), "targetPort": "dns", "protocol": "UDP"},
 			},
 		},
 		{
@@ -647,7 +647,7 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 				},
 			}),
 			want: []any{
-				map[string]any{"name": "api", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
+				map[string]any{"name": "api", "port": float64(8080), "targetPort": "api", "protocol": "TCP"},
 			},
 		},
 		{
@@ -663,7 +663,7 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 				},
 			}),
 			want: []any{
-				map[string]any{"name": "http", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
+				map[string]any{"name": "http", "port": float64(8080), "targetPort": "http", "protocol": "TCP"},
 			},
 		},
 		{
@@ -674,7 +674,42 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 				},
 			}),
 			want: []any{
-				map[string]any{"name": "my-http-endpoin", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
+				map[string]any{"name": "my-http-endpoin", "port": float64(8080), "targetPort": "my-http-endpoin", "protocol": "TCP"},
+			},
+		},
+		{
+			name: "targetPort differs from port",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"http": {Port: 80, TargetPort: 8080, Type: "HTTP"},
+				},
+			}),
+			want: []any{
+				map[string]any{"name": "http", "port": float64(80), "targetPort": "http", "protocol": "TCP"},
+			},
+		},
+		{
+			name: "UDP endpoint with distinct target port",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"dns": {Port: 53, TargetPort: 5353, Type: "UDP"},
+				},
+			}),
+			want: []any{
+				map[string]any{"name": "dns", "port": float64(53), "targetPort": "dns", "protocol": "UDP"},
+			},
+		},
+		{
+			name: "multiple endpoint names sanitizing to same value with collision handling",
+			inputs: workloadInputs(WorkloadData{
+				Endpoints: map[string]EndpointData{
+					"api-v1": {Port: 8081, TargetPort: 9091, Type: "HTTP"},
+					"api_v1": {Port: 8080, TargetPort: 9090, Type: "HTTP"},
+				},
+			}),
+			want: []any{
+				map[string]any{"name": "api-v1", "port": float64(8081), "targetPort": "api-v1", "protocol": "TCP"},
+				map[string]any{"name": "api-v1-2", "port": float64(8080), "targetPort": "api-v1-2", "protocol": "TCP"},
 			},
 		},
 	}
@@ -704,6 +739,22 @@ func TestToServicePortsMacroOnlyExpandsForWorkloadEndpoints(t *testing.T) {
 	inputs := workloadInputs(WorkloadData{})
 	inputs["other"] = map[string]any{}
 	_, err = engine.Render(`${other.toServicePorts()}`, inputs)
+	if err == nil {
+		t.Error("expected error for non-workload receiver")
+	}
+}
+
+func TestToContainerPortsMacroOnlyExpandsForWorkloadEndpoints(t *testing.T) {
+	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
+
+	_, err := engine.Render(`${workload.toContainerPorts()}`, workloadInputs(WorkloadData{}))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	inputs := workloadInputs(WorkloadData{})
+	inputs["other"] = map[string]any{}
+	_, err = engine.Render(`${other.toContainerPorts()}`, inputs)
 	if err == nil {
 		t.Error("expected error for non-workload receiver")
 	}
@@ -879,6 +930,9 @@ func TestBuildDerivedContext_EmptyInputs(t *testing.T) {
 	}
 	if derived.ServicePorts == nil {
 		t.Error("ServicePorts should be non-nil")
+	}
+	if derived.ContainerPorts == nil {
+		t.Error("ContainerPorts should be non-nil")
 	}
 	if derived.DependencyEnvVars == nil {
 		t.Error("DependencyEnvVars should be non-nil")

--- a/internal/pipeline/component/context/cel_integration_test.go
+++ b/internal/pipeline/component/context/cel_integration_test.go
@@ -301,8 +301,19 @@ func TestCELMacroIntegration(t *testing.T) {
 	t.Run("workload.toServicePorts", func(t *testing.T) {
 		got := eval(t, "workload.toServicePorts()", buildContext(t, workload, nil, ConnectionsData{}))
 		want := []any{
-			map[string]any{"name": "grpc", "port": float64(9090), "targetPort": float64(9090), "protocol": "TCP"},
-			map[string]any{"name": "http", "port": float64(8080), "targetPort": float64(8080), "protocol": "TCP"},
+			map[string]any{"name": "grpc", "port": float64(9090), "targetPort": "grpc", "protocol": "TCP"},
+			map[string]any{"name": "http", "port": float64(8080), "targetPort": "http", "protocol": "TCP"},
+		}
+		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("workload.toContainerPorts", func(t *testing.T) {
+		got := eval(t, "workload.toContainerPorts()", buildContext(t, workload, nil, ConnectionsData{}))
+		want := []any{
+			map[string]any{"name": "grpc", "containerPort": float64(9090), "protocol": "TCP"},
+			map[string]any{"name": "http", "containerPort": float64(8080), "protocol": "TCP"},
 		}
 		if diff := cmp.Diff(want, got, diffOpts...); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -369,6 +380,7 @@ func TestCELMacroIntegration(t *testing.T) {
 			"configurations.toConfigEnvsByContainer()",
 			"configurations.toSecretEnvsByContainer()",
 			"workload.toServicePorts()",
+			"workload.toContainerPorts()",
 			"dependencies.toContainerEnvs()",
 			"dependencies.toContainerVolumeMounts()",
 			"dependencies.toVolumes()",

--- a/internal/pipeline/component/context/cel_return_types.go
+++ b/internal/pipeline/component/context/cel_return_types.go
@@ -92,6 +92,13 @@ type EnvsByContainerEntry struct {
 type ServicePortEntry struct {
 	Name       string `json:"name"`
 	Port       int64  `json:"port"`
-	TargetPort int64  `json:"targetPort"`
+	TargetPort string `json:"targetPort"`
 	Protocol   string `json:"protocol"`
+}
+
+// ContainerPortEntry represents an element of derived.containerPorts.
+type ContainerPortEntry struct {
+	Name          string `json:"name"`
+	ContainerPort int64  `json:"containerPort"`
+	Protocol      string `json:"protocol"`
 }

--- a/internal/pipeline/component/context/derived.go
+++ b/internal/pipeline/component/context/derived.go
@@ -30,7 +30,8 @@ type DerivedContext struct {
 	ConfigEnvs         []EnvsByContainerEntry `json:"configEnvs"`
 	SecretEnvs         []EnvsByContainerEntry `json:"secretEnvs"`
 
-	ServicePorts []ServicePortEntry `json:"servicePorts"`
+	ServicePorts   []ServicePortEntry   `json:"servicePorts"`
+	ContainerPorts []ContainerPortEntry `json:"containerPorts"`
 
 	DependencyEnvVars      []EnvVarEntry      `json:"dependencyEnvVars"`
 	DependencyVolumeMounts []VolumeMountEntry `json:"dependencyVolumeMounts"`
@@ -52,6 +53,8 @@ func BuildDerivedContext(
 	prefix string,
 	endpointResources EndpointResourceMap,
 ) DerivedContext {
+	containerPorts, containerPortNames := buildContainerPorts(workload)
+
 	return DerivedContext{
 		ConfigFileList:         buildConfigFileList(configurations, prefix),
 		SecretFileList:         buildSecretFileList(configurations, prefix),
@@ -60,7 +63,8 @@ func BuildDerivedContext(
 		ConfigVolumes:          buildVolumes(configurations, prefix),
 		ConfigEnvs:             buildConfigEnvs(configurations, prefix),
 		SecretEnvs:             buildSecretEnvs(configurations, prefix),
-		ServicePorts:           buildServicePorts(workload),
+		ServicePorts:           buildServicePorts(workload, containerPortNames),
+		ContainerPorts:         containerPorts,
 		DependencyEnvVars:      nonNilEnvVars(dependencies.EnvVars),
 		DependencyVolumeMounts: nonNilVolumeMounts(dependencies.VolumeMounts),
 		DependencyVolumes:      nonNilVolumes(dependencies.Volumes),
@@ -181,7 +185,7 @@ func buildSecretEnvs(cc ContainerConfigurations, prefix string) []EnvsByContaine
 	}}
 }
 
-func buildServicePorts(workload WorkloadData) []ServicePortEntry {
+func buildServicePorts(workload WorkloadData, containerPortNames map[string]string) []ServicePortEntry {
 	if len(workload.Endpoints) == 0 {
 		return []ServicePortEntry{}
 	}
@@ -199,10 +203,6 @@ func buildServicePorts(workload WorkloadData) []ServicePortEntry {
 	for _, epName := range endpointNames {
 		ep := workload.Endpoints[epName]
 		port := int64(ep.Port)
-		targetPort := int64(ep.TargetPort)
-		if targetPort == 0 {
-			targetPort = port
-		}
 		protocol := mapEndpointTypeToProtocol(ep.Type)
 
 		portProtoKey := fmt.Sprintf("%d/%s", port, protocol)
@@ -217,11 +217,47 @@ func buildServicePorts(workload WorkloadData) []ServicePortEntry {
 		result = append(result, ServicePortEntry{
 			Name:       finalName,
 			Port:       port,
-			TargetPort: targetPort,
+			TargetPort: containerPortNames[epName],
 			Protocol:   protocol,
 		})
 	}
 	return result
+}
+
+func buildContainerPorts(workload WorkloadData) ([]ContainerPortEntry, map[string]string) {
+	if len(workload.Endpoints) == 0 {
+		return []ContainerPortEntry{}, map[string]string{}
+	}
+
+	endpointNames := make([]string, 0, len(workload.Endpoints))
+	for name := range workload.Endpoints {
+		endpointNames = append(endpointNames, name)
+	}
+	sort.Strings(endpointNames)
+
+	result := make([]ContainerPortEntry, 0, len(workload.Endpoints))
+	namesByEndpoint := make(map[string]string, len(workload.Endpoints))
+	usedNames := make(map[string]bool)
+
+	for _, epName := range endpointNames {
+		ep := workload.Endpoints[epName]
+		containerPort := int64(ep.TargetPort)
+		if containerPort == 0 {
+			containerPort = int64(ep.Port)
+		}
+		protocol := mapEndpointTypeToProtocol(ep.Type)
+
+		finalName := uniquePortName(epName, containerPort, usedNames)
+		usedNames[finalName] = true
+		namesByEndpoint[epName] = finalName
+
+		result = append(result, ContainerPortEntry{
+			Name:          finalName,
+			ContainerPort: containerPort,
+			Protocol:      protocol,
+		})
+	}
+	return result, namesByEndpoint
 }
 
 func uniquePortName(endpointName string, port int64, usedNames map[string]bool) string {

--- a/samples/component-types/component-grpc-service/grpc-service-component.yaml
+++ b/samples/component-types/component-grpc-service/grpc-service-component.yaml
@@ -70,6 +70,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   env: ${dependencies.toContainerEnvs()}
 
     - id: service

--- a/samples/component-types/component-http-openapi-service/http-openapi-service-component.yaml
+++ b/samples/component-types/component-http-openapi-service/http-openapi-service-component.yaml
@@ -67,6 +67,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   env: ${dependencies.toContainerEnvs()}
 
     - id: service

--- a/samples/component-types/component-tls-service/tls-service-component.yaml
+++ b/samples/component-types/component-tls-service/tls-service-component.yaml
@@ -69,6 +69,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   env: ${dependencies.toContainerEnvs()}
                   volumeMounts: ${configurations.toContainerVolumeMounts() + dependencies.toContainerVolumeMounts()}
               volumes: ${configurations.toVolumes() + dependencies.toVolumes()}

--- a/samples/component-types/component-with-configs/component-with-configs.yaml
+++ b/samples/component-types/component-with-configs/component-with-configs.yaml
@@ -79,6 +79,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   resources:
                     requests:
                       cpu: ${environmentConfigs.resources.requests.cpu}

--- a/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
+++ b/samples/component-types/component-with-embedded-traits/component-with-embedded-traits.yaml
@@ -291,6 +291,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   resources:
                     requests:
                       cpu: ${environmentConfigs.resources.requests.cpu}

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -458,6 +458,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   resources:
                     requests:
                       cpu: ${environmentConfigs.resources.requests.cpu}
@@ -719,6 +720,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   resources:
                     requests:
                       cpu: ${environmentConfigs.resources.requests.cpu}

--- a/samples/getting-started/component-types/service.yaml
+++ b/samples/getting-started/component-types/service.yaml
@@ -97,6 +97,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   resources:
                     requests:
                       cpu: ${environmentConfigs.resources.requests.cpu}

--- a/samples/getting-started/component-types/webapp.yaml
+++ b/samples/getting-started/component-types/webapp.yaml
@@ -85,6 +85,7 @@ spec:
                     ${has(workload.container.command) ? workload.container.command : oc_omit()}
                   args: |
                     ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  ports: ${workload.toContainerPorts()}
                   resources:
                     requests:
                       cpu: ${environmentConfigs.resources.requests.cpu}


### PR DESCRIPTION
## Purpose

Workload endpoints currently render into a Service with a named port and a numeric `targetPort`, but the generated container spec does not include a `ports:` block.

This means the pod does not explicitly declare the port, causing features that resolve ports by name against the pod spec to fail silently. For example:

- Linkerd `Server` resources cannot bind to the port.
- Named `NetworkPolicy` / `CiliumNetworkPolicy` port rules resolve to zero ports and may be denied under a default-deny baseline.
- Port-constraining admission policies cannot validate the intended port.
- Prometheus pod-role scraping requires relabeling workarounds to synthesize target ports.

This PR adds container port definitions derived from workload endpoints and ensures Service `targetPort` references resolve correctly.

Fixes #4329

## Approach

- Added `buildContainerPorts()` in `internal/pipeline/component/context/derived.go`.
  - Creates a derived view that generates one named container port per workload endpoint.
  - Reuses the existing sanitization and deduplication logic from `buildServicePorts()` to ensure generated Kubernetes port names are valid and unique.

- Added a new `workload.toContainerPorts()` CEL macro in `cel_extensions.go`.
  - Mirrors the existing `toServicePorts()` macro.

- Updated `ServicePortEntry.TargetPort`.
  - Changed it from a raw numeric port value to the name of the matching container port.
  - Ensures rendered Services target ports explicitly declared by the pod.

- Added `ports: ${workload.toContainerPorts()}` to container specifications in built-in `ClusterComponentType` templates under `samples/`:
  - `service`
  - `webapp`
  - `grpc-service`
  - `tls-service`
  - `http-openapi-service`
  - `component-with-configs`
  - `component-with-embedded-traits`

- `containerPort` is informational only and does not affect application bindings or traffic routing.
  - Existing workloads only require a rolling restart during upgrade.
  - No runtime behavior changes are introduced.

## Related Issues

Fixes #4329

## Checklist

- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

Container ports are named after endpoint keys so that workloads with multiple endpoints on the same port number but different visibility settings receive separate container port entries.

Kubernetes allows multiple named container ports with the same port number, so container ports are not deduplicated by `port + protocol` like Service ports.

Each endpoint requires its own unique name because the Service `targetPort` must resolve to the corresponding container port name.