### PR TITLE
fix(controller): clean up orphaned ProjectRelease snapshots on Project deletion

### DIFF
--- a/internal/controller/project/controller_finalize.go
+++ b/internal/controller/project/controller_finalize.go
@@ -111,7 +111,19 @@ func (r *Reconciler) deleteChildAndLinkedResources(ctx context.Context, project 
 		return false, err
 	}
 
-	if !componentsDeleted || !resourcesDeleted || !bindingsDeleted {
+	if !bindingsDeleted {
+		logger.Info("Waiting for ProjectReleaseBindings to be deleted before removing ProjectReleases", "name", project.Name)
+		return false, nil
+	}
+
+	// Clean up project releases
+	releasesDeleted, err := r.deleteProjectReleasesAndWait(ctx, project)
+	if err != nil {
+		logger.Error(err, "Failed to delete project releases")
+		return false, err
+	}
+
+	if !componentsDeleted || !resourcesDeleted || !releasesDeleted {
 		logger.Info("Children are still being deleted", "name", project.Name)
 		return false, nil
 	}
@@ -220,6 +232,39 @@ func (r *Reconciler) deleteProjectReleaseBindingsAndWait(ctx context.Context, pr
 		binding := &bindingsList.Items[i]
 		if err := client.IgnoreNotFound(r.Delete(ctx, binding)); err != nil {
 			return false, fmt.Errorf("failed to delete project release binding %s: %w", binding.Name, err)
+		}
+	}
+
+	return false, nil
+}
+
+// deleteProjectReleasesAndWait checks if any ProjectReleases owned by this Project
+// still exist, and deletes them if they exist. ProjectReleases are deleted after
+// ProjectReleaseBindings have been successfully deleted, since a live binding pins
+// a ProjectRelease by name via spec.projectRelease.
+func (r *Reconciler) deleteProjectReleasesAndWait(ctx context.Context, project *openchoreov1alpha1.Project) (bool, error) {
+	logger := log.FromContext(ctx).WithValues("project", project.Name)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	releasesList := &openchoreov1alpha1.ProjectReleaseList{}
+	if err := r.List(timeoutCtx, releasesList,
+		client.InNamespace(project.Namespace),
+		client.MatchingFields{controller.IndexKeyProjectReleaseOwner: project.Name}); err != nil {
+		return false, fmt.Errorf("failed to list project releases: %w", err)
+	}
+
+	if len(releasesList.Items) == 0 {
+		logger.Info("All project releases are deleted")
+		return true, nil
+	}
+
+	logger.Info("Deleting ProjectReleases", "count", len(releasesList.Items))
+	for i := range releasesList.Items {
+		release := &releasesList.Items[i]
+		if err := client.IgnoreNotFound(r.Delete(timeoutCtx, release)); err != nil {
+			return false, fmt.Errorf("failed to delete project release %s: %w", release.Name, err)
 		}
 	}
 

--- a/internal/controller/project/controller_integration_test.go
+++ b/internal/controller/project/controller_integration_test.go
@@ -1043,6 +1043,103 @@ var _ = Describe("Project Controller", func() {
 		})
 	})
 
