### PR TITLE
fix(helm): default controller-manager image pullPolicy to IfNotPresent

### DIFF
--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1888,7 +1888,7 @@
           "description": "Container image configuration",
           "properties": {
             "pullPolicy": {
-              "default": "Always",
+              "default": "IfNotPresent",
               "description": "Image pull policy",
               "enum": [
                 "Always",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -247,9 +247,9 @@ controllerManager:
     # @schema
     # description: Image pull policy
     # enum: [Always, IfNotPresent, Never]
-    # default: Always
+    # default: IfNotPresent
     # @schema
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
   # @schema
   # type: object


### PR DESCRIPTION
## Summary
- `openchoreo-control-plane`'s `controllerManager.image.pullPolicy` defaulted to `Always`, while every other component in the same chart (`openchoreoApi`, `backstage`, `clusterGateway`, `eventForwarder`, `portalAssistant`) already defaults to `IfNotPresent`.
- This silently defeats the contributor k3d single-cluster workflow (`install/k3d/single-cluster/README.md` + `make k3d.build.controller`/`k3d.load.controller`), which builds and imports controller images locally under the `latest-dev` tag: with `Always`, kubelet re-pulls the real published `ghcr.io/openchoreo/controller:latest-dev` from `ghcr.io` on every pod start/restart instead of using the locally-built image. Every build/import step reports success, but the cluster silently keeps running upstream `main`'s code — controller changes never actually take effect, with no error anywhere.
- Regenerated `values.schema.json` via `make helm-generate.openchoreo-control-plane` to match.

## Test plan
- [x] Reproduced on a local k3d single-cluster install: built and imported a controller image with an intentional local-only change, restarted the deployment, and confirmed (via the pod's `imageID`/`crictl inspect`) that it kept resolving to the real ghcr.io digest instead of the local build, until switching this default to `IfNotPresent`.
- [x] After the fix, rebuilt/reimported/restarted and confirmed the pod's `imageID` matches the locally-built image.