### PR TITLE
docs: add missing opensearch-admin-credentials secret to k3d single-cluster guide

### DIFF
--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -356,8 +356,32 @@ kubectl create configmap cluster-gateway-ca \
 
 ### Observability Plane Secrets
 
+`opensearch-admin-credentials` is required by the logs and tracing modules installed below — without it, their setup/adapter pods fail with `CreateContainerConfigError`.
+
 ```bash
 kubectl apply -f - <<EOF
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opensearch-admin-credentials
+  namespace: openchoreo-observability-plane
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: default
+  target:
+    name: opensearch-admin-credentials
+  data:
+    - secretKey: username
+      remoteRef:
+        key: opensearch-username
+        property: value
+    - secretKey: password
+      remoteRef:
+        key: opensearch-password
+        property: value
+---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -378,7 +402,7 @@ spec:
 EOF
 
 kubectl wait -n openchoreo-observability-plane \
-  --for=condition=Ready externalsecret/observer-secret --timeout=60s
+  --for=condition=Ready externalsecret/opensearch-admin-credentials externalsecret/observer-secret --timeout=60s
 ```
 
 ### Install Observability Plane

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -356,7 +356,7 @@ kubectl create configmap cluster-gateway-ca \
 
 ### Observability Plane Secrets
 
-`opensearch-admin-credentials` is required by the logs and tracing modules installed below — without it, their setup/adapter pods fail with `CreateContainerConfigError`.
+Create the `opensearch-admin-credentials` secret needed by the logs and tracing modules, together with the existing `observer-secret`:
 
 ```bash
 kubectl apply -f - <<EOF


### PR DESCRIPTION
## Summary
- The k3d single-cluster contributor guide's observability plane section never creates the `opensearch-admin-credentials` `ExternalSecret`, so the logs/tracing modules' setup and adapter pods fail with `CreateContainerConfigError` when following the guide as written.
- The curl-based `install/k3d/k3d-install.sh` script already creates this secret, and `install/k3d/multi-cluster/README.md` already documents it correctly — only the single-cluster guide was missing it.
- Adds the same `ExternalSecret` (bundled alongside the existing `observer-secret` one, matching the script's pattern) and waits on both before installing the plane.

## Test plan
- [x] Reproduced the failure and fix live on a local k3d single-cluster install following the guide step by step (observed `CreateContainerConfigError` on `opensearch-setup-logs` / `logs-adapter-opensearch` pods without the secret, resolved after adding it).