+	Context("Finalization cascades ProjectReleases", func() {
+		const (
+			nsName   = "it-cascade-pr-ns"
+			dpName   = "it-cascade-pr-dp"
+			envName  = "it-cascade-pr-env"
+			pipName  = "it-cascade-pr-pip"
+			ptName   = "it-cascade-pr-pt"
+			projName = "it-cascade-pr-proj"
+		)
+
+		nn := types.NamespacedName{Name: projName, Namespace: nsName}
+
+		BeforeEach(func() {
+			setupDependencies(nsName, dpName, envName, pipName)
+			createProjectType(nsName, ptName)
+		})
+
+		It("should delete the project's releases and isolate releases belonging to other projects", func() {
+			project := &openchoreov1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      projName,
+					Namespace: nsName,
+				},
+				Spec: openchoreov1alpha1.ProjectSpec{
+					DeploymentPipelineRef: openchoreov1alpha1.DeploymentPipelineRef{
+						Name: pipName,
+					},
+					Type: openchoreov1alpha1.ProjectTypeRef{
+						Name: ptName,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+
+			r := itReconciler()
+
+			// Reconcile until finalizer is added and a ProjectRelease is cut.
+			var cutReleaseName string
+			Eventually(func(g Gomega) {
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				fetchedProj := &openchoreov1alpha1.Project{}
+				g.Expect(k8sClient.Get(ctx, nn, fetchedProj)).To(Succeed())
+				g.Expect(fetchedProj.Status.LatestRelease).NotTo(BeNil())
+				cutReleaseName = fetchedProj.Status.LatestRelease.Name
+			}, itTimeout, itInterval).Should(Succeed())
+
+			// Create a ProjectRelease belonging to another project in the same namespace.
+			otherRelease := &openchoreov1alpha1.ProjectRelease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "it-other-project-release",
+					Namespace: nsName,
+				},
+				Spec: openchoreov1alpha1.ProjectReleaseSpec{
+					Owner: openchoreov1alpha1.ProjectReleaseOwner{
+						ProjectName: "other-project",
+					},
+					ProjectType: openchoreov1alpha1.ProjectReleaseProjectType{
+						Kind: openchoreov1alpha1.ProjectTypeRefKindProjectType,
+						Name: ptName,
+						Spec: openchoreov1alpha1.ProjectTypeSpec{
+							Resources: []openchoreov1alpha1.ResourceTemplate{
+								{
+									ID: "ns",
+									Template: &runtime.RawExtension{
+										Raw: []byte(`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"foo"}}`),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, otherRelease)).To(Succeed())
+
+			// Delete the project and drive finalization to completion.
+			Expect(k8sClient.Delete(ctx, project)).To(Succeed())
+
+			Eventually(func() bool {
+				_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+				return errors.IsNotFound(k8sClient.Get(ctx, nn, &openchoreov1alpha1.Project{}))
+			}, itTimeout, itInterval).Should(BeTrue())
+
+			// The cut ProjectRelease is deleted.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cutReleaseName, Namespace: nsName},
+					&openchoreov1alpha1.ProjectRelease{})
+				return errors.IsNotFound(err)
+			}, itTimeout, itInterval).Should(BeTrue())
+
+			// The other project's release remains untouched.
+			gotOther := &openchoreov1alpha1.ProjectRelease{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: otherRelease.Name, Namespace: nsName}, gotOther)).To(Succeed())
+		})
+	})
+
 	Context("Finalization with owned Resources", func() {
 		const (
 			nsName   = "it-finalize-res-ns"

--- a/internal/controller/project/controller_unit_test.go
+++ b/internal/controller/project/controller_unit_test.go
@@ -501,6 +501,20 @@ func newSeedTestScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+func newSeedTestRelease(name, projectName string) *openchoreov1alpha1.ProjectRelease {
+	return &openchoreov1alpha1.ProjectRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+		},
+		Spec: openchoreov1alpha1.ProjectReleaseSpec{
+			Owner: openchoreov1alpha1.ProjectReleaseOwner{
+				ProjectName: projectName,
+			},
+		},
+	}
+}
+
 func newSeedTestBinding(name, projectName, env, pin string) *openchoreov1alpha1.ProjectReleaseBinding {
 	return &openchoreov1alpha1.ProjectReleaseBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -533,12 +547,34 @@ func newSeedTestProject(latestRelease string) *openchoreov1alpha1.Project {
 	return p
 }
 
+func IndexComponentOwner(obj client.Object) []string {
+	component := obj.(*openchoreov1alpha1.Component)
+	if component.Spec.Owner.ProjectName == "" {
+		return nil
+	}
+	return []string{component.Spec.Owner.ProjectName}
+}
+
+func IndexResourceOwner(obj client.Object) []string {
+	resource := obj.(*openchoreov1alpha1.Resource)
+	if resource.Spec.Owner.ProjectName == "" {
+		return nil
+	}
+	return []string{resource.Spec.Owner.ProjectName}
+}
+
 func newSeedTestClientBuilder(t *testing.T) *fake.ClientBuilder {
 	t.Helper()
 	return fake.NewClientBuilder().
 		WithScheme(newSeedTestScheme(t)).
+		WithIndex(&openchoreov1alpha1.Component{},
+			controller.IndexKeyComponentOwnerProjectName, IndexComponentOwner).
+		WithIndex(&openchoreov1alpha1.Resource{},
+			controller.IndexKeyResourceOwnerProjectName, IndexResourceOwner).
 		WithIndex(&openchoreov1alpha1.ProjectReleaseBinding{},
-			controller.IndexKeyProjectReleaseBindingOwner, controller.IndexProjectReleaseBindingOwner)
+			controller.IndexKeyProjectReleaseBindingOwner, controller.IndexProjectReleaseBindingOwner).
+		WithIndex(&openchoreov1alpha1.ProjectRelease{},
+			controller.IndexKeyProjectReleaseOwner, controller.IndexProjectReleaseOwner)
 }
 
 func TestSeedBindingPinsSkipsWithoutLatestRelease(t *testing.T) {
@@ -685,6 +721,121 @@ func TestDeleteProjectReleaseBindingsAndWaitDeleteError(t *testing.T) {
 	_, err := r.deleteProjectReleaseBindingsAndWait(context.Background(), newSeedTestProject(""))
 	if err == nil {
 		t.Fatal("expected delete error to propagate")
+	}
+}
+
+// ── deleteProjectReleasesAndWait ──────────────────────────────────────────────
+
+func TestDeleteProjectReleasesAndWait(t *testing.T) {
+	cli := newSeedTestClientBuilder(t).
+		WithObjects(
+			newSeedTestRelease("r1", "my-project"),
+			newSeedTestRelease("r2", "my-project"),
+			newSeedTestRelease("r-other", "other-project"),
+		).
+		Build()
+	r := &Reconciler{Client: cli, Scheme: cli.Scheme(), Recorder: record.NewFakeRecorder(10)}
+	project := newSeedTestProject("")
+
+	// First pass issues the deletes and reports not-done.
+	done, err := r.deleteProjectReleasesAndWait(context.Background(), project)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if done {
+		t.Error("expected done=false while releases were being deleted")
+	}
+
+	// Second pass sees them gone.
+	done, err = r.deleteProjectReleasesAndWait(context.Background(), project)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !done {
+		t.Error("expected done=true once the project's releases are gone")
+	}
+
+	// The other project's release must be untouched.
+	got := &openchoreov1alpha1.ProjectRelease{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: "r-other", Namespace: "test-ns"}, got); err != nil {
+		t.Errorf("expected other project's release to survive, got %v", err)
+	}
+}
+
+func TestDeleteProjectReleasesAndWaitDeleteError(t *testing.T) {
+	cli := newSeedTestClientBuilder(t).
+		WithObjects(newSeedTestRelease("r1", "my-project")).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*openchoreov1alpha1.ProjectRelease); ok {
+					return errors.New("simulated delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &Reconciler{Client: cli, Scheme: cli.Scheme(), Recorder: record.NewFakeRecorder(10)}
+
+	_, err := r.deleteProjectReleasesAndWait(context.Background(), newSeedTestProject(""))
+	if err == nil {
+		t.Fatal("expected delete error to propagate")
+	}
+}
+
+func TestDeleteProjectReleasesAndWaitListError(t *testing.T) {
+	cli := newSeedTestClientBuilder(t).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*openchoreov1alpha1.ProjectReleaseList); ok {
+					return errors.New("simulated list error")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	r := &Reconciler{Client: cli, Scheme: cli.Scheme(), Recorder: record.NewFakeRecorder(10)}
+
+	_, err := r.deleteProjectReleasesAndWait(context.Background(), newSeedTestProject(""))
+	if err == nil {
+		t.Fatal("expected list error to propagate")
+	}
+}
+
+func TestDeleteChildAndLinkedResources_PendingBindingsSkipsReleaseDeletion(t *testing.T) {
+	binding := newSeedTestBinding("b-dev", "my-project", "development", "r1")
+	release := newSeedTestRelease("r1", "my-project")
+
+	releaseDeleteCalled := false
+	cli := newSeedTestClientBuilder(t).
+		WithObjects(binding, release).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*openchoreov1alpha1.ProjectRelease); ok {
+					releaseDeleteCalled = true
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &Reconciler{Client: cli, Scheme: cli.Scheme(), Recorder: record.NewFakeRecorder(10)}
+	project := newSeedTestProject("")
+
+	done, err := r.deleteChildAndLinkedResources(context.Background(), project)
+	if err != nil {
+		t.Fatalf("unexpected error deleting child resources: %v", err)
+	}
+	if done {
+		t.Error("expected deleteChildAndLinkedResources to return false while bindings are pending")
+	}
+
+	if releaseDeleteCalled {
+		t.Error("ProjectRelease.Delete was called while bindings were still pending; ordering guard is broken")
+	}
+
+	// Verify ProjectRelease remains present in the store
+	relCheck := &openchoreov1alpha1.ProjectRelease{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: release.Name, Namespace: release.Namespace}, relCheck); err != nil {
+		t.Errorf("expected ProjectRelease to remain present, got error: %v", err)
 	}
 }
 

--- a/internal/controller/project/suite_test.go
+++ b/internal/controller/project/suite_test.go
@@ -114,6 +114,10 @@ var _ = BeforeSuite(func() {
 		controller.IndexKeyProjectReleaseBindingOwner, controller.IndexProjectReleaseBindingOwner)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ProjectRelease{},
+		controller.IndexKeyProjectReleaseOwner, controller.IndexProjectReleaseOwner)
+	Expect(err).NotTo(HaveOccurred())
+
 	// Start the manager in a goroutine
 	go func() {
 		defer GinkgoRecover()

--- a/internal/controller/watch.go
+++ b/internal/controller/watch.go
@@ -52,6 +52,10 @@ const (
 	// so the Project controller can list all bindings of a project regardless of author
 	// (labels are optional on externally authored bindings).
 	IndexKeyProjectReleaseBindingOwner = "projectreleasebinding.spec.owner.projectName"
+
+	// IndexKeyProjectReleaseOwner indexes ProjectRelease by owner project name
+	// so the Project controller can list and delete all releases of a project.
+	IndexKeyProjectReleaseOwner = "projectrelease.spec.owner.projectName"
 )
 
 // MakeReleaseBindingOwnerEnvKey creates the composite index key for ReleaseBinding lookups
@@ -172,6 +176,11 @@ func SetupSharedIndexes(ctx context.Context, mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to setup ProjectReleaseBinding owner index: %w", err)
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &openchoreov1alpha1.ProjectRelease{},
+		IndexKeyProjectReleaseOwner, IndexProjectReleaseOwner); err != nil {
+		return fmt.Errorf("failed to setup ProjectRelease owner index: %w", err)
+	}
+
 	return nil
 }
 
@@ -221,6 +230,17 @@ func IndexProjectReleaseBindingOwner(obj client.Object) []string {
 		return nil
 	}
 	return []string{prb.Spec.Owner.ProjectName}
+}
+
+// IndexProjectReleaseOwner extracts the owner project name from a
+// ProjectRelease. Exported for fake-client tests so they can register
+// the same indexer the production setup uses.
+func IndexProjectReleaseOwner(obj client.Object) []string {
+	pr := obj.(*openchoreov1alpha1.ProjectRelease)
+	if pr.Spec.Owner.ProjectName == "" {
+		return nil
+	}
+	return []string{pr.Spec.Owner.ProjectName}
 }
 
 // HierarchyWatchHandler is a function that creates a watch handler for a specific hierarchy.

--- a/internal/controller/watch_test.go
+++ b/internal/controller/watch_test.go
@@ -161,3 +161,28 @@ func TestIndexProjectReleaseBindingOwner(t *testing.T) {
 		assert.Nil(t, idxFunc(prb))
 	})
 }
+
+func TestIndexProjectReleaseOwner(t *testing.T) {
+	mgr := &mockManager{indexer: &mockIndexer{}}
+	err := SetupSharedIndexes(context.Background(), mgr)
+	require.NoError(t, err)
+
+	idxFunc := mgr.indexer.indexFuncs[IndexKeyProjectReleaseOwner]
+	require.NotNil(t, idxFunc)
+
+	t.Run("with_owner_project_name", func(t *testing.T) {
+		pr := &openchoreov1alpha1.ProjectRelease{
+			Spec: openchoreov1alpha1.ProjectReleaseSpec{
+				Owner: openchoreov1alpha1.ProjectReleaseOwner{ProjectName: "my-project"},
+			},
+		}
+		got := idxFunc(pr)
+		require.Len(t, got, 1)
+		assert.Equal(t, "my-project", got[0])
+	})
+
+	t.Run("empty_owner_returns_nil", func(t *testing.T) {
+		pr := &openchoreov1alpha1.ProjectRelease{}
+		assert.Nil(t, idxFunc(pr))
+	})
+}


### PR DESCRIPTION
## Purpose
Deleting an OpenChoreo `Project` removes its `ProjectReleaseBinding`, `RenderedRelease`, `DataPlane` namespace, and the `Project` itself, but the corresponding immutable `ProjectRelease` snapshot remains in the cluster indefinitely, causing orphaned resource accumulation on repeated create/delete cycles.

## Approach
1. **Shared Indexer (`internal/controller/watch.go`)**:
   - Added and registered constant `IndexKeyProjectReleaseOwner = "projectrelease.spec.owner.projectName"`.
   - Exported `IndexProjectReleaseOwner(obj client.Object) []string` to extract `pr.Spec.Owner.ProjectName`.
2. **Project Finalization (`internal/controller/project/controller_finalize.go`)**:
   - Added function `deleteProjectReleasesAndWait(ctx, project)` to list and delete all `ProjectRelease` snapshots owned by the project.
   - Wired `deleteProjectReleasesAndWait` into `deleteChildAndLinkedResources` right after `deleteProjectReleaseBindingsAndWait` succeeds (ensuring releases are not deleted out from under live bindings).
3. **Testing**:
   - Added unit test `TestIndexProjectReleaseOwner` in `watch_test.go`.
   - Added unit tests `TestDeleteProjectReleasesAndWait` and `TestDeleteProjectReleasesAndWaitDeleteError` in `controller_unit_test.go`.
   - Added integration test `Context("Finalization cascades ProjectReleases")` in `controller_integration_test.go` verifying cascade deletion and cross-project owner index isolation.

## Related Issues
- [Fixes orphaned ProjectRelease snapshots on Project deletion.](https://github.com/openchoreo/openchoreo/issues/4400)

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
- Retention Policy Note: `ResourceRelease` supports retention policy resolution, whereas `Project` / `ProjectRelease` currently does not have a retain policy schema. Deletion of `ProjectRelease` is unconditional (matching `ProjectReleaseBinding`). Retention policy parity for `ProjectRelease` can be explored in a follow-up PR if needed.
